### PR TITLE
feat: sim CFN pseudo parameters

### DIFF
--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -98,6 +98,7 @@ export class CreateStackCommandHandler implements CommandHandler<
         parameters: SimCfnParameters.fromInput(cmd.input, {
           stackName,
         }),
+        accountRegionScope: this.accountRegionScope,
       },
     );
 

--- a/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.iso.test.ts
+++ b/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.iso.test.ts
@@ -1,0 +1,196 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/* eslint-disable no-template-curly-in-string */
+
+describe("sim CloudFormation pseudo parameters", () => {
+  it("resolves pseudo parameters in deployed Resource properties", async () => {
+    const simAws = new SimAws();
+    const cloudFormation = simAws
+      .account("123456789012")
+      .region("eu-west-2")
+      .cloudFormation();
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "PseudoResourceStack",
+      template: {
+        Resources: {
+          PseudoHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+            Properties: {
+              AccountId: {
+                Ref: "AWS::AccountId",
+              },
+              Region: {
+                Ref: "AWS::Region",
+              },
+              Partition: {
+                Ref: "AWS::Partition",
+              },
+              StackName: {
+                Ref: "AWS::StackName",
+              },
+              StackId: {
+                Ref: "AWS::StackId",
+              },
+              NotificationARNs: {
+                Ref: "AWS::NotificationARNs",
+              },
+              NoValue: {
+                Ref: "AWS::NoValue",
+              },
+              URLSuffix: {
+                Ref: "AWS::URLSuffix",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("PseudoHandle");
+
+    assertNonNullable(resource);
+    assertIdentical(resource.properties["AccountId"], "123456789012");
+    assertIdentical(resource.properties["Region"], "eu-west-2");
+    assertIdentical(resource.properties["Partition"], "aws");
+    assertIdentical(resource.properties["StackName"], "PseudoResourceStack");
+    assertIdentical(resource.properties["StackId"], "PseudoResourceStack");
+    assertIdentical(resource.properties["NoValue"], "");
+    assertIdentical(resource.properties["URLSuffix"], "sim-aws.localhost");
+
+    const notificationARNs = resource.properties["NotificationARNs"];
+
+    assertArrayLength(notificationARNs, 0);
+  });
+
+  it("resolves pseudo parameters in deployed Stack Outputs", async () => {
+    const simAws = new SimAws();
+    const cloudFormation = simAws
+      .account("123456789012")
+      .region("ap-southeast-2")
+      .cloudFormation();
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "PseudoOutputStack",
+      template: {
+        Resources: {
+          PseudoHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+          },
+        },
+        Outputs: {
+          AccountId: {
+            Value: {
+              Ref: "AWS::AccountId",
+            },
+          },
+          Region: {
+            Value: {
+              Ref: "AWS::Region",
+            },
+          },
+          Partition: {
+            Value: {
+              Ref: "AWS::Partition",
+            },
+          },
+          StackName: {
+            Value: {
+              Ref: "AWS::StackName",
+            },
+          },
+          StackId: {
+            Value: {
+              Ref: "AWS::StackId",
+            },
+          },
+          NotificationARNs: {
+            Value: {
+              Ref: "AWS::NotificationARNs",
+            },
+          },
+          NoValue: {
+            Value: {
+              Ref: "AWS::NoValue",
+            },
+          },
+          URLSuffix: {
+            Value: {
+              Ref: "AWS::URLSuffix",
+            },
+          },
+          ResourceAndPseudoSummary: {
+            Value: {
+              "Fn::Sub":
+                "${AWS::Partition}:${AWS::Region}:${AWS::AccountId}:${PseudoHandle}",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    assertIdentical(stack.outputs.get("AccountId")?.value, "123456789012");
+    assertIdentical(stack.outputs.get("Region")?.value, "ap-southeast-2");
+    assertIdentical(stack.outputs.get("Partition")?.value, "aws");
+    assertIdentical(stack.outputs.get("StackName")?.value, "PseudoOutputStack");
+    assertIdentical(stack.outputs.get("StackId")?.value, "PseudoOutputStack");
+    assertIdentical(stack.outputs.get("NoValue")?.value, "");
+    assertIdentical(stack.outputs.get("URLSuffix")?.value, "sim-aws.localhost");
+    assertIdentical(
+      stack.outputs.get("ResourceAndPseudoSummary")?.value,
+      "aws:ap-southeast-2:123456789012:PseudoHandle",
+    );
+
+    const notificationARNs = stack.outputs.get("NotificationARNs")?.value;
+
+    assertArrayLength(notificationARNs, 0);
+  });
+
+  it("uses default account and region pseudo parameters from the top-level SimAws CloudFormation service", async () => {
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "DefaultPseudoStack",
+      template: {
+        Resources: {
+          PseudoHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+          },
+        },
+        Outputs: {
+          AccountId: {
+            Value: {
+              Ref: "AWS::AccountId",
+            },
+          },
+          Region: {
+            Value: {
+              Ref: "AWS::Region",
+            },
+          },
+          URLSuffix: {
+            Value: {
+              Ref: "AWS::URLSuffix",
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    assertIdentical(stack.outputs.get("AccountId")?.value, "888888888888");
+    assertIdentical(stack.outputs.get("Region")?.value, "us-east-1");
+    assertIdentical(stack.outputs.get("URLSuffix")?.value, "sim-aws.localhost");
+  });
+});

--- a/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.ts
+++ b/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.ts
@@ -1,0 +1,68 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
+import { simAwsLocalConf } from "../../../../serve/http/local-server/sim-aws-local.conf.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../../aws/sim-aws-account.js";
+import { DEFAULT_SIM_AWS_REGION_NAME } from "../../../aws/sim-aws-region.js";
+
+interface SimCfnPseudoParametersProps {
+  readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * Resolves CloudFormation pseudo parameters for one simulated Stack scope.
+ */
+export class SimCfnPseudoParameters {
+  private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
+  private readonly stackName: string | undefined;
+
+  constructor(props: SimCfnPseudoParametersProps) {
+    this.accountRegionScope = props.accountRegionScope;
+    this.stackName = props.stackName;
+  }
+
+  /**
+   * Resolve a supported CloudFormation pseudo parameter.
+   */
+  value(name: string): SimCfnTemplateValue | undefined {
+    switch (name) {
+      case "AWS::AccountId": {
+        return this.accountRegionScope?.accountId ?? DEFAULT_SIM_AWS_ACCOUNT_ID;
+      }
+
+      case "AWS::Region": {
+        return (
+          this.accountRegionScope?.regionName ?? DEFAULT_SIM_AWS_REGION_NAME
+        );
+      }
+
+      case "AWS::Partition": {
+        return "aws";
+      }
+
+      case "AWS::StackName": {
+        return this.stackName;
+      }
+
+      case "AWS::StackId": {
+        return this.stackName;
+      }
+
+      case "AWS::NotificationARNs": {
+        return [];
+      }
+
+      case "AWS::NoValue": {
+        return "";
+      }
+
+      case "AWS::URLSuffix": {
+        return simAwsLocalConf.hostname;
+      }
+
+      default: {
+        return undefined;
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -5,9 +5,11 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCloudFormationResourceCreateContext } from "../../sim-cfn-resource.js";
+import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 
 interface SimCfnResourcePropertyResolverProps {
   readonly parameters?: SimCfnParameters | undefined;
+  readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
 }
 
 /**
@@ -25,9 +27,11 @@ interface SimCfnResourcePropertyResolverProps {
  */
 export class SimCfnResourcePropertyResolver {
   private readonly parameters: SimCfnParameters | undefined;
+  private readonly pseudoParameters: SimCfnPseudoParameters | undefined;
 
   constructor(props: SimCfnResourcePropertyResolverProps = {}) {
     this.parameters = props.parameters;
+    this.pseudoParameters = props.pseudoParameters;
   }
 
   /**
@@ -47,6 +51,7 @@ export class SimCfnResourcePropertyResolver {
   ): SimCfnTemplateValueRecord {
     const resolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters ?? new SimCfnParameters(),
+      pseudoParameters: this.pseudoParameters,
       resources: {
         has: (id): boolean => context.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {

--- a/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
+++ b/src/service/cloudformation/stack/output/sim-cfn-stack-output-resolver.ts
@@ -71,6 +71,7 @@ export class SimCfnStackOutputResolver {
   ): SimCfnTemplateValueRecord {
     return new SimCfnTemplateValueResolver({
       parameters: this.template.parameters,
+      pseudoParameters: this.template.pseudoParameters(),
       resources: {
         has: (id): boolean => this.resources.has(id),
         refValue: (id): SimCfnTemplateValue => {

--- a/src/service/cloudformation/template/node/sim-cfn-node.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-node.ts
@@ -1,6 +1,7 @@
 import type { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
 import type { SimCfnResourceRefResolver } from "../resolve/sim-cfn-resource-ref-resolver.js";
+import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 
 /**
  * Context available while resolving a parsed CloudFormation node tree.
@@ -9,6 +10,7 @@ export class SimCfnResolveContext {
   constructor(
     readonly parameters: SimCfnParameters,
     readonly resources?: SimCfnResourceRefResolver | undefined,
+    readonly pseudoParameters?: SimCfnPseudoParameters | undefined,
   ) {}
 }
 

--- a/src/service/cloudformation/template/node/sim-cfn-ref.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-ref.ts
@@ -21,6 +21,12 @@ export class SimCfnRef extends SimCfnNode {
       return context.parameters.value(this.name);
     }
 
+    const pseudoParameterValue = context.pseudoParameters?.value(this.name);
+
+    if (pseudoParameterValue !== undefined) {
+      return pseudoParameterValue;
+    }
+
     if (context.resources?.has(this.name) === true) {
       return context.resources.refValue(this.name);
     }

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -8,6 +8,8 @@ import { isRecord } from "../../../util/type-guard/record.js";
 import { SimCfnTemplateBodyValidator } from "./sim-cfn-template-body-validator.js";
 import type { SimCfnParameterDefinition } from "../parameters/sim-cfn-parameters.type.js";
 import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimCfnPseudoParameters } from "../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 
 /**
  * Parsed CloudFormation template body accepted by the simulator.
@@ -39,11 +41,13 @@ interface SimCfnTemplateProps {
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: SimCfnParameters | undefined;
   readonly stackName?: string | undefined;
+  readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
 }
 
 interface SimCfnTemplateFromJsonProps {
   readonly stackName?: string | undefined;
   readonly parameters?: SimCfnParameters | undefined;
+  readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
 }
 
 /**
@@ -55,12 +59,14 @@ export class SimCfnTemplate {
   public readonly template: CfnTemplateBodyRecord;
   public readonly stackName: string | undefined;
   public readonly parameters: SimCfnParameters;
+  private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
 
   constructor(props: SimCfnTemplateProps) {
-    const { template, parameters, stackName } = props;
+    const { template, parameters, stackName, accountRegionScope } = props;
 
     this.template = template;
     this.stackName = stackName;
+    this.accountRegionScope = accountRegionScope;
 
     new SimCfnTemplateBodyValidator({ template, stackName }).validate();
 
@@ -93,6 +99,7 @@ export class SimCfnTemplate {
       template,
       parameters: props.parameters,
       stackName: props.stackName,
+      accountRegionScope: props.accountRegionScope,
     });
   }
 
@@ -105,6 +112,7 @@ export class SimCfnTemplate {
   resourceTemplates(): SimCfnResourceTemplateRecord[] {
     const valueResolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters,
+      pseudoParameters: this.pseudoParameters(),
     });
 
     return Object.entries(this.template.Resources)
@@ -126,6 +134,7 @@ export class SimCfnTemplate {
   outputTemplates(): SimCfnOutputTemplateRecord[] {
     const valueResolver = new SimCfnTemplateValueResolver({
       parameters: this.parameters,
+      pseudoParameters: this.pseudoParameters(),
     });
 
     return Object.entries(this.template.Outputs ?? {})
@@ -136,5 +145,17 @@ export class SimCfnTemplate {
         outputKey,
         template: valueResolver.resolveRecord(outputTemplate),
       }));
+  }
+
+  /**
+   * Get the sim CFN pseudo parameters for this template.
+   *
+   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html
+   */
+  pseudoParameters(): SimCfnPseudoParameters {
+    return new SimCfnPseudoParameters({
+      accountRegionScope: this.accountRegionScope,
+      stackName: this.stackName,
+    });
   }
 }

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -6,10 +6,12 @@ import type {
   SimCfnTemplateValueRecord,
 } from "./sim-cfn-template-value.js";
 import type { SimCfnResourceRefResolver } from "../resolve/sim-cfn-resource-ref-resolver.js";
+import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 
 interface SimCfnTemplateValueResolverProps {
   readonly parameters: SimCfnParameters;
   readonly resources?: SimCfnResourceRefResolver | undefined;
+  readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
 }
 
 /**
@@ -19,7 +21,11 @@ export class SimCfnTemplateValueResolver {
   private readonly context: SimCfnResolveContext;
 
   constructor(props: SimCfnTemplateValueResolverProps) {
-    this.context = new SimCfnResolveContext(props.parameters, props.resources);
+    this.context = new SimCfnResolveContext(
+      props.parameters,
+      props.resources,
+      props.pseudoParameters,
+    );
   }
 
   /**

--- a/src/service/cloudfront/cff/adapter/sim-cff-event-adapter.iso.test.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-event-adapter.iso.test.ts
@@ -24,7 +24,7 @@ describe("sim CFF event structure adapter", () => {
       const event = adapter.toViewerRequestEvent(req);
 
       assertIdentical(event.context.eventType, "viewer-request");
-      assertTrue("requestId" in event.context);
+      assertObjectHasProperty(event.context, "requestId");
       assertIdentical(event.viewer.ip, "127.0.0.1");
       assertIdentical(event.request.method, "GET");
       assertIdentical(event.request.uri, "/path/to/resource");
@@ -43,7 +43,7 @@ describe("sim CFF event structure adapter", () => {
       const event = adapter.toViewerResponseEvent(req, res);
 
       assertIdentical(event.context.eventType, "viewer-response");
-      assertTrue("requestId" in event.context);
+      assertObjectHasProperty(event.context, "requestId");
       assertIdentical(event.request.method, "GET");
       assertIdentical(event.response.statusCode, 201);
       assertIdentical(event.response.statusDescription, "Created");

--- a/src/util/background/non-deterministic-background.iso.test.ts
+++ b/src/util/background/non-deterministic-background.iso.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, vi } from "vitest";
 import {
+  assertArrayIncludesAll,
+  assertArrayLength,
   assertFalse,
   assertIdentical,
   assertThrowsErrorAsync,
@@ -84,9 +86,8 @@ describe("background sequencing", () => {
       });
 
       await tasks.complete();
-      assertIdentical(execOrder.length, 2);
-      assertTrue(execOrder.includes(1));
-      assertTrue(execOrder.includes(2));
+      assertArrayLength(execOrder, 2);
+      assertArrayIncludesAll(execOrder, [1, 2]);
     });
 
     it("propagates task errors", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CloudFormation pseudo-parameters (`AWS::AccountId`, `AWS::Region`, `AWS::Partition`, `AWS::StackName`, `AWS::StackId`, `AWS::NotificationARNs`, `AWS::NoValue`, `AWS::URLSuffix`), enabling proper resolution within simulated CloudFormation templates and outputs.

* **Tests**
  * Added comprehensive test suite validating pseudo-parameter resolution across multiple stack deployment scenarios and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->