### PR TITLE
feat: sim IAM policy conditions

### DIFF
--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -4,6 +4,7 @@ import type {
   SimAwsPrincipal,
 } from "../../../aws/caller/sim-aws-caller.js";
 import type {
+  SimIamConditionValue,
   SimIamPolicy,
   SimIamPolicyDocument,
 } from "../../policy/sim-iam-policy.js";
@@ -27,6 +28,18 @@ export interface SimIamResourcePolicyInput {
 export interface SimIamAuthorizationInput {
   readonly action: string;
   readonly resource: string;
+
+  /**
+   * Condition values known by the service handling the simulated request, such
+   * as S3 object tags. Sim IAM automatically supplies global condition values
+   * that it can derive itself, such as aws:PrincipalArn.
+   *
+   * Context-key names are matched case-insensitively by the condition matcher,
+   * while string values remain case-sensitive. IAM-derived values take
+   * precedence over supplied values for equivalent keys.
+   */
+  readonly conditionContext?:
+    Readonly<Record<string, SimIamConditionValue>> | undefined;
 
   /**
    * Simulated request caller context.
@@ -100,7 +113,29 @@ export class SimIamAuthZContextBuilder {
       resourcePolicies: this.resourcePolicySources(input),
       action: input.action,
       resource: input.resource,
+      conditionContext: this.conditionContext(
+        input,
+        callerContext.callerPrincipal,
+      ),
       callerPrincipal: callerContext.callerPrincipal,
+    };
+  }
+
+  /**
+   * Combine service-provided condition values with global values that IAM can
+   * derive from the resolved caller.
+   */
+  private conditionContext(
+    input: SimIamAuthorizationInput,
+    callerPrincipal: SimAwsPrincipal | undefined,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    if (callerPrincipal === undefined) {
+      return input.conditionContext ?? {};
+    }
+
+    return {
+      ...input.conditionContext,
+      "aws:PrincipalArn": callerPrincipal.arn,
     };
   }
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -12,6 +12,7 @@ export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   resourcePolicies: [],
   action: "s3:GetObject",
   resource: "arn:aws:s3:::test-bucket/test-key",
+  conditionContext: {},
   callerPrincipal: {
     arn: "arn:aws:iam::123456789012:role/TestRole",
   },
@@ -24,6 +25,7 @@ export const simIamAuthZResourcePolicySourceFactory =
   new StaticFactory<SimIamAuthZPolicySource>({
     sourceType: "resource",
     document: {
+      Version: "2012-10-17",
       Statement: {
         Effect: "Allow",
         Action: "s3:GetObject",

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
@@ -1,6 +1,9 @@
 import type { SimArn } from "../../../aws/arn.js";
 import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
-import type { SimIamPolicyDocument } from "../../policy/sim-iam-policy.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocument,
+} from "../../policy/sim-iam-policy.js";
 
 export type SimIamAuthZPolicySourceType =
   | "identity-inline"
@@ -35,6 +38,7 @@ export interface SimIamAuthZContext {
 
   readonly action: string;
   readonly resource: string;
+  readonly conditionContext: Readonly<Record<string, SimIamConditionValue>>;
 
   /**
    * Resolved caller principal, if the simulated request has one.

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
@@ -8,18 +8,26 @@ import { SimIamStringLike } from "./string/like/sim-iam-string-like.js";
 
 type SimIamConditionOperatorFactory = () => SimIamConditionOperator;
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
-const operatorFactories: Readonly<
-  Record<string, SimIamConditionOperatorFactory>
-> = {
-  StringEquals: () => new SimIamStringEquals(),
-  StringLike: () => new SimIamStringLike(),
-  "ForAnyValue:StringEquals": () => new SimIamForAnyValueStringEquals(),
-  "ForAnyValue:StringLike": () => new SimIamForAnyValueStringLike(),
-  "ForAllValues:StringEquals": () => new SimIamForAllValuesStringEquals(),
-  "ForAllValues:StringLike": () => new SimIamForAllValuesStringLike(),
-};
+const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
+  ["StringEquals", (): SimIamConditionOperator => new SimIamStringEquals()],
+  ["StringLike", (): SimIamConditionOperator => new SimIamStringLike()],
+  [
+    "ForAnyValue:StringEquals",
+    (): SimIamConditionOperator => new SimIamForAnyValueStringEquals(),
+  ],
+  [
+    "ForAnyValue:StringLike",
+    (): SimIamConditionOperator => new SimIamForAnyValueStringLike(),
+  ],
+  [
+    "ForAllValues:StringEquals",
+    (): SimIamConditionOperator => new SimIamForAllValuesStringEquals(),
+  ],
+  [
+    "ForAllValues:StringLike",
+    (): SimIamConditionOperator => new SimIamForAllValuesStringLike(),
+  ],
+]);
 
 /**
  * Parses IAM condition operator keywords into their behavior objects.
@@ -32,7 +40,6 @@ export class SimIamConditionOperatorParser {
    * Parse a keyword into a condition operator, if supported.
    */
   parse(keyword: string): SimIamConditionOperator | undefined {
-    // eslint-disable-next-line security/detect-object-injection
-    return operatorFactories[keyword]?.();
+    return operatorFactories.get(keyword)?.();
   }
 }

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
@@ -1,0 +1,38 @@
+import type { SimIamConditionOperator } from "./sim-iam-condition-operator.js";
+import { SimIamForAllValuesStringEquals } from "./string/all-values/sim-iam-for-all-values-string-equals.js";
+import { SimIamForAllValuesStringLike } from "./string/all-values/sim-iam-for-all-values-string-like.js";
+import { SimIamForAnyValueStringEquals } from "./string/any-value/sim-iam-for-any-value-string-equals.js";
+import { SimIamForAnyValueStringLike } from "./string/any-value/sim-iam-for-any-value-string-like.js";
+import { SimIamStringEquals } from "./string/equals/sim-iam-string-equals.js";
+import { SimIamStringLike } from "./string/like/sim-iam-string-like.js";
+
+type SimIamConditionOperatorFactory = () => SimIamConditionOperator;
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+const operatorFactories: Readonly<
+  Record<string, SimIamConditionOperatorFactory>
+> = {
+  StringEquals: () => new SimIamStringEquals(),
+  StringLike: () => new SimIamStringLike(),
+  "ForAnyValue:StringEquals": () => new SimIamForAnyValueStringEquals(),
+  "ForAnyValue:StringLike": () => new SimIamForAnyValueStringLike(),
+  "ForAllValues:StringEquals": () => new SimIamForAllValuesStringEquals(),
+  "ForAllValues:StringLike": () => new SimIamForAllValuesStringLike(),
+};
+
+/**
+ * Parses IAM condition operator keywords into their behavior objects.
+ *
+ * Unsupported operators return undefined so condition evaluation fails closed
+ * without throwing.
+ */
+export class SimIamConditionOperatorParser {
+  /**
+   * Parse a keyword into a condition operator, if supported.
+   */
+  parse(keyword: string): SimIamConditionOperator | undefined {
+    // eslint-disable-next-line security/detect-object-injection
+    return operatorFactories[keyword]?.();
+  }
+}

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
@@ -1,0 +1,18 @@
+import type { SimIamConditionValue } from "../../../policy/sim-iam-policy.js";
+
+/**
+ * Contract implemented by every simulated IAM condition operator.
+ *
+ * Implementations own operand validation and comparison semantics. Condition
+ * document traversal and context-key lookup are handled by the policy condition
+ * matcher.
+ */
+export interface SimIamConditionOperator {
+  /**
+   * Determine whether an actual request value satisfies the expected policy value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean;
+}

--- a/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
@@ -1,0 +1,81 @@
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "./sim-iam-condition-operator.js";
+import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-parser.js";
+
+/**
+ * Matches IAM policy conditions against request condition-context values.
+ *
+ * This class coordinates condition-block evaluation and case-insensitive context
+ * key lookup. Individual condition operators encapsulate value validation,
+ * comparison, and set semantics.
+ *
+ * Unsupported operators and missing context keys fail closed by making the
+ * condition non-matching.
+ */
+export class SimIamPolicyConditionMatcher {
+  private readonly conditionContext: ReadonlyMap<string, SimIamConditionValue>;
+
+  constructor(
+    conditionContext: Readonly<Record<string, SimIamConditionValue>>,
+    private readonly operatorParser = new SimIamConditionOperatorParser(),
+  ) {
+    this.conditionContext = new Map(
+      Object.entries(conditionContext).map(([key, value]) => [
+        this.normalizeContextKey(key),
+        value,
+      ]),
+    );
+  }
+
+  /**
+   * Match every operator and every key in a condition block.
+   *
+   * Separate operators and separate keys use logical AND semantics.
+   */
+  matches(condition: SimIamPolicyDocumentCondition | undefined): boolean {
+    if (condition === undefined) {
+      return true;
+    }
+
+    return Object.entries(condition).every(([keyword, keyValues]) =>
+      this.operatorMatches(keyword, keyValues),
+    );
+  }
+
+  private operatorMatches(
+    keyword: string,
+    keyValues: Readonly<Record<string, SimIamConditionValue>>,
+  ): boolean {
+    const operator = this.operatorParser.parse(keyword);
+
+    /* v8 ignore if -- defensive */
+    if (operator === undefined) {
+      return false;
+    }
+
+    return Object.entries(keyValues).every(([key, expected]) =>
+      this.entryMatches(operator, key, expected),
+    );
+  }
+
+  private entryMatches(
+    operator: SimIamConditionOperator,
+    key: string,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const actual = this.conditionContext.get(this.normalizeContextKey(key));
+
+    if (actual === undefined) {
+      return false;
+    }
+
+    return operator.matches(actual, expected);
+  }
+
+  private normalizeContextKey(key: string): string {
+    return key.toLowerCase();
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
@@ -1,0 +1,36 @@
+import type { SimIamConditionValue } from "../../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../../sim-iam-condition-operator.js";
+import { simIamStringValues } from "../sim-iam-string-values.js";
+
+/**
+ * Base for `ForAllValues` IAM string operators.
+ */
+export abstract class SimIamForAllValuesStringConditionOperator implements SimIamConditionOperator {
+  /**
+   * Check whether a given value matches the expected value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const actualValues = simIamStringValues(actual);
+    const expectedValues = simIamStringValues(expected);
+
+    if (
+      actualValues === undefined ||
+      expectedValues === undefined ||
+      actualValues.length === 0 ||
+      expectedValues.length === 0
+    ) {
+      return false;
+    }
+
+    return actualValues.every((actualValue) =>
+      expectedValues.some((expectedValue) =>
+        this.valueMatches(actualValue, expectedValue),
+      ),
+    );
+  }
+
+  protected abstract valueMatches(actual: string, expected: string): boolean;
+}

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
@@ -1,0 +1,293 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+
+describe("sim IAM ForAllValues:StringEquals authorization", () => {
+  it("allows a request when every context value equals a policy value", () => {
+    // Given a policy accepting either of two tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When the policy accepts every supplied tag key.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["owner", "classification"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the policy allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when a scalar context value equals a policy value", () => {
+    // Given a policy accepting multiple possible tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies one accepted tag key as a scalar value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": "classification",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the single matching value satisfies the condition.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when any context value is not accepted", () => {
+    // Given a policy accepting only classification and owner tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When one supplied tag key is outside the accepted values.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["classification", "environment"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("compares every context value case-sensitively", () => {
+    // Given a policy whose accepted tag key uses lowercase text.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": "classification",
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies the tag key with different casing.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["classification", "Classification"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the differently cased value prevents the condition from matching.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request when the required context key is absent", () => {
+    // Given a policy requiring all supplied tag keys to be accepted.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization omits the required tag-key context.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [policy],
+    });
+
+    // Then the incomplete context does not allow the request.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches the principal ARN derived from the caller", () => {
+    // Given a policy accepting the caller ARN as one of its principal values.
+    const simIam = new SimIam();
+    const callerPrincipalArn =
+      "arn:aws:iam::123456789012:role/application/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:PrincipalArn": [
+                "arn:aws:iam::123456789012:role/OtherRole",
+                callerPrincipalArn,
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without explicit condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then the caller-derived principal ARN satisfies the condition.
+    assertTrue(decision.isAllowed);
+  });
+
+  it.each([
+    {
+      name: "context values",
+      expectedValues: ["classification"],
+      actualValues: [],
+    },
+    {
+      name: "policy values",
+      expectedValues: [],
+      actualValues: ["classification"],
+    },
+  ])(
+    "implicitly denies a request when $name are empty",
+    ({ expectedValues, actualValues }) => {
+      // Given a policy using the supplied accepted tag-key values.
+      const simIam = new SimIam();
+      const policy = simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:PutObjectTagging",
+            Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+            Condition: {
+              "ForAllValues:StringEquals": {
+                "aws:TagKeys": expectedValues,
+              },
+            },
+          },
+        },
+      });
+
+      // When either side of the condition comparison is empty.
+      const decision = simIam.authorize({
+        action: "s3:PutObjectTagging",
+        resource: "arn:aws:s3:::example-bucket/example-key.txt",
+        caller: SIM_AWS_ANONYMOUS_CALLER,
+        conditionContext: {
+          "aws:TagKeys": actualValues,
+        },
+        resourcePolicies: [policy],
+      });
+
+      // Then the empty values do not satisfy the condition.
+      assertTrue(decision.isImplicitDeny);
+    },
+  );
+
+  it("implicitly denies a request with a non-string context value", () => {
+    // Given a policy requiring an accepted string tag key.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringEquals": {
+              "aws:TagKeys": "classification",
+            },
+          },
+        },
+      },
+    });
+
+    // When the condition context supplies a non-string scalar value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": 42,
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the invalid string condition value does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.ts
@@ -1,0 +1,10 @@
+import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-values-string-condition-operator.js";
+
+/**
+ * IAM `ForAllValues:StringEquals` condition operator.
+ */
+export class SimIamForAllValuesStringEquals extends SimIamForAllValuesStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return actual === expected;
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
@@ -1,0 +1,209 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+
+describe("sim IAM ForAllValues:StringLike authorization", () => {
+  it("allows a request when every context value matches a policy pattern", () => {
+    // Given a policy accepting application and team tag-key patterns.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:TagKeys": ["application:*", "team-?"],
+            },
+          },
+        },
+      },
+    });
+
+    // When every supplied tag key matches one of the patterns.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["application:name", "team-a"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the policy allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when a scalar context value matches a policy pattern", () => {
+    // Given a policy accepting tag keys beginning with "application:".
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies one matching tag key as a scalar value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": "application:name",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching value satisfies the condition.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when any context value matches no pattern", () => {
+    // Given a policy accepting only application and team tag-key patterns.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:TagKeys": ["application:*", "team-*"],
+            },
+          },
+        },
+      },
+    });
+
+    // When one supplied tag key matches none of the patterns.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["application:name", "environment"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches every context value case-sensitively", () => {
+    // Given a policy pattern using lowercase text.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When one supplied tag key uses different casing.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["application:name", "Application:owner"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the differently cased value prevents the condition from matching.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request when the required context key is absent", () => {
+    // Given a policy requiring every tag key to match an application pattern.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization omits the required tag-key context.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [policy],
+    });
+
+    // Then the incomplete context does not allow the request.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a pattern against the principal ARN derived from the caller", () => {
+    // Given a policy accepting application roles from a particular account.
+    const simIam = new SimIam();
+    const callerPrincipalArn =
+      "arn:aws:iam::123456789012:role/application/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAllValues:StringLike": {
+              "aws:PrincipalArn":
+                "arn:aws:iam::123456789012:role/application/*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without explicit condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then the caller-derived principal ARN matches the policy pattern.
+    assertTrue(decision.isAllowed);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.ts
@@ -1,0 +1,13 @@
+import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-values-string-condition-operator.js";
+
+/**
+ * IAM `ForAllValues:StringLike` condition operator.
+ */
+export class SimIamForAllValuesStringLike extends SimIamForAllValuesStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return simIamWildcardMatch(expected, actual, {
+      caseSensitive: true,
+    });
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
@@ -1,0 +1,36 @@
+import type { SimIamConditionValue } from "../../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../../sim-iam-condition-operator.js";
+import { simIamStringValues } from "../sim-iam-string-values.js";
+
+/**
+ * Base for `ForAnyValue` IAM string operators.
+ */
+export abstract class SimIamForAnyValueStringConditionOperator implements SimIamConditionOperator {
+  /**
+   * Check whether a given value matches the expected value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const actualValues = simIamStringValues(actual);
+    const expectedValues = simIamStringValues(expected);
+
+    if (
+      actualValues === undefined ||
+      expectedValues === undefined ||
+      actualValues.length === 0 ||
+      expectedValues.length === 0
+    ) {
+      return false;
+    }
+
+    return actualValues.some((actualValue) =>
+      expectedValues.some((expectedValue) =>
+        this.valueMatches(actualValue, expectedValue),
+      ),
+    );
+  }
+
+  protected abstract valueMatches(actual: string, expected: string): boolean;
+}

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.iso.test.ts
@@ -1,0 +1,279 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+
+describe("sim IAM ForAnyValue:StringEquals authorization", () => {
+  it("allows a request when one of several context values equals the policy value", () => {
+    // Given a policy accepting the classification tag key.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": "classification",
+            },
+          },
+        },
+      },
+    });
+
+    // When one supplied tag key equals the accepted value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["owner", "classification", "environment"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the single matching context value allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when one context value equals one of several policy values", () => {
+    // Given a policy containing several acceptable tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": ["classification", "owner", "cost-centre"],
+            },
+          },
+        },
+      },
+    });
+
+    // When a later context value matches a later policy value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["environment", "cost-centre"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then a match anywhere across the two value sets allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when no context value equals a policy value", () => {
+    // Given a policy containing several acceptable tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When none of the supplied tag keys equals an accepted value.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["environment", "cost-centre"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("compares values case-sensitively", () => {
+    // Given a policy accepting a lowercase tag key.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": "classification",
+            },
+          },
+        },
+      },
+    });
+
+    // When every supplied variation uses different casing.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["Classification", "CLASSIFICATION"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then no differently cased value satisfies the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("treats wildcard characters as literal text", () => {
+    // Given a StringEquals policy value containing an asterisk.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When a supplied value would match only if the asterisk were a wildcard.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["application:name", "application:owner"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then StringEquals does not treat the asterisk as a wildcard.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request with an empty context value set", () => {
+    // Given a policy accepting one of two tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies the context key with no values.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": [],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then there is no value that can satisfy the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request when the required context key is absent", () => {
+    // Given a policy requiring any supplied tag key to equal an accepted value.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:TagKeys": ["classification", "owner"],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization omits the required tag-key context.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [policy],
+    });
+
+    // Then the absent context value does not satisfy the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches the principal ARN derived from the caller", () => {
+    // Given a policy accepting the caller ARN among several principal values.
+    const simIam = new SimIam();
+    const callerPrincipalArn =
+      "arn:aws:iam::123456789012:role/application/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringEquals": {
+              "aws:PrincipalArn": [
+                "arn:aws:iam::123456789012:role/OtherRole",
+                callerPrincipalArn,
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without explicit condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then the caller-derived principal ARN satisfies the condition.
+    assertTrue(decision.isAllowed);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.ts
@@ -1,0 +1,10 @@
+import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-value-string-condition-operator.js";
+
+/**
+ * IAM `ForAnyValue:StringEquals` condition operator.
+ */
+export class SimIamForAnyValueStringEquals extends SimIamForAnyValueStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return actual === expected;
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.iso.test.ts
@@ -1,0 +1,279 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+
+describe("sim IAM ForAnyValue:StringLike authorization", () => {
+  it("allows a request when one context value matches an asterisk pattern", () => {
+    // Given a policy accepting application tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When one of several supplied tag keys matches the pattern.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["owner", "application:name", "environment"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the single matching value allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when one context value matches a question-mark pattern", () => {
+    // Given a policy accepting team tag keys with one-character identifiers.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": "team-?",
+            },
+          },
+        },
+      },
+    });
+
+    // When one supplied tag key has exactly one character after the prefix.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["team-long", "team-a"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the question-mark match allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when one value matches one of several policy patterns", () => {
+    // Given a policy containing several acceptable tag-key patterns.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": ["application:*", "team-?", "cost-*"],
+            },
+          },
+        },
+      },
+    });
+
+    // When a later context value matches a later policy pattern.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["environment", "cost-centre"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then a match anywhere across the two value sets allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when no context value matches a policy pattern", () => {
+    // Given a policy accepting only application and team tag-key patterns.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": ["application:*", "team-?"],
+            },
+          },
+        },
+      },
+    });
+
+    // When none of the supplied tag keys matches either pattern.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["environment", "team-long", "cost-centre"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches values case-sensitively", () => {
+    // Given a policy pattern using lowercase text.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When every supplied variation uses different casing.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": ["Application:name", "APPLICATION:owner"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then no differently cased value satisfies the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request with an empty context value set", () => {
+    // Given a policy accepting application tag keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": "application:*",
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies the context key with no values.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "aws:TagKeys": [],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then there is no value that can satisfy the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies a request when the required context key is absent", () => {
+    // Given a policy requiring any tag key to match an accepted pattern.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:PutObjectTagging",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:TagKeys": ["application:*", "team-*"],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization omits the required tag-key context.
+    const decision = simIam.authorize({
+      action: "s3:PutObjectTagging",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [policy],
+    });
+
+    // Then the absent context value does not satisfy the condition.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a pattern against the principal ARN derived from the caller", () => {
+    // Given a policy accepting application roles from a particular account.
+    const simIam = new SimIam();
+    const callerPrincipalArn =
+      "arn:aws:iam::123456789012:role/application/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            "ForAnyValue:StringLike": {
+              "aws:PrincipalArn": [
+                "arn:aws:iam::210987654321:role/*",
+                "arn:aws:iam::123456789012:role/application/*",
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without explicit condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then the caller-derived principal ARN matches one policy pattern.
+    assertTrue(decision.isAllowed);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.ts
@@ -1,0 +1,13 @@
+import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-value-string-condition-operator.js";
+
+/**
+ * IAM `ForAnyValue:StringLike` condition operator.
+ */
+export class SimIamForAnyValueStringLike extends SimIamForAnyValueStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return simIamWildcardMatch(expected, actual, {
+      caseSensitive: true,
+    });
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals-implicit.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals-implicit.iso.test.ts
@@ -1,0 +1,76 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+
+describe("sim IAM StringEquals authorization", () => {
+  it("implicitly denies a request when the context value differs", () => {
+    // Given a policy requiring a particular StringEquals context value.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses a non-matching context value.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "private",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("implicitly denies an array-valued request context", () => {
+    // Given a StringEquals policy requiring a scalar value.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When the request supplies the matching value inside an array.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": ["public"],
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the unqualified scalar operator does not accept the request value.
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.iso.test.ts
@@ -1,0 +1,246 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+
+describe("sim IAM StringEquals authorization", () => {
+  it("allows a request when the context value exactly equals the policy value", () => {
+    // Given a policy requiring an exact StringEquals context value.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses the required context value.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching policy allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("compares StringEquals values case-sensitively", () => {
+    // Given a policy whose StringEquals value uses lowercase text.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses the same text with different casing.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "Public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the differently cased value is not accepted.
+    assertFalse(decision.isAllowed);
+  });
+
+  it("allows a request when the context value equals any policy value", () => {
+    // Given a StringEquals policy containing multiple acceptable values.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": ["internal", "public"],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses one of the acceptable values.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching value allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a specified principal when its context value matches", () => {
+    // Given a resource policy for a specific principal with a StringEquals condition.
+    const simIam = new SimIam();
+    const callerPrincipalArn = "arn:aws:iam::123456789012:role/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: callerPrincipalArn,
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When that principal authorizes with the matching context value.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the resource policy allows the specified principal.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("supplies the principal ARN condition value from the caller", () => {
+    // Given a policy conditioned on an IAM-known property of the principal.
+    const simIam = new SimIam();
+    const callerPrincipalArn = "arn:aws:iam::123456789012:role/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "aws:PrincipalArn": callerPrincipalArn,
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without supplying condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then sim IAM derives the principal condition value and allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches StringEquals condition keys case-insensitively", () => {
+    // Given a policy whose condition key uses mixed casing.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "S3:ExistingObjectTag/Classification": "public",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization supplies the same condition key with different casing.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:existingobjecttag/classification": "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the differently cased condition key still matches.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("requires every key in a StringEquals condition to match", () => {
+    // Given a policy requiring two StringEquals context keys.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringEquals: {
+              "s3:ExistingObjectTag/classification": "public",
+              "aws:RequestedRegion": "eu-west-2",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization supplies only one of the required context keys.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        "s3:ExistingObjectTag/classification": "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the incomplete condition context does not allow the request.
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.ts
@@ -1,0 +1,10 @@
+import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-condition-operator.js";
+
+/**
+ * IAM `StringEquals` condition operator.
+ */
+export class SimIamStringEquals extends SimIamScalarStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return actual === expected;
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.iso.test.ts
@@ -1,0 +1,243 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SIM_AWS_ANONYMOUS_CALLER } from "../../../../../../aws/caller/sim-aws-caller.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import { SimIam } from "../../../../../sim-iam.js";
+
+describe("sim IAM StringLike authorization", () => {
+  it("allows a request when the context value matches an asterisk wildcard", () => {
+    // Given a policy accepting classification values beginning with "pub".
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: "pub*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses a value matched by the wildcard.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        ["s3:ExistingObjectTag/classification"]: "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching policy allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request when the context value matches a question-mark wildcard", () => {
+    // Given a policy accepting one character between "publi" and "ly".
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: "publi?ly",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses a value matched by the single-character wildcard.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        ["s3:ExistingObjectTag/classification"]: "publicly",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching policy allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when the context value does not match", () => {
+    // Given a policy accepting only classification values beginning with "pub".
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: "pub*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses a value outside the accepted pattern.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        ["s3:ExistingObjectTag/classification"]: "private",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the allow statement does not match.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches StringLike values case-sensitively", () => {
+    // Given a policy whose wildcard pattern uses lowercase text.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: "pub*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses matching text with different casing.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        ["s3:ExistingObjectTag/classification"]: "Public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the case-sensitive condition does not allow the request.
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("allows a request when the context value matches any policy pattern", () => {
+    // Given a policy containing multiple acceptable StringLike patterns.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: ["internal-*", "pub*"],
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization uses a value matching one of the patterns.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      conditionContext: {
+        ["s3:ExistingObjectTag/classification"]: "public",
+      },
+      resourcePolicies: [policy],
+    });
+
+    // Then the matching pattern allows the request.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches a pattern against the principal ARN supplied by IAM", () => {
+    // Given a policy accepting role principals from a particular account.
+    const simIam = new SimIam();
+    const callerPrincipalArn =
+      "arn:aws:iam::123456789012:role/application/TestRole";
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              "aws:PrincipalArn":
+                "arn:aws:iam::123456789012:role/application/*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization identifies the caller without supplying condition context.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: { principal: callerPrincipalArn },
+      resourcePolicies: [policy],
+    });
+
+    // Then StringLike matches the principal ARN derived by sim IAM.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("implicitly denies a request when the required context key is absent", () => {
+    // Given a policy requiring a StringLike condition context value.
+    const simIam = new SimIam();
+    const policy = simIamAuthZResourcePolicySourceFactory.make({
+      document: {
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/example-key.txt",
+          Condition: {
+            StringLike: {
+              ["s3:ExistingObjectTag/classification"]: "pub*",
+            },
+          },
+        },
+      },
+    });
+
+    // When authorization omits the required condition context key.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/example-key.txt",
+      caller: SIM_AWS_ANONYMOUS_CALLER,
+      resourcePolicies: [policy],
+    });
+
+    // Then the incomplete condition context does not allow the request.
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.ts
@@ -1,0 +1,13 @@
+import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-condition-operator.js";
+
+/**
+ * IAM `StringLike` condition operator.
+ */
+export class SimIamStringLike extends SimIamScalarStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return simIamWildcardMatch(expected, actual, {
+      caseSensitive: true,
+    });
+  }
+}

--- a/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
@@ -1,0 +1,33 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../sim-iam-condition-operator.js";
+import { simIamStringValues } from "./sim-iam-string-values.js";
+
+/**
+ * Base for unqualified IAM string operators.
+ *
+ * Unqualified operators require a scalar request value. Policy values may be a
+ * scalar or an array, with multiple policy values using OR semantics.
+ */
+export abstract class SimIamScalarStringConditionOperator implements SimIamConditionOperator {
+  /**
+   * Check whether a given value matches the expected value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    if (typeof actual !== "string") {
+      return false;
+    }
+
+    const expectedValues = simIamStringValues(expected);
+
+    return Boolean(
+      expectedValues?.some((expectedValue) =>
+        this.valueMatches(actual, expectedValue),
+      ),
+    );
+  }
+
+  protected abstract valueMatches(actual: string, expected: string): boolean;
+}

--- a/src/service/iam/authorize/match/condition/string/sim-iam-string-values.ts
+++ b/src/service/iam/authorize/match/condition/string/sim-iam-string-values.ts
@@ -1,0 +1,22 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+
+/**
+ * Return a condition value as a string array.
+ *
+ * Non-string values fail validation instead of being coerced.
+ */
+export function simIamStringValues(
+  value: SimIamConditionValue,
+): readonly string[] | undefined {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.every((item): item is string => typeof item === "string")
+    ? value
+    : undefined;
+}

--- a/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
@@ -5,6 +5,7 @@ import type {
 } from "../context/sim-iam-auth-z-context.js";
 import type { SimIamParsedPolicyStatement } from "../../policy/parse/sim-iam-doc-parser.js";
 import { simIamWildcardMatch } from "../sim-iam-wildcard.js";
+import { SimIamPolicyConditionMatcher } from "./condition/sim-iam-policy-condition-matcher.js";
 
 /**
  * Matches one parsed IAM policy statement against one authorization request.
@@ -13,18 +14,21 @@ import { simIamWildcardMatch } from "../sim-iam-wildcard.js";
  * `SimIamPolicyDecision` can stay focused on policy iteration and final
  * Deny/Allow/ImplicitDeny aggregation.
  *
- * The matcher currently covers the IAM dimensions supported by the simulator:
+ * The matcher covers:
  *
  * - Principal and NotPrincipal for resource policies;
  * - Action and NotAction;
- * - Resource and NotResource.
- *
- * Conditions are not evaluated yet. A statement with a Condition is treated as
- * non-matching so the simulator does not grant access from a statement whose
- * condition semantics it cannot prove.
+ * - Resource and NotResource;
+ * - supported IAM string conditions.
  */
 export class SimIamPolicyStatementMatcher {
-  constructor(private readonly context: SimIamAuthZContext) {}
+  private readonly conditionMatcher: SimIamPolicyConditionMatcher;
+
+  constructor(private readonly context: SimIamAuthZContext) {
+    this.conditionMatcher = new SimIamPolicyConditionMatcher(
+      context.conditionContext,
+    );
+  }
 
   /**
    * Check whether a parsed statement applies to the current request.
@@ -33,15 +37,11 @@ export class SimIamPolicyStatementMatcher {
     policy: SimIamAuthZPolicySource,
     statement: SimIamParsedPolicyStatement,
   ): boolean {
-    /* v8 ignore if -- policy conditions are TODO */
-    if (statement.condition !== undefined) {
-      return false;
-    }
-
     return (
       this.principalMatches(policy, statement) &&
       this.actionMatches(statement) &&
-      this.resourceMatches(statement)
+      this.resourceMatches(statement) &&
+      this.conditionMatcher.matches(statement.condition)
     );
   }
 

--- a/src/service/iam/authorize/sim-iam-wildcard.ts
+++ b/src/service/iam/authorize/sim-iam-wildcard.ts
@@ -5,7 +5,7 @@ interface SimIamWildcardMatchOptions {
 /**
  * Match an IAM-style wildcard pattern.
  *
- * Initial support is small: "*" means zero or more characters.
+ * "*" means zero or more characters and "?" means exactly one character.
  */
 export function simIamWildcardMatch(
   pattern: string,
@@ -22,12 +22,13 @@ function wildcardMatch(
 ): boolean {
   const regexPattern = pattern
     .replaceAll(/[\\^$.*+?()[\]{}|]/gu, String.raw`\$&`)
-    .replaceAll(String.raw`\*`, ".*");
+    .replaceAll(String.raw`\*`, ".*")
+    .replaceAll(String.raw`\?`, ".");
 
   /*
    * IAM wildcard patterns are not accepted as regex syntax. They are converted
-   * from a small wildcard language where only "*" has special meaning. All other
-   * characters are escaped above.
+   * from a small wildcard language where "*" and "?" have special meaning. All
+   * other regex characters are escaped above.
    */
   // eslint-disable-next-line security/detect-non-literal-regexp
   return new RegExp(

--- a/src/service/iam/policy/sim-iam-policy.ts
+++ b/src/service/iam/policy/sim-iam-policy.ts
@@ -29,11 +29,11 @@ export type SimIamPolicyDocumentPrincipal =
   | readonly string[]
   | Readonly<Record<string, string | readonly string[]>>;
 
+export type SimIamConditionValue =
+  string | number | boolean | readonly string[];
+
 export type SimIamPolicyDocumentCondition = Readonly<
-  Record<
-    string,
-    Readonly<Record<string, string | number | boolean | readonly string[]>>
-  >
+  Record<string, Readonly<Record<string, SimIamConditionValue>>>
 >;
 
 /**


### PR DESCRIPTION
Resolves #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM policy condition support for `StringEquals`, `StringLike`, `ForAnyValue`, and `ForAllValues` operators.
  * Added condition context values, including automatic caller principal ARN matching.
  * Added wildcard support for `?` alongside existing `*` matching.
  * Supports scalar and string-list condition values with case-sensitive comparisons.

* **Bug Fixes**
  * Policy statements with supported conditions are now evaluated correctly.
  * Unsupported operators and missing context safely result in denial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->