### PR TITLE
feat: initial sim ACM

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@aws-sdk/client-dynamodb": "^3.1075.0",
     "@aws-sdk/client-s3": "^3.1075.0",
     "@eslint/js": "^10.0.1",
-    "@kensio/smartass": "^1.26.0",
+    "@kensio/smartass": "^1.27.0",
     "@smithy/smithy-client": "^4.14.2",
     "@smithy/types": "^4.15.0",
     "@types/eslint-plugin-security": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       '@kensio/smartass':
-        specifier: ^1.26.0
-        version: 1.26.0
+        specifier: ^1.27.0
+        version: 1.27.0
       '@smithy/smithy-client':
         specifier: ^4.14.2
         version: 4.14.2
@@ -528,8 +528,8 @@ packages:
     resolution: {integrity: sha512-iDk2mcmBJWkgY01OfJ4BrevOvIJ4GYB6ylIUhnKv8B4WHisFjc5M1ZzCBKiOs2QAkXC8MHsMExWuBHwnHmoDhg==}
     engines: {node: '>=24.14.0'}
 
-  '@kensio/smartass@1.26.0':
-    resolution: {integrity: sha512-yyezsGjZGjdHjePg2dCAsHT5iPhr5DUgnWf5kmE6ozVmwSejW81zAxYwRtE5OiwNDB0izxT3FrELmqRJzeIYvw==}
+  '@kensio/smartass@1.27.0':
+    resolution: {integrity: sha512-qDSit2BbQ8Yisu4pga4H45EcAWl60xpJM6HqmLQw4CVVXOaCrEreTgZ77IIAqFZqBVz6vgdJQBo13hFtL4K2LA==}
     engines: {node: '>=22.0.0'}
 
   '@napi-rs/wasm-runtime@1.1.6':
@@ -2198,7 +2198,7 @@ snapshots:
     dependencies:
       lodash: 4.18.1
 
-  '@kensio/smartass@1.26.0': {}
+  '@kensio/smartass@1.27.0': {}
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
-  - '@kensio/smartass@1.26.0'
+  - '@kensio/smartass@1.27.0'
 useNodeVersion: 24.18.0

--- a/sim-acm-plan-notes.txt
+++ b/sim-acm-plan-notes.txt
@@ -1,0 +1,492 @@
+## MVP plan: simulated ACM support in Yulin
+
+### Goal
+
+Add a lightweight simulated ACM service that is useful for CDK/local-dev/testing workflows without trying to fully reproduce real ACM or real TLS.
+
+The primary public surface should be SDK-style command support, matching the pattern already used by other Yulin services. Users should be able to create, list, describe, and delete simulated ACM certificates, then assert against those certificates in tests.
+
+Real TLS, local CA setup, browser certificate trust, and HTML/app-response modification are explicitly out of scope for the MVP.
+
+---
+
+## Design principles
+
+### 1. SDK commands first
+
+Prioritise command-handler compatibility over custom Yulin APIs.
+
+Users should be able to write tests like:
+
+```ts
+const certs = await simAws.acm().listCertificates(
+  new ListCertificatesCommand({}),
+);
+
+const described = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: certArn,
+  }),
+);
+```
+
+This matches the existing Yulin service style, where simulated services expose command-like methods and maintain in-memory state.
+
+### 2. CloudFormation/CDK support should use the same internal state
+
+`AWS::CertificateManager::Certificate` should create the same internal certificate representation as `RequestCertificateCommand`.
+
+That way, certificates created through CDK/CloudFormation are visible through the ACM SDK-style commands.
+
+This is important for common CDK code such as:
+
+```ts
+const certificate = new acm.Certificate(this, "Certificate", {
+  domainName,
+  validation: acm.CertificateValidation.fromDns(hostedZone),
+});
+```
+
+### 3. Keep validation lightweight
+
+The MVP should represent DNS validation data, but not fully enforce real-world validation rules.
+
+The useful behaviour is:
+
+* create a simulated certificate;
+* generate deterministic validation CNAMEs;
+* expose those CNAMEs through `DescribeCertificate`;
+* optionally create matching simulated Route53 records when the CloudFormation resource includes hosted-zone-backed validation;
+* allow users to assert against ACM and/or Route53 state.
+
+### 4. Avoid global low-level service config on `SimAws`
+
+Do not add detailed ACM configuration directly to the `SimAws` constructor. That could become unmanageable as more services gain options.
+
+If stricter validation modes or diagnostics are added later, prefer service-local APIs or explicit diagnostic helpers rather than global constructor config.
+
+---
+
+## New service structure
+
+Add a new service directory:
+
+```txt
+src/service/acm
+```
+
+Suggested structure:
+
+```txt
+src/service/acm/
+  sim-acm.ts
+  certificate/
+    sim-acm-certificate.ts
+    sim-acm-certificate-arn.ts
+    sim-acm-validation-record.ts
+  command/
+    request-certificate/
+      request-certificate.cmd.ts
+      request-certificate.handler.ts
+      request-certificate.iso.test.ts
+    describe-certificate/
+      describe-certificate.cmd.ts
+      describe-certificate.handler.ts
+      describe-certificate.iso.test.ts
+    list-certificates/
+      list-certificates.cmd.ts
+      list-certificates.handler.ts
+      list-certificates.iso.test.ts
+    delete-certificate/
+      delete-certificate.cmd.ts
+      delete-certificate.handler.ts
+      delete-certificate.iso.test.ts
+  cfn/
+    sim-cfn-acm-resource-factory.ts
+    certificate/
+      sim-cfn-acm-certificate-creator.ts
+      sim-cfn-acm-certificate.iso.test.ts
+```
+
+The exact naming should follow existing service conventions.
+
+---
+
+## SimAcm class
+
+Add a `SimAcm` service similar in shape to existing service classes.
+
+It should own certificate state:
+
+```ts
+export class SimAcm {
+  public readonly certificates = new Map<SimAcmCertificateArn, SimAcmCertificate>();
+
+  async requestCertificate(cmd: SimRequestCertificateCommand): Promise<SimRequestCertificateCommandOutput>;
+  async describeCertificate(cmd: SimDescribeCertificateCommand): Promise<SimDescribeCertificateCommandOutput>;
+  async listCertificates(cmd: SimListCertificatesCommand): Promise<SimListCertificatesCommandOutput>;
+  async deleteCertificate(cmd: SimDeleteCertificateCommand): Promise<SimDeleteCertificateCommandOutput>;
+
+  cfnResourceFactory(): SimCfnServiceResourceFactory;
+}
+```
+
+This mirrors the style used by `SimRoute53`, which owns hosted-zone state, exposes command methods, and exposes a CloudFormation resource factory.
+
+---
+
+## Internal certificate model
+
+Use an internal representation roughly like:
+
+```ts
+export interface SimAcmCertificate {
+  readonly certificateArn: SimAcmCertificateArn;
+  readonly domainName: string;
+  readonly subjectAlternativeNames: readonly string[];
+  readonly status: "PENDING_VALIDATION" | "ISSUED";
+  readonly validationMethod?: "DNS" | "EMAIL" | undefined;
+  readonly domainValidationOptions: readonly SimAcmDomainValidationOption[];
+  readonly createdAt: Date;
+  readonly issuedAt?: Date | undefined;
+  readonly tags?: readonly SimAcmTag[] | undefined;
+}
+
+export interface SimAcmDomainValidationOption {
+  readonly domainName: string;
+  readonly validationMethod?: "DNS" | "EMAIL" | undefined;
+  readonly resourceRecord?: SimAcmValidationRecord | undefined;
+}
+
+export interface SimAcmValidationRecord {
+  readonly name: string;
+  readonly type: "CNAME";
+  readonly value: string;
+}
+```
+
+For MVP, `status` can usually be `ISSUED` immediately. If the implementation naturally needs `PENDING_VALIDATION`, it can be used, but do not make strict validation the default.
+
+---
+
+## ARN generation
+
+Generate deterministic ACM ARNs in the correct general shape:
+
+```txt
+arn:aws:acm:{region}:{account}:certificate/{certificate-id}
+```
+
+Yulin already has AWS account/region concepts and ARN utilities in the codebase, so use the existing style where possible. The manifest shows existing AWS scope and ARN-related files such as `src/service/aws/arn.ts`, account, region, and scope registry files.
+
+Certificate IDs can be deterministic enough for tests, for example based on an incrementing counter, domain hash, or existing Yulin ID pattern.
+
+---
+
+## Validation record generation
+
+For DNS validation, generate deterministic CNAME records.
+
+Example:
+
+```txt
+Name:  _yulin-acm-<hash>.example.com.
+Type:  CNAME
+Value: _yulin-acm-<hash>.acm-validations.aws.
+```
+
+Important properties:
+
+* deterministic for stable tests;
+* unique enough across domain/cert/account/region;
+* exposed through `DescribeCertificate`;
+* compatible with Route53’s existing `CNAME` support.
+
+Route53 records already support `CNAME` and values/TTL, so this should integrate cleanly.
+
+---
+
+## SDK commands to implement first
+
+### 1. RequestCertificate
+
+Support:
+
+```ts
+DomainName
+SubjectAlternativeNames
+ValidationMethod
+DomainValidationOptions
+Tags
+```
+
+Minimum behaviour:
+
+* require `DomainName`;
+* create a certificate ARN;
+* create internal certificate state;
+* create domain validation options for the primary domain and SANs;
+* if validation method is `DNS`, include generated CNAME records;
+* return `{ CertificateArn }`.
+
+For unsupported fields, either ignore them or preserve them if easy. Avoid over-validating.
+
+### 2. DescribeCertificate
+
+Support:
+
+```ts
+CertificateArn
+```
+
+Return an AWS-ish shape containing:
+
+```ts
+Certificate: {
+  CertificateArn
+  DomainName
+  SubjectAlternativeNames
+  Status
+  DomainValidationOptions
+  CreatedAt
+  IssuedAt
+}
+```
+
+This is probably the most important command for user assertions.
+
+### 3. ListCertificates
+
+Return summary objects:
+
+```ts
+CertificateSummaryList: [
+  {
+    CertificateArn,
+    DomainName
+  }
+]
+```
+
+MVP pagination can be minimal or absent unless existing command patterns make pagination easy.
+
+### 4. DeleteCertificate
+
+Remove the certificate from internal state.
+
+Return an empty output shape.
+
+### 5. Tags, optional
+
+If low-effort, support:
+
+```txt
+AddTagsToCertificate
+ListTagsForCertificate
+RemoveTagsFromCertificate
+```
+
+But these are not necessary for the first useful MVP.
+
+---
+
+## CloudFormation support
+
+Add support for:
+
+```txt
+AWS::CertificateManager::Certificate
+```
+
+The CloudFormation creator should:
+
+1. resolve `DomainName`;
+2. resolve `SubjectAlternativeNames`;
+3. inspect `ValidationMethod`;
+4. inspect `DomainValidationOptions`;
+5. create a simulated ACM certificate through the same internal service path used by `RequestCertificate`;
+6. return the certificate ARN for `Ref`.
+
+For CDK DNS validation, the synthesized resource is likely to include hosted zone information in `DomainValidationOptions`. The MVP should use that to create matching Route53 CNAME records when feasible.
+
+Route53 already exposes record-changing behaviour through its service and command handler surface. `SimRoute53` has a `changeResourceRecordSets` command method and owns hosted-zone state.
+
+Expected useful outcome:
+
+* CDK creates `AWS::CertificateManager::Certificate`;
+* Yulin creates the sim ACM certificate;
+* Yulin creates DNS validation CNAMEs in sim Route53 when hosted-zone-backed validation is present;
+* tests can assert through ACM `DescribeCertificate` and/or Route53 state.
+
+---
+
+## SimAws wiring
+
+Add `simAws.acm()` alongside existing service accessors.
+
+The service should be account/region scoped in the same way as other regional services.
+
+CloudFront certificates are often expected to be in `us-east-1` in real AWS, but do not enforce this in the MVP. At most, preserve region in the ARN so future diagnostics can warn about it.
+
+---
+
+## HTTP/browser diagnostics
+
+Do not modify normal simulated service responses.
+
+`SimAwsHttp` currently routes requests by hostname through Route53 and dispatches to the target service controller. Injecting ACM warnings into arbitrary HTML responses would be too messy because requests might hit CloudFront, API Gateway, Lambda, S3, or other future services.
+
+For MVP, browser diagnostics can wait.
+
+A later diagnostic controller could expose read-only Yulin admin paths such as:
+
+```txt
+/_yulin/acm
+/_yulin/acm/certificates
+/_yulin/acm/certificates/:arn
+/_yulin/acm/domains/:domain
+```
+
+But this should not block the MVP. The MVP should focus on command support and CloudFormation support.
+
+---
+
+## Future diagnostics layer
+
+After MVP, add Yulin-specific helpers such as:
+
+```ts
+simAws.acm().diagnostics().checkCertificate(certificateArn);
+simAws.acm().diagnostics().checkDomain("www.example.com");
+```
+
+Possible checks:
+
+```txt
+- certificate exists
+- certificate status is ISSUED
+- certificate covers the domain
+- wildcard certificate covers the domain
+- DNS validation record exists in simulated Route53
+- CloudFront distribution uses a certificate covering its alternate domain
+- certificate region is unusual for CloudFront
+```
+
+These should produce warnings/errors as structured data, not hard failures during normal simulation.
+
+Example shape:
+
+```ts
+{
+  status: "ok" | "warning" | "error",
+  checks: [
+    {
+      id: "certificate-exists",
+      status: "ok",
+      message: "Certificate exists."
+    },
+    {
+      id: "dns-validation-record-present",
+      status: "ok",
+      message: "DNS validation CNAME exists in Route53."
+    },
+    {
+      id: "cloudfront-certificate-region",
+      status: "warning",
+      message: "CloudFront public certificates usually live in us-east-1."
+    }
+  ]
+}
+```
+
+---
+
+## Toy CA / PKI concept
+
+Do not implement real TLS.
+
+But the internal ACM model can include toy PKI metadata to make diagnostics and browser views more intuitive later:
+
+```ts
+issuer: "Yulin Sim Public CA"
+serialNumber: string
+fingerprint: string
+notBefore: Date
+notAfter: Date
+```
+
+This gives users something realistic-looking to inspect without introducing private keys, trust stores, mkcert, local CA installation, or actual HTTPS termination.
+
+For MVP, this metadata is optional. It should not be required for command compatibility.
+
+---
+
+## Testing priorities
+
+Add tests for:
+
+### RequestCertificate
+
+* creates a certificate with primary domain;
+* creates certificate with SANs;
+* returns an ARN;
+* stores DNS validation options;
+* generated validation records are deterministic.
+
+### DescribeCertificate
+
+* returns created certificate;
+* includes domain, SANs, status, validation records;
+* errors on unknown ARN.
+
+### ListCertificates
+
+* returns multiple created certificates;
+* respects account/region scoping if applicable.
+
+### DeleteCertificate
+
+* deletes certificate;
+* describing deleted cert fails.
+
+### CloudFormation/CDK
+
+* `AWS::CertificateManager::Certificate` creates a sim ACM cert;
+* `Ref` returns the cert ARN;
+* DNS validation creates expected Route53 CNAMEs when hosted-zone validation is present;
+* CDK-style certificate with `CertificateValidation.fromDns(hostedZone)` is represented well enough for assertions.
+
+---
+
+## MVP cut line
+
+Include:
+
+```txt
+- SimAcm service
+- RequestCertificate
+- DescribeCertificate
+- ListCertificates
+- DeleteCertificate
+- AWS::CertificateManager::Certificate CloudFormation support
+- deterministic DNS validation records
+- Route53 CNAME creation when CFN has hosted zone validation info
+- simAws.acm()
+```
+
+Exclude:
+
+```txt
+- real TLS
+- local CA setup
+- browser trust
+- HTML injection
+- strict CloudFront certificate enforcement
+- renewal lifecycle
+- email validation realism
+- complex pagination
+- global SimAws ACM config
+- mandatory diagnostics API
+```
+
+The result should be a boring but useful sim ACM: users can create certs via SDK or CDK, inspect them through SDK commands, and assert that their local infrastructure created the ACM and Route53 resources they expected.

--- a/src/service/acm/certificate/sim-acm-certificate.ts
+++ b/src/service/acm/certificate/sim-acm-certificate.ts
@@ -1,0 +1,96 @@
+import type { SimArn } from "../../aws/arn.js";
+
+export type SimAcmCertificateStatus = "PENDING_VALIDATION" | "ISSUED";
+export type SimAcmValidationMethod = "DNS" | "EMAIL";
+
+export interface SimAcmTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+export interface SimAcmValidationRecord {
+  readonly name: string;
+  readonly type: "CNAME";
+  readonly value: string;
+}
+
+export interface SimAcmDomainValidationOption {
+  readonly domainName: string;
+  readonly validationMethod?: SimAcmValidationMethod | undefined;
+  readonly resourceRecord?: SimAcmValidationRecord | undefined;
+}
+
+interface SimAcmCertificateProps {
+  readonly certificateArn: SimArn;
+  readonly domainName: string;
+  readonly subjectAlternativeNames?: readonly string[] | undefined;
+  readonly status?: SimAcmCertificateStatus | undefined;
+  readonly validationMethod?: SimAcmValidationMethod | undefined;
+  readonly domainValidationOptions?:
+    readonly SimAcmDomainValidationOption[] | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly issuedAt?: Date | undefined;
+  readonly tags?: readonly SimAcmTag[] | undefined;
+}
+
+/**
+ * Simulated ACM Certificate.
+ */
+export class SimAcmCertificate {
+  public readonly certificateArn: SimArn;
+  public readonly domainName: string;
+  public readonly subjectAlternativeNames: readonly string[];
+  #status: SimAcmCertificateStatus;
+  public readonly validationMethod?: SimAcmValidationMethod | undefined;
+  public readonly domainValidationOptions: readonly SimAcmDomainValidationOption[];
+  public readonly createdAt: Date;
+  #issuedAt: Date | undefined;
+  public readonly tags?: readonly SimAcmTag[] | undefined;
+
+  constructor(props: SimAcmCertificateProps) {
+    const {
+      certificateArn,
+      domainName,
+      subjectAlternativeNames = [],
+      status = "PENDING_VALIDATION",
+      validationMethod,
+      domainValidationOptions = [],
+      createdAt = new Date(),
+      issuedAt,
+      tags,
+    } = props;
+
+    this.certificateArn = certificateArn;
+    this.domainName = domainName;
+    this.subjectAlternativeNames = subjectAlternativeNames;
+    this.#status = status;
+    this.validationMethod = validationMethod;
+    this.domainValidationOptions = domainValidationOptions;
+    this.createdAt = createdAt;
+    this.#issuedAt = issuedAt;
+    this.tags = tags;
+  }
+
+  /**
+   * Get the current Status of this sim Certificate.
+   */
+  get status(): SimAcmCertificateStatus {
+    return this.#status;
+  }
+
+  /**
+   * Get when this sim Certificate was issued.
+   */
+  get issuedAt(): Date | undefined {
+    return this.#issuedAt;
+  }
+
+  /**
+   * Move the sim Certificate into ISSUED status.
+   */
+  issue(): Promise<void> {
+    this.#status = "ISSUED";
+    this.#issuedAt = new Date();
+    return Promise.resolve();
+  }
+}

--- a/src/service/acm/command/describe-certificate/describe-certificate.cmd.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate.cmd.ts
@@ -1,0 +1,67 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimAcmCertificateStatus,
+  SimAcmValidationMethod,
+} from "../../certificate/sim-acm-certificate.js";
+
+/**
+ * Minimal structural sim ACM DescribeCertificate command.
+ */
+export interface SimDescribeCertificateCommand {
+  readonly input: SimDescribeCertificateCommandInput;
+}
+
+/**
+ * Minimal structural sim ACM DescribeCertificate input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/DescribeCertificateCommand/
+ */
+export interface SimDescribeCertificateCommandInput {
+  readonly CertificateArn?: SimArn | undefined;
+}
+
+/**
+ * Minimal structural sim ACM DescribeCertificate output.
+ */
+export interface SimDescribeCertificateCommandOutput {
+  readonly Certificate?: SimAcmCertificateDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ACM CertificateDetail.
+ */
+export interface SimAcmCertificateDetail {
+  readonly CertificateArn?: SimArn | undefined;
+  readonly DomainName?: string | undefined;
+  readonly SubjectAlternativeNames?: readonly string[] | undefined;
+  readonly Status?: SimAcmCertificateStatus | undefined;
+  readonly Type?: "AMAZON_ISSUED" | undefined;
+  readonly KeyAlgorithm?: "RSA-2048" | undefined;
+  readonly SignatureAlgorithm?: "SHA256WITHRSA" | undefined;
+  readonly InUseBy?: readonly string[] | undefined;
+  readonly CreatedAt?: Date | undefined;
+  readonly IssuedAt?: Date | undefined;
+  readonly DomainValidationOptions?:
+    readonly SimAcmCertificateDomainValidation[] | undefined;
+}
+
+/**
+ * Minimal structural sim ACM DomainValidation.
+ */
+export interface SimAcmCertificateDomainValidation {
+  readonly DomainName?: string | undefined;
+  readonly ValidationMethod?: SimAcmValidationMethod | undefined;
+  readonly ValidationStatus?: SimAcmCertificateStatus | undefined;
+  readonly ResourceRecord?: SimAcmCertificateResourceRecord | undefined;
+}
+
+/**
+ * Minimal structural sim ACM ResourceRecord.
+ */
+export interface SimAcmCertificateResourceRecord {
+  readonly Name?: string | undefined;
+  readonly Type?: "CNAME" | undefined;
+  readonly Value?: string | undefined;
+}

--- a/src/service/acm/command/describe-certificate/describe-certificate.handler.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate.handler.ts
@@ -1,0 +1,68 @@
+import type { SimArn } from "../../../aws/arn.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
+import type {
+  SimDescribeCertificateCommand,
+  SimDescribeCertificateCommandOutput,
+} from "./describe-certificate.cmd.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimAcmResourceNotFoundException } from "../../error/sim-acm.error.js";
+import { SimAcmCertificateDetailFactory } from "./sim-acm-cert-detail-factory.js";
+
+interface DescribeCertificateCommandHandlerProps {
+  readonly certificates: Map<SimArn, SimAcmCertificate>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated ACM DescribeCertificateCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/DescribeCertificateCommand/
+ */
+export class DescribeCertificateCommandHandler implements CommandHandler<
+  SimDescribeCertificateCommand,
+  SimDescribeCertificateCommandOutput
+> {
+  private readonly certificates: Map<SimArn, SimAcmCertificate>;
+  private readonly background: BackgroundScheduler;
+  private readonly certificateDetailFactory =
+    new SimAcmCertificateDetailFactory();
+
+  constructor(props: DescribeCertificateCommandHandlerProps) {
+    const { certificates, background = new BackgroundTasks() } = props;
+
+    this.certificates = certificates;
+    this.background = background;
+  }
+
+  /**
+   * Describe a simulated ACM certificate.
+   */
+  async handle(
+    cmd: SimDescribeCertificateCommand,
+  ): Promise<SimDescribeCertificateCommandOutput> {
+    assertDefined(
+      cmd.input.CertificateArn,
+      "DescribeCertificateCommand.input.CertificateArn required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const certificate = this.certificates.get(cmd.input.CertificateArn);
+    if (certificate === undefined) {
+      throw new SimAcmResourceNotFoundException(
+        `No sim ACM Certificate with ARN ${cmd.input.CertificateArn}`,
+      );
+    }
+
+    return {
+      $metadata: {},
+      Certificate: this.certificateDetailFactory.make(certificate),
+    };
+  }
+}

--- a/src/service/acm/command/describe-certificate/describe-certificate.iso.test.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate.iso.test.ts
@@ -1,0 +1,226 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimAcmResourceNotFoundException } from "../../error/sim-acm.error.js";
+
+describe("ACM DescribeCertificateCommand", () => {
+  it("describes a requested DNS validated certificate", async () => {
+    // Given ACM with a requested certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("555555555555").region("eu-west-1").acm();
+
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "example.com",
+      },
+    });
+    assertNonNullable(requestOutput.CertificateArn);
+
+    // When the certificate is described.
+    const describeOutput = await simAcm.describeCertificate({
+      input: {
+        CertificateArn: requestOutput.CertificateArn,
+      },
+    });
+
+    // Then the certificate detail is returned.
+    assertNonNullable(describeOutput.Certificate);
+    assertIdentical(
+      describeOutput.Certificate.CertificateArn,
+      "arn:aws:acm:eu-west-1:555555555555:certificate/00000001",
+    );
+    assertIdentical(describeOutput.Certificate.DomainName, "example.com");
+    assertArrayLength(describeOutput.Certificate.SubjectAlternativeNames, 0);
+    assertIdentical(describeOutput.Certificate.Status, "PENDING_VALIDATION");
+    assertIdentical(describeOutput.Certificate.Type, "AMAZON_ISSUED");
+    assertIdentical(describeOutput.Certificate.KeyAlgorithm, "RSA-2048");
+    assertIdentical(
+      describeOutput.Certificate.SignatureAlgorithm,
+      "SHA256WITHRSA",
+    );
+    assertArrayLength(describeOutput.Certificate.InUseBy, 0);
+    assertNonNullable(describeOutput.Certificate.CreatedAt);
+    assertUndefined(describeOutput.Certificate.IssuedAt);
+  });
+
+  it("describes subject alternative names and DNS validation records", async () => {
+    // Given ACM with a requested certificate that has alternative names.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "example.com",
+        SubjectAlternativeNames: ["www.example.com", "api.example.com"],
+      },
+    });
+    assertNonNullable(requestOutput.CertificateArn);
+
+    // When the certificate is described.
+    const describeOutput = await simAcm.describeCertificate({
+      input: {
+        CertificateArn: requestOutput.CertificateArn,
+      },
+    });
+
+    // Then all requested names have DNS validation details.
+    assertNonNullable(describeOutput.Certificate);
+    assertArrayLength(describeOutput.Certificate.SubjectAlternativeNames, 2);
+    assertIdentical(
+      describeOutput.Certificate.SubjectAlternativeNames[0],
+      "www.example.com",
+    );
+    assertIdentical(
+      describeOutput.Certificate.SubjectAlternativeNames[1],
+      "api.example.com",
+    );
+
+    assertArrayLength(describeOutput.Certificate.DomainValidationOptions, 3);
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[0].DomainName,
+      "example.com",
+    );
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[1].DomainName,
+      "www.example.com",
+    );
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[2].DomainName,
+      "api.example.com",
+    );
+
+    for (const option of describeOutput.Certificate.DomainValidationOptions) {
+      assertIdentical(option.ValidationMethod, "DNS");
+      assertIdentical(option.ValidationStatus, "PENDING_VALIDATION");
+      assertNonNullable(option.ResourceRecord);
+      assertStringStartsWith(option.ResourceRecord.Name, "_yulin-acm-");
+      assertIdentical(option.ResourceRecord.Type, "CNAME");
+      assertStringIncludes(
+        option.ResourceRecord.Value,
+        ".acm-validations.aws.",
+      );
+    }
+  });
+
+  it("describes EMAIL validation without DNS resource records", async () => {
+    // Given ACM with an EMAIL validated certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "email.example.com",
+        ValidationMethod: "EMAIL",
+      },
+    });
+    assertNonNullable(requestOutput.CertificateArn);
+
+    // When the certificate is described.
+    const describeOutput = await simAcm.describeCertificate({
+      input: {
+        CertificateArn: requestOutput.CertificateArn,
+      },
+    });
+
+    // Then the validation method is EMAIL and no DNS record is included.
+    assertNonNullable(describeOutput.Certificate);
+    assertArrayLength(describeOutput.Certificate.DomainValidationOptions, 1);
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[0].DomainName,
+      "email.example.com",
+    );
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[0].ValidationMethod,
+      "EMAIL",
+    );
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[0].ValidationStatus,
+      "PENDING_VALIDATION",
+    );
+    assertUndefined(
+      describeOutput.Certificate.DomainValidationOptions[0].ResourceRecord,
+    );
+  });
+
+  it("describes an issued certificate after background issuance", async () => {
+    // Given ACM with a requested certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "issued.example.com",
+      },
+    });
+    assertNonNullable(requestOutput.CertificateArn);
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    // When the certificate is described after background issuance.
+    const describeOutput = await simAcm.describeCertificate({
+      input: {
+        CertificateArn: requestOutput.CertificateArn,
+      },
+    });
+
+    // Then the certificate detail shows ISSUED status.
+    assertNonNullable(describeOutput.Certificate);
+    assertIdentical(describeOutput.Certificate.Status, "ISSUED");
+    assertNonNullable(describeOutput.Certificate.IssuedAt);
+    assertArrayLength(describeOutput.Certificate.DomainValidationOptions, 1);
+    assertIdentical(
+      describeOutput.Certificate.DomainValidationOptions[0].ValidationStatus,
+      "ISSUED",
+    );
+  });
+
+  it("throws when CertificateArn is missing", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When a certificate is described without an ARN.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.describeCertificate({
+        input: {},
+      }),
+    );
+
+    // Then the request is rejected.
+    assertInstanceOf(error, Error);
+    assertStringIncludes(error.message, "CertificateArn required");
+  });
+
+  it("throws ResourceNotFoundException when the certificate does not exist", async () => {
+    // Given ACM with no matching certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("555555555555").region("eu-west-1").acm();
+
+    // When a non-existent certificate ARN is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.describeCertificate({
+        input: {
+          CertificateArn:
+            "arn:aws:acm:eu-west-1:555555555555:certificate/does-not-exist",
+        },
+      }),
+    );
+
+    // Then ACM returns ResourceNotFoundException.
+    assertInstanceOf(error, SimAcmResourceNotFoundException);
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "does-not-exist");
+  });
+});

--- a/src/service/acm/command/describe-certificate/sim-acm-cert-detail-factory.ts
+++ b/src/service/acm/command/describe-certificate/sim-acm-cert-detail-factory.ts
@@ -1,0 +1,50 @@
+import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
+import type { SimAcmCertificateDetail } from "./describe-certificate.cmd.js";
+
+/**
+ * Builds ACM DescribeCertificate certificate detail payloads.
+ *
+ * This class owns the translation from the simulator's internal certificate
+ * model to the public DescribeCertificate response shape. Keeping that
+ * translation out of the command handler lets the handler stay focused on
+ * command validation, background sequencing, lookup, and error handling.
+ */
+export class SimAcmCertificateDetailFactory {
+  /**
+   * Convert one simulated ACM certificate into the structure returned as
+   * DescribeCertificateCommandOutput.Certificate.
+   *
+   * The simulator stores certificate data in camelCase fields, while the AWS
+   * SDK response uses PascalCase member names. This method is the boundary
+   * where those naming conventions are translated.
+   */
+  make(certificate: SimAcmCertificate): SimAcmCertificateDetail {
+    return {
+      CertificateArn: certificate.certificateArn,
+      DomainName: certificate.domainName,
+      SubjectAlternativeNames: certificate.subjectAlternativeNames,
+      Status: certificate.status,
+      Type: "AMAZON_ISSUED",
+      KeyAlgorithm: "RSA-2048",
+      SignatureAlgorithm: "SHA256WITHRSA",
+      InUseBy: [],
+      CreatedAt: certificate.createdAt,
+      IssuedAt: certificate.issuedAt,
+      DomainValidationOptions: certificate.domainValidationOptions.map(
+        (option) => ({
+          DomainName: option.domainName,
+          ValidationMethod: option.validationMethod,
+          ValidationStatus: certificate.status,
+          ResourceRecord:
+            option.resourceRecord === undefined
+              ? undefined
+              : {
+                  Name: option.resourceRecord.name,
+                  Type: option.resourceRecord.type,
+                  Value: option.resourceRecord.value,
+                },
+        }),
+      ),
+    };
+  }
+}

--- a/src/service/acm/command/list-certificates/list-certificates.cmd.ts
+++ b/src/service/acm/command/list-certificates/list-certificates.cmd.ts
@@ -1,0 +1,47 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimAcmCertificateStatus } from "../../certificate/sim-acm-certificate.js";
+
+/**
+ * Minimal structural sim ACM ListCertificates command.
+ */
+export interface SimListCertificatesCommand {
+  readonly input: SimListCertificatesCommandInput;
+}
+
+/**
+ * Minimal structural sim ACM ListCertificates input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/ListCertificatesCommand/
+ */
+export interface SimListCertificatesCommandInput {
+  readonly CertificateStatuses?: readonly SimAcmCertificateStatus[] | undefined;
+  readonly MaxItems?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ACM ListCertificates output.
+ */
+export interface SimListCertificatesCommandOutput {
+  readonly CertificateSummaryList?:
+    readonly SimAcmCertificateSummary[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim ACM CertificateSummary.
+ */
+export interface SimAcmCertificateSummary {
+  readonly CertificateArn?: SimArn | undefined;
+  readonly DomainName?: string | undefined;
+  readonly SubjectAlternativeNameSummaries?: readonly string[] | undefined;
+  readonly HasAdditionalSubjectAlternativeNames?: boolean | undefined;
+  readonly Status?: SimAcmCertificateStatus | undefined;
+  readonly Type?: "TEST_ISSUED" | undefined;
+  readonly KeyAlgorithm?: "RSA-2048" | undefined;
+  readonly InUse?: boolean | undefined;
+  readonly CreatedAt?: Date | undefined;
+  readonly IssuedAt?: Date | undefined;
+}

--- a/src/service/acm/command/list-certificates/list-certificates.handler.ts
+++ b/src/service/acm/command/list-certificates/list-certificates.handler.ts
@@ -1,0 +1,123 @@
+import type { SimArn } from "../../../aws/arn.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
+import { SimAcmInvalidArgsException } from "../../error/sim-acm.error.js";
+import type {
+  SimAcmCertificateSummary,
+  SimListCertificatesCommand,
+  SimListCertificatesCommandOutput,
+} from "./list-certificates.cmd.js";
+
+interface ListCertificatesCommandHandlerProps {
+  readonly certificates: Map<SimArn, SimAcmCertificate>;
+  readonly background?: BackgroundScheduler;
+}
+
+const defaultMaxItems = 100;
+const maxMaxItems = 1000;
+
+/**
+ * Simulated ACM ListCertificatesCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/ListCertificatesCommand/
+ */
+export class ListCertificatesCommandHandler implements CommandHandler<
+  SimListCertificatesCommand,
+  SimListCertificatesCommandOutput
+> {
+  private readonly certificates: Map<SimArn, SimAcmCertificate>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(props: ListCertificatesCommandHandlerProps) {
+    const { certificates, background = new BackgroundTasks() } = props;
+
+    this.certificates = certificates;
+    this.background = background;
+  }
+
+  /**
+   * List simulated ACM certificates.
+   */
+  async handle(
+    cmd: SimListCertificatesCommand,
+  ): Promise<SimListCertificatesCommandOutput> {
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const maxItems = this.getMaxItems(cmd);
+    const startIndex = this.getStartIndex(cmd);
+    const certificates = [...this.certificates.values()].filter(
+      (certificate) =>
+        cmd.input.CertificateStatuses === undefined
+          ? true
+          : cmd.input.CertificateStatuses.includes(certificate.status),
+    );
+
+    const page = certificates.slice(startIndex, startIndex + maxItems);
+    const nextIndex = startIndex + maxItems;
+
+    return {
+      $metadata: {},
+      CertificateSummaryList: page.map((certificate) =>
+        this.makeCertificateSummary(certificate),
+      ),
+      NextToken:
+        nextIndex < certificates.length ? String(nextIndex) : undefined,
+    };
+  }
+
+  private getMaxItems(cmd: SimListCertificatesCommand): number {
+    const maxItems = cmd.input.MaxItems ?? defaultMaxItems;
+
+    if (!Number.isInteger(maxItems) || maxItems < 1 || maxItems > maxMaxItems) {
+      throw new SimAcmInvalidArgsException(
+        "ListCertificatesCommand.input.MaxItems must be an integer between 1 and 1000",
+      );
+    }
+
+    return maxItems;
+  }
+
+  private getStartIndex(cmd: SimListCertificatesCommand): number {
+    if (cmd.input.NextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(cmd.input.NextToken);
+
+    if (
+      !Number.isInteger(startIndex) ||
+      startIndex < 0 ||
+      String(startIndex) !== cmd.input.NextToken
+    ) {
+      throw new SimAcmInvalidArgsException(
+        "ListCertificatesCommand.input.NextToken is invalid",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private makeCertificateSummary(
+    certificate: SimAcmCertificate,
+  ): SimAcmCertificateSummary {
+    return {
+      CertificateArn: certificate.certificateArn,
+      DomainName: certificate.domainName,
+      SubjectAlternativeNameSummaries:
+        certificate.subjectAlternativeNames.slice(0, 100),
+      HasAdditionalSubjectAlternativeNames:
+        certificate.subjectAlternativeNames.length > 100,
+      Status: certificate.status,
+      Type: "TEST_ISSUED",
+      KeyAlgorithm: "RSA-2048",
+      InUse: false,
+      CreatedAt: certificate.createdAt,
+      IssuedAt: certificate.issuedAt,
+    };
+  }
+}

--- a/src/service/acm/command/list-certificates/list-certificates.iso.test.ts
+++ b/src/service/acm/command/list-certificates/list-certificates.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("ACM ListCertificatesCommand", () => {
+  it("lists no certificates when ACM has none", async () => {
+    // Given ACM with no certificates.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When certificates are listed.
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    // Then an empty certificate summary list is returned.
+    assertArrayLength(listOutput.CertificateSummaryList, 0);
+    assertUndefined(listOutput.NextToken);
+  });
+
+  it("lists requested certificates in creation order", async () => {
+    // Given ACM with multiple requested certificates.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("555555555555").region("eu-west-1").acm();
+
+    const firstOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "one.example.com",
+      },
+    });
+    const secondOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "two.example.com",
+      },
+    });
+    const thirdOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "three.example.com",
+      },
+    });
+
+    // When certificates are listed.
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    // Then the certificate summaries are returned in creation order.
+    assertArrayLength(listOutput.CertificateSummaryList, 3);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      firstOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      "arn:aws:acm:eu-west-1:555555555555:certificate/00000001",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "one.example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[1].CertificateArn,
+      secondOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[1].DomainName,
+      "two.example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[2].CertificateArn,
+      thirdOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[2].DomainName,
+      "three.example.com",
+    );
+    assertUndefined(listOutput.NextToken);
+  });
+
+  it("returns certificate summary fields", async () => {
+    // Given ACM with a requested certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "summary.example.com",
+        SubjectAlternativeNames: ["www.summary.example.com"],
+      },
+    });
+
+    // When certificates are listed.
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    // Then the certificate summary contains the expected fields.
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      requestOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "summary.example.com",
+    );
+    assertArrayLength(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries,
+      1,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries[0],
+      "www.summary.example.com",
+    );
+    assertFalse(
+      listOutput.CertificateSummaryList[0].HasAdditionalSubjectAlternativeNames,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].Status,
+      "PENDING_VALIDATION",
+    );
+    assertIdentical(listOutput.CertificateSummaryList[0].Type, "TEST_ISSUED");
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].KeyAlgorithm,
+      "RSA-2048",
+    );
+    assertFalse(listOutput.CertificateSummaryList[0].InUse);
+    assertNonNullable(listOutput.CertificateSummaryList[0].CreatedAt);
+    assertUndefined(listOutput.CertificateSummaryList[0].IssuedAt);
+  });
+
+  it("truncates subject alternative name summaries after 100 names", async () => {
+    // Given ACM with a certificate that has more than 100 subject alternative names.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const subjectAlternativeNames = Array.from(
+      { length: 101 },
+      (_, index) => `san-${String(index).padStart(3, "0")}.example.com`,
+    );
+
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "many-sans.example.com",
+        SubjectAlternativeNames: subjectAlternativeNames,
+      },
+    });
+
+    // When certificates are listed.
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    // Then only the first 100 subject alternative names are summarized.
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertArrayLength(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries,
+      100,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries[0],
+      "san-000.example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries[99],
+      "san-099.example.com",
+    );
+    assertTrue(
+      listOutput.CertificateSummaryList[0].HasAdditionalSubjectAlternativeNames,
+    );
+  });
+});

--- a/src/service/acm/command/list-certificates/list-certs-page-filter.iso.test.ts
+++ b/src/service/acm/command/list-certificates/list-certs-page-filter.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimAcmInvalidArgsException } from "../../error/sim-acm.error.js";
+
+describe("ACM ListCertificatesCommand pagination and filters", () => {
+  it("filters certificates by PENDING_VALIDATION status", async () => {
+    // Given ACM with newly requested certificates.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "one-pending.example.com",
+      },
+    });
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "two-pending.example.com",
+      },
+    });
+
+    // When certificates are listed with the PENDING_VALIDATION status filter.
+    const listOutput = await simAcm.listCertificates({
+      input: {
+        CertificateStatuses: ["PENDING_VALIDATION"],
+      },
+    });
+
+    // Then only pending certificates are returned.
+    assertArrayLength(listOutput.CertificateSummaryList, 2);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].Status,
+      "PENDING_VALIDATION",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[1].Status,
+      "PENDING_VALIDATION",
+    );
+  });
+
+  it("filters certificates by ISSUED status", async () => {
+    // Given ACM with a requested certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "issued.example.com",
+      },
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    // When certificates are listed with the ISSUED status filter.
+    const listOutput = await simAcm.listCertificates({
+      input: {
+        CertificateStatuses: ["ISSUED"],
+      },
+    });
+
+    // Then issued certificates are returned.
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "issued.example.com",
+    );
+    assertIdentical(listOutput.CertificateSummaryList[0].Status, "ISSUED");
+    assertNonNullable(listOutput.CertificateSummaryList[0].IssuedAt);
+  });
+
+  it("paginates certificates using MaxItems and NextToken", async () => {
+    // Given ACM with more certificates than the requested page size.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "one.example.com",
+      },
+    });
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "two.example.com",
+      },
+    });
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "three.example.com",
+      },
+    });
+
+    // When certificates are listed with a two-item page size.
+    const firstPageOutput = await simAcm.listCertificates({
+      input: {
+        MaxItems: 2,
+      },
+    });
+
+    // Then the first page includes a token for the remaining certificates.
+    assertArrayLength(firstPageOutput.CertificateSummaryList, 2);
+    assertIdentical(
+      firstPageOutput.CertificateSummaryList[0].DomainName,
+      "one.example.com",
+    );
+    assertIdentical(
+      firstPageOutput.CertificateSummaryList[1].DomainName,
+      "two.example.com",
+    );
+    assertIdentical(firstPageOutput.NextToken, "2");
+
+    // When the next page is requested with the token.
+    const secondPageOutput = await simAcm.listCertificates({
+      input: {
+        MaxItems: 2,
+        NextToken: firstPageOutput.NextToken,
+      },
+    });
+
+    // Then the remaining certificate is returned and pagination ends.
+    assertArrayLength(secondPageOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      secondPageOutput.CertificateSummaryList[0].DomainName,
+      "three.example.com",
+    );
+    assertUndefined(secondPageOutput.NextToken);
+  });
+
+  it("returns an empty page when NextToken starts after the last certificate", async () => {
+    // Given ACM with one certificate.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    await simAcm.requestCertificate({
+      input: {
+        DomainName: "one.example.com",
+      },
+    });
+
+    // When certificates are listed from a token after the last certificate.
+    const listOutput = await simAcm.listCertificates({
+      input: {
+        NextToken: "1",
+      },
+    });
+
+    // Then an empty page is returned.
+    assertArrayLength(listOutput.CertificateSummaryList, 0);
+    assertUndefined(listOutput.NextToken);
+  });
+
+  it("throws InvalidArgsException when MaxItems is zero", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When certificates are listed with an invalid page size.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.listCertificates({
+        input: {
+          MaxItems: 0,
+        },
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "MaxItems");
+  });
+
+  it("throws InvalidArgsException when MaxItems is greater than 1000", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When certificates are listed with a page size above the maximum.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.listCertificates({
+        input: {
+          MaxItems: 1001,
+        },
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "MaxItems");
+  });
+
+  it("throws InvalidArgsException when MaxItems is not an integer", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When certificates are listed with a fractional page size.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.listCertificates({
+        input: {
+          MaxItems: 1.5,
+        },
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "MaxItems");
+  });
+
+  it("throws InvalidArgsException when NextToken is invalid", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When certificates are listed with an invalid next token.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.listCertificates({
+        input: {
+          NextToken: "not-a-token",
+        },
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "NextToken");
+  });
+});

--- a/src/service/acm/command/request-certificate/request-cert-factory.ts
+++ b/src/service/acm/command/request-certificate/request-cert-factory.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimAcmCertificate,
+  type SimAcmDomainValidationOption,
+  type SimAcmTag,
+  type SimAcmValidationMethod,
+  type SimAcmValidationRecord,
+} from "../../certificate/sim-acm-certificate.js";
+import type { SimRequestCertificateCommand } from "./request-certificate.cmd.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface RequestCertificateFactoryProps {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Builds simulated ACM certificates for RequestCertificateCommand.
+ *
+ * The command handler keeps ownership of command validation, repository writes,
+ * and background scheduling. This factory keeps the certificate-shaping rules
+ * in one place: ARN assignment, validation method defaults, domain validation
+ * options, deterministic DNS validation records, and tag copying.
+ */
+export class RequestCertificateFactory {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(props: RequestCertificateFactoryProps) {
+    this.accountRegionScope = props.accountRegionScope;
+  }
+
+  /**
+   * Create the certificate entity that will be stored by the handler.
+   *
+   * The caller supplies the certificate count because the backing Map is owned
+   * by the ACM service state. Keeping the count as an input avoids giving this
+   * class write access to the certificate store while still producing stable
+   * ARNs that match the existing simulator behavior.
+   */
+  makeCertificate(
+    cmd: SimRequestCertificateCommand,
+    certificateCount: number,
+  ): SimAcmCertificate {
+    const certificateArn = this.makeCertificateArn(certificateCount);
+    const validationMethod = cmd.input.ValidationMethod ?? "DNS";
+    const domainNames = [
+      cmd.input.DomainName,
+      ...(cmd.input.SubjectAlternativeNames ?? []),
+    ];
+    assertDefined(
+      cmd.input.DomainName,
+      "SimRequestCertificateCommand.input.DomainName required",
+    );
+
+    return new SimAcmCertificate({
+      certificateArn,
+      domainName: cmd.input.DomainName,
+      subjectAlternativeNames: cmd.input.SubjectAlternativeNames ?? [],
+      status: "PENDING_VALIDATION",
+      validationMethod,
+      domainValidationOptions: domainNames.map((domainName) => {
+        assertDefined(
+          domainName,
+          "SimRequestCertificateCommand input DomainName / SubjectAlternativeNames required",
+        );
+        return this.makeDomainValidationOption(domainName, validationMethod);
+      }),
+      createdAt: new Date(),
+      tags: cmd.input.Tags?.map((tag): SimAcmTag => ({
+        Key: tag.Key,
+        Value: tag.Value,
+      })),
+    });
+  }
+
+  /**
+   * Generate the next simulator ARN in the current account and Region.
+   *
+   * ACM certificate IDs are represented as eight-digit sequence numbers to keep
+   * test output stable and easy to read. The simulator does not need globally
+   * unique randomness here because each ACM scope owns its own certificate Map.
+   */
+  private makeCertificateArn(certificateCount: number): SimArn {
+    const certificateId = String(certificateCount + 1).padStart(8, "0");
+
+    return `arn:aws:acm:${this.accountRegionScope.regionName}:${this.accountRegionScope.accountId}:certificate/${certificateId}`;
+  }
+
+  /**
+   * Build the per-domain validation option returned by ACM.
+   *
+   * DNS validation includes a CNAME record. Other validation methods keep the
+   * resource record unset, matching AWS SDK shapes where the record is only
+   * available when ACM can provide one.
+   */
+  private makeDomainValidationOption(
+    domainName: string,
+    validationMethod: SimAcmValidationMethod,
+  ): SimAcmDomainValidationOption {
+    return {
+      domainName,
+      validationMethod,
+      resourceRecord:
+        validationMethod === "DNS"
+          ? this.makeValidationRecord(domainName)
+          : undefined,
+    };
+  }
+
+  /**
+   * Build a deterministic DNS validation CNAME for a domain.
+   *
+   * The account, Region, and domain are part of the hash input, so the same
+   * domain can receive different validation records in different simulated AWS
+   * scopes. The short hash keeps records readable while remaining stable across
+   * test runs.
+   */
+  private makeValidationRecord(domainName: string): SimAcmValidationRecord {
+    const hash = createHash("sha256")
+      .update(
+        [
+          this.accountRegionScope.accountId,
+          this.accountRegionScope.regionName,
+          domainName,
+        ].join(":"),
+      )
+      .digest("hex")
+      .slice(0, 16);
+
+    return {
+      name: `_yulin-acm-${hash}.${domainName}.`,
+      type: "CNAME",
+      value: `_yulin-acm-${hash}.acm-validations.aws.`,
+    };
+  }
+}

--- a/src/service/acm/command/request-certificate/request-certificate.cmd.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.cmd.ts
@@ -1,0 +1,48 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimAcmValidationMethod } from "../../certificate/sim-acm-certificate.js";
+
+/**
+ * Minimal structural sim ACM RequestCertificate command.
+ */
+export interface SimRequestCertificateCommand {
+  readonly input: SimRequestCertificateCommandInput;
+}
+
+/**
+ * Minimal structural sim ACM RequestCertificate input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/RequestCertificateCommand/
+ */
+export interface SimRequestCertificateCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly SubjectAlternativeNames?: readonly string[] | undefined;
+  readonly ValidationMethod?: SimAcmValidationMethod | undefined;
+  readonly DomainValidationOptions?:
+    readonly SimRequestCertificateDomainValidationOption[] | undefined;
+  readonly Tags?: readonly SimRequestCertificateTag[] | undefined;
+}
+
+/**
+ * Minimal structural sim ACM domain validation option input.
+ */
+export interface SimRequestCertificateDomainValidationOption {
+  readonly DomainName?: string | undefined;
+  readonly ValidationDomain?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ACM tag input.
+ */
+export interface SimRequestCertificateTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim ACM RequestCertificate output.
+ */
+export interface SimRequestCertificateCommandOutput {
+  readonly CertificateArn?: SimArn | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/acm/command/request-certificate/request-certificate.handler.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.handler.ts
@@ -1,0 +1,89 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimArn } from "../../../aws/arn.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type {
+  SimRequestCertificateCommand,
+  SimRequestCertificateCommandOutput,
+} from "./request-certificate.cmd.js";
+import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
+import {
+  SimAcmInvalidArgsException,
+  SimAcmTooManyTagsException,
+} from "../../error/sim-acm.error.js";
+import { RequestCertificateFactory } from "./request-cert-factory.js";
+
+interface RequestCertificateCommandHandlerProps {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly certificates: Map<SimArn, SimAcmCertificate>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated ACM RequestCertificateCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/acm/command/RequestCertificateCommand/
+ */
+export class RequestCertificateCommandHandler implements CommandHandler<
+  SimRequestCertificateCommand,
+  SimRequestCertificateCommandOutput
+> {
+  private readonly certificates: Map<SimArn, SimAcmCertificate>;
+  private readonly background: BackgroundScheduler;
+  private readonly certificateFactory: RequestCertificateFactory;
+
+  constructor(props: RequestCertificateCommandHandlerProps) {
+    const {
+      accountRegionScope,
+      certificates,
+      background = new BackgroundTasks(),
+    } = props;
+
+    this.certificates = certificates;
+    this.background = background;
+    this.certificateFactory = new RequestCertificateFactory({
+      accountRegionScope,
+    });
+  }
+
+  /**
+   * Request a simulated ACM certificate.
+   */
+  async handle(
+    cmd: SimRequestCertificateCommand,
+  ): Promise<SimRequestCertificateCommandOutput> {
+    if (cmd.input.DomainName === undefined || cmd.input.DomainName === "") {
+      throw new SimAcmInvalidArgsException(
+        "RequestCertificateCommand.input.DomainName required",
+      );
+    }
+
+    if ((cmd.input.Tags?.length ?? 0) > 50) {
+      throw new SimAcmTooManyTagsException(
+        "RequestCertificateCommand.input.Tags cannot contain more than 50 tags",
+      );
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const certificate = this.certificateFactory.makeCertificate(
+      cmd,
+      this.certificates.size,
+    );
+    const { certificateArn } = certificate;
+
+    this.certificates.set(certificateArn, certificate);
+
+    // Schedule background task to issue the sim Certificate.
+    this.background.schedule(() => certificate.issue());
+
+    return {
+      $metadata: {},
+      CertificateArn: certificateArn,
+    };
+  }
+}

--- a/src/service/acm/command/request-certificate/request-certificate.iso.test.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.iso.test.ts
@@ -1,0 +1,249 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimAcmInvalidArgsException,
+  SimAcmTooManyTagsException,
+} from "../../error/sim-acm.error.js";
+
+describe("ACM RequestCertificateCommand", () => {
+  it("requests a certificate for a domain name", async () => {
+    // Given ACM in a known account and region.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("555555555555").region("eu-west-1").acm();
+
+    // When a certificate is requested for a domain name.
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "example.com",
+      },
+    });
+
+    // Then the certificate ARN is returned and the certificate is present.
+    assertIdentical(
+      requestOutput.CertificateArn,
+      "arn:aws:acm:eu-west-1:555555555555:certificate/00000001",
+    );
+
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      requestOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].Status,
+      "PENDING_VALIDATION",
+    );
+  });
+
+  it("requests a certificate with subject alternative names", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.region("me-south-1").acm();
+
+    // When a certificate is requested with subject alternative names.
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "example.com",
+        SubjectAlternativeNames: ["www.example.com", "api.example.com"],
+      },
+    });
+
+    // Then the certificate summary includes the requested names.
+    assertNonNullable(requestOutput.CertificateArn);
+
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      requestOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "example.com",
+    );
+    assertArrayLength(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries,
+      2,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries[0],
+      "www.example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].SubjectAlternativeNameSummaries[1],
+      "api.example.com",
+    );
+  });
+
+  it("allows multiple certificates for the same domain", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.account("123456789012").acm();
+
+    // When the same domain is requested twice.
+    const firstOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "duplicate.example.com",
+      },
+    });
+    const secondOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "duplicate.example.com",
+      },
+    });
+
+    // Then both requests succeed with distinct certificate ARNs.
+    assertIdentical(
+      firstOutput.CertificateArn,
+      "arn:aws:acm:us-east-1:123456789012:certificate/00000001",
+    );
+    assertIdentical(
+      secondOutput.CertificateArn,
+      "arn:aws:acm:us-east-1:123456789012:certificate/00000002",
+    );
+
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    assertArrayLength(listOutput.CertificateSummaryList, 2);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      firstOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[1].CertificateArn,
+      secondOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "duplicate.example.com",
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[1].DomainName,
+      "duplicate.example.com",
+    );
+  });
+
+  it("throws InvalidArgsException when DomainName is missing", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When a certificate is requested without a domain name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.requestCertificate({
+        input: {},
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "DomainName required");
+  });
+
+  it("throws InvalidArgsException when DomainName is empty", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    // When a certificate is requested with an empty domain name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.requestCertificate({
+        input: {
+          DomainName: "",
+        },
+      }),
+    );
+
+    // Then ACM rejects the request as invalid.
+    assertInstanceOf(error, SimAcmInvalidArgsException);
+    assertIdentical(error.name, "InvalidArgsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "DomainName required");
+  });
+
+  it("throws TooManyTagsException when more than 50 tags are requested", async () => {
+    // Given ACM and too many request tags.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const tags = Array.from({ length: 51 }, (_, index) => ({
+      Key: `key-${String(index)}`,
+      Value: `value-${String(index)}`,
+    }));
+
+    // When a certificate is requested with too many tags.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAcm.requestCertificate({
+        input: {
+          DomainName: "too-many-tags.example.com",
+          Tags: tags,
+        },
+      }),
+    );
+
+    // Then ACM rejects the request with the tag limit error.
+    assertInstanceOf(error, SimAcmTooManyTagsException);
+    assertIdentical(error.name, "TooManyTagsException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, "more than 50 tags");
+  });
+
+  it("accepts 50 tags on a requested certificate", async () => {
+    // Given ACM and the maximum allowed number of tags.
+    const simAws = new SimAws();
+    const simAcm = simAws.acm();
+
+    const tags = Array.from({ length: 50 }, (_, index) => ({
+      Key: `key-${String(index)}`,
+      Value: `value-${String(index)}`,
+    }));
+
+    // When a certificate is requested with exactly 50 tags.
+    const requestOutput = await simAcm.requestCertificate({
+      input: {
+        DomainName: "fifty-tags.example.com",
+        Tags: tags,
+      },
+    });
+
+    // Then the request succeeds and the certificate is present.
+    assertNonNullable(requestOutput.CertificateArn);
+
+    const listOutput = await simAcm.listCertificates({
+      input: {},
+    });
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      requestOutput.CertificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "fifty-tags.example.com",
+    );
+  });
+});

--- a/src/service/acm/error/sim-acm.error.ts
+++ b/src/service/acm/error/sim-acm.error.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal metadata shape for simulated ACM errors.
+ */
+export interface SimAcmErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated ACM errors.
+ */
+export class SimAcmError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimAcmErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated ACM InvalidArgsException error.
+ */
+export class SimAcmInvalidArgsException extends SimAcmError {
+  public override readonly name = "InvalidArgsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ACM ResourceNotFoundException error.
+ */
+export class SimAcmResourceNotFoundException extends SimAcmError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated ACM TooManyTagsException error.
+ */
+export class SimAcmTooManyTagsException extends SimAcmError {
+  public override readonly name = "TooManyTagsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -1,0 +1,90 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import {
+  type SimAwsAccountRegionScope,
+  simAwsAccountRegionScopeFactory,
+} from "../aws/sim-aws-account-region-scope.js";
+import type { SimArn } from "../aws/arn.js";
+import type {
+  SimRequestCertificateCommand,
+  SimRequestCertificateCommandOutput,
+} from "./command/request-certificate/request-certificate.cmd.js";
+import { RequestCertificateCommandHandler } from "./command/request-certificate/request-certificate.handler.js";
+import type { SimAcmCertificate } from "./certificate/sim-acm-certificate.js";
+import type {
+  SimDescribeCertificateCommand,
+  SimDescribeCertificateCommandOutput,
+} from "./command/describe-certificate/describe-certificate.cmd.js";
+import { DescribeCertificateCommandHandler } from "./command/describe-certificate/describe-certificate.handler.js";
+import type {
+  SimListCertificatesCommand,
+  SimListCertificatesCommandOutput,
+} from "./command/list-certificates/list-certificates.cmd.js";
+import { ListCertificatesCommandHandler } from "./command/list-certificates/list-certificates.handler.js";
+
+interface SimAcmProps {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated ACM. Handles SDK commands. Emulates AWS behaviour and state.
+ */
+export class SimAcm {
+  public readonly certificates = new Map<SimArn, SimAcmCertificate>();
+
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly background: BackgroundScheduler;
+
+  constructor(props: SimAcmProps = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      background = new BackgroundTasks(),
+    } = props;
+
+    this.accountRegionScope = accountRegionScope;
+    this.background = background;
+  }
+
+  /**
+   * Handle a Describe Certificate Command from the SDK.
+   */
+  async describeCertificate(
+    cmd: SimDescribeCertificateCommand,
+  ): Promise<SimDescribeCertificateCommandOutput> {
+    const handler = new DescribeCertificateCommandHandler({
+      certificates: this.certificates,
+      background: this.background,
+    });
+    return await handler.handle(cmd);
+  }
+
+  /**
+   * Handle a List Certificates Command from the SDK.
+   */
+  async listCertificates(
+    cmd: SimListCertificatesCommand,
+  ): Promise<SimListCertificatesCommandOutput> {
+    const handler = new ListCertificatesCommandHandler({
+      certificates: this.certificates,
+      background: this.background,
+    });
+    return await handler.handle(cmd);
+  }
+
+  /**
+   * Handle a Request Certificate Command from the SDK.
+   */
+  async requestCertificate(
+    cmd: SimRequestCertificateCommand,
+  ): Promise<SimRequestCertificateCommandOutput> {
+    const handler = new RequestCertificateCommandHandler({
+      accountRegionScope: this.accountRegionScope,
+      certificates: this.certificates,
+      background: this.background,
+    });
+    return await handler.handle(cmd);
+  }
+}

--- a/src/service/aws/arn.ts
+++ b/src/service/aws/arn.ts
@@ -9,7 +9,7 @@ import { faker } from "@faker-js/faker";
 export type SimArnServiceName = string;
 
 export type SimArn =
-  `arn:aws:${SimArnServiceName}:${AwsRegionName | ""}:${SimAwsAccountId}:${string}/${string}`;
+  `arn:aws:${string}:${string}:${string}:${string}/${string}`;
 
 export interface SimArnComponents {
   partition: "aws";

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -12,6 +12,7 @@ import type { SimRoute53 } from "../../route53/index.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
+import { SimAcm } from "../../acm/sim-acm.js";
 
 interface SimAwsServiceFactoryProps {
   readonly simAws: SimAws;
@@ -48,6 +49,16 @@ export class SimAwsServiceFactory {
       simAws: props.simAws,
       background: props.background,
       cloudFrontRegistry: this.cloudFrontRegistry,
+    });
+  }
+
+  /**
+   * Create simulated ACM for an Account Region scope.
+   */
+  createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
+    return new SimAcm({
+      accountRegionScope: scope.accountRegionScope,
+      background: this.background,
     });
   }
 

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -16,6 +16,7 @@ import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
+import type { SimAcm } from "../acm/sim-acm.js";
 
 export type SimAccountRegionScopeKey = `${SimAwsAccountId}:${AwsRegionName}`;
 
@@ -52,6 +53,15 @@ export class SimAwsAccountRegionContainer {
       accountId: this.account.accountId,
       regionName: this.region.regionName,
     };
+  }
+
+  /**
+   * Get simulated ACM for this account and region.
+   */
+  acm(): SimAcm {
+    return this.memo.getOrCreate("acm", () =>
+      this.simAws.serviceFactory.createAcm(this),
+    );
   }
 
   /**

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -7,6 +7,7 @@ import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimAcm } from "../acm/sim-acm.js";
 
 export type SimAwsAccountId = Brand<string, "SimAwsAccountId">;
 
@@ -40,6 +41,13 @@ export class SimAwsAccount {
    */
   region(regionName?: AwsRegionName): SimAwsAccountRegionContainer {
     return this.simAws.accountRegionScope(this.accountId, regionName);
+  }
+
+  /**
+   * Get simulated ACM for this Account's default Region.
+   */
+  acm(): SimAcm {
+    return this.region().acm();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -6,6 +6,7 @@ import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb } from "../dynamodb/index.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimAcm } from "../acm/sim-acm.js";
 
 export const AWS_REGION_NAMES = [
   "us-east-1",
@@ -79,6 +80,13 @@ export class SimAwsRegion {
       accountId as SimAwsAccountId,
       this.regionName,
     );
+  }
+
+  /**
+   * Get simulated ACM for this Region's default Account.
+   */
+  acm(): SimAcm {
+    return this.account().acm();
   }
 
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -22,6 +22,7 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
 import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
+import type { SimAcm } from "../acm/sim-acm.js";
 
 interface SimAwsProps {
   readonly defaultAccountId?: SimAwsAccountId;
@@ -86,6 +87,13 @@ export class SimAws {
     regionName: AwsRegionName = this.defaultRegionName,
   ): SimAwsAccountRegionContainer {
     return this.scopes.accountRegionScope(accountId, regionName);
+  }
+
+  /**
+   * Get simulated ACM in the default Account Region scope.
+   */
+  acm(): SimAcm {
+    return this.accountRegionScope().acm();
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated ACM support for requesting, listing, and describing certificates.
  * Certificates now support DNS and email validation, subject alternative names, tags, and deterministic certificate IDs.
  * ACM is now accessible from the top-level AWS simulation and related account/region contexts.

* **Bug Fixes**
  * Added input validation and clearer errors for missing domains, invalid pagination values, missing certificate IDs, and excessive tags.
  * List results now handle pagination and certificate status filtering correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->