### PR TITLE
feat: complete sim SDK intercepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,57 @@ npm i -D @kensio/yulin
 
 ## Usage
 
+### Intercept AWS SDK clients
+
+If your code uses the AWS SDK, you can intercept AWS SDK clients and route their Commands to
+simulated AWS services. Your implementation code uses the SDK as normal and never needs to know that
+it's dealing with a simulator behind the scenes:
+
+```typescript
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(S3Client); // Intercepts every instance of the client class.
+
+// The code under test uses the AWS SDK as normal.
+const s3Client = new S3Client({ region: "eu-west-2" });
+await s3Client.send(new CreateBucketCommand({ Bucket: "foo-bucket" }));
+await s3Client.send(
+  new PutObjectCommand({
+    Bucket: "foo-bucket",
+    Key: "foo.txt",
+    Body: "Hello, world!",
+  }),
+);
+
+const output = await s3Client.send(
+  new GetObjectCommand({ Bucket: "foo-bucket", Key: "foo.txt" }),
+);
+console.log(await output.Body?.transformToString()); // "Hello, world!"
+
+simSdk.restoreAll(); // Or `using simSdk = new SimSdk();` to restore on scope exit.
+```
+
+You can intercept a client class, as above, or a single client instance. The simulated Account and
+Region scope is resolved per send: the Region comes from the sending client's configuration, and
+the Account from the ambient `simAws.runAs(...)` caller when one is set, falling back to the
+simulation defaults.
+
+Each `SimSdk` owns its own isolated simulated AWS, available as `simSdk.simAws` when a test needs
+to seed or inspect simulated state directly. To share state with an existing simulation, wrap it
+with `new SimSdk({ simAws })`.
+
+See the [simulated AWS SDK docs](./docs/sdk "Simulated AWS SDK docs") for full usage.
+
 ### Direct interaction with simulated AWS
 
-Create and interact directly with a simulated AWS:
+You can also create and interact directly with a simulated AWS:
 
 ```typescript
 import { SimAws } from "@kensio/yulin";

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -78,15 +78,21 @@ The simulated Account and Region scope is resolved for each sent Command, never 
 2. The **Account** comes from the ambient `simAws.runAs(...)` caller when one is set, falling back
    to the simulation default Account.
 
+The resolved caller is passed through to the simulated service, so simulated
+[IAM](../services/iam/) authorization applies to it exactly as for direct sim service use: a
+caller without permission for a Command is denied, like real AWS. When no caller can be
+identified, Commands run as the simulation's default Account root.
+
 `runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent
-during the run are attributed to that caller's Account — with no changes to the client or the code
-under test:
+during the run are attributed to that caller — with no changes to the client or the code under
+test:
 
 ```typescript sim-sdk-run-as
 /**
  * Attributing intercepted SDK Commands to a caller with runAs.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateBucketCommand,
   ListBucketsCommand,
@@ -98,11 +104,38 @@ import { SimSdk } from "@kensio/yulin/sdk";
 const simAws = new SimAws();
 const simSdk = new SimSdk({ simAws });
 
-// Seed a Bucket in a specific simulated Account.
-await simAws
-  .account("222222222222")
+// Seed a Bucket, and a Role allowed to list Buckets, in a simulated Account.
+const account = simAws.account("222222222222");
+await account
   .s3()
   .createBucket(new CreateBucketCommand({ Bucket: "team-bucket" }));
+await account.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "TeamRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::222222222222:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+await account.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "TeamRole",
+    PolicyName: "list-buckets",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:ListAllMyBuckets",
+        Resource: "*",
+      },
+    }),
+  }),
+);
 
 const s3Client = new S3Client({ region: "us-east-1" });
 simSdk.intercept(s3Client);
@@ -110,7 +143,8 @@ simSdk.intercept(s3Client);
 await simAws.runAs(
   { kind: "arn", arn: "arn:aws:iam::222222222222:role/TeamRole" },
   async () => {
-    // Sent as the TeamRole caller, so resolved in Account 222222222222.
+    // Sent as the TeamRole caller: resolved in Account 222222222222 and
+    // authorized against the Role's simulated IAM permissions.
     const output = await s3Client.send(new ListBucketsCommand({}));
     console.log(output.Buckets); // [{ Name: "team-bucket" }]
   },

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,157 @@
+# Simulated AWS SDK
+
+Yulin can intercept AWS SDK clients and route their Commands to simulated AWS services. The code
+under test uses the AWS SDK exactly as it would in production, and never needs to know that it's
+dealing with a simulator behind the scenes.
+
+This is the recommended way to use Yulin for testing implementation code that already uses the AWS
+SDK. Direct interaction with `SimAws` remains useful for seeding and inspecting simulated state
+from within tests.
+
+## How it works
+
+`SimSdk` replaces the `send` method of an intercepted SDK client. Each sent Command is routed by
+name to the matching operation of a simulated AWS service, and the result is returned to the
+caller as a normal SDK response. Nothing touches the network.
+
+Every `SimSdk` owns a simulated AWS environment. You can let it create its own, or give it an
+existing one to share:
+
+- `new SimSdk()` creates an isolated `SimAws` internally, available as `simSdk.simAws`.
+- `new SimSdk({ simAws })` wraps a `SimAws` you already have.
+
+## Basic usage
+
+Intercept an SDK client class, then use the SDK as normal:
+
+```typescript sim-sdk-intercept-s3
+/**
+ * Intercepting the S3 SDK client with simulated AWS behind it.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(S3Client); // Intercepts every instance of the class.
+
+// From here on, this is ordinary AWS SDK code.
+const s3Client = new S3Client({ region: "eu-west-2" });
+await s3Client.send(new CreateBucketCommand({ Bucket: "foo-bucket" }));
+await s3Client.send(
+  new PutObjectCommand({
+    Bucket: "foo-bucket",
+    Key: "hello.txt",
+    Body: "Hello, world!",
+  }),
+);
+
+const output = await s3Client.send(
+  new GetObjectCommand({ Bucket: "foo-bucket", Key: "hello.txt" }),
+);
+console.log(await output.Body?.transformToString()); // "Hello, world!"
+
+simSdk.restoreAll();
+```
+
+You can intercept a client class or a client instance:
+
+- **A class** (`simSdk.intercept(S3Client)`) intercepts every instance of it, including instances
+  the code under test constructs later. This is the most common choice.
+- **An instance** (`simSdk.intercept(s3Client)`) intercepts only that instance, which is useful
+  when a specific client should hit the simulator while others are handled differently.
+
+A client can only have one interception at a time: intercepting an already-intercepted client
+throws a diagnostic error rather than silently replacing the existing interception.
+
+## Account and Region scope
+
+The simulated Account and Region scope is resolved for each sent Command, never fixed per client:
+
+1. The **Region** comes from the sending client's own configuration, such as
+   `new S3Client({ region: "eu-west-2" })`, falling back to the simulation default.
+2. The **Account** comes from the ambient `simAws.runAs(...)` caller when one is set, falling back
+   to the simulation default Account.
+
+`runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent
+during the run are attributed to that caller's Account — with no changes to the client or the code
+under test:
+
+```typescript sim-sdk-run-as
+/**
+ * Attributing intercepted SDK Commands to a caller with runAs.
+ */
+
+import {
+  CreateBucketCommand,
+  ListBucketsCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simAws = new SimAws();
+const simSdk = new SimSdk({ simAws });
+
+// Seed a Bucket in a specific simulated Account.
+await simAws
+  .account("222222222222")
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "team-bucket" }));
+
+const s3Client = new S3Client({ region: "us-east-1" });
+simSdk.intercept(s3Client);
+
+await simAws.runAs(
+  { kind: "arn", arn: "arn:aws:iam::222222222222:role/TeamRole" },
+  async () => {
+    // Sent as the TeamRole caller, so resolved in Account 222222222222.
+    const output = await s3Client.send(new ListBucketsCommand({}));
+    console.log(output.Buckets); // [{ Name: "team-bucket" }]
+  },
+);
+
+simSdk.restoreAll();
+```
+
+The ambient caller is scoped to its own `SimAws` instance, so separate simulations in the same
+process never observe each other's callers.
+
+## Restoring interception
+
+Restoring puts back the client's real SDK `send`:
+
+- `interception.restore()` restores one interception; `simSdk.intercept(...)` returns the handle.
+- `simSdk.restoreAll()` restores everything intercepted through that `SimSdk`.
+- `SimSdk` and interception handles are disposable, so `using simSdk = new SimSdk();` restores
+  automatically at the end of the scope — convenient in tests.
+
+## Choosing Commands to intercept
+
+By default every Command sent through an intercepted client is routed to the simulator. To
+intercept only specific Commands, pass an allow list of Command classes or names:
+`simSdk.intercept(s3Client, { commands: [GetObjectCommand] })`. Commands outside the allow list
+throw a diagnostic error.
+
+## Supported services and Commands
+
+All simulated services support SDK interception: ACM, CloudFormation, CloudFront, DynamoDB, IAM,
+Route53, S3, and STS. Each service's own docs under [docs/services](../services/) list the
+Commands it simulates.
+
+Sending a Command the simulated service doesn't support throws an error naming the Command and
+listing the supported ones, so gaps show up clearly in test output rather than as silent
+misbehaviour. Clients for AWS services Yulin doesn't simulate at all are rejected the same way.
+
+## Limitations
+
+- Only `client.send(command)` is intercepted. SDK utilities that bypass `send`, such as
+  `getSignedUrl`, are not simulated. Paginators and waiters go through `send`, so they work.
+- Simulated errors carry SDK-shaped `name` and `$metadata`, but are not instances of the real SDK
+  exception classes: match errors with `error.name`, not `instanceof`.
+- The callback form of `send(command, callback)` is not supported; use the promise form.

--- a/docs/sdk/sim-sdk-intercept-s3.example.ts
+++ b/docs/sdk/sim-sdk-intercept-s3.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Intercepting the S3 SDK client with simulated AWS behind it.
+ */
+
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(S3Client); // Intercepts every instance of the class.
+
+// From here on, this is ordinary AWS SDK code.
+const s3Client = new S3Client({ region: "eu-west-2" });
+await s3Client.send(new CreateBucketCommand({ Bucket: "foo-bucket" }));
+await s3Client.send(
+  new PutObjectCommand({
+    Bucket: "foo-bucket",
+    Key: "hello.txt",
+    Body: "Hello, world!",
+  }),
+);
+
+const output = await s3Client.send(
+  new GetObjectCommand({ Bucket: "foo-bucket", Key: "hello.txt" }),
+);
+console.log(await output.Body?.transformToString()); // "Hello, world!"
+
+simSdk.restoreAll();

--- a/docs/sdk/sim-sdk-run-as.example.ts
+++ b/docs/sdk/sim-sdk-run-as.example.ts
@@ -2,6 +2,7 @@
  * Attributing intercepted SDK Commands to a caller with runAs.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateBucketCommand,
   ListBucketsCommand,
@@ -13,11 +14,38 @@ import { SimSdk } from "@kensio/yulin/sdk";
 const simAws = new SimAws();
 const simSdk = new SimSdk({ simAws });
 
-// Seed a Bucket in a specific simulated Account.
-await simAws
-  .account("222222222222")
+// Seed a Bucket, and a Role allowed to list Buckets, in a simulated Account.
+const account = simAws.account("222222222222");
+await account
   .s3()
   .createBucket(new CreateBucketCommand({ Bucket: "team-bucket" }));
+await account.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "TeamRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::222222222222:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+await account.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "TeamRole",
+    PolicyName: "list-buckets",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:ListAllMyBuckets",
+        Resource: "*",
+      },
+    }),
+  }),
+);
 
 const s3Client = new S3Client({ region: "us-east-1" });
 simSdk.intercept(s3Client);
@@ -25,7 +53,8 @@ simSdk.intercept(s3Client);
 await simAws.runAs(
   { kind: "arn", arn: "arn:aws:iam::222222222222:role/TeamRole" },
   async () => {
-    // Sent as the TeamRole caller, so resolved in Account 222222222222.
+    // Sent as the TeamRole caller: resolved in Account 222222222222 and
+    // authorized against the Role's simulated IAM permissions.
     const output = await s3Client.send(new ListBucketsCommand({}));
     console.log(output.Buckets); // [{ Name: "team-bucket" }]
   },

--- a/docs/sdk/sim-sdk-run-as.example.ts
+++ b/docs/sdk/sim-sdk-run-as.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Attributing intercepted SDK Commands to a caller with runAs.
+ */
+
+import {
+  CreateBucketCommand,
+  ListBucketsCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simAws = new SimAws();
+const simSdk = new SimSdk({ simAws });
+
+// Seed a Bucket in a specific simulated Account.
+await simAws
+  .account("222222222222")
+  .s3()
+  .createBucket(new CreateBucketCommand({ Bucket: "team-bucket" }));
+
+const s3Client = new S3Client({ region: "us-east-1" });
+simSdk.intercept(s3Client);
+
+await simAws.runAs(
+  { kind: "arn", arn: "arn:aws:iam::222222222222:role/TeamRole" },
+  async () => {
+    // Sent as the TeamRole caller, so resolved in Account 222222222222.
+    const output = await s3Client.send(new ListBucketsCommand({}));
+    console.log(output.Buckets); // [{ Name: "team-bucket" }]
+  },
+);
+
+simSdk.restoreAll();

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -16,6 +16,7 @@
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/route53": ["../src/service/route53/index.ts"],
       "@kensio/yulin/s3": ["../src/service/s3/index.ts"],
+      "@kensio/yulin/sdk": ["../src/sdk/index.ts"],
       "@kensio/yulin/serve": ["../src/serve/index.ts"]
     }
   },

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -7,9 +7,12 @@ export type {
 export { SimSdkInterception } from "./sim-sdk-interception.js";
 export type {
   SimSdkCommand,
+  SimSdkCommandContext,
   SimSdkCommandRoute,
   SimSdkCommandRouter,
 } from "./router/sim-sdk-command-router.type.js";
+export { simSdkCallerOptions } from "./router/sim-sdk-caller-options.js";
+export type { SimSdkCallerOptions } from "./router/sim-sdk-caller-options.js";
 export { simSdkStreamBody } from "./stream/sim-sdk-stream-body.js";
 export type {
   SimSdkStreamBody,

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -23,8 +23,29 @@ export function resolveSimSdkCommandRouter(
   const scoped = simAws.account(accountId).region(regionName);
 
   switch (serviceId) {
+    case "ACM": {
+      return scoped.acm().sdkCommandRouter();
+    }
+    case "CloudFormation": {
+      return scoped.cloudFormation().sdkCommandRouter();
+    }
+    case "CloudFront": {
+      return scoped.cloudFront().sdkCommandRouter();
+    }
+    case "DynamoDB": {
+      return scoped.dynamoDb().sdkCommandRouter();
+    }
+    case "IAM": {
+      return scoped.iam().sdkCommandRouter();
+    }
+    case "Route 53": {
+      return scoped.route53().sdkCommandRouter();
+    }
     case "S3": {
       return scoped.s3().sdkCommandRouter();
+    }
+    case "STS": {
+      return scoped.sts().sdkCommandRouter();
     }
     default: {
       throw new SimSdkUnknownServiceError(

--- a/src/sdk/router/sim-sdk-caller-options.ts
+++ b/src/sdk/router/sim-sdk-caller-options.ts
@@ -1,0 +1,24 @@
+import type { SimAwsPrincipal } from "../../service/aws/caller/sim-aws-caller.js";
+import type { SimSdkCommandContext } from "./sim-sdk-command-router.type.js";
+
+/**
+ * Simulated service request options carrying the resolved caller.
+ *
+ * Structurally compatible with each simulated service's own request options,
+ * such as SimS3RequestOptions and SimDynamoDbRequestOptions.
+ */
+export interface SimSdkCallerOptions {
+  readonly caller: SimAwsPrincipal;
+}
+
+/**
+ * Build service request options from a routed Command's context, so service
+ * routers can pass the resolved caller through to simulated operations in one
+ * expression. Returns undefined when no caller applies, preserving each
+ * operation's default-caller behaviour.
+ */
+export function simSdkCallerOptions(
+  context: SimSdkCommandContext,
+): SimSdkCallerOptions | undefined {
+  return context.caller === undefined ? undefined : { caller: context.caller };
+}

--- a/src/sdk/router/sim-sdk-command-router.type.ts
+++ b/src/sdk/router/sim-sdk-command-router.type.ts
@@ -1,3 +1,5 @@
+import type { SimAwsPrincipal } from "../../service/aws/caller/sim-aws-caller.js";
+
 /**
  * Minimal structural SDK Command shape as received by interception.
  */
@@ -6,9 +8,26 @@ export interface SimSdkCommand {
 }
 
 /**
+ * Per-send context resolved by the interception engine for a routed Command.
+ */
+export interface SimSdkCommandContext {
+  /**
+   * The most accurate simulated caller the engine could resolve for this
+   * send, such as the ambient SimAws.runAs principal, when one applies.
+   * Routes pass it through to the simulated service operation so IAM
+   * authorization applies to the caller rather than the Account root
+   * default.
+   */
+  readonly caller?: SimAwsPrincipal | undefined;
+}
+
+/**
  * Route one intercepted SDK Command to a simulated service operation.
  */
-export type SimSdkCommandRoute = (command: SimSdkCommand) => Promise<unknown>;
+export type SimSdkCommandRoute = (
+  command: SimSdkCommand,
+  context: SimSdkCommandContext,
+) => Promise<unknown>;
 
 /**
  * Routes intercepted SDK Commands to the operations of one scoped simulated

--- a/src/sdk/sim-sdk-command-dispatcher.ts
+++ b/src/sdk/sim-sdk-command-dispatcher.ts
@@ -1,4 +1,5 @@
 import { SimAwsCallerResolver } from "../service/aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsPrincipal } from "../service/aws/caller/sim-aws-caller.js";
 import { simAwsRunAsContext } from "../service/aws/caller/sim-aws-run-as-context.js";
 import type { SimAws } from "../service/aws/sim-aws.js";
 import {
@@ -42,7 +43,8 @@ export class SimSdkCommandDispatcher {
     }
 
     const serviceId = simSdkClientServiceId(client);
-    const accountId = this.ambientAccountId() ?? this.simAws.defaultAccountId;
+    const caller = this.ambientCaller();
+    const accountId = callerAccountId(caller) ?? this.simAws.defaultAccountId;
     const regionName = await simSdkClientRegionName(
       client,
       this.simAws.defaultRegionName,
@@ -64,22 +66,30 @@ export class SimSdkCommandDispatcher {
       );
     }
 
-    return await route(command);
+    return await route(command, { caller });
   }
 
   /**
-   * Resolve the AWS Account of the ambient SimAws.runAs caller, if one is
-   * set for this dispatcher's SimAws instance and identifies an Account.
+   * Get the ambient SimAws.runAs caller for this dispatcher's SimAws
+   * instance, if one is set.
    *
    * Only this SimAws instance's own run-as caller applies: a run-as on a
    * different SimAws instance is a different simulated universe and never
    * affects Commands dispatched here.
    */
-  private ambientAccountId(): string | undefined {
-    const caller = simAwsRunAsContext.currentCaller(this.simAws);
-    if (caller === undefined) {
-      return undefined;
-    }
-    return new SimAwsCallerResolver().resolve(caller, caller).accountId;
+  private ambientCaller(): SimAwsPrincipal | undefined {
+    return simAwsRunAsContext.currentCaller(this.simAws);
   }
+}
+
+/**
+ * Resolve the AWS Account a caller belongs to, when it identifies one.
+ */
+function callerAccountId(
+  caller: SimAwsPrincipal | undefined,
+): string | undefined {
+  if (caller === undefined) {
+    return undefined;
+  }
+  return new SimAwsCallerResolver().resolve(caller, caller).accountId;
 }

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -7,6 +7,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   assertFalse,
   assertIdentical,
@@ -26,6 +27,46 @@ import { SimSdk } from "./sim-sdk.js";
 interface SdkClientLike {
   readonly config: { readonly serviceId: string; readonly region: string };
   send(command: object): Promise<unknown>;
+}
+
+/**
+ * Create an IAM Role allowed to list Buckets in one simulated Account, so
+ * run-as callers in these tests hold real simulated IAM permissions.
+ */
+async function createBucketListerRole(
+  simAws: SimAws,
+  accountId: string,
+  roleName: string,
+): Promise<string> {
+  const simIam = simAws.account(accountId).iam();
+  await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "list-buckets",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "s3:ListAllMyBuckets",
+          Resource: "*",
+        },
+      }),
+    }),
+  );
+  return `arn:aws:iam::${accountId}:role/${roleName}`;
 }
 
 describe("simulated AWS SDK", () => {
@@ -85,6 +126,12 @@ describe("simulated AWS SDK", () => {
       new CreateBucketCommand({ Bucket: "bucket-c" }),
     );
 
+    const roleArn = await createBucketListerRole(
+      simAws,
+      "222222222222",
+      "test-role",
+    );
+
     const client = new S3Client({ region: "us-east-1" });
     simSdk.intercept(client);
 
@@ -94,13 +141,10 @@ describe("simulated AWS SDK", () => {
     const defaultScopeOutput = await client.send(new ListBucketsCommand({}));
     assertIdentical(defaultScopeOutput.Buckets?.length ?? 0, 0);
 
-    await simAws.runAs(
-      { kind: "arn", arn: "arn:aws:iam::222222222222:role/test-role" },
-      async () => {
-        const runAsOutput = await client.send(new ListBucketsCommand({}));
-        assertIdentical(runAsOutput.Buckets?.[0]?.Name, "bucket-c");
-      },
-    );
+    await simAws.runAs({ kind: "arn", arn: roleArn }, async () => {
+      const runAsOutput = await client.send(new ListBucketsCommand({}));
+      assertIdentical(runAsOutput.Buckets?.[0]?.Name, "bucket-c");
+    });
   });
 
   it("resolves each intercepted client's ambient caller from its own SimAws", async () => {
@@ -125,32 +169,35 @@ describe("simulated AWS SDK", () => {
       .s3()
       .createBucket(new CreateBucketCommand({ Bucket: "bucket-other" }));
 
+    const oneRoleArn = await createBucketListerRole(
+      simAws,
+      "222222222222",
+      "one-role",
+    );
+    const otherRoleArn = await createBucketListerRole(
+      otherSimAws,
+      "333333333333",
+      "other-role",
+    );
+
     const client = new S3Client({ region: "us-east-1" });
     simSdk.intercept(client);
     const otherClient = new S3Client({ region: "us-east-1" });
     otherSimSdk.intercept(otherClient);
 
-    await simAws.runAs(
-      { kind: "arn", arn: "arn:aws:iam::222222222222:role/one-role" },
-      async () => {
-        await otherSimAws.runAs(
-          { kind: "arn", arn: "arn:aws:iam::333333333333:role/other-role" },
-          async () => {
-            // client belongs to simAws, so it resolves simAws's own runAs
-            // caller, even inside otherSimAws's nested runAs.
-            const output = await client.send(new ListBucketsCommand({}));
-            assertIdentical(output.Buckets?.[0]?.Name, "bucket-one");
+    await simAws.runAs({ kind: "arn", arn: oneRoleArn }, async () => {
+      await otherSimAws.runAs({ kind: "arn", arn: otherRoleArn }, async () => {
+        // client belongs to simAws, so it resolves simAws's own runAs
+        // caller, even inside otherSimAws's nested runAs.
+        const output = await client.send(new ListBucketsCommand({}));
+        assertIdentical(output.Buckets?.[0]?.Name, "bucket-one");
 
-            // otherClient belongs to otherSimAws, so it resolves the nested
-            // runAs caller from otherSimAws.
-            const otherOutput = await otherClient.send(
-              new ListBucketsCommand({}),
-            );
-            assertIdentical(otherOutput.Buckets?.[0]?.Name, "bucket-other");
-          },
-        );
-      },
-    );
+        // otherClient belongs to otherSimAws, so it resolves the nested
+        // runAs caller from otherSimAws.
+        const otherOutput = await otherClient.send(new ListBucketsCommand({}));
+        assertIdentical(otherOutput.Buckets?.[0]?.Name, "bucket-other");
+      });
+    });
   });
 
   it("restores the real client send when the sim SDK is disposed", () => {

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -7,7 +7,6 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { DynamoDBClient, ListTablesCommand } from "@aws-sdk/client-dynamodb";
 import {
   assertFalse,
   assertIdentical,
@@ -23,6 +22,11 @@ import {
   SimSdkInvalidClientError,
 } from "./error/sim-sdk.error.js";
 import { SimSdk } from "./sim-sdk.js";
+
+interface SdkClientLike {
+  readonly config: { readonly serviceId: string; readonly region: string };
+  send(command: object): Promise<unknown>;
+}
 
 describe("simulated AWS SDK", () => {
   it("round-trips S3 Commands through an intercepted client alone", async () => {
@@ -242,14 +246,18 @@ describe("simulated AWS SDK", () => {
 
   it("rejects a client for a service without SDK interception support", async () => {
     using simSdk = new SimSdk();
-    const client = new DynamoDBClient({ region: "us-east-1" });
+    // A structurally valid SDK client for a service Yulin does not simulate.
+    const client: SdkClientLike = {
+      config: { serviceId: "SQS", region: "us-east-1" },
+      send: () => Promise.resolve("real send"),
+    };
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new ListTablesCommand({}));
+      await client.send({ input: {} });
     });
 
-    assertStringIncludes(error.message, "DynamoDB");
+    assertStringIncludes(error.message, "SQS");
   });
 
   it("rejects intercepting a client that is already intercepted", () => {

--- a/src/service/acm/sdk/sim-acm-sdk-command-router.iso.test.ts
+++ b/src/service/acm/sdk/sim-acm-sdk-command-router.iso.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "vitest";
+import {
+  ACMClient,
+  DeleteCertificateCommand,
+  DescribeCertificateCommand,
+  ListCertificatesCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated ACM SDK Command routing", () => {
+  it("round-trips certificate Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new ACMClient({ region: "eu-west-1" });
+    simSdk.intercept(client);
+
+    const requestOutput = await client.send(
+      new RequestCertificateCommand({ DomainName: "example.com" }),
+    );
+
+    // The certificate ARN carries the scope resolved per send: the client's
+    // Region and the sim default Account.
+    assertIdentical(
+      requestOutput.CertificateArn,
+      "arn:aws:acm:eu-west-1:888888888888:certificate/00000001",
+    );
+
+    const listOutput = await client.send(new ListCertificatesCommand({}));
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "example.com",
+    );
+
+    assertNonNullable(requestOutput.CertificateArn);
+    const describeOutput = await client.send(
+      new DescribeCertificateCommand({
+        CertificateArn: requestOutput.CertificateArn,
+      }),
+    );
+    assertNonNullable(describeOutput.Certificate);
+    assertIdentical(describeOutput.Certificate.DomainName, "example.com");
+    assertIdentical(describeOutput.Certificate.Status, "PENDING_VALIDATION");
+  });
+
+  it("shares certificate state with direct sim ACM use", async () => {
+    using simSdk = new SimSdk();
+    const simAcm = simSdk.simAws.region("eu-west-1").acm();
+    await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "direct.example.com" }),
+    );
+
+    const client = new ACMClient({ region: "eu-west-1" });
+    simSdk.intercept(client);
+
+    const listOutput = await client.send(new ListCertificatesCommand({}));
+
+    assertArrayLength(listOutput.CertificateSummaryList, 1);
+    assertIdentical(
+      listOutput.CertificateSummaryList[0].DomainName,
+      "direct.example.com",
+    );
+  });
+
+  it("rejects a Command simulated ACM does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new ACMClient({ region: "eu-west-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new DeleteCertificateCommand({
+          CertificateArn:
+            "arn:aws:acm:eu-west-1:888888888888:certificate/00000001",
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "DeleteCertificateCommand");
+    assertStringIncludes(error.message, "RequestCertificateCommand");
+  });
+});

--- a/src/service/acm/sdk/sim-acm-sdk-command-router.ts
+++ b/src/service/acm/sdk/sim-acm-sdk-command-router.ts
@@ -1,7 +1,8 @@
-import type {
-  SimSdkCommandRoute,
-  SimSdkCommandRouter,
-} from "../../../sdk/router/sim-sdk-command-router.type.js";
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
 import type { SimDescribeCertificateCommand } from "../command/describe-certificate/describe-certificate.cmd.js";
 import type { SimListCertificatesCommand } from "../command/list-certificates/list-certificates.cmd.js";
 import type { SimRequestCertificateCommand } from "../command/request-certificate/request-certificate.cmd.js";
@@ -17,21 +18,26 @@ export class SimAcmSdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "DescribeCertificateCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simAcm.describeCertificate(
             command as SimDescribeCertificateCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "ListCertificatesCommand",
-        async (command): Promise<unknown> =>
-          await simAcm.listCertificates(command as SimListCertificatesCommand),
+        async (command, context): Promise<unknown> =>
+          await simAcm.listCertificates(
+            command as SimListCertificatesCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "RequestCertificateCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simAcm.requestCertificate(
             command as SimRequestCertificateCommand,
+            simSdkCallerOptions(context),
           ),
       ],
     ]);

--- a/src/service/acm/sdk/sim-acm-sdk-command-router.ts
+++ b/src/service/acm/sdk/sim-acm-sdk-command-router.ts
@@ -1,0 +1,53 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimDescribeCertificateCommand } from "../command/describe-certificate/describe-certificate.cmd.js";
+import type { SimListCertificatesCommand } from "../command/list-certificates/list-certificates.cmd.js";
+import type { SimRequestCertificateCommand } from "../command/request-certificate/request-certificate.cmd.js";
+import type { SimAcm } from "../sim-acm.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated ACM instance.
+ */
+export class SimAcmSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simAcm: SimAcm) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "DescribeCertificateCommand",
+        async (command): Promise<unknown> =>
+          await simAcm.describeCertificate(
+            command as SimDescribeCertificateCommand,
+          ),
+      ],
+      [
+        "ListCertificatesCommand",
+        async (command): Promise<unknown> =>
+          await simAcm.listCertificates(command as SimListCertificatesCommand),
+      ],
+      [
+        "RequestCertificateCommand",
+        async (command): Promise<unknown> =>
+          await simAcm.requestCertificate(
+            command as SimRequestCertificateCommand,
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated ACM can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated ACM supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -27,6 +27,8 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimAcmSdkCommandRouter } from "./sdk/sim-acm-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 
 export interface SimAcmRequestOptions {
   readonly caller?: SimAwsCaller;
@@ -50,6 +52,7 @@ export class SimAcm {
   private readonly cfnFactory = new SimAcmCfnResourceFactory({
     acm: this,
   });
+  private readonly sdkRouter = new SimAcmSdkCommandRouter(this);
 
   constructor(properties: SimAcmProperties = {}) {
     const {
@@ -114,5 +117,12 @@ export class SimAcm {
    */
   cfnResourceFactory(): SimAcmCfnResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }

--- a/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.iso.test.ts
+++ b/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.iso.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "vitest";
+import {
+  CloudFormationClient,
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated CloudFormation SDK Command routing", () => {
+  it("deploys a Stack with resources through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new CloudFormationClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const stackCreation = await client.send(
+      new CreateStackCommand({
+        StackName: "intercepted-stack",
+        TemplateBody: JSON.stringify({
+          Resources: {
+            FooBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "cfn-intercepted-bucket" },
+            },
+          },
+        }),
+      }),
+    );
+    assertIdentical(stackCreation.StackId, "intercepted-stack");
+
+    // Stack creation returns before resources finish deploying.
+    await simSdk.simAws
+      .region("eu-west-2")
+      .cloudFormation()
+      .waitForStackDeployComplete("intercepted-stack");
+
+    const describeOut = await client.send(
+      new DescribeStacksCommand({ StackName: "intercepted-stack" }),
+    );
+    assertIdentical(describeOut.Stacks?.[0]?.StackStatus, "CREATE_COMPLETE");
+
+    // And simulated CloudFormation created the Bucket in simulated S3, in
+    // the scope resolved from the intercepted client's Region.
+    assertNonNullable(
+      simSdk.simAws
+        .region("eu-west-2")
+        .s3()
+        .getSimBucketByName("cfn-intercepted-bucket"),
+    );
+  });
+
+  it("rejects a Command simulated CloudFormation does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new CloudFormationClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new DeleteStackCommand({ StackName: "some-stack" }));
+    });
+
+    assertStringIncludes(error.message, "DeleteStackCommand");
+    assertStringIncludes(error.message, "CreateStackCommand");
+  });
+});

--- a/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.ts
+++ b/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.ts
@@ -1,0 +1,47 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimCreateStackCommand } from "../command/create-stack/create-stack.cmd.js";
+import type { SimDescribeStacksCommand } from "../command/describe-stacks/describe-stacks.cmd.js";
+import type { SimCloudFormation } from "../sim-cloudformation.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated CloudFormation
+ * instance.
+ */
+export class SimCloudFormationSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simCloudFormation: SimCloudFormation) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateStackCommand",
+        async (command): Promise<unknown> =>
+          await simCloudFormation.createStack(command as SimCreateStackCommand),
+      ],
+      [
+        "DescribeStacksCommand",
+        async (command): Promise<unknown> =>
+          await simCloudFormation.describeStacks(
+            command as SimDescribeStacksCommand,
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated CloudFormation can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated CloudFormation
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -27,6 +27,8 @@ import {
 import type { SimCloudFormationDeployTemplateFileProps as SimCloudFormationDeployTemplateFileProperties } from "./deploy/sim-cfn-template-file-loader.js";
 import type { SimCfnExecutableResourceBinding } from "./bind/sim-cfn-exec-binding.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
 interface SimCloudFormationProperties {
   readonly simAws: SimAws;
@@ -44,6 +46,7 @@ export class SimCloudFormation {
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly stacks = new Map<SimCloudFormationStackName, SimCfnStack>();
   private readonly templateDeployer: SimCloudFormationTemplateDeployer;
+  private readonly sdkRouter = new SimCloudFormationSdkCommandRouter(this);
 
   constructor(properties: SimCloudFormationProperties) {
     const {
@@ -124,6 +127,13 @@ export class SimCloudFormation {
     properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnStack> {
     return await this.templateDeployer.deployTemplateFile(properties);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 
   private async createStackWithContext(

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from "vitest";
+import {
+  CloudFrontClient,
+  CreateDistributionCommand,
+  CreateFunctionCommand,
+  DeleteDistributionCommand,
+  GetDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+import type { SimCloudFrontFunctionName } from "../cff/sim-cloudfront-function.js";
+
+describe("simulated CloudFront SDK Command routing", () => {
+  it("round-trips Distribution Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    await simSdk.simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "origin-bucket" }));
+
+    const client = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const distroCreation = await client.send(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "sdk-intercept-ref-1",
+          DefaultRootObject: "index.html",
+          Origins: {
+            Items: [
+              {
+                Id: "origin1",
+                DomainName: "origin-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            Quantity: 1,
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "origin1",
+            ViewerProtocolPolicy: "redirect-to-https",
+            AllowedMethods: { Items: ["GET", "HEAD"], Quantity: 2 },
+          },
+          Comment: "SDK intercepted distribution",
+          Enabled: true,
+        },
+      }),
+    );
+
+    assertNonNullable(distroCreation.Distribution?.Id);
+    const distroOut = await client.send(
+      new GetDistributionCommand({ Id: distroCreation.Distribution.Id }),
+    );
+
+    assertIdentical(distroOut.Distribution?.Id, distroCreation.Distribution.Id);
+  });
+
+  it("routes CreateFunctionCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const distroCreation = await client.send(
+      new CreateFunctionCommand({
+        Name: "intercepted-cff",
+        FunctionConfig: {
+          Comment: "SDK intercepted CloudFront Function",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: Buffer.from(`
+          function handler(event) {
+            return event.request;
+          }
+        `),
+      }),
+    );
+
+    assertIdentical(distroCreation.FunctionSummary?.Status, "UNPUBLISHED");
+    assertNonNullable(
+      simSdk.simAws
+        .cloudFront()
+        .getCloudFrontFunctionByName(
+          "intercepted-cff" as SimCloudFrontFunctionName,
+        ),
+    );
+  });
+
+  it("rejects a Command simulated CloudFront does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new DeleteDistributionCommand({ Id: "D123" }));
+    });
+
+    assertStringIncludes(error.message, "DeleteDistributionCommand");
+    assertStringIncludes(error.message, "CreateDistributionCommand");
+  });
+});

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -1,6 +1,7 @@
-import type {
-  SimSdkCommandRoute,
-  SimSdkCommandRouter,
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimCreateDistributionCommand } from "../command/create-distribution/create-distribution.cmd.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.cmd.js";
@@ -18,23 +19,26 @@ export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "CreateDistributionCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simCloudFront.createDistribution(
             command as SimCreateDistributionCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "CreateFunctionCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simCloudFront.createFunction(
             command as SimCreateFunctionCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "GetDistributionCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simCloudFront.getDistribution(
             command as SimGetDistributionCommand,
+            simSdkCallerOptions(context),
           ),
       ],
     ]);

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -1,0 +1,57 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimCreateDistributionCommand } from "../command/create-distribution/create-distribution.cmd.js";
+import type { SimCreateFunctionCommand } from "../command/create-function/create-function.cmd.js";
+import type { SimGetDistributionCommand } from "../command/get-distribution/get-distribution.cmd.js";
+import type { SimCloudFront } from "../sim-cloudfront.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated CloudFront
+ * instance.
+ */
+export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simCloudFront: SimCloudFront) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateDistributionCommand",
+        async (command): Promise<unknown> =>
+          await simCloudFront.createDistribution(
+            command as SimCreateDistributionCommand,
+          ),
+      ],
+      [
+        "CreateFunctionCommand",
+        async (command): Promise<unknown> =>
+          await simCloudFront.createFunction(
+            command as SimCreateFunctionCommand,
+          ),
+      ],
+      [
+        "GetDistributionCommand",
+        async (command): Promise<unknown> =>
+          await simCloudFront.getDistribution(
+            command as SimGetDistributionCommand,
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated CloudFront can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated CloudFront supports
+   * it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -41,6 +41,8 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 
 export interface SimCloudFrontRequestOptions {
   readonly caller?: SimAwsCaller;
@@ -75,6 +77,7 @@ export class SimCloudFront {
   private readonly cfnFactory = new SimCloudFrontCloudFormationResourceFactory(
     this,
   );
+  private readonly sdkRouter = new SimCloudFrontSdkCommandRouter(this);
 
   constructor(properties: SimCloudFrontProperties = {}) {
     const {
@@ -197,5 +200,12 @@ export class SimCloudFront {
    */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "vitest";
+import {
+  CreateTableCommand,
+  DescribeTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  ListTablesCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated DynamoDB SDK Command routing", () => {
+  it("round-trips Table Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const tableCreation = await client.send(
+      new CreateTableCommand({
+        TableName: "InterceptTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      }),
+    );
+    assertIdentical(
+      tableCreation.TableDescription?.TableName,
+      "InterceptTable",
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const describeOut = await client.send(
+      new DescribeTableCommand({ TableName: "InterceptTable" }),
+    );
+    assertIdentical(describeOut.Table?.TableStatus, "ACTIVE");
+
+    const listOut = await client.send(new ListTablesCommand({}));
+    assertIdentical(listOut.TableNames?.[0], "InterceptTable");
+
+    // And the intercepted Table is in the client Region's simulated scope.
+    const directListOut = await simSdk.simAws
+      .region("eu-west-2")
+      .dynamoDb()
+      .listTables(new ListTablesCommand({}));
+    assertIdentical(directListOut.TableNames?.[0], "InterceptTable");
+  });
+
+  it("routes PutItemCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: "ItemTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const putOut = await client.send(
+      new PutItemCommand({
+        TableName: "ItemTable",
+        Item: { id: { S: "item-1" }, name: { S: "First item" } },
+      }),
+    );
+
+    assertNonNullable(putOut.$metadata);
+  });
+
+  it("rejects a Command simulated DynamoDB does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new GetItemCommand({
+          TableName: "InterceptTable",
+          Key: { id: { S: "item-1" } },
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "GetItemCommand");
+    assertStringIncludes(error.message, "PutItemCommand");
+  });
+});

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -9,11 +9,13 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import {
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { SimSdk } from "../../../sdk/index.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 
 describe("simulated DynamoDB SDK Command routing", () => {
   it("round-trips Table Commands through an intercepted client", async () => {
@@ -70,6 +72,35 @@ describe("simulated DynamoDB SDK Command routing", () => {
     );
 
     assertNonNullable(putOut.$metadata);
+  });
+
+  it("does not give a denied run-as caller root privileges", async () => {
+    using simSdk = new SimSdk();
+    const accountId = simSdk.simAws.defaultAccountId;
+    const client = new DynamoDBClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    // The ambient caller has no IAM permissions, so intercepted Commands
+    // must be authorized as that caller and denied, rather than falling back
+    // to the Account root default.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simSdk.simAws.runAs(
+        { kind: "arn", arn: `arn:aws:iam::${accountId}:role/NoPermsRole` },
+        async () => {
+          await client.send(
+            new CreateTableCommand({
+              TableName: "DeniedTable",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+            }),
+          );
+        },
+      );
+    });
+    assertInstanceOf(error, SimIamAccessDenied);
+
+    // And no Table was created with root privileges.
+    const listOut = await client.send(new ListTablesCommand({}));
+    assertIdentical(listOut.TableNames?.length, 0);
   });
 
   it("rejects a Command simulated DynamoDB does not support", async () => {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -1,0 +1,57 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimCreateTableCommand } from "../command/create-table/create-table.cmd.js";
+import type { SimDescribeTableCommand } from "../command/describe-table/describe-table.cmd.js";
+import type { SimListTablesCommand } from "../command/list-tables/list-tables.cmd.js";
+import type { SimPutItemCommand } from "../command/put-item/put-item.cmd.js";
+import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated DynamoDB instance.
+ */
+export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simDynamoDatabase: SimDynamoDatabase) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateTableCommand",
+        async (command): Promise<unknown> =>
+          await simDynamoDatabase.createTable(command as SimCreateTableCommand),
+      ],
+      [
+        "DescribeTableCommand",
+        async (command): Promise<unknown> =>
+          await simDynamoDatabase.describeTable(
+            command as SimDescribeTableCommand,
+          ),
+      ],
+      [
+        "ListTablesCommand",
+        async (command): Promise<unknown> =>
+          await simDynamoDatabase.listTables(command as SimListTablesCommand),
+      ],
+      [
+        "PutItemCommand",
+        async (command): Promise<unknown> =>
+          await simDynamoDatabase.putItem(command as SimPutItemCommand),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated DynamoDB can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated DynamoDB supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -1,6 +1,7 @@
-import type {
-  SimSdkCommandRoute,
-  SimSdkCommandRouter,
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimCreateTableCommand } from "../command/create-table/create-table.cmd.js";
 import type { SimDescribeTableCommand } from "../command/describe-table/describe-table.cmd.js";
@@ -18,25 +19,35 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "CreateTableCommand",
-        async (command): Promise<unknown> =>
-          await simDynamoDatabase.createTable(command as SimCreateTableCommand),
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.createTable(
+            command as SimCreateTableCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "DescribeTableCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simDynamoDatabase.describeTable(
             command as SimDescribeTableCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "ListTablesCommand",
-        async (command): Promise<unknown> =>
-          await simDynamoDatabase.listTables(command as SimListTablesCommand),
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.listTables(
+            command as SimListTablesCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "PutItemCommand",
-        async (command): Promise<unknown> =>
-          await simDynamoDatabase.putItem(command as SimPutItemCommand),
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.putItem(
+            command as SimPutItemCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
     ]);
   }

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -33,6 +33,8 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimDynamoDatabaseSdkCommandRouter } from "./sdk/sim-dynamodb-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
 export interface SimDynamoDbRequestOptions {
   readonly caller?: SimAwsCaller;
@@ -56,6 +58,7 @@ export class SimDynamoDb {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
 
   constructor(properties: SimDynamoDatabaseProperties = {}) {
     const {
@@ -129,5 +132,12 @@ export class SimDynamoDb {
       iam: this.iam,
     });
     return await handler.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }

--- a/src/service/iam/command/user/sim-iam-user-command-handlers.ts
+++ b/src/service/iam/command/user/sim-iam-user-command-handlers.ts
@@ -1,0 +1,83 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimIamCredentialRegistry } from "../../credential/sim-iam-credential-registry.js";
+import type { SimIamUserCredentialGenerator } from "../../credential/user/sim-iam-user-credential-generator.js";
+import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
+import { CreateAccessKeyCommandHandler } from "./create-access-key/create-access-key.handler.js";
+import type {
+  SimCreateAccessKeyCommand,
+  SimCreateAccessKeyCommandOutput,
+} from "./create-access-key/create-access-key.cmd.js";
+import { CreateUserCommandHandler } from "./create-user/create-user.handler.js";
+import type {
+  SimCreateUserCommand,
+  SimCreateUserCommandOutput,
+} from "./create-user/create-user.cmd.js";
+
+interface SimIamUserCommandHandlersProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly credentialRegistry: SimIamCredentialRegistry;
+  readonly credentialGenerator: SimIamUserCredentialGenerator;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Wires and runs the SDK command handlers that operate on IAM Users.
+ *
+ * Grouping the user command wiring here keeps the SimIam facade a thin
+ * delegator while keeping all user-keyed command handlers in one cohesive
+ * place, mirroring the role command handlers.
+ */
+export class SimIamUserCommandHandlers {
+  private readonly accountId: SimAwsAccountId;
+  private readonly users: Map<SimIamUsername, SimIamUser>;
+  private readonly credentialRegistry: SimIamCredentialRegistry;
+  private readonly credentialGenerator: SimIamUserCredentialGenerator;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimIamUserCommandHandlersProperties) {
+    const {
+      accountId,
+      users,
+      credentialRegistry,
+      credentialGenerator,
+      background,
+    } = properties;
+
+    this.accountId = accountId;
+    this.users = users;
+    this.credentialRegistry = credentialRegistry;
+    this.credentialGenerator = credentialGenerator;
+    this.background = background;
+  }
+
+  /**
+   * Handle a CreateUser command from the SDK.
+   */
+  async createUser(
+    command: SimCreateUserCommand,
+  ): Promise<SimCreateUserCommandOutput> {
+    const handler = new CreateUserCommandHandler({
+      accountId: this.accountId,
+      users: this.users,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+
+  /**
+   * Handle a CreateAccessKey command from the SDK.
+   */
+  async createAccessKey(
+    command: SimCreateAccessKeyCommand,
+  ): Promise<SimCreateAccessKeyCommandOutput> {
+    const handler = new CreateAccessKeyCommandHandler({
+      users: this.users,
+      credentialRegistry: this.credentialRegistry,
+      credentialGenerator: this.credentialGenerator,
+      background: this.background,
+    });
+    return await handler.handle(command);
+  }
+}

--- a/src/service/iam/credential/sim-iam-credential-registry.ts
+++ b/src/service/iam/credential/sim-iam-credential-registry.ts
@@ -11,9 +11,9 @@ import {
 /**
  * Stores and authenticates simulated IAM access keys.
  *
- * The registry is deliberately agnostic about the principal type represented
- * by an access key. Temporary sessions and future IAM-user access keys share
- * the same lookup and authentication behavior.
+ * The registry is agnostic about the principal type represented by an access
+ * key. Temporary sessions and future IAM-user access keys share the same lookup
+ * and authentication behavior.
  */
 export class SimIamCredentialRegistry {
   private readonly accessKeys = new Map<string, SimIamAccessKey>();

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.iso.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from "vitest";
+import {
+  AttachRolePolicyCommand,
+  CreateAccessKeyCommand,
+  CreatePolicyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  DeleteRoleCommand,
+  GetPolicyCommand,
+  GetRoleCommand,
+  IAMClient,
+  ListPoliciesCommand,
+  ListRolesCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+
+const allowAllPolicyDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [{ Effect: "Allow", Action: "s3:GetObject", Resource: "*" }],
+});
+
+describe("simulated IAM SDK Command routing", () => {
+  it("round-trips Role Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const roleCreation = await client.send(
+      new CreateRoleCommand({
+        RoleName: "InterceptRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    assertNonNullable(roleCreation.Role?.Arn);
+
+    const roleOut = await client.send(
+      new GetRoleCommand({ RoleName: "InterceptRole" }),
+    );
+    assertIdentical(roleOut.Role?.Arn, roleCreation.Role.Arn);
+
+    const rolesOut = await client.send(new ListRolesCommand({}));
+    assertIdentical(rolesOut.Roles?.[0]?.RoleName, "InterceptRole");
+
+    await client.send(
+      new PutRolePolicyCommand({
+        RoleName: "InterceptRole",
+        PolicyName: "inline-policy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+  });
+
+  it("round-trips managed Policy Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const policyCreation = await client.send(
+      new CreatePolicyCommand({
+        PolicyName: "InterceptPolicy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+    assertNonNullable(policyCreation.Policy?.Arn);
+
+    const policyOut = await client.send(
+      new GetPolicyCommand({ PolicyArn: policyCreation.Policy.Arn }),
+    );
+    assertIdentical(policyOut.Policy?.PolicyName, "InterceptPolicy");
+
+    const policiesOut = await client.send(new ListPoliciesCommand({}));
+    assertIdentical(policiesOut.Policies?.[0]?.PolicyName, "InterceptPolicy");
+
+    await client.send(
+      new CreateRoleCommand({
+        RoleName: "AttachTargetRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await client.send(
+      new AttachRolePolicyCommand({
+        RoleName: "AttachTargetRole",
+        PolicyArn: policyCreation.Policy.Arn,
+      }),
+    );
+  });
+
+  it("round-trips User Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const userCreation = await client.send(
+      new CreateUserCommand({ UserName: "InterceptUser" }),
+    );
+    assertNonNullable(userCreation.User?.Arn);
+
+    await client.send(
+      new PutUserPolicyCommand({
+        UserName: "InterceptUser",
+        PolicyName: "inline-user-policy",
+        PolicyDocument: allowAllPolicyDocument,
+      }),
+    );
+
+    const accessKeyCreation = await client.send(
+      new CreateAccessKeyCommand({ UserName: "InterceptUser" }),
+    );
+    assertNonNullable(accessKeyCreation.AccessKey?.AccessKeyId);
+
+    // And the created access key resolves in sim IAM to the User.
+    const identity = simSdk.simAws.iam().credentials.resolveCredentials({
+      accessKeyId: accessKeyCreation.AccessKey.AccessKeyId,
+      secretAccessKey: accessKeyCreation.AccessKey.SecretAccessKey ?? "",
+    });
+    assertIdentical(identity.principal.kind, "arn");
+  });
+
+  it("rejects a Command simulated IAM does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new IAMClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new DeleteRoleCommand({ RoleName: "InterceptRole" }));
+    });
+
+    assertStringIncludes(error.message, "DeleteRoleCommand");
+    assertStringIncludes(error.message, "CreateRoleCommand");
+  });
+});

--- a/src/service/iam/sdk/sim-iam-sdk-command-router.ts
+++ b/src/service/iam/sdk/sim-iam-sdk-command-router.ts
@@ -1,0 +1,97 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimCreatePolicyCommand } from "../command/policy/create-policy/create-policy.cmd.js";
+import type { SimGetPolicyCommand } from "../command/policy/get-policy/get-policy.cmd.js";
+import type { SimListPoliciesCommand } from "../command/policy/list-policies/list-policies.cmd.js";
+import type { SimPutRolePolicyCommand } from "../command/policy/put-role-policy/put-role-policy.cmd.js";
+import type { SimPutUserPolicyCommand } from "../command/policy/put-user-policy/put-user-policy.cmd.js";
+import type { SimAttachRolePolicyCommand } from "../command/role/attach-role-policy/attach-role-policy.cmd.js";
+import type { SimCreateRoleCommand } from "../command/role/create-role/create-role.cmd.js";
+import type { SimGetRoleCommand } from "../command/role/get-role/get-role.cmd.js";
+import type { SimListRolesCommand } from "../command/role/list-roles/list-roles.cmd.js";
+import type { SimCreateAccessKeyCommand } from "../command/user/create-access-key/create-access-key.cmd.js";
+import type { SimCreateUserCommand } from "../command/user/create-user/create-user.cmd.js";
+import type { SimIam } from "../sim-iam.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated IAM instance.
+ */
+export class SimIamSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simIam: SimIam) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "AttachRolePolicyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.attachRolePolicy(command as SimAttachRolePolicyCommand),
+      ],
+      [
+        "CreateAccessKeyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.createAccessKey(command as SimCreateAccessKeyCommand),
+      ],
+      [
+        "CreatePolicyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.createPolicy(command as SimCreatePolicyCommand),
+      ],
+      [
+        "CreateRoleCommand",
+        async (command): Promise<unknown> =>
+          await simIam.createRole(command as SimCreateRoleCommand),
+      ],
+      [
+        "CreateUserCommand",
+        async (command): Promise<unknown> =>
+          await simIam.createUser(command as SimCreateUserCommand),
+      ],
+      [
+        "GetPolicyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.getPolicy(command as SimGetPolicyCommand),
+      ],
+      [
+        "GetRoleCommand",
+        async (command): Promise<unknown> =>
+          await simIam.getRole(command as SimGetRoleCommand),
+      ],
+      [
+        "ListPoliciesCommand",
+        async (command): Promise<unknown> =>
+          await simIam.listPolicies(command as SimListPoliciesCommand),
+      ],
+      [
+        "ListRolesCommand",
+        async (command): Promise<unknown> =>
+          await simIam.listRoles(command as SimListRolesCommand),
+      ],
+      [
+        "PutRolePolicyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.putRolePolicy(command as SimPutRolePolicyCommand),
+      ],
+      [
+        "PutUserPolicyCommand",
+        async (command): Promise<unknown> =>
+          await simIam.putUserPolicy(command as SimPutUserPolicyCommand),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated IAM can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated IAM supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -62,12 +62,11 @@ import type {
   SimCreateUserCommand,
   SimCreateUserCommandOutput,
 } from "./command/user/create-user/create-user.cmd.js";
-import { CreateUserCommandHandler } from "./command/user/create-user/create-user.handler.js";
 import type {
   SimCreateAccessKeyCommand,
   SimCreateAccessKeyCommandOutput,
 } from "./command/user/create-access-key/create-access-key.cmd.js";
-import { CreateAccessKeyCommandHandler } from "./command/user/create-access-key/create-access-key.handler.js";
+import { SimIamUserCommandHandlers } from "./command/user/sim-iam-user-command-handlers.js";
 import type {
   SimPutUserPolicyCommand,
   SimPutUserPolicyCommandOutput,
@@ -76,6 +75,8 @@ import { PutUserPolicyCommandHandler } from "./command/policy/put-user-policy/pu
 import { SimIamCloudFormationResourceFactory } from "./cfn/sim-cfn-iam-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamSdkCommandRouter } from "./sdk/sim-iam-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
 interface SimIamProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -107,9 +108,10 @@ export class SimIam implements SimIamInterServiceAuthZ {
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
-  private readonly userCredentialGenerator: SimIamUserCredentialGenerator;
   private readonly cfnFactory: SimCfnServiceResourceFactory;
   private readonly roleCommands: SimIamRoleCommandHandlers;
+  private readonly userCommands: SimIamUserCommandHandlers;
+  private readonly sdkRouter = new SimIamSdkCommandRouter(this);
 
   constructor(properties: SimIamProperties = {}) {
     const {
@@ -123,7 +125,6 @@ export class SimIam implements SimIamInterServiceAuthZ {
     this.accountRegionScope = accountRegionScope;
     this.background = background;
     this.credentials = credentialRegistry;
-    this.userCredentialGenerator = userCredentialGenerator;
     this.sessionManager = new SimIamSessionManager({
       accountId: accountRegionScope.accountId,
       roles: this.roles,
@@ -134,6 +135,13 @@ export class SimIam implements SimIamInterServiceAuthZ {
     this.roleCommands = new SimIamRoleCommandHandlers({
       accountId: accountRegionScope.accountId,
       roles: this.roles,
+      background: this.background,
+    });
+    this.userCommands = new SimIamUserCommandHandlers({
+      accountId: accountRegionScope.accountId,
+      users: this.users,
+      credentialRegistry,
+      credentialGenerator: userCredentialGenerator,
       background: this.background,
     });
   }
@@ -261,13 +269,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
   async createUser(
     command: SimCreateUserCommand,
   ): Promise<SimCreateUserCommandOutput> {
-    const handler = new CreateUserCommandHandler({
-      accountId: this.accountRegionScope.accountId,
-      users: this.users,
-      background: this.background,
-    });
-
-    return await handler.handle(command);
+    return await this.userCommands.createUser(command);
   }
 
   /**
@@ -276,14 +278,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
   async createAccessKey(
     command: SimCreateAccessKeyCommand,
   ): Promise<SimCreateAccessKeyCommandOutput> {
-    const handler = new CreateAccessKeyCommandHandler({
-      users: this.users,
-      credentialRegistry: this.credentials,
-      credentialGenerator: this.userCredentialGenerator,
-      background: this.background,
-    });
-
-    return await handler.handle(command);
+    return await this.userCommands.createAccessKey(command);
   }
 
   /**
@@ -291,5 +286,12 @@ export class SimIam implements SimIamInterServiceAuthZ {
    */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "vitest";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  DeleteHostedZoneCommand,
+  GetHostedZoneCommand,
+  ListHostedZonesByNameCommand,
+  Route53Client,
+} from "@aws-sdk/client-route-53";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+import { assertIsSimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+
+describe("simulated Route53 SDK Command routing", () => {
+  it("round-trips Hosted Zone Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new Route53Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const zoneCreation = await client.send(
+      new CreateHostedZoneCommand({
+        Name: "example.com",
+        CallerReference: "sdk-intercept-ref-1",
+      }),
+    );
+    assertNonNullable(zoneCreation.HostedZone?.Id);
+    const hostedZoneId = zoneCreation.HostedZone.Id;
+
+    const zoneOut = await client.send(
+      new GetHostedZoneCommand({ Id: hostedZoneId }),
+    );
+    assertIdentical(zoneOut.HostedZone?.Name, "example.com.");
+
+    const listOutput = await client.send(
+      new ListHostedZonesByNameCommand({ DNSName: "example.com" }),
+    );
+    assertIdentical(listOutput.HostedZones?.[0]?.Id, hostedZoneId);
+  });
+
+  it("routes ChangeResourceRecordSetsCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new Route53Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const zoneCreation = await client.send(
+      new CreateHostedZoneCommand({
+        Name: "records.example.com",
+        CallerReference: "sdk-intercept-ref-2",
+      }),
+    );
+    assertNonNullable(zoneCreation.HostedZone?.Id);
+
+    const changeOutput = await client.send(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: zoneCreation.HostedZone.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "UPSERT",
+              ResourceRecordSet: {
+                Name: "www.records.example.com",
+                Type: "A",
+                TTL: 300,
+                ResourceRecords: [{ Value: "192.0.2.10" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    assertIdentical(changeOutput.ChangeInfo?.Status, "PENDING");
+
+    await simSdk.simAws.backgroundTasksComplete();
+    assertIsSimRoute53HostedZoneId(zoneCreation.HostedZone.Id);
+    const hostedZone = simSdk.simAws
+      .route53()
+      .hostedZones.get(zoneCreation.HostedZone.Id);
+    assertIdentical(hostedZone?.status, "INSYNC");
+  });
+
+  it("rejects a Command simulated Route53 does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new Route53Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new DeleteHostedZoneCommand({ Id: "Z123" }));
+    });
+
+    assertStringIncludes(error.message, "DeleteHostedZoneCommand");
+    assertStringIncludes(error.message, "CreateHostedZoneCommand");
+  });
+});

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.ts
@@ -1,0 +1,61 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimChangeResourceRecordSetsCommand } from "../command/change-resource-record-sets/change-resource-record-sets.cmd.js";
+import type { SimCreateHostedZoneCommand } from "../command/create-hosted-zone/create-hosted-zone.cmd.js";
+import type { SimGetHostedZoneCommand } from "../command/get-hosted-zone/get-hosted-zone.cmd.js";
+import type { SimListHostedZonesByNameCommand } from "../command/list-hosted-zones-by-name/list-hosted-zones-by-name.cmd.js";
+import type { SimRoute53 } from "../sim-route53.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Route53 instance.
+ */
+export class SimRoute53SdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simRoute53: SimRoute53) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "ChangeResourceRecordSetsCommand",
+        async (command): Promise<unknown> =>
+          await simRoute53.changeResourceRecordSets(
+            command as SimChangeResourceRecordSetsCommand,
+          ),
+      ],
+      [
+        "CreateHostedZoneCommand",
+        async (command): Promise<unknown> =>
+          await simRoute53.createHostedZone(
+            command as SimCreateHostedZoneCommand,
+          ),
+      ],
+      [
+        "GetHostedZoneCommand",
+        async (command): Promise<unknown> =>
+          await simRoute53.getHostedZone(command as SimGetHostedZoneCommand),
+      ],
+      [
+        "ListHostedZonesByNameCommand",
+        async (command): Promise<unknown> =>
+          await simRoute53.listHostedZonesByName(
+            command as SimListHostedZonesByNameCommand,
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Route53 can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Route53 supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.ts
@@ -1,6 +1,7 @@
-import type {
-  SimSdkCommandRoute,
-  SimSdkCommandRouter,
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimChangeResourceRecordSetsCommand } from "../command/change-resource-record-sets/change-resource-record-sets.cmd.js";
 import type { SimCreateHostedZoneCommand } from "../command/create-hosted-zone/create-hosted-zone.cmd.js";
@@ -18,28 +19,34 @@ export class SimRoute53SdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "ChangeResourceRecordSetsCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simRoute53.changeResourceRecordSets(
             command as SimChangeResourceRecordSetsCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "CreateHostedZoneCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simRoute53.createHostedZone(
             command as SimCreateHostedZoneCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "GetHostedZoneCommand",
-        async (command): Promise<unknown> =>
-          await simRoute53.getHostedZone(command as SimGetHostedZoneCommand),
+        async (command, context): Promise<unknown> =>
+          await simRoute53.getHostedZone(
+            command as SimGetHostedZoneCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "ListHostedZonesByNameCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await simRoute53.listHostedZonesByName(
             command as SimListHostedZonesByNameCommand,
+            simSdkCallerOptions(context),
           ),
       ],
     ]);

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -34,6 +34,8 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimRoute53SdkCommandRouter } from "./sdk/sim-route53-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
 export interface SimRoute53RequestOptions {
   readonly caller?: SimAwsCaller;
@@ -59,6 +61,7 @@ export class SimRoute53 {
   private readonly cfnFactory = new SimRoute53CloudFormationResourceFactory({
     route53: this,
   });
+  private readonly sdkRouter = new SimRoute53SdkCommandRouter(this);
 
   private readonly resolver: SimRoute53Resolver;
 
@@ -150,5 +153,12 @@ export class SimRoute53 {
    */
   cfnResourceFactory(): SimCfnServiceResourceFactory {
     return this.cfnFactory;
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -103,7 +103,7 @@ describe("simulated S3 SDK Command routing", () => {
 
     const route = router.route("GetObjectCommand");
     assertDefined(route, "GetObjectCommand route should exist");
-    const output = await route({ input: {} });
+    const output = await route({ input: {} }, {});
 
     assertIdentical((output as { Body?: unknown }).Body, undefined);
   });

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -1,8 +1,9 @@
 import type {
+  SimSdkCallerOptions,
   SimSdkCommandRoute,
   SimSdkCommandRouter,
 } from "../../../sdk/index.js";
-import { simSdkStreamBody } from "../../../sdk/index.js";
+import { simSdkCallerOptions, simSdkStreamBody } from "../../../sdk/index.js";
 import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.cmd.js";
 import type {
   SimGetObjectCommand,
@@ -25,41 +26,60 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "CreateBucketCommand",
-        async (command): Promise<unknown> =>
-          await simS3.createBucket(command as SimCreateBucketCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.createBucket(
+            command as SimCreateBucketCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "GetObjectCommand",
-        async (command): Promise<unknown> =>
+        async (command, context): Promise<unknown> =>
           await getObjectWithSdkStreamBody(
             simS3,
             command as SimGetObjectCommand,
+            simSdkCallerOptions(context),
           ),
       ],
       [
         "ListBucketsCommand",
-        async (command): Promise<unknown> =>
-          await simS3.listBuckets(command as SimListBucketsCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.listBuckets(
+            command as SimListBucketsCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "ListObjectsCommand",
-        async (command): Promise<unknown> =>
-          await simS3.listObjects(command as SimListObjectsCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.listObjects(
+            command as SimListObjectsCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "PutBucketPolicyCommand",
-        async (command): Promise<unknown> =>
-          await simS3.putBucketPolicy(command as SimPutBucketPolicyCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.putBucketPolicy(
+            command as SimPutBucketPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "PutBucketWebsiteCommand",
-        async (command): Promise<unknown> =>
-          await simS3.putBucketWebsite(command as SimPutBucketWebsiteCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.putBucketWebsite(
+            command as SimPutBucketWebsiteCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
       [
         "PutObjectCommand",
-        async (command): Promise<unknown> =>
-          await simS3.putObject(command as SimPutObjectCommand),
+        async (command, context): Promise<unknown> =>
+          await simS3.putObject(
+            command as SimPutObjectCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
     ]);
   }
@@ -86,8 +106,9 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
 async function getObjectWithSdkStreamBody(
   simS3: SimS3,
   command: SimGetObjectCommand,
+  options: SimSdkCallerOptions | undefined,
 ): Promise<SimGetObjectCommandOutput> {
-  const output = await simS3.getObject(command);
+  const output = await simS3.getObject(command, options);
   if (output.Body === undefined) {
     return output;
   }

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -1,8 +1,8 @@
 import type {
   SimSdkCommandRoute,
   SimSdkCommandRouter,
-} from "../../../sdk/router/sim-sdk-command-router.type.js";
-import { simSdkStreamBody } from "../../../sdk/stream/sim-sdk-stream-body.js";
+} from "../../../sdk/index.js";
+import { simSdkStreamBody } from "../../../sdk/index.js";
 import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.cmd.js";
 import type {
   SimGetObjectCommand,

--- a/src/service/sts/sdk/sim-sts-sdk-command-router.iso.test.ts
+++ b/src/service/sts/sdk/sim-sts-sdk-command-router.iso.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "vitest";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  AssumeRoleCommand,
+  GetCallerIdentityCommand,
+  STSClient,
+} from "@aws-sdk/client-sts";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated STS SDK Command routing", () => {
+  it("routes AssumeRoleCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const accountId = simSdk.simAws.defaultAccountId;
+    const targetRoleArn = `arn:aws:iam::${accountId}:role/InterceptTargetRole`;
+
+    // A Role trusting the Account root, which is the default caller for
+    // intercepted Commands sent without recognised credentials.
+    await simSdk.simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "InterceptTargetRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    const client = new STSClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const output = await client.send(
+      new AssumeRoleCommand({
+        RoleArn: targetRoleArn,
+        RoleSessionName: "intercepted-session",
+      }),
+    );
+
+    assertIdentical(
+      output.AssumedRoleUser?.Arn,
+      `arn:aws:sts::${accountId}:assumed-role/InterceptTargetRole/intercepted-session`,
+    );
+
+    // And the returned session credentials resolve in sim IAM to the Role.
+    const credentials = output.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    const identity = simSdk.simAws.iam().credentials.resolveCredentials({
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken,
+    });
+    assertObjectMatches(identity, {
+      identityPolicyPrincipal: { kind: "arn", arn: targetRoleArn },
+    });
+  });
+
+  it("rejects a Command simulated STS does not support", async () => {
+    using simSdk = new SimSdk();
+    const client = new STSClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(new GetCallerIdentityCommand({}));
+    });
+
+    assertStringIncludes(error.message, "GetCallerIdentityCommand");
+    assertStringIncludes(error.message, "AssumeRoleCommand");
+  });
+});

--- a/src/service/sts/sdk/sim-sts-sdk-command-router.ts
+++ b/src/service/sts/sdk/sim-sts-sdk-command-router.ts
@@ -1,6 +1,7 @@
-import type {
-  SimSdkCommandRoute,
-  SimSdkCommandRouter,
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimAssumeRoleCommand } from "../command/assume-role/assume-role.cmd.js";
 import type { SimSts } from "../sim-sts.js";
@@ -15,8 +16,11 @@ export class SimStsSdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       [
         "AssumeRoleCommand",
-        async (command): Promise<unknown> =>
-          await simSts.assumeRole(command as SimAssumeRoleCommand),
+        async (command, context): Promise<unknown> =>
+          await simSts.assumeRole(
+            command as SimAssumeRoleCommand,
+            simSdkCallerOptions(context),
+          ),
       ],
     ]);
   }

--- a/src/service/sts/sdk/sim-sts-sdk-command-router.ts
+++ b/src/service/sts/sdk/sim-sts-sdk-command-router.ts
@@ -1,0 +1,37 @@
+import type {
+  SimSdkCommandRoute,
+  SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimAssumeRoleCommand } from "../command/assume-role/assume-role.cmd.js";
+import type { SimSts } from "../sim-sts.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated STS instance.
+ */
+export class SimStsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simSts: SimSts) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "AssumeRoleCommand",
+        async (command): Promise<unknown> =>
+          await simSts.assumeRole(command as SimAssumeRoleCommand),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated STS can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated STS supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -12,6 +12,8 @@ import { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsPrincipal } from "../aws/caller/sim-aws-caller.js";
+import { SimStsSdkCommandRouter } from "./sdk/sim-sts-sdk-command-router.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
 interface SimStsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -30,6 +32,7 @@ export class SimSts {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
   private readonly iamResolver: SimIamAccountResolver;
+  private readonly sdkRouter = new SimStsSdkCommandRouter(this);
 
   constructor(properties: SimStsProperties = {}) {
     this.accountRegionScope =
@@ -53,5 +56,12 @@ export class SimSts {
       background: this.background,
     });
     return await handler.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS SDK client interception for simulated ACM, CloudFormation, CloudFront, DynamoDB, IAM, Route 53, S3, and STS services.
  * Added support for running intercepted commands under a specified simulated identity.
  * Added command allow-listing, restoration controls, and clear errors for unsupported commands.
* **Documentation**
  * Added a comprehensive Simulated AWS SDK guide and usage examples.
  * Updated usage guidance for SDK interception and direct simulated AWS access.
* **Tests**
  * Added end-to-end coverage for supported command routing and unsupported-command handling across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->