### PR TITLE
feat: initial sim CFN stack deployment, resource creation

### DIFF
--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundCompleter,
 } from "../../../../util/background/background.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   SimCloudFormationStack,
   type SimCloudFormationStackName,
@@ -18,6 +19,7 @@ import { SimCloudFormationAlreadyExistsException } from "../../error/sim-cloudfr
 
 interface CreateStackCommandHandlerProps {
   readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stacks: Map<SimCloudFormationStackName, SimCloudFormationStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
 }
@@ -32,6 +34,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   SimCreateStackCommandOutput
 > {
   private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stacks: Map<
     SimCloudFormationStackName,
     SimCloudFormationStack
@@ -39,9 +42,10 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly background: BackgroundScheduler & BackgroundCompleter;
 
   constructor(props: CreateStackCommandHandlerProps) {
-    const { simAws, stacks, background } = props;
+    const { simAws, accountRegionScope, stacks, background } = props;
 
     this.simAws = simAws;
+    this.accountRegionScope = accountRegionScope;
     this.stacks = stacks;
     this.background = background;
   }
@@ -74,6 +78,7 @@ export class CreateStackCommandHandler implements CommandHandler<
 
     const stack = new SimCloudFormationStack({
       simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
       background: this.background,
       stackName,
       template,

--- a/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
@@ -56,7 +56,7 @@ describe("CloudFormation CreateStackCommand", () => {
         TemplateBody: JSON.stringify({
           Resources: {
             ExampleResource: {
-              Type: "Custom::Example",
+              Type: "AWS::CloudFormation::WaitConditionHandle",
               Properties: {
                 Value: "example",
               },
@@ -65,6 +65,8 @@ describe("CloudFormation CreateStackCommand", () => {
         }),
       },
     });
+
+    await cloudFormation.waitForStackDeployComplete("test-stack");
 
     // Then the Stack records the template Resources by logical ID.
     const stack = cloudFormation.stacks.get("test-stack" as never);
@@ -76,7 +78,10 @@ describe("CloudFormation CreateStackCommand", () => {
 
     assertNonNullable(resource);
     assertIdentical(resource.logicalId, "ExampleResource");
-    assertIdentical(resource.template["Type"], "Custom::Example");
+    assertIdentical(
+      resource.template["Type"],
+      "AWS::CloudFormation::WaitConditionHandle",
+    );
   });
 
   it("completes Stack deployment in background tasks", async () => {

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
@@ -34,4 +34,5 @@ export interface SimCloudFormationStackDescription {
   readonly StackId?: string | undefined;
   readonly StackName?: SimCloudFormationStackName | undefined;
   readonly StackStatus?: SimCloudFormationStackStatus | undefined;
+  readonly StackStatusReason?: string | undefined;
 }

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
@@ -77,6 +77,7 @@ export class DescribeStacksCommandHandler implements CommandHandler<
       StackId: stack.stackName,
       StackName: stack.stackName,
       StackStatus: stack.status,
+      StackStatusReason: stack.error?.message,
     };
   }
 }

--- a/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.iso.test.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.iso.test.ts
@@ -1,0 +1,85 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCloudFormationResourceCreateContext } from "../sim-cfn-resource.js";
+import { SimCfnResource } from "../sim-cfn-resource.js";
+import {
+  SimCfnCfnResourceFactory,
+  SimCloudFormationWaitConditionHandle,
+} from "./sim-cfn-cfn-resource-factory.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { BackgroundTasks } from "../../../../util/background/background.js";
+
+describe("SimCfnCfnResourceFactory", () => {
+  it("creates a WaitConditionHandle resource", async () => {
+    // Given a CloudFormation Resource factory and a WaitConditionHandle Resource.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleHandle",
+      template: {
+        Type: "AWS::CloudFormation::WaitConditionHandle",
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map(),
+    };
+    const factory = new SimCfnCfnResourceFactory();
+
+    // When the WaitConditionHandle resource type is created.
+    const simResource = await factory.create(
+      "WaitConditionHandle",
+      resource,
+      context,
+    );
+
+    // Then a simulated WaitConditionHandle is returned for the same Resource.
+    assertInstanceOf(simResource, SimCloudFormationWaitConditionHandle);
+    assertIdentical(simResource.resource, resource);
+  });
+
+  it("rejects unsupported CloudFormation resource types", async () => {
+    // Given a CloudFormation Resource factory and an unsupported Resource type.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleUnsupportedResource",
+      template: {
+        Type: "AWS::CloudFormation::UnsupportedResource",
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map(),
+    };
+    const factory = new SimCfnCfnResourceFactory();
+
+    // When creation is attempted, then it rejects with an unsupported Resource
+    // type error.
+    const error = await assertThrowsErrorAsync(async () =>
+      factory.create("UnsupportedResource", resource, context),
+    );
+
+    // Then the unsupported Resource type name is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Unsupported sim CloudFormation CloudFormation Resource UnsupportedResource",
+    );
+  });
+});

--- a/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-cfn-resource-factory.ts
@@ -1,0 +1,45 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "./sim-cfn-resource-factory.type.js";
+
+/**
+ * Simulated AWS::CloudFormation::WaitConditionHandle resource.
+ *
+ * This acts as an example resource for testing sim CloudFormation without
+ * involving other sim services.
+ */
+export class SimCloudFormationWaitConditionHandle {
+  constructor(public readonly resource: SimCfnResource) {}
+}
+
+/**
+ * CloudFormation Resource factory for simulated CloudFormation resources such
+ * as AWS::CloudFormation::WaitConditionHandle.
+ */
+export class SimCfnCfnResourceFactory implements SimCfnServiceResourceFactory {
+  /**
+   * Create a simulated CloudFormation resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    void context;
+
+    await Promise.resolve();
+
+    switch (resourceTypeName) {
+      case "WaitConditionHandle": {
+        return new SimCloudFormationWaitConditionHandle(resource);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim CloudFormation CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
@@ -1,0 +1,18 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../sim-cfn-resource.js";
+
+export interface SimCfnServiceResourceFactory {
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined>;
+}
+
+export interface SimCloudFormationParsedResourceType {
+  readonly providerName: string;
+  readonly serviceName: string;
+  readonly resourceTypeName: string;
+}

--- a/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.iso.test.ts
+++ b/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.iso.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "vitest";
+import { assertIdentical, assertThrowsError } from "@kensio/smartass";
+
+import { parseSimCloudFormationResourceType } from "./sim-cfn-resource-parser.js";
+
+describe("parseSimCloudFormationResourceType", () => {
+  it("parses a valid sim CloudFormation Resource type", () => {
+    // Given a valid CloudFormation-style Resource type label.
+    const resourceType = "AWS::S3::Bucket";
+
+    // When the Resource type label is parsed.
+    const parsedResourceType = parseSimCloudFormationResourceType(resourceType);
+
+    // Then the provider, service and Resource type names are extracted.
+    assertIdentical(parsedResourceType.providerName, "AWS");
+    assertIdentical(parsedResourceType.serviceName, "S3");
+    assertIdentical(parsedResourceType.resourceTypeName, "Bucket");
+  });
+
+  it("rejects a Resource type without enough parts", () => {
+    // Given a Resource type label missing the Resource type name.
+    const resourceType = "AWS::S3";
+
+    // When parsing is attempted, then it throws an invalid Resource type error.
+    const error = assertThrowsError(() =>
+      parseSimCloudFormationResourceType(resourceType),
+    );
+
+    // Then the original invalid Resource type is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Invalid sim CloudFormation Resource type AWS::S3",
+    );
+  });
+
+  it("rejects a Resource type with an empty provider name", () => {
+    // Given a Resource type label with an empty provider segment.
+    const resourceType = "::S3::Bucket";
+
+    // When parsing is attempted, then it throws an invalid Resource type error.
+    const error = assertThrowsError(() =>
+      parseSimCloudFormationResourceType(resourceType),
+    );
+
+    // Then the original invalid Resource type is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Invalid sim CloudFormation Resource type ::S3::Bucket",
+    );
+  });
+
+  it("rejects a Resource type with an empty service name", () => {
+    // Given a Resource type label with an empty service segment.
+    const resourceType = "AWS::::Bucket";
+
+    // When parsing is attempted, then it throws an invalid Resource type error.
+    const error = assertThrowsError(() =>
+      parseSimCloudFormationResourceType(resourceType),
+    );
+
+    // Then the original invalid Resource type is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Invalid sim CloudFormation Resource type AWS::::Bucket",
+    );
+  });
+
+  it("rejects a Resource type with an empty Resource type name", () => {
+    // Given a Resource type label with an empty Resource type segment.
+    const resourceType = "AWS::S3::";
+
+    // When parsing is attempted, then it throws an invalid Resource type error.
+    const error = assertThrowsError(() =>
+      parseSimCloudFormationResourceType(resourceType),
+    );
+
+    // Then the original invalid Resource type is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Invalid sim CloudFormation Resource type AWS::S3::",
+    );
+  });
+});

--- a/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
+++ b/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
@@ -1,0 +1,29 @@
+import type { SimCloudFormationParsedResourceType } from "../factory/sim-cfn-resource-factory.type.js";
+
+/**
+ * Parse a sim CloudFormation Resource type label like AWS::S3::Bucket to
+ * extract the service and resource type names.
+ */
+export function parseSimCloudFormationResourceType(
+  resourceType: string,
+): SimCloudFormationParsedResourceType {
+  const [providerName, serviceName, resourceTypeName] =
+    resourceType.split("::");
+
+  if (
+    providerName === undefined ||
+    serviceName === undefined ||
+    resourceTypeName === undefined ||
+    providerName.length === 0 ||
+    serviceName.length === 0 ||
+    resourceTypeName.length === 0
+  ) {
+    throw new Error(`Invalid sim CloudFormation Resource type ${resourceType}`);
+  }
+
+  return {
+    providerName,
+    serviceName,
+    resourceTypeName,
+  };
+}

--- a/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
+++ b/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
@@ -1,12 +1,10 @@
 import type { SimCloudFormationParsedResourceType } from "../factory/sim-cfn-resource-factory.type.js";
+import { assertDefined } from "../../../../util/defined/defined.js";
 
 /**
  * Parse a sim CloudFormation Resource type label like AWS::S3::Bucket to
  * extract the service and resource type names.
  */
-export function parseSimCloudFormationResourceType(
-  resourceType: string,
-): SimCloudFormationParsedResourceType {
 export function parseSimCloudFormationResourceType(
   resourceType: string,
 ): SimCloudFormationParsedResourceType {
@@ -16,6 +14,15 @@ export function parseSimCloudFormationResourceType(
   }
 
   const [providerName, serviceName, resourceTypeName] = parts;
+  assertDefined(
+    providerName,
+    `CloudFormation provider name in ${resourceType}`,
+  );
+  assertDefined(serviceName, `CloudFormation service name in ${resourceType}`);
+  assertDefined(
+    resourceTypeName,
+    `CloudFormation resource type name in ${resourceType}`,
+  );
 
   if (
     providerName.length === 0 ||
@@ -24,7 +31,6 @@ export function parseSimCloudFormationResourceType(
   ) {
     throw new Error(`Invalid sim CloudFormation Resource type ${resourceType}`);
   }
-}
 
   return {
     providerName,

--- a/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
+++ b/src/service/cloudformation/resource/parser/sim-cfn-resource-parser.ts
@@ -7,19 +7,24 @@ import type { SimCloudFormationParsedResourceType } from "../factory/sim-cfn-res
 export function parseSimCloudFormationResourceType(
   resourceType: string,
 ): SimCloudFormationParsedResourceType {
-  const [providerName, serviceName, resourceTypeName] =
-    resourceType.split("::");
+export function parseSimCloudFormationResourceType(
+  resourceType: string,
+): SimCloudFormationParsedResourceType {
+  const parts = resourceType.split("::");
+  if (parts.length !== 3) {
+    throw new Error(`Invalid sim CloudFormation Resource type ${resourceType}`);
+  }
+
+  const [providerName, serviceName, resourceTypeName] = parts;
 
   if (
-    providerName === undefined ||
-    serviceName === undefined ||
-    resourceTypeName === undefined ||
     providerName.length === 0 ||
     serviceName.length === 0 ||
     resourceTypeName.length === 0
   ) {
     throw new Error(`Invalid sim CloudFormation Resource type ${resourceType}`);
   }
+}
 
   return {
     providerName,

--- a/src/service/cloudformation/resource/resolver/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolver/sim-cfn-service-resolver.iso.test.ts
@@ -1,0 +1,120 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
+import { resolveSimCloudFormationServiceResourceFactory } from "./sim-cfn-service-resolver.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+describe("resolveSimCloudFormationServiceResourceFactory", () => {
+  it("resolves the CloudFormation Resource factory", () => {
+    // Given a parsed AWS::CloudFormation Resource type in a scoped SimAws.
+    const simAws = new SimAws();
+    const accountRegionScope: SimAwsAccountRegionScope = {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    };
+
+    // When the service Resource factory is resolved.
+    const factory = resolveSimCloudFormationServiceResourceFactory(
+      simAws,
+      accountRegionScope,
+      {
+        providerName: "AWS",
+        serviceName: "CloudFormation",
+        resourceTypeName: "WaitConditionHandle",
+      },
+    );
+
+    // Then the CloudFormation-specific factory is returned.
+    assertInstanceOf(factory, SimCfnCfnResourceFactory);
+  });
+
+  it("resolves the S3 Resource factory in the requested Account and Region scope", () => {
+    // Given a parsed AWS::S3 Resource type and an explicit Account/Region scope.
+    const simAws = new SimAws();
+    const accountRegionScope: SimAwsAccountRegionScope = {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    };
+    const scopedAws = simAws.accountRegionScope(
+      accountRegionScope.accountId,
+      accountRegionScope.regionName,
+    );
+
+    // When the service Resource factory is resolved.
+    const factory = resolveSimCloudFormationServiceResourceFactory(
+      simAws,
+      accountRegionScope,
+      {
+        providerName: "AWS",
+        serviceName: "S3",
+        resourceTypeName: "Bucket",
+      },
+    );
+
+    // Then the factory comes from the S3 service for that exact scope.
+    assertIdentical(factory, scopedAws.s3().cfnResourceFactory());
+  });
+
+  it("rejects unsupported Resource providers", () => {
+    // Given a parsed Resource type with a provider other than AWS.
+    const simAws = new SimAws();
+    const accountRegionScope: SimAwsAccountRegionScope = {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    };
+
+    // When resolution is attempted, then it throws an unsupported provider error.
+    const error = assertThrowsError(() =>
+      resolveSimCloudFormationServiceResourceFactory(
+        simAws,
+        accountRegionScope,
+        {
+          providerName: "Custom",
+          serviceName: "S3",
+          resourceTypeName: "Bucket",
+        },
+      ),
+    );
+
+    // Then the unsupported provider name is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Unsupported sim CloudFormation Resource provider Custom",
+    );
+  });
+
+  it("rejects unsupported AWS Resource services", () => {
+    // Given a parsed AWS Resource type for a service with no sim factory.
+    const simAws = new SimAws();
+    const accountRegionScope: SimAwsAccountRegionScope = {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    };
+
+    // When resolution is attempted, then it throws an unsupported service error.
+    const error = assertThrowsError(() =>
+      resolveSimCloudFormationServiceResourceFactory(
+        simAws,
+        accountRegionScope,
+        {
+          providerName: "AWS",
+          serviceName: "DynamoDB",
+          resourceTypeName: "Table",
+        },
+      ),
+    );
+
+    // Then the unsupported service name is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Unsupported sim CloudFormation Resource service DynamoDB",
+    );
+  });
+});

--- a/src/service/cloudformation/resource/resolver/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolver/sim-cfn-service-resolver.ts
@@ -1,0 +1,41 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimCloudFormationParsedResourceType,
+  SimCfnServiceResourceFactory,
+} from "../factory/sim-cfn-resource-factory.type.js";
+import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
+
+/**
+ * Resolve a scoped simulated service CloudFormation Resource factory.
+ */
+export function resolveSimCloudFormationServiceResourceFactory(
+  simAws: SimAws,
+  accountRegionScope: SimAwsAccountRegionScope,
+  resourceType: SimCloudFormationParsedResourceType,
+): SimCfnServiceResourceFactory {
+  if (resourceType.providerName !== "AWS") {
+    throw new Error(
+      `Unsupported sim CloudFormation Resource provider ${resourceType.providerName}`,
+    );
+  }
+
+  const scopedAws = simAws.accountRegionScope(
+    accountRegionScope.accountId,
+    accountRegionScope.regionName,
+  );
+
+  switch (resourceType.serviceName) {
+    case "CloudFormation": {
+      return new SimCfnCfnResourceFactory();
+    }
+    case "S3": {
+      return scopedAws.s3().cfnResourceFactory();
+    }
+    default: {
+      throw new Error(
+        `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,
+      );
+    }
+  }
+}

--- a/src/service/cloudformation/resource/sim-cfn-resource.iso.test.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.iso.test.ts
@@ -1,0 +1,303 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BackgroundTasks } from "../../../util/background/background.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimCfnResource,
+  type SimCloudFormationResourceCreateContext,
+} from "./sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
+
+describe("SimCfnResource", () => {
+  it("exposes initial template state before creation", () => {
+    // Given a CloudFormation Resource template with Type, Properties and
+    // DependsOn fields.
+    const simAws = new SimAws();
+    const simResource = { bucketName: "existing-bucket" };
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "test-bucket",
+        },
+        DependsOn: ["FirstDependency", 123, "SecondDependency"],
+      },
+      simResource,
+    });
+
+    // When the Resource is inspected before creation.
+    const dependencies = resource.dependencies();
+
+    // Then the raw template values are exposed in Resource-shaped form.
+    assertIdentical(resource.logicalId, "TestResource");
+    assertIdentical(resource.status, "CREATE_PENDING");
+    assertIdentical(resource.deployed, false);
+    assertIdentical(resource.createComplete, false);
+    assertIdentical(resource.type, "AWS::S3::Bucket");
+    assertIdentical(resource.properties["BucketName"], "test-bucket");
+    assertIdentical(resource.simResource, simResource);
+    assertUndefined(resource.error);
+    assertArrayLength(dependencies, 2);
+    assertIdentical(dependencies[0], "FirstDependency");
+    assertIdentical(dependencies[1], "SecondDependency");
+  });
+
+  it("returns empty defaults for non-Resource-shaped template fields", () => {
+    // Given a template where Type and Properties are not valid Resource fields.
+    const simAws = new SimAws();
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        Type: 123,
+        Properties: ["not", "a", "record"],
+        DependsOn: 456,
+      },
+    });
+
+    // When the Resource fields are read.
+    const properties = resource.properties;
+    const dependencies = resource.dependencies();
+
+    // Then invalid optional fields are treated as absent.
+    assertUndefined(resource.type);
+    assertIdentical(Object.keys(properties).length, 0);
+    assertArrayLength(dependencies, 0);
+  });
+
+  it("supports a single string dependency", () => {
+    // Given a Resource with DependsOn declared as a single logical ID string.
+    const simAws = new SimAws();
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        DependsOn: "SingleDependency",
+      },
+    });
+
+    // When dependencies are read.
+    const dependencies = resource.dependencies();
+
+    // Then the dependency is returned as a one-item list.
+    assertArrayLength(dependencies, 1);
+    assertIdentical(dependencies[0], "SingleDependency");
+  });
+
+  it("allows creation only after all dependencies are complete", () => {
+    // Given a Resource depending on one complete Resource and one pending
+    // Resource.
+    const simAws = new SimAws();
+    const completeDependency = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "CompleteDependency",
+      template: {},
+    });
+    completeDependency.markCreateComplete();
+
+    const pendingDependency = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "PendingDependency",
+      template: {},
+    });
+
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        DependsOn: ["CompleteDependency", "PendingDependency"],
+      },
+    });
+    const resources = new Map<string, SimCfnResource>([
+      ["CompleteDependency", completeDependency],
+      ["PendingDependency", pendingDependency],
+    ]);
+
+    // When dependency status is checked before all dependencies are complete.
+    const canCreateBefore = resource.canCreate(resources);
+
+    pendingDependency.markCreateComplete();
+
+    // Then creation becomes allowed only once every dependency is complete.
+    assertIdentical(canCreateBefore, false);
+    assertIdentical(resource.canCreate(resources), true);
+  });
+
+  it("marks creation status transitions explicitly", () => {
+    // Given a Resource that already has a simulated backing object.
+    const simAws = new SimAws();
+    const originalSimResource = { bucketName: "original-bucket" };
+    const replacementSimResource = { bucketName: "replacement-bucket" };
+    const createError = new Error("creation failed");
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {},
+      simResource: originalSimResource,
+    });
+
+    // When explicit creation status helpers are used.
+    resource.markCreateInProgress();
+    const inProgressStatus = resource.status;
+    const inProgressDeployed = resource.deployed;
+    const inProgressCreateComplete = resource.createComplete;
+
+    resource.markCreateFailed(createError);
+    const failedStatus = resource.status;
+    const failedCreateComplete = resource.createComplete;
+    const failedError = resource.error;
+
+    resource.markCreateComplete();
+    const completeWithoutReplacement = resource.simResource;
+
+    resource.markCreateComplete(replacementSimResource);
+    const completeWithReplacement = resource.simResource;
+
+    // Then each helper updates status, terminal flags, error and sim Resource
+    // state consistently.
+    assertIdentical(inProgressStatus, "CREATE_IN_PROGRESS");
+    assertIdentical(inProgressDeployed, false);
+    assertIdentical(inProgressCreateComplete, false);
+
+    assertIdentical(failedStatus, "CREATE_FAILED");
+    assertIdentical(failedCreateComplete, true);
+    assertIdentical(failedError, createError);
+
+    assertIdentical(completeWithoutReplacement, originalSimResource);
+    assertIdentical(completeWithReplacement, replacementSimResource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.deployed, true);
+    assertIdentical(resource.createComplete, true);
+    assertUndefined(resource.error);
+  });
+
+  it("creates the backing simulated Resource through an injected factory", async () => {
+    // Given a Resource with an isolated factory injected for creation.
+    const simAws = new SimAws();
+    const background = new BackgroundTasks();
+    const createdSimResource = { bucketName: "created-bucket" };
+
+    const cfnResourceFactory: SimCfnServiceResourceFactory = {
+      async create(
+        resourceTypeName,
+        _resourceFromFactory,
+        context,
+      ): Promise<object> {
+        await Promise.resolve();
+
+        assertIdentical(resourceTypeName, "Bucket");
+        assertIdentical(context.background, background);
+
+        return createdSimResource;
+      },
+    };
+
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        Type: "AWS::S3::Bucket",
+      },
+      cfnResourceFactory,
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map([["TestResource", resource]]),
+    };
+
+    // When the Resource is created.
+    const createPromise = resource.create(context);
+
+    assertIdentical(resource.status, "CREATE_IN_PROGRESS");
+
+    await createPromise;
+
+    // Then the injected factory result is recorded and the Resource completes.
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.simResource, createdSimResource);
+    assertIdentical(resource.deployed, true);
+    assertIdentical(resource.createComplete, true);
+    assertUndefined(resource.error);
+  });
+
+  it("fails creation when Type is missing", async () => {
+    // Given a Resource template without a Type field.
+    const simAws = new SimAws();
+    const background = new BackgroundTasks();
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {},
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map([["TestResource", resource]]),
+    };
+
+    // When creation is attempted, then it rejects with a Resource-specific
+    // missing Type error.
+    const error = await assertThrowsErrorAsync(async () =>
+      resource.create(context),
+    );
+
+    // Then the failure is recorded on the Resource.
+    assertNonNullable(error);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestResource is missing a Type",
+    );
+    assertIdentical(resource.status, "CREATE_FAILED");
+    assertIdentical(resource.createComplete, true);
+    assertIdentical(resource.error, error);
+  });
+
+  it("wraps non-Error creation failures", async () => {
+    // Given an injected factory that rejects with a non-Error value.
+    const simAws = new SimAws();
+    const background = new BackgroundTasks();
+    const resource = new SimCfnResource({
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      logicalId: "TestResource",
+      template: {
+        Type: "AWS::S3::Bucket",
+      },
+      cfnResourceFactory: {
+        async create() {
+          await Promise.resolve();
+
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw "factory failed";
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map([["TestResource", resource]]),
+    };
+
+    // When creation fails with a non-Error thrown value.
+    const error = await assertThrowsErrorAsync(async () =>
+      resource.create(context),
+    );
+
+    // Then the thrown value is wrapped as an Error and stored on the Resource.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource creation failed: factory failed",
+    );
+    assertIdentical(resource.status, "CREATE_FAILED");
+    assertIdentical(resource.createComplete, true);
+    assertIdentical(resource.error, error);
+  });
+});

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -1,0 +1,231 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
+import { parseSimCloudFormationResourceType } from "./parser/sim-cfn-resource-parser.js";
+import { resolveSimCloudFormationServiceResourceFactory } from "./resolver/sim-cfn-service-resolver.js";
+
+interface SimCloudFormationResourceProps<T extends object = object> {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly logicalId: string;
+  readonly template: Record<string, unknown>;
+  readonly simResource?: T | undefined;
+  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+}
+
+/**
+ * Simulated CloudFormation Resource status.
+ */
+export type SimCloudFormationResourceStatus =
+  | "CREATE_PENDING"
+  | "CREATE_IN_PROGRESS"
+  | "CREATE_COMPLETE"
+  | "CREATE_FAILED";
+
+export interface SimCloudFormationResourceCreateContext {
+  readonly simAws: SimAws;
+  readonly background: BackgroundScheduler;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+}
+
+/**
+ * Lightweight simulated CloudFormation Resource record.
+ *
+ * This represents a Resource entry from a CloudFormation template and can point
+ * at the actual simulated AWS resource created from it, such as a SimS3Bucket.
+ */
+export class SimCfnResource<T extends object = object> {
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
+  public readonly logicalId: string;
+  public readonly template: Record<string, unknown>;
+  private _status: SimCloudFormationResourceStatus = "CREATE_PENDING";
+  private _simResource: T | undefined;
+  private deployError: Error | undefined;
+  private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
+
+  constructor(props: SimCloudFormationResourceProps<T>) {
+    const {
+      accountRegionScope,
+      logicalId,
+      template,
+      simResource,
+      cfnResourceFactory,
+    } = props;
+
+    this.accountRegionScope = accountRegionScope;
+    this.logicalId = logicalId;
+    this.template = template;
+    this._simResource = simResource;
+    this.cfnResourceFactory = cfnResourceFactory;
+  }
+
+  /**
+   * Get the current Resource status.
+   */
+  public get status(): SimCloudFormationResourceStatus {
+    return this._status;
+  }
+
+  /**
+   * Whether this Resource has been deployed into simulated AWS.
+   */
+  public get deployed(): boolean {
+    return this._status === "CREATE_COMPLETE";
+  }
+
+  /**
+   * Whether this Resource has reached a terminal creation status.
+   */
+  public get createComplete(): boolean {
+    return (
+      this._status === "CREATE_COMPLETE" || this._status === "CREATE_FAILED"
+    );
+  }
+
+  /**
+   * The CloudFormation Resource type.
+   */
+  public get type(): string | undefined {
+    const type = this.template["Type"];
+    return typeof type === "string" ? type : undefined;
+  }
+
+  /**
+   * The CloudFormation Resource properties.
+   */
+  public get properties(): Record<string, unknown> {
+    const properties = this.template["Properties"];
+
+    if (isRecord(properties)) {
+      return properties;
+    }
+
+    return {};
+  }
+
+  /**
+   * The simulated AWS resource represented by this CloudFormation Resource.
+   */
+  public get simResource(): T | undefined {
+    return this._simResource;
+  }
+
+  /**
+   * Get the deployment error, if Resource creation failed.
+   */
+  public get error(): Error | undefined {
+    return this.deployError;
+  }
+
+  /**
+   * Return logical IDs this Resource depends on.
+   */
+  dependencies(): string[] {
+    const dependsOn = this.template["DependsOn"];
+
+    if (typeof dependsOn === "string") {
+      return [dependsOn];
+    }
+
+    if (Array.isArray(dependsOn)) {
+      return dependsOn.filter((dependency): dependency is string => {
+        return typeof dependency === "string";
+      });
+    }
+
+    return [];
+  }
+
+  /**
+   * Whether this Resource can be created based on Resource dependency status.
+   */
+  canCreate(resources: ReadonlyMap<string, SimCfnResource>): boolean {
+    return this.dependencies().every((dependency) => {
+      return resources.get(dependency)?.status === "CREATE_COMPLETE";
+    });
+  }
+
+  /**
+   * Create this Resource into simulated AWS as a background operation.
+   */
+  create(context: SimCloudFormationResourceCreateContext): Promise<void> {
+    this.markCreateInProgress();
+
+    return new Promise<void>((resolve, reject) => {
+      context.background.schedule(async () => {
+        try {
+          await context.background.sequence();
+
+          const simResource = await this.createSimResource(context);
+          this.markCreateComplete(simResource as T | undefined);
+          resolve();
+        } catch (error) {
+          const resourceError =
+            error instanceof Error
+              ? error
+              : new Error(
+                  `Sim CloudFormation Resource creation failed: ${String(error)}`,
+                );
+
+          this.markCreateFailed(resourceError);
+          reject(resourceError);
+        }
+      });
+    });
+  }
+
+  /**
+   * Mark this Resource as creation in progress.
+   */
+  markCreateInProgress(): void {
+    this.deployError = undefined;
+    this._status = "CREATE_IN_PROGRESS";
+  }
+
+  /**
+   * Mark this Resource as successfully created.
+   */
+  markCreateComplete(simResource?: T): void {
+    if (simResource !== undefined) {
+      this._simResource = simResource;
+    }
+
+    this.deployError = undefined;
+    this._status = "CREATE_COMPLETE";
+  }
+
+  /**
+   * Mark this Resource as failed to create.
+   */
+  markCreateFailed(error?: Error): void {
+    this.deployError = error;
+    this._status = "CREATE_FAILED";
+  }
+
+  private async createSimResource(
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const { type } = this;
+
+    if (type === undefined) {
+      throw new Error(
+        `Sim CloudFormation Resource ${this.logicalId} is missing a Type`,
+      );
+    }
+
+    const resourceType = parseSimCloudFormationResourceType(type);
+    const factory =
+      this.cfnResourceFactory ??
+      resolveSimCloudFormationServiceResourceFactory(
+        context.simAws,
+        this.accountRegionScope,
+        resourceType,
+      );
+
+    return await factory.create(resourceType.resourceTypeName, this, context);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -68,6 +68,7 @@ export class SimCloudFormation {
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
     });
@@ -88,6 +89,18 @@ export class SimCloudFormation {
   }
 
   /**
+   * Wait for a simulated CloudFormation Stack deploy operation to complete.
+   */
+  async waitForStackDeployComplete(
+    stackName: SimCloudFormationStackName | string,
+  ): Promise<void> {
+    const stack = this.stacks.get(stackName as SimCloudFormationStackName);
+    assertDefined(stack, `Sim CloudFormation Stack named ${stackName}`);
+
+    await stack.waitForDeployComplete();
+  }
+
+  /**
    * Convenience wrapper method to create and deploy a simulated CloudFormation
    * Stack from a parsed template object.
    */
@@ -103,10 +116,10 @@ export class SimCloudFormation {
       },
     });
 
-    await this.background.complete();
-
     const stack = this.stacks.get(stackName as SimCloudFormationStackName);
     assertDefined(stack, `Sim CloudFormation Stack named ${stackName}`);
+
+    await stack.waitForDeployComplete();
 
     return stack;
   }

--- a/src/service/cloudformation/stack/sim-cloudformation-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cloudformation-stack.iso.test.ts
@@ -1,5 +1,9 @@
 import { describe, it } from "vitest";
-import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { SimAws } from "../../aws/sim-aws.js";
 
 describe("SimCloudFormationStack", () => {
@@ -119,5 +123,43 @@ describe("SimCloudFormationStack", () => {
       stack.error.message,
       "Could not resolve simulated CloudFormation Resource dependencies in Stack TestStack",
     );
+  });
+
+  it("throws when deploy is called while create is in progress", async () => {
+    const simAws = new SimAws();
+
+    const cloudFormation = simAws.cloudFormation();
+    await cloudFormation.createStack({
+      input: {
+        StackName: "TestStack",
+        TemplateBody: JSON.stringify({
+          Resources: {
+            TestBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: {
+                BucketName: "test-bucket",
+              },
+            },
+          },
+        }),
+      },
+    });
+
+    const stack = cloudFormation.stacks.get("TestStack" as never);
+    assertNonNullable(stack);
+    assertIdentical(stack.status, "CREATE_IN_PROGRESS");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.deploy();
+    });
+
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack TestStack cannot be deployed from CREATE_IN_PROGRESS status",
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    assertIdentical(stack.status, "CREATE_COMPLETE");
   });
 });

--- a/src/service/cloudformation/stack/sim-cloudformation-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cloudformation-stack.iso.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { SimAws } from "../../aws/sim-aws.js";
 
 describe("SimCloudFormationStack", () => {
@@ -84,5 +84,40 @@ describe("SimCloudFormationStack", () => {
       "ap-southeast-2",
     );
     assertIdentical(stack.status, "CREATE_COMPLETE");
+  });
+
+  it("fails deployment when Resource dependencies cannot be resolved", async () => {
+    const simAws = new SimAws();
+
+    const cloudFormation = simAws.cloudFormation();
+    await cloudFormation.createStack({
+      input: {
+        StackName: "TestStack",
+        TemplateBody: JSON.stringify({
+          Resources: {
+            FirstBucket: {
+              Type: "AWS::S3::Bucket",
+              DependsOn: "SecondBucket",
+            },
+            SecondBucket: {
+              Type: "AWS::S3::Bucket",
+              DependsOn: "FirstBucket",
+            },
+          },
+        }),
+      },
+    });
+
+    const stack = cloudFormation.stacks.get("TestStack" as never);
+    assertNonNullable(stack);
+
+    await simAws.backgroundTasksComplete();
+
+    assertIdentical(stack.status, "CREATE_FAILED");
+    assertNonNullable(stack.error);
+    assertIdentical(
+      stack.error.message,
+      "Could not resolve simulated CloudFormation Resource dependencies in Stack TestStack",
+    );
   });
 });

--- a/src/service/cloudformation/stack/sim-cloudformation-stack.ts
+++ b/src/service/cloudformation/stack/sim-cloudformation-stack.ts
@@ -1,6 +1,8 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { Brand } from "../../../util/brand.type.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimCfnResource } from "../resource/sim-cfn-resource.js";
 
 /**
  * Parsed CloudFormation template object.
@@ -17,15 +19,12 @@ export type SimCloudFormationStackName = Brand<
 export type SimCloudFormationStackStatus =
   | "REVIEW_IN_PROGRESS"
   | "CREATE_IN_PROGRESS"
-  | "CREATE_COMPLETE";
-
-export interface SimCloudFormationResource {
-  readonly logicalId: string;
-  readonly template: Record<string, unknown>;
-}
+  | "CREATE_COMPLETE"
+  | "CREATE_FAILED";
 
 interface SimCloudFormationStackProps {
   readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
   readonly stackName: SimCloudFormationStackName;
   readonly template: SimCloudFormationTemplate;
@@ -41,16 +40,23 @@ interface SimCloudFormationStackProps {
  */
 export class SimCloudFormationStack {
   private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
   private _status: SimCloudFormationStackStatus = "REVIEW_IN_PROGRESS";
+
+  private deployCompletePromise: Promise<void> | undefined;
+  private deployError: Error | undefined;
+
   public readonly stackName: SimCloudFormationStackName;
   public readonly template: SimCloudFormationTemplate;
-  public readonly resources = new Map<string, SimCloudFormationResource>();
+  public readonly resources = new Map<string, SimCfnResource>();
 
   constructor(props: SimCloudFormationStackProps) {
-    const { simAws, background, stackName, template } = props;
+    const { simAws, accountRegionScope, background, stackName, template } =
+      props;
 
     this.simAws = simAws;
+    this.accountRegionScope = accountRegionScope;
     this.background = background;
     this.stackName = stackName;
     this.template = template;
@@ -66,19 +72,86 @@ export class SimCloudFormationStack {
   }
 
   /**
+   * Get the deployment error, if Stack deployment failed.
+   */
+  public get error(): Error | undefined {
+    return this.deployError;
+  }
+
+  /**
    * Deploy this Stack into simulated AWS.
    */
   async deploy(): Promise<void> {
     await this.background.sequence();
 
     this._status = "CREATE_IN_PROGRESS";
-    this.background.schedule(async () => this.deployResources());
+    this.deployError = undefined;
+    this.deployCompletePromise = new Promise<void>((resolve) => {
+      this.background.schedule(async () => {
+        try {
+          await this.deployResources();
+          this._status = "CREATE_COMPLETE";
+        } catch (error) {
+          const stackError =
+            error instanceof Error
+              ? error
+              : new Error(
+                  `Sim CloudFormation Stack deploy failed: ${String(error)}`,
+                );
+
+          this._status = "CREATE_FAILED";
+          this.deployError = stackError;
+        } finally {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Wait for the stack to finish deploying.
+   */
+  async waitForDeployComplete(): Promise<void> {
+    if (this.deployCompletePromise !== undefined) {
+      await this.deployCompletePromise;
+    }
+
+    if (this.deployError !== undefined) {
+      throw this.deployError;
+    }
   }
 
   private async deployResources(): Promise<void> {
-    void this.simAws;
+    let pendingResources = new Set(this.resources.values());
 
-    await Promise.resolve();
+    while (pendingResources.size > 0) {
+      const creatableResources = [...pendingResources].filter((resource) => {
+        return resource.canCreate(this.resources);
+      });
+
+      if (creatableResources.length === 0) {
+        throw new Error(
+          `Could not resolve simulated CloudFormation Resource dependencies in Stack ${this.stackName}`,
+        );
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.all(
+        creatableResources.map(async (resource) => {
+          await resource.create({
+            simAws: this.simAws,
+            background: this.background,
+            resources: this.resources,
+          });
+        }),
+      );
+
+      pendingResources = new Set(
+        [...pendingResources].filter((resource) => {
+          return !resource.createComplete;
+        }),
+      );
+    }
 
     this._status = "CREATE_COMPLETE";
   }
@@ -90,18 +163,21 @@ export class SimCloudFormationStack {
       return;
     }
 
-    /* v8 ignore start -- not implemented yet TODO */
     for (const [logicalId, resourceTemplate] of Object.entries(resources)) {
+      /* v8 ignore if -- safety catch */
       if (!isRecord(resourceTemplate)) {
         continue;
       }
 
-      this.resources.set(logicalId, {
+      this.resources.set(
         logicalId,
-        template: resourceTemplate,
-      });
+        new SimCfnResource({
+          accountRegionScope: this.accountRegionScope,
+          logicalId,
+          template: resourceTemplate,
+        }),
+      );
     }
-    /* v8 ignore stop -- not implemented yet TODO */
   }
 }
 

--- a/src/service/cloudformation/stack/sim-cloudformation-stack.ts
+++ b/src/service/cloudformation/stack/sim-cloudformation-stack.ts
@@ -79,13 +79,20 @@ export class SimCloudFormationStack {
   }
 
   /**
-   * Deploy this Stack into simulated AWS.
+   * Deploy this simulated Stack into simulated AWS.
    */
   async deploy(): Promise<void> {
-    await this.background.sequence();
+    if (this._status !== "REVIEW_IN_PROGRESS") {
+      throw new Error(
+        `Sim CloudFormation Stack ${this.stackName} cannot be deployed from ${this._status} status`,
+      );
+    }
 
     this._status = "CREATE_IN_PROGRESS";
     this.deployError = undefined;
+
+    await this.background.sequence();
+
     this.deployCompletePromise = new Promise<void>((resolve) => {
       this.background.schedule(async () => {
         try {

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
@@ -1,0 +1,145 @@
+import { ListBucketsCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { SimS3BucketAlreadyExists } from "../../error/sim-s3.error.js";
+
+describe("S3 CloudFormation Bucket Resource", () => {
+  it("creates a simulated S3 Bucket from an AWS::S3::Bucket Resource", async () => {
+    // Given a CloudFormation template declaring an S3 Bucket Resource.
+    const bucketTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "test-bucket",
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "test-stack",
+      template: bucketTemplate,
+    });
+
+    // Then sim CloudFormation creates the Bucket in sim S3.
+    const listBucketsOutput = await simAws
+      .s3()
+      .listBuckets(new ListBucketsCommand());
+
+    assertArrayLength(listBucketsOutput.Buckets, 1);
+    assertIdentical(listBucketsOutput.Buckets[0].Name, "test-bucket");
+
+    const bucket = simAws.s3().getSimBucketByName("test-bucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+
+    const resource = stack.resources.get("TestBucket");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.simResource, bucket);
+  });
+
+  it("uses the logical ID as the Bucket name when BucketName is not specified", async () => {
+    // Given a CloudFormation template declaring an S3 Bucket without BucketName.
+    const unnamedBucketTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+        },
+      },
+    };
+
+    // When the template is deployed through simulated CloudFormation.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "test-stack",
+      template: unnamedBucketTemplate,
+    });
+
+    // Then the simulated S3 Bucket is created using the logical ID fallback.
+    const bucket = simAws.s3().getSimBucketByName("testbucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, "testbucket");
+
+    const resource = stack.resources.get("TestBucket");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.simResource, bucket);
+  });
+
+  it("creates Buckets in the CloudFormation Account Region scope and rejects duplicate names from another scope", async () => {
+    // Given CloudFormation in one specific Account Region scope and another
+    // CloudFormation service in a different Account Region scope.
+    const bucketTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "scoped-test-bucket",
+          },
+        },
+      },
+    };
+    const simAws = new SimAws();
+    const firstScopeCfn = simAws
+      .account("111111111111")
+      .region("eu-west-1")
+      .cloudFormation();
+    const otherScopeCfn = simAws
+      .account("222222222222")
+      .region("eu-west-2")
+      .cloudFormation();
+
+    // When the Bucket template is deployed through the first scoped
+    // CloudFormation service.
+    await firstScopeCfn.deployTemplate({
+      stackName: "source-stack",
+      template: bucketTemplate,
+    });
+
+    // Then the Bucket exists in that Account Region scope.
+    const firstScopeBucket = simAws
+      .account("111111111111")
+      .region("eu-west-1")
+      .s3()
+      .getSimBucketByName("scoped-test-bucket");
+    const otherScopeBucket = simAws
+      .account("222222222222")
+      .region("eu-west-2")
+      .s3()
+      .getSimBucketByName("scoped-test-bucket");
+
+    assertNonNullable(firstScopeBucket);
+    assertInstanceOf(firstScopeBucket, SimS3Bucket);
+    assertUndefined(otherScopeBucket);
+
+    // When the same Bucket name is deployed through CloudFormation in the other
+    // Account Region scope, then S3's global Bucket name uniqueness is enforced.
+    const error = await assertThrowsErrorAsync(async () =>
+      otherScopeCfn.deployTemplate({
+        stackName: "other-stack",
+        template: bucketTemplate,
+      }),
+    );
+    assertInstanceOf(error, SimS3BucketAlreadyExists);
+  });
+});

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.iso.test.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.iso.test.ts
@@ -1,0 +1,119 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCloudFormationResourceCreateContext } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimS3CloudFormationResourceFactory } from "./sim-cfn-s3-resource-factory.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { BackgroundTasks } from "../../../util/background/background.js";
+
+describe("SimS3CloudFormationResourceFactory", () => {
+  it("creates an S3 Bucket using the configured BucketName", async () => {
+    // Given an S3 CloudFormation Resource factory and a Bucket resource with an
+    // explicit BucketName.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const simS3 = simAws.s3();
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleBucket",
+      template: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "example-bucket",
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map(),
+    };
+    const factory = new SimS3CloudFormationResourceFactory(simS3);
+
+    // When the Bucket resource type is created.
+    const bucket = await factory.create("Bucket", resource, context);
+
+    // Then the named Bucket is created and returned.
+    const storedBucket = simS3.getSimBucketByName("example-bucket");
+
+    assertNonNullable(storedBucket);
+    assertIdentical(bucket, storedBucket);
+  });
+
+  it("creates an S3 Bucket using the lower-case logical ID by default", async () => {
+    // Given an S3 CloudFormation Resource factory and a Bucket resource without a
+    // BucketName.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const simS3 = simAws.s3();
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleBucket",
+      template: {
+        Type: "AWS::S3::Bucket",
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map(),
+    };
+    const factory = new SimS3CloudFormationResourceFactory(simS3);
+
+    // When the Bucket resource type is created.
+    const bucket = await factory.create("Bucket", resource, context);
+
+    // Then a Bucket named from the lower-case logical ID is created and returned.
+    const storedBucket = simS3.getSimBucketByName("examplebucket");
+
+    assertNonNullable(storedBucket);
+    assertIdentical(bucket, storedBucket);
+  });
+
+  it("rejects unsupported S3 resource types", async () => {
+    // Given an S3 CloudFormation Resource factory and an unsupported Resource type.
+    const background = new BackgroundTasks();
+    const simAws = new SimAws({ background });
+    const simS3 = simAws.s3();
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleUnsupportedResource",
+      template: {
+        Type: "AWS::S3::UnsupportedResource",
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      background,
+      resources: new Map(),
+    };
+    const factory = new SimS3CloudFormationResourceFactory(simS3);
+
+    // When creation is attempted, then it rejects with an unsupported Resource
+    // type error.
+    const error = await assertThrowsErrorAsync(async () =>
+      factory.create("UnsupportedResource", resource, context),
+    );
+
+    // Then the unsupported Resource type name is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Unsupported sim S3 CloudFormation Resource UnsupportedResource",
+    );
+  });
+});

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -1,0 +1,67 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimS3 } from "../sim-s3.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
+
+/**
+ * CloudFormation Resource factory for simulated S3 resources.
+ */
+export class SimS3CloudFormationResourceFactory implements SimCfnServiceResourceFactory {
+  constructor(private readonly simS3: SimS3) {}
+
+  /**
+   * Create a simulated S3 resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    void context;
+
+    switch (resourceTypeName) {
+      case "Bucket": {
+        return await this.createBucket(resource);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim S3 CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+
+  private async createBucket(resource: SimCfnResource): Promise<SimS3Bucket> {
+    const bucketName = this.bucketNameForResource(resource);
+
+    await this.simS3.createBucket({
+      input: {
+        Bucket: bucketName,
+      },
+    });
+
+    const bucket = this.simS3.getSimBucketByName(bucketName);
+
+    /* v8 ignore if -- cannot happen in practice */
+    if (bucket === undefined) {
+      throw new Error(
+        `Expected sim S3 Bucket ${bucketName} to exist after CloudFormation creation`,
+      );
+    }
+
+    return bucket;
+  }
+
+  private bucketNameForResource(resource: SimCfnResource): string {
+    const bucketName = resource.properties["BucketName"];
+
+    if (typeof bucketName === "string") {
+      return bucketName;
+    }
+
+    return resource.logicalId.toLowerCase();
+  }
+}

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -40,6 +40,8 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../util/background/background.js";
+import { SimS3CloudFormationResourceFactory } from "./cfn/sim-cfn-s3-resource-factory.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 
 interface SimS3Props {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -58,6 +60,7 @@ export class SimS3 {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly s3GlobalRegistry: SimS3GlobalRegistry;
   private readonly background: BackgroundScheduler;
+  private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
 
   constructor(props: SimS3Props = {}) {
     const {
@@ -191,5 +194,12 @@ export class SimS3 {
     bucket.configureSimStorage(
       new FilesystemS3BucketStorage({ directoryPath }),
     );
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return this.cfnFactory;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CloudFormation stack deployments now resolve resource dependencies automatically during creation.
  * Simulated CloudFormation now supports `AWS::S3::Bucket` and `AWS::CloudFormation::WaitConditionHandle`.
  * Added `waitForStackDeployComplete` to wait for a stack’s simulated deployment to finish.
* **Bug Fixes / Improvements**
  * Stack descriptions now include an optional status failure reason for clearer diagnostics.
  * Deployment completion now consistently reflects success or failure, including `CREATE_FAILED` with surfaced deployment errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->