### PR TITLE
fix: replace lazy `unknown` types with clearer explicit types

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -116,7 +116,7 @@ export default defineConfig(
 
       // ── Discourage lazy `unknown` typing ─────────────
       "no-restricted-syntax": [
-        "warn",
+        "error",
         {
           selector:
             "TSUnknownKeyword:not(.params > TSTypeAnnotation > TSUnknownKeyword)",

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -114,6 +114,17 @@ export default defineConfig(
         },
       ],
 
+      // ── Discourage lazy `unknown` typing ─────────────
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector:
+            "TSUnknownKeyword:not(.params > TSTypeAnnotation > TSUnknownKeyword)",
+          message:
+            "Avoid `unknown` as a type, except when narrowing a function parameter to a concrete type.",
+        },
+      ],
+
       // ── General quality ──────────────────────────────
       "no-console": "warn",
       eqeqeq: ["error", "always"],

--- a/src/serve/http/local-server/wait-node-server-listen.iso.test.ts
+++ b/src/serve/http/local-server/wait-node-server-listen.iso.test.ts
@@ -41,6 +41,7 @@ describe("waitNodeServerListen", () => {
 
     server.emit("error", cause);
 
+    // @ts-expect-error -- testing error
     const error = await promiseError(wait);
 
     assertIdentical(error, cause);
@@ -54,15 +55,22 @@ class TestServer extends EventEmitter {
   readonly listening = false;
 
   asNodeServer(): Server {
-    return this as unknown as Server;
+    // @ts-expect-error -- test mock
+    return this;
   }
 }
 
-async function promiseError(promise: Promise<unknown>): Promise<unknown> {
+async function promiseError(promise: Promise<never>): Promise<Error> {
   try {
     await promise;
   } catch (error) {
-    return error;
+    if (error instanceof Error) {
+      return error;
+    }
+
+    throw new TypeError("Expected promise to reject with an Error", {
+      cause: error,
+    });
   }
 
   throw new Error("Expected promise to reject");

--- a/src/service/aws/metadata/response-metadata.type.ts
+++ b/src/service/aws/metadata/response-metadata.type.ts
@@ -1,0 +1,8 @@
+export interface SimResponseMetadata {
+  readonly httpStatusCode?: number;
+  readonly requestId?: string;
+  readonly extendedRequestId?: string;
+  readonly cfId?: string;
+  readonly attempts?: number;
+  readonly totalRetryDelay?: number;
+}

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -32,7 +32,7 @@ export class SimAwsAccountRegionContainer {
   private readonly simAws: SimAws;
   public readonly account: SimAwsAccount;
   public readonly region: SimAwsRegion;
-  private readonly memo = new Memo<unknown>();
+  private readonly memo = new Memo<object>();
 
   public readonly accountRegionScope: SimAwsAccountRegionScope;
 

--- a/src/service/cloudformation/command/create-stack/create-stack.cmd.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim CloudFormation CreateStack command.
  */
@@ -26,5 +28,5 @@ export interface SimCreateStackCommandInput {
  */
 export interface SimCreateStackCommandOutput {
   readonly StackId?: string;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
@@ -2,6 +2,7 @@ import type {
   SimCloudFormationStackName,
   SimCloudFormationStackStatus,
 } from "../../stack/sim-cfn-stack.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim CloudFormation DescribeStacks command.
@@ -24,7 +25,7 @@ export interface SimDescribeStacksCommandInput {
  */
 export interface SimDescribeStacksCommandOutput {
   readonly Stacks?: SimCloudFormationStackDescription[] | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.iso.test.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.iso.test.ts
@@ -239,6 +239,7 @@ describe("SimCfnParameters", () => {
       new SimCfnParameters({
         stackName: "TestStack",
         definitions: {
+          // @ts-expect-error -- testing bad input
           BucketName: "not-a-parameter-definition",
         },
       });

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.ts
@@ -85,7 +85,7 @@ export class SimCfnParameters {
    * presence checks and default-value resolution.
    */
   withDefinitions(
-    definitions: Record<string, unknown> | undefined,
+    definitions: Record<string, SimCfnParameterDefinition> | undefined,
   ): SimCfnParameters {
     return new SimCfnParameters({
       definitions,
@@ -125,7 +125,7 @@ export class SimCfnParameters {
   }
 
   private recordDefinitions(
-    definitions: Record<string, unknown> | undefined,
+    definitions: Record<string, SimCfnParameterDefinition> | undefined,
   ): void {
     if (definitions === undefined) {
       return;

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.ts
@@ -1,32 +1,21 @@
 import { isRecord } from "../../../util/type-guard/record.js";
-
-type SimCloudFormationParameterValue = string;
-
-type SimCloudFormationParameterValues = Record<
-  string,
-  SimCloudFormationParameterValue
->;
-
-export interface SimCloudFormationParameterInput {
-  readonly Parameters?:
-    | readonly {
-        readonly ParameterKey?: string | undefined;
-        readonly ParameterValue?: string | undefined;
-      }[]
-    | undefined;
-}
-
-interface SimCfnParametersProps {
-  readonly definitions?: Record<string, unknown> | undefined;
-  readonly values?: SimCloudFormationParameterValues | undefined;
-  readonly stackName?: string | undefined;
-}
+import type {
+  SimCfnParameterDefinition,
+  SimCfnParametersProps,
+  SimCloudFormationParameterInput,
+  SimCloudFormationParameterValue,
+  SimCloudFormationParameterValues,
+} from "./sim-cfn-parameters.type.js";
 
 /**
- * Convenience wrapper for a CloudFormation template Parameters section.
+ * Resolves CloudFormation Parameters for a simulated Stack.
+ *
+ * This class keeps the template Parameter definitions and the runtime Parameter
+ * values together. Values supplied by command input take precedence, then any
+ * missing values are filled from string defaults in the template definitions.
  */
 export class SimCfnParameters {
-  private readonly definitions = new Map<string, Record<string, unknown>>();
+  private readonly definitions = new Map<string, SimCfnParameterDefinition>();
   private readonly values = new Map<string, SimCloudFormationParameterValue>();
   private readonly stackName: string | undefined;
 
@@ -41,7 +30,11 @@ export class SimCfnParameters {
   }
 
   /**
-   * Create Parameters from CloudFormation command-style Parameter inputs.
+   * Create Parameters from a CloudFormation command-like input object.
+   *
+   * AWS command inputs carry Parameters as an array of key/value objects, while
+   * this wrapper stores values in a map keyed by Parameter name. Incomplete
+   * array entries are ignored because they cannot contribute a usable runtime value.
    */
   static fromInput(
     input: SimCloudFormationParameterInput,
@@ -67,7 +60,11 @@ export class SimCfnParameters {
   }
 
   /**
-   * Create Parameters from already-normalized Parameter values.
+   * Create Parameters from already-normalized values.
+   *
+   * This is useful for tests and internal callers that already have a plain
+   * Parameter-name-to-value record and do not need AWS command input
+   * conversion.
    */
   static fromValues(
     values: SimCloudFormationParameterValues,
@@ -80,7 +77,12 @@ export class SimCfnParameters {
   }
 
   /**
-   * Return a copy of this Parameters wrapper with template definitions attached.
+   * Return a copy of this Parameters wrapper with template definitions
+   * attached.
+   *
+   * Template parsing can happen after command input normalization, so this
+   * keeps existing explicit values while adding the definitions needed for
+   * presence checks and default-value resolution.
    */
   withDefinitions(
     definitions: Record<string, unknown> | undefined,
@@ -93,14 +95,22 @@ export class SimCfnParameters {
   }
 
   /**
-   * Whether the template defines a Parameter with this name.
+   * Whether the template declares a Parameter with this name.
+   *
+   * This checks definitions only. A Parameter can be declared even when no
+   * runtime value has been supplied or defaulted.
    */
   has(parameterName: string): boolean {
     return this.definitions.has(parameterName);
   }
 
   /**
-   * Resolve a template Parameter value.
+   * Resolve the runtime value for a declared or referenced Parameter.
+   *
+   * The returned value may have come from command input or from a string
+   * Default in the template definition. Missing values are treated as
+   * template/runtime errors because a Ref to a Parameter must resolve to a
+   * concrete value.
    */
   value(parameterName: string): SimCloudFormationParameterValue {
     const value = this.values.get(parameterName);
@@ -146,7 +156,7 @@ export class SimCfnParameters {
         continue;
       }
 
-      const defaultValue = parameterDefinition["Default"];
+      const defaultValue = parameterDefinition.Default;
 
       if (typeof defaultValue === "string") {
         this.values.set(parameterName, defaultValue);

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
@@ -40,7 +40,7 @@ export interface SimCloudFormationParameterInput {
  * command input or already-normalized test/setup data.
  */
 export interface SimCfnParametersProps {
-  readonly definitions?: Record<string, unknown> | undefined;
+  readonly definitions?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly values?: SimCloudFormationParameterValues | undefined;
   readonly stackName?: string | undefined;
 }

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.type.ts
@@ -1,0 +1,68 @@
+import type { SimCfnTemplateValue } from "../template/value/sim-cfn-template-value.js";
+
+/**
+ * Runtime value for a CloudFormation Parameter after command input and template
+ * defaults have been applied.
+ *
+ * The simulator currently supports string Parameter values because AWS
+ * CloudFormation command inputs provide ParameterValue as a string.
+ */
+export type SimCloudFormationParameterValue = string;
+
+/**
+ * Normalized Parameter values keyed by CloudFormation Parameter name.
+ */
+export type SimCloudFormationParameterValues = Record<
+  string,
+  SimCloudFormationParameterValue
+>;
+
+/**
+ * Minimal structural shape accepted from CloudFormation command inputs.
+ *
+ * This intentionally models only the Parameters collection used by
+ * create/update style commands, rather than a complete AWS SDK command input
+ * type.
+ */
+export interface SimCloudFormationParameterInput {
+  readonly Parameters?:
+    | readonly {
+        readonly ParameterKey?: string | undefined;
+        readonly ParameterValue?: string | undefined;
+      }[]
+    | undefined;
+}
+
+/**
+ * Construction options for the Parameters wrapper.
+ *
+ * Definitions come from a template Parameters section, while values come from
+ * command input or already-normalized test/setup data.
+ */
+export interface SimCfnParametersProps {
+  readonly definitions?: Record<string, unknown> | undefined;
+  readonly values?: SimCloudFormationParameterValues | undefined;
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * Minimal CloudFormation template Parameter definition understood by the
+ * simulator.
+ *
+ * Most fields are recorded for structural typing/documentation. Runtime
+ * behavior currently only applies string Default values when a command does not
+ * provide an explicit Parameter value.
+ */
+export interface SimCfnParameterDefinition {
+  readonly Type?: string | undefined;
+  readonly Default?: SimCfnTemplateValue | undefined;
+  readonly Description?: string | undefined;
+  readonly AllowedValues?: readonly SimCfnTemplateValue[] | undefined;
+  readonly AllowedPattern?: string | undefined;
+  readonly ConstraintDescription?: string | undefined;
+  readonly MinLength?: number | undefined;
+  readonly MaxLength?: number | undefined;
+  readonly MinValue?: number | undefined;
+  readonly MaxValue?: number | undefined;
+  readonly NoEcho?: boolean | undefined;
+}

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -117,7 +117,7 @@ export class SimCfnResource<T extends object = object> {
    * Missing or non-object Properties are treated as an empty object by the
    * Resource template reader.
    */
-  public get properties(): Record<string, unknown> {
+  public get properties(): SimCfnTemplateValueRecord {
     return this.resourceTemplateReader.properties();
   }
 

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -11,12 +11,13 @@ import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-fa
 import { SimCfnResourceCreateOperation } from "./create/sim-cfn-resource-create-operation.js";
 import { SimCfnResourceCreationState } from "./state/sim-cfn-resource-creation-state.js";
 import { SimCfnResourceTemplateReader } from "./template/sim-cfn-resource-template-reader.js";
+import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
 
 interface SimCloudFormationResourceProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly background?: BackgroundScheduler;
   readonly logicalId?: string;
-  readonly template?: Record<string, unknown>;
+  readonly template?: SimCfnTemplateValueRecord;
   readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
 }
 
@@ -57,7 +58,7 @@ export interface SimCloudFormationResourceCreateContext {
 export class SimCfnResource<T extends object = object> {
   public readonly accountRegionScope: SimAwsAccountRegionScope;
   public readonly logicalId: string;
-  public readonly template: Record<string, unknown>;
+  public readonly template: SimCfnTemplateValueRecord;
   private readonly creationState = new SimCfnResourceCreationState<T>();
   private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
   private readonly background: BackgroundScheduler;

--- a/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
+++ b/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
@@ -1,11 +1,15 @@
 import { isRecord } from "../../../../util/type-guard/record.js";
 import { parseSimCfnResourceDependencies } from "../dependency/sim-cfn-resource-dependencies.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
 
 /**
  * Reads CloudFormation Resource-level fields from one Resource template object.
  *
- * This is intentionally narrower than SimCfnTemplate. SimCfnTemplate represents
- * the whole stack template body: it validates top-level template shape, resolves
+ * This is narrower than SimCfnTemplate. SimCfnTemplate represents the whole
+ * stack template body: it validates top-level template shape, resolves
  * Parameters, and extracts Resource entries.
  *
  * SimCfnResourceTemplateReader only works after that extraction step. It reads
@@ -13,7 +17,7 @@ import { parseSimCfnResourceDependencies } from "../dependency/sim-cfn-resource-
  * DependsOn, so SimCfnResource can stay focused on Resource lifecycle state.
  */
 export class SimCfnResourceTemplateReader {
-  constructor(private readonly template: Record<string, unknown>) {}
+  constructor(private readonly template: SimCfnTemplateValueRecord) {}
 
   /**
    * The CloudFormation Resource type, for example AWS::S3::Bucket.
@@ -30,14 +34,14 @@ export class SimCfnResourceTemplateReader {
    * CloudFormation Resources may omit Properties. In that case, and when the
    * field is not an object, the simulator treats it as an empty object.
    */
-  properties(): Record<string, unknown> {
+  properties(): SimCfnTemplateValueRecord {
     const properties = this.template["Properties"];
 
-    if (isRecord(properties)) {
-      return properties;
+    if (!isSimCfnTemplateValueRecord(properties)) {
+      return {};
     }
 
-    return {};
+    return properties;
   }
 
   /**
@@ -49,4 +53,10 @@ export class SimCfnResourceTemplateReader {
   dependencies(): string[] {
     return parseSimCfnResourceDependencies(this.template["DependsOn"]);
   }
+}
+
+function isSimCfnTemplateValueRecord(
+  value: SimCfnTemplateValue | undefined,
+): value is SimCfnTemplateValueRecord {
+  return isRecord(value);
 }

--- a/src/service/cloudformation/template/sim-cfn-template-params.iso.test.ts
+++ b/src/service/cloudformation/template/sim-cfn-template-params.iso.test.ts
@@ -250,6 +250,7 @@ describe("SimCfnTemplate params", () => {
         stackName: "TestStack",
         template: {
           Parameters: {
+            // @ts-expect-error -- testing bad input
             BucketName: "not-a-parameter-definition",
           },
           Resources: {

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -6,6 +6,7 @@ import type {
 } from "./value/sim-cfn-template-value.js";
 import { isRecord } from "../../../util/type-guard/record.js";
 import { SimCfnTemplateBodyValidator } from "./sim-cfn-template-body-validator.js";
+import type { SimCfnParameterDefinition } from "../parameters/sim-cfn-parameters.type.js";
 
 /**
  * Parsed CloudFormation template body accepted by the simulator.
@@ -13,7 +14,7 @@ import { SimCfnTemplateBodyValidator } from "./sim-cfn-template-body-validator.j
  * Yulin accepts already-parsed templates and does not parse JSON or YAML itself.
  */
 export interface CfnTemplateBodyRecord {
-  readonly Parameters?: Record<string, unknown> | undefined;
+  readonly Parameters?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly Resources: Record<string, SimCfnTemplateValue>;
   readonly [sectionName: string]: unknown;
 }

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -16,7 +16,11 @@ import type { SimCfnParameterDefinition } from "../parameters/sim-cfn-parameters
 export interface CfnTemplateBodyRecord {
   readonly Parameters?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly Resources: Record<string, SimCfnTemplateValue>;
-  readonly [sectionName: string]: unknown;
+  readonly [sectionName: string]:
+    | Record<string, SimCfnParameterDefinition>
+    | Record<string, SimCfnTemplateValue>
+    | SimCfnTemplateValue
+    | undefined;
 }
 
 export interface SimCfnResourceTemplateRecord {

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -69,10 +69,10 @@ export class SimCfnTemplate {
     templateBody: string,
     props: SimCfnTemplateFromJsonProps = {},
   ): SimCfnTemplate {
-    let template: unknown;
+    let template: CfnTemplateBodyRecord;
 
     try {
-      template = JSON.parse(templateBody);
+      template = JSON.parse(templateBody) as CfnTemplateBodyRecord;
     } catch (error) {
       throw new Error(
         `Sim CloudFormation Stack ${props.stackName ?? "unknown"} TemplateBody must be valid JSON`,
@@ -83,7 +83,7 @@ export class SimCfnTemplate {
     }
 
     return new SimCfnTemplate({
-      template: template as CfnTemplateBodyRecord,
+      template,
       parameters: props.parameters,
       stackName: props.stackName,
     });

--- a/src/service/cloudfront/cff/function-code-input/cff-function-code-input.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-function-code-input.ts
@@ -70,10 +70,10 @@ export class CffUint8ArrayFunctionCodeExtractor<
     ${source}
     handler;
     `);
-    const handler: unknown = script.runInContext(context, {
+    const handler = script.runInContext(context, {
       timeout: 50, // Real CloudFront Functions have a short timeout.
       breakOnSigint: true,
-    });
+    }) as CloudFrontFunction.Handler;
 
     if (typeof handler !== "function") {
       throw new TypeError(

--- a/src/service/cloudfront/command/create-distribution/create-distribution.cmd.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim CloudFront CreateDistribution command.
  */
@@ -30,7 +32,7 @@ export interface SimCreateDistributionCommandOutput {
       }
     | undefined;
   readonly Location?: string | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/cloudfront/command/create-function/create-function.cmd.ts
+++ b/src/service/cloudfront/command/create-function/create-function.cmd.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim CloudFront CreateFunction command.
@@ -29,7 +30,7 @@ export interface SimCreateFunctionCommandInput {
  * Minimal structural sim CloudFront CreateFunction output.
  */
 export interface SimCreateFunctionCommandOutput {
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
   FunctionSummary: SimCloudFrontFunctionSummary;
   FunctionMetadata: SimCloudFrontFunctionMetadata;
 }

--- a/src/service/cloudfront/command/get-distribution/get-distribution.cmd.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.cmd.ts
@@ -1,4 +1,5 @@
 import type { SimCloudFrontDistributionConfig } from "../create-distribution/create-distribution.cmd.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim CloudFront GetDistribution command.
@@ -31,5 +32,5 @@ export interface SimGetDistributionCommandOutput {
           | undefined;
       }
     | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/dynamodb/command/create-table/create-table.cmd.ts
+++ b/src/service/dynamodb/command/create-table/create-table.cmd.ts
@@ -35,7 +35,7 @@ export interface SimDynamoDbTableDescription {
   readonly KeySchema?: SimDynamoDbKeySchemaElement[] | undefined;
   readonly TableStatus?: SimDynamoDbTableStatus;
   readonly CreationDateTime?: Date;
-  readonly GlobalSecondaryIndexes?: readonly unknown[];
+  readonly GlobalSecondaryIndexes?: readonly SimDynamoDbGlobalSecondaryIndexDescription[];
 }
 
 /**
@@ -75,3 +75,38 @@ export type SimDynamoDbTableStatus =
   | "INACCESSIBLE_ENCRYPTION_CREDENTIALS"
   | "ARCHIVING"
   | "ARCHIVED";
+
+/**
+ * Minimal structural sim DynamoDB global secondary index description.
+ */
+export interface SimDynamoDbGlobalSecondaryIndexDescription {
+  readonly IndexName?: string | undefined;
+  readonly KeySchema?: readonly SimDynamoDbKeySchemaElement[] | undefined;
+  readonly Projection?: SimDynamoDbProjection | undefined;
+  readonly IndexStatus?: SimDynamoDbIndexStatus | undefined;
+  readonly IndexArn?: SimArn | undefined;
+  readonly ItemCount?: number | undefined;
+  readonly IndexSizeBytes?: number | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB projection.
+ */
+export interface SimDynamoDbProjection {
+  readonly ProjectionType?: SimDynamoDbProjectionType | undefined;
+  readonly NonKeyAttributes?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB projection type.
+ */
+export type SimDynamoDbProjectionType = "ALL" | "KEYS_ONLY" | "INCLUDE";
+
+/**
+ * Minimal structural sim DynamoDB index status.
+ */
+export type SimDynamoDbIndexStatus =
+  | "CREATING"
+  | "UPDATING"
+  | "DELETING"
+  | "ACTIVE";

--- a/src/service/dynamodb/command/create-table/create-table.cmd.ts
+++ b/src/service/dynamodb/command/create-table/create-table.cmd.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim DynamoDB CreateTable command.
@@ -21,7 +22,7 @@ export interface SimCreateTableCommandInput {
  */
 export interface SimCreateTableCommandOutput {
   readonly TableDescription?: SimDynamoDbTableDescription;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/dynamodb/command/describe-table/describe-table.cmd.ts
+++ b/src/service/dynamodb/command/describe-table/describe-table.cmd.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbTableDescription } from "../create-table/create-table.cmd.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim DynamoDB DescribeTable command.
@@ -19,5 +20,5 @@ export interface SimDescribeTableCommandInput {
  */
 export interface SimDescribeTableCommandOutput {
   readonly Table?: SimDynamoDbTableDescription | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/dynamodb/command/list-tables/list-tables.cmd.ts
+++ b/src/service/dynamodb/command/list-tables/list-tables.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim DynamoDB ListTables command.
  */
@@ -19,5 +21,5 @@ export interface SimListTablesCommandInput {
 export interface SimListTablesCommandOutput {
   readonly TableNames?: readonly string[] | undefined;
   readonly LastEvaluatedTableName?: string | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/dynamodb/command/put-item/put-item.cmd.ts
+++ b/src/service/dynamodb/command/put-item/put-item.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim DynamoDB PutItem command.
  */
@@ -18,7 +20,7 @@ export interface SimPutItemCommandInput {
  */
 export interface SimPutItemCommandOutput {
   readonly Attributes?: Record<string, SimDynamoDbAttributeValue> | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/dynamodb/command/put-item/put-item.iso.test.ts
+++ b/src/service/dynamodb/command/put-item/put-item.iso.test.ts
@@ -87,7 +87,7 @@ describe("DynamoDB PutItemCommand", () => {
           BS: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
         },
       },
-      assertAttribute: (attributes: { binaryTags?: { BS?: string[] } }) => {
+      assertAttribute: (attributes: { binaryTags?: { BS?: Uint8Array[] } }) => {
         assertBufferEqual(
           attributes.binaryTags?.BS?.[1],
           new Uint8Array([4, 5, 6]),

--- a/src/service/dynamodb/command/put-item/put-item.iso.test.ts
+++ b/src/service/dynamodb/command/put-item/put-item.iso.test.ts
@@ -15,7 +15,7 @@ describe("DynamoDB PutItemCommand", () => {
       item: {
         userName: { S: "Foo McBar" },
       },
-      assertAttribute: (attributes: { userName?: { S: unknown } }) => {
+      assertAttribute: (attributes: { userName?: { S: string } }) => {
         assertIdentical(attributes.userName?.S, "Foo McBar");
       },
     },
@@ -24,7 +24,7 @@ describe("DynamoDB PutItemCommand", () => {
       item: {
         favouriteNumber: { N: "42" },
       },
-      assertAttribute: (attributes: { favouriteNumber?: { N: unknown } }) => {
+      assertAttribute: (attributes: { favouriteNumber?: { N: string } }) => {
         assertIdentical(attributes.favouriteNumber?.N, "42");
       },
     },
@@ -33,7 +33,7 @@ describe("DynamoDB PutItemCommand", () => {
       item: {
         likesPizza: { BOOL: true },
       },
-      assertAttribute: (attributes: { likesPizza?: { BOOL: unknown } }) => {
+      assertAttribute: (attributes: { likesPizza?: { BOOL: boolean } }) => {
         assertTrue(attributes.likesPizza?.BOOL);
       },
     },
@@ -42,7 +42,7 @@ describe("DynamoDB PutItemCommand", () => {
       item: {
         missingValue: { NULL: true },
       },
-      assertAttribute: (attributes: { missingValue?: { NULL: unknown } }) => {
+      assertAttribute: (attributes: { missingValue?: { NULL: boolean } }) => {
         assertTrue(attributes.missingValue?.NULL);
       },
     },
@@ -53,7 +53,7 @@ describe("DynamoDB PutItemCommand", () => {
           B: new Uint8Array([137, 80, 78, 71]),
         },
       },
-      assertAttribute: (attributes: { profilePicture?: { B: unknown } }) => {
+      assertAttribute: (attributes: { profilePicture?: { B: Uint8Array } }) => {
         assertBufferEqual(
           attributes.profilePicture?.B,
           new Uint8Array([137, 80, 78, 71]),
@@ -66,7 +66,7 @@ describe("DynamoDB PutItemCommand", () => {
         favouriteColours: { SS: ["purple", "red"] },
       },
       assertAttribute: (attributes: {
-        favouriteColours?: { SS?: unknown[] };
+        favouriteColours?: { SS?: string[] };
       }) => {
         assertIdentical(attributes.favouriteColours?.SS?.[0], "purple");
       },
@@ -76,7 +76,7 @@ describe("DynamoDB PutItemCommand", () => {
       item: {
         luckyNumbers: { NS: ["7", "13", "42"] },
       },
-      assertAttribute: (attributes: { luckyNumbers?: { NS?: unknown[] } }) => {
+      assertAttribute: (attributes: { luckyNumbers?: { NS?: string[] } }) => {
         assertIdentical(attributes.luckyNumbers?.NS?.[2], "42");
       },
     },
@@ -87,7 +87,7 @@ describe("DynamoDB PutItemCommand", () => {
           BS: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])],
         },
       },
-      assertAttribute: (attributes: { binaryTags?: { BS?: unknown[] } }) => {
+      assertAttribute: (attributes: { binaryTags?: { BS?: string[] } }) => {
         assertBufferEqual(
           attributes.binaryTags?.BS?.[1],
           new Uint8Array([4, 5, 6]),
@@ -102,7 +102,7 @@ describe("DynamoDB PutItemCommand", () => {
         },
       },
       assertAttribute: (attributes: {
-        shoppingList?: { L?: { S?: unknown }[] };
+        shoppingList?: { L?: { S?: string }[] };
       }) => {
         assertIdentical(attributes.shoppingList?.L?.[0]?.S, "milk");
       },
@@ -127,11 +127,11 @@ describe("DynamoDB PutItemCommand", () => {
       assertAttribute: (attributes: {
         address?: {
           M?: {
-            street?: { S?: unknown };
-            city?: { S?: unknown };
-            postcode?: { S?: unknown };
+            street?: { S?: string };
+            city?: { S?: string };
+            postcode?: { S?: string };
             coordinates?: {
-              M?: { lat: { N?: unknown }; lon: { N?: unknown } };
+              M?: { lat: { N?: string }; lon: { N?: string } };
             };
           };
         };

--- a/src/service/s3/command/create-bucket/create-bucket.cmd.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim S3 CreateBucket command.
  */
@@ -18,5 +20,5 @@ export interface SimCreateBucketCommandInput {
 export interface SimCreateBucketCommandOutput {
   readonly BucketArn?: string;
   readonly Location?: string;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/get-object/get-object.cmd.ts
+++ b/src/service/s3/command/get-object/get-object.cmd.ts
@@ -1,4 +1,5 @@
 import type { Readable } from "node:stream";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim S3 GetObject command.
@@ -21,5 +22,5 @@ export interface SimGetObjectCommandInput {
 export interface SimGetObjectCommandOutput {
   readonly Body?: Readable;
   readonly Metadata?: Record<string, string>;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/list-buckets/list-buckets.cmd.ts
+++ b/src/service/s3/command/list-buckets/list-buckets.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim S3 ListBuckets command.
  */
@@ -21,7 +23,7 @@ export interface SimListBucketsCommandOutput {
   readonly Buckets?: SimS3BucketSummary[] | undefined;
   readonly ContinuationToken?: string | undefined;
   readonly Prefix?: string | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/s3/command/list-objects/list-objects.cmd.ts
+++ b/src/service/s3/command/list-objects/list-objects.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim S3 ListObjects command.
  */
@@ -26,7 +28,7 @@ export interface SimListObjectsCommandOutput {
   readonly MaxKeys?: number;
   readonly IsTruncated?: boolean;
   readonly NextMarker?: string | undefined;
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/s3/command/put-bucket-website/put-bucket-website.cmd.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website.cmd.ts
@@ -1,3 +1,5 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
 /**
  * Minimal structural sim S3 PutBucketWebsite command.
  */
@@ -17,7 +19,7 @@ export interface SimPutBucketWebsiteCommandInput {
  * Minimal structural sim S3 PutBucketWebsite output.
  */
 export interface SimPutBucketWebsiteCommandOutput {
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/s3/command/put-object/put-object.cmd.ts
+++ b/src/service/s3/command/put-object/put-object.cmd.ts
@@ -1,4 +1,5 @@
 import type { Readable } from "node:stream";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 
 /**
  * Minimal structural sim S3 PutObject command.
@@ -22,7 +23,7 @@ export interface SimPutObjectCommandInput {
  * Minimal structural sim S3 PutObject output.
  */
 export interface SimPutObjectCommandOutput {
-  readonly $metadata: Record<string, unknown>;
+  readonly $metadata: SimResponseMetadata;
 }
 
 /**

--- a/src/service/s3/command/put-object/put-object.iso.test.ts
+++ b/src/service/s3/command/put-object/put-object.iso.test.ts
@@ -148,7 +148,8 @@ describe("S3 PutObjectCommand", () => {
         new PutObjectCommand({
           Bucket: bucketName,
           Key: "foo.txt",
-          Body: 123 as unknown as Uint8Array,
+          // @ts-expect-error -- testing bad input
+          Body: 123,
         }),
       );
     });

--- a/src/util/background/non-deterministic-background.ts
+++ b/src/util/background/non-deterministic-background.ts
@@ -60,15 +60,13 @@ export class NonDeterministicBackgroundTasks
       // eslint-disable-next-line no-await-in-loop
       const results = await Promise.allSettled(this.pending);
       // Check if any promises rejected and capture the first error
-      let firstError: unknown;
-      for (const result of results) {
-        if (result.status === "rejected") {
-          firstError = result.reason;
-          break;
-        }
-      }
-      if (firstError !== undefined) {
-        throw firstError as Error;
+      const firstRejected = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+
+      if (firstRejected !== undefined) {
+        throw firstRejected.reason;
       }
     }
   }

--- a/src/util/type-guard/record.ts
+++ b/src/util/type-guard/record.ts
@@ -1,6 +1,7 @@
 /**
  * Check if a given value is a Record<string, unknown>
  */
+// eslint-disable-next-line no-restricted-syntax
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety across CloudFormation, CloudFront, DynamoDB, and S3 command outputs by switching `$metadata` to a shared structured response-metadata type.
  * Improved CloudFormation template/parameter/resource typing for stricter, clearer parameter and default handling.

* **Bug Fixes**
  * Background task draining now throws the first rejected task’s rejection reason directly (instead of a cast), improving error correctness.

* **Tests**
  * Updated TypeScript expectations in simulator tests to better enforce intentionally invalid inputs.

* **Chores**
  * ESLint now discourages broad `unknown` usage with an explicit exception for narrowing contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->