### PR TITLE
feat: sim Route53 reject duplicate zone caller reference

### DIFF
--- a/src/service/route53/command/create-hosted-zone/create-hosted-zone.handler.ts
+++ b/src/service/route53/command/create-hosted-zone/create-hosted-zone.handler.ts
@@ -13,6 +13,7 @@ import {
   makeSimRoute53HostedZoneId,
   type SimRoute53HostedZoneId,
 } from "./sim-route53-zone-id.js";
+import { SimRoute53HostedZoneAlreadyExists } from "../../error/sim-route53.error.js";
 
 interface CreateHostedZoneCommandHandlerProps {
   readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
@@ -59,6 +60,15 @@ export class CreateHostedZoneCommandHandler implements CommandHandler<
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
+
+    const existingHostedZone = [...this.hostedZones.values()].find(
+      (hostedZone) => hostedZone.callerReference === callerReference,
+    );
+    if (existingHostedZone !== undefined) {
+      throw new SimRoute53HostedZoneAlreadyExists(
+        `A sim Route53 Hosted Zone with caller reference ${callerReference} already exists`,
+      );
+    }
 
     const hostedZone = new SimRoute53HostedZone({
       id: hostedZoneId,

--- a/src/service/route53/command/create-hosted-zone/create-hosted-zone.iso.test.ts
+++ b/src/service/route53/command/create-hosted-zone/create-hosted-zone.iso.test.ts
@@ -14,6 +14,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { assertIsSimRoute53HostedZoneId } from "./sim-route53-zone-id.js";
+import { SimRoute53HostedZoneAlreadyExists } from "../../error/sim-route53.error.js";
 
 describe("Route53 CreateHostedZoneCommand", () => {
   it("creates a Hosted Zone in SimRoute53", async () => {
@@ -234,5 +235,33 @@ describe("Route53 CreateHostedZoneCommand", () => {
 
     // Then the Hosted Zone has moved to INSYNC.
     assertIdentical(hostedZone.status, "INSYNC");
+  });
+
+  it("throws when a Hosted Zone already exists for the same caller reference", async () => {
+    // Given a simulated Route53 service with an existing Hosted Zone.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    await simRoute53.createHostedZone({
+      input: {
+        Name: "first.example.com",
+        CallerReference: "duplicate-caller-reference",
+      },
+    });
+
+    // When another Hosted Zone is created with the same CallerReference.
+    const error = await assertThrowsErrorAsync(async () =>
+      simRoute53.createHostedZone({
+        input: {
+          Name: "second.example.com",
+          CallerReference: "duplicate-caller-reference",
+        },
+      }),
+    );
+
+    // Then the duplicate CallerReference is rejected.
+    assertInstanceOf(error, SimRoute53HostedZoneAlreadyExists);
+    assertIdentical(error.name, "HostedZoneAlreadyExists");
+    assertStringIncludes(error.message, "duplicate-caller-reference");
   });
 });

--- a/src/service/route53/error/sim-route53.error.ts
+++ b/src/service/route53/error/sim-route53.error.ts
@@ -27,3 +27,14 @@ export class SimRoute53NoSuchHostedZone extends SimRoute53Error {
     super(message, { httpStatusCode: 404 });
   }
 }
+
+/**
+ * Simulated Route53 HostedZoneAlreadyExists error.
+ */
+export class SimRoute53HostedZoneAlreadyExists extends SimRoute53Error {
+  public override readonly name = "HostedZoneAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/route53/error/sim-route53.error.ts
+++ b/src/service/route53/error/sim-route53.error.ts
@@ -35,6 +35,6 @@ export class SimRoute53HostedZoneAlreadyExists extends SimRoute53Error {
   public override readonly name = "HostedZoneAlreadyExists";
 
   constructor(message: string) {
-    super(message, { httpStatusCode: 400 });
+    super(message, { httpStatusCode: 409 });
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a hosted zone now correctly rejects duplicate caller references instead of creating another zone.
  * Added a clearer error response for this case, including the expected error name and message details.
  * Expanded test coverage to verify duplicate hosted zone creation is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->