### PR TITLE
test: replace node:fs with TempDir util across all tests

### DIFF
--- a/src/service/s3/bucket/s3-bucket.iso.test.ts
+++ b/src/service/s3/bucket/s3-bucket.iso.test.ts
@@ -10,9 +10,6 @@ import {
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
-import { mkdir, mkdtemp } from "node:fs/promises";
-import path from "node:path";
-import { tmpdir } from "node:os";
 import { SimS3Object } from "../object/s3-object.js";
 import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
 import { SimS3Bucket } from "./sim-s3-bucket.js";
@@ -234,11 +231,10 @@ interface StorageFactory {
 }
 
 async function makeFilesystemStorage(): Promise<FilesystemS3BucketStorage> {
-  const tempRootPath = await mkdtemp(path.join(tmpdir(), "yulin-s3-test-"));
-  const directoryPath = path.join(tempRootPath, "public");
+  const tempDir = new TempDir();
+  await tempDir.resolvePath();
 
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  await mkdir(directoryPath);
-
-  return new FilesystemS3BucketStorage({ directoryPath });
+  return new FilesystemS3BucketStorage({
+    directoryPath: tempDir.join("public"),
+  });
 }

--- a/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "vitest";
-import { mkdtemp } from "node:fs/promises";
 import path from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import {
   assertStringIncludes,
   assertThrowsError,
@@ -24,7 +23,7 @@ describe("Filesystem simulated S3 storage safety", () => {
     const error = assertThrowsError(
       () =>
         new FilesystemS3BucketStorage({
-          directoryPath: path.parse(tmpdir()).root,
+          directoryPath: path.parse(homedir()).root,
         }),
     );
 
@@ -39,11 +38,14 @@ describe("Filesystem simulated S3 storage safety", () => {
     assertStringIncludes(error.message, "must not be the user home directory");
   });
 
-  it("rejects storage directory path with parent directory segment", () => {
+  it("rejects storage directory path with parent directory segment", async () => {
+    const testDir = new TempDir();
+    await testDir.resolvePath();
+
     const error = assertThrowsError(
       () =>
         new FilesystemS3BucketStorage({
-          directoryPath: `${tmpdir()}/../public`,
+          directoryPath: `${testDir.path()}/../public`,
         }),
     );
 
@@ -51,8 +53,9 @@ describe("Filesystem simulated S3 storage safety", () => {
   });
 
   it("rejects storage directory path with unsafe directory name", async () => {
-    const tempRootPath = await mkdtemp(path.join(tmpdir(), "yulin-s3-test-"));
-    const directoryPath = path.join(tempRootPath, "private");
+    const testDir = new TempDir();
+    await testDir.resolvePath();
+    const directoryPath = testDir.join("private");
 
     const error = assertThrowsError(
       () => new FilesystemS3BucketStorage({ directoryPath }),
@@ -87,7 +90,7 @@ describe("Filesystem simulated S3 storage safety", () => {
     const error = await assertThrowsErrorAsync(async () => {
       await storage.putObject(
         new SimS3Object({
-          key: path.join(tmpdir(), "secret.txt"),
+          key: testDir.join("secret.txt"),
           body: Buffer.from("secret"),
         }),
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated S3 bucket storage and filesystem safety test infrastructure to use improved temporary directory utilities for cleaner test setup and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->