### PR TITLE
fix: sim CloudFront alternate domains in sim CloudFront Registry

### DIFF
--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -7,7 +7,7 @@ import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-sco
 import type { SimAws } from "../sim-aws.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
 import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
-import { SimCloudFrontRegistry } from "../../cloudfront/sim-cloud-front-registry.js";
+import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
 import { SimDynamoDb } from "../../dynamodb/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -16,7 +16,7 @@ import {
 import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scope.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
-import type { SimCloudFrontRegistry } from "../cloudfront/sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -92,6 +92,13 @@ export class CreateDistributionCommandHandler implements CommandHandler<
       this.accountId,
     );
 
+    for (const alternateDomainName of distribution.getAlternateDomainNames()) {
+      this.cloudFrontRegistry.registerAlternateDomainName(
+        alternateDomainName,
+        distribution.distributionId,
+      );
+    }
+
     // Schedule background task to complete deployment of the sim Distribution.
     this.background.schedule(() => distribution.completeDeployment());
 

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -3,7 +3,7 @@ import type {
   SimCreateDistributionCommand,
   SimCreateDistributionCommandOutput,
 } from "./create-distribution.cmd.js";
-import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import {
   SimCloudFrontDistribution,
   type SimCloudFrontDistributionId,

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -1,5 +1,5 @@
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import type { SimCloudFrontDistroRouter } from "../../router/sim-cloud-front-distro-router.js";
 import { SimCloudFrontDistroRouter as DefaultSimCloudFrontDistroRouter } from "../../router/sim-cloud-front-distro-router.js";
 import type { SimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-front-behavior-resolver.js";

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.iso.test.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.iso.test.ts
@@ -1,0 +1,27 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontRegistry } from "./sim-cloud-front-registry.js";
+import type { SimCloudFrontDistributionId } from "../distribution/sim-cloudfront-distribution.js";
+
+describe("SimCloudFrontRegistry", () => {
+  it("throws when an alternate domain name is registered to a different Distribution", () => {
+    const registry = new SimCloudFrontRegistry();
+
+    registry.registerAlternateDomainName(
+      "cdn.example.test",
+      "EDISTRIBUTION01" as SimCloudFrontDistributionId,
+    );
+
+    const error = assertThrowsError(() => {
+      registry.registerAlternateDomainName(
+        "cdn.example.test",
+        "EDISTRIBUTION02" as SimCloudFrontDistributionId,
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Sim CloudFront alternate domain name cdn.example.test is already registered to Distribution EDISTRIBUTION01",
+    );
+  });
+});

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.ts
@@ -1,8 +1,8 @@
 import {
   makeDistributionId,
   type SimCloudFrontDistributionId,
-} from "./distribution/sim-cloudfront-distribution.js";
-import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+} from "../distribution/sim-cloudfront-distribution.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 
 /**
  * Simulated CloudFront cross-Account registry of Distribution IDs.
@@ -67,6 +67,18 @@ export class SimCloudFrontRegistry {
     alternateDomainName: string,
     distributionId: SimCloudFrontDistributionId,
   ): void {
+    const existingDistributionId =
+      this.alternateDomainDistributionIds.get(alternateDomainName);
+
+    if (
+      existingDistributionId !== undefined &&
+      existingDistributionId !== distributionId
+    ) {
+      throw new Error(
+        `Sim CloudFront alternate domain name ${alternateDomainName} is already registered to Distribution ${existingDistributionId}`,
+      );
+    }
+
     this.alternateDomainDistributionIds.set(
       alternateDomainName,
       distributionId,

--- a/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.iso.test.ts
+++ b/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.iso.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "vitest";
+import { assertUndefined } from "@kensio/smartass";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import { SimCloudFrontAlternateDomainRouter } from "./sim-cf-alternate-domain-router.js";
+import type { SimCloudFrontDistributionId } from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+describe("Sim CloudFront Alternate Domain Router", () => {
+  describe("route alternate domain names to distributions", () => {
+    it("returns undefined when alternate domain name is not registered", () => {
+      const router = new SimCloudFrontAlternateDomainRouter({
+        simAws: new SimAws(),
+        cloudFrontRegistry: new SimCloudFrontRegistry(),
+      });
+
+      assertUndefined(
+        router.routeForAlternateDomainName("unknown.example.test"),
+      );
+    });
+
+    it("returns undefined when registered alternate domain distribution has no account", () => {
+      const cloudFrontRegistry = new SimCloudFrontRegistry();
+      cloudFrontRegistry.registerAlternateDomainName(
+        "cdn.example.test",
+        "ENOTREGISTERED1" as SimCloudFrontDistributionId,
+      );
+
+      const router = new SimCloudFrontAlternateDomainRouter({
+        simAws: new SimAws(),
+        cloudFrontRegistry,
+      });
+
+      assertUndefined(router.routeForAlternateDomainName("cdn.example.test"));
+    });
+
+    it("returns undefined when registered alternate domain distribution does not exist", () => {
+      const accountId = "555555555555" as SimAwsAccountId;
+      const distributionId = "ENOTREGISTERED1" as SimCloudFrontDistributionId;
+      const cloudFrontRegistry = new SimCloudFrontRegistry();
+
+      cloudFrontRegistry.registerDistribution(distributionId, accountId);
+      cloudFrontRegistry.registerAlternateDomainName(
+        "cdn.example.test",
+        distributionId,
+      );
+
+      const router = new SimCloudFrontAlternateDomainRouter({
+        simAws: new SimAws(),
+        cloudFrontRegistry,
+      });
+
+      assertUndefined(router.routeForAlternateDomainName("cdn.example.test"));
+    });
+  });
+});

--- a/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.iso.test.ts
+++ b/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.iso.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import { assertUndefined } from "@kensio/smartass";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import { SimCloudFrontAlternateDomainRouter } from "./sim-cf-alternate-domain-router.js";
 import type { SimCloudFrontDistributionId } from "../../distribution/sim-cloudfront-distribution.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";

--- a/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.ts
+++ b/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.ts
@@ -1,18 +1,18 @@
 import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
-} from "../distribution/sim-cloudfront-distribution.js";
-import type { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
-import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimCloudFrontDistroRoute } from "./sim-cloud-front-distro-router.js";
+} from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCloudFrontDistroRoute } from "../sim-cloud-front-distro-router.js";
 
 /**
  * Routes CloudFront alternate domain names to matching simulated Distributions.
  *
  * Lookup is attempted in two tiers:
  * 1. The inline `distributions` map — fast path for directly supplied distributions.
- * 2. All accounts known to the SimCloudFrontRegistry — needed when distributions
- *    were created through the sim CloudFront API rather than supplied inline.
+ * 2. The SimCloudFrontRegistry alternate-domain index — lookup for
+ *    distributions created through the sim CloudFront API.
  */
 export class SimCloudFrontAlternateDomainRouter {
   private readonly simAws: SimAws;
@@ -56,20 +56,29 @@ export class SimCloudFrontAlternateDomainRouter {
       }
     }
 
-    // Tier 2: walk every registered account and search their live distributions.
-    // This is exhaustive — alternate domain names are not indexed in the
-    // registry, so a full scan is required.
-    for (const accountId of this.cloudFrontRegistry.accountIdsWithDistributions()) {
-      const cloudFront = this.simAws.accountRegionScope(accountId).cloudFront();
-      const distribution = [...cloudFront.getDistributions().values()].find(
-        (distro) => distro.hasAlternateDomainName(alternateDomainName),
+    const distributionId =
+      this.cloudFrontRegistry.distributionIdForAlternateDomainName(
+        alternateDomainName,
       );
 
-      if (distribution !== undefined) {
-        return { cloudFront, distribution };
-      }
+    if (distributionId === undefined) {
+      return undefined;
     }
 
-    return undefined;
+    const accountId =
+      this.cloudFrontRegistry.accountIdForDistribution(distributionId);
+
+    if (accountId === undefined) {
+      return undefined;
+    }
+
+    const cloudFront = this.simAws.accountRegionScope(accountId).cloudFront();
+    const distribution = cloudFront.getSimDistributionById(distributionId);
+
+    if (distribution === undefined) {
+      return undefined;
+    }
+
+    return { cloudFront, distribution };
   }
 }

--- a/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.ts
+++ b/src/service/cloudfront/router/alternate-domain/sim-cf-alternate-domain-router.ts
@@ -2,7 +2,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "../../distribution/sim-cloudfront-distribution.js";
-import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimCloudFrontDistroRoute } from "../sim-cloud-front-distro-router.js";
 

--- a/src/service/cloudfront/router/distro-id/extract-cf-host-distro-id.ts
+++ b/src/service/cloudfront/router/distro-id/extract-cf-host-distro-id.ts
@@ -1,4 +1,4 @@
-import type { SimCloudFrontDistributionId } from "../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontDistributionId } from "../../distribution/sim-cloudfront-distribution.js";
 
 /**
  * Try to extract a CloudFront Distribution ID from a hostname which could

--- a/src/service/cloudfront/router/distro-id/sim-cf-distro-id-router.ts
+++ b/src/service/cloudfront/router/distro-id/sim-cf-distro-id-router.ts
@@ -2,7 +2,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "../../distribution/sim-cloudfront-distribution.js";
-import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";

--- a/src/service/cloudfront/router/distro-id/sim-cf-distro-id-router.ts
+++ b/src/service/cloudfront/router/distro-id/sim-cf-distro-id-router.ts
@@ -1,12 +1,12 @@
 import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
-} from "../distribution/sim-cloudfront-distribution.js";
-import type { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
-import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimCloudFront } from "../sim-cloudfront.js";
-import type { SimCloudFrontDistroRoute } from "./sim-cloud-front-distro-router.js";
+} from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontRegistry } from "../../sim-cloud-front-registry.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontDistroRoute } from "../sim-cloud-front-distro-router.js";
 
 /**
  * Routes a CloudFront Distribution ID to the appropriate sim Distribution.

--- a/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
+++ b/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
@@ -5,7 +5,7 @@ import type {
 import { assertNotNull } from "../../../util/type-guard/defined.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
-import type { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
+import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { extractCloudFrontHostDistroId } from "./distro-id/extract-cf-host-distro-id.js";
 import { SimCloudFrontAlternateDomainRouter } from "./alternate-domain/sim-cf-alternate-domain-router.js";

--- a/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
+++ b/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
@@ -7,9 +7,9 @@ import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
 import type { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import { extractCloudFrontHostDistroId } from "./extract-cf-host-distro-id.js";
-import { SimCloudFrontAlternateDomainRouter } from "./sim-cf-alternate-domain-router.js";
-import { SimCloudFrontDistroIdRouter } from "./sim-cf-distro-id-router.js";
+import { extractCloudFrontHostDistroId } from "./distro-id/extract-cf-host-distro-id.js";
+import { SimCloudFrontAlternateDomainRouter } from "./alternate-domain/sim-cf-alternate-domain-router.js";
+import { SimCloudFrontDistroIdRouter } from "./distro-id/sim-cf-distro-id-router.js";
 
 export interface SimCloudFrontDistroRoute {
   readonly cloudFront: SimCloudFront;

--- a/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
+++ b/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
@@ -14,7 +14,7 @@ import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
 import { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import { extractCloudFrontHostDistroId } from "./extract-cf-host-distro-id.js";
+import { extractCloudFrontHostDistroId } from "./distro-id/extract-cf-host-distro-id.js";
 
 describe("Sim CloudFront Distribution Router", () => {
   describe("route requests to distributions", () => {

--- a/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
+++ b/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
@@ -12,7 +12,7 @@ import {
 import { SimAws } from "../../aws/sim-aws.js";
 import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
-import { SimCloudFrontRegistry } from "../sim-cloud-front-registry.js";
+import { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { extractCloudFrontHostDistroId } from "./distro-id/extract-cf-host-distro-id.js";
 

--- a/src/service/cloudfront/sim-cloud-front-registry.ts
+++ b/src/service/cloudfront/sim-cloud-front-registry.ts
@@ -22,6 +22,11 @@ export class SimCloudFrontRegistry {
     Set<SimCloudFrontDistributionId>
   >();
 
+  private readonly alternateDomainDistributionIds = new Map<
+    string,
+    SimCloudFrontDistributionId
+  >();
+
   /**
    * Allocate a globally unique simulated CloudFront Distribution ID.
    */
@@ -56,18 +61,33 @@ export class SimCloudFrontRegistry {
   }
 
   /**
+   * Register an alternate domain name to a simulated CloudFront Distribution ID.
+   */
+  registerAlternateDomainName(
+    alternateDomainName: string,
+    distributionId: SimCloudFrontDistributionId,
+  ): void {
+    this.alternateDomainDistributionIds.set(
+      alternateDomainName,
+      distributionId,
+    );
+  }
+
+  /**
+   * Get the Distribution ID registered for an alternate domain name.
+   */
+  distributionIdForAlternateDomainName(
+    alternateDomainName: string,
+  ): SimCloudFrontDistributionId | undefined {
+    return this.alternateDomainDistributionIds.get(alternateDomainName);
+  }
+
+  /**
    * Get the Account ID which owns a simulated CloudFront Distribution ID.
    */
   accountIdForDistribution(
     distributionId: SimCloudFrontDistributionId,
   ): SimAwsAccountId | undefined {
     return this.distributionAccountIds.get(distributionId);
-  }
-
-  /**
-   * Get Account IDs which currently own simulated CloudFront Distributions.
-   */
-  accountIdsWithDistributions(): Iterable<SimAwsAccountId> {
-    return this.accountDistributionIds.keys();
   }
 }

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -1,4 +1,4 @@
-import { SimCloudFrontRegistry } from "./sim-cloud-front-registry.js";
+import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
 import { CreateDistributionCommandHandler } from "./command/create-distribution/create-distribution.handler.js";
 import type {
   SimCloudFrontDistribution,


### PR DESCRIPTION
Register CloudFront alternate domains in CloudFront Registry for O(1) lookup rather than the previous O(n) scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CloudFront distributions now register alternate domain names with the registry for centralized lookup and routing.
  * Added validation to prevent duplicate alternate domain name registrations across distributions.

* **Tests**
  * Added test coverage for alternate domain name registration and routing scenarios.

* **Refactor**
  * Reorganized CloudFront registry module structure and updated import paths across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->