### PR TITLE
feat: sim ACM sim CloudFormation

### DIFF
--- a/src/service/acm/cfn/property/sim-cfn-acm-cert-prop-reader.ts
+++ b/src/service/acm/cfn/property/sim-cfn-acm-cert-prop-reader.ts
@@ -128,7 +128,6 @@ export class SimCfnAcmCertificatePropertyListReader {
   private tag(value: unknown, index: number): SimRequestCertificateTag {
     const propertyPath = `Tags[${String(index)}]`;
 
-    /* v8 ignore if */
     if (!isRecord(value)) {
       throw this.propertyError(propertyPath, "must be an object");
     }

--- a/src/service/acm/cfn/property/sim-cfn-acm-cert-prop-reader.ts
+++ b/src/service/acm/cfn/property/sim-cfn-acm-cert-prop-reader.ts
@@ -1,0 +1,158 @@
+import type {
+  SimRequestCertificateDomainValidationOption,
+  SimRequestCertificateTag,
+} from "../../command/request-certificate/request-certificate.cmd.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+interface SimCfnAcmCertificatePropertyListReaderProps {
+  readonly logicalId: string;
+}
+
+/**
+ * Reads AWS::ACM::Certificate properties whose CloudFormation shape is an
+ * array.
+ *
+ * This class keeps array traversal and nested object validation out of
+ * SimCfnAcmCertificateProperties. The outer properties reader stays focused on
+ * top-level CloudFormation fields, while this reader owns the repeated rules
+ * for list properties:
+ *
+ * - the property must be an array when it is present;
+ * - each array item is validated with an index-aware error path;
+ * - nested optional string fields are checked before being returned to the
+ *   request-certificate command shape.
+ */
+export class SimCfnAcmCertificatePropertyListReader {
+  private readonly logicalId: string;
+
+  constructor(props: SimCfnAcmCertificatePropertyListReaderProps) {
+    this.logicalId = props.logicalId;
+  }
+
+  /**
+   * Read Certificate SubjectAlternativeNames.
+   *
+   * CloudFormation accepts this property as a list of DNS names. The simulator
+   * stores the already-resolved template values, so each entry must be a plain
+   * string by this point.
+   */
+  subjectAlternativeNames(value: unknown): readonly string[] {
+    this.assertArray(value, "SubjectAlternativeNames");
+
+    for (const [index, item] of value.entries()) {
+      if (typeof item !== "string") {
+        throw this.propertyError(
+          `SubjectAlternativeNames[${String(index)}]`,
+          "must be a string",
+        );
+      }
+    }
+
+    return value as readonly string[];
+  }
+
+  /**
+   * Read Certificate DomainValidationOptions.
+   *
+   * Each option is a small object with optional string fields. The simulator
+   * returns the command input shape because the ACM resource factory can pass it
+   * directly into the request-certificate flow.
+   */
+  domainValidationOptions(
+    value: unknown,
+  ): readonly SimRequestCertificateDomainValidationOption[] {
+    this.assertArray(value, "DomainValidationOptions");
+
+    return value.map((item, index) => this.domainValidationOption(item, index));
+  }
+
+  /**
+   * Read Certificate Tags.
+   *
+   * Tags follow the AWS SDK command shape where Key and Value are optional
+   * strings. Invalid nested values are reported with the exact array index so a
+   * failing template is easy to locate.
+   */
+  tags(value: unknown): readonly SimRequestCertificateTag[] {
+    this.assertArray(value, "Tags");
+
+    return value.map((item, index) => this.tag(item, index));
+  }
+
+  private assertArray(
+    value: unknown,
+    propertyName:
+      "SubjectAlternativeNames" | "DomainValidationOptions" | "Tags",
+  ): asserts value is unknown[] {
+    if (!Array.isArray(value)) {
+      throw this.propertyError(propertyName, "must be an array");
+    }
+  }
+
+  private domainValidationOption(
+    value: unknown,
+    index: number,
+  ): SimRequestCertificateDomainValidationOption {
+    const propertyPath = `DomainValidationOptions[${String(index)}]`;
+
+    if (!isRecord(value)) {
+      throw this.propertyError(propertyPath, "must be an object");
+    }
+
+    const domainName = value["DomainName"];
+    const validationDomain = value["ValidationDomain"];
+
+    if (domainName !== undefined && typeof domainName !== "string") {
+      throw this.propertyError(
+        `${propertyPath}.DomainName`,
+        "must be a string",
+      );
+    }
+
+    if (
+      validationDomain !== undefined &&
+      typeof validationDomain !== "string"
+    ) {
+      throw this.propertyError(
+        `${propertyPath}.ValidationDomain`,
+        "must be a string",
+      );
+    }
+
+    return {
+      DomainName: domainName,
+      ValidationDomain: validationDomain,
+    };
+  }
+
+  private tag(value: unknown, index: number): SimRequestCertificateTag {
+    const propertyPath = `Tags[${String(index)}]`;
+
+    /* v8 ignore if */
+    if (!isRecord(value)) {
+      throw this.propertyError(propertyPath, "must be an object");
+    }
+
+    const key = value["Key"];
+    const tagValue = value["Value"];
+
+    if (key !== undefined && typeof key !== "string") {
+      throw this.propertyError(`${propertyPath}.Key`, "must be a string");
+    }
+
+    if (tagValue !== undefined && typeof tagValue !== "string") {
+      throw this.propertyError(`${propertyPath}.Value`, "must be a string");
+    }
+
+    return {
+      Key: key,
+      Value: tagValue,
+    };
+  }
+
+  private propertyError(propertyPath: string, reason: string): Error {
+    return new Error(
+      `Invalid AWS::ACM::Certificate Resource ${this.logicalId} property ${propertyPath}: ${reason}`,
+    );
+  }
+}

--- a/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.iso.test.ts
+++ b/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.iso.test.ts
@@ -1,0 +1,251 @@
+import { assertIdentical, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnAcmCertificatePropertyListReader } from "./sim-cfn-acm-cert-prop-reader.js";
+import { SimCfnAcmCertificateProperties } from "./sim-cfn-acm-cert-properties.js";
+
+describe("SimCfnAcmCertificateProperties", () => {
+  it("rejects a non-string DomainName", () => {
+    // Given ACM certificate properties with an invalid DomainName shape.
+    const properties = new SimCfnAcmCertificateProperties({
+      logicalId: "InvalidCertificate",
+      properties: {
+        DomainName: 123,
+      },
+    });
+
+    // When DomainName is read, then the property reader reports the invalid
+    // property path.
+    const error = assertThrowsError(() => properties.domainName());
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property DomainName: must be a string",
+    );
+  });
+
+  it("rejects an unsupported ValidationMethod", () => {
+    // Given ACM certificate properties with a ValidationMethod other than DNS or
+    // EMAIL.
+    const properties = new SimCfnAcmCertificateProperties({
+      logicalId: "InvalidCertificate",
+      properties: {
+        ValidationMethod: "HTTP",
+      },
+    });
+
+    // When ValidationMethod is read, then the property reader reports the invalid
+    // property path.
+    const error = assertThrowsError(() => properties.validationMethod());
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property ValidationMethod: must be DNS or EMAIL",
+    );
+  });
+});
+
+describe("SimCfnAcmCertificatePropertyListReader", () => {
+  it("rejects SubjectAlternativeNames when it is not an array", () => {
+    // Given an ACM certificate list-property reader.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When SubjectAlternativeNames is read from a non-array value, then the
+    // reader reports the invalid property path.
+    const error = assertThrowsError(() =>
+      reader.subjectAlternativeNames("www.example.test"),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property SubjectAlternativeNames: must be an array",
+    );
+  });
+
+  it("rejects SubjectAlternativeNames items that are not strings", () => {
+    // Given an ACM certificate SubjectAlternativeNames array with a non-string
+    // item.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When SubjectAlternativeNames is read, then the reader reports the indexed
+    // invalid property path.
+    const error = assertThrowsError(() =>
+      reader.subjectAlternativeNames(["www.example.test", 123]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property SubjectAlternativeNames[1]: must be a string",
+    );
+  });
+
+  it("rejects DomainValidationOptions when it is not an array", () => {
+    // Given an ACM certificate list-property reader.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When DomainValidationOptions is read from a non-array value, then the
+    // reader reports the invalid property path.
+    const error = assertThrowsError(() =>
+      reader.domainValidationOptions({
+        DomainName: "example.test",
+      }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property DomainValidationOptions: must be an array",
+    );
+  });
+
+  it("rejects DomainValidationOptions items that are not objects", () => {
+    // Given an ACM certificate DomainValidationOptions array with a non-object
+    // item.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When DomainValidationOptions is read, then the reader reports the indexed
+    // invalid property path.
+    const error = assertThrowsError(() =>
+      reader.domainValidationOptions(["example.test"]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property DomainValidationOptions[0]: must be an object",
+    );
+  });
+
+  it("rejects a non-string DomainValidationOptions DomainName", () => {
+    // Given an ACM certificate DomainValidationOptions item with a non-string
+    // DomainName.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When DomainValidationOptions is read, then the reader reports the nested
+    // invalid property path.
+    const error = assertThrowsError(() =>
+      reader.domainValidationOptions([
+        {
+          DomainName: 123,
+        },
+      ]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property DomainValidationOptions[0].DomainName: must be a string",
+    );
+  });
+
+  it("rejects a non-string DomainValidationOptions ValidationDomain", () => {
+    // Given an ACM certificate DomainValidationOptions item with a non-string
+    // ValidationDomain.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When DomainValidationOptions is read, then the reader reports the nested
+    // invalid property path.
+    const error = assertThrowsError(() =>
+      reader.domainValidationOptions([
+        {
+          ValidationDomain: 123,
+        },
+      ]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property DomainValidationOptions[0].ValidationDomain: must be a string",
+    );
+  });
+
+  it("rejects Tags when it is not an array", () => {
+    // Given an ACM certificate list-property reader.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When Tags is read from a non-array value, then the reader reports the
+    // invalid property path.
+    const error = assertThrowsError(() =>
+      reader.tags({
+        Key: "Purpose",
+        Value: "test",
+      }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property Tags: must be an array",
+    );
+  });
+
+  it("rejects Tags items that are not objects", () => {
+    // Given an ACM certificate Tags array with a non-object item.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When Tags is read, then the reader reports the indexed invalid property
+    // path.
+    const error = assertThrowsError(() => reader.tags(["Purpose"]));
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property Tags[0]: must be an object",
+    );
+  });
+
+  it("rejects a non-string Tag Key", () => {
+    // Given an ACM certificate Tags item with a non-string Key.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When Tags is read, then the reader reports the nested invalid property
+    // path.
+    const error = assertThrowsError(() =>
+      reader.tags([
+        {
+          Key: 123,
+        },
+      ]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property Tags[0].Key: must be a string",
+    );
+  });
+
+  it("rejects a non-string Tag Value", () => {
+    // Given an ACM certificate Tags item with a non-string Value.
+    const reader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: "InvalidCertificate",
+    });
+
+    // When Tags is read, then the reader reports the nested invalid property
+    // path.
+    const error = assertThrowsError(() =>
+      reader.tags([
+        {
+          Value: 123,
+        },
+      ]),
+    );
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::ACM::Certificate Resource InvalidCertificate property Tags[0].Value: must be a string",
+    );
+  });
+});

--- a/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.ts
+++ b/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.ts
@@ -1,0 +1,112 @@
+import type { SimAcmValidationMethod } from "../../certificate/sim-acm-certificate.js";
+import type {
+  SimRequestCertificateDomainValidationOption,
+  SimRequestCertificateTag,
+} from "../../command/request-certificate/request-certificate.cmd.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnAcmCertificatePropertyListReader } from "./sim-cfn-acm-cert-prop-reader.js";
+
+interface SimCfnAcmCertificatePropertiesProps {
+  readonly logicalId: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads and validates CloudFormation AWS::ACM::Certificate properties for
+ * sim ACM certificate creation.
+ */
+export class SimCfnAcmCertificateProperties {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly listReader: SimCfnAcmCertificatePropertyListReader;
+
+  constructor(props: SimCfnAcmCertificatePropertiesProps) {
+    this.logicalId = props.logicalId;
+    this.properties = props.properties;
+    this.listReader = new SimCfnAcmCertificatePropertyListReader({
+      logicalId: this.logicalId,
+    });
+  }
+
+  /**
+   * Get the Certificate DomainName property.
+   */
+  domainName(): string | undefined {
+    const value = this.properties["DomainName"];
+
+    /* v8 ignore if */
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.propertyError("DomainName", "must be a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Get the Certificate SubjectAlternativeNames property.
+   */
+  subjectAlternativeNames(): readonly string[] | undefined {
+    const value = this.properties["SubjectAlternativeNames"];
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.listReader.subjectAlternativeNames(value);
+  }
+
+  /**
+   * Get the Certificate ValidationMethod property.
+   */
+  validationMethod(): SimAcmValidationMethod | undefined {
+    const value = this.properties["ValidationMethod"];
+
+    /* v8 ignore if */
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value !== "DNS" && value !== "EMAIL") {
+      throw this.propertyError("ValidationMethod", "must be DNS or EMAIL");
+    }
+
+    return value;
+  }
+
+  /**
+   * Get the Certificate DomainValidationOptions property.
+   */
+  domainValidationOptions():
+    readonly SimRequestCertificateDomainValidationOption[] | undefined {
+    const value = this.properties["DomainValidationOptions"];
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.listReader.domainValidationOptions(value);
+  }
+
+  /**
+   * Get the Certificate Tags property.
+   */
+  tags(): readonly SimRequestCertificateTag[] | undefined {
+    const value = this.properties["Tags"];
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.listReader.tags(value);
+  }
+
+  private propertyError(propertyPath: string, reason: string): Error {
+    return new Error(
+      `Invalid AWS::ACM::Certificate Resource ${this.logicalId} property ${propertyPath}: ${reason}`,
+    );
+  }
+}

--- a/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
@@ -1,0 +1,269 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimArn } from "../../aws/arn.js";
+
+describe("Sim ACM CloudFormation Certificate", () => {
+  it("deploys an ACM Certificate and exposes CloudFormation values", async () => {
+    // Given a sim CloudFormation template with an ACM Certificate and Outputs
+    // for its Ref and supported GetAtt values.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "acm-certificate-values-stack",
+      template: {
+        Resources: {
+          SiteCertificate: {
+            Type: "AWS::CertificateManager::Certificate",
+            Properties: {
+              DomainName: "example.test",
+              ValidationMethod: "DNS",
+            },
+          },
+        },
+        Outputs: {
+          CertificateRef: {
+            Value: {
+              Ref: "SiteCertificate",
+            },
+          },
+          CertificateArn: {
+            Value: {
+              "Fn::GetAtt": ["SiteCertificate", "CertificateArn"],
+            },
+          },
+          CertificateStatus: {
+            Value: {
+              "Fn::GetAtt": ["SiteCertificate", "CertificateStatus"],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the CloudFormation Outputs expose the simulated certificate values.
+    const certificateRef = stack.outputs.get("CertificateRef")?.value;
+    const certificateArn = stack.outputs.get("CertificateArn")?.value;
+
+    assertStringStartsWith(certificateRef, "arn:aws:acm:");
+    assertIdentical(certificateArn, certificateRef);
+    assertIdentical(
+      stack.outputs.get("CertificateStatus")?.value,
+      "PENDING_VALIDATION",
+    );
+
+    // And the certificate can be found through the sim ACM list-certificates
+    // command.
+    await simAws.backgroundTasksComplete();
+
+    const listOutput = await simAws.acm().listCertificates({
+      input: {},
+    });
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].CertificateArn,
+      certificateArn,
+    );
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "example.test",
+    );
+    assertIdentical(listOutput.CertificateSummaryList[0].Status, "ISSUED");
+  });
+
+  it("deploys an ACM Certificate with DNS validation details", async () => {
+    // Given a sim CloudFormation template with an ACM Certificate using DNS
+    // validation, subject alternative names, domain validation options, and tags.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "acm-certificate-dns-validation-stack",
+      template: {
+        Resources: {
+          SiteCertificate: {
+            Type: "AWS::CertificateManager::Certificate",
+            Properties: {
+              DomainName: "example.test",
+              SubjectAlternativeNames: [
+                "www.example.test",
+                "assets.example.test",
+              ],
+              ValidationMethod: "DNS",
+              DomainValidationOptions: [
+                {
+                  DomainName: "example.test",
+                  ValidationDomain: "example.test",
+                },
+                {
+                  DomainName: "www.example.test",
+                  ValidationDomain: "example.test",
+                },
+              ],
+              Tags: [
+                {
+                  Key: "Purpose",
+                  Value: "iso-test",
+                },
+              ],
+            },
+          },
+        },
+        Outputs: {
+          CertificateArn: {
+            Value: {
+              Ref: "SiteCertificate",
+            },
+          },
+        },
+      },
+    });
+
+    // Then describe-certificate returns the deployed certificate details.
+    await simAws.backgroundTasksComplete();
+
+    const certificateArn = stack.outputs.get("CertificateArn")?.value;
+    assertStringStartsWith(certificateArn, "arn:aws:acm:");
+
+    const describeOutput = await simAws.acm().describeCertificate({
+      input: {
+        CertificateArn: certificateArn as SimArn,
+      },
+    });
+
+    const certificate = describeOutput.Certificate;
+    assertNonNullable(certificate);
+    assertIdentical(certificate.CertificateArn, certificateArn);
+    assertIdentical(certificate.DomainName, "example.test");
+    assertIdentical(certificate.Status, "ISSUED");
+    assertIdentical(certificate.Type, "AMAZON_ISSUED");
+    assertIdentical(certificate.KeyAlgorithm, "RSA-2048");
+    assertIdentical(certificate.SignatureAlgorithm, "SHA256WITHRSA");
+    assertArrayLength(certificate.SubjectAlternativeNames, 2);
+    assertIdentical(certificate.SubjectAlternativeNames[0], "www.example.test");
+    assertIdentical(
+      certificate.SubjectAlternativeNames[1],
+      "assets.example.test",
+    );
+
+    // And DNS validation records are available for the primary domain and each
+    // subject alternative name.
+    assertArrayLength(certificate.DomainValidationOptions, 3);
+
+    const primaryValidation = certificate.DomainValidationOptions[0];
+    assertIdentical(primaryValidation.DomainName, "example.test");
+    assertIdentical(primaryValidation.ValidationMethod, "DNS");
+    assertIdentical(primaryValidation.ValidationStatus, "ISSUED");
+    assertStringStartsWith(
+      primaryValidation.ResourceRecord?.Name,
+      "_yulin-acm-",
+    );
+    assertIdentical(primaryValidation.ResourceRecord.Type, "CNAME");
+    assertStringStartsWith(
+      primaryValidation.ResourceRecord.Value,
+      "_yulin-acm-",
+    );
+
+    assertIdentical(
+      certificate.DomainValidationOptions[1].DomainName,
+      "www.example.test",
+    );
+    assertIdentical(
+      certificate.DomainValidationOptions[2].DomainName,
+      "assets.example.test",
+    );
+  });
+
+  it("deploys an ACM Certificate with EMAIL validation", async () => {
+    // Given a sim CloudFormation template with an ACM Certificate using EMAIL
+    // validation.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "acm-certificate-email-validation-stack",
+      template: {
+        Resources: {
+          EmailCertificate: {
+            Type: "AWS::CertificateManager::Certificate",
+            Properties: {
+              DomainName: "mail.example.test",
+              ValidationMethod: "EMAIL",
+            },
+          },
+        },
+        Outputs: {
+          CertificateArn: {
+            Value: {
+              Ref: "EmailCertificate",
+            },
+          },
+        },
+      },
+    });
+
+    // Then describe-certificate shows EMAIL validation without DNS resource
+    // records.
+    await simAws.backgroundTasksComplete();
+
+    const certificateArn = stack.outputs.get("CertificateArn")?.value;
+    assertStringStartsWith(certificateArn, "arn:aws:acm:");
+
+    const describeOutput = await simAws.acm().describeCertificate({
+      input: {
+        CertificateArn: certificateArn as SimArn,
+      },
+    });
+
+    const validation = describeOutput.Certificate?.DomainValidationOptions?.[0];
+
+    assertIdentical(
+      describeOutput.Certificate?.DomainName,
+      "mail.example.test",
+    );
+    assertIdentical(describeOutput.Certificate.Status, "ISSUED");
+    assertIdentical(validation?.DomainName, "mail.example.test");
+    assertIdentical(validation.ValidationMethod, "EMAIL");
+    assertUndefined(validation.ResourceRecord);
+  });
+
+  it("records unsupported ACM CloudFormation resource types as skipped", async () => {
+    // Given a sim CloudFormation template with an unsupported ACM resource type.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "unsupported-acm-resource-stack",
+      template: {
+        Resources: {
+          UnsupportedAcmResource: {
+            Type: "AWS::CertificateManager::UnsupportedResource",
+          },
+        },
+      },
+    });
+
+    // Then the Stack completes, but records the unsupported resource as skipped.
+    const skippedResource = stack.skippedResources[0];
+
+    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 1);
+    assertNonNullable(skippedResource);
+    assertIdentical(skippedResource.logicalId, "UnsupportedAcmResource");
+    assertTrue(skippedResource.skipped);
+    assertIdentical(
+      skippedResource.skippedReason,
+      "Unsupported sim ACM CloudFormation Resource UnsupportedResource",
+    );
+  });
+});

--- a/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
@@ -1,0 +1,80 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import { SimAcm } from "../sim-acm.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAcmCertificate } from "../certificate/sim-acm-certificate.js";
+import { SimCfnAcmCertificateProperties } from "./property/sim-cfn-acm-cert-properties.js";
+
+interface SimAcmCfnResourceFactoryProps {
+  readonly acm?: SimAcm | undefined;
+}
+
+/**
+ * CloudFormation Resource factory for simulated ACM resources.
+ */
+export class SimAcmCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly acm: SimAcm;
+
+  constructor(props: SimAcmCfnResourceFactoryProps = {}) {
+    const { acm = new SimAcm() } = props;
+
+    this.acm = acm;
+  }
+
+  /**
+   * Create a simulated ACM resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Certificate": {
+        return await this.createCertificate(resource, context);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim ACM CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+
+  private async createCertificate(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimAcmCertificate> {
+    const properties = new SimCfnAcmCertificateProperties({
+      logicalId: resource.logicalId,
+      properties: context.resolvedProperties ?? resource.properties,
+    });
+
+    const requestCertificateOutput = await this.acm.requestCertificate({
+      input: {
+        DomainName: properties.domainName(),
+        SubjectAlternativeNames: properties.subjectAlternativeNames(),
+        ValidationMethod: properties.validationMethod(),
+        DomainValidationOptions: properties.domainValidationOptions(),
+        Tags: properties.tags(),
+      },
+    });
+
+    const certificateArn = requestCertificateOutput.CertificateArn;
+    assertDefined(
+      certificateArn,
+      `sim ACM Certificate ARN after CloudFormation creation for ${resource.logicalId}`,
+    );
+
+    const certificate = this.acm.certificates.get(certificateArn);
+    assertDefined(
+      certificate,
+      `sim ACM Certificate ${certificateArn} after CloudFormation creation`,
+    );
+
+    return certificate;
+  }
+}

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -23,6 +23,7 @@ import type {
   SimListCertificatesCommandOutput,
 } from "./command/list-certificates/list-certificates.cmd.js";
 import { ListCertificatesCommandHandler } from "./command/list-certificates/list-certificates.handler.js";
+import { SimAcmCfnResourceFactory } from "./cfn/sim-cfn-acm-resource-factory.js";
 
 interface SimAcmProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -37,6 +38,9 @@ export class SimAcm {
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
+  private readonly cfnFactory = new SimAcmCfnResourceFactory({
+    acm: this,
+  });
 
   constructor(props: SimAcmProps = {}) {
     const {
@@ -86,5 +90,12 @@ export class SimAcm {
       background: this.background,
     });
     return await handler.handle(cmd);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimAcmCfnResourceFactory {
+    return this.cfnFactory;
   }
 }

--- a/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-proj.loc.test.ts
+++ b/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-proj.loc.test.ts
@@ -67,6 +67,7 @@ function handler(event) {
       `
 import * as cdk from "aws-cdk-lib/core";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import { aws_certificatemanager as acm } from "aws-cdk-lib";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
@@ -74,7 +75,7 @@ import * as route53 from "aws-cdk-lib/aws-route53";
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, "TestStack", {
-  env: { account: "111111111111", region: "eu-west-2" },
+  env: { account: "111111111111", region: "us-east-1" },
 });
 
 const siteBucket = new s3.Bucket(stack, "SiteBucket", {
@@ -96,13 +97,19 @@ const redirectFunction = new cloudfront.Function(
   },
 );
 
+const domainName = "example.test";
 const hostedZone = new route53.HostedZone(stack, "SiteHostedZone", {
-  zoneName: "example.test",
+  zoneName: domainName,
+});
+const certificate = new acm.Certificate(stack, "Certificate", {
+  domainName,
+  validation: acm.CertificateValidation.fromDns(hostedZone),
 });
 
 const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
   defaultRootObject: "index.html",
   domainNames: ["www.example.test"],
+  certificate,
   defaultBehavior: {
     origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
     viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -150,17 +157,17 @@ new s3deploy.BucketDeployment(stack, "DeploySite", {
 new cdk.CfnOutput(stack, "SiteBucketName", {
   value: siteBucket.bucketName,
 });
-
 new cdk.CfnOutput(stack, "CloudFrontDistributionId", {
   value: distribution.distributionId,
 });
-
 new cdk.CfnOutput(stack, "DistributionDomainName", {
   value: distribution.distributionDomainName,
 });
-
 new cdk.CfnOutput(stack, "SiteHostname", {
   value: "www.example.test",
+});
+new cdk.CfnOutput(stack, "CertArn", {
+  value: certificate.certificateArn,
 });
 
 app.synth();
@@ -191,6 +198,8 @@ app.synth();
     );
     const siteHostname = stack.outputs.get("SiteHostname")?.value;
     assertIdentical(siteHostname, "www.example.test");
+    const certArn = stack.outputs.get("CertArn")?.value;
+    assertStringStartsWith(certArn, "arn:aws:acm:");
 
     // And we should be able to interact with the test demo project.
     const distroRes = await fetch(

--- a/src/service/cloudformation/resource/cfn/acm/sim-acm-certificate-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/acm/sim-acm-certificate-cfn.ts
@@ -1,0 +1,45 @@
+import type { SimAcmCertificate } from "../../../../acm/certificate/sim-acm-certificate.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimAcmCertificateCfnProps {
+  readonly certificate: SimAcmCertificate;
+}
+
+/**
+ * CloudFormation-facing values for a simulated ACM Certificate.
+ */
+export class SimAcmCertificateCfn implements SimCfnResourceValueAdapter {
+  private readonly certificate: SimAcmCertificate;
+
+  constructor(props: SimAcmCertificateCfnProps) {
+    this.certificate = props.certificate;
+  }
+
+  /**
+   * AWS::CertificateManager::Certificate Ref returns the certificate ARN.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.certificate.certificateArn;
+  }
+
+  /**
+   * AWS::CertificateManager::Certificate attributes supported by the simulator.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "CertificateArn": {
+        return this.certificate.certificateArn;
+      }
+      case "CertificateStatus": {
+        return this.certificate.status;
+      }
+      default: {
+        /* v8 ignore next */
+        throw new Error(
+          `Unsupported AWS::CertificateManager::Certificate attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -8,6 +8,8 @@ import { SimCloudFrontFunction } from "../../../cloudfront/cff/sim-cloudfront-fu
 import { SimCloudFrontFunctionCfn } from "./cloudfront/sim-cloudfront-function-cfn.js";
 import { SimRoute53HostedZone } from "../../../route53/hosted-zone/sim-route53-hosted-zone.js";
 import { SimRoute53HostedZoneCfn } from "./route53/sim-route53-hosted-zone-cfn.js";
+import { SimAcmCertificateCfn } from "./acm/sim-acm-certificate-cfn.js";
+import { SimAcmCertificate } from "../../../acm/certificate/sim-acm-certificate.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -31,6 +33,15 @@ interface SimCfnResourceValueAdapterProps {
 export function simCfnResourceValueAdapter(
   props: SimCfnResourceValueAdapterProps,
 ): SimCfnResourceValueAdapter {
+  if (
+    props.type === "AWS::CertificateManager::Certificate" &&
+    props.simResource instanceof SimAcmCertificate
+  ) {
+    return new SimAcmCertificateCfn({
+      certificate: props.simResource,
+    });
+  }
+
   if (
     props.type === "AWS::S3::Bucket" &&
     props.simResource instanceof SimS3Bucket

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -41,6 +41,10 @@ export function resolveSimCloudFormationServiceResourceFactory(
   );
 
   switch (resourceType.serviceName) {
+    case "ACM":
+    case "CertificateManager": {
+      return scopedAws.acm().cfnResourceFactory();
+    }
     case "CloudFormation": {
       return new SimCfnCfnResourceFactory();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for ACM certificates, including DNS and email validation, tags, and subject alternative names.
  * Certificate values now appear correctly in stack outputs and resource attributes, including ARN and status.
  * CDK-based site deployments can now wire in an ACM certificate for CloudFront.

* **Bug Fixes**
  * Improved handling of unsupported ACM resource types by marking them as skipped instead of failing the stack.
  * Added clearer validation errors for invalid certificate property values and shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->