### PR TITLE
feat: sim IAM account root caller principal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
 export { SimAws } from "./service/aws/sim-aws.js";
-export { SimAwsAccount } from "./service/aws/sim-aws-account.js";
-export { SimAwsRegion } from "./service/aws/sim-aws-region.js";
-export { SimAwsAccountRegionContainer } from "./service/aws/sim-aws-account-region-scope.js";
+export { SIM_AWS_ANONYMOUS_CALLER } from "./service/aws/caller/sim-aws-caller.js";
 export type { AwsRegionName } from "./service/aws/sim-aws-region.js";
 export type { SimAwsAccountId } from "./service/aws/sim-aws-account.js";
-export type { SimAwsAccountRegionScope } from "./service/aws/sim-aws-account-region-scope.js";

--- a/src/service/aws/caller/sim-aws-account-root-principal.ts
+++ b/src/service/aws/caller/sim-aws-account-root-principal.ts
@@ -1,0 +1,16 @@
+import type { SimAwsAccountId } from "../sim-aws-account.js";
+import type { SimAwsPrincipal } from "./sim-aws-caller.js";
+
+/**
+ * Make the intrinsic root principal for a simulated AWS Account.
+ */
+export function makeSimAwsAccountRootPrincipal(
+  accountId: SimAwsAccountId,
+): SimAwsPrincipal {
+  return {
+    arn: `arn:aws:iam::${accountId}:root`,
+    accountId,
+    principalType: "root",
+    name: "root",
+  };
+}

--- a/src/service/aws/caller/sim-aws-caller.ts
+++ b/src/service/aws/caller/sim-aws-caller.ts
@@ -1,7 +1,7 @@
 import type { SimAwsAccountId } from "../sim-aws-account.js";
 
 export type SimAwsPrincipalType =
-  "anonymous" | "root" | "user" | "role" | "assumed-role" | "service";
+  "root" | "user" | "role" | "assumed-role" | "service";
 
 /**
  * Simulated AWS principal making a request.
@@ -18,13 +18,32 @@ export interface SimAwsPrincipal {
 }
 
 /**
- * Optional caller context for simulated AWS service operations.
- *
- * This is the authoritative place for request identity. The principal field
- * identifies who is making the request when that has been resolved. Additional
- * request attributes can be added here later for IAM condition keys without
- * changing individual service command shapes.
+ * A request made by an authenticated simulated AWS principal.
  */
-export interface SimAwsCallerContext {
-  readonly principal?: SimAwsPrincipal | string | undefined;
+export interface SimAwsPrincipalCallerContext {
+  readonly kind?: "principal" | undefined;
+  readonly principal: SimAwsPrincipal | string;
 }
+
+/**
+ * A request made without an authenticated AWS principal.
+ */
+export interface SimAwsAnonymousCallerContext {
+  readonly kind: "anonymous";
+}
+
+/**
+ * Caller context for a simulated AWS service operation.
+ *
+ * Omitting the caller allows the service to apply its default caller. Supplying
+ * an anonymous caller explicitly suppresses that fallback.
+ */
+export type SimAwsCallerContext =
+  SimAwsPrincipalCallerContext | SimAwsAnonymousCallerContext;
+
+/**
+ * Reusable caller context for an explicitly anonymous request.
+ */
+export const SIM_AWS_ANONYMOUS_CALLER = {
+  kind: "anonymous",
+} as const satisfies SimAwsAnonymousCallerContext;

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -10,6 +10,8 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
+import { makeSimAwsAccountRootPrincipal } from "./caller/sim-aws-account-root-principal.js";
 
 export type SimAwsAccountId = Brand<string, "SimAwsAccountId">;
 
@@ -36,6 +38,13 @@ export class SimAwsAccount {
 
     this.simAws = simAws;
     this.accountId = accountId;
+  }
+
+  /**
+   * Intrinsic root principal for this simulated AWS Account.
+   */
+  get rootPrincipal(): SimAwsPrincipal {
+    return makeSimAwsAccountRootPrincipal(this.accountId);
   }
 
   /**

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -77,7 +77,10 @@ export class SimIamAuthZCallerContextBuilder {
   private rootPolicySources(
     callerPrincipal: SimAwsPrincipal | undefined,
   ): readonly SimIamAuthZPolicySource[] {
-    if (callerPrincipal?.arn !== this.defaultCallerPrincipal?.arn) {
+    if (
+      this.defaultCallerPrincipal === undefined ||
+      callerPrincipal?.arn !== this.defaultCallerPrincipal.arn
+    ) {
       return [];
     }
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -1,0 +1,99 @@
+import type {
+  SimAwsCallerContext,
+  SimAwsPrincipal,
+} from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
+
+interface SimIamAuthZCallerContext {
+  readonly callerPrincipal: SimAwsPrincipal | undefined;
+  readonly rootPolicySources: readonly SimIamAuthZPolicySource[];
+}
+
+/**
+ * Resolves the caller principal and any policy sources implied by that caller.
+ *
+ * Authorization requests may omit a caller, provide an anonymous caller,
+ * provide a principal ARN, or provide a complete principal object. This builder
+ * applies those cases consistently before identity and resource policies are
+ * collected.
+ *
+ * The configured default principal represents the simulated account root. It is
+ * used only when the request omits a caller. An explicit anonymous caller does
+ * not fall back to root, allowing services to evaluate unauthenticated
+ * requests.
+ *
+ * Root access is modelled as an inline identity policy because the authorizer
+ * evaluates all permissions through policy sources. Keeping that policy here
+ * ties it to the rule that identifies the default root principal rather than to
+ * general authorization-context assembly.
+ */
+export class SimIamAuthZCallerContextBuilder {
+  private readonly defaultCallerPrincipal?: SimAwsPrincipal | undefined;
+
+  constructor(defaultCallerPrincipal?: SimAwsPrincipal) {
+    this.defaultCallerPrincipal = defaultCallerPrincipal;
+  }
+
+  /**
+   * Resolve request caller data and add the simulated root policy when
+   * applicable.
+   */
+  build(caller: SimAwsCallerContext | undefined): SimIamAuthZCallerContext {
+    const callerPrincipal = this.callerPrincipal(caller);
+
+    return {
+      callerPrincipal,
+      rootPolicySources: this.rootPolicySources(callerPrincipal),
+    };
+  }
+
+  /**
+   * Convert the caller representation used by simulated AWS services into the
+   * principal representation consumed by IAM authorization.
+   */
+  private callerPrincipal(
+    caller: SimAwsCallerContext | undefined,
+  ): SimAwsPrincipal | undefined {
+    if (caller?.kind === "anonymous") {
+      return undefined;
+    }
+
+    if (typeof caller?.principal === "string") {
+      return {
+        arn: caller.principal,
+      };
+    }
+
+    return caller?.principal ?? this.defaultCallerPrincipal;
+  }
+
+  /**
+   * Give the configured account-root principal unrestricted identity access.
+   *
+   * Comparing ARNs rather than object identity ensures that an explicitly
+   * supplied principal object for the same root ARN receives the same simulated
+   * root permissions as an omitted caller.
+   */
+  private rootPolicySources(
+    callerPrincipal: SimAwsPrincipal | undefined,
+  ): readonly SimIamAuthZPolicySource[] {
+    if (callerPrincipal?.arn !== this.defaultCallerPrincipal?.arn) {
+      return [];
+    }
+
+    return [
+      {
+        sourceType: "identity-inline",
+        policyName: "SimAwsAccountRootAccess",
+        document: {
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "*",
+            Resource: "*",
+          },
+        },
+      },
+    ];
+  }
+}

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -13,6 +13,7 @@ import type {
   SimIamAuthZPolicySource,
 } from "./sim-iam-auth-z-context.js";
 import { SimIamAuthZIdentityPolicySourceBuilder } from "./identity-policy-source/sim-iam-auth-z-id-pol-src-builder.js";
+import { SimIamAuthZCallerContextBuilder } from "./sim-iam-auth-z-caller-context-builder.js";
 
 export interface SimIamResourcePolicyInput {
   readonly document: SimIamPolicyDocument;
@@ -30,9 +31,9 @@ export interface SimIamAuthorizationInput {
   /**
    * Simulated request caller context.
    *
-   * Services should pass this when they know who is making the request. If it is
-   * omitted, the request is evaluated as having no resolved principal. Resource
-   * policies with Principal "*" may still match; identity policies will not.
+   * If omitted, authorization defaults to the root principal of the sim Account
+   * owning the sim IAM instance. An explicit anonymous caller suppresses that
+   * fallback and is evaluated without an authenticated principal.
    */
   readonly caller?: SimAwsCallerContext | undefined;
 
@@ -68,12 +69,17 @@ export interface SimIamAuthorizationInput {
  * focused on composing the authorization request.
  */
 export class SimIamAuthZContextBuilder {
+  private readonly callerContextBuilder: SimIamAuthZCallerContextBuilder;
   private readonly identityPolicySourceBuilder: SimIamAuthZIdentityPolicySourceBuilder;
 
   constructor(
     policies: ReadonlyMap<SimArn, SimIamPolicy>,
     roles: ReadonlyMap<SimIamRoleName, SimIamRole>,
+    defaultCallerPrincipal?: SimAwsPrincipal,
   ) {
+    this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
+      defaultCallerPrincipal,
+    );
     this.identityPolicySourceBuilder =
       new SimIamAuthZIdentityPolicySourceBuilder({ policies, roles });
   }
@@ -82,29 +88,20 @@ export class SimIamAuthZContextBuilder {
    * Build the context consumed by SimIamAuthorizer.
    */
   build(input: SimIamAuthorizationInput): SimIamAuthZContext {
-    const callerPrincipal = this.callerPrincipal(input.caller);
+    const callerContext = this.callerContextBuilder.build(input.caller);
 
     return {
-      identityPolicies: this.identityPolicySourceBuilder.build(
-        callerPrincipal?.arn,
-      ),
+      identityPolicies: [
+        ...this.identityPolicySourceBuilder.build(
+          callerContext.callerPrincipal?.arn,
+        ),
+        ...callerContext.rootPolicySources,
+      ],
       resourcePolicies: this.resourcePolicySources(input),
       action: input.action,
       resource: input.resource,
-      callerPrincipal,
+      callerPrincipal: callerContext.callerPrincipal,
     };
-  }
-
-  private callerPrincipal(
-    caller: SimAwsCallerContext | undefined,
-  ): SimAwsPrincipal | undefined {
-    if (typeof caller?.principal === "string") {
-      return {
-        arn: caller.principal,
-      };
-    }
-
-    return caller?.principal;
   }
 
   /**

--- a/src/service/iam/authorize/sim-iam-auth-z-caller.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-caller.iso.test.ts
@@ -29,20 +29,6 @@ describe("Sim IAM authorization caller", () => {
     assertArrayLength(decision.explicitDenyStatements, 0);
   });
 
-  it("allows an unresolved caller as the current account root", () => {
-    const simAws = new SimAws();
-
-    const simIam = simAws.account("123456789012").iam();
-
-    const decision = simIam.authorize({
-      action: "s3:GetObject",
-      resource: "arn:aws:s3:::example-bucket/example-key.txt",
-    });
-
-    assertIdentical(decision.value, SimIamPolicyDecisionValue.Allow);
-    assertTrue(decision.isAllowed);
-  });
-
   it("implicitly denies an anonymous caller without a resource-policy allow", () => {
     const simAws = new SimAws();
 

--- a/src/service/iam/authorize/sim-iam-auth-z-caller.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-caller.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../aws/caller/sim-aws-caller.js";
+
+describe("Sim IAM authorization caller", () => {
+  it("allows an omitted caller as the current account root", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.Allow);
+    assertFalse(decision.isDenied);
+    assertFalse(decision.isImplicitDeny);
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.isExplicitDeny);
+    assertArrayLength(decision.allowStatements, 1);
+    assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+
+  it("allows an unresolved caller as the current account root", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.Allow);
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies an anonymous caller without a resource-policy allow", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.isDenied);
+    assertTrue(decision.isImplicitDeny);
+    assertFalse(decision.isAllowed);
+    assertFalse(decision.isExplicitDeny);
+    assertArrayLength(decision.allowStatements, 0);
+    assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+
+  it("allows an anonymous caller through a wildcard resource policy", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/public/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [
+        {
+          document: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: "*",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::example-bucket/public/*",
+            },
+          },
+        },
+      ],
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.Allow);
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.isDenied);
+    assertArrayLength(decision.allowStatements, 1);
+    assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+
+  it("does not match the account root principal for an anonymous caller", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [
+        {
+          document: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: "arn:aws:iam::123456789012:root",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::example-bucket/*",
+            },
+          },
+        },
+      ],
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.isImplicitDeny);
+    assertArrayLength(decision.allowStatements, 0);
+  });
+
+  it("applies an explicit resource-policy deny to an anonymous caller", () => {
+    const simAws = new SimAws();
+
+    const simIam = simAws.account("123456789012").iam();
+
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/private/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [
+        {
+          document: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::example-bucket/*",
+              },
+              {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::example-bucket/private/*",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertTrue(decision.isExplicitDeny);
+    assertTrue(decision.isDenied);
+    assertFalse(decision.isAllowed);
+    assertArrayLength(decision.allowStatements, 1);
+    assertArrayLength(decision.explicitDenyStatements, 1);
+  });
+
+  it("allows an explicitly supplied account root principal", () => {
+    const simAws = new SimAws();
+    const account = simAws.account("123456789012");
+
+    const decision = account.iam().authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: {
+        principal: account.rootPrincipal,
+      },
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.Allow);
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.allowStatements, 1);
+    assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+
+  it("does not give another account root implicit access", () => {
+    const simAws = new SimAws();
+    const resourceAccount = simAws.account("123456789012");
+    const callerAccount = simAws.account("210987654321");
+
+    const decision = resourceAccount.iam().authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: {
+        principal: callerAccount.rootPrincipal,
+      },
+    });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.isDenied);
+    assertTrue(decision.isImplicitDeny);
+    assertFalse(decision.isAllowed);
+    assertArrayLength(decision.allowStatements, 0);
+    assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+});

--- a/src/service/iam/authorize/sim-iam-auth-z.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z.iso.test.ts
@@ -14,24 +14,35 @@ import { SimAws } from "../../aws/sim-aws.js";
 import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
 
 describe("Sim IAM authorization", () => {
-  it("implicitly denies when no principal is supplied", () => {
+  it("explicitly denies the default root when a resource policy denies it", () => {
     const simAws = new SimAws();
 
     const simIam = simAws.account("123456789012").iam();
 
     const decision = simIam.authorize({
       action: "s3:GetObject",
-      resource: "arn:aws:s3:::example-bucket/example-key.txt",
-      caller: { principal: undefined },
+      resource: "arn:aws:s3:::example-bucket/private/example-key.txt",
+      resourcePolicies: [
+        {
+          document: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Deny",
+              Principal: "arn:aws:iam::123456789012:root",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::example-bucket/private/*",
+            },
+          },
+        },
+      ],
     });
 
-    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
     assertTrue(decision.isDenied);
-    assertTrue(decision.isImplicitDeny);
+    assertTrue(decision.isExplicitDeny);
     assertFalse(decision.isAllowed);
-    assertFalse(decision.isExplicitDeny);
-    assertArrayLength(decision.allowStatements, 0);
-    assertArrayLength(decision.explicitDenyStatements, 0);
+    assertArrayLength(decision.allowStatements, 1);
+    assertArrayLength(decision.explicitDenyStatements, 1);
   });
 
   it("implicitly denies an unknown principal", () => {

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -6,10 +6,12 @@ import {
   type SimIamAuthorizationInput,
 } from "./context/sim-iam-auth-z-context-builder.js";
 import { SimIamPolicyDecision } from "./sim-iam-decision.js";
+import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 
 interface SimIamAuthorizerProps {
   readonly policies: ReadonlyMap<SimArn, SimIamPolicy>;
   readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
+  readonly defaultCallerPrincipal?: SimAwsPrincipal | undefined;
 }
 
 /**
@@ -27,6 +29,7 @@ export class SimIamAuthorizer {
     this.contextBuilder = new SimIamAuthZContextBuilder(
       props.policies,
       props.roles,
+      props.defaultCallerPrincipal,
     );
   }
 

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -1,6 +1,1 @@
 export { SimIam } from "./sim-iam.js";
-export type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
-export type {
-  SimIamPolicyId,
-  SimIamPolicyName,
-} from "./policy/sim-iam-policy.js";

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -46,6 +46,7 @@ import type {
   SimPutRolePolicyCommandOutput,
 } from "./command/policy/put-role-policy/put-role-policy.cmd.js";
 import { PutRolePolicyCommandHandler } from "./command/policy/put-role-policy/put-role-policy.handler.js";
+import { makeSimAwsAccountRootPrincipal } from "../aws/caller/sim-aws-account-root-principal.js";
 
 interface SimIamProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -84,14 +85,17 @@ export class SimIam {
    * Evaluate an IAM authorization attempt against policies relevant to the
    * request caller.
    *
-   * New simulated service integrations should pass caller.principal when they
-   * have a resolved simulated caller context. If caller is omitted, the request
-   * is evaluated without a resolved principal.
+   * If the caller is omitted, authorization defaults to the root principal of
+   * the sim Account owning this sim IAM instance. An explicit anonymous caller
+   * suppresses that fallback and is evaluated without identity policies.
    */
   authorize(input: SimIamAuthorizationInput): SimIamPolicyDecision {
     return new SimIamAuthorizer({
       policies: this.policies,
       roles: this.roles,
+      defaultCallerPrincipal: makeSimAwsAccountRootPrincipal(
+        this.accountRegionScope.accountId,
+      ),
     }).authorize(input);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for simulated AWS account root principals.
  * Authorization now defaults to the account root when no caller is provided.
  * Added explicit anonymous caller handling for unauthenticated requests.
  * Anonymous requests can be allowed or denied through resource policies.
  * Added clearer caller context handling for root, user, role, service, and assumed-role principals.

* **API Changes**
  * Updated public exports for AWS and IAM types and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->