### PR TITLE
feat: initial sim IAM commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
       "import": "./dist/config/eslint/index.js",
       "types": "./dist/config/eslint/index.d.ts"
     },
+    "./iam": {
+      "import": "./dist/service/iam/index.js",
+      "types": "./dist/service/iam/index.d.ts"
+    },
     "./package.json": "./package.json",
     "./s3": {
       "import": "./dist/service/s3/index.js",
@@ -86,24 +90,25 @@
     "@aws-sdk/client-cloudformation": "^3.1079.0",
     "@aws-sdk/client-cloudfront": "^3.1079.0",
     "@aws-sdk/client-dynamodb": "^3.1079.0",
+    "@aws-sdk/client-iam": "^3.1079.0",
     "@aws-sdk/client-route-53": "^3.1079.0",
     "@aws-sdk/client-s3": "^3.1079.0",
     "@eslint/js": "^10.0.1",
-    "@kensio/smartass": "^1.30.0",
+    "@kensio/smartass": "^1.31.0",
     "@smithy/smithy-client": "^4.14.6",
     "@smithy/types": "^4.15.1",
     "@types/eslint-plugin-security": "^3.0.1",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^25.9.4",
     "@vitest/coverage-v8": "^4.1.9",
-    "@vitest/eslint-plugin": "^1.6.20",
+    "@vitest/eslint-plugin": "^1.6.21",
     "aws-cdk": "^2.1129.0",
     "aws-cdk-lib": "^2.261.0",
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "^10.6.0",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jsdoc": "^63.0.10",
+    "eslint-plugin-jsdoc": "^63.0.11",
     "eslint-plugin-no-secrets": "^2.3.3",
     "eslint-plugin-security": "^4.0.1",
     "eslint-plugin-unicorn": "^64.0.0",
@@ -119,7 +124,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.5.0",
-    "@kensio/part-factory": "^1.4.0",
+    "@kensio/part-factory": "^1.5.0",
     "lodash-es": "^4.18.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
       '@kensio/part-factory':
-        specifier: ^1.4.0
+        specifier: ^1.5.0
         version: 1.5.0
       lodash-es:
         specifier: ^4.18.1
@@ -30,6 +30,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1079.0
         version: 3.1079.0
+      '@aws-sdk/client-iam':
+        specifier: ^3.1079.0
+        version: 3.1079.0
       '@aws-sdk/client-route-53':
         specifier: ^3.1079.0
         version: 3.1079.0
@@ -40,7 +43,7 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       '@kensio/smartass':
-        specifier: ^1.30.0
+        specifier: ^1.31.0
         version: 1.31.0
       '@smithy/smithy-client':
         specifier: ^4.14.6
@@ -61,8 +64,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       '@vitest/eslint-plugin':
-        specifier: ^1.6.20
-        version: 1.6.20(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
+        specifier: ^1.6.21
+        version: 1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       aws-cdk:
         specifier: ^2.1129.0
         version: 2.1129.0
@@ -82,8 +85,8 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-jsdoc:
-        specifier: ^63.0.10
-        version: 63.0.10(eslint@10.6.0(jiti@2.7.0))
+        specifier: ^63.0.11
+        version: 63.0.11(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-no-secrets:
         specifier: ^2.3.3
         version: 2.3.3(eslint@10.6.0(jiti@2.7.0))
@@ -154,6 +157,10 @@ packages:
 
   '@aws-sdk/client-dynamodb@3.1079.0':
     resolution: {integrity: sha512-njnQvv5lqyzX42Af/Z3nuxm6eK9/OPDYkaIah3m2sJoudAKkvvJ5jOTAtw8zGhu5zviT4Sa9giYC1FHkabuAFA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-iam@3.1079.0':
+    resolution: {integrity: sha512-BKM1GzF00yeIchUvXbcM3bw72F1JFCgum7s7e95bM+WGeOflpkx1e19OUzABbZnTdmjBf1o7IZ84+qmwoQI8Aw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-route-53@3.1079.0':
@@ -274,8 +281,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@es-joy/jsdoccomment@0.87.0':
-    resolution: {integrity: sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==}
+  '@es-joy/jsdoccomment@0.88.0':
+    resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@es-joy/resolve.exports@1.2.0':
@@ -787,8 +794,8 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/eslint-plugin@1.6.20':
-    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
+  '@vitest/eslint-plugin@1.6.21':
+    resolution: {integrity: sha512-5nu7QuW5Dg9v4I9t9ZiU1Hh91BoG0x3lOzOWYTsr1bqpIqcHYzFSQ052LvZwGtEm7Trh+Mr2heYEmZ4LkDjfaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
@@ -886,8 +893,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.41:
-    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -962,8 +969,8 @@ packages:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
 
-  electron-to-chromium@1.5.385:
-    resolution: {integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==}
+  electron-to-chromium@1.5.387:
+    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -991,8 +998,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-jsdoc@63.0.10:
-    resolution: {integrity: sha512-A9UIWsCquaKnit7rasXxYf12hhGIdDRjv65/RUE3AxbT6rdKBvr3MjH37g3gP+g4ipQMXuMn9slFKjO+vqNfkg==}
+  eslint-plugin-jsdoc@63.0.11:
+    resolution: {integrity: sha512-QhLmqREgRJSIKg0r23ckTVaNK1lmMsTmpyY5Hv7NTCHNWTFZx/8PqycWhR0p0Lk/U5aJ6H3zAKMQ0xB2NkN0sA==}
     engines: {node: ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -1752,6 +1759,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-iam@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-route-53@3.1079.0':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -1978,7 +1996,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.87.0':
+  '@es-joy/jsdoccomment@0.88.0':
     dependencies:
       '@types/estree': 1.0.9
       '@typescript-eslint/types': 8.62.1
@@ -2405,7 +2423,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0))
 
-  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
+  '@vitest/eslint-plugin@1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
@@ -2498,7 +2516,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.41: {}
+  baseline-browser-mapping@2.10.42: {}
 
   bowser@2.14.1: {}
 
@@ -2508,9 +2526,9 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.41
+      baseline-browser-mapping: 2.10.42
       caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.385
+      electron-to-chromium: 1.5.387
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -2554,7 +2572,7 @@ snapshots:
 
   diff@5.2.2: {}
 
-  electron-to-chromium@1.5.385: {}
+  electron-to-chromium@1.5.387: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -2597,9 +2615,9 @@ snapshots:
     dependencies:
       eslint: 10.6.0(jiti@2.7.0)
 
-  eslint-plugin-jsdoc@63.0.10(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-jsdoc@63.0.11(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
-      '@es-joy/jsdoccomment': 0.87.0
+      '@es-joy/jsdoccomment': 0.88.0
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.7

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -10,6 +10,7 @@ import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-
 import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimRoute53 } from "../../route53/index.js";
 import type { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
+import { SimIam } from "../../iam/index.js";
 
 interface SimAwsAccountServiceCacheProps {
   readonly simAws: SimAws;
@@ -25,6 +26,7 @@ export class SimAwsAccountServiceCache {
   private readonly simAws: SimAws;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cloudFrontRegistry: SimCloudFrontRegistry;
+  private readonly iamServices = new Map<SimAwsAccountId, SimIam>();
   private readonly route53Registry: SimRoute53Registry;
 
   private readonly cloudFrontServices = new Map<
@@ -59,6 +61,24 @@ export class SimAwsAccountServiceCache {
     }
 
     return cloudFront;
+  }
+
+  /**
+   * Create or get simulated IAM for an Account scope.
+   */
+  createIam(scope: SimAwsAccountRegionContainer): SimIam {
+    const { accountId } = scope.accountRegionScope;
+
+    let iam = this.iamServices.get(accountId);
+
+    if (iam === undefined) {
+      iam = new SimIam({
+        accountRegionScope: scope.accountRegionScope,
+      });
+      this.iamServices.set(accountId, iam);
+    }
+
+    return iam;
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -24,6 +24,8 @@ interface SimAwsAccountServiceCacheProps {
  */
 export class SimAwsAccountServiceCache {
   private readonly simAws: SimAws;
+  // TODO: SimAwsAccountServiceCache sometimes uses its own background instance,
+  // and sometimes has one passed in to methods. Should be unified.
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cloudFrontRegistry: SimCloudFrontRegistry;
   private readonly iamServices = new Map<SimAwsAccountId, SimIam>();
@@ -66,7 +68,10 @@ export class SimAwsAccountServiceCache {
   /**
    * Create or get simulated IAM for an Account scope.
    */
-  createIam(scope: SimAwsAccountRegionContainer): SimIam {
+  createIam(
+    scope: SimAwsAccountRegionContainer,
+    background: BackgroundScheduler,
+  ): SimIam {
     const { accountId } = scope.accountRegionScope;
 
     let iam = this.iamServices.get(accountId);
@@ -74,6 +79,7 @@ export class SimAwsAccountServiceCache {
     if (iam === undefined) {
       iam = new SimIam({
         accountRegionScope: scope.accountRegionScope,
+        background,
       });
       this.iamServices.set(accountId, iam);
     }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -14,6 +14,7 @@ import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import { SimAcm } from "../../acm/sim-acm.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
+import type { SimIam } from "../../iam/index.js";
 
 interface SimAwsServiceFactoryProps {
   readonly simAws: SimAws;
@@ -91,6 +92,13 @@ export class SimAwsServiceFactory {
       accountRegionScope: scope.accountRegionScope,
       background: this.background,
     });
+  }
+
+  /**
+   * Create or get simulated IAM for an Account scope.
+   */
+  createIam(scope: SimAwsAccountRegionContainer): SimIam {
+    return this.accountServices.createIam(scope);
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -98,7 +98,7 @@ export class SimAwsServiceFactory {
    * Create or get simulated IAM for an Account scope.
    */
   createIam(scope: SimAwsAccountRegionContainer): SimIam {
-    return this.accountServices.createIam(scope);
+    return this.accountServices.createIam(scope, this.background);
   }
 
   /**

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -8,6 +8,7 @@ import type { SimDynamoDb } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimIam } from "../iam/index.js";
 
 export type SimAccountRegionScopeKey = `${SimAwsAccountId}:${AwsRegionName}`;
 
@@ -79,6 +80,15 @@ export class SimAwsAccountRegionContainer {
   dynamoDb(): SimDynamoDb {
     return this.memo.getOrCreate("dynamoDb", () =>
       this.simAws.serviceFactory.createDynamoDb(this),
+    );
+  }
+
+  /**
+   * Get simulated IAM for this account.
+   */
+  iam(): SimIam {
+    return this.memo.getOrCreate("iam", () =>
+      this.simAws.serviceFactory.createIam(this),
     );
   }
 

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -9,6 +9,7 @@ import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimRoute53 } from "../route53/index.js";
+import type { SimIam } from "../iam/index.js";
 
 export type SimAwsAccountId = Brand<string, "SimAwsAccountId">;
 
@@ -70,6 +71,13 @@ export class SimAwsAccount {
    */
   dynamoDb(): SimDynamoDb {
     return this.region().dynamoDb();
+  }
+
+  /**
+   * Get simulated IAM for this Account.
+   */
+  iam(): SimIam {
+    return this.region().iam();
   }
 
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -23,6 +23,7 @@ import type { SimRoute53 } from "../route53/index.js";
 import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
 import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimIam } from "../iam/index.js";
 
 interface SimAwsProps {
   readonly defaultAccountId?: SimAwsAccountId;
@@ -115,6 +116,13 @@ export class SimAws {
    */
   dynamoDb(): SimDynamoDb {
     return this.accountRegionScope().dynamoDb();
+  }
+
+  /**
+   * Get simulated IAM in the default Account scope.
+   */
+  iam(): SimIam {
+    return this.accountRegionScope().iam();
   }
 
   /**

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.iso.test.ts
@@ -5,9 +5,9 @@ import {
   assertThrowsError,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
-import type { SimCfnResource } from "../../../../resource/sim-cfn-resource.js";
 import type { SimCdkOutContext } from "../../../sim-cdk-out-context.js";
 import { SimCdkBucketDeploySource } from "./sim-cdk-bucket-deploy-source.js";
+import { simCfnResourceFactory } from "../../../../resource/sim-cfn-resource.factory.js";
 
 describe("SimCdkBucketDeploySource", () => {
   it("resolves the filesystem source directory for a matching zip asset object key", () => {
@@ -39,7 +39,7 @@ describe("SimCdkBucketDeploySource", () => {
 
     // When the source directory is resolved for the object key.
     const sourceDirectoryPath = source.sourceDirectoryPathForObjectKey(
-      makeResource(),
+      simCfnResourceFactory.make({ logicalId: "DeploySite" }),
       "abc123.zip",
       cdkOutContext,
     );
@@ -91,7 +91,7 @@ describe("SimCdkBucketDeploySource", () => {
 
     // When the second asset destination object key is resolved.
     const sourceDirectoryPath = source.sourceDirectoryPathForObjectKey(
-      makeResource(),
+      simCfnResourceFactory.make({ logicalId: "DeploySite" }),
       "second.zip",
       cdkOutContext,
     );
@@ -111,7 +111,7 @@ describe("SimCdkBucketDeploySource", () => {
     // diagnostic message explaining how to provide CDK assembly metadata.
     const error = assertThrowsError(() =>
       source.sourceDirectoryPathForObjectKey(
-        makeResource("DeploySite"),
+        simCfnResourceFactory.make({ logicalId: "DeploySite" }),
         "abc123.zip",
         undefined,
       ),
@@ -162,7 +162,7 @@ describe("SimCdkBucketDeploySource", () => {
     // formatted BucketDeployment asset resolution error.
     const error = assertThrowsError(() =>
       source.sourceDirectoryPathForObjectKey(
-        makeResource("DeploySite"),
+        simCfnResourceFactory.make({ logicalId: "DeploySite" }),
         "missing.zip",
         cdkOutContext,
       ),
@@ -218,7 +218,7 @@ describe("SimCdkBucketDeploySource", () => {
     // rejected with a diagnostic error.
     const error = assertThrowsError(() =>
       source.sourceDirectoryPathForObjectKey(
-        makeResource("DeploySite"),
+        simCfnResourceFactory.make({ logicalId: "DeploySite" }),
         "abc123.zip",
         cdkOutContext,
       ),
@@ -263,7 +263,7 @@ describe("SimCdkBucketDeploySource", () => {
     // template directory is rejected with a diagnostic error.
     const error = assertThrowsError(() =>
       source.sourceDirectoryPathForObjectKey(
-        makeResource("DeploySite"),
+        simCfnResourceFactory.make({ logicalId: "DeploySite" }),
         "abc123.zip",
         cdkOutContext,
       ),
@@ -287,9 +287,3 @@ describe("SimCdkBucketDeploySource", () => {
     );
   });
 });
-
-function makeResource(logicalId = "DeploySite"): SimCfnResource {
-  return {
-    logicalId,
-  } as SimCfnResource;
-}

--- a/src/service/iam/command/create-policy/create-policy-record-factory.ts
+++ b/src/service/iam/command/create-policy/create-policy-record-factory.ts
@@ -1,0 +1,83 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type {
+  SimIamPolicy,
+  SimIamPolicyDocument,
+  SimIamPolicyName,
+} from "../../policy/sim-iam-policy.js";
+import { makeSimPolicyId } from "../../policy/sim-iam-policy-arn.js";
+import type {
+  SimCreatePolicyCommand,
+  SimCreatePolicyCommandOutput,
+} from "./create-policy.cmd.js";
+import type { JSONString } from "../../../../util/type-guard/json.js";
+
+interface CreatePolicyRecordFactoryProps {
+  readonly arn: SimArn;
+  readonly path: string;
+  readonly policyName: SimIamPolicyName;
+  readonly cmd: SimCreatePolicyCommand;
+}
+
+/**
+ * Builds IAM Policy records and CreatePolicy responses.
+ *
+ * The handler owns command orchestration: validation, sequencing, duplicate
+ * checks, and persistence. This factory owns the shape of the stored policy and
+ * the shape returned to the SDK caller. Keeping those transformations here
+ * reduces handler complexity and keeps field-mapping decisions in one place.
+ */
+export class CreatePolicyRecordFactory {
+  /**
+   * Create the simulator's stored policy model from validated command data.
+   *
+   * The same timestamp is used for CreateDate and UpdateDate because a newly
+   * created IAM policy has not had a later update event. The default version
+   * starts at v1, matching IAM's managed policy version model.
+   */
+  makePolicy(props: CreatePolicyRecordFactoryProps): SimIamPolicy {
+    const { arn, path, policyName, cmd } = props;
+    const now = new Date();
+
+    return {
+      arn,
+      policyId: makeSimPolicyId(),
+      policyName,
+      path,
+      defaultVersionId: "v1",
+      attachmentCount: 0,
+      permissionsBoundaryUsageCount: 0,
+      isAttachable: true,
+      description: cmd.input.Description,
+      createDate: now,
+      updateDate: now,
+      policyDocument: cmd.input.PolicyDocument as
+        JSONString<SimIamPolicyDocument> | undefined,
+    };
+  }
+
+  /**
+   * Convert the simulator's internal policy record into the SDK response shape.
+   *
+   * The policy document is stored locally but is not returned by CreatePolicy.
+   * IAM callers retrieve policy document content through policy-version APIs,
+   * so this method exposes only the metadata fields included in CreatePolicy
+   * output.
+   */
+  makeOutput(policy: SimIamPolicy): SimCreatePolicyCommandOutput {
+    return {
+      Policy: {
+        PolicyName: policy.policyName,
+        PolicyId: policy.policyId,
+        Arn: policy.arn,
+        Path: policy.path,
+        DefaultVersionId: policy.defaultVersionId,
+        AttachmentCount: policy.attachmentCount,
+        PermissionsBoundaryUsageCount: policy.permissionsBoundaryUsageCount,
+        IsAttachable: policy.isAttachable,
+        Description: policy.description,
+        CreateDate: policy.createDate,
+        UpdateDate: policy.updateDate,
+      },
+    };
+  }
+}

--- a/src/service/iam/command/create-policy/create-policy.cmd.ts
+++ b/src/service/iam/command/create-policy/create-policy.cmd.ts
@@ -1,0 +1,28 @@
+import type { SimArn } from "../../../aws/arn.js";
+
+export interface SimCreatePolicyCommandInput {
+  readonly PolicyName?: string | undefined;
+  readonly Path?: string | undefined;
+  readonly PolicyDocument?: string | undefined;
+  readonly Description?: string | undefined;
+}
+
+export interface SimCreatePolicyCommand {
+  readonly input: SimCreatePolicyCommandInput;
+}
+
+export interface SimCreatePolicyCommandOutput {
+  readonly Policy: {
+    readonly PolicyName: string;
+    readonly PolicyId: string;
+    readonly Arn: SimArn;
+    readonly Path: string;
+    readonly DefaultVersionId: string;
+    readonly AttachmentCount: number;
+    readonly PermissionsBoundaryUsageCount: number;
+    readonly IsAttachable: boolean;
+    readonly Description?: string | undefined;
+    readonly CreateDate: Date;
+    readonly UpdateDate: Date;
+  };
+}

--- a/src/service/iam/command/create-policy/create-policy.handler.ts
+++ b/src/service/iam/command/create-policy/create-policy.handler.ts
@@ -16,6 +16,7 @@ import type {
 import { makeSimPolicyArn } from "../../policy/sim-iam-policy-arn.js";
 import { normalisePolicyPath } from "../../policy/sim-iam-policy-path.js";
 import { CreatePolicyRecordFactory } from "./create-policy-record-factory.js";
+import { SimIamEntityAlreadyExists } from "../../error/sim-iam.error.js";
 
 interface CreatePolicyCommandHandlerProps {
   readonly accountId: SimAwsAccountId;
@@ -66,8 +67,12 @@ export class CreatePolicyCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
+    // TODO: when we later have sim IAM Registry, uniqueness check should be
+    // cross-account.
     if (this.policies.has(arn)) {
-      throw new Error(`Sim IAM Policy already exists: ${arn}`);
+      throw new SimIamEntityAlreadyExists(
+        `Sim IAM Policy already exists: ${arn}`,
+      );
     }
 
     const policy = this.policyFactory.makePolicy({

--- a/src/service/iam/command/create-policy/create-policy.handler.ts
+++ b/src/service/iam/command/create-policy/create-policy.handler.ts
@@ -1,0 +1,84 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type {
+  SimCreatePolicyCommand,
+  SimCreatePolicyCommandOutput,
+} from "./create-policy.cmd.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type {
+  SimIamPolicy,
+  SimIamPolicyName,
+} from "../../policy/sim-iam-policy.js";
+import { makeSimPolicyArn } from "../../policy/sim-iam-policy-arn.js";
+import { normalisePolicyPath } from "../../policy/sim-iam-policy-path.js";
+import { CreatePolicyRecordFactory } from "./create-policy-record-factory.js";
+
+interface CreatePolicyCommandHandlerProps {
+  readonly accountId: SimAwsAccountId;
+  readonly policies: Map<SimArn, SimIamPolicy>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM CreatePolicyCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/CreatePolicyCommand/
+ */
+export class CreatePolicyCommandHandler implements CommandHandler<
+  SimCreatePolicyCommand,
+  SimCreatePolicyCommandOutput
+> {
+  private readonly accountId: SimAwsAccountId;
+  private readonly policies: Map<SimArn, SimIamPolicy>;
+  private readonly background: BackgroundScheduler;
+  private readonly policyFactory = new CreatePolicyRecordFactory();
+
+  constructor(props: CreatePolicyCommandHandlerProps) {
+    const { accountId, policies, background = new BackgroundTasks() } = props;
+    this.accountId = accountId;
+    this.policies = policies;
+    this.background = background;
+  }
+
+  /**
+   * Handle a CreatePolicyCommand from the SDK.
+   */
+  async handle(
+    cmd: SimCreatePolicyCommand,
+  ): Promise<SimCreatePolicyCommandOutput> {
+    const policyName = cmd.input.PolicyName as SimIamPolicyName | undefined;
+
+    if (policyName === undefined || policyName.length === 0) {
+      throw new Error("PolicyName is required");
+    }
+
+    const path = normalisePolicyPath(cmd.input.Path);
+    const arn = makeSimPolicyArn({
+      accountId: this.accountId,
+      path,
+      policyName,
+    });
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    if (this.policies.has(arn)) {
+      throw new Error(`Sim IAM Policy already exists: ${arn}`);
+    }
+
+    const policy = this.policyFactory.makePolicy({
+      arn,
+      path,
+      policyName,
+      cmd,
+    });
+
+    this.policies.set(arn, policy);
+
+    return this.policyFactory.makeOutput(policy);
+  }
+}

--- a/src/service/iam/command/create-policy/create-policy.iso.test.ts
+++ b/src/service/iam/command/create-policy/create-policy.iso.test.ts
@@ -1,0 +1,250 @@
+import { CreatePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+describe("IAM CreatePolicyCommand", () => {
+  it("creates an IAM Policy through the top-level SimIam service", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const createPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "TestPolicy",
+        Path: "/service-role/",
+        Description: "Policy used by CreatePolicyCommand tests",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    assertIdentical(createPolicyOutput.Policy.PolicyName, "TestPolicy");
+    assertIdentical(createPolicyOutput.Policy.Path, "/service-role/");
+    assertIdentical(createPolicyOutput.Policy.DefaultVersionId, "v1");
+    assertIdentical(createPolicyOutput.Policy.AttachmentCount, 0);
+    assertIdentical(createPolicyOutput.Policy.PermissionsBoundaryUsageCount, 0);
+    assertTrue(createPolicyOutput.Policy.IsAttachable);
+    assertIdentical(
+      createPolicyOutput.Policy.Description,
+      "Policy used by CreatePolicyCommand tests",
+    );
+    assertNonNullable(createPolicyOutput.Policy.PolicyId);
+    assertIdentical(
+      createPolicyOutput.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/service-role/TestPolicy",
+    );
+    assertInstanceOf(createPolicyOutput.Policy.CreateDate, Date);
+    assertInstanceOf(createPolicyOutput.Policy.UpdateDate, Date);
+    assertIdentical(
+      createPolicyOutput.Policy.UpdateDate,
+      createPolicyOutput.Policy.CreateDate,
+    );
+  });
+
+  it("defaults optional values when creating an IAM Policy", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const createPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "DefaultedPolicy",
+        PolicyDocument: undefined,
+      }),
+    );
+
+    assertIdentical(createPolicyOutput.Policy.PolicyName, "DefaultedPolicy");
+    assertIdentical(createPolicyOutput.Policy.Path, "/");
+    assertIdentical(
+      createPolicyOutput.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/DefaultedPolicy",
+    );
+    assertUndefined(createPolicyOutput.Policy.Description);
+    assertIdentical(createPolicyOutput.Policy.DefaultVersionId, "v1");
+    assertIdentical(createPolicyOutput.Policy.AttachmentCount, 0);
+    assertIdentical(createPolicyOutput.Policy.PermissionsBoundaryUsageCount, 0);
+    assertTrue(createPolicyOutput.Policy.IsAttachable);
+    assertInstanceOf(createPolicyOutput.Policy.CreateDate, Date);
+    assertInstanceOf(createPolicyOutput.Policy.UpdateDate, Date);
+  });
+
+  it("normalises IAM Policy paths", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const withoutSlashes = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "WithoutSlashes",
+        Path: "application",
+        PolicyDocument: undefined,
+      }),
+    );
+    const withoutTrailingSlash = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "WithoutTrailingSlash",
+        Path: "/service-role",
+        PolicyDocument: undefined,
+      }),
+    );
+    const emptyPath = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "EmptyPath",
+        Path: "",
+        PolicyDocument: undefined,
+      }),
+    );
+
+    assertIdentical(withoutSlashes.Policy.Path, "/application/");
+    assertIdentical(
+      withoutSlashes.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/application/WithoutSlashes",
+    );
+    assertIdentical(withoutTrailingSlash.Policy.Path, "/service-role/");
+    assertIdentical(
+      withoutTrailingSlash.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/service-role/WithoutTrailingSlash",
+    );
+    assertIdentical(emptyPath.Policy.Path, "/");
+    assertIdentical(
+      emptyPath.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/EmptyPath",
+    );
+  });
+
+  it("uses the SimAws default account ID when building the IAM Policy ARN", async () => {
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+    });
+
+    const simIam = simAws.iam();
+
+    const createPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "AccountScopedPolicy",
+        Path: "/application/",
+        PolicyDocument: undefined,
+      }),
+    );
+
+    assertIdentical(
+      createPolicyOutput.Policy.Arn,
+      `arn:aws:iam::${accountId}:policy/application/AccountScopedPolicy`,
+    );
+  });
+
+  it("throws when PolicyName is undefined", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createPolicy(
+        new CreatePolicyCommand({
+          PolicyName: undefined,
+          PolicyDocument: undefined,
+        }),
+      ),
+    );
+
+    assertIdentical(error.message, "PolicyName is required");
+  });
+
+  it("throws when PolicyName is empty", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createPolicy(
+        new CreatePolicyCommand({
+          PolicyName: "",
+          PolicyDocument: undefined,
+        }),
+      ),
+    );
+
+    assertIdentical(error.message, "PolicyName is required");
+  });
+
+  it("throws when creating a duplicate IAM Policy in the same path", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "DuplicatePolicy",
+        Path: "/application/",
+        PolicyDocument: undefined,
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createPolicy(
+        new CreatePolicyCommand({
+          PolicyName: "DuplicatePolicy",
+          Path: "/application",
+          PolicyDocument: undefined,
+        }),
+      ),
+    );
+
+    assertIdentical(
+      error.message,
+      "Sim IAM Policy already exists: arn:aws:iam::123456789012:policy/application/DuplicatePolicy",
+    );
+  });
+
+  it("allows policies with the same name in different paths", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const firstPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "SharedPolicyName",
+        Path: "/application/",
+        PolicyDocument: undefined,
+      }),
+    );
+    const secondPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "SharedPolicyName",
+        Path: "/service-role/",
+        PolicyDocument: undefined,
+      }),
+    );
+
+    assertIdentical(firstPolicyOutput.Policy.PolicyName, "SharedPolicyName");
+    assertIdentical(secondPolicyOutput.Policy.PolicyName, "SharedPolicyName");
+    assertIdentical(firstPolicyOutput.Policy.Path, "/application/");
+    assertIdentical(secondPolicyOutput.Policy.Path, "/service-role/");
+    assertIdentical(
+      firstPolicyOutput.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/application/SharedPolicyName",
+    );
+    assertIdentical(
+      secondPolicyOutput.Policy.Arn,
+      "arn:aws:iam::123456789012:policy/service-role/SharedPolicyName",
+    );
+  });
+});

--- a/src/service/iam/command/get-policy/get-policy.cmd.ts
+++ b/src/service/iam/command/get-policy/get-policy.cmd.ts
@@ -1,0 +1,25 @@
+import type { SimArn } from "../../../aws/arn.js";
+
+export interface SimGetPolicyCommandInput {
+  readonly PolicyArn?: string | undefined;
+}
+
+export interface SimGetPolicyCommand {
+  readonly input: SimGetPolicyCommandInput;
+}
+
+export interface SimGetPolicyCommandOutput {
+  readonly Policy: {
+    readonly PolicyName: string;
+    readonly PolicyId: string;
+    readonly Arn: SimArn;
+    readonly Path: string;
+    readonly DefaultVersionId: string;
+    readonly AttachmentCount: number;
+    readonly PermissionsBoundaryUsageCount: number;
+    readonly IsAttachable: boolean;
+    readonly Description?: string | undefined;
+    readonly CreateDate: Date;
+    readonly UpdateDate: Date;
+  };
+}

--- a/src/service/iam/command/get-policy/get-policy.handler.ts
+++ b/src/service/iam/command/get-policy/get-policy.handler.ts
@@ -1,0 +1,73 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimArn } from "../../../aws/arn.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimIamPolicy } from "../../policy/sim-iam-policy.js";
+import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+import type {
+  SimGetPolicyCommand,
+  SimGetPolicyCommandOutput,
+} from "./get-policy.cmd.js";
+
+interface GetPolicyCommandHandlerProps {
+  readonly policies: Map<SimArn, SimIamPolicy>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM GetPolicyCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/GetPolicyCommand/
+ */
+export class GetPolicyCommandHandler implements CommandHandler<
+  SimGetPolicyCommand,
+  SimGetPolicyCommandOutput
+> {
+  private readonly policies: Map<SimArn, SimIamPolicy>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(props: GetPolicyCommandHandlerProps) {
+    const { policies, background = new BackgroundTasks() } = props;
+
+    this.policies = policies;
+    this.background = background;
+  }
+
+  /**
+   * Handle a GetPolicyCommand from the SDK.
+   */
+  async handle(cmd: SimGetPolicyCommand): Promise<SimGetPolicyCommandOutput> {
+    const policyArn = cmd.input.PolicyArn as SimArn | undefined;
+
+    if (policyArn === undefined || policyArn.length === 0) {
+      throw new Error("PolicyArn is required");
+    }
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const policy = this.policies.get(policyArn);
+
+    if (policy === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM Policy with ARN ${policyArn}`);
+    }
+
+    return {
+      Policy: {
+        PolicyName: policy.policyName,
+        PolicyId: policy.policyId,
+        Arn: policy.arn,
+        Path: policy.path,
+        DefaultVersionId: policy.defaultVersionId,
+        AttachmentCount: policy.attachmentCount,
+        PermissionsBoundaryUsageCount: policy.permissionsBoundaryUsageCount,
+        IsAttachable: policy.isAttachable,
+        Description: policy.description,
+        CreateDate: policy.createDate,
+        UpdateDate: policy.updateDate,
+      },
+    };
+  }
+}

--- a/src/service/iam/command/get-policy/get-policy.iso.test.ts
+++ b/src/service/iam/command/get-policy/get-policy.iso.test.ts
@@ -1,0 +1,96 @@
+import { CreatePolicyCommand, GetPolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+
+describe("IAM GetPolicyCommand", () => {
+  it("gets an IAM Policy through the top-level SimIam service", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    const createPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "TestPolicy",
+        Path: "/service-role/",
+        Description: "Policy used by GetPolicyCommand tests",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    assertNonNullable(
+      createPolicyOutput.Policy.Arn,
+      "Policy ARN should be defined",
+    );
+
+    const getPolicyOutput = await simIam.getPolicy(
+      new GetPolicyCommand({
+        PolicyArn: createPolicyOutput.Policy.Arn,
+      }),
+    );
+
+    assertIdentical(getPolicyOutput.Policy.PolicyName, "TestPolicy");
+    assertIdentical(getPolicyOutput.Policy.Arn, createPolicyOutput.Policy.Arn);
+    assertIdentical(getPolicyOutput.Policy.Path, "/service-role/");
+    assertIdentical(getPolicyOutput.Policy.DefaultVersionId, "v1");
+    assertIdentical(getPolicyOutput.Policy.AttachmentCount, 0);
+    assertIdentical(getPolicyOutput.Policy.PermissionsBoundaryUsageCount, 0);
+    assertTrue(getPolicyOutput.Policy.IsAttachable);
+    assertIdentical(
+      getPolicyOutput.Policy.Description,
+      "Policy used by GetPolicyCommand tests",
+    );
+    assertIdentical(
+      getPolicyOutput.Policy.PolicyId,
+      createPolicyOutput.Policy.PolicyId,
+    );
+    assertNonNullable(getPolicyOutput.Policy.CreateDate);
+    assertNonNullable(getPolicyOutput.Policy.UpdateDate);
+  });
+
+  it("throws on undefined Policy ARN", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    await assertThrowsErrorAsync(async () =>
+      simIam.getPolicy(
+        new GetPolicyCommand({
+          PolicyArn: undefined,
+        }),
+      ),
+    );
+  });
+
+  it("throws on getting a non-existent IAM Policy", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.getPolicy(
+        new GetPolicyCommand({
+          PolicyArn: "arn:aws:iam::123456789012:policy/MissingPolicy",
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
+  });
+});

--- a/src/service/iam/command/list-policies/list-policies.cmd.ts
+++ b/src/service/iam/command/list-policies/list-policies.cmd.ts
@@ -1,0 +1,35 @@
+import type { SimArn } from "../../../aws/arn.js";
+
+export type SimIamPolicyScopeType = "All" | "AWS" | "Local";
+export type SimIamPolicyUsageType = "PermissionsPolicy" | "PermissionsBoundary";
+
+export interface SimListPoliciesCommandInput {
+  readonly Scope?: SimIamPolicyScopeType | undefined;
+  readonly OnlyAttached?: boolean | undefined;
+  readonly PathPrefix?: string | undefined;
+  readonly PolicyUsageFilter?: SimIamPolicyUsageType | undefined;
+  readonly Marker?: string | undefined;
+  readonly MaxItems?: number | undefined;
+}
+
+export interface SimListPoliciesCommand {
+  readonly input: SimListPoliciesCommandInput;
+}
+
+export interface SimListPoliciesCommandOutput {
+  readonly Policies: {
+    readonly PolicyName: string;
+    readonly PolicyId: string;
+    readonly Arn: SimArn;
+    readonly Path: string;
+    readonly DefaultVersionId: string;
+    readonly AttachmentCount: number;
+    readonly PermissionsBoundaryUsageCount: number;
+    readonly IsAttachable: boolean;
+    readonly Description?: string | undefined;
+    readonly CreateDate: Date;
+    readonly UpdateDate: Date;
+  }[];
+  readonly IsTruncated?: boolean;
+  readonly Marker?: string | undefined;
+}

--- a/src/service/iam/command/list-policies/list-policies.handler.ts
+++ b/src/service/iam/command/list-policies/list-policies.handler.ts
@@ -1,0 +1,127 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { SimArn } from "../../../aws/arn.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import type { SimIamPolicy } from "../../policy/sim-iam-policy.js";
+import type {
+  SimListPoliciesCommand,
+  SimListPoliciesCommandOutput,
+} from "./list-policies.cmd.js";
+
+interface ListPoliciesCommandHandlerProps {
+  readonly policies: Map<SimArn, SimIamPolicy>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM ListPoliciesCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/ListPoliciesCommand/
+ */
+export class ListPoliciesCommandHandler implements CommandHandler<
+  SimListPoliciesCommand,
+  SimListPoliciesCommandOutput
+> {
+  private readonly policies: Map<SimArn, SimIamPolicy>;
+  private readonly background: BackgroundScheduler;
+
+  constructor(props: ListPoliciesCommandHandlerProps) {
+    const { policies, background = new BackgroundTasks() } = props;
+
+    this.policies = policies;
+    this.background = background;
+  }
+
+  /**
+   * Handle a ListPoliciesCommand from the SDK.
+   */
+  async handle(
+    cmd: SimListPoliciesCommand,
+  ): Promise<SimListPoliciesCommandOutput> {
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const maxItems = cmd.input.MaxItems ?? 100;
+    const policies = this.matchingPolicies(cmd);
+
+    const startArn =
+      cmd.input.Marker === undefined
+        ? undefined
+        : ListPoliciesCommandHandler.parseMarker(cmd.input.Marker);
+
+    const startIndex =
+      startArn === undefined
+        ? 0
+        : Math.max(
+            0,
+            policies.findIndex((policy) => policy.arn === startArn) + 1,
+          );
+
+    const page = policies.slice(startIndex, startIndex + maxItems);
+    const lastPolicy = page.at(-1);
+    const isTruncated = startIndex + page.length < policies.length;
+
+    return {
+      Policies: page.map((policy) => ({
+        PolicyName: policy.policyName,
+        PolicyId: policy.policyId,
+        Arn: policy.arn,
+        Path: policy.path,
+        DefaultVersionId: policy.defaultVersionId,
+        AttachmentCount: policy.attachmentCount,
+        PermissionsBoundaryUsageCount: policy.permissionsBoundaryUsageCount,
+        IsAttachable: policy.isAttachable,
+        Description: policy.description,
+        CreateDate: policy.createDate,
+        UpdateDate: policy.updateDate,
+      })),
+      IsTruncated: isTruncated,
+      Marker:
+        isTruncated && lastPolicy !== undefined
+          ? ListPoliciesCommandHandler.makeMarker(lastPolicy.arn)
+          : undefined,
+    };
+  }
+
+  private matchingPolicies(cmd: SimListPoliciesCommand): SimIamPolicy[] {
+    const policies = [...this.policies.values()].toSorted((a, b) =>
+      a.arn.localeCompare(b.arn),
+    );
+
+    return policies.filter((policy) => {
+      if (cmd.input.Scope === "AWS") {
+        return false;
+      }
+
+      if (cmd.input.OnlyAttached === true && policy.attachmentCount === 0) {
+        return false;
+      }
+
+      if (
+        cmd.input.PathPrefix !== undefined &&
+        !policy.path.startsWith(cmd.input.PathPrefix)
+      ) {
+        return false;
+      }
+
+      if (
+        cmd.input.PolicyUsageFilter === "PermissionsBoundary" &&
+        policy.permissionsBoundaryUsageCount === 0
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  private static makeMarker(policyArn: SimArn): string {
+    return Buffer.from(policyArn, "utf8").toString("base64url");
+  }
+
+  private static parseMarker(marker: string): SimArn {
+    return Buffer.from(marker, "base64url").toString("utf8") as SimArn;
+  }
+}

--- a/src/service/iam/command/list-policies/list-policies.iso.test.ts
+++ b/src/service/iam/command/list-policies/list-policies.iso.test.ts
@@ -1,0 +1,238 @@
+import { CreatePolicyCommand, ListPoliciesCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("IAM ListPoliciesCommand", () => {
+  it("lists IAM Policies through the top-level SimIam service", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    const readPolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ReadPolicy",
+        Path: "/service-role/",
+        Description: "Allows reads",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+    const writePolicyOutput = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "WritePolicy",
+        Path: "/application/",
+        Description: "Allows writes",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "s3:PutObject",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    const listPoliciesOutput = await simIam.listPolicies(
+      new ListPoliciesCommand(),
+    );
+
+    assertArrayLength(listPoliciesOutput.Policies, 2);
+    assertFalse(listPoliciesOutput.IsTruncated);
+    assertUndefined(listPoliciesOutput.Marker);
+
+    const listedPolicyNames = listPoliciesOutput.Policies.map(
+      (policy) => policy.PolicyName,
+    ).toSorted();
+
+    assertIdentical(listedPolicyNames[0], "ReadPolicy");
+    assertIdentical(listedPolicyNames[1], "WritePolicy");
+
+    const readPolicy = listPoliciesOutput.Policies.find(
+      (policy) => policy.PolicyName === "ReadPolicy",
+    );
+    assertNonNullable(readPolicy);
+    assertIdentical(readPolicy.Arn, readPolicyOutput.Policy.Arn);
+    assertIdentical(readPolicy.PolicyId, readPolicyOutput.Policy.PolicyId);
+    assertIdentical(readPolicy.Path, "/service-role/");
+    assertIdentical(readPolicy.DefaultVersionId, "v1");
+    assertIdentical(readPolicy.AttachmentCount, 0);
+    assertIdentical(readPolicy.PermissionsBoundaryUsageCount, 0);
+    assertTrue(readPolicy.IsAttachable);
+    assertIdentical(readPolicy.Description, "Allows reads");
+    assertNonNullable(readPolicy.CreateDate);
+    assertNonNullable(readPolicy.UpdateDate);
+
+    const writePolicy = listPoliciesOutput.Policies.find(
+      (policy) => policy.PolicyName === "WritePolicy",
+    );
+    assertNonNullable(writePolicy);
+    assertIdentical(writePolicy.Arn, writePolicyOutput.Policy.Arn);
+    assertIdentical(writePolicy.PolicyId, writePolicyOutput.Policy.PolicyId);
+  });
+
+  it("filters IAM Policies by path prefix", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ServiceRolePolicy",
+        Path: "/service-role/",
+        PolicyDocument: "{}",
+      }),
+    );
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "ApplicationPolicy",
+        Path: "/application/",
+        PolicyDocument: "{}",
+      }),
+    );
+
+    const listPoliciesOutput = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        PathPrefix: "/service-role/",
+      }),
+    );
+
+    assertArrayLength(listPoliciesOutput.Policies, 1);
+    assertIdentical(
+      listPoliciesOutput.Policies[0].PolicyName,
+      "ServiceRolePolicy",
+    );
+    assertIdentical(listPoliciesOutput.Policies[0].Path, "/service-role/");
+    assertFalse(listPoliciesOutput.IsTruncated);
+    assertUndefined(listPoliciesOutput.Marker);
+  });
+
+  it("returns no policies for the AWS scope", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "LocalPolicy",
+        PolicyDocument: "{}",
+      }),
+    );
+
+    const listPoliciesOutput = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        Scope: "AWS",
+      }),
+    );
+
+    assertArrayLength(listPoliciesOutput.Policies, 0);
+    assertFalse(listPoliciesOutput.IsTruncated);
+    assertUndefined(listPoliciesOutput.Marker);
+  });
+
+  it("paginates IAM Policies with markers", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "AlphaPolicy",
+        PolicyDocument: "{}",
+      }),
+    );
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "BetaPolicy",
+        PolicyDocument: "{}",
+      }),
+    );
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "GammaPolicy",
+        PolicyDocument: "{}",
+      }),
+    );
+
+    const firstPage = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        MaxItems: 2,
+      }),
+    );
+
+    assertArrayLength(firstPage.Policies, 2);
+    assertTrue(firstPage.IsTruncated);
+    assertNonNullable(firstPage.Marker);
+
+    const firstPagePolicyNames = firstPage.Policies.map(
+      (policy) => policy.PolicyName,
+    );
+
+    const secondPage = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        Marker: firstPage.Marker,
+        MaxItems: 2,
+      }),
+    );
+
+    assertArrayLength(secondPage.Policies, 1);
+    assertFalse(secondPage.IsTruncated);
+    assertUndefined(secondPage.Marker);
+
+    const allPolicyNames = [
+      ...firstPagePolicyNames,
+      ...secondPage.Policies.map((policy) => policy.PolicyName),
+    ].toSorted();
+
+    assertIdentical(allPolicyNames[0], "AlphaPolicy");
+    assertIdentical(allPolicyNames[1], "BetaPolicy");
+    assertIdentical(allPolicyNames[2], "GammaPolicy");
+  });
+
+  it("excludes unattached and permissions policies when requested", async () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.iam();
+
+    await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "UnattachedPolicy",
+        PolicyDocument: "{}",
+      }),
+    );
+
+    const onlyAttachedOutput = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        OnlyAttached: true,
+      }),
+    );
+    const permissionsBoundaryOutput = await simIam.listPolicies(
+      new ListPoliciesCommand({
+        PolicyUsageFilter: "PermissionsBoundary",
+      }),
+    );
+
+    assertArrayLength(onlyAttachedOutput.Policies, 0);
+    assertFalse(onlyAttachedOutput.IsTruncated);
+    assertArrayLength(permissionsBoundaryOutput.Policies, 0);
+    assertFalse(permissionsBoundaryOutput.IsTruncated);
+  });
+});

--- a/src/service/iam/error/sim-iam.error.ts
+++ b/src/service/iam/error/sim-iam.error.ts
@@ -27,3 +27,14 @@ export class SimIamNoSuchEntity extends SimIamError {
     super(message, { httpStatusCode: 404 });
   }
 }
+
+/**
+ * Simulated IAM EntityAlreadyExists error.
+ */
+export class SimIamEntityAlreadyExists extends SimIamError {
+  public override readonly name = "EntityAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/iam/error/sim-iam.error.ts
+++ b/src/service/iam/error/sim-iam.error.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimal metadata shape for simulated IAM errors.
+ */
+export interface SimIamErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated IAM errors.
+ */
+export class SimIamError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimIamErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated IAM NoSuchEntity error.
+ */
+export class SimIamNoSuchEntity extends SimIamError {
+  public override readonly name = "NoSuchEntity";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -1,0 +1,6 @@
+export { SimIam } from "./sim-iam.js";
+export type { SimIamPolicy } from "./policy/sim-iam-policy.js";
+export type {
+  SimIamPolicyId,
+  SimIamPolicyName,
+} from "./policy/sim-iam-policy.js";

--- a/src/service/iam/policy/sim-iam-policy-arn.ts
+++ b/src/service/iam/policy/sim-iam-policy-arn.ts
@@ -1,0 +1,25 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamPolicyId, SimIamPolicyName } from "./sim-iam-policy.js";
+import type { SimArn } from "../../aws/arn.js";
+import { faker } from "@faker-js/faker";
+
+/**
+ * Make a sim IAM policy ARN.
+ */
+export function makeSimPolicyArn(props: {
+  readonly accountId: SimAwsAccountId;
+  readonly path: string;
+  readonly policyName: SimIamPolicyName;
+}): SimArn {
+  return `arn:aws:iam::${props.accountId}:policy${props.path}${props.policyName}` as SimArn;
+}
+
+/**
+ * Make a sim IAM policy ID.
+ */
+export function makeSimPolicyId(): SimIamPolicyId {
+  return faker.string.alphanumeric({
+    length: 21,
+    casing: "upper",
+  }) as SimIamPolicyId;
+}

--- a/src/service/iam/policy/sim-iam-policy-path.ts
+++ b/src/service/iam/policy/sim-iam-policy-path.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalise a sim IAM policy path by adding and removing slashes.
+ */
+export function normalisePolicyPath(path: string | undefined): string {
+  if (path === undefined || path.length === 0) {
+    return "/";
+  }
+
+  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  return withLeadingSlash.endsWith("/")
+    ? withLeadingSlash
+    : `${withLeadingSlash}/`;
+}

--- a/src/service/iam/policy/sim-iam-policy.ts
+++ b/src/service/iam/policy/sim-iam-policy.ts
@@ -1,0 +1,52 @@
+import type { JSONString } from "../../../util/type-guard/json.js";
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimArn } from "../../aws/arn.js";
+
+export type SimIamPolicyName = Brand<string, "SimIamPolicyName">;
+export type SimIamPolicyId = Brand<string, "SimIamPolicyId">;
+
+export interface SimIamPolicyDocument {
+  readonly Version?: string | undefined;
+  readonly Id?: string | undefined;
+  readonly Statement:
+    SimIamPolicyDocumentStatement | readonly SimIamPolicyDocumentStatement[];
+}
+
+export interface SimIamPolicyDocumentStatement {
+  readonly Sid?: string | undefined;
+  readonly Effect: "Allow" | "Deny";
+  readonly Action?: string | readonly string[] | undefined;
+  readonly NotAction?: string | readonly string[] | undefined;
+  readonly Resource?: string | readonly string[] | undefined;
+  readonly NotResource?: string | readonly string[] | undefined;
+  readonly Principal?: SimIamPolicyDocumentPrincipal | undefined;
+  readonly NotPrincipal?: SimIamPolicyDocumentPrincipal | undefined;
+  readonly Condition?: SimIamPolicyDocumentCondition | undefined;
+}
+
+export type SimIamPolicyDocumentPrincipal =
+  | string
+  | readonly string[]
+  | Readonly<Record<string, string | readonly string[]>>;
+
+export type SimIamPolicyDocumentCondition = Readonly<
+  Record<
+    string,
+    Readonly<Record<string, string | number | boolean | readonly string[]>>
+  >
+>;
+
+export interface SimIamPolicy {
+  readonly arn: SimArn;
+  readonly policyId: SimIamPolicyId;
+  readonly policyName: SimIamPolicyName;
+  readonly path: string;
+  readonly defaultVersionId: string;
+  readonly attachmentCount: number;
+  readonly permissionsBoundaryUsageCount: number;
+  readonly isAttachable: boolean;
+  readonly description?: string | undefined;
+  readonly createDate: Date;
+  readonly updateDate: Date;
+  readonly policyDocument?: JSONString<SimIamPolicyDocument> | undefined;
+}

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -17,9 +17,14 @@ import type {
   SimListPoliciesCommandOutput,
 } from "./command/list-policies/list-policies.cmd.js";
 import { ListPoliciesCommandHandler } from "./command/list-policies/list-policies.handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
 
 interface SimIamProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly background?: BackgroundScheduler;
 }
 
 /**
@@ -33,12 +38,16 @@ export class SimIam {
   private readonly policies = new Map<SimArn, SimIamPolicy>();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly background: BackgroundScheduler;
 
   constructor(props: SimIamProps = {}) {
-    const { accountRegionScope = simAwsAccountRegionScopeFactory.make() } =
-      props;
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      background = new BackgroundTasks(),
+    } = props;
 
     this.accountRegionScope = accountRegionScope;
+    this.background = background;
   }
 
   /**
@@ -50,6 +59,7 @@ export class SimIam {
     const handler = new CreatePolicyCommandHandler({
       accountId: this.accountRegionScope.accountId,
       policies: this.policies,
+      background: this.background,
     });
     return await handler.handle(cmd);
   }
@@ -62,6 +72,7 @@ export class SimIam {
   ): Promise<SimGetPolicyCommandOutput> {
     const handler = new GetPolicyCommandHandler({
       policies: this.policies,
+      background: this.background,
     });
     return await handler.handle(cmd);
   }
@@ -74,6 +85,7 @@ export class SimIam {
   ): Promise<SimListPoliciesCommandOutput> {
     const handler = new ListPoliciesCommandHandler({
       policies: this.policies,
+      background: this.background,
     });
     return await handler.handle(cmd);
   }

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -1,0 +1,80 @@
+import type { SimArn } from "../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { CreatePolicyCommandHandler } from "./command/create-policy/create-policy.handler.js";
+import type {
+  SimCreatePolicyCommand,
+  SimCreatePolicyCommandOutput,
+} from "./command/create-policy/create-policy.cmd.js";
+import type { SimIamPolicy } from "./policy/sim-iam-policy.js";
+import { GetPolicyCommandHandler } from "./command/get-policy/get-policy.handler.js";
+import type {
+  SimGetPolicyCommand,
+  SimGetPolicyCommandOutput,
+} from "./command/get-policy/get-policy.cmd.js";
+import type {
+  SimListPoliciesCommand,
+  SimListPoliciesCommandOutput,
+} from "./command/list-policies/list-policies.cmd.js";
+import { ListPoliciesCommandHandler } from "./command/list-policies/list-policies.handler.js";
+
+interface SimIamProps {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+}
+
+/**
+ * Simulated IAM. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * IAM is account-scoped in AWS. Yulin constructs it from an Account/Region
+ * scope for consistency with the other service factories, but memoises one
+ * service facade per Account.
+ */
+export class SimIam {
+  private readonly policies = new Map<SimArn, SimIamPolicy>();
+
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(props: SimIamProps = {}) {
+    const { accountRegionScope = simAwsAccountRegionScopeFactory.make() } =
+      props;
+
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * Handle a Create Policy Command from the SDK.
+   */
+  async createPolicy(
+    cmd: SimCreatePolicyCommand,
+  ): Promise<SimCreatePolicyCommandOutput> {
+    const handler = new CreatePolicyCommandHandler({
+      accountId: this.accountRegionScope.accountId,
+      policies: this.policies,
+    });
+    return await handler.handle(cmd);
+  }
+
+  /**
+   * Handle a Get Policy Command from the SDK.
+   */
+  async getPolicy(
+    cmd: SimGetPolicyCommand,
+  ): Promise<SimGetPolicyCommandOutput> {
+    const handler = new GetPolicyCommandHandler({
+      policies: this.policies,
+    });
+    return await handler.handle(cmd);
+  }
+
+  /**
+   * Handle a List Policies Command from the SDK.
+   */
+  async listPolicies(
+    cmd: SimListPoliciesCommand,
+  ): Promise<SimListPoliciesCommandOutput> {
+    const handler = new ListPoliciesCommandHandler({
+      policies: this.policies,
+    });
+    return await handler.handle(cmd);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simulated IAM service with account-scoped access from the main AWS simulation.
  * Introduced support for creating, retrieving, and listing IAM policies.
  * Added a new public IAM subpath export for easier importing.
* **Bug Fixes**
  * Improved policy path handling and ARN generation for more consistent results.
  * Added clearer errors when policies are missing or duplicate names are used in the same path.
* **Tests**
  * Added coverage for policy creation, retrieval, filtering, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->