### PR TITLE
feat: sim IAM credentials as caller auth option

### DIFF
--- a/src/service/aws/caller/sim-aws-caller-resolver.ts
+++ b/src/service/aws/caller/sim-aws-caller-resolver.ts
@@ -1,14 +1,28 @@
-import type { SimAwsPrincipal } from "./sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+  SimCredentialCaller,
+} from "./sim-aws-caller.js";
+import type { SimIamCredentialIdentity } from "../../iam/credential/sim-aws-credentials.js";
+
+export interface SimAwsCredentialIdentityResolver {
+  resolveCredentials(
+    credentials: SimCredentialCaller["credentials"],
+    now?: Date,
+  ): SimIamCredentialIdentity;
+}
 
 /**
  * Caller information normalized for simulated AWS service operations.
  *
- * Metadata that cannot be derived from the supplied principal is left
- * undefined.
+ * The effective principal is used for request context and diagnostics. The
+ * identity-policy principal identifies the IAM entity whose policies apply.
  */
 export interface SimAwsResolvedCaller {
   readonly principal: SimAwsPrincipal;
+  readonly identityPolicyPrincipal: SimAwsPrincipal;
   readonly arn?: string | undefined;
+  readonly identityPolicyArn?: string | undefined;
   readonly accountId?: string | undefined;
   readonly service?: string | undefined;
 }
@@ -17,22 +31,60 @@ export interface SimAwsResolvedCaller {
  * Resolves caller input at a simulated AWS operation boundary.
  *
  * An omitted caller resolves to the supplied operation default. Explicit
- * anonymity is preserved.
+ * anonymity is preserved. Credential callers are authenticated before a
+ * resolved caller is returned.
  */
 export class SimAwsCallerResolver {
+  private readonly credentialIdentityResolver?:
+    SimAwsCredentialIdentityResolver | undefined;
+
+  constructor(credentialIdentityResolver?: SimAwsCredentialIdentityResolver) {
+    this.credentialIdentityResolver = credentialIdentityResolver;
+  }
+
   /**
    * Resolve and normalize a simulated AWS caller.
    */
   resolve(
-    caller: SimAwsPrincipal | undefined,
+    caller: SimAwsCaller | undefined,
     defaultPrincipal: SimAwsPrincipal,
   ): SimAwsResolvedCaller {
-    const principal = caller ?? defaultPrincipal;
+    if (caller?.kind === "credentials") {
+      if (this.credentialIdentityResolver === undefined) {
+        throw new Error(
+          "Simulated credential callers require an IAM credential resolver",
+        );
+      }
 
+      const identity = this.credentialIdentityResolver.resolveCredentials(
+        caller.credentials,
+      );
+
+      return this.normalized(
+        identity.principal,
+        identity.identityPolicyPrincipal,
+      );
+    }
+
+    const principal = caller ?? defaultPrincipal;
+    return this.normalized(principal, principal);
+  }
+
+  private normalized(
+    principal: SimAwsPrincipal,
+    identityPolicyPrincipal: SimAwsPrincipal,
+  ): SimAwsResolvedCaller {
     if (principal.kind === "arn") {
+      const identityPolicyArn =
+        identityPolicyPrincipal.kind === "arn"
+          ? identityPolicyPrincipal.arn
+          : undefined;
+
       return {
         principal,
+        identityPolicyPrincipal,
         arn: principal.arn,
+        identityPolicyArn,
         accountId: this.accountId(principal.arn),
       };
     }
@@ -40,11 +92,15 @@ export class SimAwsCallerResolver {
     if (principal.kind === "service") {
       return {
         principal,
+        identityPolicyPrincipal,
         service: principal.service,
       };
     }
 
-    return { principal };
+    return {
+      principal,
+      identityPolicyPrincipal,
+    };
   }
 
   /**

--- a/src/service/aws/caller/sim-aws-caller.ts
+++ b/src/service/aws/caller/sim-aws-caller.ts
@@ -1,3 +1,5 @@
+import type { SimAwsCredentials } from "../../iam/credential/sim-aws-credentials.js";
+
 /**
  * Resolved sim principal with an ARN, such as an IAM user or role.
  */
@@ -22,7 +24,23 @@ export interface SimAnonymousPrincipal {
 }
 
 /**
- * Resolved simulated AWS identity making a request.
+ * Simulated credentials supplied at an AWS operation boundary.
+ *
+ * Credentials are authentication material rather than a resolved principal.
+ * They must be authenticated before authorization.
+ */
+export interface SimCredentialCaller {
+  readonly kind: "credentials";
+  readonly credentials: SimAwsCredentials;
+}
+
+/**
+ * Resolved simulated AWS identity.
  */
 export type SimAwsPrincipal =
   SimArnPrincipal | SimServicePrincipal | SimAnonymousPrincipal;
+
+/**
+ * Caller accepted by simulated AWS service operations.
+ */
+export type SimAwsCaller = SimAwsPrincipal | SimCredentialCaller;

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -1,8 +1,12 @@
 import {
   SimAwsCallerResolver,
+  type SimAwsCredentialIdentityResolver,
   type SimAwsResolvedCaller,
 } from "../../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
 
 interface SimIamAuthZCallerContext {
@@ -18,18 +22,22 @@ interface SimIamAuthZCallerContext {
  * not fall back to root.
  */
 export class SimIamAuthZCallerContextBuilder {
-  private readonly callerResolver = new SimAwsCallerResolver();
+  private readonly callerResolver: SimAwsCallerResolver;
   private readonly defaultCallerPrincipal: SimAwsPrincipal;
 
-  constructor(defaultCallerPrincipal: SimAwsPrincipal) {
+  constructor(
+    defaultCallerPrincipal: SimAwsPrincipal,
+    credentialIdentityResolver: SimAwsCredentialIdentityResolver,
+  ) {
     this.defaultCallerPrincipal = defaultCallerPrincipal;
+    this.callerResolver = new SimAwsCallerResolver(credentialIdentityResolver);
   }
 
   /**
    * Resolve request caller data and add the simulated root policy when
    * applicable.
    */
-  build(caller: SimAwsPrincipal | undefined): SimIamAuthZCallerContext {
+  build(caller: SimAwsCaller | undefined): SimIamAuthZCallerContext {
     const resolvedCaller = this.callerResolver.resolve(
       caller,
       this.defaultCallerPrincipal,

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -1,5 +1,8 @@
 import type { SimArn } from "../../../aws/arn.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../../aws/caller/sim-aws-caller.js";
 import type {
   SimIamConditionValue,
   SimIamPolicy,
@@ -13,7 +16,10 @@ import type {
 } from "./sim-iam-auth-z-context.js";
 import { SimIamAuthZIdentityPolicyCoordinator } from "./identity-policy-source/sim-iam-auth-z-id-pol-coordinator.js";
 import { SimIamAuthZCallerContextBuilder } from "./sim-iam-auth-z-caller-context-builder.js";
-import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type {
+  SimAwsCredentialIdentityResolver,
+  SimAwsResolvedCaller,
+} from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
 
 export interface SimIamResourcePolicyInput {
@@ -48,11 +54,10 @@ export interface SimIamAuthorizationInput {
   /**
    * Simulated request caller.
    *
-   * If omitted, authorization defaults to the root principal of the sim Account
-   * owning the sim IAM instance. An explicit anonymous principal suppresses that
-   * fallback and is evaluated without an authenticated principal.
+   * If credentials are supplied, they are authenticated before policy
+   * evaluation. If omitted, authorization defaults to the Account root.
    */
-  readonly caller?: SimAwsPrincipal | undefined;
+  readonly caller?: SimAwsCaller | undefined;
 
   /**
    * Resource policies supplied by the service that owns the target resource.
@@ -94,9 +99,11 @@ export class SimIamAuthZContextBuilder {
     roles: ReadonlyMap<SimIamRoleName, SimIamRole>,
     users: ReadonlyMap<SimIamUsername, SimIamUser>,
     defaultCallerPrincipal: SimAwsPrincipal,
+    credentialIdentityResolver: SimAwsCredentialIdentityResolver,
   ) {
     this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
       defaultCallerPrincipal,
+      credentialIdentityResolver,
     );
     this.identityPolicyCoordinator = new SimIamAuthZIdentityPolicyCoordinator({
       policies,
@@ -113,7 +120,9 @@ export class SimIamAuthZContextBuilder {
 
     return {
       identityPolicies: [
-        ...this.identityPolicyCoordinator.build(callerContext.caller.arn),
+        ...this.identityPolicyCoordinator.build(
+          callerContext.caller.identityPolicyArn,
+        ),
         ...callerContext.rootPolicySources,
       ],
       resourcePolicies: this.resourcePolicySources(input),
@@ -126,19 +135,24 @@ export class SimIamAuthZContextBuilder {
 
   /**
    * Combine service-provided condition values with global values that IAM can
-   * derive from the resolved caller.
+   * derive from the resolved caller. aws:PrincipalArn identifies the IAM
+   * identity whose policies apply; for temporary Role credentials this is the
+   * underlying Role ARN, rather than the STS assumed-role session ARN retained
+   * as the effective caller for diagnostics.
    */
   private conditionContext(
     input: SimIamAuthorizationInput,
     caller: SimAwsResolvedCaller,
   ): Readonly<Record<string, SimIamConditionValue>> {
-    if (caller.arn === undefined) {
+    const principalArn = caller.identityPolicyArn ?? caller.arn;
+
+    if (principalArn === undefined) {
       return input.conditionContext ?? {};
     }
 
     return {
       ...input.conditionContext,
-      "aws:PrincipalArn": caller.arn,
+      "aws:PrincipalArn": principalArn,
     };
   }
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -14,6 +14,10 @@ export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   resource: "arn:aws:s3:::test-bucket/test-key",
   conditionContext: {},
   caller: {
+    identityPolicyPrincipal: {
+      kind: "arn",
+      arn: "arn:aws:iam::123456789012:role/TestRole",
+    },
     principal: {
       kind: "arn",
       arn: "arn:aws:iam::123456789012:role/TestRole",

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -8,12 +8,14 @@ import {
 import { SimIamPolicyDecision } from "./sim-iam-decision.js";
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
+import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
 
 interface SimIamAuthorizerProps {
   readonly policies: ReadonlyMap<SimArn, SimIamPolicy>;
   readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly defaultCallerPrincipal: SimAwsPrincipal;
+  readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
 }
 
 /**
@@ -33,6 +35,7 @@ export class SimIamAuthorizer {
       props.roles,
       props.users,
       props.defaultCallerPrincipal,
+      props.credentialIdentityResolver,
     );
   }
 

--- a/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
@@ -54,10 +54,18 @@ export class SimIamAllowAllAuth implements SimIamInterServiceAuthZ {
    * the result because no policies or principal rules are evaluated here.
    */
   authorize(input: SimIamAuthorizationInput): SimIamAuthorizationDecision {
+    const caller =
+      input.caller?.kind === "credentials"
+        ? this.callerResolver.resolve(
+            { kind: "anonymous" },
+            { kind: "anonymous" },
+          )
+        : this.callerResolver.resolve(input.caller, {
+            kind: "anonymous",
+          });
+
     return {
-      caller: this.callerResolver.resolve(input.caller, {
-        kind: "anonymous",
-      }),
+      caller,
       isAllowed: true,
       isDenied: false,
     };

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.cmd.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.cmd.ts
@@ -1,0 +1,15 @@
+import type { JSONString } from "../../../../../util/type-guard/json.js";
+import type { SimIamPolicyDocument } from "../../../policy/sim-iam-policy.js";
+
+export interface SimPutUserPolicyCommandInput {
+  readonly UserName?: string | undefined;
+  readonly PolicyName?: string | undefined;
+  readonly PolicyDocument?:
+    JSONString<SimIamPolicyDocument> | string | undefined;
+}
+
+export interface SimPutUserPolicyCommand {
+  readonly input: SimPutUserPolicyCommandInput;
+}
+
+export type SimPutUserPolicyCommandOutput = Record<string, never>;

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
@@ -1,0 +1,71 @@
+import type { CommandHandler } from "../../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../../util/background/background.js";
+import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
+import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
+import { SimIamPolicyDocumentValidator } from "../../../validate/sim-iam-policy-doc-validator.js";
+import type {
+  SimPutUserPolicyCommand,
+  SimPutUserPolicyCommandOutput,
+} from "./put-user-policy.cmd.js";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+
+interface PutUserPolicyCommandHandlerProps {
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * IAM PutUserPolicyCommand handler.
+ *
+ * PutUserPolicy creates or replaces an inline identity-based permissions policy
+ * stored directly on a user. It does not create a managed IAM policy.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/iam/command/PutUserPolicyCommand/
+ */
+export class PutUserPolicyCommandHandler implements CommandHandler<
+  SimPutUserPolicyCommand,
+  SimPutUserPolicyCommandOutput
+> {
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly background: BackgroundScheduler;
+  private readonly policyDocValidator: SimIamPolicyDocumentValidator;
+
+  constructor(props: PutUserPolicyCommandHandlerProps) {
+    const { users, background = new BackgroundTasks() } = props;
+
+    this.users = users;
+    this.background = background;
+    this.policyDocValidator = new SimIamPolicyDocumentValidator();
+  }
+
+  /**
+   * Handle a PutUserPolicyCommand from the SDK.
+   */
+  async handle(
+    cmd: SimPutUserPolicyCommand,
+  ): Promise<SimPutUserPolicyCommandOutput> {
+    const username = cmd.input.UserName as SimIamUsername | undefined;
+    assertDefined(username, "PutUserPolicyCommand.input.UserName");
+    const policyName = cmd.input.PolicyName;
+    assertDefined(policyName, "PutUserPolicyCommand.input.PolicyName");
+    const policyDocument = cmd.input.PolicyDocument;
+
+    this.policyDocValidator.validateRequired(policyDocument);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const user = this.users.get(username);
+
+    if (user === undefined) {
+      throw new SimIamNoSuchEntity(`No IAM User with name ${username}`);
+    }
+
+    user.inlinePolicies.set(policyName, policyDocument);
+
+    return {};
+  }
+}

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  CreateUserCommand,
+  ListPoliciesCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import {
+  SimIamMalformedPolicyDocument,
+  SimIamNoSuchEntity,
+} from "../../../error/sim-iam.error.js";
+
+describe("IAM PutUserPolicyCommand", () => {
+  it("adds an inline identity policy to a User", async () => {
+    // Given an IAM User exists.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const createUserOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ApplicationUser",
+      }),
+    );
+
+    // When an inline identity policy is added to the User.
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ApplicationUser",
+        PolicyName: "ReadObjects",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::example-bucket/*",
+          },
+        }),
+      }),
+    );
+
+    const decision = simIam.authorize({
+      caller: {
+        kind: "arn",
+        arn: createUserOutput.User.Arn,
+      },
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/object.txt",
+    });
+
+    // Then the inline policy grants access.
+    assertTrue(decision.isAllowed);
+    assertIdentical(decision.value, "Allow");
+
+    // And the inline policy is not exposed as a managed policy.
+    const listOutput = await simIam.listPolicies(new ListPoliciesCommand({}));
+    assertArrayLength(listOutput.Policies, 0);
+  });
+
+  it("replaces an existing inline User policy with the same name", async () => {
+    // Given a User with an allowing inline policy.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const createUserOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ApplicationUser",
+      }),
+    );
+
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ApplicationUser",
+        PolicyName: "ObjectAccess",
+        PolicyDocument: JSON.stringify({
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::example-bucket/*",
+          },
+        }),
+      }),
+    );
+
+    // When a policy with the same name replaces it.
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ApplicationUser",
+        PolicyName: "ObjectAccess",
+        PolicyDocument: JSON.stringify({
+          Statement: {
+            Effect: "Deny",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::example-bucket/*",
+          },
+        }),
+      }),
+    );
+
+    const decision = simIam.authorize({
+      caller: {
+        kind: "arn",
+        arn: createUserOutput.User.Arn,
+      },
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::example-bucket/object.txt",
+    });
+
+    // Then only the replacement policy applies.
+    assertTrue(decision.isExplicitDeny);
+  });
+
+  it("throws when the IAM User does not exist", async () => {
+    const simIam = new SimAws().iam();
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.putUserPolicy(
+        new PutUserPolicyCommand({
+          UserName: "MissingUser",
+          PolicyName: "ObjectAccess",
+          PolicyDocument: JSON.stringify({
+            Statement: {
+              Effect: "Allow",
+              Action: "s3:GetObject",
+              Resource: "*",
+            },
+          }),
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamNoSuchEntity);
+    assertIdentical(error.message, "No IAM User with name MissingUser");
+  });
+
+  it("rejects a malformed inline policy document", async () => {
+    const simIam = new SimAws().iam();
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ApplicationUser",
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.putUserPolicy(
+        new PutUserPolicyCommand({
+          UserName: "ApplicationUser",
+          PolicyName: "InvalidPolicy",
+          PolicyDocument: JSON.stringify({
+            Statement: {
+              Effect: "Allow",
+              Resource: "*",
+            },
+          }),
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      "IAM policy statement must define either Action or NotAction",
+    );
+  });
+});

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -72,6 +72,11 @@ import type {
 } from "./command/user/create-access-key/create-access-key.cmd.js";
 import { CreateAccessKeyCommandHandler } from "./command/user/create-access-key/create-access-key.handler.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimPutUserPolicyCommand,
+  SimPutUserPolicyCommandOutput,
+} from "./command/policy/put-user-policy/put-user-policy.cmd.js";
+import { PutUserPolicyCommandHandler } from "./command/policy/put-user-policy/put-user-policy.handler.js";
 
 interface SimIamProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -151,6 +156,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
       defaultCallerPrincipal: makeSimAwsAccountRootPrincipal(
         this.accountRegionScope.accountId,
       ),
+      credentialIdentityResolver: this,
     }).authorize(input);
   }
 
@@ -202,6 +208,19 @@ export class SimIam implements SimIamInterServiceAuthZ {
   ): Promise<SimPutRolePolicyCommandOutput> {
     const handler = new PutRolePolicyCommandHandler({
       roles: this.roles,
+      background: this.background,
+    });
+    return await handler.handle(cmd);
+  }
+
+  /**
+   * Handle an IAM PutUserPolicy command.
+   */
+  async putUserPolicy(
+    cmd: SimPutUserPolicyCommand,
+  ): Promise<SimPutUserPolicyCommandOutput> {
+    const handler = new PutUserPolicyCommandHandler({
+      users: this.users,
       background: this.background,
     });
     return await handler.handle(cmd);

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -4,6 +4,7 @@ import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
 import { validateS3BucketName } from "./validate/validate-s3-bucket-name.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
@@ -15,6 +16,7 @@ interface SimS3BucketProps {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly storage?: SimS3BucketStorage;
   readonly website?: SimS3BucketWebsite;
+  readonly policy?: SimIamPolicyDocument | undefined;
 }
 
 /**
@@ -25,6 +27,7 @@ export class SimS3Bucket {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private storage: SimS3BucketStorage;
   private website: SimS3BucketWebsite;
+  private policy: SimIamPolicyDocument | undefined;
 
   constructor(props: SimS3BucketProps) {
     const {
@@ -32,6 +35,7 @@ export class SimS3Bucket {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       storage = new MemoryS3BucketStorage(),
       website = new SimS3BucketWebsite(),
+      policy,
     } = props;
 
     validateS3BucketName(bucketName);
@@ -40,6 +44,7 @@ export class SimS3Bucket {
     this.accountRegionScope = accountRegionScope;
     this.storage = storage;
     this.website = website;
+    this.policy = policy;
   }
 
   /**
@@ -82,6 +87,20 @@ export class SimS3Bucket {
    */
   getWebsite(): SimS3BucketWebsite {
     return this.website;
+  }
+
+  /**
+   * Configure the Bucket resource policy.
+   */
+  configurePolicy(policy: SimIamPolicyDocument): void {
+    this.policy = policy;
+  }
+
+  /**
+   * Get the Bucket resource policy.
+   */
+  getPolicy(): SimIamPolicyDocument | undefined {
+    return this.policy;
   }
 
   /**

--- a/src/service/s3/command/create-bucket/create-bucket-iam-cred.iso.test.ts
+++ b/src/service/s3/command/create-bucket/create-bucket-iam-cred.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+
+describe("S3 CreateBucketCommand IAM credential authorization", () => {
+  it("allows IAM User access key credentials through the User policy", async () => {
+    // Given an IAM User whose inline policy permits creation of one Bucket.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const simS3 = simAws.account(accountId).region(region).s3();
+
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "BucketUser",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "BucketUser",
+        PolicyName: "CreateCredentialBucket",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:CreateBucket",
+            Resource: "arn:aws:s3:::user-credential-bucket",
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "BucketUser",
+      }),
+    );
+
+    // When the User supplies its long-lived access key credentials.
+    const output = await simS3.createBucket(
+      new CreateBucketCommand({
+        Bucket: "user-credential-bucket",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then IAM authenticates the User, applies its policy, and permits creation.
+    assertIdentical(output.BucketArn, "arn:aws:s3:::user-credential-bucket");
+    assertIdentical(
+      simS3.findBucketScope("user-credential-bucket")?.regionName,
+      region,
+    );
+  });
+
+  it("allows assumed Role credentials through the underlying Role policy", async () => {
+    // Given an assumable Role whose identity policy allows one Bucket.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/CredentialBucketCreator`;
+
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "CredentialBucketCreator",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "CredentialBucketCreator",
+        PolicyName: "CreateCredentialBucket",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:CreateBucket",
+            Resource: "arn:aws:s3:::assumed-role-credential-bucket",
+          },
+        }),
+      }),
+    );
+
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "create-bucket-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    // When the temporary credentials are supplied as the S3 caller.
+    const output = await simS3.createBucket(
+      new CreateBucketCommand({
+        Bucket: "assumed-role-credential-bucket",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: credentials.AccessKeyId,
+            secretAccessKey: credentials.SecretAccessKey,
+            sessionToken: credentials.SessionToken,
+          },
+        },
+      },
+    );
+
+    // Then the session is the effective caller while the Role policy allows
+    // creation.
+    assertIdentical(
+      output.BucketArn,
+      "arn:aws:s3:::assumed-role-credential-bucket",
+    );
+    assertIdentical(
+      simS3.findBucketScope("assumed-role-credential-bucket")?.regionName,
+      region,
+    );
+  });
+});

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 
 interface CreateBucketCommandHandlerProps {
@@ -29,7 +29,7 @@ interface CreateBucketCommandHandlerProps {
 }
 
 interface CreateBucketCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**

--- a/src/service/s3/command/get-object/get-object-authorizer.ts
+++ b/src/service/s3/command/get-object/get-object-authorizer.ts
@@ -1,7 +1,7 @@
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 
 interface GetObjectAuthorizerProps {
   readonly iam: SimIamInterServiceAuthZ;
@@ -26,16 +26,23 @@ export class GetObjectAuthorizer {
   /**
    * Ensure the caller may read the requested S3 Object.
    */
-  authorize(
-    bucketName: SimS3BucketName,
-    key: string,
-    caller?: SimAwsPrincipal,
-  ): void {
-    const resource = `arn:aws:s3:::${bucketName}/${key}`;
+  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
+    const policy = bucket.getPolicy();
     const decision = this.iam.authorize({
       action: GetObjectAuthorizer.action,
       resource,
       caller,
+      resourcePolicies:
+        policy === undefined
+          ? []
+          : [
+              {
+                document: policy,
+                policyName: "BucketPolicy",
+                resourceArn: `arn:aws:s3:::${bucket.bucketName}`,
+              },
+            ],
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/get-object/get-object-iam-cred.iso.test.ts
+++ b/src/service/s3/command/get-object/get-object-iam-cred.iso.test.ts
@@ -1,0 +1,368 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamInvalidCredentials } from "../../../iam/credential/error/sim-iam-credential.error.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+
+describe("S3 GetObjectCommand IAM credential authorization", () => {
+  it("allows IAM User credentials when the policy condition matches", async () => {
+    // Given an Object and an IAM User permitted to read it as that principal.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "user-credential-reads" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "user-credential-reads",
+        Key: "reports/current.json",
+        Body: '{"status":"ready"}',
+        Metadata: {
+          source: "credential-test",
+        },
+      }),
+    );
+    const userOut = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ObjectReader",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ObjectReader",
+        PolicyName: "ReadCurrentReport",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::user-credential-reads/reports/current.json",
+            Condition: {
+              StringEquals: {
+                "aws:PrincipalArn": userOut.User.Arn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "ObjectReader",
+      }),
+    );
+
+    // When the User reads the Object with its long-lived credentials.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "user-credential-reads",
+        Key: "reports/current.json",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then IAM authenticates the User and S3 streams the stored Object.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from('{"status":"ready"}'),
+    );
+    assertIdentical(output.Metadata?.["source"], "credential-test");
+  });
+
+  it("allows IAM User credentials through a Bucket resource policy", async () => {
+    // Given a User without an identity policy and a Bucket policy granting it access.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "resource-policy-reads" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "resource-policy-reads",
+        Key: "shared/document.txt",
+        Body: "granted by the bucket policy",
+      }),
+    );
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "BucketPolicyReader",
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "BucketPolicyReader",
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "resource-policy-reads",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: userOutput.User.Arn,
+            },
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::resource-policy-reads/shared/document.txt",
+          },
+        }),
+      }),
+    );
+
+    // When the User requests the Object with its long-lived credentials.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "resource-policy-reads",
+        Key: "shared/document.txt",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then the Bucket policy grants access and S3 returns the stored body.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("granted by the bucket policy"),
+    );
+  });
+
+  it("allows assumed Role credentials through the underlying Role policy", async () => {
+    // Given an assumable Role permitted to read one stored Object.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/TemporaryObjectReader`;
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "temporary-credential-reads" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "temporary-credential-reads",
+        Key: "documents/session.txt",
+        Body: "read through an STS session",
+      }),
+    );
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "TemporaryObjectReader",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "TemporaryObjectReader",
+        PolicyName: "ReadSessionDocument",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource:
+              "arn:aws:s3:::temporary-credential-reads/documents/session.txt",
+          },
+        }),
+      }),
+    );
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "get-object-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    // When S3 receives the temporary access key, secret, and session token.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "temporary-credential-reads",
+        Key: "documents/session.txt",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: credentials.AccessKeyId,
+            secretAccessKey: credentials.SecretAccessKey,
+            sessionToken: credentials.SessionToken,
+          },
+        },
+      },
+    );
+
+    // Then the credentials resolve through STS to the Role and storage returns the body.
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("read through an STS session"),
+    );
+  });
+
+  it("denies valid User credentials without permission for the Object", async () => {
+    // Given a valid IAM User access key whose policy permits a different Object.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-denied-reads" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "credential-denied-reads",
+        Key: "private/secret.txt",
+        Body: "secret",
+      }),
+    );
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "LimitedReader",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "LimitedReader",
+        PolicyName: "ReadPublicObjects",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::credential-denied-reads/public/*",
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "LimitedReader",
+      }),
+    );
+
+    // When the authenticated User requests an Object outside its policy resource.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "credential-denied-reads",
+          Key: "private/secret.txt",
+        }),
+        {
+          caller: {
+            kind: "credentials",
+            credentials: {
+              accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+              secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+            },
+          },
+        },
+      ),
+    );
+
+    // Then authentication succeeds but IAM denies the exact Object resource.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:GetObject");
+    assertIdentical(
+      error.resource,
+      "arn:aws:s3:::credential-denied-reads/private/secret.txt",
+    );
+  });
+
+  it("rejects invalid credentials before revealing whether an Object exists", async () => {
+    // Given an existing Bucket and credentials containing an unknown access key.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-authentication-reads" }),
+    );
+
+    // When the invalid credentials request a missing Object.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "credential-authentication-reads",
+          Key: "missing.txt",
+        }),
+        {
+          caller: {
+            kind: "credentials",
+            credentials: {
+              accessKeyId: "AKIAUNKNOWN",
+              secretAccessKey: "not-a-valid-secret",
+            },
+          },
+        },
+      ),
+    );
+
+    // Then credential authentication fails before S3 performs Object lookup.
+    assertInstanceOf(error, SimIamInvalidCredentials);
+    assertIdentical(error.reason, "unknown-access-key");
+  });
+});

--- a/src/service/s3/command/get-object/get-object.handler.ts
+++ b/src/service/s3/command/get-object/get-object.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { GetObjectAuthorizer } from "./get-object-authorizer.js";
 import { GetObjectLoader } from "./get-object-loader.js";
 
@@ -28,7 +28,7 @@ interface GetObjectCommandHandlerProps {
 }
 
 interface GetObjectCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -83,7 +83,7 @@ export class GetObjectCommandHandler implements CommandHandler<
     // Complete request sequencing before authorization and storage access.
     await this.background.sequence();
 
-    this.authorizer.authorize(bucketName, cmd.input.Key, opts?.caller);
+    this.authorizer.authorize(bucket, cmd.input.Key, opts?.caller);
 
     return await this.loader.load(bucket, cmd.input.Key);
   }

--- a/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
@@ -1,4 +1,4 @@
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 
@@ -36,7 +36,7 @@ export class ListBucketsAuthorizer {
    * omitted caller, which defaults to Account root, from an explicit anonymous
    * caller, which has no identity policy permissions.
    */
-  authorize(caller?: SimAwsPrincipal): void {
+  authorize(caller?: SimAwsCaller): void {
     const decision = this.iam.authorize({
       action: ListBucketsAuthorizer.action,
       resource: ListBucketsAuthorizer.resource,

--- a/src/service/s3/command/list-buckets/list-buckets-iam-cred.iso.test.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-iam-cred.iso.test.ts
@@ -1,0 +1,375 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { CreateBucketCommand, ListBucketsCommand } from "@aws-sdk/client-s3";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamInvalidCredentials } from "../../../iam/credential/error/sim-iam-credential.error.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+describe("S3 ListBucketsCommand IAM credential authorization", () => {
+  it("allows IAM User credentials and paginates only that Account's matching Buckets", async () => {
+    // Given two matching Buckets, another Account's Bucket, and a User allowed to list its Account.
+    const accountId = makeSimAwsAccountId();
+    const otherAccountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "reports-archive" }),
+    );
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "reports-current" }),
+    );
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "application-assets" }),
+    );
+    await simAws
+      .account(otherAccountId)
+      .s3()
+      .createBucket(
+        new CreateBucketCommand({ Bucket: "reports-other-account" }),
+      );
+
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "CredentialBucketLister",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "CredentialBucketLister",
+        PolicyName: "ListOwnBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListAllMyBuckets",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "aws:PrincipalArn": userOutput.User.Arn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "CredentialBucketLister",
+      }),
+    );
+
+    // When the User requests the first filtered page using its access key.
+    const firstPage = await simS3.listBuckets(
+      new ListBucketsCommand({
+        Prefix: "reports-",
+        MaxBuckets: 1,
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then authentication and authorization succeed before S3 builds an Account-scoped page.
+    assertArrayLength(firstPage.Buckets, 1);
+    assertIdentical(firstPage.Buckets[0].Name, "reports-archive");
+    assertNonNullable(firstPage.ContinuationToken);
+
+    // And the continuation token reaches the next part of the listing simulation.
+    const secondPage = await simS3.listBuckets(
+      new ListBucketsCommand({
+        Prefix: "reports-",
+        MaxBuckets: 1,
+        ContinuationToken: firstPage.ContinuationToken,
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+    assertArrayLength(secondPage.Buckets, 1);
+    assertIdentical(secondPage.Buckets[0].Name, "reports-current");
+    assertUndefined(secondPage.ContinuationToken);
+  });
+
+  it("allows assumed Role credentials through the underlying Role policy", async () => {
+    // Given an assumable Role allowed to list Buckets and an Account containing one Bucket.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/TemporaryBucketLister`;
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "temporary-session-bucket" }),
+    );
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "TemporaryBucketLister",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "TemporaryBucketLister",
+        PolicyName: "ListBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListAllMyBuckets",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "aws:PrincipalArn": roleArn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "list-buckets-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    // When S3 receives the temporary access key, secret, and session token.
+    const output = await simS3.listBuckets(new ListBucketsCommand(), {
+      caller: {
+        kind: "credentials",
+        credentials: {
+          accessKeyId: credentials.AccessKeyId,
+          secretAccessKey: credentials.SecretAccessKey,
+          sessionToken: credentials.SessionToken,
+        },
+      },
+    });
+
+    // Then the session resolves to the Role policy and S3 returns the Account's Bucket.
+    assertArrayLength(output.Buckets, 1);
+    assertIdentical(output.Buckets[0].Name, "temporary-session-bucket");
+  });
+
+  it("denies valid User credentials without ListAllMyBuckets permission", async () => {
+    // Given a valid User access key whose policy permits a different S3 action.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "authorization-denied-bucket" }),
+    );
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ObjectOnlyUser",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ObjectOnlyUser",
+        PolicyName: "ReadObjectsOnly",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::authorization-denied-bucket/*",
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "ObjectOnlyUser",
+      }),
+    );
+
+    // When the authenticated User attempts the account-level listing operation.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.listBuckets(new ListBucketsCommand(), {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      }),
+    );
+
+    // Then authentication succeeds but IAM denies the required global resource.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:ListAllMyBuckets");
+    assertIdentical(error.resource, "*");
+  });
+
+  it("rejects an incorrect secret before reading Bucket state", async () => {
+    // Given an authorized User access key and a Bucket that would otherwise be listed.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-protected-listing" }),
+    );
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "AuthorizedBucketLister",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "AuthorizedBucketLister",
+        PolicyName: "ListBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListAllMyBuckets",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "AuthorizedBucketLister",
+      }),
+    );
+
+    // When the registered access key is supplied with an incorrect secret.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.listBuckets(new ListBucketsCommand(), {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: "incorrect-secret-access-key",
+          },
+        },
+      }),
+    );
+
+    // Then credential authentication fails before authorization or page construction.
+    assertInstanceOf(error, SimIamInvalidCredentials);
+    assertIdentical(error.reason, "secret-access-key-mismatch");
+  });
+
+  it("requires the session token for assumed Role credentials", async () => {
+    // Given valid temporary credentials for a Role allowed to list Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/TokenRequiredBucketLister`;
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "session-token-protected-listing" }),
+    );
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "TokenRequiredBucketLister",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "TokenRequiredBucketLister",
+        PolicyName: "ListBuckets",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListAllMyBuckets",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "missing-token-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    const accessKeyId = credentials.AccessKeyId;
+    assertNonNullable(accessKeyId);
+    const secretAccessKey = credentials.SecretAccessKey;
+    assertNonNullable(secretAccessKey);
+
+    // When the temporary access key and secret are supplied without the session token.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.listBuckets(new ListBucketsCommand(), {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId,
+            secretAccessKey,
+          },
+        },
+      }),
+    );
+
+    // Then authentication rejects the incomplete temporary credential set.
+    assertInstanceOf(error, SimIamInvalidCredentials);
+    assertIdentical(error.reason, "session-token-missing");
+  });
+});

--- a/src/service/s3/command/list-buckets/list-buckets.handler.ts
+++ b/src/service/s3/command/list-buckets/list-buckets.handler.ts
@@ -15,7 +15,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { ListBucketsAuthorizer } from "./list-buckets-authorizer.js";
 import { ListBucketsPageBuilder } from "./list-buckets-page-builder.js";
 
@@ -26,7 +26,7 @@ interface ListBucketsCommandHandlerProps {
 }
 
 interface ListBucketsCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**

--- a/src/service/s3/command/list-objects/list-objects-authorizer.ts
+++ b/src/service/s3/command/list-objects/list-objects-authorizer.ts
@@ -1,17 +1,17 @@
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 
 interface ListObjectsAuthorizerProps {
   readonly iam: SimIamInterServiceAuthZ;
 }
 
 interface ListObjectsAuthorizationInput {
-  readonly bucketName: SimS3BucketName;
+  readonly bucket: SimS3Bucket;
   readonly prefix?: string | undefined;
   readonly maxKeys: number;
-  readonly caller?: SimAwsPrincipal | undefined;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -39,7 +39,8 @@ export class ListObjectsAuthorizer {
    * Ensure the caller may list the requested portion of the Bucket namespace.
    */
   authorize(input: ListObjectsAuthorizationInput): void {
-    const resource = `arn:aws:s3:::${input.bucketName}`;
+    const resource = `arn:aws:s3:::${input.bucket.bucketName}`;
+    const policy = input.bucket.getPolicy();
     const decision = this.iam.authorize({
       action: ListObjectsAuthorizer.action,
       resource,
@@ -48,6 +49,16 @@ export class ListObjectsAuthorizer {
         "s3:prefix": input.prefix ?? "",
         "s3:max-keys": input.maxKeys,
       },
+      resourcePolicies:
+        policy === undefined
+          ? []
+          : [
+              {
+                document: policy,
+                policyName: "BucketPolicy",
+                resourceArn: resource,
+              },
+            ],
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/list-objects/list-objects-iam-cred.iso.test.ts
+++ b/src/service/s3/command/list-objects/list-objects-iam-cred.iso.test.ts
@@ -1,0 +1,368 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  ListObjectsCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+describe("S3 ListObjectsCommand IAM credential authorization", () => {
+  it("allows IAM User credentials with matching conditions and paginates the listing", async () => {
+    // Given an IAM User allowed to list one prefix in one-key pages.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-report-listing" }),
+    );
+    await Promise.all([
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "credential-report-listing",
+          Key: "reports/a.json",
+          Body: "a",
+        }),
+      ),
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "credential-report-listing",
+          Key: "reports/b.json",
+          Body: "bb",
+        }),
+      ),
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "credential-report-listing",
+          Key: "private/secret.json",
+          Body: "secret",
+        }),
+      ),
+    ]);
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ConditionalObjectLister",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ConditionalObjectLister",
+        PolicyName: "ListReportsOneAtATime",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "arn:aws:s3:::credential-report-listing",
+            Condition: {
+              StringLike: {
+                "s3:prefix": "reports/*",
+              },
+              NumericLessThanEquals: {
+                "s3:max-keys": 1,
+              },
+              StringEquals: {
+                "aws:PrincipalArn": userOutput.User.Arn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "ConditionalObjectLister",
+      }),
+    );
+
+    // When the User lists the first authorized page with its long-lived credentials.
+    const firstPage = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "credential-report-listing",
+        Prefix: "reports/",
+        MaxKeys: 1,
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then IAM authorizes the matching request and S3 returns the first page.
+    assertArrayLength(firstPage.Contents, 1);
+    assertIdentical(firstPage.Contents[0].Key, "reports/a.json");
+    assertIdentical(firstPage.NextMarker, "reports/a.json");
+
+    // When the User supplies the marker to request the next page.
+    const secondPage = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "credential-report-listing",
+        Prefix: "reports/",
+        MaxKeys: 1,
+        Marker: firstPage.NextMarker,
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then pagination resumes after the marker without exposing other prefixes.
+    assertArrayLength(secondPage.Contents, 1);
+    assertIdentical(secondPage.Contents[0].Key, "reports/b.json");
+    assertUndefined(secondPage.NextMarker);
+  });
+
+  it("allows IAM User credentials through a Bucket resource policy", async () => {
+    // Given a User without an identity policy and a Bucket policy granting listing access.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "resource-policy-listing" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "resource-policy-listing",
+        Key: "shared/document.txt",
+        Body: "granted by the bucket policy",
+      }),
+    );
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "BucketPolicyLister",
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "BucketPolicyLister",
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "resource-policy-listing",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: userOutput.User.Arn,
+            },
+            Action: "s3:ListBucket",
+            Resource: "arn:aws:s3:::resource-policy-listing",
+          },
+        }),
+      }),
+    );
+
+    // When the User lists the Bucket with its long-lived credentials.
+    const output = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "resource-policy-listing",
+        Prefix: "shared/",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then the Bucket policy grants access and S3 returns the stored key.
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "shared/document.txt");
+  });
+
+  it("allows assumed Role credentials through the underlying Role policy", async () => {
+    // Given an assumable Role allowed to list a Bucket and a stored Object.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/TemporaryObjectLister`;
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "temporary-credential-listing" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "temporary-credential-listing",
+        Key: "documents/session.txt",
+        Body: "listed through STS",
+      }),
+    );
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "TemporaryObjectLister",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "TemporaryObjectLister",
+        PolicyName: "ListSessionDocuments",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "arn:aws:s3:::temporary-credential-listing",
+          },
+        }),
+      }),
+    );
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "list-objects-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    // When the temporary access key, secret, and session token are supplied to S3.
+    const output = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "temporary-credential-listing",
+        Prefix: "documents/",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: credentials.AccessKeyId,
+            secretAccessKey: credentials.SecretAccessKey,
+            sessionToken: credentials.SessionToken,
+          },
+        },
+      },
+    );
+
+    // Then the session resolves to the Role and S3 returns the stored Object key.
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "documents/session.txt");
+  });
+
+  it("denies valid User credentials when the requested prefix does not satisfy the policy condition", async () => {
+    // Given a User permitted to list only the reports prefix of a Bucket.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "prefix-protected-listing" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "prefix-protected-listing",
+        Key: "private/secret.json",
+      }),
+    );
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ReportsOnlyLister",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ReportsOnlyLister",
+        PolicyName: "ListReportsOnly",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:ListBucket",
+            Resource: "arn:aws:s3:::prefix-protected-listing",
+            Condition: {
+              StringLike: {
+                "s3:prefix": "reports/*",
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "ReportsOnlyLister",
+      }),
+    );
+
+    // When the authenticated User attempts to list the private prefix.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.listObjects(
+        new ListObjectsCommand({
+          Bucket: "prefix-protected-listing",
+          Prefix: "private/",
+        }),
+        {
+          caller: {
+            kind: "credentials",
+            credentials: {
+              accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+              secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+            },
+          },
+        },
+      ),
+    );
+
+    // Then IAM denies the Bucket-level listing before S3 reads Object keys.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:ListBucket");
+    assertIdentical(error.resource, "arn:aws:s3:::prefix-protected-listing");
+  });
+});

--- a/src/service/s3/command/list-objects/list-objects.handler.ts
+++ b/src/service/s3/command/list-objects/list-objects.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { ListObjectsAuthorizer } from "./list-objects-authorizer.js";
 import { ListObjectsPageBuilder } from "./list-objects-page-builder.js";
 
@@ -28,7 +28,7 @@ interface ListObjectsCommandHandlerProps {
 }
 
 interface ListObjectsCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -81,7 +81,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
 
     const maxKeys = cmd.input.MaxKeys ?? 1000;
     this.authorizer.authorize({
-      bucketName,
+      bucket,
       prefix: cmd.input.Prefix,
       maxKeys,
       caller: opts?.caller,

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
@@ -1,0 +1,41 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+
+interface PutBucketPolicyAuthorizerProps {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 PutBucketPolicy request.
+ */
+export class PutBucketPolicyAuthorizer {
+  private static readonly action = "s3:PutBucketPolicy";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(props: PutBucketPolicyAuthorizerProps) {
+    this.iam = props.iam;
+  }
+
+  /**
+   * Ensure the caller may replace the Bucket policy.
+   */
+  authorize(bucketName: SimS3BucketName, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:s3:::${bucketName}`;
+    const decision = this.iam.authorize({
+      action: PutBucketPolicyAuthorizer.action,
+      resource,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: PutBucketPolicyAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.cmd.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.cmd.ts
@@ -1,0 +1,23 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 PutBucketPolicy command.
+ */
+export interface SimPutBucketPolicyCommand {
+  readonly input: SimPutBucketPolicyCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketPolicy input.
+ */
+export interface SimPutBucketPolicyCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Policy?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketPolicy output.
+ */
+export interface SimPutBucketPolicyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { jsonParse } from "../../../../util/type-guard/json.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamPolicyDocumentValidator } from "../../../iam/validate/sim-iam-policy-doc-validator.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+import { PutBucketPolicyAuthorizer } from "./put-bucket-policy-authorizer.js";
+import type {
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput,
+} from "./put-bucket-policy.cmd.js";
+
+interface PutBucketPolicyCommandHandlerProps {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface PutBucketPolicyCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 PutBucketPolicyCommand handler.
+ */
+export class PutBucketPolicyCommandHandler implements CommandHandler<
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: PutBucketPolicyAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly policyValidator: SimIamPolicyDocumentValidator;
+
+  constructor(props: PutBucketPolicyCommandHandlerProps) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = props;
+
+    this.buckets = buckets;
+    this.authorizer = new PutBucketPolicyAuthorizer({ iam });
+    this.background = background;
+    this.policyValidator = new SimIamPolicyDocumentValidator();
+  }
+
+  /**
+   * Validate, authorize, and replace a Bucket's resource policy.
+   */
+  async handle(
+    cmd: SimPutBucketPolicyCommand,
+    opts?: PutBucketPolicyCommandHandlerOptions,
+  ): Promise<SimPutBucketPolicyCommandOutput> {
+    assertDefined(cmd.input.Bucket, "PutBucketPolicyCommand.input.Bucket");
+    assertDefined(cmd.input.Policy, "PutBucketPolicyCommand.input.Policy");
+    this.policyValidator.validateRequired(cmd.input.Policy);
+
+    const bucketName = cmd.input.Bucket as SimS3BucketName;
+    const bucket = this.buckets.get(bucketName);
+    if (bucket === undefined) {
+      throw new SimS3NoSuchBucket(`No S3 Bucket named ${bucketName}`);
+    }
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucketName, opts?.caller);
+
+    bucket.configurePolicy(jsonParse(cmd.input.Policy));
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.iso.test.ts
@@ -1,0 +1,335 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimIamMalformedPolicyDocument } from "../../../iam/error/sim-iam.error.js";
+import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+describe("S3 PutBucketPolicyCommand", () => {
+  it("configures a Bucket policy that grants an IAM User Object write access", async () => {
+    // Given a Bucket and an IAM User with access key credentials but no identity policy.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "policy-granted-writes" }),
+    );
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({ UserName: "BucketPolicyWriter" }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "BucketPolicyWriter" }),
+    );
+
+    // When the Account root caller applies a policy granting the User one Object write.
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "policy-granted-writes",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: userOutput.User.Arn,
+            },
+            Action: "s3:PutObject",
+            Resource: "arn:aws:s3:::policy-granted-writes/shared/report.txt",
+          },
+        }),
+      }),
+    );
+
+    // Then the next S3 operation uses the policy to authorize and persist the Object.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "policy-granted-writes",
+        Key: "shared/report.txt",
+        Body: "written through a bucket policy",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "policy-granted-writes",
+        Key: "shared/report.txt",
+      }),
+    );
+
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("written through a bucket policy"),
+    );
+  });
+
+  it("allows a Role to configure a Bucket policy when its policy condition matches", async () => {
+    // Given a Role allowed to put a policy only when it is the effective principal.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "conditional-policy-bucket" }),
+    );
+    const createRoleOutput = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ConditionalPolicyAdministrator",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    const roleArn = createRoleOutput.Role.Arn;
+
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ConditionalPolicyAdministrator",
+        PolicyName: "PutConditionalBucketPolicy",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:PutBucketPolicy",
+            Resource: "arn:aws:s3:::conditional-policy-bucket",
+            Condition: {
+              StringEquals: {
+                "aws:PrincipalArn": roleArn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    // When the Role configures a Bucket policy as the matching principal.
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "conditional-policy-bucket",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:PutObject",
+            Resource: "arn:aws:s3:::conditional-policy-bucket/public/*",
+          },
+        }),
+      }),
+      {
+        caller: { kind: "arn", arn: roleArn },
+      },
+    );
+
+    // Then the configured policy reaches authorization for a subsequent anonymous write.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "conditional-policy-bucket",
+        Key: "public/notice.txt",
+        Body: "published",
+      }),
+      {
+        caller: { kind: "anonymous" },
+      },
+    );
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "conditional-policy-bucket",
+        Key: "public/notice.txt",
+      }),
+    );
+
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("published"),
+    );
+  });
+
+  it("denies a caller without PutBucketPolicy permission", async () => {
+    // Given an existing Bucket and a Role without an S3 policy-administration grant.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "protected-policy-bucket" }),
+    );
+    const createRoleOutput = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "UnprivilegedPolicyWriter",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the unprivileged Role attempts to configure the Bucket policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        new PutBucketPolicyCommand({
+          Bucket: "protected-policy-bucket",
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: "*",
+              Action: "s3:PutObject",
+              Resource: "arn:aws:s3:::protected-policy-bucket/*",
+            },
+          }),
+        }),
+        {
+          caller: { kind: "arn", arn: createRoleOutput.Role.Arn },
+        },
+      ),
+    );
+
+    // Then IAM denies the Bucket-level policy administration action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:PutBucketPolicy");
+    assertIdentical(error.resource, "arn:aws:s3:::protected-policy-bucket");
+  });
+
+  it("rejects missing required request inputs", async () => {
+    // Given the top-level simulated S3 service.
+    const simS3 = new SimAws().s3();
+
+    // When PutBucketPolicy is called without its required Bucket.
+    const bucketError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        // @ts-expect-error -- testing invalid input
+        new PutBucketPolicyCommand({
+          Policy: JSON.stringify({ Version: "2012-10-17", Statement: [] }),
+        }),
+      ),
+    );
+
+    // Then request validation identifies the missing Bucket input.
+    assertStringIncludes(
+      bucketError.message,
+      "PutBucketPolicyCommand.input.Bucket",
+    );
+
+    // When PutBucketPolicy is called without its required Policy.
+    const policyError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        // @ts-expect-error -- testing invalid input
+        new PutBucketPolicyCommand({
+          Bucket: "missing-policy-bucket",
+        }),
+      ),
+    );
+
+    // Then request validation identifies the missing Policy input.
+    assertStringIncludes(
+      policyError.message,
+      "PutBucketPolicyCommand.input.Policy",
+    );
+  });
+
+  it("rejects a non-existent Bucket before configuring its policy", async () => {
+    // Given the top-level simulated S3 service without the requested Bucket.
+    const simS3 = new SimAws().s3();
+
+    // When PutBucketPolicy targets the missing Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        new PutBucketPolicyCommand({
+          Bucket: "does-not-exist",
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: "*",
+              Action: "s3:PutObject",
+              Resource: "arn:aws:s3:::does-not-exist/*",
+            },
+          }),
+        }),
+      ),
+    );
+
+    // Then S3 returns its missing-Bucket error.
+    assertInstanceOf(error, SimS3NoSuchBucket);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("rejects a policy document with an invalid statement effect", async () => {
+    // Given an existing Bucket and an invalid IAM policy document.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "invalid-policy-bucket" }),
+    );
+
+    // When PutBucketPolicy receives the malformed policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        new PutBucketPolicyCommand({
+          Bucket: "invalid-policy-bucket",
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Permit",
+              Principal: "*",
+              Action: "s3:PutObject",
+              Resource: "arn:aws:s3:::invalid-policy-bucket/*",
+            },
+          }),
+        }),
+      ),
+    );
+
+    // Then policy validation rejects it before the Bucket policy is changed.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+  });
+});

--- a/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
@@ -1,4 +1,4 @@
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
@@ -39,7 +39,7 @@ export class PutBucketWebsiteAuthorizer {
    * This method returns only for an allowed decision. A denied decision becomes
    * the service-shaped access error expected by callers of the S3 simulation.
    */
-  authorize(bucketName: SimS3BucketName, caller?: SimAwsPrincipal): void {
+  authorize(bucketName: SimS3BucketName, caller?: SimAwsCaller): void {
     const resource = `arn:aws:s3:::${bucketName}`;
     const decision = this.iam.authorize({
       action: PutBucketWebsiteAuthorizer.action,

--- a/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website.handler.ts
@@ -15,7 +15,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimIam } from "../../../iam/index.js";
 import { PutBucketWebsiteAuthorizer } from "./put-bucket-website-authorizer.js";
 
@@ -26,7 +26,7 @@ interface PutBucketWebsiteCommandHandlerProps {
 }
 
 interface PutBucketWebsiteCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**

--- a/src/service/s3/command/put-object/put-object-authorizer.ts
+++ b/src/service/s3/command/put-object/put-object-authorizer.ts
@@ -1,7 +1,7 @@
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 
 interface PutObjectAuthorizerProps {
   readonly iam: SimIamInterServiceAuthZ;
@@ -26,16 +26,23 @@ export class PutObjectAuthorizer {
   /**
    * Ensure the caller may create or replace the requested S3 Object.
    */
-  authorize(
-    bucketName: SimS3BucketName,
-    key: string,
-    caller?: SimAwsPrincipal,
-  ): void {
-    const resource = `arn:aws:s3:::${bucketName}/${key}`;
+  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
+    const policy = bucket.getPolicy();
     const decision = this.iam.authorize({
       action: PutObjectAuthorizer.action,
       resource,
       caller,
+      resourcePolicies:
+        policy === undefined
+          ? []
+          : [
+              {
+                document: policy,
+                policyName: "BucketPolicy",
+                resourceArn: `arn:aws:s3:::${bucket.bucketName}`,
+              },
+            ],
     });
 
     if (decision.isDenied) {

--- a/src/service/s3/command/put-object/put-object-iam-cred.iso.test.ts
+++ b/src/service/s3/command/put-object/put-object-iam-cred.iso.test.ts
@@ -1,0 +1,383 @@
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamInvalidCredentials } from "../../../iam/credential/error/sim-iam-credential.error.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+describe("S3 PutObjectCommand IAM credential authorization", () => {
+  it("allows IAM User credentials when the policy condition matches", async () => {
+    // Given an IAM User permitted to write one Object as its own principal.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "user-credential-writes" }),
+    );
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "ConditionalObjectWriter",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "ConditionalObjectWriter",
+        PolicyName: "WriteCurrentReport",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:PutObject",
+            Resource:
+              "arn:aws:s3:::user-credential-writes/reports/current.json",
+            Condition: {
+              StringEquals: {
+                "aws:PrincipalArn": userOutput.User.Arn,
+              },
+            },
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "ConditionalObjectWriter",
+      }),
+    );
+
+    // When the User writes the authorized Object with its long-lived credentials.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "user-credential-writes",
+        Key: "reports/current.json",
+        Body: '{"status":"ready"}',
+        Metadata: {
+          source: "credential-test",
+        },
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then IAM permits the write and the next S3 operation reads the stored Object.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "user-credential-writes",
+        Key: "reports/current.json",
+      }),
+    );
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from('{"status":"ready"}'),
+    );
+    assertIdentical(output.Metadata?.["source"], "credential-test");
+  });
+
+  it("allows IAM User credentials through a Bucket resource policy", async () => {
+    // Given a User without an identity policy and a Bucket policy granting one write.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "resource-policy-writes" }),
+    );
+    const userOutput = await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "BucketPolicyWriter",
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "BucketPolicyWriter",
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "resource-policy-writes",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: userOutput.User.Arn,
+            },
+            Action: "s3:PutObject",
+            Resource: "arn:aws:s3:::resource-policy-writes/shared/document.txt",
+          },
+        }),
+      }),
+    );
+
+    // When the User writes the Object with its long-lived credentials.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "resource-policy-writes",
+        Key: "shared/document.txt",
+        Body: "granted by the bucket policy",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+            secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+          },
+        },
+      },
+    );
+
+    // Then the Bucket policy grants access and S3 stores the supplied body.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "resource-policy-writes",
+        Key: "shared/document.txt",
+      }),
+    );
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("granted by the bucket policy"),
+    );
+  });
+
+  it("allows assumed Role credentials through the underlying Role policy", async () => {
+    // Given an assumable Role permitted to write one Object.
+    const accountId = makeSimAwsAccountId();
+    const region = makeAwsRegionName();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region(region).s3();
+    const roleArn = `arn:aws:iam::${accountId}:role/TemporaryObjectWriter`;
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "temporary-credential-writes" }),
+    );
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "TemporaryObjectWriter",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: {
+              AWS: `arn:aws:iam::${accountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "TemporaryObjectWriter",
+        PolicyName: "WriteSessionDocument",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:PutObject",
+            Resource:
+              "arn:aws:s3:::temporary-credential-writes/documents/session.txt",
+          },
+        }),
+      }),
+    );
+    const assumeRoleOutput = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        RoleSessionName: "put-object-session",
+      }),
+    );
+    const credentials = assumeRoleOutput.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    // When S3 receives the temporary access key, secret, and session token.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "temporary-credential-writes",
+        Key: "documents/session.txt",
+        Body: "written through an STS session",
+      }),
+      {
+        caller: {
+          kind: "credentials",
+          credentials: {
+            accessKeyId: credentials.AccessKeyId,
+            secretAccessKey: credentials.SecretAccessKey,
+            sessionToken: credentials.SessionToken,
+          },
+        },
+      },
+    );
+
+    // Then the session resolves to the Role and S3 persists the Object.
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "temporary-credential-writes",
+        Key: "documents/session.txt",
+      }),
+    );
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("written through an STS session"),
+    );
+  });
+
+  it("denies valid User credentials without permission for the Object and retains existing content", async () => {
+    // Given an existing Object and a User permitted to write only public Objects.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-denied-writes" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "credential-denied-writes",
+        Key: "private/secret.txt",
+        Body: "original secret",
+      }),
+    );
+    await simIam.createUser(
+      new CreateUserCommand({
+        UserName: "LimitedWriter",
+      }),
+    );
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "LimitedWriter",
+        PolicyName: "WritePublicObjects",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:PutObject",
+            Resource: "arn:aws:s3:::credential-denied-writes/public/*",
+          },
+        }),
+      }),
+    );
+    const accessKeyOutput = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({
+        UserName: "LimitedWriter",
+      }),
+    );
+
+    // When the authenticated User attempts to replace an Object outside its policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "credential-denied-writes",
+          Key: "private/secret.txt",
+          Body: "replacement secret",
+        }),
+        {
+          caller: {
+            kind: "credentials",
+            credentials: {
+              accessKeyId: accessKeyOutput.AccessKey.AccessKeyId,
+              secretAccessKey: accessKeyOutput.AccessKey.SecretAccessKey,
+            },
+          },
+        },
+      ),
+    );
+
+    // Then IAM denies the exact Object resource before S3 mutates stored content.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:PutObject");
+    assertIdentical(
+      error.resource,
+      "arn:aws:s3:::credential-denied-writes/private/secret.txt",
+    );
+
+    const output = await simS3.getObject(
+      new GetObjectCommand({
+        Bucket: "credential-denied-writes",
+        Key: "private/secret.txt",
+      }),
+    );
+    assertInstanceOf(output.Body, Readable);
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body),
+      Buffer.from("original secret"),
+    );
+  });
+
+  it("rejects invalid credentials before creating an Object", async () => {
+    // Given an existing Bucket and credentials containing an unknown access key.
+    const simAws = new SimAws();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "credential-authentication-writes" }),
+    );
+
+    // When the invalid credentials attempt to write an Object.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "credential-authentication-writes",
+          Key: "new.txt",
+          Body: "must not be stored",
+        }),
+        {
+          caller: {
+            kind: "credentials",
+            credentials: {
+              accessKeyId: "AKIAUNKNOWN",
+              secretAccessKey: "not-a-valid-secret",
+            },
+          },
+        },
+      ),
+    );
+
+    // Then credential authentication fails before S3 authorizes or stores the Object.
+    assertInstanceOf(error, SimIamInvalidCredentials);
+    assertIdentical(error.reason, "unknown-access-key");
+  });
+});

--- a/src/service/s3/command/put-object/put-object.handler.ts
+++ b/src/service/s3/command/put-object/put-object.handler.ts
@@ -17,7 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { PutObjectAuthorizer } from "./put-object-authorizer.js";
 import { PutObjectBuilder } from "./put-object-builder.js";
 
@@ -28,7 +28,7 @@ interface PutObjectCommandHandlerProps {
 }
 
 interface PutObjectCommandHandlerOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -84,7 +84,7 @@ export class PutObjectCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    this.authorizer.authorize(bucketName, cmd.input.Key, opts?.caller);
+    this.authorizer.authorize(bucket, cmd.input.Key, opts?.caller);
 
     const object = this.objectBuilder.build(cmd);
     await bucket.putObject(object);

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -40,14 +40,19 @@ import {
 import { SimS3CloudFormationResourceFactory } from "./cfn/sim-cfn-s3-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import type { SimAwsPrincipal } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput,
+} from "./command/put-bucket-policy/put-bucket-policy.cmd.js";
+import { PutBucketPolicyCommandHandler } from "./command/put-bucket-policy/put-bucket-policy.handler.js";
 
 export interface SimS3RequestOptions {
-  readonly caller?: SimAwsPrincipal;
+  readonly caller?: SimAwsCaller;
 }
 
 interface SimS3Props {
@@ -96,6 +101,21 @@ export class SimS3 {
       accountRegionScope: this.accountRegionScope,
       buckets: this.buckets,
       s3GlobalRegistry: this.s3GlobalRegistry,
+      iam: this.iam,
+      background: this.background,
+    });
+    return await handler.handle(cmd, opts);
+  }
+
+  /**
+   * Handle a Put Bucket Policy Command from the SDK.
+   */
+  async putBucketPolicy(
+    cmd: SimPutBucketPolicyCommand,
+    opts?: SimS3RequestOptions,
+  ): Promise<SimPutBucketPolicyCommandOutput> {
+    const handler = new PutBucketPolicyCommandHandler({
+      buckets: this.buckets,
       iam: this.iam,
       background: this.background,
     });


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM `PutUserPolicy` support for creating and replacing inline user policies.
  * Added S3 `PutBucketPolicy` support, including bucket policy configuration and retrieval.
  * Added IAM credential authentication for S3 operations, including user access keys and assumed-role credentials.
  * S3 authorization now supports bucket resource policies for object, listing, and write operations.

* **Bug Fixes**
  * Improved validation and error handling for invalid credentials, missing resources, and malformed policies.

* **Tests**
  * Added coverage for credential-based authorization, policy conditions, pagination, access denial, and policy replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->