### PR TITLE
fix: remove sim S3 storage allowChangeStorage mechanism

### DIFF
--- a/src/service/s3/bucket/s3-bucket.iso.test.ts
+++ b/src/service/s3/bucket/s3-bucket.iso.test.ts
@@ -16,7 +16,6 @@ import { tmpdir } from "node:os";
 import { SimS3Object } from "../object/s3-object.js";
 import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
 import { SimS3Bucket } from "./sim-s3-bucket.js";
-import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { TempDir } from "../../../util/filesystem/temp-dir.js";
 import { SimS3 } from "../sim-s3.js";
 import { Readable } from "node:stream";
@@ -147,23 +146,6 @@ describe("Simulated S3 Bucket", () => {
     assertNonNullable(object);
     assertIdentical(object.key, "foo.txt");
     assertBufferEqual(object.body, Buffer.from("foo"));
-  });
-
-  it("rejects changing storage implementation after storing Objects", async () => {
-    const bucket = new SimS3Bucket({ bucketName: "bucket-a" });
-
-    await bucket.putObject(
-      new SimS3Object({ key: "foo.txt", body: Buffer.from("foo") }),
-    );
-
-    const error = assertThrowsError(() => {
-      bucket.configureSimStorage(new MemoryS3BucketStorage());
-    });
-
-    assertStringIncludes(
-      error.message,
-      "Cannot change simulated S3 storage implementation",
-    );
   });
 
   it("gets a static website URL", () => {

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -66,9 +66,6 @@ export class SimS3Bucket {
    * Change the storage implementation for this simulated S3 Bucket.
    */
   configureSimStorage(storage: SimS3BucketStorage): void {
-    if (!this.storage.allowChangeStorage()) {
-      throw new Error("Cannot change simulated S3 storage implementation");
-    }
     this.storage = storage;
   }
 

--- a/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import { homedir, tmpdir } from "node:os";
 import {
-  assertFalse,
   assertStringIncludes,
   assertThrowsError,
   assertThrowsErrorAsync,
@@ -76,18 +75,6 @@ describe("Filesystem simulated S3 storage safety", () => {
     });
 
     assertStringIncludes(error.message, "must not contain '..'");
-  });
-
-  it("allows custom safe storage directory names", async () => {
-    const tempRootPath = await mkdtemp(path.join(tmpdir(), "yulin-s3-test-"));
-    const directoryPath = path.join(tempRootPath, "private");
-
-    const storage = new FilesystemS3BucketStorage({
-      directoryPath,
-      allowedDirectoryNames: ["private"],
-    });
-
-    assertFalse(storage.allowChangeStorage());
   });
 
   it("rejects absolute Object key", async () => {

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
@@ -3,7 +3,6 @@ import { symlink } from "node:fs/promises";
 import {
   assertArrayLength,
   assertBufferEqual,
-  assertFalse,
   assertIdentical,
   assertNonNullable,
   assertUndefined,
@@ -49,12 +48,6 @@ describe("Filesystem simulated S3 storage", () => {
     const objects = await storage.listObjects();
 
     assertArrayLength(objects, 0);
-  });
-
-  it("does not allow changing storage implementation", async () => {
-    const storage = await makeFilesystemStorage();
-
-    assertFalse(storage.allowChangeStorage());
   });
 
   it("lists Objects from the filesystem", async () => {

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -98,15 +98,6 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
     await writeFile(filePath, object.body);
   }
 
-  /**
-   * Is it OK to change to a different storage implementation?
-   * For now, we're assuming that a user should not need to change from a
-   * filesystem storage at runtime, so this is always false.
-   */
-  allowChangeStorage(): boolean {
-    return false;
-  }
-
   private filePathForObjectKey(key: string): string {
     this.safety.assertSafeObjectKey(key);
 

--- a/src/service/s3/storage/s3-bucket-storage.ts
+++ b/src/service/s3/storage/s3-bucket-storage.ts
@@ -15,9 +15,4 @@ export interface SimS3BucketStorage {
    * List simulated Objects in storage.
    */
   listObjects(prefix?: string): Promise<SimS3Object[]>;
-
-  /**
-   * Is it OK to change to a different storage implementation?
-   */
-  allowChangeStorage(): boolean;
 }

--- a/src/service/s3/storage/s3-memory-storage.ts
+++ b/src/service/s3/storage/s3-memory-storage.ts
@@ -32,13 +32,4 @@ export class MemoryS3BucketStorage implements SimS3BucketStorage {
     this.objects.set(object.key, object);
     return Promise.resolve();
   }
-
-  /**
-   * Is it OK to change to a different storage implementation?
-   * To reduce unexpected behaviours, we disallow changing from in-memory
-   * storage if it currently contains any objects.
-   */
-  allowChangeStorage(): boolean {
-    return this.objects.size === 0;
-  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified S3 storage management by removing restrictions on switching storage implementations. Storage backend changes are now permitted at any point in the application lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->