### PR TITLE
feat: sim CloudFormation Stack Outputs

### DIFF
--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
@@ -50,6 +50,9 @@ new s3deploy.BucketDeployment(stack, "DeploySite", {
   destinationBucket: bucket,
   prune: true,
 });
+new cdk.CfnOutput(stack, "SiteBucketWebsiteUrl", {
+  value: bucket.bucketWebsiteUrl,
+});
 app.synth();
 `,
     );
@@ -59,21 +62,24 @@ app.synth();
 
     // When we deploy the template into sim CloudFormation.
     const simCfn = simAws.cloudFormation();
-    await simCfn.deployTemplateFile(
+    const stack = await simCfn.deployTemplateFile(
       path.join(cdkOutDir, "TestStack.template.json"),
     );
 
-    // Then we should be able to fetch the objects from the local sim server.
-    const rootRes = await fetch(
-      `http://foo-bucket.s3-website.us-east-1.sim-aws.localhost:${srv.port}/`,
+    const websiteUrlOut = stack.outputs.get("SiteBucketWebsiteUrl")?.value;
+    assertIdentical(
+      websiteUrlOut,
+      "http://foo-bucket.s3-website.us-east-1.sim-aws.localhost/",
     );
+    const websiteRoot = srv.localUrl(websiteUrlOut).toString().trimEnd();
+
+    // Then we should be able to fetch the objects from the local sim server.
+    const rootRes = await fetch(websiteRoot);
     assertIdentical(rootRes.status, 200);
     assertStringIncludes(rootRes.headers.get("content-type"), "text/html");
     assertStringIncludes(await rootRes.text(), "<h1>Root</h1>");
 
-    const fooRes = await fetch(
-      `http://foo-bucket.s3-website.us-east-1.sim-aws.localhost:${srv.port}/foo/`,
-    );
+    const fooRes = await fetch(`${websiteRoot}foo/`);
     assertIdentical(fooRes.status, 200);
     assertStringIncludes(fooRes.headers.get("content-type"), "text/html");
     assertStringIncludes(await fooRes.text(), "<h1>Foo</h1>");

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.cmd.ts
@@ -3,6 +3,7 @@ import type {
   SimCloudFormationStackStatus,
 } from "../../stack/sim-cfn-stack.js";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
 
 /**
  * Minimal structural sim CloudFormation DescribeStacks command.
@@ -36,4 +37,15 @@ export interface SimCloudFormationStackDescription {
   readonly StackName?: SimCloudFormationStackName | undefined;
   readonly StackStatus?: SimCloudFormationStackStatus | undefined;
   readonly StackStatusReason?: string | undefined;
+  readonly Outputs?: SimCloudFormationStackOutputDescription[] | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation Stack Output description.
+ */
+export interface SimCloudFormationStackOutputDescription {
+  readonly OutputKey?: string | undefined;
+  readonly OutputValue?: SimCfnTemplateValue | undefined;
+  readonly Description?: string | undefined;
+  readonly ExportName?: SimCfnTemplateValue | undefined;
 }

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
@@ -8,14 +8,15 @@ import type {
   SimCloudFormationStackName,
 } from "../../stack/sim-cfn-stack.js";
 import type {
-  SimCloudFormationStackDescription,
   SimDescribeStacksCommand,
   SimDescribeStacksCommandOutput,
 } from "./describe-stacks.cmd.js";
+import { SimCfnStackDescriber } from "./sim-cfn-stack-describer.js";
 
 interface DescribeStacksCommandHandlerProps {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background?: BackgroundScheduler;
+  readonly describer?: SimCfnStackDescriber;
 }
 
 /**
@@ -29,12 +30,18 @@ export class DescribeStacksCommandHandler implements CommandHandler<
 > {
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler;
+  private readonly describer: SimCfnStackDescriber;
 
   constructor(props: DescribeStacksCommandHandlerProps) {
-    const { stacks, background = new BackgroundTasks() } = props;
+    const {
+      stacks,
+      background = new BackgroundTasks(),
+      describer = new SimCfnStackDescriber(),
+    } = props;
 
     this.stacks = stacks;
     this.background = background;
+    this.describer = describer;
   }
 
   /**
@@ -54,25 +61,16 @@ export class DescribeStacksCommandHandler implements CommandHandler<
       const stack = this.stacks.get(stackName);
 
       return {
-        Stacks: stack === undefined ? [] : [this.describeStack(stack)],
+        Stacks: stack === undefined ? [] : [this.describer.describe(stack)],
         $metadata: {},
       };
     }
 
     return {
       Stacks: [...this.stacks.values()].map((stack) =>
-        this.describeStack(stack),
+        this.describer.describe(stack),
       ),
       $metadata: {},
-    };
-  }
-
-  private describeStack(stack: SimCfnStack): SimCloudFormationStackDescription {
-    return {
-      StackId: stack.stackName,
-      StackName: stack.stackName,
-      StackStatus: stack.lifecycle.status,
-      StackStatusReason: stack.lifecycle.error?.message,
     };
   }
 }

--- a/src/service/cloudformation/command/describe-stacks/sim-cfn-stack-describer.ts
+++ b/src/service/cloudformation/command/describe-stacks/sim-cfn-stack-describer.ts
@@ -1,0 +1,36 @@
+import type { SimCfnStack } from "../../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackDescription } from "./describe-stacks.cmd.js";
+
+/**
+ * Converts an internal simulated CloudFormation Stack into the public
+ * DescribeStacks StackDescription shape.
+ *
+ * The command handler owns request handling concerns such as StackName
+ * filtering, background task sequencing, and response metadata. This class owns
+ * only the stable field mapping from SimCfnStack state to the minimal
+ * AWS-compatible description returned by the simulator.
+ */
+export class SimCfnStackDescriber {
+  /**
+   * Describe one simulated Stack for a DescribeStacks response.
+   *
+   * Only fields currently represented by the simulator are populated. Stack
+   * identity and lifecycle fields come directly from SimCfnStack, while Outputs
+   * are expanded from the Stack's output map into the array shape used by
+   * CloudFormation responses.
+   */
+  describe(stack: SimCfnStack): SimCloudFormationStackDescription {
+    return {
+      StackId: stack.stackName,
+      StackName: stack.stackName,
+      StackStatus: stack.lifecycle.status,
+      StackStatusReason: stack.lifecycle.error?.message,
+      Outputs: [...stack.outputs.values()].map((output) => ({
+        OutputKey: output.outputKey,
+        OutputValue: output.value,
+        Description: output.description,
+        ExportName: output.exportName,
+      })),
+    };
+  }
+}

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
@@ -1,0 +1,122 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplate } from "../../template/sim-cfn-template.js";
+import { SimCfnTemplateValueResolver } from "../../template/value/sim-cfn-template-value-resolver.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+import type { SimCfnStackOutput } from "./sim-cfn-stack-output.js";
+
+interface SimCfnStackOutputResolverProps {
+  readonly template: SimCfnTemplate;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+}
+
+/**
+ * Resolves CloudFormation Outputs after Stack Resources have been created.
+ *
+ * Outputs can reference Resources via the same intrinsic functions supported by
+ * Resource properties, so this class adapts the Stack Resource map into the
+ * template value resolver's Resource resolver shape.
+ */
+export class SimCfnStackOutputResolver {
+  private readonly template: SimCfnTemplate;
+  private readonly resources: ReadonlyMap<string, SimCfnResource>;
+
+  constructor(props: SimCfnStackOutputResolverProps) {
+    this.template = props.template;
+    this.resources = props.resources;
+  }
+
+  /**
+   * Resolve all Stack Outputs.
+   */
+  resolve(): Map<string, SimCfnStackOutput> {
+    return new Map(
+      this.template.outputTemplates().map((outputTemplate) => {
+        const resolvedTemplate = this.resolveOutputTemplate(
+          outputTemplate.template,
+        );
+
+        return [
+          outputTemplate.outputKey,
+          {
+            outputKey: outputTemplate.outputKey,
+            value: this.value(outputTemplate.outputKey, resolvedTemplate),
+            description: this.description(resolvedTemplate),
+            exportName: this.exportName(resolvedTemplate),
+          },
+        ];
+      }),
+    );
+  }
+
+  private value(
+    outputKey: string,
+    template: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValue {
+    const value = template["Value"];
+
+    if (value === undefined) {
+      throw new TypeError(
+        `Sim CloudFormation Output ${outputKey} must have a Value`,
+      );
+    }
+
+    return value;
+  }
+
+  private resolveOutputTemplate(
+    template: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValueRecord {
+    return new SimCfnTemplateValueResolver({
+      parameters: this.template.parameters,
+      resources: {
+        has: (id): boolean => this.resources.has(id),
+        refValue: (id): SimCfnTemplateValue => {
+          const resource = this.resources.get(id);
+
+          /* v8 ignore if -- defensive catch for inconsistent context */
+          if (resource === undefined) {
+            return { Ref: id };
+          }
+
+          return resource.refValue;
+        },
+        attributeValue: (id, attributeName): SimCfnTemplateValue => {
+          const resource = this.resources.get(id);
+
+          /* v8 ignore if -- defensive catch for inconsistent context */
+          if (resource === undefined) {
+            return { "Fn::GetAtt": [id, attributeName] };
+          }
+
+          return resource.attributeValue(attributeName);
+        },
+      },
+    }).resolveRecord(template);
+  }
+
+  private description(template: SimCfnTemplateValueRecord): string | undefined {
+    const description = template["Description"];
+
+    return typeof description === "string" ? description : undefined;
+  }
+
+  private exportName(
+    template: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValue | undefined {
+    const exportValue = template["Export"];
+
+    if (
+      typeof exportValue === "object" &&
+      exportValue !== null &&
+      !Array.isArray(exportValue) &&
+      "Name" in exportValue
+    ) {
+      return exportValue["Name"];
+    }
+
+    return undefined;
+  }
+}

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output.ts
@@ -1,0 +1,11 @@
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
+
+/**
+ * Runtime representation of one resolved CloudFormation Stack Output.
+ */
+export interface SimCfnStackOutput {
+  readonly outputKey: string;
+  readonly value: SimCfnTemplateValue;
+  readonly description?: string | undefined;
+  readonly exportName?: SimCfnTemplateValue | undefined;
+}

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-outputs.iso.test.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-outputs.iso.test.ts
@@ -1,0 +1,244 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("sim CloudFormation Stack Outputs", () => {
+  it("resolves stack Outputs after deployment", async () => {
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "TestStack",
+      template: {
+        Resources: {
+          SiteBucket397A1860: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "site-bucket",
+            },
+          },
+        },
+        Outputs: {
+          SiteBucketName: {
+            Value: {
+              Ref: "SiteBucket397A1860",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    assertIdentical(stack.outputs.get("SiteBucketName")?.value, "site-bucket");
+  });
+
+  it("resolves Outputs from Resources created through dependency chains", async () => {
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "OutputDependencyStack",
+      template: {
+        Resources: {
+          SourceBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "source-output-bucket",
+            },
+          },
+          DerivedFunction: {
+            Type: "AWS::CloudFront::Function",
+            DependsOn: "SourceBucket",
+            Properties: {
+              Name: {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      Ref: "SourceBucket",
+                    },
+                    "derived-function",
+                  ],
+                ],
+              },
+              FunctionConfig: {
+                Comment: {
+                  "Fn::Sub": "Depends on ${SourceBucket}",
+                },
+                Runtime: "cloudfront-js-2.0",
+              },
+              FunctionCode: `
+function handler(event) {
+  return event.request;
+}
+`,
+            },
+          },
+        },
+        Outputs: {
+          SourceBucketName: {
+            Value: {
+              Ref: "SourceBucket",
+            },
+          },
+          DerivedFunctionName: {
+            Value: {
+              Ref: "DerivedFunction",
+            },
+          },
+          DependencySummary: {
+            Value: {
+              "Fn::Sub": "${SourceBucket} -> ${DerivedFunction}",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    assertIdentical(
+      stack.outputs.get("SourceBucketName")?.value,
+      "source-output-bucket",
+    );
+    assertIdentical(
+      stack.outputs.get("DerivedFunctionName")?.value,
+      "source-output-bucket-derived-function",
+    );
+    assertIdentical(
+      stack.outputs.get("DependencySummary")?.value,
+      "source-output-bucket -> source-output-bucket-derived-function",
+    );
+  });
+
+  it("exposes resolved Outputs through DescribeStacks", async () => {
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.deployTemplate({
+      stackName: "DescribeOutputStack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "describe-output-bucket",
+            },
+          },
+        },
+        Outputs: {
+          SiteBucketName: {
+            Description: "The simulated site bucket name",
+            Value: {
+              Ref: "SiteBucket",
+            },
+          },
+        },
+      },
+    });
+
+    const result = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({
+        StackName: "DescribeOutputStack",
+      }),
+    );
+    const describedStack = result.Stacks?.[0];
+    const output = describedStack?.Outputs?.find(
+      (item) => item.OutputKey === "SiteBucketName",
+    );
+
+    assertNonNullable(output);
+    assertIdentical(output.OutputKey, "SiteBucketName");
+    assertIdentical(output.OutputValue, "describe-output-bucket");
+    assertIdentical(output.Description, "The simulated site bucket name");
+  });
+
+  it("resolves Output Export names", async () => {
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "ExportOutputStack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "export-output-bucket",
+            },
+          },
+        },
+        Outputs: {
+          SiteBucketName: {
+            Value: {
+              Ref: "SiteBucket",
+            },
+            Export: {
+              Name: {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      Ref: "SiteBucket",
+                    },
+                    "SiteBucketName",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    assertIdentical(
+      stack.outputs.get("SiteBucketName")?.exportName,
+      "export-output-bucket-SiteBucketName",
+    );
+
+    const result = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({
+        StackName: "ExportOutputStack",
+      }),
+    );
+    const describedStack = result.Stacks?.[0];
+    const output = describedStack?.Outputs?.find(
+      (item) => item.OutputKey === "SiteBucketName",
+    );
+
+    assertNonNullable(output);
+    assertIdentical(output.OutputValue, "export-output-bucket");
+    assertIdentical(output.ExportName, "export-output-bucket-SiteBucketName");
+  });
+
+  it("fails deployment when an Output has no Value", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "InvalidOutputStack",
+        template: {
+          Resources: {},
+          Outputs: {
+            MissingValue: {
+              Description: "No Value field",
+            },
+          },
+        },
+      }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Output MissingValue must have a Value",
+    );
+  });
+});

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -12,6 +12,8 @@ import { makeSimCfnStackResourceMap } from "./resource-map/sim-cfn-stack-resourc
 import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deployment-lifecycle.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
+import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
 
 export type SimCloudFormationStackName = Brand<
   string,
@@ -60,6 +62,7 @@ export class SimCfnStack {
   public readonly stackName: SimCloudFormationStackName;
   public readonly template: CfnTemplateBodyRecord;
   public readonly resources: Map<string, SimCfnResource>;
+  public outputs = new Map<string, SimCfnStackOutput>();
 
   constructor(props: SimCloudFormationStackProps) {
     const {
@@ -136,5 +139,13 @@ export class SimCfnStack {
     });
 
     await resourceCreator.createAll();
+    this.resolveOutputs();
+  }
+
+  private resolveOutputs(): void {
+    this.outputs = new SimCfnStackOutputResolver({
+      template: this.cfnTemplate,
+      resources: this.resources,
+    }).resolve();
   }
 }

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -17,6 +17,7 @@ import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
 export interface CfnTemplateBodyRecord {
   readonly Parameters?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly Resources: Record<string, SimCfnTemplateValue>;
+  readonly Outputs?: Record<string, SimCfnTemplateValue> | undefined;
   readonly [sectionName: string]:
     | Record<string, SimCfnParameterDefinition>
     | Record<string, SimCfnTemplateValue>
@@ -26,6 +27,11 @@ export interface CfnTemplateBodyRecord {
 
 export interface SimCfnResourceTemplateRecord {
   readonly logicalId: string;
+  readonly template: SimCfnTemplateValueRecord;
+}
+
+export interface SimCfnOutputTemplateRecord {
+  readonly outputKey: string;
   readonly template: SimCfnTemplateValueRecord;
 }
 
@@ -108,6 +114,27 @@ export class SimCfnTemplate {
       .map(([logicalId, resourceTemplate]) => ({
         logicalId,
         template: valueResolver.resolveRecord(resourceTemplate),
+      }));
+  }
+
+  /**
+   * Get Output template entries with parameter-only expressions resolved.
+   *
+   * Resource-backed intrinsic functions are intentionally left unresolved here
+   * because Outputs are resolved after Resource creation.
+   */
+  outputTemplates(): SimCfnOutputTemplateRecord[] {
+    const valueResolver = new SimCfnTemplateValueResolver({
+      parameters: this.parameters,
+    });
+
+    return Object.entries(this.template.Outputs ?? {})
+      .filter((entry): entry is [string, SimCfnTemplateValueRecord] => {
+        return isRecord(entry[1]);
+      })
+      .map(([outputKey, outputTemplate]) => ({
+        outputKey,
+        template: valueResolver.resolveRecord(outputTemplate),
       }));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFormation stacks now support Stack Outputs, including optional descriptions and export names.
  * Stack outputs are properly resolved after deployment and accessible via the DescribeStacks command.
  * Local deployments now correctly reference and serve output values in tests and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->