### PR TITLE
feat: initial simulated Route53

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "import": "./dist/service/s3/index.js",
       "types": "./dist/service/s3/index.d.ts"
     },
+    "./route53": {
+      "import": "./dist/service/route53/index.js",
+      "types": "./dist/service/route53/index.d.ts"
+    },
     "./serve": {
       "import": "./dist/serve/index.js",
       "types": "./dist/serve/index.d.ts"
@@ -75,7 +79,7 @@
   ],
   "author": "Kensio Software",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.7.0",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.1070.0",
     "@aws-sdk/client-cloudfront": "^3.1063.0",

--- a/src/serve/http/sim-aws-http.iso.test.ts
+++ b/src/serve/http/sim-aws-http.iso.test.ts
@@ -51,6 +51,28 @@ describe("Simulated AWS HTTP", () => {
     assertStringIncludes(resBody, "S3 bucket named my-site not found");
   });
 
+  it("routes custom domains to CloudFront through simulated Route53", async () => {
+    const simAws = new SimAws();
+    simAws.route53().upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["d123.cloudfront.net"],
+    });
+
+    const simAwsHttp = new SimAwsHttp({ simAws });
+
+    const res = await simAwsHttp.fetch(
+      new Request("http://www.foo.com.sim-aws.localhost/"),
+    );
+
+    assertIdentical(res.status, 404);
+    const resBody = await res.text();
+    assertStringIncludes(
+      resBody,
+      "Suitable sim CloudFront Distribution not found",
+    );
+  });
+
   it("serves an S3 Object over simulated HTTP when static website hosting is configured", async () => {
     const simAws = new SimAws();
 

--- a/src/serve/http/sim-aws-http.ts
+++ b/src/serve/http/sim-aws-http.ts
@@ -1,4 +1,3 @@
-import { SimAwsLocalServiceResolver } from "../resolve/sim-aws-local-service-resolver.js";
 import { SimAwsServiceControllerContainer } from "../controller/container/sim-aws-service-controller-container.js";
 import { SimAws } from "../../service/aws/sim-aws.js";
 
@@ -10,11 +9,12 @@ interface SimAwsHttpProps {
  * HTTP interface for sending requests into a simulated AWS environment.
  */
 export class SimAwsHttp {
-  private readonly serviceResolver = new SimAwsLocalServiceResolver();
+  private readonly simAws: SimAws;
   private readonly controllers: SimAwsServiceControllerContainer;
 
   constructor(props: SimAwsHttpProps = {}) {
     const { simAws = new SimAws() } = props;
+    this.simAws = simAws;
     this.controllers = new SimAwsServiceControllerContainer({ simAws });
   }
 
@@ -38,7 +38,7 @@ export class SimAwsHttp {
         return new Response("Missing Host header\n", { status: 400 });
       }
 
-      const target = this.serviceResolver.resolveHost(hostname);
+      const target = this.simAws.route53().resolveHttpHost(hostname);
       if (target === undefined) {
         return new Response(`Unknown simulated AWS host ${hostname} \n`, {
           status: 501,

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -1,0 +1,75 @@
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../util/background/background.js";
+import type { SimAwsAccountId } from "../sim-aws-account.js";
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import type { SimAws } from "../sim-aws.js";
+import type { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
+import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
+import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
+import { SimRoute53 } from "../../route53/index.js";
+
+interface SimAwsAccountServiceCacheProps {
+  readonly simAws: SimAws;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly cloudFrontRegistry: SimCloudFrontRegistry;
+}
+
+/**
+ * Cache for simulated AWS services scoped by account.
+ */
+export class SimAwsAccountServiceCache {
+  private readonly simAws: SimAws;
+  private readonly background: BackgroundScheduler & BackgroundCompleter;
+  private readonly cloudFrontRegistry: SimCloudFrontRegistry;
+
+  private readonly cloudFrontServices = new Map<
+    SimAwsAccountId,
+    SimCloudFront
+  >();
+  private readonly route53Services = new Map<SimAwsAccountId, SimRoute53>();
+
+  constructor(props: SimAwsAccountServiceCacheProps) {
+    this.simAws = props.simAws;
+    this.background = props.background;
+    this.cloudFrontRegistry = props.cloudFrontRegistry;
+  }
+
+  /**
+   * Create or get simulated CloudFront for an Account scope.
+   */
+  createCloudFront(scope: SimAwsAccountRegionContainer): SimCloudFront {
+    const { accountId } = scope.accountRegionScope;
+
+    let cloudFront = this.cloudFrontServices.get(accountId);
+
+    if (cloudFront === undefined) {
+      cloudFront = new SimCloudFront({
+        accountRegionScope: scope.accountRegionScope,
+        cloudFrontRegistry: this.cloudFrontRegistry,
+        s3OriginResolver: makeSimCfS3OriginResolver(this.simAws, scope),
+        background: this.background,
+      });
+      this.cloudFrontServices.set(accountId, cloudFront);
+    }
+
+    return cloudFront;
+  }
+
+  /**
+   * Create or get simulated Route53 for an Account scope.
+   */
+  createRoute53(scope: SimAwsAccountRegionContainer): SimRoute53 {
+    const { accountId } = scope.accountRegionScope;
+
+    let route53 = this.route53Services.get(accountId);
+
+    if (route53 === undefined) {
+      route53 = new SimRoute53();
+      this.route53Services.set(accountId, route53);
+    }
+
+    return route53;
+  }
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -2,16 +2,16 @@ import type {
   BackgroundCompleter,
   BackgroundScheduler,
 } from "../../../util/background/background.js";
-import type { SimAwsAccountId } from "../sim-aws-account.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
-import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
-import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
+import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimDynamoDb } from "../../dynamodb/index.js";
+import type { SimRoute53 } from "../../route53/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
+import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 
 interface SimAwsServiceFactoryProps {
   readonly simAws: SimAws;
@@ -32,14 +32,16 @@ export class SimAwsServiceFactory {
 
   private readonly _cloudFrontRegistry = new SimCloudFrontRegistry();
 
-  private readonly cloudFrontServices = new Map<
-    SimAwsAccountId,
-    SimCloudFront
-  >();
+  private readonly accountServices: SimAwsAccountServiceCache;
 
   constructor(props: SimAwsServiceFactoryProps) {
     this.simAws = props.simAws;
     this.background = props.background;
+    this.accountServices = new SimAwsAccountServiceCache({
+      simAws: props.simAws,
+      background: props.background,
+      cloudFrontRegistry: this._cloudFrontRegistry,
+    });
   }
 
   /**
@@ -57,21 +59,7 @@ export class SimAwsServiceFactory {
    * Create or get simulated CloudFront for an Account scope.
    */
   createCloudFront(scope: SimAwsAccountRegionContainer): SimCloudFront {
-    const { accountId } = scope.accountRegionScope;
-
-    let cloudFront = this.cloudFrontServices.get(accountId);
-
-    if (cloudFront === undefined) {
-      cloudFront = new SimCloudFront({
-        accountRegionScope: scope.accountRegionScope,
-        cloudFrontRegistry: this._cloudFrontRegistry,
-        s3OriginResolver: makeSimCfS3OriginResolver(this.simAws, scope),
-        background: this.background,
-      });
-      this.cloudFrontServices.set(accountId, cloudFront);
-    }
-
-    return cloudFront;
+    return this.accountServices.createCloudFront(scope);
   }
 
   /**
@@ -92,6 +80,13 @@ export class SimAwsServiceFactory {
       accountRegionScope: scope.accountRegionScope,
       background: this.background,
     });
+  }
+
+  /**
+   * Create or get simulated Route53 for an Account scope.
+   */
+  createRoute53(scope: SimAwsAccountRegionContainer): SimRoute53 {
+    return this.accountServices.createRoute53(scope);
   }
 
   /**

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -15,6 +15,7 @@ import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimRoute53 } from "../route53/index.js";
 
 export type SimAccountRegionScopeKey = `${SimAwsAccountId}:${AwsRegionName}`;
 
@@ -77,6 +78,15 @@ export class SimAwsAccountRegionContainer {
   dynamoDb(): SimDynamoDb {
     return this.memo.getOrCreate("dynamoDb", () =>
       this.simAws._serviceFactory.createDynamoDb(this),
+    );
+  }
+
+  /**
+   * Get simulated Route53 for this account.
+   */
+  route53(): SimRoute53 {
+    return this.memo.getOrCreate("route53", () =>
+      this.simAws._serviceFactory.createRoute53(this),
     );
   }
 

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -19,6 +19,7 @@ import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimCloudFrontRegistry } from "../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimRoute53 } from "../route53/index.js";
 import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
 import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
 
@@ -102,6 +103,13 @@ export class SimAws {
    */
   dynamoDb(): SimDynamoDb {
     return this.accountRegionScope().dynamoDb();
+  }
+
+  /**
+   * Get simulated Route53 in the default Account scope.
+   */
+  route53(): SimRoute53 {
+    return this.accountRegionScope().route53();
   }
 
   /**

--- a/src/service/route53/index.ts
+++ b/src/service/route53/index.ts
@@ -1,0 +1,6 @@
+export { SimRoute53 } from "./sim-route53.js";
+export type {
+  SimRoute53HttpResolution,
+  SimRoute53Record,
+  SimRoute53RecordType,
+} from "./record/sim-route53-record.js";

--- a/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
@@ -28,6 +28,28 @@ describe("sim Route53 local name utils", () => {
       // Then no logical DNS name is returned.
       assertUndefined(logicalName);
     });
+
+    it("returns undefined for logical names with leading empty labels", () => {
+      // Given a local Route53 name whose logical name starts with an empty label.
+      const localName = ".www.foo.com.sim-aws.localhost";
+
+      // When converting the local name to a logical DNS name.
+      const logicalName = simRoute53LogicalName(localName);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
+
+    it("returns undefined for logical names with trailing empty labels", () => {
+      // Given a local Route53 name whose logical name ends with an empty label.
+      const localName = "www.foo.com..sim-aws.localhost";
+
+      // When converting the local name to a logical DNS name.
+      const logicalName = simRoute53LogicalName(localName);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
   });
 
   describe("simRoute53LocalName", () => {

--- a/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.iso.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "vitest";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import {
+  simRoute53LocalName,
+  simRoute53LogicalName,
+} from "./sim-route53-local-name.js";
+
+describe("sim Route53 local name utils", () => {
+  describe("simRoute53LogicalName", () => {
+    it("returns undefined for empty logical names", () => {
+      // Given a local Route53 name with no logical name before the suffix.
+      const localName = "sim-aws.localhost";
+
+      // When converting the local name to a logical DNS name.
+      const logicalName = simRoute53LogicalName(localName);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
+
+    it("returns undefined for logical names containing empty labels", () => {
+      // Given a local Route53 name whose logical name contains an empty label.
+      const localName = "www..foo.com.sim-aws.localhost";
+
+      // When converting the local name to a logical DNS name.
+      const logicalName = simRoute53LogicalName(localName);
+
+      // Then no logical DNS name is returned.
+      assertUndefined(logicalName);
+    });
+  });
+
+  describe("simRoute53LocalName", () => {
+    it("returns already-local Route53 names unchanged after normalisation", () => {
+      // Given a Route53 name that already ends with the simulated local suffix.
+      const logicalName = "WWW.FOO.COM.SIM-AWS.LOCALHOST.";
+
+      // When converting it to a local Route53 name.
+      const localName = simRoute53LocalName(logicalName);
+
+      // Then the existing local name is returned in normalised form.
+      assertIdentical(localName, "www.foo.com.sim-aws.localhost");
+    });
+  });
+});

--- a/src/service/route53/local-name/sim-route53-local-name.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.ts
@@ -20,8 +20,10 @@ export function simRoute53LogicalName(localName: string): string | undefined {
   }
 
   const logicalName = normalisedName.slice(0, -simRoute53LocalSuffix.length);
+  const logicalNameLabels = logicalName.split(".");
 
-  if (logicalName.length === 0 || logicalName.includes("..")) {
+  // Reject empty labels before normalization can hide malformed hostnames.
+  if (logicalNameLabels.some((label) => label.length === 0)) {
     return undefined;
   }
 

--- a/src/service/route53/local-name/sim-route53-local-name.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.ts
@@ -1,0 +1,42 @@
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+
+export const simRoute53LocalSuffix = SimAwsLocalUrl.localhostSuffix;
+
+/**
+ * Normalise a Route53 name for case-insensitive matching.
+ */
+export function normaliseSimRoute53Name(name: string): string {
+  return name.toLowerCase().replaceAll(/\.+$/g, "");
+}
+
+/**
+ * Convert a Yulin-local Route53 name to a logical DNS name.
+ */
+export function simRoute53LogicalName(localName: string): string | undefined {
+  const normalisedName = normaliseSimRoute53Name(localName);
+
+  if (!normalisedName.endsWith(simRoute53LocalSuffix)) {
+    return undefined;
+  }
+
+  const logicalName = normalisedName.slice(0, -simRoute53LocalSuffix.length);
+
+  if (logicalName.length === 0 || logicalName.includes("..")) {
+    return undefined;
+  }
+
+  return logicalName;
+}
+
+/**
+ * Convert a logical DNS name to a Yulin-local Route53 name.
+ */
+export function simRoute53LocalName(logicalName: string): string {
+  const normalisedName = normaliseSimRoute53Name(logicalName);
+
+  if (normalisedName.endsWith(simRoute53LocalSuffix)) {
+    return normalisedName;
+  }
+
+  return `${normalisedName}${simRoute53LocalSuffix}`;
+}

--- a/src/service/route53/record/sim-route53-record.ts
+++ b/src/service/route53/record/sim-route53-record.ts
@@ -1,0 +1,21 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+
+export type SimRoute53RecordType =
+  | "A"
+  | "AAAA"
+  | "CNAME"
+  | "TXT"
+  | "NS"
+  | "SOA";
+
+export interface SimRoute53Record {
+  readonly name: string;
+  readonly type: SimRoute53RecordType;
+  readonly values: readonly string[];
+  readonly ttl?: number;
+}
+
+export interface SimRoute53HttpResolution {
+  readonly target: SimAwsServiceTarget;
+  readonly rewrittenHostname?: string;
+}

--- a/src/service/route53/resolve/sim-route53-resolver.iso.test.ts
+++ b/src/service/route53/resolve/sim-route53-resolver.iso.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { SimRoute53Zone } from "../zone/sim-route53-zone.js";
+import { SimRoute53Resolver } from "./sim-route53-resolver.js";
+
+describe("SimRoute53Resolver", () => {
+  it("resolves S3 website built-in local hostnames", () => {
+    // Given a resolver backed by an empty Route53 zone.
+    const resolver = new SimRoute53Resolver({ zone: new SimRoute53Zone() });
+
+    // When resolving a local S3 website hostname.
+    const target = resolver.resolveHttpHost(
+      "bucket-a.s3-website.eu-west-1.sim-aws.localhost",
+    );
+
+    // Then the hostname maps to the matching simulated S3 website target.
+    assertNonNullable(target);
+    assertIdentical(target.service, "s3");
+    assertIdentical(target.resourceName, "bucket-a");
+    assertIdentical(target.regionName, "eu-west-1");
+  });
+
+  it("resolves CloudFront built-in local hostnames", () => {
+    // Given a resolver backed by an empty Route53 zone.
+    const resolver = new SimRoute53Resolver({ zone: new SimRoute53Zone() });
+
+    // When resolving a local CloudFront hostname.
+    const target = resolver.resolveHttpHost(
+      "distro123.cloudfront.net.sim-aws.localhost",
+    );
+
+    // Then the hostname maps to the matching simulated CloudFront target.
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "distro123");
+    assertUndefined(target.regionName);
+  });
+
+  it("follows CNAME chains to built-in local hostnames", () => {
+    // Given a resolver with chained CNAME records for a custom domain.
+    const zone = new SimRoute53Zone();
+    zone.upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["cdn.foo.com"],
+    });
+    zone.upsertRecord({
+      name: "cdn.foo.com",
+      type: "CNAME",
+      values: ["distro123.cloudfront.net"],
+    });
+    const resolver = new SimRoute53Resolver({ zone });
+
+    // When resolving the local hostname for the custom domain.
+    const target = resolver.resolveHttpHost("www.foo.com.sim-aws.localhost");
+
+    // Then the resolver follows the chain to the final service target.
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "distro123");
+  });
+
+  it("returns undefined for non-local hostnames", () => {
+    // Given a resolver backed by an empty Route53 zone.
+    const resolver = new SimRoute53Resolver({ zone: new SimRoute53Zone() });
+
+    // When resolving a hostname outside the simulated local domain.
+    const target = resolver.resolveHttpHost("distro123.cloudfront.net");
+
+    // Then no simulated service target is returned.
+    assertUndefined(target);
+  });
+
+  it("returns undefined for missing CNAME targets", () => {
+    // Given a resolver with no records for a custom local hostname.
+    const resolver = new SimRoute53Resolver({ zone: new SimRoute53Zone() });
+
+    // When resolving that custom local hostname.
+    const target = resolver.resolveHttpHost("www.foo.com.sim-aws.localhost");
+
+    // Then no simulated service target is returned.
+    assertUndefined(target);
+  });
+
+  it("returns undefined for incomplete built-in local hostnames", () => {
+    // Given a resolver backed by an empty Route53 zone.
+    const resolver = new SimRoute53Resolver({ zone: new SimRoute53Zone() });
+
+    // When resolving a local hostname without enough service labels.
+    const target = resolver.resolveHttpHost("cloudfront.net.sim-aws.localhost");
+
+    // Then no simulated service target is returned.
+    assertUndefined(target);
+  });
+
+  it("stops CNAME loops", () => {
+    // Given a resolver with CNAME records that point back to each other.
+    const zone = new SimRoute53Zone();
+    zone.upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["cdn.foo.com"],
+    });
+    zone.upsertRecord({
+      name: "cdn.foo.com",
+      type: "CNAME",
+      values: ["www.foo.com"],
+    });
+    const resolver = new SimRoute53Resolver({ zone });
+
+    // When resolving a local hostname that enters the loop.
+    const target = resolver.resolveHttpHost("www.foo.com.sim-aws.localhost");
+
+    // Then the resolver stops without returning a service target.
+    assertUndefined(target);
+  });
+});

--- a/src/service/route53/resolve/sim-route53-resolver.ts
+++ b/src/service/route53/resolve/sim-route53-resolver.ts
@@ -116,15 +116,16 @@ export class SimRoute53Resolver {
   ): SimAwsServiceTarget | undefined {
     const labels = logicalName.split(".");
 
-    if (labels.length < 3) {
+    if (labels.length !== 3) {
       return undefined;
     }
 
-    if (labels.at(-2) !== cloudFrontServiceLabel || labels.at(-1) !== "net") {
+    const [distroId, service, topLevelDomain] = labels;
+
+    if (service !== cloudFrontServiceLabel || topLevelDomain !== "net") {
       return undefined;
     }
 
-    const distroId = labels.at(-3);
     /* v8 ignore if -- defensive check */
     if (distroId === undefined || distroId.length === 0) {
       return undefined;

--- a/src/service/route53/resolve/sim-route53-resolver.ts
+++ b/src/service/route53/resolve/sim-route53-resolver.ts
@@ -1,0 +1,138 @@
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import type { SimRoute53Zone } from "../zone/sim-route53-zone.js";
+import {
+  simRoute53LocalName,
+  simRoute53LogicalName,
+} from "../local-name/sim-route53-local-name.js";
+
+const s3WebsiteServiceLabel = "s3-website";
+const cloudFrontServiceLabel = "cloudfront";
+const maxCnameDepth = 8;
+
+interface SimRoute53ResolverProps {
+  readonly zone: SimRoute53Zone;
+}
+
+/**
+ * Resolves Yulin-local hostnames through simulated Route53 records.
+ */
+export class SimRoute53Resolver {
+  private readonly zone: SimRoute53Zone;
+
+  constructor(props: SimRoute53ResolverProps) {
+    this.zone = props.zone;
+  }
+
+  /**
+   * Resolve a Yulin-local HTTP hostname to a simulated AWS service target.
+   */
+  resolveHttpHost(hostname: string): SimAwsServiceTarget | undefined {
+    const initialLogicalName = simRoute53LogicalName(hostname);
+    if (initialLogicalName === undefined) {
+      return undefined;
+    }
+
+    let localName = simRoute53LocalName(initialLogicalName);
+    const visitedNames = new Set<string>();
+
+    for (let depth = 0; depth <= maxCnameDepth; depth += 1) {
+      if (visitedNames.has(localName)) {
+        return undefined;
+      }
+      visitedNames.add(localName);
+
+      const directTarget = this.builtinLocalServiceTarget(localName);
+      if (directTarget !== undefined) {
+        return directTarget;
+      }
+
+      const logicalName = simRoute53LogicalName(localName);
+      /* v8 ignore if -- defensive check */
+      if (logicalName === undefined) {
+        return undefined;
+      }
+
+      const cname = this.zone.record(logicalName, "CNAME");
+      const cnameTarget = cname?.values[0];
+      if (cnameTarget === undefined || cnameTarget.length === 0) {
+        return undefined;
+      }
+
+      localName = simRoute53LocalName(cnameTarget);
+    }
+
+    /* v8 ignore next -- defensive fallback */
+    return undefined;
+  }
+
+  private builtinLocalServiceTarget(
+    hostname: string,
+  ): SimAwsServiceTarget | undefined {
+    const logicalName = simRoute53LogicalName(hostname);
+    /* v8 ignore if -- defensive check */
+    if (logicalName === undefined) {
+      return undefined;
+    }
+
+    return (
+      this.s3WebsiteServiceTarget(logicalName) ??
+      this.cloudFrontServiceTarget(logicalName)
+    );
+  }
+
+  private s3WebsiteServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length < 3) {
+      return undefined;
+    }
+
+    const service = labels.at(-2);
+    const regionName = labels.at(-1) as AwsRegionName | undefined;
+
+    if (service !== s3WebsiteServiceLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    const resourceName = labels.slice(0, -2).join(".");
+
+    /* v8 ignore if -- defensive check */
+    if (resourceName.length === 0 || regionName.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "s3",
+      resourceName,
+      regionName,
+    };
+  }
+
+  private cloudFrontServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length < 3) {
+      return undefined;
+    }
+
+    if (labels.at(-2) !== cloudFrontServiceLabel || labels.at(-1) !== "net") {
+      return undefined;
+    }
+
+    const distroId = labels.at(-3);
+    /* v8 ignore if -- defensive check */
+    if (distroId === undefined || distroId.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "cloudFront",
+      resourceName: distroId,
+    };
+  }
+}

--- a/src/service/route53/sim-route53.iso.test.ts
+++ b/src/service/route53/sim-route53.iso.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { SimRoute53 } from "./sim-route53.js";
+
+describe("SimRoute53", () => {
+  it("resolves CloudFront built-in local hostname", () => {
+    const route53 = new SimRoute53();
+
+    const target = route53.resolveHttpHost(
+      "abcd1234.cloudfront.net.sim-aws.localhost",
+    );
+
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "abcd1234");
+    assertUndefined(target.regionName);
+  });
+
+  it("resolves S3 website built-in local hostname", () => {
+    const route53 = new SimRoute53();
+
+    const target = route53.resolveHttpHost(
+      "bucket-a.s3-website.eu-west-1.sim-aws.localhost",
+    );
+
+    assertNonNullable(target);
+    assertIdentical(target.service, "s3");
+    assertIdentical(target.resourceName, "bucket-a");
+    assertIdentical(target.regionName, "eu-west-1");
+  });
+
+  it("returns undefined for non-local hostnames", () => {
+    const route53 = new SimRoute53();
+
+    assertUndefined(route53.resolveHttpHost("abcd1234.cloudfront.net"));
+  });
+
+  it("returns undefined for malformed local names", () => {
+    const route53 = new SimRoute53();
+
+    assertUndefined(
+      route53.resolveHttpHost("..cloudfront.net.sim-aws.localhost"),
+    );
+  });
+
+  it("resolves custom CNAME from local domain to CloudFront distro", () => {
+    const route53 = new SimRoute53();
+    route53.upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["d123.cloudfront.net"],
+    });
+
+    const target = route53.resolveHttpHost("www.foo.com.sim-aws.localhost");
+
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "d123");
+  });
+
+  it("follows CNAME chains", () => {
+    const route53 = new SimRoute53();
+    route53.upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["cdn.foo.com"],
+    });
+    route53.upsertRecord({
+      name: "cdn.foo.com",
+      type: "CNAME",
+      values: ["d123.cloudfront.net"],
+    });
+
+    const target = route53.resolveHttpHost("www.foo.com.sim-aws.localhost");
+
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "d123");
+  });
+
+  it("stops CNAME loops", () => {
+    const route53 = new SimRoute53();
+    route53.upsertRecord({
+      name: "www.foo.com",
+      type: "CNAME",
+      values: ["cdn.foo.com"],
+    });
+    route53.upsertRecord({
+      name: "cdn.foo.com",
+      type: "CNAME",
+      values: ["www.foo.com"],
+    });
+
+    assertUndefined(route53.resolveHttpHost("www.foo.com.sim-aws.localhost"));
+  });
+
+  it("resolves TXT records for logical names", () => {
+    const route53 = new SimRoute53();
+    route53.upsertRecord({
+      name: "_abc.foo.com",
+      type: "TXT",
+      values: ["validation-token"],
+    });
+
+    const record = route53.record("_abc.foo.com", "TXT");
+
+    assertNonNullable(record);
+    assertIdentical(record.values[0], "validation-token");
+  });
+
+  it("normalises trailing dots and casing", () => {
+    const route53 = new SimRoute53();
+    route53.upsertRecord({
+      name: "WWW.FOO.COM.",
+      type: "CNAME",
+      values: ["D123.CLOUDFRONT.NET."],
+    });
+
+    const target = route53.resolveHttpHost("WWW.FOO.COM.SIM-AWS.LOCALHOST.");
+
+    assertNonNullable(target);
+    assertIdentical(target.service, "cloudFront");
+    assertIdentical(target.resourceName, "d123");
+  });
+});

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -1,0 +1,40 @@
+import type {
+  SimRoute53Record,
+  SimRoute53RecordType,
+} from "./record/sim-route53-record.js";
+import type { SimAwsServiceTarget } from "../../serve/controller/sim-service-controller.js";
+import { SimRoute53Zone } from "./zone/sim-route53-zone.js";
+import { SimRoute53Resolver } from "./resolve/sim-route53-resolver.js";
+import { normaliseSimRoute53Name } from "./local-name/sim-route53-local-name.js";
+
+/**
+ * Simulated Route53 service for Yulin-local name resolution.
+ */
+export class SimRoute53 {
+  private readonly zone = new SimRoute53Zone();
+  private readonly resolver = new SimRoute53Resolver({ zone: this.zone });
+
+  /**
+   * Create or replace a simulated Route53 record.
+   */
+  upsertRecord(record: SimRoute53Record): void {
+    this.zone.upsertRecord(record);
+  }
+
+  /**
+   * Get a simulated Route53 record by logical name and type.
+   */
+  record(
+    name: string,
+    type: SimRoute53RecordType,
+  ): SimRoute53Record | undefined {
+    return this.zone.record(normaliseSimRoute53Name(name), type);
+  }
+
+  /**
+   * Resolve a Yulin-local HTTP hostname to a simulated AWS service target.
+   */
+  resolveHttpHost(hostname: string): SimAwsServiceTarget | undefined {
+    return this.resolver.resolveHttpHost(hostname);
+  }
+}

--- a/src/service/route53/zone/sim-route53-zone.ts
+++ b/src/service/route53/zone/sim-route53-zone.ts
@@ -35,7 +35,18 @@ export class SimRoute53Zone {
     name: string,
     type: SimRoute53RecordType,
   ): SimRoute53Record | undefined {
-    return this.records.get(recordKey(normaliseSimRoute53Name(name), type));
+    const record = this.records.get(
+      recordKey(normaliseSimRoute53Name(name), type),
+    );
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    return {
+      ...record,
+      values: [...record.values],
+    };
   }
 }
 

--- a/src/service/route53/zone/sim-route53-zone.ts
+++ b/src/service/route53/zone/sim-route53-zone.ts
@@ -1,0 +1,51 @@
+import type {
+  SimRoute53Record,
+  SimRoute53RecordType,
+} from "../record/sim-route53-record.js";
+import { normaliseSimRoute53Name } from "../local-name/sim-route53-local-name.js";
+
+/**
+ * Internal storage for simulated Route53 records.
+ */
+export class SimRoute53Zone {
+  private readonly records = new Map<string, SimRoute53Record>();
+
+  /**
+   * Create or replace a record in this zone.
+   */
+  upsertRecord(record: SimRoute53Record): void {
+    const normalisedRecord = {
+      ...record,
+      name: normaliseSimRoute53Name(record.name),
+      values: record.values.map((value) =>
+        normaliseRecordValue(record.type, value),
+      ),
+    };
+
+    this.records.set(
+      recordKey(normalisedRecord.name, normalisedRecord.type),
+      normalisedRecord,
+    );
+  }
+
+  /**
+   * Get a record by logical name and type.
+   */
+  record(
+    name: string,
+    type: SimRoute53RecordType,
+  ): SimRoute53Record | undefined {
+    return this.records.get(recordKey(normaliseSimRoute53Name(name), type));
+  }
+}
+
+function recordKey(name: string, type: SimRoute53RecordType): string {
+  return `${type}:${name}`;
+}
+
+function normaliseRecordValue(
+  type: SimRoute53RecordType,
+  value: string,
+): string {
+  return type === "TXT" ? value : normaliseSimRoute53Name(value);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Route 53 simulation support with in-memory record storage, local-name normalization, and HTTP hostname resolution (including built-in S3/CloudFront mappings and custom CNAME chains).
  * Exposed a new public Route 53 entrypoint and added account/region-level access to the service.
  * Improved simulated AWS HTTP routing to resolve custom domains through Route 53.
* **Bug Fixes**
  * Added/expanded handling for malformed hostnames, missing CNAME targets, and CNAME loop detection.
  * Updated routing tests to cover custom-domain resolution failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->