### PR TITLE
feat: sim CloudFormation Fn::Sub intrinsic function

### DIFF
--- a/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
+++ b/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
@@ -100,6 +100,12 @@ export class SimCfnFnSubVariableResolver {
    * Whether a resolved value is still an unresolved intrinsic expression.
    */
   private isDeferredExpression(value: SimCfnTemplateValue): boolean {
-    return typeof value === "object" && value !== null;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return false;
+    }
+
+    const keys = Object.keys(value);
+
+    return keys.includes("Ref") || keys.some((key) => key.startsWith("Fn::"));
   }
 }

--- a/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
+++ b/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
@@ -1,0 +1,99 @@
+import type {
+  SimCfnNode,
+  SimCfnResolveContext,
+} from "../../../sim-cfn-node.js";
+import type { SimCfnTemplateValue } from "../../../../value/sim-cfn-template-value.js";
+import { assertDefined } from "../../../../../../../util/type-guard/defined.js";
+import { SimCfnGetAtt } from "../../get-att/sim-cfn-fn-get-att.js";
+import { SimCfnRef } from "../../../sim-cfn-ref.js";
+
+/**
+ * Resolves Fn::Sub variables from explicit overrides or implicit Ref/GetAtt
+ * expressions.
+ */
+export class SimCfnFnSubVariableResolver {
+  constructor(private readonly variables: ReadonlyMap<string, SimCfnNode>) {}
+
+  /**
+   * Resolve all variable names used by a Fn::Sub template.
+   */
+  resolveAll(
+    variableNames: readonly string[],
+    context: SimCfnResolveContext,
+  ): ReadonlyMap<string, SimCfnTemplateValue> {
+    return new Map(
+      variableNames.map((variableName) => [
+        variableName,
+        this.resolveRequiredStringOrDeferred(variableName, context),
+      ]),
+    );
+  }
+
+  /**
+   * Convert resolved variables to string variables after deferred expressions
+   * have already been ruled out.
+   */
+  stringVariables(
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): ReadonlyMap<string, string> {
+    return new Map(
+      [...resolvedVariables].map(([name, value]) => {
+        /* v8 ignore if -- unreachable defensive check */
+        if (typeof value !== "string") {
+          throw new TypeError(
+            `Sim CloudFormation Fn::Sub variable ${name} must resolve to a string, got ${typeof value}`,
+          );
+        }
+
+        return [name, value];
+      }),
+    );
+  }
+
+  private resolveRequiredStringOrDeferred(
+    variableName: string,
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    const resolved = this.resolveVariable(variableName, context);
+
+    if (typeof resolved !== "string" && !this.isDeferredExpression(resolved)) {
+      throw new TypeError(
+        `Sim CloudFormation Fn::Sub variable ${variableName} must resolve to a string, got ${typeof resolved}`,
+      );
+    }
+
+    return resolved;
+  }
+
+  private resolveVariable(
+    variableName: string,
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    const explicitVariable = this.variables.get(variableName);
+
+    if (explicitVariable !== undefined) {
+      return explicitVariable.resolve(context);
+    }
+
+    if (variableName.includes(".")) {
+      const [logicalId, ...attributeParts] = variableName.split(".");
+      assertDefined(
+        logicalId,
+        `Logical ID in CFN Fn::Sub variable ${variableName}`,
+      );
+
+      return new SimCfnGetAtt(logicalId, attributeParts.join(".")).resolve(
+        context,
+      );
+    }
+
+    return new SimCfnRef(variableName).resolve(context);
+  }
+
+  /**
+   * Whether a resolved value is still an unresolved intrinsic expression.
+   */
+  private isDeferredExpression(value: SimCfnTemplateValue): boolean {
+    return typeof value === "object" && value !== null;
+  }
+}

--- a/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
+++ b/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-variable-resolver.ts
@@ -82,6 +82,12 @@ export class SimCfnFnSubVariableResolver {
         `Logical ID in CFN Fn::Sub variable ${variableName}`,
       );
 
+      if (logicalId === "") {
+        throw new Error(
+          `Logical ID in CFN Fn::Sub variable ${variableName} must be non-empty`,
+        );
+      }
+
       return new SimCfnGetAtt(logicalId, attributeParts.join(".")).resolve(
         context,
       );

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
@@ -1,0 +1,144 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("CloudFormation Fn::Sub literals", () => {
+  it("substitutes explicit variable values", async () => {
+    const subTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                "${Prefix}-${Name}",
+                {
+                  Prefix: "my",
+                  Name: "bucket",
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subTemplate,
+    });
+
+    const bucket = simAws.s3().getSimBucketByName("my-bucket");
+
+    assertNonNullable(bucket);
+    assertIdentical(bucket.bucketName, "my-bucket");
+  });
+
+  it("substitutes explicit variable values that contain Parameter Refs", async () => {
+    const subTemplate = {
+      Parameters: {
+        Environment: {
+          Type: "String",
+          Default: "dev",
+        },
+      },
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                "my-${EnvName}-bucket",
+                {
+                  EnvName: {
+                    Ref: "Environment",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subTemplate,
+    });
+
+    const bucket = simAws.s3().getSimBucketByName("my-dev-bucket");
+
+    assertNonNullable(bucket);
+    assertIdentical(bucket.bucketName, "my-dev-bucket");
+  });
+
+  it("keeps escaped substitutions literal", async () => {
+    const subTemplate = {
+      Resources: {
+        WaitHandle: {
+          Type: "AWS::CloudFormation::WaitConditionHandle",
+          Properties: {
+            Value: {
+              "Fn::Sub": "literal-${!Name}",
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subTemplate,
+    });
+
+    const resource = stack.resources.get("WaitHandle");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.properties["Value"], "literal-${Name}");
+  });
+
+  it("throws when an Fn::Sub variable does not resolve to a string", async () => {
+    const invalidSubTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                "my-${Name}-bucket",
+                {
+                  Name: 123,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub variable Name must resolve to a string, got number",
+    );
+  });
+});

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
@@ -1,0 +1,263 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("CloudFormation Fn::Sub Resource referential", () => {
+  it("substitutes a Parameter Ref in a string to name an S3 Bucket", async () => {
+    const subTemplate = {
+      Parameters: {
+        Environment: {
+          Type: "String",
+        },
+      },
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": "my-${Environment}-bucket",
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subTemplate,
+      parameters: {
+        Environment: "prod",
+      },
+    });
+
+    const bucket = simAws.s3().getSimBucketByName("my-prod-bucket");
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, "my-prod-bucket");
+
+    const resource = stack.resources.get("TestBucket");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertIdentical(resource.simResource, bucket);
+  });
+
+  it("resolves a Resource Ref inside Fn::Sub when creating another Resource", async () => {
+    // Given a template where one S3 Bucket name is built from a Fn::Sub reference
+    // to another S3 Bucket Resource.
+    const subRefTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": "${SourceBucket}-derived",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subRefTemplate,
+    });
+
+    // Then the Resource Ref is deferred during template parsing and resolved
+    // during creation of the derived Bucket.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("source-bucket-derived");
+
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(sourceBucket.bucketName, "source-bucket");
+    assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertIdentical(sourceResource?.status, "CREATE_COMPLETE");
+    assertIdentical(derivedResource?.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, sourceBucket);
+    assertIdentical(derivedResource.simResource, derivedBucket);
+  });
+
+  it("resolves a Resource Ref from an explicit Fn::Sub variable map", async () => {
+    // Given a template where Fn::Sub's template variable is an alias, and the
+    // explicit variable map contains the actual Resource Ref dependency.
+    const subRefTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                "${BucketName}-derived",
+                {
+                  BucketName: {
+                    Ref: "SourceBucket",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subRefTemplate,
+    });
+
+    // Then the explicit variable Ref is discovered as a dependency and resolves
+    // during creation of the derived Bucket.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("source-bucket-derived");
+
+    assertNonNullable(sourceBucket);
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(sourceBucket.bucketName, "source-bucket");
+    assertIdentical(derivedBucket.bucketName, "source-bucket-derived");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertNonNullable(sourceResource);
+    assertNonNullable(derivedResource);
+    assertIdentical(sourceResource.status, "CREATE_COMPLETE");
+    assertIdentical(derivedResource.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, sourceBucket);
+    assertIdentical(derivedResource.simResource, derivedBucket);
+  });
+
+  it("resolves a Resource attribute reference inside Fn::Sub", async () => {
+    // Given a template where Fn::Sub references a Resource attribute using
+    // ${LogicalId.AttributeName} syntax.
+    const subGetAttTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": "${SourceBucket.Arn}-derived",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: subGetAttTemplate,
+    });
+
+    // Then the dotted Fn::Sub variable is resolved as a Resource attribute when
+    // creating the derived Bucket.
+    const sourceBucket = simAws.s3().getSimBucketByName("source-bucket");
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("source-bucket.Arn-derived");
+
+    assertNonNullable(sourceBucket);
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(sourceBucket, SimS3Bucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(sourceBucket.bucketName, "source-bucket");
+    assertIdentical(derivedBucket.bucketName, "source-bucket.Arn-derived");
+
+    const sourceResource = stack.resources.get("SourceBucket");
+    const derivedResource = stack.resources.get("DerivedBucket");
+
+    assertNonNullable(sourceResource);
+    assertNonNullable(derivedResource);
+    assertIdentical(sourceResource.status, "CREATE_COMPLETE");
+    assertIdentical(derivedResource.status, "CREATE_COMPLETE");
+    assertIdentical(sourceResource.simResource, sourceBucket);
+    assertIdentical(derivedResource.simResource, derivedBucket);
+  });
+
+  it("throws when an explicit Fn::Sub variable is not resolved while preserving an unresolved Resource Ref", async () => {
+    // Given a template where Fn::Sub has a deferred Resource Ref and an explicit
+    // variable map entry that is not used by the template string.
+    const invalidSubTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                "${SourceBucket}-derived",
+                {
+                  UnusedName: "unused",
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    // Then preserving the unresolved Fn::Sub fails on the unused explicit variable.
+    assertInstanceOf(error, Error);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub variable UnusedName was not resolved",
+    );
+  });
+});

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
@@ -260,4 +260,33 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
       "Sim CloudFormation Fn::Sub variable UnusedName was not resolved",
     );
   });
+
+  it("throws when a dotted Fn::Sub variable has an empty logical ID", async () => {
+    const invalidSubTemplate = {
+      Resources: {
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": "${.AttributeName}",
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    assertInstanceOf(error, Error);
+    assertIdentical(
+      error.message,
+      "Logical ID in CFN Fn::Sub variable .AttributeName must be non-empty",
+    );
+  });
 });

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
@@ -1,0 +1,167 @@
+import { SimCfnNode, type SimCfnResolveContext } from "../../sim-cfn-node.js";
+import { SimCfnGetAtt } from "../get-att/sim-cfn-fn-get-att.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { SimCfnRef } from "../../sim-cfn-ref.js";
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+import { SimCfnFnSubTemplate } from "./template/sim-cfn-fn-sub-template.js";
+
+/**
+ * Simulated CloudFormation `Fn::Sub` intrinsic function.
+ *
+ * Supported shapes:
+ *
+ * {
+ *   "Fn::Sub": "arn:aws:s3:::${BucketName}"
+ * }
+ *
+ * {
+ *   "Fn::Sub": ["${Prefix}-${Name}", { "Prefix": "my", "Name": { "Ref": "Env" } }]
+ * }
+ */
+export class SimCfnFnSub extends SimCfnNode {
+  private readonly subTemplate: SimCfnFnSubTemplate;
+
+  constructor(
+    private readonly template: string,
+    private readonly variables: ReadonlyMap<string, SimCfnNode> = new Map(),
+  ) {
+    super();
+
+    this.subTemplate = new SimCfnFnSubTemplate(template);
+  }
+
+  /**
+   * Resolve every substitution variable and replace it in the template string.
+   *
+   * If a referenced value is still unresolved, this node re-emits itself in
+   * template form so a later Resource resolution pass can finish it.
+   */
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const resolvedVariables = new Map<string, SimCfnTemplateValue>();
+
+    for (const variableName of this.subTemplate.variableNames()) {
+      const resolved = this.resolveVariable(variableName, context);
+
+      if (
+        typeof resolved !== "string" &&
+        !this.isDeferredExpression(resolved)
+      ) {
+        throw new TypeError(
+          `Sim CloudFormation Fn::Sub variable ${variableName} must resolve to a string, got ${typeof resolved}`,
+        );
+      }
+
+      resolvedVariables.set(variableName, resolved);
+    }
+
+    // Resource Refs/GetAtts can be unresolved during the initial template pass,
+    // before Resources have been created. Preserve the Fn::Sub expression so
+    // the later Resource-creation resolution pass can substitute the final
+    // string.
+    if (
+      [...resolvedVariables.values()].some((value) => typeof value !== "string")
+    ) {
+      return this.unresolvedTemplateValue(resolvedVariables);
+    }
+
+    return this.subTemplate.substitute(this.stringVariables(resolvedVariables));
+  }
+
+  /**
+   * Collect referenced names from explicit variable values and implicit
+   * substitution references.
+   */
+  override referencedNames(): string[] {
+    return [
+      ...[...this.variables.values()].flatMap((value) =>
+        value.referencedNames(),
+      ),
+      ...this.subTemplate
+        .logicalNames()
+        .filter((name) => !this.variables.has(name)),
+    ];
+  }
+
+  private resolveVariable(
+    variableName: string,
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    const explicitVariable = this.variables.get(variableName);
+
+    if (explicitVariable !== undefined) {
+      return explicitVariable.resolve(context);
+    }
+
+    if (variableName.includes(".")) {
+      const [logicalId, ...attributeParts] = variableName.split(".");
+      assertDefined(
+        logicalId,
+        `Logical ID in CFN Fn::Sub variable ${variableName}`,
+      );
+      const attributeName = attributeParts.join(".");
+
+      return new SimCfnGetAtt(logicalId, attributeName).resolve(context);
+    }
+
+    return new SimCfnRef(variableName).resolve(context);
+  }
+
+  private unresolvedTemplateValue(
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): SimCfnTemplateValue {
+    if (this.variables.size === 0) {
+      return { "Fn::Sub": this.template };
+    }
+
+    return {
+      "Fn::Sub": [
+        this.template,
+        Object.fromEntries(
+          [...this.variables.keys()].map((name) => [
+            name,
+            this.requiredResolvedVariable(name, resolvedVariables),
+          ]),
+        ),
+      ],
+    };
+  }
+
+  private requiredResolvedVariable(
+    name: string,
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): SimCfnTemplateValue {
+    const resolved = resolvedVariables.get(name);
+
+    if (resolved === undefined) {
+      throw new Error(
+        `Sim CloudFormation Fn::Sub variable ${name} was not resolved`,
+      );
+    }
+
+    return resolved;
+  }
+
+  private stringVariables(
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): ReadonlyMap<string, string> {
+    return new Map(
+      [...resolvedVariables].map(([name, value]) => {
+        /* v8 ignore if -- unreachable defensive check */
+        if (typeof value !== "string") {
+          throw new TypeError(
+            `Sim CloudFormation Fn::Sub variable ${name} must resolve to a string, got ${typeof value}`,
+          );
+        }
+
+        return [name, value];
+      }),
+    );
+  }
+
+  /**
+   * Whether a resolved value is still an unresolved intrinsic expression.
+   */
+  private isDeferredExpression(value: SimCfnTemplateValue): boolean {
+    return typeof value === "object" && value !== null;
+  }
+}

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
@@ -1,9 +1,7 @@
 import { SimCfnNode, type SimCfnResolveContext } from "../../sim-cfn-node.js";
-import { SimCfnGetAtt } from "../get-att/sim-cfn-fn-get-att.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
-import { SimCfnRef } from "../../sim-cfn-ref.js";
-import { assertDefined } from "../../../../../../util/type-guard/defined.js";
 import { SimCfnFnSubTemplate } from "./template/sim-cfn-fn-sub-template.js";
+import { SimCfnFnSubVariableResolver } from "./resolve/sim-cfn-fn-sub-variable-resolver.js";
 
 /**
  * Simulated CloudFormation `Fn::Sub` intrinsic function.
@@ -20,6 +18,7 @@ import { SimCfnFnSubTemplate } from "./template/sim-cfn-fn-sub-template.js";
  */
 export class SimCfnFnSub extends SimCfnNode {
   private readonly subTemplate: SimCfnFnSubTemplate;
+  private readonly variableResolver: SimCfnFnSubVariableResolver;
 
   constructor(
     private readonly template: string,
@@ -28,6 +27,7 @@ export class SimCfnFnSub extends SimCfnNode {
     super();
 
     this.subTemplate = new SimCfnFnSubTemplate(template);
+    this.variableResolver = new SimCfnFnSubVariableResolver(variables);
   }
 
   /**
@@ -37,22 +37,10 @@ export class SimCfnFnSub extends SimCfnNode {
    * template form so a later Resource resolution pass can finish it.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
-    const resolvedVariables = new Map<string, SimCfnTemplateValue>();
-
-    for (const variableName of this.subTemplate.variableNames()) {
-      const resolved = this.resolveVariable(variableName, context);
-
-      if (
-        typeof resolved !== "string" &&
-        !this.isDeferredExpression(resolved)
-      ) {
-        throw new TypeError(
-          `Sim CloudFormation Fn::Sub variable ${variableName} must resolve to a string, got ${typeof resolved}`,
-        );
-      }
-
-      resolvedVariables.set(variableName, resolved);
-    }
+    const resolvedVariables = this.variableResolver.resolveAll(
+      this.subTemplate.variableNames(),
+      context,
+    );
 
     // Resource Refs/GetAtts can be unresolved during the initial template pass,
     // before Resources have been created. Preserve the Fn::Sub expression so
@@ -64,7 +52,9 @@ export class SimCfnFnSub extends SimCfnNode {
       return this.unresolvedTemplateValue(resolvedVariables);
     }
 
-    return this.subTemplate.substitute(this.stringVariables(resolvedVariables));
+    return this.subTemplate.substitute(
+      this.variableResolver.stringVariables(resolvedVariables),
+    );
   }
 
   /**
@@ -77,33 +67,10 @@ export class SimCfnFnSub extends SimCfnNode {
         value.referencedNames(),
       ),
       ...this.subTemplate
-        .logicalNames()
-        .filter((name) => !this.variables.has(name)),
+        .variableNames()
+        .filter((variableName) => !this.variables.has(variableName))
+        .map((variableName) => variableName.split(".")[0] ?? variableName),
     ];
-  }
-
-  private resolveVariable(
-    variableName: string,
-    context: SimCfnResolveContext,
-  ): SimCfnTemplateValue {
-    const explicitVariable = this.variables.get(variableName);
-
-    if (explicitVariable !== undefined) {
-      return explicitVariable.resolve(context);
-    }
-
-    if (variableName.includes(".")) {
-      const [logicalId, ...attributeParts] = variableName.split(".");
-      assertDefined(
-        logicalId,
-        `Logical ID in CFN Fn::Sub variable ${variableName}`,
-      );
-      const attributeName = attributeParts.join(".");
-
-      return new SimCfnGetAtt(logicalId, attributeName).resolve(context);
-    }
-
-    return new SimCfnRef(variableName).resolve(context);
   }
 
   private unresolvedTemplateValue(
@@ -139,29 +106,5 @@ export class SimCfnFnSub extends SimCfnNode {
     }
 
     return resolved;
-  }
-
-  private stringVariables(
-    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
-  ): ReadonlyMap<string, string> {
-    return new Map(
-      [...resolvedVariables].map(([name, value]) => {
-        /* v8 ignore if -- unreachable defensive check */
-        if (typeof value !== "string") {
-          throw new TypeError(
-            `Sim CloudFormation Fn::Sub variable ${name} must resolve to a string, got ${typeof value}`,
-          );
-        }
-
-        return [name, value];
-      }),
-    );
-  }
-
-  /**
-   * Whether a resolved value is still an unresolved intrinsic expression.
-   */
-  private isDeferredExpression(value: SimCfnTemplateValue): boolean {
-    return typeof value === "object" && value !== null;
   }
 }

--- a/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.iso.test.ts
@@ -1,0 +1,95 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnFnSubTemplate } from "./sim-cfn-fn-sub-template.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("SimAws CloudFormation Fn::Sub template string", () => {
+  it("returns no variable names for a template without substitutions", () => {
+    // Given a template string with no Fn::Sub variables.
+    const template = new SimCfnFnSubTemplate("plain-bucket-name");
+
+    // When the variable names are read.
+    const variableNames = template.variableNames();
+
+    // Then no variable names are returned.
+    assertArrayLength(variableNames, 0);
+  });
+
+  it("returns unique non-escaped variable names in first-seen order", () => {
+    // Given a template string with repeated and escaped variables.
+    const template = new SimCfnFnSubTemplate(
+      "${Prefix}-${Name}-${Prefix}-${!Literal}",
+    );
+
+    // When the variable names are read.
+    const variableNames = template.variableNames();
+
+    // Then repeated names are deduplicated and escaped names are ignored.
+    assertArrayLength(variableNames, 2);
+    assertIdentical(variableNames[0], "Prefix");
+    assertIdentical(variableNames[1], "Name");
+  });
+
+  it("substitutes every matching variable occurrence", () => {
+    // Given a template string with repeated variables.
+    const template = new SimCfnFnSubTemplate("${Prefix}-${Name}-${Prefix}");
+
+    // When resolved values are substituted.
+    const resolved = template.substitute(
+      new Map([
+        ["Prefix", "my"],
+        ["Name", "bucket"],
+      ]),
+    );
+
+    // Then every variable occurrence is replaced.
+    assertIdentical(resolved, "my-bucket-my");
+  });
+
+  it("keeps escaped variables literal during substitution", () => {
+    // Given a template string with an escaped Fn::Sub variable.
+    const template = new SimCfnFnSubTemplate("literal-${!Name}-${Name}");
+
+    // When resolved values are substituted.
+    const resolved = template.substitute(new Map([["Name", "bucket"]]));
+
+    // Then the escaped variable is emitted literally.
+    assertIdentical(resolved, "literal-${Name}-bucket");
+  });
+
+  it("returns logical names with attribute suffixes removed", () => {
+    // Given a template string with Ref-style and GetAtt-style variables.
+    const template = new SimCfnFnSubTemplate(
+      "${Bucket}-${Distribution.DomainName}",
+    );
+
+    // When logical names are read.
+    const logicalNames = template.logicalNames();
+
+    // Then attribute suffixes are removed.
+    assertArrayLength(logicalNames, 2);
+    assertIdentical(logicalNames[0], "Bucket");
+    assertIdentical(logicalNames[1], "Distribution");
+  });
+
+  it("throws when a substitution variable has no resolved value", () => {
+    // Given a template string with a variable.
+    const template = new SimCfnFnSubTemplate("${Name}");
+
+    // When substitution runs without that variable, then it throws.
+    const error = assertThrowsError(() => {
+      template.substitute(new Map());
+    });
+
+    // Then the missing variable is named in the error.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub variable Name was not resolved",
+    );
+  });
+});

--- a/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.ts
+++ b/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.ts
@@ -1,0 +1,60 @@
+/**
+ * Template-string helper for CloudFormation Fn::Sub.
+ *
+ * Owns the `${Name}` syntax details so the Fn::Sub node can focus on resolving
+ * CloudFormation values.
+ */
+export class SimCfnFnSubTemplate {
+  private static readonly variablePattern = /\${(!?)([\w.:]+)}/g;
+
+  constructor(private readonly template: string) {}
+
+  /**
+   * Return non-escaped substitution variable names from this template.
+   */
+  variableNames(): string[] {
+    return [
+      ...new Set(
+        [...this.template.matchAll(SimCfnFnSubTemplate.variablePattern)]
+          .filter((match) => match[1] !== "!")
+          .map((match) => match[2])
+          .filter((name): name is string => name !== undefined),
+      ),
+    ];
+  }
+
+  /**
+   * Replace substitution variables with already-resolved string values.
+   */
+  substitute(variables: ReadonlyMap<string, string>): string {
+    return this.template.replace(
+      SimCfnFnSubTemplate.variablePattern,
+      (_match, escaped: string, variableName: string): string => {
+        if (escaped === "!") {
+          return `\${${variableName}}`;
+        }
+
+        const resolved = variables.get(variableName);
+
+        if (resolved === undefined) {
+          throw new Error(
+            `Sim CloudFormation Fn::Sub variable ${variableName} was not resolved`,
+          );
+        }
+
+        return resolved;
+      },
+    );
+  }
+
+  /**
+   * Convert Fn::Sub variable names to referenced CloudFormation logical names.
+   */
+  logicalNames(): string[] {
+    return this.variableNames().map((name) => this.logicalName(name));
+  }
+
+  private logicalName(variableName: string): string {
+    return variableName.split(".")[0] ?? variableName;
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValue } from "../../value/sim-cfn-template-value.js"
 import { SimCfnFnGetAttParser } from "./get-att/sim-cfn-fn-get-att-parser.js";
 import { SimCfnFnJoinParser } from "./join/sim-cfn-fn-join-parser.js";
 import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
+import { SimCfnFnSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
 
 /**
  * Parses CloudFormation intrinsic function objects.
@@ -19,11 +20,14 @@ import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
  * that need child values parsed recursively.
  */
 export class SimCfnFunctionParser {
-  private readonly fnGetAttParser = new SimCfnFnGetAttParser();
+  private readonly fnGetAttParser: SimCfnFnGetAttParser;
   private readonly fnJoinParser: SimCfnFnJoinParser;
+  private readonly fnSubParser: SimCfnFnSubParser;
 
   constructor(valueParser: SimCfnValueParser) {
+    this.fnGetAttParser = new SimCfnFnGetAttParser();
     this.fnJoinParser = new SimCfnFnJoinParser(valueParser);
+    this.fnSubParser = new SimCfnFnSubParser(valueParser);
   }
 
   /**
@@ -59,6 +63,10 @@ export class SimCfnFunctionParser {
   ): SimCfnNode {
     if (functionName === "Fn::Join") {
       return this.fnJoinParser.parse(value);
+    }
+
+    if (functionName === "Fn::Sub") {
+      return this.fnSubParser.parse(value);
     }
 
     if (functionName === "Fn::GetAtt") {

--- a/src/service/cloudformation/template/parse/fn/sub/sim-cfn-fn-sub-parser.iso.test.ts
+++ b/src/service/cloudformation/template/parse/fn/sub/sim-cfn-fn-sub-parser.iso.test.ts
@@ -1,0 +1,103 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("CloudFormation Fn::Sub parser", () => {
+  it("throws when an Fn::Sub value is not a valid shape", async () => {
+    const invalidSubTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": ["my-${Name}-bucket"],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    assertInstanceOf(error, Error);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub value must be a string or [string, variables]",
+    );
+  });
+
+  it("throws when an Fn::Sub array template is not a string", async () => {
+    const invalidSubTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": [
+                123,
+                {
+                  Name: "bucket",
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub template must be a string",
+    );
+  });
+
+  it("throws when an Fn::Sub variables value is not an object", async () => {
+    const invalidSubTemplate = {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": ["my-${Name}-bucket", "bucket"],
+            },
+          },
+        },
+      },
+    };
+
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "test-stack",
+        template: invalidSubTemplate,
+      }),
+    );
+
+    assertInstanceOf(error, TypeError);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Sub variables must be an object",
+    );
+  });
+});

--- a/src/service/cloudformation/template/parse/fn/sub/sim-cfn-fn-sub-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sub/sim-cfn-fn-sub-parser.ts
@@ -1,0 +1,62 @@
+import { isRecord } from "../../../../../../util/type-guard/record.js";
+import { SimCfnFnSub } from "../../../node/fn/sub/sim-cfn-fn-sub.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
+
+/**
+ * Parses CloudFormation Fn::Sub values.
+ *
+ * Fn::Sub has either shape:
+ *
+ * {
+ *   "Fn::Sub": "prefix-${Name}"
+ * }
+ *
+ * or:
+ *
+ * {
+ *   "Fn::Sub": ["prefix-${Name}", { "Name": { "Ref": "SomeName" } }]
+ * }
+ */
+export class SimCfnFnSubParser {
+  constructor(private readonly valueParser: SimCfnValueParser) {}
+
+  /**
+   * Parse and validate the value inside a Fn::Sub expression.
+   */
+  parse(value: SimCfnTemplateValue): SimCfnFnSub {
+    if (typeof value === "string") {
+      return new SimCfnFnSub(value);
+    }
+
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error(
+        "Sim CloudFormation Fn::Sub value must be a string or [string, variables]",
+      );
+    }
+
+    const [template, variables] = value;
+
+    if (typeof template !== "string") {
+      throw new TypeError(
+        "Sim CloudFormation Fn::Sub template must be a string",
+      );
+    }
+
+    if (!isRecord(variables)) {
+      throw new TypeError(
+        "Sim CloudFormation Fn::Sub variables must be an object",
+      );
+    }
+
+    return new SimCfnFnSub(
+      template,
+      new Map(
+        Object.entries(variables).map(([name, variableValue]) => [
+          name,
+          this.valueParser.parse(variableValue),
+        ]),
+      ),
+    );
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added simulation support for CloudFormation `Fn::Sub`, including template string substitution, explicit variable mappings, parameter `Ref`, and attribute/dotted-name resolution.
  * Preserves escaped literals (e.g., `${!Name}`) and defers resolution when values depend on other resources.
  * Improves validation by failing with clear error messaging when substitutions resolve to non-string values or when the `Fn::Sub` structure is invalid.

* **Tests**
  * Added coverage for `Fn::Sub` parsing, substitution/escaping behavior, referential/deferred resolution, and exact error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->