### PR TITLE
fix: eslint disallow undefined error conditions, this.props

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -141,11 +141,7 @@ try {
     }),
   );
 
-  const distroHostname = createDistributionOutput.Distribution?.DomainName;
-
-  if (distroHostname === undefined) {
-    throw new Error("Expected sim CloudFront Distribution hostname");
-  }
+  const distroHostname = createDistributionOutput.Distribution!.DomainName!;
 
   const url = srv.localUrl(`http://${distroHostname}/hello.txt`);
   const response = await fetch(url);
@@ -261,11 +257,7 @@ try {
     }),
   );
 
-  const distroHostname = createDistributionOutput.Distribution?.DomainName;
-
-  if (distroHostname === undefined) {
-    throw new Error("Expected sim CloudFront Distribution hostname");
-  }
+  const distroHostname = createDistributionOutput.Distribution!.DomainName!;
 
   const url = srv.localUrl(`http://${distroHostname}/old-page.html`);
   const response = await fetch(url, { redirect: "manual" });

--- a/docs/services/cloudfront/serve-sim-cloudfront-localhost.example.ts
+++ b/docs/services/cloudfront/serve-sim-cloudfront-localhost.example.ts
@@ -55,11 +55,7 @@ try {
     }),
   );
 
-  const distroHostname = createDistributionOutput.Distribution?.DomainName;
-
-  if (distroHostname === undefined) {
-    throw new Error("Expected sim CloudFront Distribution hostname");
-  }
+  const distroHostname = createDistributionOutput.Distribution!.DomainName!;
 
   const url = srv.localUrl(`http://${distroHostname}/hello.txt`);
   const response = await fetch(url);

--- a/docs/services/cloudfront/sim-cloudfront-function.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function.example.ts
@@ -92,11 +92,7 @@ try {
     }),
   );
 
-  const distroHostname = createDistributionOutput.Distribution?.DomainName;
-
-  if (distroHostname === undefined) {
-    throw new Error("Expected sim CloudFront Distribution hostname");
-  }
+  const distroHostname = createDistributionOutput.Distribution!.DomainName!;
 
   const url = srv.localUrl(`http://${distroHostname}/old-page.html`);
   const response = await fetch(url, { redirect: "manual" });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -115,7 +115,7 @@ export default defineConfig(
         },
       ],
 
-      // ── Discourage lazy `unknown` typing ─────────────
+      // ── Discourage various undesirable patterns ─────────────
       "no-restricted-syntax": [
         "error",
         {
@@ -123,6 +123,18 @@ export default defineConfig(
             "TSUnknownKeyword:not(.params > TSTypeAnnotation > TSUnknownKeyword)",
           message:
             "Avoid `unknown` as a type, except when narrowing a function parameter to a concrete type.",
+        },
+        {
+          selector:
+            "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Identifier'][test.left.name='undefined'], [test.right.type='Identifier'][test.right.name='undefined']):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
+          message:
+            "Use `assertDefined(value, description)` instead of throwing `Error` from an `undefined` guard.",
+        },
+        {
+          selector:
+            "IfStatement[test.type='BinaryExpression'][test.operator='===']:matches([test.left.type='Literal'][test.left.value=null], [test.right.type='Literal'][test.right.value=null]):has(ThrowStatement[argument.type='NewExpression'][argument.callee.name='Error'])",
+          message:
+            "Use `assertNotNull(value, description)` instead of throwing `Error` from a `null` guard.",
         },
       ],
 
@@ -230,6 +242,7 @@ export default defineConfig(
     files: ["docs/**/*.example.ts", "docs/**/*.examples.ts"],
     rules: {
       "no-console": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
     },
   },
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -136,6 +136,12 @@ export default defineConfig(
           message:
             "Use `assertNotNull(value, description)` instead of throwing `Error` from a `null` guard.",
         },
+        {
+          selector:
+            "MemberExpression[object.type='ThisExpression'][property.type='Identifier'][property.name='props']",
+          message:
+            "Do not reuse `this.props`. Destructure constructor props into class members instead.",
+        },
       ],
 
       // ── General quality ──────────────────────────────

--- a/src/serve/http/local-server/sim-aws-local-server.iso.test.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.iso.test.ts
@@ -1,5 +1,5 @@
 import net from "node:net";
-import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { assertStringEndsWith, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAwsLocalServer } from "./sim-aws-local-server.js";
 
@@ -16,7 +16,7 @@ describe("SimAwsLocalServer", () => {
       assertStringIncludes(responseText, "HTTP/1.1 400 Bad Request");
       assertStringIncludes(
         responseText,
-        "local sim server nodeRequest.headers.host must be defined",
+        "local sim server nodeRequest.headers.host required",
       );
     } finally {
       server.close();
@@ -36,11 +36,9 @@ describe("SimAwsLocalServer", () => {
         responseText.toLowerCase(),
         "content-type: text/plain; charset=utf-8",
       );
-      assertIdentical(
-        responseText.endsWith(
-          "local sim server nodeRequest.headers.host must be defined",
-        ),
-        true,
+      assertStringEndsWith(
+        responseText,
+        "local sim server nodeRequest.headers.host required",
       );
     } finally {
       server.close();

--- a/src/serve/http/node-fetch-http-adapter.ts
+++ b/src/serve/http/node-fetch-http-adapter.ts
@@ -10,7 +10,7 @@ export class NodeFetchHttpAdapter {
    */
   nodeRequestToFetchRequest(nodeRequest: IncomingMessage): Request {
     const host = nodeRequest.headers.host;
-    assertDefined(host, "local sim server nodeRequest.headers.host");
+    assertDefined(host, "local sim server nodeRequest.headers.host required");
     const url = new URL(nodeRequest.url ?? "/", `http://${host}`);
 
     return new Request(url, {

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/error-message/sim-cdk-bucket-deploy-error-message.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/error-message/sim-cdk-bucket-deploy-error-message.ts
@@ -12,24 +12,32 @@ interface SimCdkBucketDeploymentAssetErrorMessageProps {
  * Formats CDK BucketDeployment asset resolution error messages.
  */
 export class SimCdkBucketDeployErrorMessage {
-  constructor(
-    private readonly props: SimCdkBucketDeploymentAssetErrorMessageProps,
-  ) {}
+  private readonly resource: SimCfnResource;
+  private readonly sourceObjectKey: string;
+  private readonly cdkOutContext: SimCdkOutContext | undefined;
+  private readonly reason: string;
+
+  constructor(props: SimCdkBucketDeploymentAssetErrorMessageProps) {
+    this.resource = props.resource;
+    this.sourceObjectKey = props.sourceObjectKey;
+    this.cdkOutContext = props.cdkOutContext;
+    this.reason = props.reason;
+  }
 
   /**
    * Build the complete asset resolution error message.
    */
   toString(): string {
     return [
-      `Could not configure Custom::CDKBucketDeployment ${this.props.resource.logicalId}.`,
+      `Could not configure Custom::CDKBucketDeployment ${this.resource.logicalId}.`,
       "",
       "Referenced source object key:",
-      this.props.sourceObjectKey,
+      this.sourceObjectKey,
       "",
       "Expected asset metadata in:",
-      this.props.cdkOutContext?.assetsManifestPath ?? "unknown assets manifest",
+      this.cdkOutContext?.assetsManifestPath ?? "unknown assets manifest",
       "",
-      this.props.reason,
+      this.reason,
       "",
       "Run `cdk synth` and ensure the cloud assembly is available.",
     ].join("\n");

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
@@ -7,6 +7,7 @@ import type {
   SimCloudFormationResourceCreateContext,
 } from "../../../resource/sim-cfn-resource.js";
 import { SimCdkBucketDeploySource } from "./source/sim-cdk-bucket-deploy-source.js";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
  * CloudFormation Resource factory for CDK BucketDeployment compatibility.
@@ -88,12 +89,10 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
       )
       .s3()
       .getSimBucketByName(destinationBucketName);
-
-    if (bucket === undefined) {
-      throw new Error(
-        `Custom::CDKBucketDeployment destination Bucket ${destinationBucketName} does not exist`,
-      );
-    }
+    assertDefined(
+      bucket,
+      `Custom::CDKBucketDeployment destination Bucket ${destinationBucketName} does not exist`,
+    );
 
     bucket.configureSimStorage(
       new FilesystemS3BucketStorage({

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
@@ -42,6 +42,7 @@ export class SimCdkBucketDeploySource {
       sourceObjectKey,
     );
 
+    // eslint-disable-next-line no-restricted-syntax
     if (fileAsset?.source?.path === undefined) {
       throw new Error(
         new SimCdkBucketDeployErrorMessage({

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -2,13 +2,21 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "../stack/sim-cfn-stack.js";
-import type { SimCreateStackCommandOutput } from "../command/create-stack/create-stack.cmd.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import { SimCfnTemplateFileLoader } from "./sim-cfn-template-file-loader.js";
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../util/background/background.js";
+import type { SimCreateStackCommandOutput } from "../command/create-stack/create-stack.cmd.js";
+import { CreateStackCommandHandler } from "../command/create-stack/create-stack.handler.js";
+import { faker } from "@faker-js/faker";
 
 export interface SimCloudFormationCreateStackProps {
   readonly stackName?: SimCloudFormationStackName | string;
@@ -24,24 +32,10 @@ export interface SimCloudFormationDeployTemplateFileProps {
 }
 
 interface SimCloudFormationTemplateDeployerProps {
-  readonly createStackWithContext: (
-    cmd: {
-      readonly input: {
-        readonly StackName: SimCloudFormationStackName | string;
-        readonly TemplateBody: string;
-        readonly Parameters: readonly {
-          readonly ParameterKey: string;
-          readonly ParameterValue: string;
-        }[];
-      };
-    },
-    cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnExecutableResourceBinding[],
-  ) => Promise<SimCreateStackCommandOutput>;
-  readonly getStackByName: (
-    stackName: SimCloudFormationStackName | string,
-  ) => SimCfnStack | undefined;
-  readonly defaultStackName: () => SimCloudFormationStackName;
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
 }
 
 /**
@@ -55,9 +49,18 @@ interface SimCloudFormationTemplateDeployerProps {
  * - return the created Stack.
  */
 export class SimCloudFormationTemplateDeployer {
+  private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly templateFileLoader = new SimCfnTemplateFileLoader();
 
-  constructor(private readonly props: SimCloudFormationTemplateDeployerProps) {}
+  constructor(props: SimCloudFormationTemplateDeployerProps) {
+    this.simAws = props.simAws;
+    this.accountRegionScope = props.accountRegionScope;
+    this.stacks = props.stacks;
+    this.background = props.background;
+  }
 
   /**
    * Create and deploy a simulated CloudFormation Stack from a parsed template
@@ -67,7 +70,7 @@ export class SimCloudFormationTemplateDeployer {
     props: SimCloudFormationCreateStackProps,
   ): Promise<SimCfnStack> {
     return await this.deployTemplateWithContext({
-      stackName: props.stackName ?? this.props.defaultStackName(),
+      stackName: props.stackName ?? makeSimCloudFormationStackName(),
       template: props.template,
       parameters: props.parameters,
       bindings: props.bindings,
@@ -93,7 +96,7 @@ export class SimCloudFormationTemplateDeployer {
     readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
     readonly cdkOutContext?: SimCdkOutContext | undefined;
   }): Promise<SimCfnStack> {
-    await this.props.createStackWithContext(
+    await this.createStackWithContext(
       {
         input: {
           StackName: props.stackName,
@@ -110,11 +113,46 @@ export class SimCloudFormationTemplateDeployer {
       props.bindings,
     );
 
-    const stack = this.props.getStackByName(props.stackName);
+    const stack = this.stacks.get(
+      props.stackName as SimCloudFormationStackName,
+    );
     assertDefined(stack, `Sim CloudFormation Stack named ${props.stackName}`);
 
     await stack.waitForDeployComplete();
 
     return stack;
   }
+
+  private async createStackWithContext(
+    cmd: {
+      readonly input: {
+        readonly StackName: SimCloudFormationStackName | string;
+        readonly TemplateBody: string;
+        readonly Parameters: readonly {
+          readonly ParameterKey: string;
+          readonly ParameterValue: string;
+        }[];
+      };
+    },
+    cdkOutContext?: SimCdkOutContext,
+    bindings?: readonly SimCfnExecutableResourceBinding[],
+  ): Promise<SimCreateStackCommandOutput> {
+    const handler = new CreateStackCommandHandler({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
+      stacks: this.stacks,
+      background: this.background,
+      cdkOutContext,
+      bindings,
+    });
+
+    return await handler.handle(cmd);
+  }
+}
+
+/**
+ * Generate a fake CloudFormation Stack name.
+ */
+function makeSimCloudFormationStackName(): SimCloudFormationStackName {
+  return `SimStack${faker.string.alphanumeric({ length: 8 })}` as SimCloudFormationStackName;
 }

--- a/src/service/cloudformation/parameters/sim-cfn-parameters.ts
+++ b/src/service/cloudformation/parameters/sim-cfn-parameters.ts
@@ -6,6 +6,7 @@ import type {
   SimCloudFormationParameterValue,
   SimCloudFormationParameterValues,
 } from "./sim-cfn-parameters.type.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 /**
  * Resolves CloudFormation Parameters for a simulated Stack.
@@ -114,12 +115,10 @@ export class SimCfnParameters {
    */
   value(parameterName: string): SimCloudFormationParameterValue {
     const value = this.values.get(parameterName);
-
-    if (value === undefined) {
-      throw new Error(
-        `Sim CloudFormation Stack ${this.stackNameLabel()} parameter ${parameterName} is missing a value`,
-      );
-    }
+    assertDefined(
+      value,
+      `Sim CloudFormation Stack ${this.stackNameLabel()} parameter ${parameterName} is missing a value`,
+    );
 
     return value;
   }

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-distribution-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-distribution-cfn.ts
@@ -3,20 +3,24 @@ import type { SimCloudFrontDistribution } from "../../../../cloudfront/distribut
 import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
 
 interface SimCloudFrontDistributionCfnProps {
-  readonly distribution: SimCloudFrontDistribution;
+  readonly distro: SimCloudFrontDistribution;
 }
 
 /**
  * CloudFormation-facing behavior for an AWS::CloudFront::Distribution Resource.
  */
 export class SimCloudFrontDistributionCfn implements SimCfnResourceValueAdapter {
-  constructor(private readonly props: SimCloudFrontDistributionCfnProps) {}
+  private readonly distro: SimCloudFrontDistribution;
+
+  constructor(props: SimCloudFrontDistributionCfnProps) {
+    this.distro = props.distro;
+  }
 
   /**
    * CloudFormation Ref for AWS::CloudFront::Distribution returns the Distribution ID.
    */
   refValue(): SimCfnTemplateValue {
-    return this.props.distribution.distributionId;
+    return this.distro.distributionId;
   }
 
   /**
@@ -25,13 +29,13 @@ export class SimCloudFrontDistributionCfn implements SimCfnResourceValueAdapter 
   attributeValue(attributeName: string): SimCfnTemplateValue {
     switch (attributeName) {
       case "DomainName": {
-        return `${this.props.distribution.distributionId.toLowerCase()}.cloudfront.net`;
+        return `${this.distro.distributionId.toLowerCase()}.cloudfront.net`;
       }
       case "Id": {
-        return this.props.distribution.distributionId;
+        return this.distro.distributionId;
       }
       default: {
-        return `${this.props.distribution.distributionId}.${attributeName}`;
+        return `${this.distro.distributionId}.${attributeName}`;
       }
     }
   }

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-function-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-function-cfn.ts
@@ -10,13 +10,17 @@ interface SimCloudFrontFunctionCfnProps {
  * CloudFormation-facing behavior for an AWS::CloudFront::Function Resource.
  */
 export class SimCloudFrontFunctionCfn implements SimCfnResourceValueAdapter {
-  constructor(private readonly props: SimCloudFrontFunctionCfnProps) {}
+  private readonly cloudFrontFunction;
+
+  constructor(props: SimCloudFrontFunctionCfnProps) {
+    this.cloudFrontFunction = props.cloudFrontFunction;
+  }
 
   /**
    * CloudFormation Ref for AWS::CloudFront::Function returns the Function name.
    */
   refValue(): SimCfnTemplateValue {
-    return this.props.cloudFrontFunction.name;
+    return this.cloudFrontFunction.name;
   }
 
   /**
@@ -26,11 +30,11 @@ export class SimCloudFrontFunctionCfn implements SimCfnResourceValueAdapter {
     switch (attributeName) {
       case "FunctionARN":
       case "FunctionMetadata.FunctionARN": {
-        return this.props.cloudFrontFunction.arn;
+        return this.cloudFrontFunction.arn;
       }
       default: {
         /* v8 ignore next */
-        return `${this.props.cloudFrontFunction.name}.${attributeName}`;
+        return `${this.cloudFrontFunction.name}.${attributeName}`;
       }
     }
   }

--- a/src/service/cloudformation/resource/cfn/route53/sim-route53-hosted-zone-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/route53/sim-route53-hosted-zone-cfn.ts
@@ -10,13 +10,17 @@ interface SimRoute53HostedZoneCfnProps {
  * CloudFormation-facing values for a simulated Route53 Hosted Zone.
  */
 export class SimRoute53HostedZoneCfn implements SimCfnResourceValueAdapter {
-  constructor(private readonly props: SimRoute53HostedZoneCfnProps) {}
+  private readonly hostedZone: SimRoute53HostedZone;
+
+  constructor(props: SimRoute53HostedZoneCfnProps) {
+    this.hostedZone = props.hostedZone;
+  }
 
   /**
    * AWS::Route53::HostedZone Ref returns the hosted zone ID.
    */
   refValue(): SimCfnTemplateValue {
-    return this.props.hostedZone.id;
+    return this.hostedZone.id;
   }
 
   /**
@@ -25,7 +29,7 @@ export class SimRoute53HostedZoneCfn implements SimCfnResourceValueAdapter {
   attributeValue(attributeName: string): SimCfnTemplateValue {
     switch (attributeName) {
       case "Id": {
-        return this.props.hostedZone.id;
+        return this.hostedZone.id;
       }
       case "NameServers": {
         return [

--- a/src/service/cloudformation/resource/cfn/s3/sim-s3-bucket-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/s3/sim-s3-bucket-cfn.ts
@@ -3,7 +3,6 @@ import type { SimS3Bucket } from "../../../../s3/bucket/sim-s3-bucket.js";
 import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
 
 interface SimS3BucketCfnProps {
-  readonly logicalId: string;
   readonly bucket: SimS3Bucket;
 }
 
@@ -15,13 +14,17 @@ interface SimS3BucketCfnProps {
  * Fn::GetAtt values.
  */
 export class SimS3BucketCfn implements SimCfnResourceValueAdapter {
-  constructor(private readonly props: SimS3BucketCfnProps) {}
+  private readonly bucket: SimS3Bucket;
+
+  constructor(props: SimS3BucketCfnProps) {
+    this.bucket = props.bucket;
+  }
 
   /**
    * CloudFormation Ref for AWS::S3::Bucket returns the bucket name.
    */
   refValue(): SimCfnTemplateValue {
-    return this.props.bucket.bucketName;
+    return this.bucket.bucketName;
   }
 
   /**
@@ -29,21 +32,21 @@ export class SimS3BucketCfn implements SimCfnResourceValueAdapter {
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     if (attributeName === "Arn") {
-      return `arn:aws:s3:::${this.props.bucket.bucketName}`;
+      return `arn:aws:s3:::${this.bucket.bucketName}`;
     }
 
     if (attributeName === "DomainName") {
-      return `${this.props.bucket.bucketName}.s3.amazonaws.com`;
+      return `${this.bucket.bucketName}.s3.amazonaws.com`;
     }
 
     if (attributeName === "RegionalDomainName") {
-      return `${this.props.bucket.bucketName}.s3.${this.props.bucket.getAccountRegionScope().regionName}.amazonaws.com`;
+      return `${this.bucket.bucketName}.s3.${this.bucket.getAccountRegionScope().regionName}.amazonaws.com`;
     }
 
     if (attributeName === "WebsiteURL") {
-      return this.props.bucket.getWebsiteUrl().toString();
+      return this.bucket.getWebsiteUrl().toString();
     }
 
-    return `${this.props.bucket.bucketName}.${attributeName}`;
+    return `${this.bucket.bucketName}.${attributeName}`;
   }
 }

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
@@ -10,19 +10,23 @@ interface SimCfnDefaultResourceValueAdapterProps {
  * simulator support.
  */
 export class SimCfnDefaultResourceValueAdapter implements SimCfnResourceValueAdapter {
-  constructor(private readonly props: SimCfnDefaultResourceValueAdapterProps) {}
+  private readonly logicalId: string;
+
+  constructor(props: SimCfnDefaultResourceValueAdapterProps) {
+    this.logicalId = props.logicalId;
+  }
 
   /**
    * Default physical-ID stand-in.
    */
   refValue(): SimCfnTemplateValue {
-    return this.props.logicalId;
+    return this.logicalId;
   }
 
   /**
    * Default attribute stand-in.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
-    return `${this.props.logicalId}.${attributeName}`;
+    return `${this.logicalId}.${attributeName}`;
   }
 }

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -36,7 +36,6 @@ export function simCfnResourceValueAdapter(
     props.simResource instanceof SimS3Bucket
   ) {
     return new SimS3BucketCfn({
-      logicalId: props.logicalId,
       bucket: props.simResource,
     });
   }
@@ -46,7 +45,7 @@ export function simCfnResourceValueAdapter(
     props.simResource instanceof SimCloudFrontDistribution
   ) {
     return new SimCloudFrontDistributionCfn({
-      distribution: props.simResource,
+      distro: props.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
@@ -5,6 +5,7 @@ import type {
 import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
 import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
 import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface SimCfnResourceCreatorProps<T extends object> {
   readonly resource: SimCfnResource<T>;
@@ -45,12 +46,10 @@ export class SimCfnResourceCreator<T extends object = object> {
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const { type } = this.resource;
-
-    if (type === undefined) {
-      throw new Error(
-        `Sim CloudFormation Resource ${this.resource.logicalId} is missing a Type`,
-      );
-    }
+    assertDefined(
+      type,
+      `Sim CloudFormation Resource ${this.resource.logicalId} is missing a Type`,
+    );
 
     const resourceType = parseSimCloudFormationResourceType(type);
     const factory =

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import {
   type SimAwsAccountRegionScope,
   simAwsAccountRegionScopeFactory,
@@ -58,15 +57,10 @@ export class SimCloudFormation {
     this.background = background;
     this.accountRegionScope = accountRegionScope;
     this.templateDeployer = new SimCloudFormationTemplateDeployer({
-      createStackWithContext: async (
-        cmd,
-        cdkOutContext,
-        bindings,
-      ): Promise<SimCreateStackCommandOutput> =>
-        await this.createStackWithContext(cmd, cdkOutContext, bindings),
-      getStackByName: (stackName): SimCfnStack | undefined =>
-        this.getStackByName(stackName),
-      defaultStackName: makeSimCloudFormationStackName,
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
+      stacks: this.stacks,
+      background: this.background,
     });
   }
 
@@ -148,11 +142,4 @@ export class SimCloudFormation {
   ): Promise<SimCfnStack> {
     return await this.templateDeployer.deployTemplateFile(props);
   }
-}
-
-/**
- * Generate a fake CloudFormation Stack name.
- */
-export function makeSimCloudFormationStackName(): SimCloudFormationStackName {
-  return `SimStack${faker.string.alphanumeric({ length: 8 })}` as SimCloudFormationStackName;
 }

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
@@ -33,10 +33,7 @@ describe("SimCfnTemplate Fn::FindInMap Resources", () => {
 
     const resourceTemplates = template.resourceTemplates();
     const resourceTemplate = resourceTemplates[0];
-
-    if (resourceTemplate === undefined) {
-      throw new Error("Expected TestInstance Resource template");
-    }
+    assertNonNullable(resourceTemplate);
 
     assertObjectMatches(resourceTemplate.template, {
       Type: "AWS::EC2::Instance",
@@ -81,10 +78,7 @@ describe("SimCfnTemplate Fn::FindInMap Resources", () => {
 
     const resourceTemplates = template.resourceTemplates();
     const resourceTemplate = resourceTemplates[0];
-
-    if (resourceTemplate === undefined) {
-      throw new Error("Expected TestBucket Resource template");
-    }
+    assertNonNullable(resourceTemplate);
 
     assertObjectMatches(resourceTemplate.template, {
       Type: "AWS::S3::Bucket",

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
@@ -2,6 +2,7 @@ import { SimCfnNode } from "../../sim-cfn-node.js";
 import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import { isRecord } from "../../../../../../util/type-guard/record.js";
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
 
 /**
  * Simulated CloudFormation `Fn::FindInMap` intrinsic function.
@@ -45,12 +46,10 @@ export class SimCfnFnFindInMap extends SimCfnNode {
 
     // eslint-disable-next-line security/detect-object-injection
     const value = topLevel[secondLevelKey];
-
-    if (value === undefined) {
-      throw new Error(
-        `Sim CloudFormation Fn::FindInMap could not find map ${mapName}.${topLevelKey}.${secondLevelKey}`,
-      );
-    }
+    assertDefined(
+      value,
+      `Sim CloudFormation Fn::FindInMap could not find map ${mapName}.${topLevelKey}.${secondLevelKey}`,
+    );
 
     return value;
   }

--- a/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-unresolved-value.ts
+++ b/src/service/cloudformation/template/node/fn/sub/resolve/sim-cfn-fn-sub-unresolved-value.ts
@@ -1,0 +1,58 @@
+import type { SimCfnNode } from "../../../sim-cfn-node.js";
+import type { SimCfnTemplateValue } from "../../../../value/sim-cfn-template-value.js";
+import { assertDefined } from "../../../../../../../util/type-guard/defined.js";
+
+interface SimCfnFnSubUnresolvedValueProps {
+  readonly template: string;
+  readonly variables: ReadonlyMap<string, SimCfnNode>;
+}
+
+/**
+ * Rebuilds an unresolved CloudFormation `Fn::Sub` template value.
+ */
+export class SimCfnFnSubUnresolvedValue {
+  private readonly template: string;
+  private readonly variables: ReadonlyMap<string, SimCfnNode>;
+
+  constructor(props: SimCfnFnSubUnresolvedValueProps) {
+    this.template = props.template;
+    this.variables = props.variables;
+  }
+
+  /**
+   * Re-emit the original Fn::Sub expression with any explicit variables resolved
+   * as far as possible.
+   */
+  toTemplateValue(
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): SimCfnTemplateValue {
+    if (this.variables.size === 0) {
+      return { "Fn::Sub": this.template };
+    }
+
+    return {
+      "Fn::Sub": [
+        this.template,
+        Object.fromEntries(
+          [...this.variables.keys()].map((name) => [
+            name,
+            this.requiredResolvedVariable(name, resolvedVariables),
+          ]),
+        ),
+      ],
+    };
+  }
+
+  private requiredResolvedVariable(
+    name: string,
+    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
+  ): SimCfnTemplateValue {
+    const resolved = resolvedVariables.get(name);
+    assertDefined(
+      resolved,
+      `Sim CloudFormation Fn::Sub variable ${name} was not resolved`,
+    );
+
+    return resolved;
+  }
+}

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.
 import { SimCfnFnSubTemplate } from "./template/sim-cfn-fn-sub-template.js";
 import { SimCfnFnSubVariableResolver } from "./resolve/sim-cfn-fn-sub-variable-resolver.js";
 import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import { SimCfnFnSubUnresolvedValue } from "./resolve/sim-cfn-fn-sub-unresolved-value.js";
 
 /**
  * Simulated CloudFormation `Fn::Sub` intrinsic function.
@@ -20,15 +21,20 @@ import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-cont
 export class SimCfnFnSub extends SimCfnNode {
   private readonly subTemplate: SimCfnFnSubTemplate;
   private readonly variableResolver: SimCfnFnSubVariableResolver;
+  private readonly unresolvedValue: SimCfnFnSubUnresolvedValue;
 
   constructor(
-    private readonly template: string,
+    template: string,
     private readonly variables: ReadonlyMap<string, SimCfnNode> = new Map(),
   ) {
     super();
 
     this.subTemplate = new SimCfnFnSubTemplate(template);
     this.variableResolver = new SimCfnFnSubVariableResolver(variables);
+    this.unresolvedValue = new SimCfnFnSubUnresolvedValue({
+      template,
+      variables,
+    });
   }
 
   /**
@@ -50,7 +56,7 @@ export class SimCfnFnSub extends SimCfnNode {
     if (
       [...resolvedVariables.values()].some((value) => typeof value !== "string")
     ) {
-      return this.unresolvedTemplateValue(resolvedVariables);
+      return this.unresolvedValue.toTemplateValue(resolvedVariables);
     }
 
     return this.subTemplate.substitute(
@@ -72,40 +78,5 @@ export class SimCfnFnSub extends SimCfnNode {
         .filter((variableName) => !this.variables.has(variableName))
         .map((variableName) => variableName.split(".")[0] ?? variableName),
     ];
-  }
-
-  private unresolvedTemplateValue(
-    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
-  ): SimCfnTemplateValue {
-    if (this.variables.size === 0) {
-      return { "Fn::Sub": this.template };
-    }
-
-    return {
-      "Fn::Sub": [
-        this.template,
-        Object.fromEntries(
-          [...this.variables.keys()].map((name) => [
-            name,
-            this.requiredResolvedVariable(name, resolvedVariables),
-          ]),
-        ),
-      ],
-    };
-  }
-
-  private requiredResolvedVariable(
-    name: string,
-    resolvedVariables: ReadonlyMap<string, SimCfnTemplateValue>,
-  ): SimCfnTemplateValue {
-    const resolved = resolvedVariables.get(name);
-
-    if (resolved === undefined) {
-      throw new Error(
-        `Sim CloudFormation Fn::Sub variable ${name} was not resolved`,
-      );
-    }
-
-    return resolved;
   }
 }

--- a/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.ts
+++ b/src/service/cloudformation/template/node/fn/sub/template/sim-cfn-fn-sub-template.ts
@@ -1,3 +1,5 @@
+import { assertDefined } from "../../../../../../../util/type-guard/defined.js";
+
 /**
  * Template-string helper for CloudFormation Fn::Sub.
  *
@@ -35,12 +37,10 @@ export class SimCfnFnSubTemplate {
         }
 
         const resolved = variables.get(variableName);
-
-        if (resolved === undefined) {
-          throw new Error(
-            `Sim CloudFormation Fn::Sub variable ${variableName} was not resolved`,
-          );
-        }
+        assertDefined(
+          resolved,
+          `Sim CloudFormation Fn::Sub variable ${variableName} was not resolved`,
+        );
 
         return resolved;
       },

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
@@ -5,6 +5,7 @@ import { SimCfnFnJoinParser } from "./join/sim-cfn-fn-join-parser.js";
 import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
 import { SimCfnFnSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
 import { SimCfnFnFindInMapParser } from "./find-in-map/sim-cfn-fn-find-in-map-parser.js";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
  * Parses CloudFormation intrinsic function objects.
@@ -114,10 +115,10 @@ export class SimCfnFunctionParser {
     entries: readonly (readonly [string, SimCfnTemplateValue])[],
   ): readonly [string, SimCfnTemplateValue] {
     const entry = entries[0];
-
-    if (entry === undefined) {
-      throw new Error("Expected exactly one Sim CloudFormation template entry");
-    }
+    assertDefined(
+      entry,
+      "Expected one Sim CloudFormation template entry, got none",
+    );
 
     return entry;
   }

--- a/src/service/cloudformation/template/parse/node/sim-cfn-node-parser.iso.test.ts
+++ b/src/service/cloudformation/template/parse/node/sim-cfn-node-parser.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertObjectMatches,
+  assertStringIncludes,
   assertThrowsError,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
@@ -153,9 +154,9 @@ describe("SimCfnNodeParser", () => {
         });
       });
 
-      assertIdentical(
+      assertStringIncludes(
         error.message,
-        "Expected exactly one Sim CloudFormation template entry",
+        "Expected one Sim CloudFormation template entry",
       );
     } finally {
       objectEntries.mockRestore();

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-creator.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-creator.ts
@@ -31,7 +31,11 @@ interface SimCfnCfFunctionCreatorProps {
  * with template parsing and executable binding selection.
  */
 export class SimCfnCffCreator {
-  constructor(private readonly props: SimCfnCfFunctionCreatorProps) {}
+  private readonly cloudFront;
+
+  constructor(props: SimCfnCfFunctionCreatorProps) {
+    this.cloudFront = props.cloudFront;
+  }
 
   /**
    * Create a simulated CloudFront Function from one resolved
@@ -53,14 +57,14 @@ export class SimCfnCffCreator {
       bindings: context?.bindings,
     }).build();
 
-    const output = await this.props.cloudFront.createFunction({
+    const output = await this.cloudFront.createFunction({
       input: createInput,
     });
 
     const createdFunctionName = output.FunctionSummary
       .Name as SimCloudFrontFunctionName;
     const cloudFrontFunction =
-      this.props.cloudFront.getCloudFrontFunctionByName(createdFunctionName);
+      this.cloudFront.getCloudFrontFunctionByName(createdFunctionName);
 
     assertDefined(
       cloudFrontFunction,

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -16,7 +16,11 @@ interface SimCfnCfDistroCreatorProps {
  * Creates simulated CloudFront Distributions from CloudFormation Resources.
  */
 export class SimCfnCfDistroCreator {
-  constructor(private readonly props: SimCfnCfDistroCreatorProps) {}
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(props: SimCfnCfDistroCreatorProps) {
+    this.cloudFront = props.cloudFront;
+  }
 
   /**
    * Create a simulated CloudFront Distribution from an
@@ -42,7 +46,7 @@ export class SimCfnCfDistroCreator {
       distributionConfig: distributionConfigValue,
     }).validate();
 
-    const output = await this.props.cloudFront.createDistribution({
+    const output = await this.cloudFront.createDistribution({
       input: {
         DistributionConfig: distributionConfig,
       },
@@ -54,8 +58,7 @@ export class SimCfnCfDistroCreator {
       `AWS::CloudFront::Distribution ${resource.logicalId} created Distribution Id`,
     );
 
-    const distribution =
-      this.props.cloudFront.getSimDistributionById(distributionId);
+    const distribution = this.cloudFront.getSimDistributionById(distributionId);
 
     assertDefined(
       distribution,

--- a/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution.handler.ts
@@ -12,6 +12,7 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface GetDistributionCommandHandlerProps {
   readonly distributions: Map<
@@ -48,9 +49,7 @@ export class GetDistributionCommandHandler implements CommandHandler<
   async handle(
     cmd: SimGetDistributionCommand,
   ): Promise<SimGetDistributionCommandOutput> {
-    if (cmd.input.Id === undefined) {
-      throw new Error("GetDistributionCommand.input.Id is required");
-    }
+    assertDefined(cmd.input.Id, "GetDistributionCommand.input.Id");
     const distributionId = cmd.input.Id as SimCloudFrontDistributionId;
 
     // Allow for potential non-deterministic sequencing of async events.

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.ts
@@ -2,6 +2,7 @@ import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCloudFrontS3OriginResolver } from "./sim-cloudfront-s3-origin.js";
 import { bucketNameFromCfS3OriginDomainName } from "./sim-cf-s3-origin-bucket-name.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 /**
  * Create an S3 Origin Resolver backed by a simulated AWS Account/Region scope.
@@ -13,11 +14,10 @@ export function makeSimCfS3OriginResolver(
   return (originDomainName: string) => {
     const bucketName = bucketNameFromCfS3OriginDomainName(originDomainName);
     const bucketScope = simAws.s3().findBucketScope(bucketName);
-    if (bucketScope === undefined) {
-      throw new Error(
-        `Unable to find sim S3 Bucket ${bucketName} for sim CloudFront S3 Origin`,
-      );
-    }
+    assertDefined(
+      bucketScope,
+      `Unable to find sim S3 Bucket ${bucketName} for sim CloudFront S3 Origin`,
+    );
 
     return simAws
       .region(bucketScope.regionName)

--- a/src/service/dynamodb/command/create-table/create-table.handler.ts
+++ b/src/service/dynamodb/command/create-table/create-table.handler.ts
@@ -42,7 +42,10 @@ export class CreateTableCommandHandler implements CommandHandler<
   async handle(
     cmd: SimCreateTableCommand,
   ): Promise<SimCreateTableCommandOutput> {
-    assertDefined(cmd.input.TableName, "CreateTableCommand.input.TableName");
+    assertDefined(
+      cmd.input.TableName,
+      "CreateTableCommand.input.TableName required",
+    );
 
     const tableName = cmd.input.TableName as DynamoDbTableName;
     if (this.tables.has(tableName)) {

--- a/src/service/dynamodb/command/create-table/create-table.iso.test.ts
+++ b/src/service/dynamodb/command/create-table/create-table.iso.test.ts
@@ -61,7 +61,7 @@ describe("DynamoDB CreateTableCommand", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "CreateTableCommand.input.TableName must be defined",
+      "CreateTableCommand.input.TableName required",
     );
   });
 

--- a/src/service/dynamodb/command/describe-table/describe-table.handler.ts
+++ b/src/service/dynamodb/command/describe-table/describe-table.handler.ts
@@ -12,6 +12,7 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface DescribeTableCommandHandlerProps {
   readonly tables: Map<DynamoDbTableName, SimDynamoDbTable>;
@@ -42,9 +43,7 @@ export class DescribeTableCommandHandler implements CommandHandler<
   async handle(
     cmd: SimDescribeTableCommand,
   ): Promise<SimDescribeTableCommandOutput> {
-    if (cmd.input.TableName === undefined) {
-      throw new Error("DescribeTableCommand.input.TableName is required");
-    }
+    assertDefined(cmd.input.TableName, "DescribeTableCommand.input.TableName");
     const tableName = cmd.input.TableName as DynamoDbTableName;
 
     // Allow for potential non-deterministic sequencing of async events.

--- a/src/service/dynamodb/command/put-item/put-item-errors.iso.test.ts
+++ b/src/service/dynamodb/command/put-item/put-item-errors.iso.test.ts
@@ -35,7 +35,7 @@ describe("DynamoDB PutItemCommand errors", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "DynamoDB Item partition key userId must be defined",
+      "DynamoDB Item partition key userId required",
     );
   });
 
@@ -156,7 +156,7 @@ describe("DynamoDB PutItemCommand errors", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "PutItemCommand.input.TableName is required",
+      "PutItemCommand.input.TableName required",
     );
   });
 
@@ -202,9 +202,6 @@ describe("DynamoDB PutItemCommand errors", () => {
     });
 
     assertInstanceOf(error, Error);
-    assertStringIncludes(
-      error.message,
-      "PutItemCommand.input.Item is required",
-    );
+    assertStringIncludes(error.message, "PutItemCommand.input.Item required");
   });
 });

--- a/src/service/dynamodb/command/put-item/put-item.handler.ts
+++ b/src/service/dynamodb/command/put-item/put-item.handler.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../table/sim-dynamodb-table.js";
 import { DynamoDbItem } from "../../item/dynamodb-item.js";
 import { SimDynamoDbResourceNotFoundException } from "../../error/dynamodb.error.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface PutItemCommandHandlerProps {
   readonly tables: Map<DynamoDbTableName, SimDynamoDbTable>;
@@ -34,9 +35,7 @@ export class PutItemCommandHandler implements CommandHandler<
    */
   async handle(cmd: SimPutItemCommand): Promise<SimPutItemCommandOutput> {
     const tableName = cmd.input.TableName as DynamoDbTableName | undefined;
-    if (tableName === undefined) {
-      throw new Error("PutItemCommand.input.TableName is required");
-    }
+    assertDefined(tableName, "PutItemCommand.input.TableName required");
 
     const table = this.tables.get(tableName);
     if (table === undefined) {
@@ -45,9 +44,7 @@ export class PutItemCommandHandler implements CommandHandler<
       );
     }
 
-    if (cmd.input.Item === undefined) {
-      throw new Error("PutItemCommand.input.Item is required");
-    }
+    assertDefined(cmd.input.Item, "PutItemCommand.input.Item required");
 
     const item = DynamoDbItem.fromAttributeValues(cmd.input.Item);
 

--- a/src/service/dynamodb/table/dynamodb-key-schema.ts
+++ b/src/service/dynamodb/table/dynamodb-key-schema.ts
@@ -61,7 +61,7 @@ export class DynamoDbKeySchema {
     const partitionKeyAttr = item.attributes[this.hashKeyAttributeName];
     assertDefined(
       partitionKeyAttr,
-      `DynamoDB Item partition key ${this.hashKeyAttributeName}`,
+      `DynamoDB Item partition key ${this.hashKeyAttributeName} required`,
     );
     const partitionKey = partitionKeyAttr.value;
     if (!DynamoDbKeySchema.canBeDynamoDbKey(partitionKey)) {

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-r53-zone-creator.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-r53-zone-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import { assertIsSimRoute53HostedZoneId } from "../../command/create-hosted-zone/sim-route53-zone-id.js";
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
 import type { SimRoute53 } from "../../sim-route53.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface SimCfnRoute53HostedZoneCreatorProps {
   readonly route53: SimRoute53;
@@ -68,13 +69,10 @@ export class SimCfnRoute53HostedZoneCreator {
     assertIsSimRoute53HostedZoneId(hostedZoneId);
 
     const hostedZone = this.route53.hostedZones.get(hostedZoneId);
-
-    /* v8 ignore if -- defensive diagnostic */
-    if (hostedZone === undefined) {
-      throw new Error(
-        `Expected sim Route53 Hosted Zone ${hostedZoneId} to exist after CloudFormation creation`,
-      );
-    }
+    assertDefined(
+      hostedZone,
+      `Sim Route53 Hosted Zone ${hostedZoneId} after CloudFormation creation`,
+    );
 
     return hostedZone;
   }

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
@@ -1,14 +1,10 @@
 import type { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
-import {
-  normalizeSimRoute53HostedZoneId,
-  type SimRoute53HostedZoneId,
-} from "../../../command/create-hosted-zone/sim-route53-zone-id.js";
-import { normaliseSimRoute53Name } from "../../../local-name/sim-route53-local-name.js";
 import type { SimRoute53Record } from "../../../record/sim-route53-record.js";
 import type { SimRoute53 } from "../../../sim-route53.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 import { SimCfnRoute53RecordSetBuilder } from "../build/sim-cfn-r53-record-set-builder.js";
+import { SimCfnRoute53RecordSetHostedZoneResolver } from "../resolve/sim-cfn-r53-rec-set-zone-resolver.js";
 
 interface SimCfnRoute53RecordSetApplicatorProps {
   readonly route53: SimRoute53;
@@ -19,9 +15,13 @@ interface SimCfnRoute53RecordSetApplicatorProps {
  */
 export class SimCfnRoute53RecordSetApplicator {
   private readonly route53: SimRoute53;
+  private readonly hostedZoneResolver: SimCfnRoute53RecordSetHostedZoneResolver;
 
   constructor(props: SimCfnRoute53RecordSetApplicatorProps) {
     this.route53 = props.route53;
+    this.hostedZoneResolver = new SimCfnRoute53RecordSetHostedZoneResolver({
+      route53: this.route53,
+    });
   }
 
   /**
@@ -31,7 +31,10 @@ export class SimCfnRoute53RecordSetApplicator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<SimRoute53Record> {
-    const hostedZoneId = this.hostedZoneId(resource, properties);
+    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
+      resource,
+      properties,
+    );
     const recordSet = new SimCfnRoute53RecordSetBuilder(
       resource,
       properties,
@@ -63,44 +66,5 @@ export class SimCfnRoute53RecordSetApplicator {
     assertDefined(record, "Sim Route53 Record after update");
 
     return record;
-  }
-
-  private hostedZoneId(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): SimRoute53HostedZoneId {
-    const hostedZoneId = properties["HostedZoneId"];
-
-    if (hostedZoneId !== undefined) {
-      if (typeof hostedZoneId !== "string") {
-        throw new TypeError(
-          `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneId must be a string`,
-        );
-      }
-
-      return normalizeSimRoute53HostedZoneId(hostedZoneId);
-    }
-
-    const hostedZoneName = properties["HostedZoneName"];
-
-    if (typeof hostedZoneName !== "string") {
-      throw new TypeError(
-        `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneId or HostedZoneName must be a string`,
-      );
-    }
-
-    const normalizedHostedZoneName = `${normaliseSimRoute53Name(hostedZoneName)}.`;
-
-    const hostedZone = [...this.route53.hostedZones.values()].find(
-      (candidate) => candidate.name === normalizedHostedZoneName,
-    );
-
-    if (hostedZone === undefined) {
-      throw new Error(
-        `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneName ${hostedZoneName} was not found`,
-      );
-    }
-
-    return hostedZone.id;
   }
 }

--- a/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.ts
+++ b/src/service/route53/cfn/record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.ts
@@ -1,0 +1,72 @@
+import type { SimCfnResource } from "../../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  normalizeSimRoute53HostedZoneId,
+  type SimRoute53HostedZoneId,
+} from "../../../command/create-hosted-zone/sim-route53-zone-id.js";
+import { normaliseSimRoute53Name } from "../../../local-name/sim-route53-local-name.js";
+import type { SimRoute53 } from "../../../sim-route53.js";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+
+interface SimCfnRoute53RecordSetHostedZoneResolverProps {
+  readonly route53: SimRoute53;
+}
+
+/**
+ * Resolves the target Hosted Zone for an AWS::Route53::RecordSet resource.
+ */
+export class SimCfnRoute53RecordSetHostedZoneResolver {
+  private readonly route53: SimRoute53;
+
+  constructor(props: SimCfnRoute53RecordSetHostedZoneResolverProps) {
+    this.route53 = props.route53;
+  }
+
+  /**
+   * Resolve the Hosted Zone ID from either HostedZoneId or HostedZoneName.
+   */
+  hostedZoneId(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimRoute53HostedZoneId {
+    const hostedZoneId = properties["HostedZoneId"];
+
+    if (hostedZoneId !== undefined) {
+      if (typeof hostedZoneId !== "string") {
+        throw new TypeError(
+          `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneId must be a string`,
+        );
+      }
+
+      return normalizeSimRoute53HostedZoneId(hostedZoneId);
+    }
+
+    return this.hostedZoneIdFromName(resource, properties);
+  }
+
+  private hostedZoneIdFromName(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimRoute53HostedZoneId {
+    const hostedZoneName = properties["HostedZoneName"];
+
+    if (typeof hostedZoneName !== "string") {
+      throw new TypeError(
+        `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneId or HostedZoneName must be a string`,
+      );
+    }
+
+    const normalizedHostedZoneName = `${normaliseSimRoute53Name(hostedZoneName)}.`;
+
+    const hostedZone = [...this.route53.hostedZones.values()].find(
+      (candidate) => candidate.name === normalizedHostedZoneName,
+    );
+
+    assertDefined(
+      hostedZone,
+      `Invalid AWS::Route53::RecordSet ${resource.logicalId}: HostedZoneName ${hostedZoneName} was not found`,
+    );
+
+    return hostedZone.id;
+  }
+}

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -7,6 +7,7 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
 import type { SimS3WebsiteConfiguration } from "../command/put-bucket-website/put-bucket-website.cmd.js";
 import { validateS3BucketName } from "../bucket/validate/validate-s3-bucket-name.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 /**
  * CloudFormation Resource factory for simulated S3 resources.
@@ -48,13 +49,10 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
     });
 
     const bucket = this.simS3.getSimBucketByName(bucketName);
-
-    /* v8 ignore if -- cannot happen in practice */
-    if (bucket === undefined) {
-      throw new Error(
-        `Expected sim S3 Bucket ${bucketName} to exist after CloudFormation creation`,
-      );
-    }
+    assertDefined(
+      bucket,
+      `sim S3 Bucket ${bucketName} after CloudFormation creation`,
+    );
 
     const websiteConfiguration = this.websiteConfigurationForResource(
       resource,

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -54,7 +54,10 @@ export class CreateBucketCommandHandler implements CommandHandler<
   async handle(
     cmd: SimCreateBucketCommand,
   ): Promise<SimCreateBucketCommandOutput> {
-    assertDefined(cmd.input.Bucket, "CreateBucketCommand.input.Bucket");
+    assertDefined(
+      cmd.input.Bucket,
+      "CreateBucketCommand.input.Bucket required",
+    );
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();

--- a/src/service/s3/command/create-bucket/create-bucket.iso.test.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.iso.test.ts
@@ -44,7 +44,7 @@ describe("S3 CreateBucketCommand", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "CreateBucketCommand.input.Bucket must be defined",
+      "CreateBucketCommand.input.Bucket required",
     );
   });
 

--- a/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
@@ -44,10 +44,13 @@ export class PutBucketWebsiteCommandHandler implements CommandHandler<
   async handle(
     cmd: SimPutBucketWebsiteCommand,
   ): Promise<SimPutBucketWebsiteCommandOutput> {
-    assertDefined(cmd.input.Bucket, "PutBucketWebsiteCommand.input.Bucket");
+    assertDefined(
+      cmd.input.Bucket,
+      "PutBucketWebsiteCommand.input.Bucket required",
+    );
     assertDefined(
       cmd.input.WebsiteConfiguration,
-      "PutBucketWebsiteCommand.input.WebsiteConfiguration",
+      "PutBucketWebsiteCommand.input.WebsiteConfiguration required",
     );
 
     const bucketName = cmd.input.Bucket as SimS3BucketName;

--- a/src/service/s3/command/put-bucket-website/put-bucket-website.iso.test.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website.iso.test.ts
@@ -245,7 +245,7 @@ describe("S3 PutBucketWebsiteCommand", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "PutBucketWebsiteCommand.input.Bucket must be defined",
+      "PutBucketWebsiteCommand.input.Bucket required",
     );
   });
 
@@ -266,7 +266,7 @@ describe("S3 PutBucketWebsiteCommand", () => {
     assertInstanceOf(error, Error);
     assertStringIncludes(
       error.message,
-      "PutBucketWebsiteCommand.input.WebsiteConfiguration must be defined",
+      "PutBucketWebsiteCommand.input.WebsiteConfiguration required",
     );
   });
 

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -5,6 +5,7 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { FilesystemS3StorageSafety } from "./s3-filesystem-safety.js";
 import { metadataForFilesystemS3ObjectKey } from "./s3-filesystem-object-metadata.js";
 import { filesystemPathExists } from "./filesystem-path-exists.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 
 interface FilesystemS3BucketStorageProps {
   readonly directoryPath: string;
@@ -75,11 +76,7 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
         .filter((key) => prefix === undefined || key.startsWith(prefix))
         .map(async (key) => {
           const object = await this.getObject(key);
-
-          /* v8 ignore next -- defensive guard for filesystem race */
-          if (object === undefined) {
-            throw new Error(`Object listed but not found: ${key}`);
-          }
+          assertDefined(object, "Sim S3 filesystem storage listed object");
 
           return object;
         }),

--- a/src/util/filesystem/temp-dir.ts
+++ b/src/util/filesystem/temp-dir.ts
@@ -29,6 +29,7 @@ export class TempDir {
    * Return the absolute path to this temporary directory.
    */
   path(): string {
+    // eslint-disable-next-line no-restricted-syntax
     if (this.dirPath === undefined) {
       throw new Error(
         "TempDir path has not yet been resolved. Call resolvePath() or writeFile() first.",

--- a/src/util/type-guard/defined.iso.test.ts
+++ b/src/util/type-guard/defined.iso.test.ts
@@ -6,7 +6,7 @@ describe("type-guard assertion util functions", () => {
   describe("assertDefined", () => {
     it("throws on undefined value", () => {
       const error = assertThrowsError(() => {
-        assertDefined(undefined, "foo value");
+        assertDefined(undefined, "foo value must be defined");
       });
       assertIdentical(error.message, "foo value must be defined");
     });
@@ -19,7 +19,7 @@ describe("type-guard assertion util functions", () => {
   describe("assertNotNull", () => {
     it("throws on null value", () => {
       const error = assertThrowsError(() => {
-        assertNotNull(null, "foo value");
+        assertNotNull(null, "foo value must not be null");
       });
       assertIdentical(error.message, "foo value must not be null");
     });

--- a/src/util/type-guard/defined.ts
+++ b/src/util/type-guard/defined.ts
@@ -11,10 +11,10 @@ class RequiredValueNullError extends Error {
  */
 export function assertDefined<T>(
   value: T | undefined,
-  description: string,
+  message: string,
 ): asserts value is T {
   if (value === undefined) {
-    throw new RequiredValueUndefinedError(`${description} must be defined`);
+    throw new RequiredValueUndefinedError(message);
   }
 }
 
@@ -23,9 +23,9 @@ export function assertDefined<T>(
  */
 export function assertNotNull<T>(
   value: T | null,
-  description: string,
+  message: string,
 ): asserts value is T {
   if (value === null) {
-    throw new RequiredValueNullError(`${description} must not be null`);
+    throw new RequiredValueNullError(message);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving Route53 record sets from either zone ID or zone name.
  * Improved CloudFormation examples for running CloudFront locally.

* **Bug Fixes**
  * Standardized required-field validation across S3, DynamoDB, CloudFront, Route53, and CloudFormation flows.
  * Updated several error messages to be clearer and more consistent when values are missing.

* **Documentation**
  * Refined CloudFront localhost example docs to match the latest usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->