### PR TITLE
feat: initial simulated SDK for command interception

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
       "import": "./dist/service/route53/index.js",
       "types": "./dist/service/route53/index.d.ts"
     },
+    "./sdk": {
+      "import": "./dist/sdk/index.js",
+      "types": "./dist/sdk/index.d.ts"
+    },
     "./serve": {
       "import": "./dist/serve/index.js",
       "types": "./dist/serve/index.d.ts"

--- a/src/sdk/client/sim-sdk-client.iso.test.ts
+++ b/src/sdk/client/sim-sdk-client.iso.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdkInvalidClientError } from "../error/sim-sdk.error.js";
+import {
+  simSdkClientRegionName,
+  simSdkClientServiceId,
+} from "./sim-sdk-client.js";
+
+describe("simulated SDK client service identity", () => {
+  it("reads the service id from the client config", () => {
+    const client = { config: { serviceId: "S3" } };
+
+    assertIdentical(simSdkClientServiceId(client), "S3");
+  });
+
+  it("rejects a client that is not an object", () => {
+    const error = assertThrowsError(() => simSdkClientServiceId("nope"));
+
+    assertInstanceOf(error, SimSdkInvalidClientError);
+  });
+
+  it("rejects a client without a config", () => {
+    const error = assertThrowsError(() => simSdkClientServiceId({}));
+
+    assertInstanceOf(error, SimSdkInvalidClientError);
+  });
+
+  it("rejects a client config without a service id", () => {
+    const error = assertThrowsError(() =>
+      simSdkClientServiceId({ config: { serviceId: "" } }),
+    );
+
+    assertInstanceOf(error, SimSdkInvalidClientError);
+  });
+});
+
+describe("simulated SDK client Region resolution", () => {
+  it("uses a client Region configured as a string", async () => {
+    const client = { config: { region: "eu-west-2" } };
+
+    assertIdentical(
+      await simSdkClientRegionName(client, "us-east-1"),
+      "eu-west-2",
+    );
+  });
+
+  it("resolves a client Region provider function", async () => {
+    const client = { config: { region: () => Promise.resolve("eu-west-2") } };
+
+    assertIdentical(
+      await simSdkClientRegionName(client, "us-east-1"),
+      "eu-west-2",
+    );
+  });
+
+  it("falls back when the client has no Region configured", async () => {
+    const client = { config: { serviceId: "S3" } };
+
+    assertIdentical(
+      await simSdkClientRegionName(client, "us-east-1"),
+      "us-east-1",
+    );
+  });
+
+  it("falls back when the client Region provider fails", async () => {
+    const client = {
+      config: {
+        region: () => Promise.reject(new Error("Region is missing")),
+      },
+    };
+
+    assertIdentical(
+      await simSdkClientRegionName(client, "us-east-1"),
+      "us-east-1",
+    );
+  });
+
+  it("falls back when the client Region provider resolves a non-string", async () => {
+    const client = { config: { region: () => Promise.resolve(42) } };
+
+    assertIdentical(
+      await simSdkClientRegionName(client, "us-east-1"),
+      "us-east-1",
+    );
+  });
+
+  it("rejects an unknown AWS Region name", async () => {
+    const client = { config: { region: "narnia-1" } };
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simSdkClientRegionName(client, "us-east-1");
+    });
+
+    assertInstanceOf(error, SimSdkInvalidClientError);
+  });
+});

--- a/src/sdk/client/sim-sdk-client.ts
+++ b/src/sdk/client/sim-sdk-client.ts
@@ -1,0 +1,75 @@
+import {
+  AWS_REGION_NAMES,
+  type AwsRegionName,
+} from "../../service/aws/sim-aws-region.js";
+import { isRecord } from "../../util/type-guard/record.js";
+import { SimSdkInvalidClientError } from "../error/sim-sdk.error.js";
+
+/**
+ * Get the resolved config of an SDK client, if it has one.
+ */
+function clientConfig(client: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(client)) {
+    return undefined;
+  }
+  const config = client["config"];
+  return isRecord(config) ? config : undefined;
+}
+
+/**
+ * Identify the AWS service an intercepted SDK client belongs to.
+ *
+ * Real SDK clients carry the service identity in their resolved config, e.g.
+ * "S3" or "DynamoDB", which is more reliable than parsing class names.
+ */
+export function simSdkClientServiceId(client: unknown): string {
+  const serviceId = clientConfig(client)?.["serviceId"];
+  if (typeof serviceId !== "string" || serviceId.length === 0) {
+    throw new SimSdkInvalidClientError(
+      "Intercepted SDK client has no config.serviceId to identify its AWS " +
+        "service",
+    );
+  }
+  return serviceId;
+}
+
+/**
+ * Resolve the AWS Region an intercepted SDK client is configured for.
+ *
+ * Real SDK clients normalize the region to an async provider function. The
+ * fallback Region is used when the client has no region configured or its
+ * provider fails, so interception never depends on real environment or
+ * network region resolution.
+ */
+export async function simSdkClientRegionName(
+  client: unknown,
+  fallback: AwsRegionName,
+): Promise<AwsRegionName> {
+  const region = clientConfig(client)?.["region"];
+  if (typeof region === "string") {
+    return toAwsRegionName(region);
+  }
+  if (typeof region !== "function") {
+    return fallback;
+  }
+
+  let resolved: unknown;
+  try {
+    resolved = await (region as () => unknown)();
+  } catch {
+    return fallback;
+  }
+  return typeof resolved === "string" ? toAwsRegionName(resolved) : fallback;
+}
+
+/**
+ * Validate that a client-configured region string is a known AWS Region.
+ */
+function toAwsRegionName(value: string): AwsRegionName {
+  if (!(AWS_REGION_NAMES as readonly string[]).includes(value)) {
+    throw new SimSdkInvalidClientError(
+      `Intercepted SDK client Region ${value} is not a known AWS Region`,
+    );
+  }
+  return value as AwsRegionName;
+}

--- a/src/sdk/error/sim-sdk.error.ts
+++ b/src/sdk/error/sim-sdk.error.ts
@@ -33,6 +33,16 @@ export class SimSdkCommandNotInterceptedError extends SimSdkError {
 }
 
 /**
+ * The SDK client instance or client class is already intercepted.
+ *
+ * Multiple simultaneous interceptions of the same client could only ever be
+ * confusing, so the existing interception must be restored first.
+ */
+export class SimSdkAlreadyInterceptedError extends SimSdkError {
+  public override readonly name = "SimSdkAlreadyInterceptedError";
+}
+
+/**
  * The intercepted SDK client send was called with an unsupported callback
  * argument.
  */

--- a/src/sdk/error/sim-sdk.error.ts
+++ b/src/sdk/error/sim-sdk.error.ts
@@ -1,0 +1,48 @@
+/**
+ * Base class for simulated AWS SDK errors.
+ */
+export class SimSdkError extends Error {}
+
+/**
+ * The intercepted client is not usable for simulated AWS SDK routing.
+ */
+export class SimSdkInvalidClientError extends SimSdkError {
+  public override readonly name = "SimSdkInvalidClientError";
+}
+
+/**
+ * The intercepted client belongs to an AWS service without simulated AWS SDK
+ * interception support.
+ */
+export class SimSdkUnknownServiceError extends SimSdkError {
+  public override readonly name = "SimSdkUnknownServiceError";
+}
+
+/**
+ * The intercepted SDK Command is not supported by the simulated AWS service.
+ */
+export class SimSdkUnsupportedCommandError extends SimSdkError {
+  public override readonly name = "SimSdkUnsupportedCommandError";
+}
+
+/**
+ * The SDK Command is excluded by an interception's Command allow list.
+ */
+export class SimSdkCommandNotInterceptedError extends SimSdkError {
+  public override readonly name = "SimSdkCommandNotInterceptedError";
+}
+
+/**
+ * The intercepted SDK client send was called with an unsupported callback
+ * argument.
+ */
+export class SimSdkCallbackNotSupportedError extends SimSdkError {
+  public override readonly name = "SimSdkCallbackNotSupportedError";
+}
+
+/**
+ * A simulated SDK stream body was consumed more than once.
+ */
+export class SimSdkStreamAlreadyConsumedError extends SimSdkError {
+  public override readonly name = "SimSdkStreamAlreadyConsumedError";
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,26 @@
+export { SimSdk } from "./sim-sdk.js";
+export type {
+  SimSdkCommandType,
+  SimSdkInterceptOptions,
+  SimSdkInterceptTarget,
+} from "./sim-sdk.js";
+export { SimSdkInterception } from "./sim-sdk-interception.js";
+export type {
+  SimSdkCommand,
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "./router/sim-sdk-command-router.type.js";
+export { simSdkStreamBody } from "./stream/sim-sdk-stream-body.js";
+export type {
+  SimSdkStreamBody,
+  SimSdkStreamBodyMethods,
+} from "./stream/sim-sdk-stream-body.js";
+export {
+  SimSdkError,
+  SimSdkCallbackNotSupportedError,
+  SimSdkCommandNotInterceptedError,
+  SimSdkInvalidClientError,
+  SimSdkStreamAlreadyConsumedError,
+  SimSdkUnknownServiceError,
+  SimSdkUnsupportedCommandError,
+} from "./error/sim-sdk.error.js";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -17,6 +17,7 @@ export type {
 } from "./stream/sim-sdk-stream-body.js";
 export {
   SimSdkError,
+  SimSdkAlreadyInterceptedError,
   SimSdkCallbackNotSupportedError,
   SimSdkCommandNotInterceptedError,
   SimSdkInvalidClientError,

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -1,0 +1,36 @@
+import type { SimAwsAccountId } from "../../service/aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
+import type { SimAws } from "../../service/aws/sim-aws.js";
+import { SimSdkUnknownServiceError } from "../error/sim-sdk.error.js";
+import type { SimSdkCommandRouter } from "./sim-sdk-command-router.type.js";
+
+/**
+ * Resolve the scoped simulated service SDK Command router for an intercepted
+ * client's AWS service.
+ *
+ * Mirrors the CloudFormation service resolver: the interception engine
+ * resolves the Account/Region scope and the service identity, then the scoped
+ * simulated service owns its own Command routing. Simulated services come
+ * into existence lazily here, on the first intercepted Command that reaches
+ * them.
+ */
+export function resolveSimSdkCommandRouter(
+  simAws: SimAws,
+  serviceId: string,
+  accountId: SimAwsAccountId | string,
+  regionName: AwsRegionName,
+): SimSdkCommandRouter {
+  const scoped = simAws.account(accountId).region(regionName);
+
+  switch (serviceId) {
+    case "S3": {
+      return scoped.s3().sdkCommandRouter();
+    }
+    default: {
+      throw new SimSdkUnknownServiceError(
+        `Simulated AWS has no SDK interception support for service ` +
+          `${serviceId} yet`,
+      );
+    }
+  }
+}

--- a/src/sdk/router/sim-sdk-command-router.type.ts
+++ b/src/sdk/router/sim-sdk-command-router.type.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimal structural SDK Command shape as received by interception.
+ */
+export interface SimSdkCommand {
+  readonly input?: unknown;
+}
+
+/**
+ * Route one intercepted SDK Command to a simulated service operation.
+ */
+export type SimSdkCommandRoute = (command: SimSdkCommand) => Promise<unknown>;
+
+/**
+ * Routes intercepted SDK Commands to the operations of one scoped simulated
+ * AWS service instance.
+ *
+ * Each simulated service owns its router implementation, next to its
+ * CloudFormation resource factory: the SDK interception engine routes, but
+ * never knows service Command schemas.
+ */
+export interface SimSdkCommandRouter {
+  /**
+   * The SDK Command names this simulated service can handle.
+   */
+  supportedCommandNames(): readonly string[];
+
+  /**
+   * Get the route for an SDK Command name, if the simulated service supports
+   * it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined;
+}

--- a/src/sdk/send-patch.iso.test.ts
+++ b/src/sdk/send-patch.iso.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "vitest";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { SimSdkCallbackNotSupportedError } from "./error/sim-sdk.error.js";
+import { installSendPatch } from "./send-patch.js";
+
+interface SendCapable {
+  send(command: object, ...rest: unknown[]): Promise<unknown>;
+}
+
+class FakeClient implements SendCapable {
+  send(): Promise<unknown> {
+    return Promise.resolve("real send");
+  }
+}
+
+function ownSendValue(target: object): unknown {
+  return Object.getOwnPropertyDescriptor(target, "send")?.value;
+}
+
+describe("SDK client send patch", () => {
+  it("routes send calls to the handler with the command and client", async () => {
+    const client: SendCapable = new FakeClient();
+    const seen: { command?: object; client?: unknown } = {};
+
+    const patch = installSendPatch(client, (command, sendClient) => {
+      seen.command = command;
+      seen.client = sendClient;
+      return Promise.resolve("simulated send");
+    });
+
+    const command = { input: {} };
+    assertIdentical(await client.send(command), "simulated send");
+    assertIdentical(seen.command, command);
+    assertIdentical(seen.client, client);
+    assertTrue(patch.isInstalled());
+  });
+
+  it("patches a client class prototype for all instances", async () => {
+    class PrototypeClient implements SendCapable {
+      send(): Promise<unknown> {
+        return Promise.resolve("real send");
+      }
+    }
+    const patch = installSendPatch(
+      PrototypeClient.prototype,
+      (_command, client) => Promise.resolve(client),
+    );
+
+    const clientA: SendCapable = new PrototypeClient();
+    const clientB: SendCapable = new PrototypeClient();
+    assertIdentical(await clientA.send({}), clientA);
+    assertIdentical(await clientB.send({}), clientB);
+
+    patch.restore();
+    assertIdentical(await clientA.send({}), "real send");
+  });
+
+  it("restores the inherited send when the instance had no own send", async () => {
+    const client: SendCapable = new FakeClient();
+
+    const patch = installSendPatch(client, () => Promise.resolve("simulated"));
+    assertTrue(Object.hasOwn(client, "send"));
+
+    patch.restore();
+    assertFalse(Object.hasOwn(client, "send"));
+    assertFalse(patch.isInstalled());
+    assertIdentical(await client.send({}), "real send");
+  });
+
+  it("restores a previous own send", async () => {
+    const client: SendCapable = new FakeClient();
+    const ownSend = (): Promise<unknown> => Promise.resolve("own send");
+    client.send = ownSend;
+
+    const patch = installSendPatch(client, () => Promise.resolve("simulated"));
+    assertIdentical(await client.send({}), "simulated");
+
+    patch.restore();
+    assertIdentical(ownSendValue(client), ownSend);
+    assertIdentical(await client.send({}), "own send");
+  });
+
+  it("does not clobber a send installed after the patch", () => {
+    const client: SendCapable = new FakeClient();
+    const patch = installSendPatch(client, () => Promise.resolve("simulated"));
+
+    const laterSend = (): Promise<unknown> => Promise.resolve("later send");
+    client.send = laterSend;
+
+    assertFalse(patch.isInstalled());
+    patch.restore();
+    assertIdentical(ownSendValue(client), laterSend);
+  });
+
+  it("rejects callback-style send calls", async () => {
+    const client: SendCapable = new FakeClient();
+    installSendPatch(client, () => Promise.resolve("simulated"));
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send({}, () => undefined);
+    });
+
+    assertInstanceOf(error, SimSdkCallbackNotSupportedError);
+  });
+});

--- a/src/sdk/send-patch.iso.test.ts
+++ b/src/sdk/send-patch.iso.test.ts
@@ -3,10 +3,15 @@ import {
   assertFalse,
   assertIdentical,
   assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
   assertThrowsErrorAsync,
   assertTrue,
 } from "@kensio/smartass";
-import { SimSdkCallbackNotSupportedError } from "./error/sim-sdk.error.js";
+import {
+  SimSdkAlreadyInterceptedError,
+  SimSdkCallbackNotSupportedError,
+} from "./error/sim-sdk.error.js";
 import { installSendPatch } from "./send-patch.js";
 
 interface SendCapable {
@@ -96,6 +101,40 @@ describe("SDK client send patch", () => {
     assertFalse(patch.isInstalled());
     patch.restore();
     assertIdentical(ownSendValue(client), laterSend);
+  });
+
+  it("rejects patching a send that is already patched", () => {
+    const client: SendCapable = new FakeClient();
+    installSendPatch(client, () => Promise.resolve("simulated"));
+
+    const error = assertThrowsError(() => {
+      installSendPatch(client, () => Promise.resolve("simulated again"));
+    });
+
+    assertInstanceOf(error, SimSdkAlreadyInterceptedError);
+    assertStringIncludes(error.message, "FakeClient");
+  });
+
+  it("names an unnameable patch target as target in the rejection", () => {
+    const bare = Object.create(null) as object;
+    installSendPatch(bare, () => Promise.resolve("simulated"));
+
+    const error = assertThrowsError(() => {
+      installSendPatch(bare, () => Promise.resolve("simulated again"));
+    });
+
+    assertStringIncludes(error.message, "SDK client target");
+  });
+
+  it("allows patching again after a restore", async () => {
+    const client: SendCapable = new FakeClient();
+    const first = installSendPatch(client, () => Promise.resolve("first"));
+    first.restore();
+
+    const second = installSendPatch(client, () => Promise.resolve("second"));
+
+    assertTrue(second.isInstalled());
+    assertIdentical(await client.send({}), "second");
   });
 
   it("rejects callback-style send calls", async () => {

--- a/src/sdk/send-patch.ts
+++ b/src/sdk/send-patch.ts
@@ -1,0 +1,83 @@
+import { SimSdkCallbackNotSupportedError } from "./error/sim-sdk.error.js";
+
+/**
+ * Handler for SDK Commands sent through a patched client send method.
+ * Receives the SDK Command instance and the client send was called on.
+ */
+export type SimSdkSendHandler = (
+  command: object,
+  client: unknown,
+) => Promise<unknown>;
+
+/**
+ * An installed send patch on one SDK client instance or client class
+ * prototype.
+ */
+export interface SimSdkSendPatch {
+  /**
+   * Whether the patched send is still the one installed on the target.
+   */
+  isInstalled(): boolean;
+
+  /**
+   * Restore the send behaviour the target had before this patch.
+   *
+   * Does nothing if the patched send was replaced after installation, so a
+   * later patch by other code is never clobbered.
+   */
+  restore(): void;
+}
+
+/**
+ * Install a simulated send method on an SDK client instance or client class
+ * prototype.
+ *
+ * The patch shadows the inherited SDK send with an own property, which is why
+ * no SDK import is needed: restoring simply removes the shadow so the real
+ * inherited send resolves again.
+ */
+export function installSendPatch(
+  target: object,
+  handler: SimSdkSendHandler,
+): SimSdkSendPatch {
+  const previous = Object.getOwnPropertyDescriptor(target, "send");
+
+  const patched = async function (
+    this: unknown,
+    command: object,
+    ...rest: unknown[]
+  ): Promise<unknown> {
+    const callback = rest.find((argument) => typeof argument === "function");
+    if (callback !== undefined) {
+      throw new SimSdkCallbackNotSupportedError(
+        "Simulated SDK interception does not support callback-style send; " +
+          "use the promise form instead",
+      );
+    }
+    // eslint-disable-next-line unicorn/no-this-outside-of-class -- this is the client instance send was called on, which the handler needs for per-send config resolution.
+    return await handler(command, this);
+  };
+
+  Object.defineProperty(target, "send", {
+    value: patched,
+    writable: true,
+    configurable: true,
+  });
+
+  const isInstalled = (): boolean =>
+    Object.getOwnPropertyDescriptor(target, "send")?.value === patched;
+
+  return {
+    isInstalled,
+    restore(): void {
+      if (!isInstalled()) {
+        return;
+      }
+      if (previous === undefined) {
+        Reflect.deleteProperty(target, "send");
+        return;
+      }
+      Object.defineProperty(target, "send", previous);
+    },
+  };
+}

--- a/src/sdk/send-patch.ts
+++ b/src/sdk/send-patch.ts
@@ -1,4 +1,14 @@
-import { SimSdkCallbackNotSupportedError } from "./error/sim-sdk.error.js";
+import {
+  SimSdkAlreadyInterceptedError,
+  SimSdkCallbackNotSupportedError,
+} from "./error/sim-sdk.error.js";
+
+/**
+ * All send functions installed by simulated SDK interception, so a second
+ * interception of an already-intercepted target can be rejected, including
+ * across separate SimSdk instances.
+ */
+const installedSends = new WeakSet<object>();
 
 /**
  * Handler for SDK Commands sent through a patched client send method.
@@ -41,6 +51,13 @@ export function installSendPatch(
   handler: SimSdkSendHandler,
 ): SimSdkSendPatch {
   const previous = Object.getOwnPropertyDescriptor(target, "send");
+  const previousSend: unknown = previous?.value;
+  if (typeof previousSend === "function" && installedSends.has(previousSend)) {
+    throw new SimSdkAlreadyInterceptedError(
+      `SDK client ${patchTargetName(target)} is already intercepted; ` +
+        `restore the existing interception before intercepting it again`,
+    );
+  }
 
   const patched = async function (
     this: unknown,
@@ -58,6 +75,7 @@ export function installSendPatch(
     return await handler(command, this);
   };
 
+  installedSends.add(patched);
   Object.defineProperty(target, "send", {
     value: patched,
     writable: true,
@@ -80,4 +98,14 @@ export function installSendPatch(
       Object.defineProperty(target, "send", previous);
     },
   };
+}
+
+/**
+ * Name a patch target for diagnostics: the client's class name for instances
+ * and prototypes alike, when it has one.
+ */
+function patchTargetName(target: object): string {
+  const constructor = (target as { constructor?: { name?: string } })
+    .constructor;
+  return constructor?.name ?? "target";
 }

--- a/src/sdk/sim-sdk-command-dispatcher.ts
+++ b/src/sdk/sim-sdk-command-dispatcher.ts
@@ -70,6 +70,10 @@ export class SimSdkCommandDispatcher {
   /**
    * Resolve the AWS Account of the ambient SimAws.runAs caller, if one is
    * set for this dispatcher's SimAws instance and identifies an Account.
+   *
+   * Only this SimAws instance's own run-as caller applies: a run-as on a
+   * different SimAws instance is a different simulated universe and never
+   * affects Commands dispatched here.
    */
   private ambientAccountId(): string | undefined {
     const caller = simAwsRunAsContext.currentCaller(this.simAws);

--- a/src/sdk/sim-sdk-command-dispatcher.ts
+++ b/src/sdk/sim-sdk-command-dispatcher.ts
@@ -1,0 +1,81 @@
+import { SimAwsCallerResolver } from "../service/aws/caller/sim-aws-caller-resolver.js";
+import { simAwsRunAsContext } from "../service/aws/caller/sim-aws-run-as-context.js";
+import type { SimAws } from "../service/aws/sim-aws.js";
+import {
+  simSdkClientRegionName,
+  simSdkClientServiceId,
+} from "./client/sim-sdk-client.js";
+import {
+  SimSdkCommandNotInterceptedError,
+  SimSdkUnsupportedCommandError,
+} from "./error/sim-sdk.error.js";
+import { resolveSimSdkCommandRouter } from "./router/resolve-sim-sdk-command-router.js";
+
+/**
+ * Dispatches intercepted SDK Commands to simulated AWS service operations.
+ *
+ * The Account/Region scope and caller are resolved per dispatched Command,
+ * never per client, so ambient callers such as SimAws.runAs, and later
+ * simulated Lambda execution roles, take effect at send time.
+ */
+export class SimSdkCommandDispatcher {
+  private readonly simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.simAws = simAws;
+  }
+
+  /**
+   * Route one intercepted SDK Command to a simulated service operation.
+   */
+  async dispatch(
+    command: object,
+    client: unknown,
+    commandNames: ReadonlySet<string> | undefined,
+  ): Promise<unknown> {
+    const commandName = command.constructor.name;
+    if (commandNames !== undefined && !commandNames.has(commandName)) {
+      throw new SimSdkCommandNotInterceptedError(
+        `SDK Command ${commandName} is not in this interception's Command ` +
+          `allow list`,
+      );
+    }
+
+    const serviceId = simSdkClientServiceId(client);
+    const accountId = this.ambientAccountId() ?? this.simAws.defaultAccountId;
+    const regionName = await simSdkClientRegionName(
+      client,
+      this.simAws.defaultRegionName,
+    );
+
+    const router = resolveSimSdkCommandRouter(
+      this.simAws,
+      serviceId,
+      accountId,
+      regionName,
+    );
+    const route = router.route(commandName);
+    if (route === undefined) {
+      throw new SimSdkUnsupportedCommandError(
+        `Simulated ${serviceId} does not support SDK Command ` +
+          `${commandName}. Supported Commands: ${router
+            .supportedCommandNames()
+            .join(", ")}`,
+      );
+    }
+
+    return await route(command);
+  }
+
+  /**
+   * Resolve the AWS Account of the ambient SimAws.runAs caller, if one is
+   * set for this dispatcher's SimAws instance and identifies an Account.
+   */
+  private ambientAccountId(): string | undefined {
+    const caller = simAwsRunAsContext.currentCaller(this.simAws);
+    if (caller === undefined) {
+      return undefined;
+    }
+    return new SimAwsCallerResolver().resolve(caller, caller).accountId;
+  }
+}

--- a/src/sdk/sim-sdk-interception.ts
+++ b/src/sdk/sim-sdk-interception.ts
@@ -1,0 +1,35 @@
+import type { SimSdkSendPatch } from "./send-patch.js";
+
+/**
+ * One live SDK client interception: a restorable binding from an SDK client
+ * instance or client class to simulated AWS.
+ */
+export class SimSdkInterception implements Disposable {
+  private readonly patch: SimSdkSendPatch;
+
+  constructor(patch: SimSdkSendPatch) {
+    this.patch = patch;
+  }
+
+  /**
+   * Whether this interception is still installed on its client.
+   */
+  isActive(): boolean {
+    return this.patch.isInstalled();
+  }
+
+  /**
+   * Restore the client's real SDK send behaviour.
+   */
+  restore(): void {
+    this.patch.restore();
+  }
+
+  /**
+   * Restore on dispose, so interceptions work with `using` declarations.
+   */
+  // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- Symbol.dispose is standard from ES2024; the lint rule does not know it yet.
+  [Symbol.dispose](): void {
+    this.restore();
+  }
+}

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -1,0 +1,238 @@
+import { describe, it } from "vitest";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListBucketsCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { DynamoDBClient, ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { SimAws } from "../service/aws/sim-aws.js";
+import { SimSdkInvalidClientError } from "./error/sim-sdk.error.js";
+import { SimSdk } from "./sim-sdk.js";
+
+describe("simulated AWS SDK", () => {
+  it("round-trips S3 Commands through an intercepted client alone", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-a" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "foo.txt",
+        Body: "Hello, world!",
+      }),
+    );
+    const output = await client.send(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "foo.txt" }),
+    );
+
+    assertIdentical(await output.Body?.transformToString(), "Hello, world!");
+  });
+
+  it("shares state between direct sim service use and intercepted clients", async () => {
+    const simAws = new SimAws();
+    using simSdk = new SimSdk({ simAws });
+
+    const simS3 = simAws.account().region("eu-west-2").s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-b" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-b",
+        Key: "bar.txt",
+        Body: "Direct sim state",
+      }),
+    );
+
+    const client = new S3Client({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const output = await client.send(
+      new GetObjectCommand({ Bucket: "bucket-b", Key: "bar.txt" }),
+    );
+
+    assertIdentical(await output.Body?.transformToString(), "Direct sim state");
+  });
+
+  it("resolves the Account scope per send from ambient run-as context", async () => {
+    const simAws = new SimAws();
+    using simSdk = new SimSdk({ simAws });
+
+    const otherAccountS3 = simAws
+      .account("222222222222")
+      .region("us-east-1")
+      .s3();
+    await otherAccountS3.createBucket(
+      new CreateBucketCommand({ Bucket: "bucket-c" }),
+    );
+
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    // The same intercepted client instance resolves a different Account scope
+    // depending on the ambient caller at the time of each send, so scope must
+    // never be memoized per client.
+    const defaultScopeOutput = await client.send(new ListBucketsCommand({}));
+    assertIdentical(defaultScopeOutput.Buckets?.length ?? 0, 0);
+
+    await simAws.runAs(
+      { kind: "arn", arn: "arn:aws:iam::222222222222:role/test-role" },
+      async () => {
+        const runAsOutput = await client.send(new ListBucketsCommand({}));
+        assertIdentical(runAsOutput.Buckets?.[0]?.Name, "bucket-c");
+      },
+    );
+  });
+
+  it("restores the real client send when the sim SDK is disposed", () => {
+    const client = new S3Client({ region: "us-east-1" });
+    assertFalse(Object.hasOwn(client, "send"));
+
+    {
+      using simSdk = new SimSdk();
+      const interception = simSdk.intercept(client);
+      assertTrue(interception.isActive());
+      assertTrue(Object.hasOwn(client, "send"));
+    }
+
+    assertFalse(Object.hasOwn(client, "send"));
+  });
+
+  it("restores a single interception without restoring the rest", () => {
+    using simSdk = new SimSdk();
+    const clientA = new S3Client({ region: "us-east-1" });
+    const clientB = new S3Client({ region: "us-east-1" });
+
+    const interceptionA = simSdk.intercept(clientA);
+    const interceptionB = simSdk.intercept(clientB);
+
+    interceptionA.restore();
+
+    assertFalse(interceptionA.isActive());
+    assertTrue(interceptionB.isActive());
+  });
+
+  it("rejects a Command the simulated service does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new HeadObjectCommand({ Bucket: "bucket-a", Key: "foo.txt" }),
+      );
+    });
+
+    assertStringIncludes(error.message, "HeadObjectCommand");
+    assertStringIncludes(error.message, "GetObjectCommand");
+  });
+
+  it("intercepts every instance of a client class", async () => {
+    using simSdk = new SimSdk();
+    simSdk.intercept(S3Client);
+
+    const client = new S3Client({ region: "eu-west-2" });
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-class" }));
+
+    const direct = await simSdk.simAws
+      .account()
+      .region("eu-west-2")
+      .s3()
+      .listBuckets(new ListBucketsCommand({}));
+
+    assertIdentical(direct.Buckets?.[0]?.Name, "bucket-class");
+  });
+
+  it("ignores ambient run-as context from an unrelated SimAws", async () => {
+    const unrelatedSimAws = new SimAws();
+    using simSdk = new SimSdk();
+
+    await simSdk.simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "bucket-default" }));
+
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await unrelatedSimAws.runAs(
+      { kind: "arn", arn: "arn:aws:iam::333333333333:role/other-role" },
+      async () => {
+        const output = await client.send(new ListBucketsCommand({}));
+        assertIdentical(output.Buckets?.[0]?.Name, "bucket-default");
+      },
+    );
+  });
+
+  it("restores an interception disposed with using", () => {
+    const simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+
+    {
+      using interception = simSdk.intercept(client);
+      assertTrue(interception.isActive());
+    }
+
+    assertFalse(Object.hasOwn(client, "send"));
+  });
+
+  it("rejects a client for a service without SDK interception support", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new ListTablesCommand({}));
+    });
+
+    assertStringIncludes(error.message, "DynamoDB");
+  });
+
+  it("rejects intercepting a client class without a prototype", () => {
+    using simSdk = new SimSdk();
+
+    const error = assertThrowsError(() => {
+      simSdk.intercept(() => undefined);
+    });
+
+    assertInstanceOf(error, SimSdkInvalidClientError);
+  });
+
+  it("only intercepts the Commands in an explicit allow list", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client, { commands: [ListBucketsCommand] });
+
+    const output = await client.send(new ListBucketsCommand({}));
+    assertIdentical(output.Buckets?.length ?? 0, 0);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new GetObjectCommand({ Bucket: "bucket-a", Key: "foo.txt" }),
+      );
+    });
+
+    assertStringIncludes(error.message, "GetObjectCommand");
+  });
+
+  it("accepts Command allow list entries as plain names", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client, { commands: ["ListBucketsCommand"] });
+
+    const output = await client.send(new ListBucketsCommand({}));
+
+    assertIdentical(output.Buckets?.length ?? 0, 0);
+  });
+});

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -99,6 +99,56 @@ describe("simulated AWS SDK", () => {
     );
   });
 
+  it("resolves each intercepted client's ambient caller from its own SimAws", async () => {
+    // Two SimSdk/SimAws pairs are two isolated simulated universes, and
+    // runAs is per universe rather than a global identity switch: running as
+    // a caller on one SimAws never masks the ambient caller of another. So
+    // with two nested runAs on different SimAws instances, each intercepted
+    // client still resolves the caller of the SimAws it belongs to.
+    const simAws = new SimAws();
+    using simSdk = new SimSdk({ simAws });
+    const otherSimAws = new SimAws();
+    using otherSimSdk = new SimSdk({ simAws: otherSimAws });
+
+    await simAws
+      .account("222222222222")
+      .region("us-east-1")
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "bucket-one" }));
+    await otherSimAws
+      .account("333333333333")
+      .region("us-east-1")
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "bucket-other" }));
+
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+    const otherClient = new S3Client({ region: "us-east-1" });
+    otherSimSdk.intercept(otherClient);
+
+    await simAws.runAs(
+      { kind: "arn", arn: "arn:aws:iam::222222222222:role/one-role" },
+      async () => {
+        await otherSimAws.runAs(
+          { kind: "arn", arn: "arn:aws:iam::333333333333:role/other-role" },
+          async () => {
+            // client belongs to simAws, so it resolves simAws's own runAs
+            // caller, even inside otherSimAws's nested runAs.
+            const output = await client.send(new ListBucketsCommand({}));
+            assertIdentical(output.Buckets?.[0]?.Name, "bucket-one");
+
+            // otherClient belongs to otherSimAws, so it resolves the nested
+            // runAs caller from otherSimAws.
+            const otherOutput = await otherClient.send(
+              new ListBucketsCommand({}),
+            );
+            assertIdentical(otherOutput.Buckets?.[0]?.Name, "bucket-other");
+          },
+        );
+      },
+    );
+  });
+
   it("restores the real client send when the sim SDK is disposed", () => {
     const client = new S3Client({ region: "us-east-1" });
     assertFalse(Object.hasOwn(client, "send"));

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -18,7 +18,10 @@ import {
   assertTrue,
 } from "@kensio/smartass";
 import { SimAws } from "../service/aws/sim-aws.js";
-import { SimSdkInvalidClientError } from "./error/sim-sdk.error.js";
+import {
+  SimSdkAlreadyInterceptedError,
+  SimSdkInvalidClientError,
+} from "./error/sim-sdk.error.js";
 import { SimSdk } from "./sim-sdk.js";
 
 describe("simulated AWS SDK", () => {
@@ -197,6 +200,32 @@ describe("simulated AWS SDK", () => {
     });
 
     assertStringIncludes(error.message, "DynamoDB");
+  });
+
+  it("rejects intercepting a client that is already intercepted", () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = assertThrowsError(() => {
+      simSdk.intercept(client);
+    });
+
+    assertInstanceOf(error, SimSdkAlreadyInterceptedError);
+    assertStringIncludes(error.message, "S3Client");
+  });
+
+  it("rejects intercepting a client already intercepted by another SimSdk", () => {
+    using firstSimSdk = new SimSdk();
+    using secondSimSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    firstSimSdk.intercept(client);
+
+    const error = assertThrowsError(() => {
+      secondSimSdk.intercept(client);
+    });
+
+    assertInstanceOf(error, SimSdkAlreadyInterceptedError);
   });
 
   it("rejects intercepting a client class without a prototype", () => {

--- a/src/sdk/sim-sdk.ts
+++ b/src/sdk/sim-sdk.ts
@@ -1,0 +1,133 @@
+import { SimAws } from "../service/aws/sim-aws.js";
+import { SimSdkInvalidClientError } from "./error/sim-sdk.error.js";
+import { installSendPatch } from "./send-patch.js";
+import { SimSdkCommandDispatcher } from "./sim-sdk-command-dispatcher.js";
+import { SimSdkInterception } from "./sim-sdk-interception.js";
+
+interface SimSdkProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * An SDK Command type given to an interception's Command allow list, such as
+ * an SDK Command class. Only the name is read; the SDK itself is never
+ * imported by simulated AWS.
+ */
+export interface SimSdkCommandType {
+  readonly name: string;
+}
+
+/**
+ * Options for intercepting one SDK client instance or client class.
+ */
+export interface SimSdkInterceptOptions {
+  /**
+   * Only intercept these SDK Commands, given as Command classes or Command
+   * names. All Commands are intercepted when omitted.
+   */
+  readonly commands?: readonly (SimSdkCommandType | string)[];
+}
+
+/**
+ * An SDK client instance or client class to intercept.
+ */
+export type SimSdkInterceptTarget = object;
+
+/**
+ * The simulated AWS SDK.
+ *
+ * Intercepts AWS SDK client sends and routes their Commands to simulated AWS
+ * services, so implementation code using SDK clients never needs to know it
+ * is dealing with simulated AWS behind the scenes.
+ *
+ * Owns a SimAws instance, created on demand or supplied, so most tests can
+ * work through intercepted SDK clients alone and never touch SimAws directly.
+ */
+export class SimSdk implements Disposable {
+  public readonly simAws: SimAws;
+
+  private readonly dispatcher: SimSdkCommandDispatcher;
+  private readonly interceptions = new Set<SimSdkInterception>();
+
+  constructor(properties: SimSdkProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.simAws = simAws;
+    this.dispatcher = new SimSdkCommandDispatcher(simAws);
+  }
+
+  /**
+   * Intercept an SDK client instance or client class.
+   *
+   * Intercepting a class intercepts every instance of it. The Account/Region
+   * scope and caller are resolved per send, never per client: from the
+   * ambient SimAws.runAs caller and the sending client's configured Region,
+   * falling back to the SimAws defaults.
+   */
+  intercept(
+    target: SimSdkInterceptTarget,
+    options: SimSdkInterceptOptions = {},
+  ): SimSdkInterception {
+    const commandNames = interceptedCommandNames(options);
+    const patch = installSendPatch(
+      patchTarget(target),
+      async (command, client) =>
+        await this.dispatcher.dispatch(command, client, commandNames),
+    );
+
+    const interception = new SimSdkInterception(patch);
+    this.interceptions.add(interception);
+    return interception;
+  }
+
+  /**
+   * Restore the real SDK send behaviour of every client intercepted through
+   * this SimSdk.
+   */
+  restoreAll(): void {
+    for (const interception of this.interceptions) {
+      interception.restore();
+    }
+    this.interceptions.clear();
+  }
+
+  /**
+   * Restore all on dispose, so a SimSdk works with `using` declarations.
+   */
+  // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- Symbol.dispose is standard from ES2024; the lint rule does not know it yet.
+  [Symbol.dispose](): void {
+    this.restoreAll();
+  }
+}
+
+/**
+ * Normalize an interception's Command allow list to Command names.
+ */
+function interceptedCommandNames(
+  options: SimSdkInterceptOptions,
+): ReadonlySet<string> | undefined {
+  if (options.commands === undefined) {
+    return undefined;
+  }
+  return new Set(
+    options.commands.map((command) =>
+      typeof command === "string" ? command : command.name,
+    ),
+  );
+}
+
+/**
+ * Resolve the object to patch for an interception target: the target itself
+ * for a client instance, or the prototype for a client class.
+ */
+function patchTarget(target: SimSdkInterceptTarget): object {
+  if (typeof target !== "function") {
+    return target;
+  }
+  const prototype = (target as { prototype?: unknown }).prototype;
+  if (typeof prototype !== "object" || prototype === null) {
+    throw new SimSdkInvalidClientError(
+      "Intercepted SDK client class has no prototype to patch",
+    );
+  }
+  return prototype;
+}

--- a/src/sdk/sim-sdk.ts
+++ b/src/sdk/sim-sdk.ts
@@ -62,6 +62,10 @@ export class SimSdk implements Disposable {
    * scope and caller are resolved per send, never per client: from the
    * ambient SimAws.runAs caller and the sending client's configured Region,
    * falling back to the SimAws defaults.
+   *
+   * A client can only have one interception at a time: intercepting an
+   * already-intercepted client throws SimSdkAlreadyInterceptedError until the
+   * existing interception is restored.
    */
   intercept(
     target: SimSdkInterceptTarget,

--- a/src/sdk/stream/sim-sdk-stream-body.iso.test.ts
+++ b/src/sdk/stream/sim-sdk-stream-body.iso.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "vitest";
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { SimSdkStreamAlreadyConsumedError } from "../error/sim-sdk.error.js";
+import { simSdkStreamBody } from "./sim-sdk-stream-body.js";
+
+describe("simulated SDK stream body", () => {
+  it("transforms to a string like the real SDK", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    assertIdentical(await body.transformToString(), "Hello, world!");
+  });
+
+  it("transforms to a string in a given encoding", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    assertIdentical(
+      await body.transformToString("base64"),
+      Buffer.from("Hello, world!").toString("base64"),
+    );
+  });
+
+  it("transforms to a byte array", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    const bytes = await body.transformToByteArray();
+
+    assertInstanceOf(bytes, Uint8Array);
+    assertBufferEqual(Buffer.from(bytes), Buffer.from("Hello, world!"));
+  });
+
+  it("transforms to a web stream", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    const webStream = body.transformToWebStream();
+
+    assertIdentical(await text(webStream), "Hello, world!");
+  });
+
+  it("remains readable directly as a Readable stream", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    assertIdentical(await text(body), "Hello, world!");
+  });
+
+  it("rejects a second consumption like the real SDK", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+    await body.transformToString();
+
+    const error = assertThrowsError(() => body.transformToWebStream());
+
+    assertInstanceOf(error, SimSdkStreamAlreadyConsumedError);
+  });
+});

--- a/src/sdk/stream/sim-sdk-stream-body.iso.test.ts
+++ b/src/sdk/stream/sim-sdk-stream-body.iso.test.ts
@@ -6,6 +6,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertThrowsError,
+  assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { SimSdkStreamAlreadyConsumedError } from "../error/sim-sdk.error.js";
 import { simSdkStreamBody } from "./sim-sdk-stream-body.js";
@@ -54,6 +55,19 @@ describe("simulated SDK stream body", () => {
     await body.transformToString();
 
     const error = assertThrowsError(() => body.transformToWebStream());
+
+    assertInstanceOf(error, SimSdkStreamAlreadyConsumedError);
+  });
+
+  it("rejects a transform after the body was read directly", async () => {
+    const body = simSdkStreamBody(Readable.from("Hello, world!"));
+
+    const chunks = await Array.fromAsync(body);
+    assertIdentical(chunks.join(""), "Hello, world!");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await body.transformToString();
+    });
 
     assertInstanceOf(error, SimSdkStreamAlreadyConsumedError);
   });

--- a/src/sdk/stream/sim-sdk-stream-body.ts
+++ b/src/sdk/stream/sim-sdk-stream-body.ts
@@ -1,0 +1,56 @@
+import { Readable } from "node:stream";
+import { buffer } from "node:stream/consumers";
+import type { ReadableStream } from "node:stream/web";
+import { SimSdkStreamAlreadyConsumedError } from "../error/sim-sdk.error.js";
+
+/**
+ * The transform methods the real AWS SDK mixes into streaming output payloads
+ * such as the S3 GetObject Body.
+ */
+export interface SimSdkStreamBodyMethods {
+  transformToByteArray(): Promise<Uint8Array>;
+  transformToString(encoding?: BufferEncoding): Promise<string>;
+  transformToWebStream(): ReadableStream<Uint8Array>;
+}
+
+/**
+ * A simulated SDK streaming output payload: a Readable with the SDK stream
+ * transform methods mixed in.
+ */
+export type SimSdkStreamBody = Readable & SimSdkStreamBodyMethods;
+
+/**
+ * Mix the SDK stream transform methods into a simulated streaming output
+ * payload.
+ *
+ * Matches real SDK behaviour: the payload can only be consumed once, whether
+ * through a transform method or by reading the stream directly.
+ */
+export function simSdkStreamBody(body: Readable): SimSdkStreamBody {
+  let consumed = false;
+  const consume = (): Readable => {
+    if (consumed) {
+      throw new SimSdkStreamAlreadyConsumedError(
+        "Simulated SDK stream body was already consumed and cannot be " +
+          "transformed again",
+      );
+    }
+    consumed = true;
+    return body;
+  };
+
+  const methods: SimSdkStreamBodyMethods = {
+    async transformToByteArray(): Promise<Uint8Array> {
+      return new Uint8Array(await buffer(consume()));
+    },
+    async transformToString(encoding?: BufferEncoding): Promise<string> {
+      const bytes = await buffer(consume());
+      return bytes.toString(encoding);
+    },
+    transformToWebStream(): ReadableStream<Uint8Array> {
+      return Readable.toWeb(consume()) as ReadableStream<Uint8Array>;
+    },
+  };
+
+  return Object.assign(body, methods);
+}

--- a/src/sdk/stream/sim-sdk-stream-body.ts
+++ b/src/sdk/stream/sim-sdk-stream-body.ts
@@ -28,6 +28,21 @@ export type SimSdkStreamBody = Readable & SimSdkStreamBodyMethods;
  */
 export function simSdkStreamBody(body: Readable): SimSdkStreamBody {
   let consumed = false;
+
+  // Node funnels every real consumption path (pipe(), on("data", ...), and
+  // for-await iteration) through calls to the public read(). Overriding it
+  // here, rather than adding a "data"/"readable" listener, detects direct
+  // reads without switching the stream into flowing mode itself, which would
+  // start consuming it before any caller asked for that.
+  const originalRead = body.read.bind(body);
+  body.read = (size?: number): unknown => {
+    const chunk: unknown = originalRead(size);
+    if (chunk !== null) {
+      consumed = true;
+    }
+    return chunk;
+  };
+
   const consume = (): Readable => {
     if (consumed) {
       throw new SimSdkStreamAlreadyConsumedError(

--- a/src/service/aws/caller/sim-aws-run-as-context.iso.test.ts
+++ b/src/service/aws/caller/sim-aws-run-as-context.iso.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "vitest";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { simAwsRunAsContext } from "./sim-aws-run-as-context.js";
+import type { SimAwsPrincipal } from "./sim-aws-caller.js";
+
+const callerA: SimAwsPrincipal = {
+  kind: "arn",
+  arn: "arn:aws:iam::111111111111:role/caller-a",
+};
+const callerB: SimAwsPrincipal = {
+  kind: "arn",
+  arn: "arn:aws:iam::222222222222:role/caller-b",
+};
+
+describe("simulated AWS run-as context", () => {
+  it("has no ambient caller outside a run", () => {
+    assertUndefined(simAwsRunAsContext.currentCaller({}));
+  });
+
+  it("resolves the ambient caller for the running owner", async () => {
+    const owner = {};
+
+    await simAwsRunAsContext.run(owner, callerA, () => {
+      assertIdentical(simAwsRunAsContext.currentCaller(owner), callerA);
+      return Promise.resolve();
+    });
+  });
+
+  it("restores the outer caller after a nested run for the same owner", async () => {
+    const owner = {};
+
+    await simAwsRunAsContext.run(owner, callerA, async () => {
+      await simAwsRunAsContext.run(owner, callerB, () => {
+        assertIdentical(simAwsRunAsContext.currentCaller(owner), callerB);
+        return Promise.resolve();
+      });
+
+      assertIdentical(simAwsRunAsContext.currentCaller(owner), callerA);
+    });
+  });
+
+  it("keeps an outer owner's caller visible during a nested run for another owner", async () => {
+    const ownerA = {};
+    const ownerB = {};
+
+    await simAwsRunAsContext.run(ownerA, callerA, async () => {
+      await simAwsRunAsContext.run(ownerB, callerB, () => {
+        assertIdentical(simAwsRunAsContext.currentCaller(ownerA), callerA);
+        assertIdentical(simAwsRunAsContext.currentCaller(ownerB), callerB);
+        return Promise.resolve();
+      });
+
+      assertIdentical(simAwsRunAsContext.currentCaller(ownerA), callerA);
+      assertUndefined(simAwsRunAsContext.currentCaller(ownerB));
+    });
+  });
+});

--- a/src/service/aws/caller/sim-aws-run-as-context.ts
+++ b/src/service/aws/caller/sim-aws-run-as-context.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { SimAwsPrincipal } from "./sim-aws-caller.js";
+
+interface SimAwsRunAsFrame {
+  readonly owner: object;
+  readonly caller: SimAwsPrincipal;
+}
+
+const storage = new AsyncLocalStorage<SimAwsRunAsFrame>();
+
+/**
+ * Ambient simulated caller context, tracked with Node.js asynchronous context
+ * tracking.
+ *
+ * The ambient caller is scoped to one owning SimAws instance so that separate
+ * simulations in the same process never observe each other's callers. Nested
+ * runs stack: the innermost frame wins, and the outer frame is restored when
+ * the inner function completes.
+ */
+export const simAwsRunAsContext = {
+  /**
+   * Run a function with an ambient caller for one SimAws owner.
+   */
+  async run<T>(
+    owner: object,
+    caller: SimAwsPrincipal,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    return await storage.run({ owner, caller }, run);
+  },
+
+  /**
+   * Get the current ambient caller for an owner, if there is one.
+   */
+  currentCaller(owner: object): SimAwsPrincipal | undefined {
+    const frame = storage.getStore();
+    if (frame?.owner !== owner) {
+      return undefined;
+    }
+    return frame.caller;
+  },
+};

--- a/src/service/aws/caller/sim-aws-run-as-context.ts
+++ b/src/service/aws/caller/sim-aws-run-as-context.ts
@@ -1,42 +1,59 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { SimAwsPrincipal } from "./sim-aws-caller.js";
 
-interface SimAwsRunAsFrame {
-  readonly owner: object;
-  readonly caller: SimAwsPrincipal;
-}
+/**
+ * The SimAws instance an ambient caller belongs to.
+ *
+ * Each SimAws instance is its own isolated simulated AWS universe, with its
+ * own Accounts and IAM state, so ambient callers are tracked per instance: a
+ * caller only has meaning within the SimAws it was set for, and a run-as on
+ * one SimAws never affects what another SimAws observes. The owner is typed
+ * as a bare object because only its identity is used, as a key; this also
+ * keeps this module free of a runtime SimAws dependency.
+ */
+export type SimAwsRunAsOwner = object;
 
-const storage = new AsyncLocalStorage<SimAwsRunAsFrame>();
+/**
+ * The ambient caller for each SimAws instance currently inside a run.
+ */
+type SimAwsRunAsCallers = ReadonlyMap<SimAwsRunAsOwner, SimAwsPrincipal>;
+
+const storage = new AsyncLocalStorage<SimAwsRunAsCallers>();
 
 /**
  * Ambient simulated caller context, tracked with Node.js asynchronous context
  * tracking.
  *
- * The ambient caller is scoped to one owning SimAws instance so that separate
- * simulations in the same process never observe each other's callers. Nested
- * runs stack: the innermost frame wins, and the outer frame is restored when
- * the inner function completes.
+ * The caller is the simulated principal, such as an IAM Role, that simulated
+ * AWS operations are attributed to while the run executes: the simulated
+ * answer to "who is making these AWS calls?". It is ambient in that it
+ * applies to everything called during the run, without being passed
+ * explicitly.
+ *
+ * Callers are keyed by owning SimAws instance. Nested runs stack: the
+ * innermost caller wins for its own SimAws, a run for a different SimAws
+ * leaves this one's caller visible throughout, and each SimAws gets its
+ * previous caller back when a nested run completes.
  */
 export const simAwsRunAsContext = {
   /**
-   * Run a function with an ambient caller for one SimAws owner.
+   * Run a function with an ambient caller for one owning SimAws instance.
    */
   async run<T>(
-    owner: object,
+    owner: SimAwsRunAsOwner,
     caller: SimAwsPrincipal,
     run: () => Promise<T>,
   ): Promise<T> {
-    return await storage.run({ owner, caller }, run);
+    const callers = new Map(storage.getStore());
+    callers.set(owner, caller);
+    return await storage.run(callers, run);
   },
 
   /**
-   * Get the current ambient caller for an owner, if there is one.
+   * Get the current ambient caller for one owning SimAws instance, if a run
+   * is active for it.
    */
-  currentCaller(owner: object): SimAwsPrincipal | undefined {
-    const frame = storage.getStore();
-    if (frame?.owner !== owner) {
-      return undefined;
-    }
-    return frame.caller;
+  currentCaller(owner: SimAwsRunAsOwner): SimAwsPrincipal | undefined {
+    return storage.getStore()?.get(owner);
   },
 };

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -26,6 +26,8 @@ import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimSts } from "../sts/sim-sts.js";
+import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
+import { simAwsRunAsContext } from "./caller/sim-aws-run-as-context.js";
 
 interface SimAwsProperties {
   readonly defaultAccountId?: SimAwsAccountId;
@@ -164,6 +166,17 @@ export class SimAws {
    */
   cloudFrontRegistry(): SimCloudFrontRegistry {
     return this.serviceFactory.cloudFrontRegistry;
+  }
+
+  /**
+   * Run a function with an ambient simulated caller for this SimAws instance.
+   *
+   * Simulated AWS operations during the run resolve this caller when no
+   * explicit caller is given, including SDK Commands routed by interception.
+   * Runs may be nested; the innermost caller wins.
+   */
+  async runAs<T>(caller: SimAwsPrincipal, run: () => Promise<T>): Promise<T> {
+    return await simAwsRunAsContext.run(this, caller, run);
   }
 
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -171,9 +171,14 @@ export class SimAws {
   /**
    * Run a function with an ambient simulated caller for this SimAws instance.
    *
-   * Simulated AWS operations during the run resolve this caller when no
+   * The caller is the simulated principal, such as an IAM Role, that
+   * simulated AWS operations during the run are attributed to when no
    * explicit caller is given, including SDK Commands routed by interception.
-   * Runs may be nested; the innermost caller wins.
+   *
+   * The caller is scoped to this SimAws instance, not global: each SimAws is
+   * its own simulated universe, so running as a caller here never changes
+   * what a different SimAws instance observes. Runs on the same instance may
+   * be nested; the innermost caller wins.
    */
   async runAs<T>(caller: SimAwsPrincipal, run: () => Promise<T>): Promise<T> {
     return await simAwsRunAsContext.run(this, caller, run);

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "vitest";
+import {
+  CreateBucketCommand,
+  ListObjectsCommand,
+  PutBucketPolicyCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimSdk } from "../../../sdk/index.js";
+import type { SimS3 } from "../sim-s3.js";
+import { SimS3SdkCommandRouter } from "./sim-s3-sdk-command-router.js";
+
+describe("simulated S3 SDK Command routing", () => {
+  it("routes ListObjectsCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-a" }));
+    await client.send(
+      new PutObjectCommand({ Bucket: "bucket-a", Key: "a.txt", Body: "a" }),
+    );
+    await client.send(
+      new PutObjectCommand({ Bucket: "bucket-a", Key: "b.txt", Body: "b" }),
+    );
+
+    const output = await client.send(
+      new ListObjectsCommand({ Bucket: "bucket-a" }),
+    );
+
+    assertIdentical(output.Contents?.length, 2);
+  });
+
+  it("routes PutBucketWebsiteCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-web" }));
+    await client.send(
+      new PutBucketWebsiteCommand({
+        Bucket: "bucket-web",
+        WebsiteConfiguration: {
+          IndexDocument: { Suffix: "index.html" },
+        },
+      }),
+    );
+
+    const websiteUrl = simSdk.simAws.s3().getBucketWebsiteUrl("bucket-web");
+
+    assertStringIncludes(websiteUrl.href, "bucket-web");
+  });
+
+  it("routes PutBucketPolicyCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-policy" }));
+
+    const output = await client.send(
+      new PutBucketPolicyCommand({
+        Bucket: "bucket-policy",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: "*",
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::bucket-policy/*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    assertIdentical(typeof output.$metadata, "object");
+  });
+
+  it("lists its supported SDK Command names", () => {
+    const router = new SimS3SdkCommandRouter({} as SimS3);
+
+    const supported = router.supportedCommandNames();
+
+    assertIdentical(supported.length, 7);
+    assertTrue(supported.includes("GetObjectCommand"));
+    assertIdentical(router.route("HeadObjectCommand"), undefined);
+  });
+
+  it("passes through a GetObject output without a Body", async () => {
+    const simS3Stub = {
+      getObject: () => Promise.resolve({ $metadata: {} }),
+    } as unknown as SimS3;
+    const router = new SimS3SdkCommandRouter(simS3Stub);
+
+    const route = router.route("GetObjectCommand");
+    assertDefined(route, "GetObjectCommand route should exist");
+    const output = await route({ input: {} });
+
+    assertIdentical((output as { Body?: unknown }).Body, undefined);
+  });
+});

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -1,0 +1,95 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/router/sim-sdk-command-router.type.js";
+import { simSdkStreamBody } from "../../../sdk/stream/sim-sdk-stream-body.js";
+import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.cmd.js";
+import type {
+  SimGetObjectCommand,
+  SimGetObjectCommandOutput,
+} from "../command/get-object/get-object.cmd.js";
+import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.cmd.js";
+import type { SimListObjectsCommand } from "../command/list-objects/list-objects.cmd.js";
+import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.cmd.js";
+import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.cmd.js";
+import type { SimPutObjectCommand } from "../command/put-object/put-object.cmd.js";
+import type { SimS3 } from "../sim-s3.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated S3 instance.
+ */
+export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simS3: SimS3) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateBucketCommand",
+        async (command): Promise<unknown> =>
+          await simS3.createBucket(command as SimCreateBucketCommand),
+      ],
+      [
+        "GetObjectCommand",
+        async (command): Promise<unknown> =>
+          await getObjectWithSdkStreamBody(
+            simS3,
+            command as SimGetObjectCommand,
+          ),
+      ],
+      [
+        "ListBucketsCommand",
+        async (command): Promise<unknown> =>
+          await simS3.listBuckets(command as SimListBucketsCommand),
+      ],
+      [
+        "ListObjectsCommand",
+        async (command): Promise<unknown> =>
+          await simS3.listObjects(command as SimListObjectsCommand),
+      ],
+      [
+        "PutBucketPolicyCommand",
+        async (command): Promise<unknown> =>
+          await simS3.putBucketPolicy(command as SimPutBucketPolicyCommand),
+      ],
+      [
+        "PutBucketWebsiteCommand",
+        async (command): Promise<unknown> =>
+          await simS3.putBucketWebsite(command as SimPutBucketWebsiteCommand),
+      ],
+      [
+        "PutObjectCommand",
+        async (command): Promise<unknown> =>
+          await simS3.putObject(command as SimPutObjectCommand),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated S3 can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated S3 supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}
+
+/**
+ * Get an Object and mix the SDK stream transform methods into its Body, so
+ * SDK callers can use e.g. Body.transformToString() as with real S3.
+ */
+async function getObjectWithSdkStreamBody(
+  simS3: SimS3,
+  command: SimGetObjectCommand,
+): Promise<SimGetObjectCommandOutput> {
+  const output = await simS3.getObject(command);
+  if (output.Body === undefined) {
+    return output;
+  }
+  return { ...output, Body: simSdkStreamBody(output.Body) };
+}

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -50,6 +50,8 @@ import type {
   SimPutBucketPolicyCommandOutput,
 } from "./command/put-bucket-policy/put-bucket-policy.cmd.js";
 import { PutBucketPolicyCommandHandler } from "./command/put-bucket-policy/put-bucket-policy.handler.js";
+import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 
 export interface SimS3RequestOptions {
   readonly caller?: SimAwsCaller;
@@ -75,6 +77,7 @@ export class SimS3 {
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly background: BackgroundScheduler;
   private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
+  private readonly sdkRouter = new SimS3SdkCommandRouter(this);
 
   constructor(properties: SimS3Properties = {}) {
     const {
@@ -244,5 +247,12 @@ export class SimS3 {
    */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public SDK interception API for routing AWS SDK commands through simulated services.
  * Added support for intercepting S3 client operations, including configurable command filtering.
  * Added SDK-style streaming response bodies with string, byte array, and web stream transformations.
  * Added caller context support for running operations under simulated identities.
  * Added structured errors for unsupported services, commands, callbacks, and invalid clients.
  * Exposed the SDK through a dedicated package entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->