### PR TITLE
feat: initial sim CFN Ref pointing to other template Resources

### DIFF
--- a/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
@@ -4,8 +4,7 @@ import type {
   SimCloudFormationResourceCreateContext,
 } from "../sim-cfn-resource.js";
 import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
-import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
-import { resolveSimCloudFormationServiceResourceFactory } from "../resolver/sim-cfn-service-resolver.js";
+import { SimCfnResourceCreator } from "./sim-cfn-resource-creator.js";
 
 interface SimCfnResourceCreateOperationProps<T extends object> {
   readonly background: BackgroundScheduler;
@@ -15,20 +14,35 @@ interface SimCfnResourceCreateOperationProps<T extends object> {
 
 /**
  * Runs the asynchronous CloudFormation Resource creation lifecycle.
+ *
+ * This class owns the CloudFormation-facing operation concerns: scheduling the
+ * create work in the background, moving the Resource through create states, and
+ * translating thrown creation errors into Resource failure state.
+ *
+ * It does not know how to construct the underlying simulated AWS service
+ * Resource. That responsibility belongs to {@link SimCfnResourceCreator}.
  */
 export class SimCfnResourceCreateOperation<T extends object = object> {
   private readonly background: BackgroundScheduler;
   private readonly resource: SimCfnResource<T>;
-  private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
+  private readonly creator: SimCfnResourceCreator<T>;
 
   constructor(props: SimCfnResourceCreateOperationProps<T>) {
     this.background = props.background;
     this.resource = props.resource;
-    this.cfnResourceFactory = props.cfnResourceFactory;
+    this.creator = new SimCfnResourceCreator({
+      resource: props.resource,
+      cfnResourceFactory: props.cfnResourceFactory,
+    });
   }
 
   /**
-   * Create the Resource into simulated AWS as a background operation.
+   * Start Resource creation as a background operation.
+   *
+   * The returned Promise resolves or rejects with the background creation work,
+   * while the Resource itself is updated through CloudFormation create states:
+   * in progress before scheduling, complete after the creator returns, or
+   * failed if the creator or background sequence throws.
    */
   run(context: SimCloudFormationResourceCreateContext): Promise<void> {
     this.resource.markCreateInProgress();
@@ -38,7 +52,7 @@ export class SimCfnResourceCreateOperation<T extends object = object> {
         try {
           await this.background.sequence();
 
-          const simResource = await this.createSimResource(context);
+          const simResource = await this.creator.create(context);
           this.resource.markCreateComplete(simResource as T | undefined);
           resolve();
         } catch (error) {
@@ -49,33 +63,6 @@ export class SimCfnResourceCreateOperation<T extends object = object> {
         }
       });
     });
-  }
-
-  private async createSimResource(
-    context: SimCloudFormationResourceCreateContext,
-  ): Promise<object | undefined> {
-    const { type } = this.resource;
-
-    if (type === undefined) {
-      throw new Error(
-        `Sim CloudFormation Resource ${this.resource.logicalId} is missing a Type`,
-      );
-    }
-
-    const resourceType = parseSimCloudFormationResourceType(type);
-    const factory =
-      this.cfnResourceFactory ??
-      resolveSimCloudFormationServiceResourceFactory(
-        context.simAws,
-        this.resource.accountRegionScope,
-        resourceType,
-      );
-
-    return await factory.create(
-      resourceType.resourceTypeName,
-      this.resource,
-      context,
-    );
   }
 
   private resourceCreationError(error: unknown): Error {

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
@@ -1,0 +1,75 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
+import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
+import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
+
+interface SimCfnResourceCreatorProps<T extends object> {
+  readonly resource: SimCfnResource<T>;
+  readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+}
+
+/**
+ * Creates the underlying simulated AWS service Resource for a CloudFormation
+ * Resource.
+ *
+ * This class owns the service-facing creation details: validating and parsing
+ * the CloudFormation Resource type, resolving the appropriate service Resource
+ * factory, resolving CloudFormation properties, and invoking the factory.
+ *
+ * It does not manage the asynchronous CloudFormation operation lifecycle.
+ * Background scheduling, Resource state transitions, and failure handling
+ * belong to SimCfnResourceCreateOperation.
+ */
+export class SimCfnResourceCreator<T extends object = object> {
+  private readonly resource: SimCfnResource<T>;
+  private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
+
+  constructor(props: SimCfnResourceCreatorProps<T>) {
+    this.resource = props.resource;
+    this.cfnResourceFactory = props.cfnResourceFactory;
+  }
+
+  /**
+   * Create the underlying simulated AWS service Resource.
+   *
+   * The supplied context is enriched with properties resolved from the
+   * CloudFormation Resource before it is passed to the service Resource
+   * factory.
+   * A factory supplied in the constructor is used directly; otherwise the
+   * factory is resolved from the Resource type and target account/Region scope.
+   */
+  async create(
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const { type } = this.resource;
+
+    if (type === undefined) {
+      throw new Error(
+        `Sim CloudFormation Resource ${this.resource.logicalId} is missing a Type`,
+      );
+    }
+
+    const resourceType = parseSimCloudFormationResourceType(type);
+    const factory =
+      this.cfnResourceFactory ??
+      resolveSimCloudFormationServiceResourceFactory(
+        context.simAws,
+        this.resource.accountRegionScope,
+        resourceType,
+      );
+
+    const resolvedContext: SimCloudFormationResourceCreateContext = {
+      ...context,
+      resolvedProperties: this.resource.resolvedProperties(context),
+    };
+
+    return await factory.create(
+      resourceType.resourceTypeName,
+      this.resource,
+      resolvedContext,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/dependency/sim-cfn-resource-dependencies.ts
+++ b/src/service/cloudformation/resource/dependency/sim-cfn-resource-dependencies.ts
@@ -1,3 +1,6 @@
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { parseSimCfnNode } from "../../template/parse/sim-cfn-node-parser.js";
+
 /**
  * Return CloudFormation Resource logical IDs from a DependsOn template value.
  */
@@ -13,4 +16,22 @@ export function parseSimCfnResourceDependencies(dependsOn: unknown): string[] {
   }
 
   return [];
+}
+
+/**
+ * Return implicit dependency logical IDs created by Ref expressions inside a
+ * Resource template.
+ *
+ * Only names that match a known Resource logical ID become dependencies. Refs to
+ * Parameters or pseudo-parameters do not create Resource ordering constraints.
+ */
+export function parseSimCfnResourceRefDependencies(
+  template: SimCfnTemplateValueRecord,
+  resourceLogicalIds: ReadonlySet<string>,
+): string[] {
+  const referencedNames = parseSimCfnNode(template).referencedNames();
+
+  return [...new Set(referencedNames)].filter((name) =>
+    resourceLogicalIds.has(name),
+  );
 }

--- a/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
+++ b/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
@@ -49,6 +49,7 @@ describe("CloudFormation Resource Ref value", () => {
     assertNonNullable(sourceResource);
     assertNonNullable(derivedResource);
     assertIdentical(sourceResource.refValue, "source-bucket");
+    assertIdentical(derivedResource.refValue, "derived-from-source-bucket");
   });
 
   it("falls back to the Resource logical ID when the created sim Resource has no refValue()", async () => {

--- a/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
+++ b/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
@@ -1,0 +1,141 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3Bucket } from "../../../s3/bucket/sim-s3-bucket.js";
+import { SimCloudFormationWaitConditionHandle } from "../factory/sim-cfn-cfn-resource-factory.js";
+
+describe("CloudFormation Resource Ref value", () => {
+  it("uses a created sim Resource refValue() when the Resource provides one", async () => {
+    // Given a template where one Bucket name Refs another S3 Bucket Resource.
+    const template = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Join": ["-", ["derived", "from", { Ref: "SourceBucket" }]],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template,
+    });
+
+    // Then Ref resolves via the S3 Bucket sim Resource's service-specific
+    // refValue(), so the derived Bucket name is based on the source Bucket
+    // name.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertNonNullable(sourceBucket);
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertNonNullable(sourceResource);
+    assertNonNullable(derivedResource);
+    assertIdentical(sourceResource.refValue, "source-bucket");
+  });
+
+  it("falls back to the Resource logical ID when the created sim Resource has no refValue()", async () => {
+    // Given a template where an S3 Bucket name Refs a CloudFormation Resource
+    // whose created sim Resource does not provide a service-specific Ref value.
+    const template = {
+      Resources: {
+        handle: {
+          Type: "AWS::CloudFormation::WaitConditionHandle",
+        },
+        bucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              Ref: "handle",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template,
+    });
+
+    // Then Ref resolves to the logical ID fallback.
+    const bucket = simAws.s3().getSimBucketByName("handle");
+    const handleResource = stack.resources.get("handle");
+    const bucketResource = stack.resources.get("bucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, "handle");
+
+    assertNonNullable(handleResource);
+    assertNonNullable(bucketResource);
+    assertIdentical(handleResource.status, "CREATE_COMPLETE");
+    assertIdentical(bucketResource.status, "CREATE_COMPLETE");
+    assertInstanceOf(
+      handleResource.simResource,
+      SimCloudFormationWaitConditionHandle,
+    );
+    assertIdentical(handleResource.refValue, "handle");
+    assertIdentical(bucketResource.simResource, bucket);
+  });
+
+  it("uses the logical ID fallback inside Fn::Join when the created sim Resource has no refValue()", async () => {
+    // Given a template where a Bucket name is built from a Ref to a Resource
+    // whose created sim Resource does not provide refValue().
+    const template = {
+      Resources: {
+        handle: {
+          Type: "AWS::CloudFormation::WaitConditionHandle",
+        },
+        bucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Join": ["-", [{ Ref: "handle" }, "bucket"]],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template,
+    });
+
+    // Then the Resource Ref contributes the logical ID fallback to the joined value.
+    const bucket = simAws.s3().getSimBucketByName("handle-bucket");
+    const handleResource = stack.resources.get("handle");
+    const bucketResource = stack.resources.get("bucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, "handle-bucket");
+
+    assertNonNullable(handleResource);
+    assertNonNullable(bucketResource);
+    assertIdentical(handleResource.refValue, "handle");
+    assertIdentical(bucketResource.simResource, bucket);
+  });
+});

--- a/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.ts
+++ b/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal shape a created sim Resource may implement to control its
+ * CloudFormation Ref value.
+ */
+interface SimCfnResourceRefValueProvider {
+  refValue(): string;
+}
+
+function hasRefValue(
+  value: object | undefined,
+): value is SimCfnResourceRefValueProvider {
+  return (
+    value !== undefined &&
+    "refValue" in value &&
+    typeof (value as SimCfnResourceRefValueProvider).refValue === "function"
+  );
+}
+
+/**
+ * Resolve the value returned by { "Ref": logicalId } for a Resource.
+ *
+ * CloudFormation Ref values are Resource-type specific. A created simulated AWS
+ * object can expose refValue() to provide that service-specific value. If it
+ * does not, the Resource logical ID is used as a stable physical-ID stand-in.
+ */
+export function simCfnResourceRefValue(
+  logicalId: string,
+  simResource: object | undefined,
+): string {
+  if (hasRefValue(simResource)) {
+    return simResource.refValue();
+  }
+
+  return logicalId;
+}

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.iso.test.ts
@@ -1,7 +1,0 @@
-import { describe, it } from "vitest";
-
-describe("Sim CFN resource property resolver", () => {
-  it("leaves an unresolved Ref dependency in place for the next pass", () => {
-    //
-  });
-});

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.iso.test.ts
@@ -1,0 +1,7 @@
+import { describe, it } from "vitest";
+
+describe("Sim CFN resource property resolver", () => {
+  it("leaves an unresolved Ref dependency in place for the next pass", () => {
+    //
+  });
+});

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -1,4 +1,4 @@
-import type { SimCfnParameters } from "../../../parameters/sim-cfn-parameters.js";
+import { SimCfnParameters } from "../../../parameters/sim-cfn-parameters.js";
 import { SimCfnTemplateValueResolver } from "../../../template/value/sim-cfn-template-value-resolver.js";
 import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCloudFormationResourceCreateContext } from "../../sim-cfn-resource.js";
@@ -30,10 +30,9 @@ export class SimCfnResourcePropertyResolver {
   /**
    * Resolve the Resource Properties object for service-specific creation.
    *
-   * If no Parameters are available, the raw Properties object is returned
-   * because there is no late Resource-level substitution to perform. Otherwise,
    * Parameters and Resource Refs are resolved through
-   * {@link SimCfnTemplateValueResolver}.
+   * {@link SimCfnTemplateValueResolver}. If no Parameters are available, an empty
+   * Parameter resolver is used so Resource Refs can still resolve.
    *
    * Resource Refs are read from the creation context. If a referenced Resource
    * is unexpectedly absent, the Ref is preserved as `{ Ref: logicalId }` rather
@@ -43,12 +42,8 @@ export class SimCfnResourcePropertyResolver {
     properties: SimCfnTemplateValueRecord,
     context: SimCloudFormationResourceCreateContext,
   ): SimCfnTemplateValueRecord {
-    if (this.parameters === undefined) {
-      return properties;
-    }
-
     const resolver = new SimCfnTemplateValueResolver({
-      parameters: this.parameters,
+      parameters: this.parameters ?? new SimCfnParameters(),
       resources: {
         has: (id): boolean => context.resources.has(id),
         refValue: (id): string | { Ref: string } => {

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -1,0 +1,69 @@
+import type { SimCfnParameters } from "../../../parameters/sim-cfn-parameters.js";
+import { SimCfnTemplateValueResolver } from "../../../template/value/sim-cfn-template-value-resolver.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFormationResourceCreateContext } from "../../sim-cfn-resource.js";
+
+interface SimCfnResourcePropertyResolverProps {
+  readonly parameters?: SimCfnParameters | undefined;
+}
+
+/**
+ * Resolves CloudFormation Resource Properties immediately before Resource
+ * creation.
+ *
+ * This is the Resource-level resolution pass. It runs after stack dependencies
+ * have been evaluated and just before the service-specific Resource factory is
+ * called, so Refs to already-created Resources can be converted to those
+ * Resources' CloudFormation Ref values.
+ *
+ * Template-wide validation and early Parameter handling happen elsewhere. This
+ * class only adapts the current Resource creation context into the shape needed
+ * by SimCfnTemplateValueResolver.
+ */
+export class SimCfnResourcePropertyResolver {
+  private readonly parameters: SimCfnParameters | undefined;
+
+  constructor(props: SimCfnResourcePropertyResolverProps = {}) {
+    this.parameters = props.parameters;
+  }
+
+  /**
+   * Resolve the Resource Properties object for service-specific creation.
+   *
+   * If no Parameters are available, the raw Properties object is returned
+   * because there is no late Resource-level substitution to perform. Otherwise,
+   * Parameters and Resource Refs are resolved through
+   * {@link SimCfnTemplateValueResolver}.
+   *
+   * Resource Refs are read from the creation context. If a referenced Resource
+   * is unexpectedly absent, the Ref is preserved as `{ Ref: logicalId }` rather
+   * than being converted to an invalid value.
+   */
+  resolve(
+    properties: SimCfnTemplateValueRecord,
+    context: SimCloudFormationResourceCreateContext,
+  ): SimCfnTemplateValueRecord {
+    if (this.parameters === undefined) {
+      return properties;
+    }
+
+    const resolver = new SimCfnTemplateValueResolver({
+      parameters: this.parameters,
+      resources: {
+        has: (id): boolean => context.resources.has(id),
+        refValue: (id): string | { Ref: string } => {
+          const dependency = context.resources.get(id);
+
+          /* v8 ignore if -- defensive catch for inconsistent context */
+          if (dependency === undefined) {
+            return { Ref: id };
+          }
+
+          return dependency.refValue;
+        },
+      },
+    });
+
+    return resolver.resolveRecord(properties);
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
@@ -5,11 +5,11 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimAws } from "../../../aws/sim-aws.js";
-import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
+import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
 import { resolveSimCloudFormationServiceResourceFactory } from "./sim-cfn-service-resolver.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
 
 describe("resolveSimCloudFormationServiceResourceFactory", () => {
   it("resolves the CloudFormation Resource factory", () => {

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -1,10 +1,10 @@
-import type { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
 import type {
   SimCloudFormationParsedResourceType,
   SimCfnServiceResourceFactory,
-} from "../factory/sim-cfn-resource-factory.type.js";
-import { SimCfnCfnResourceFactory } from "../factory/sim-cfn-cfn-resource-factory.js";
+} from "../../factory/sim-cfn-resource-factory.type.js";
+import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
 
 /**
  * Resolve a scoped simulated service CloudFormation Resource factory.

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -12,6 +12,9 @@ import { SimCfnResourceCreateOperation } from "./create/sim-cfn-resource-create-
 import { SimCfnResourceCreationState } from "./state/sim-cfn-resource-creation-state.js";
 import { SimCfnResourceTemplateReader } from "./template/sim-cfn-resource-template-reader.js";
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import type { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
+import { SimCfnResourcePropertyResolver } from "./resolve/property/sim-cfn-resource-property-resolver.js";
+import { simCfnResourceRefValue } from "./ref/sim-cfn-resource-ref-value.js";
 
 interface SimCloudFormationResourceProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -19,6 +22,8 @@ interface SimCloudFormationResourceProps {
   readonly logicalId?: string;
   readonly template?: SimCfnTemplateValueRecord;
   readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
+  readonly parameters?: SimCfnParameters | undefined;
+  readonly resourceLogicalIds?: ReadonlySet<string> | undefined;
 }
 
 /**
@@ -36,6 +41,7 @@ export type SimCloudFormationResourceStatus =
 export interface SimCloudFormationResourceCreateContext {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
 }
 
 /**
@@ -61,8 +67,10 @@ export class SimCfnResource<T extends object = object> {
   public readonly template: SimCfnTemplateValueRecord;
   private readonly creationState = new SimCfnResourceCreationState<T>();
   private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
+  private readonly propertyResolver: SimCfnResourcePropertyResolver;
   private readonly background: BackgroundScheduler;
   private readonly cfnResourceFactory: SimCfnServiceResourceFactory | undefined;
+  private readonly resourceLogicalIds: ReadonlySet<string>;
 
   constructor(props: SimCloudFormationResourceProps = {}) {
     const {
@@ -71,6 +79,8 @@ export class SimCfnResource<T extends object = object> {
       logicalId = "Resource",
       template = {},
       cfnResourceFactory,
+      parameters,
+      resourceLogicalIds = new Set(),
     } = props;
 
     this.accountRegionScope = accountRegionScope;
@@ -78,7 +88,9 @@ export class SimCfnResource<T extends object = object> {
     this.logicalId = logicalId;
     this.template = template;
     this.resourceTemplateReader = new SimCfnResourceTemplateReader(template);
+    this.propertyResolver = new SimCfnResourcePropertyResolver({ parameters });
     this.cfnResourceFactory = cfnResourceFactory;
+    this.resourceLogicalIds = resourceLogicalIds;
   }
 
   /**
@@ -122,6 +134,18 @@ export class SimCfnResource<T extends object = object> {
   }
 
   /**
+   * The value returned when this Resource is referenced via { "Ref": logicalId }.
+   *
+   * Mirroring CloudFormation, not every Resource type defines a meaningful Ref
+   * value. A created sim Resource may expose refValue() to override this (for
+   * example, an S3 Bucket returns its bucket name); otherwise the logical ID is
+   * used as a stand-in for the physical ID.
+   */
+  public get refValue(): string {
+    return simCfnResourceRefValue(this.logicalId, this.simResource);
+  }
+
+  /**
    * The simulated AWS object created for this CloudFormation Resource.
    *
    * For example, an AWS::S3::Bucket Resource may point at a simulated S3 Bucket
@@ -142,9 +166,24 @@ export class SimCfnResource<T extends object = object> {
   /**
    * Logical IDs of Resources that must complete before this Resource can
    * create.
+   *
+   * Includes both explicit DependsOn entries and implicit dependencies from Ref
+   * expressions that target other Resources.
    */
   dependencies(): string[] {
-    return this.resourceTemplateReader.dependencies();
+    return this.resourceTemplateReader.dependencies(this.resourceLogicalIds);
+  }
+
+  /**
+   * Resolve this Resource's Properties, including Refs to other Resources.
+   *
+   * Called by the creation operation once every dependency has reached
+   * CREATE_COMPLETE, so referenced Resources have valid Ref values.
+   */
+  resolvedProperties(
+    context: SimCloudFormationResourceCreateContext,
+  ): SimCfnTemplateValueRecord {
+    return this.propertyResolver.resolve(this.properties, context);
   }
 
   /**

--- a/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
+++ b/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "../../../../util/type-guard/record.js";
-import { parseSimCfnResourceDependencies } from "../dependency/sim-cfn-resource-dependencies.js";
+import {
+  parseSimCfnResourceDependencies,
+  parseSimCfnResourceRefDependencies,
+} from "../dependency/sim-cfn-resource-dependencies.js";
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
@@ -45,13 +48,25 @@ export class SimCfnResourceTemplateReader {
   }
 
   /**
-   * Logical IDs this Resource depends on.
+   * Logical IDs on which this Resource depends.
+   *
+   * Combines explicit DependsOn entries with implicit dependencies introduced
+   * by Ref expressions that point at other Resources. The set of Resource
+   * logical IDs distinguishes Resource Refs from Parameter Refs.
    *
    * DependsOn may be absent, a string, or a list of strings. Dependency parsing
    * is delegated so this reader only exposes the normalized string list.
    */
-  dependencies(): string[] {
-    return parseSimCfnResourceDependencies(this.template["DependsOn"]);
+  dependencies(resourceLogicalIds: ReadonlySet<string> = new Set()): string[] {
+    const dependsOn = parseSimCfnResourceDependencies(
+      this.template["DependsOn"],
+    );
+    const refDependencies = parseSimCfnResourceRefDependencies(
+      this.template,
+      resourceLogicalIds,
+    );
+
+    return [...new Set([...dependsOn, ...refDependencies])];
   }
 }
 

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
@@ -18,7 +18,12 @@ export function makeSimCfnStackResourceMap(
   const { accountRegionScope, background, template } = props;
   const resources = new Map<string, SimCfnResource>();
 
-  for (const resourceTemplate of template.resourceTemplates()) {
+  const resourceTemplates = template.resourceTemplates();
+  const resourceLogicalIds = new Set(
+    resourceTemplates.map((resourceTemplate) => resourceTemplate.logicalId),
+  );
+
+  for (const resourceTemplate of resourceTemplates) {
     resources.set(
       resourceTemplate.logicalId,
       new SimCfnResource({
@@ -26,6 +31,8 @@ export function makeSimCfnStackResourceMap(
         background,
         logicalId: resourceTemplate.logicalId,
         template: resourceTemplate.template,
+        parameters: template.parameters,
+        resourceLogicalIds,
       }),
     );
   }

--- a/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.ts
+++ b/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.ts
@@ -1,4 +1,5 @@
 import { SimCfnNode, type SimCfnResolveContext } from "../../sim-cfn-node.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 
 /**
  * Simulated CloudFormation `Fn::Join` intrinsic function.
@@ -18,26 +19,60 @@ export class SimCfnFnJoin extends SimCfnNode {
   }
 
   /**
-   * Resolve each value to a string and join them with the delimiter.
+   * Resolve each value and join them with the delimiter.
+   *
+   * Joining happens only when every value has resolved to a string. If any
+   * value is still an unresolved expression (for example a Resource `Ref`
+   * during the up-front pass before Resources exist), this node re-emits
+   * itself in template form. A later resolution pass can finish it once the
+   * referenced Resources are available.
    */
-  resolve(context: SimCfnResolveContext): string {
-    return this.values
-      .map((value) => this.resolveStringValue(value, context))
-      .join(this.delimiter);
-  }
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const resolved = this.values.map((value) =>
+      this.resolveValue(value, context),
+    );
 
-  private resolveStringValue(
-    value: SimCfnNode,
-    context: SimCfnResolveContext,
-  ): string {
-    const resolved = value.resolve(context);
-
-    if (typeof resolved !== "string") {
-      throw new TypeError(
-        `Sim CloudFormation Fn::Join values must each resolve to a string, got ${typeof resolved}`,
-      );
+    if (resolved.every((value): value is string => typeof value === "string")) {
+      return resolved.join(this.delimiter);
     }
 
-    return resolved;
+    return { "Fn::Join": [this.delimiter, resolved] };
+  }
+
+  /**
+   * Collect referenced names from every joined value.
+   */
+  override referencedNames(): string[] {
+    return this.values.flatMap((value) => value.referencedNames());
+  }
+
+  private resolveValue(
+    value: SimCfnNode,
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    const resolved = value.resolve(context);
+
+    if (typeof resolved === "string") {
+      return resolved;
+    }
+
+    if (this.isDeferredExpression(resolved)) {
+      return resolved;
+    }
+
+    throw new TypeError(
+      `Sim CloudFormation Fn::Join values must each resolve to a string, got ${typeof resolved}`,
+    );
+  }
+
+  /**
+   * Whether a resolved value is still an unresolved intrinsic expression.
+   *
+   * Only object-shaped values (a preserved `Ref` or nested function object)
+   * are treated as deferred. Other non-string primitives such as numbers are
+   * genuine type errors.
+   */
+  private isDeferredExpression(value: SimCfnTemplateValue): boolean {
+    return typeof value === "object" && value !== null;
   }
 }

--- a/src/service/cloudformation/template/node/sim-cfn-list.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-list.ts
@@ -15,4 +15,11 @@ export class SimCfnList extends SimCfnNode {
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue[] {
     return this.items.map((item) => item.resolve(context));
   }
+
+  /**
+   * Collect referenced names from every item.
+   */
+  override referencedNames(): string[] {
+    return this.items.flatMap((item) => item.referencedNames());
+  }
 }

--- a/src/service/cloudformation/template/node/sim-cfn-node.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-node.ts
@@ -1,11 +1,15 @@
 import type { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+import type { SimCfnResourceRefResolver } from "../resolve/sim-cfn-resource-ref-resolver.js";
 
 /**
  * Context available while resolving a parsed CloudFormation node tree.
  */
 export class SimCfnResolveContext {
-  constructor(readonly parameters: SimCfnParameters) {}
+  constructor(
+    readonly parameters: SimCfnParameters,
+    readonly resources?: SimCfnResourceRefResolver | undefined,
+  ) {}
 }
 
 /**
@@ -20,4 +24,15 @@ export abstract class SimCfnNode {
    * Resolve this node to a concrete template value.
    */
   abstract resolve(context: SimCfnResolveContext): SimCfnTemplateValue;
+
+  /**
+   * Logical names referenced via Ref anywhere in this node subtree.
+   *
+   * This is used to discover implicit dependencies between Resources. Container
+   * nodes forward to their children; leaf nodes contribute nothing unless they
+   * are a Ref.
+   */
+  referencedNames(): string[] {
+    return [];
+  }
 }

--- a/src/service/cloudformation/template/node/sim-cfn-object.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-object.ts
@@ -17,4 +17,11 @@ export class SimCfnObject extends SimCfnNode {
       [...this.entries].map(([key, node]) => [key, node.resolve(context)]),
     );
   }
+
+  /**
+   * Collect referenced names from every property value.
+   */
+  override referencedNames(): string[] {
+    return [...this.entries.values()].flatMap((node) => node.referencedNames());
+  }
 }

--- a/src/service/cloudformation/template/node/sim-cfn-ref.iso.test.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-ref.iso.test.ts
@@ -1,0 +1,255 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFormationWaitConditionHandle } from "../../resource/factory/sim-cfn-cfn-resource-factory.js";
+import { SimS3Bucket } from "../../../s3/bucket/sim-s3-bucket.js";
+
+describe("CloudFormation Ref Resource value", () => {
+  it("preserves an S3 Bucket Resource Ref in stored Resource properties", async () => {
+    // Given a template where a WaitConditionHandle property Refs an S3 Bucket.
+    const refTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        WaitHandle: {
+          Type: "AWS::CloudFormation::WaitConditionHandle",
+          Properties: {
+            BucketName: {
+              Ref: "SourceBucket",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: refTemplate,
+    });
+
+    // Then both Resources are created successfully.
+    const bucket = simAws.s3().getSimBucketByName("source-bucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, "source-bucket");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const waitHandleResource = stack.resources.get("WaitHandle");
+
+    assertNonNullable(sourceResource);
+    assertNonNullable(waitHandleResource);
+    assertIdentical(sourceResource.status, "CREATE_COMPLETE");
+    assertIdentical(waitHandleResource.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, bucket);
+    assertInstanceOf(
+      waitHandleResource.simResource,
+      SimCloudFormationWaitConditionHandle,
+    );
+
+    // Stored Resource properties represent the template-facing Resource shape, not
+    // an externally observable CloudFormation runtime property bag.
+    assertObjectMatches(waitHandleResource.properties["BucketName"], {
+      Ref: "SourceBucket",
+    });
+  });
+
+  it("resolves a Resource Ref inside Fn::Join when creating another Resource", async () => {
+    // Given a template where one S3 Bucket name is built from a Ref to another
+    // S3 Bucket Resource.
+    const refJoinTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Join": ["-", [{ Ref: "SourceBucket" }, "derived"]],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: refJoinTemplate,
+    });
+
+    // Then the Resource Ref resolves to the source Bucket name during creation of
+    // the derived Bucket.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("source-bucket-derived");
+
+    assertNonNullable(sourceBucket);
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(sourceBucket.bucketName, "source-bucket");
+    assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertNonNullable(sourceResource);
+    assertNonNullable(derivedResource);
+    assertIdentical(sourceResource.status, "CREATE_COMPLETE");
+    assertIdentical(derivedResource.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, sourceBucket);
+    assertIdentical(derivedResource.simResource, derivedBucket);
+  });
+
+  it("resolves Parameter and Resource Refs together inside Fn::Join", async () => {
+    // Given a template where a Bucket name combines an up-front Parameter Ref
+    // with a Resource Ref that must be deferred until Resource creation.
+    const mixedRefJoinTemplate = {
+      Parameters: {
+        BucketPrefix: {
+          Type: "String",
+        },
+      },
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Join": [
+                "-",
+                [{ Ref: "BucketPrefix" }, { Ref: "SourceBucket" }, "derived"],
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: mixedRefJoinTemplate,
+      parameters: {
+        BucketPrefix: "prefix",
+      },
+    });
+
+    // Then the Parameter Ref resolves during template processing, while the
+    // Resource Ref resolves during creation of the derived Bucket.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("prefix-source-bucket-derived");
+
+    assertNonNullable(sourceBucket);
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(sourceBucket.bucketName, "source-bucket");
+    assertIdentical(derivedBucket.bucketName, "prefix-source-bucket-derived");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertNonNullable(sourceResource);
+    assertNonNullable(derivedResource);
+    assertIdentical(sourceResource.status, "CREATE_COMPLETE");
+    assertIdentical(derivedResource.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, sourceBucket);
+    assertIdentical(derivedResource.simResource, derivedBucket);
+  });
+
+  it("resolves multiple Resource Refs inside the same Fn::Join", async () => {
+    // Given a template where one Bucket name depends on multiple Resource Refs.
+    const multipleResourceRefJoinTemplate = {
+      Resources: {
+        FirstBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "bucket-a",
+          },
+        },
+        SecondBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: { "Fn::Join": ["-", [{ Ref: "FirstBucket" }, "b"]] },
+          },
+        },
+        CombinedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Join": [
+                "-",
+                [{ Ref: "FirstBucket" }, { Ref: "SecondBucket" }],
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: multipleResourceRefJoinTemplate,
+    });
+
+    // Then both Resource Refs resolve before the dependent Bucket is created.
+    const firstBucket = simAws.s3().getSimBucketByName("bucket-a");
+    const secondBucket = simAws.s3().getSimBucketByName("bucket-a-b");
+    const combinedBucket = simAws
+      .s3()
+      .getSimBucketByName("bucket-a-bucket-a-b");
+
+    assertNonNullable(firstBucket);
+    assertNonNullable(secondBucket);
+    assertNonNullable(combinedBucket);
+    assertInstanceOf(firstBucket, SimS3Bucket);
+    assertInstanceOf(secondBucket, SimS3Bucket);
+    assertInstanceOf(combinedBucket, SimS3Bucket);
+    assertIdentical(firstBucket.bucketName, "bucket-a");
+    assertIdentical(secondBucket.bucketName, "bucket-a-b");
+    assertIdentical(combinedBucket.bucketName, "bucket-a-bucket-a-b");
+
+    const firstResource = stack.resources.get("FirstBucket");
+    const secondResource = stack.resources.get("SecondBucket");
+    const combinedResource = stack.resources.get("CombinedBucket");
+
+    assertNonNullable(firstResource);
+    assertNonNullable(secondResource);
+    assertNonNullable(combinedResource);
+    assertIdentical(firstResource.status, "CREATE_COMPLETE");
+    assertIdentical(secondResource.status, "CREATE_COMPLETE");
+    assertIdentical(combinedResource.status, "CREATE_COMPLETE");
+    assertIdentical(firstResource.simResource, firstBucket);
+    assertIdentical(secondResource.simResource, secondBucket);
+    assertIdentical(combinedResource.simResource, combinedBucket);
+  });
+});

--- a/src/service/cloudformation/template/node/sim-cfn-ref.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-ref.ts
@@ -10,13 +10,28 @@ export class SimCfnRef extends SimCfnNode {
   }
 
   /**
-   * Resolve the reference from parameters, or preserve it if it is unknown.
+   * Resolve the reference.
+   *
+   * Parameters take precedence, then a referenced Resource's Ref value when a
+   * Resource resolve is available. Otherwise the Ref is preserved unresolved,
+   * which happens during the up-front pass before Resources exist.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
     if (context.parameters.has(this.name)) {
       return context.parameters.value(this.name);
     }
 
+    if (context.resources?.has(this.name) === true) {
+      return context.resources.refValue(this.name);
+    }
+
     return { Ref: this.name };
+  }
+
+  /**
+   * Expose the referenced name for implicit dependency discovery.
+   */
+  override referencedNames(): string[] {
+    return [this.name];
   }
 }

--- a/src/service/cloudformation/template/resolve/sim-cfn-resource-ref-resolver.ts
+++ b/src/service/cloudformation/template/resolve/sim-cfn-resource-ref-resolver.ts
@@ -1,0 +1,20 @@
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+
+/**
+ * Resolves a `{ "Ref": "LogicalId" }` to another Resource's Ref value.
+ *
+ * This is only available once Resources exist at creation time. During the
+ * up-front template resolution pass it is omitted, so Resource Refs are left
+ * unresolved until the referenced Resource has been created.
+ */
+export interface SimCfnResourceRefResolver {
+  /**
+   * Whether a Resource with this logical ID exists in the Stack.
+   */
+  has(logicalId: string): boolean;
+
+  /**
+   * The value the referenced Resource returns for Ref.
+   */
+  refValue(logicalId: string): SimCfnTemplateValue;
+}

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -48,7 +48,7 @@ interface SimCfnTemplateFromJsonProps {
 export class SimCfnTemplate {
   public readonly template: CfnTemplateBodyRecord;
   public readonly stackName: string | undefined;
-  private readonly parameters: SimCfnParameters;
+  public readonly parameters: SimCfnParameters;
 
   constructor(props: SimCfnTemplateProps) {
     const { template, parameters, stackName } = props;
@@ -92,6 +92,9 @@ export class SimCfnTemplate {
 
   /**
    * Get Resource template entries with CloudFormation value expressions resolved.
+   *
+   * Parameters and parameter-only intrinsic functions are resolved here.
+   * Refs to other Resources are left unresolved because the referenced Resources do not exist yet; they are resolved at Resource creation time.
    */
   resourceTemplates(): SimCfnResourceTemplateRecord[] {
     const valueResolver = new SimCfnTemplateValueResolver({

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -5,9 +5,11 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "./sim-cfn-template-value.js";
+import type { SimCfnResourceRefResolver } from "../resolve/sim-cfn-resource-ref-resolver.js";
 
 interface SimCfnTemplateValueResolverProps {
   readonly parameters: SimCfnParameters;
+  readonly resources?: SimCfnResourceRefResolver | undefined;
 }
 
 /**
@@ -17,7 +19,7 @@ export class SimCfnTemplateValueResolver {
   private readonly context: SimCfnResolveContext;
 
   constructor(props: SimCfnTemplateValueResolverProps) {
-    this.context = new SimCfnResolveContext(props.parameters);
+    this.context = new SimCfnResolveContext(props.parameters, props.resources);
   }
 
   /**

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -99,4 +99,13 @@ export class SimS3Bucket {
       this.website,
     );
   }
+
+  /**
+   * The value CloudFormation returns for { "Ref": "<Bucket logical ID>" }.
+   *
+   * Mirroring AWS, a referenced S3 Bucket resolves to its bucket name.
+   */
+  refValue(): string {
+    return this.bucketName;
+  }
 }

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -20,11 +20,9 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
-    void context;
-
     switch (resourceTypeName) {
       case "Bucket": {
-        return await this.createBucket(resource);
+        return await this.createBucket(resource, context);
       }
       default: {
         throw new Error(
@@ -34,8 +32,11 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
     }
   }
 
-  private async createBucket(resource: SimCfnResource): Promise<SimS3Bucket> {
-    const bucketName = this.bucketNameForResource(resource);
+  private async createBucket(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimS3Bucket> {
+    const bucketName = this.bucketNameForResource(resource, context);
 
     await this.simS3.createBucket({
       input: {
@@ -55,8 +56,12 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
     return bucket;
   }
 
-  private bucketNameForResource(resource: SimCfnResource): string {
-    const bucketName = resource.properties["BucketName"];
+  private bucketNameForResource(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): string {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const bucketName = properties["BucketName"];
 
     if (typeof bucketName === "string") {
       return bucketName;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CloudFormation `Ref` expressions now resolve to service-specific values (e.g., S3 bucket names).
  * `Fn::Join` now properly handles resource references, deferring resolution until resource creation.
  * Implicit dependencies are automatically discovered through `Ref` expressions in templates.

* **Bug Fixes**
  * S3 bucket names in joined strings now correctly resolve when referencing other bucket resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->