### PR TITLE
feat: sim Lambda sim CloudFormation support, inc. bindings

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -31,6 +31,7 @@ Sim CloudFormation currently supports:
   - `AWS::CloudFormation::WaitConditionHandle`
   - `AWS::S3::Bucket`
   - `AWS::CloudFront::Distribution`
+  - `AWS::Lambda::Function`
   - CloudFront Functions used by CDK-generated templates
   - selected CDK custom resources such as CDK S3 BucketDeployment
 
@@ -672,6 +673,61 @@ The `bindings` array matches a template resource logical ID to a local handler f
 especially useful when CDK has embedded or transformed CloudFront Function source in synthesized
 output, but your test wants to provide an executable local function directly.
 
+## Lambda function bindings
+
+`AWS::Lambda::Function` resources support the same bindings, and this is the most convenient way
+to deploy Lambdas through sim CloudFormation: the deployed function is backed by your real
+in-process handler, so tests can close over test state and step through the handler in a debugger,
+while the stack still wires roles, grants, and references exactly as the template declares. A
+bound function may omit template `Code` and `Handler` entirely.
+
+```typescript sim-cloudformation-lambda-binding
+/**
+ * Binding a real in-process Lambda handler during template deployment.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "GreeterFunction",
+      handler: (event: { name: string }): string => `Hello ${event.name}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "greeter",
+    Payload: JSON.stringify({ name: "Yulin" }),
+  }),
+);
+
+console.log(new TextDecoder().decode(output.Payload));
+```
+
+Bindings can target the CloudFormation logical ID (or the CDK construct ID recovered from
+synthesized metadata), the function name, or the function ARN. Bound handlers still run with the
+function's execution Role as the ambient simulated caller, so downstream calls made through
+`SimSdk`-intercepted clients are authorized by simulated IAM as on real Lambda. Functions without
+a matching binding keep their template code, running in the simulated vm runtime.
+
 ## Serving deployed resources on localhost
 
 CloudFormation itself is not served as an HTTP API. Instead, you deploy infrastructure through Sim
@@ -897,6 +953,7 @@ Current supported resource areas include:
 - `AWS::CloudFormation::WaitConditionHandle`
 - `AWS::S3::Bucket`
 - `AWS::CloudFront::Distribution`
+- `AWS::Lambda::Function`
 - selected CloudFront Function resources emitted by CDK
 - selected CDK custom resources, including CDK S3 BucketDeployment
 

--- a/docs/services/cloudformation/sim-cloudformation-lambda-binding.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-lambda-binding.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Binding a real in-process Lambda handler during template deployment.
+ */
+
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "GreeterFunction",
+      handler: (event: { name: string }): string => `Hello ${event.name}`,
+    },
+  ],
+});
+
+const output = await simAws.lambda().invoke(
+  new InvokeCommand({
+    FunctionName: "greeter",
+    Payload: JSON.stringify({ name: "Yulin" }),
+  }),
+);
+
+console.log(new TextDecoder().decode(output.Payload));

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -27,6 +27,7 @@ Sim IAM currently supports:
 - CloudFormation resources:
   - `AWS::IAM::Role`
   - `AWS::IAM::ManagedPolicy`
+  - `AWS::IAM::Policy` (inline policies put onto referenced Roles)
 
 The simulator focuses on useful behavior for isolated tests and local development rather than full
 IAM feature parity. Unsupported IAM options may be ignored or may throw errors depending on whether
@@ -518,7 +519,11 @@ that never mention IAM keep working.
 
 ## CloudFormation Roles and Managed Policies
 
-Sim CloudFormation can create IAM resources from `AWS::IAM::Role` and `AWS::IAM::ManagedPolicy`.
+Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy`, and
+`AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each Role named in `Roles` as an
+inline policy — the pattern CDK grants such as `bucket.grantRead(fn)` synthesize as a
+"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals, so naming
+them fails creation rather than silently dropping the grant.
 
 ```typescript sim-iam-cloudformation
 /**

--- a/src/sdk/module/sim-sdk-module-client-interceptor.iso.test.ts
+++ b/src/sdk/module/sim-sdk-module-client-interceptor.iso.test.ts
@@ -1,0 +1,186 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdkModuleClientInterceptor } from "./sim-sdk-module-client-interceptor.js";
+
+/**
+ * A minimal SDK-shaped client class: send lives on the prototype, like the
+ * smithy Client base class provides for real SDK v3 clients.
+ */
+class FakeSdkClient {
+  constructor(readonly clientConfiguration?: { region?: string }) {}
+
+  send(command: object): Promise<unknown> {
+    return Promise.resolve({ realSend: command });
+  }
+}
+
+/**
+ * A minimal SDK-shaped Command class: no send method.
+ */
+class FakeSdkCommand {
+  constructor(readonly input: object) {}
+}
+
+class FakeSdkError extends Error {}
+
+const fakeSdkConstant = "fake-sdk-constant";
+
+interface RecordedSend {
+  readonly command: object;
+  readonly client: unknown;
+}
+
+function makeInterceptor(defaultRegionName?: "eu-west-2"): {
+  interceptor: SimSdkModuleClientInterceptor;
+  sends: RecordedSend[];
+} {
+  const sends: RecordedSend[] = [];
+  const interceptor = new SimSdkModuleClientInterceptor({
+    sendHandler: (command, client) => {
+      sends.push({ command, client });
+      return Promise.resolve("sim-send-result");
+    },
+    defaultRegionName,
+  });
+  return { interceptor, sends };
+}
+
+function fakeModuleExports(): Record<string, unknown> {
+  return {
+    FakeSdkClient,
+    FakeSdkCommand,
+    FakeSdkError,
+    fakeSdkConstant,
+  };
+}
+
+describe("SimSdkModuleClientInterceptor", () => {
+  it("send-patches instances of intercepted client classes", async () => {
+    // Given a module whose client class export has been intercepted.
+    const { interceptor, sends } = makeInterceptor();
+    const intercepted = interceptor.interceptModule(fakeModuleExports()) as {
+      FakeSdkClient: typeof FakeSdkClient;
+    };
+
+    // When a client is constructed from the intercepted module and sends a
+    // command.
+    const client = new intercepted.FakeSdkClient();
+    const command = new FakeSdkCommand({ Bucket: "bucket" });
+    const result = await client.send(command);
+
+    // Then the send went to the simulated send handler with the command and
+    // the sending client.
+    assertIdentical(result, "sim-send-result");
+    assertArrayLength(sends, 1);
+    const recordedSend = sends[0];
+    assertNonNullable(recordedSend);
+    assertIdentical(recordedSend.command, command);
+    assertIdentical(recordedSend.client, client);
+
+    // And the patch is an own property on the instance, so the real class
+    // prototype stays untouched for direct module users.
+    assertTrue(Object.hasOwn(client, "send"));
+    assertInstanceOf(client, FakeSdkClient);
+    const directInstance = new FakeSdkClient();
+    assertFalse(Object.hasOwn(directInstance, "send"));
+    const directResult = (await directInstance.send(command)) as {
+      realSend: object;
+    };
+    assertIdentical(directResult.realSend, command);
+  });
+
+  it("passes non-client exports through by identity", () => {
+    // Given a module with command, error, and constant exports.
+    const { interceptor } = makeInterceptor();
+
+    // When the module is intercepted.
+    const intercepted = interceptor.interceptModule(
+      fakeModuleExports(),
+    ) as Record<string, unknown>;
+
+    // Then everything without a prototype send passes through unchanged.
+    assertIdentical(intercepted["FakeSdkCommand"], FakeSdkCommand);
+    assertIdentical(intercepted["FakeSdkError"], FakeSdkError);
+    assertIdentical(intercepted["fakeSdkConstant"], fakeSdkConstant);
+  });
+
+  it("does not mutate the source module exports", () => {
+    // Given a module exports object.
+    const { interceptor } = makeInterceptor();
+    const moduleExports = fakeModuleExports();
+
+    // When the module is intercepted.
+    const intercepted = interceptor.interceptModule(moduleExports) as Record<
+      string,
+      unknown
+    >;
+
+    // Then the source exports still expose the unwrapped client class, as the
+    // host module registry caches that object process-wide.
+    assertIdentical(moduleExports["FakeSdkClient"], FakeSdkClient);
+    assertFalse(intercepted["FakeSdkClient"] === FakeSdkClient);
+  });
+
+  it("defaults the client region when none is configured", () => {
+    // Given an interceptor with a default region, as the Lambda runtime
+    // scope provides.
+    const { interceptor } = makeInterceptor("eu-west-2");
+    const intercepted = interceptor.interceptModule(fakeModuleExports()) as {
+      FakeSdkClient: typeof FakeSdkClient;
+    };
+
+    // When clients are constructed without a region, with an explicit
+    // region, and with no configuration at all.
+    const unconfigured = new intercepted.FakeSdkClient();
+    const noRegion = new intercepted.FakeSdkClient({});
+    const explicitRegion = new intercepted.FakeSdkClient({
+      region: "us-east-1",
+    });
+
+    // Then the default region is injected only when none was configured.
+    assertIdentical(unconfigured.clientConfiguration?.region, "eu-west-2");
+    assertIdentical(noRegion.clientConfiguration?.region, "eu-west-2");
+    assertIdentical(explicitRegion.clientConfiguration?.region, "us-east-1");
+  });
+
+  it("leaves constructor arguments alone without a default region", () => {
+    // Given an interceptor without a default region.
+    const { interceptor } = makeInterceptor();
+    const intercepted = interceptor.interceptModule(fakeModuleExports()) as {
+      FakeSdkClient: typeof FakeSdkClient;
+    };
+
+    // When a client is constructed without configuration.
+    const client = new intercepted.FakeSdkClient();
+
+    // Then no configuration is injected.
+    assertUndefined(client.clientConfiguration);
+  });
+
+  it("leaves non-object configuration arguments alone", () => {
+    // Given an intercepted client class and a default region.
+    const { interceptor } = makeInterceptor("eu-west-2");
+    const intercepted = interceptor.interceptModule({
+      FakeSdkClient,
+    }) as { FakeSdkClient: new (configuration: unknown) => FakeSdkClient };
+
+    // When a client is constructed with a non-object configuration value.
+    const client = new intercepted.FakeSdkClient("not-a-configuration");
+
+    // Then the argument passes through unchanged for the real class to
+    // handle.
+    assertIdentical(
+      client.clientConfiguration as unknown as string,
+      "not-a-configuration",
+    );
+  });
+});

--- a/src/sdk/module/sim-sdk-module-client-interceptor.ts
+++ b/src/sdk/module/sim-sdk-module-client-interceptor.ts
@@ -1,0 +1,132 @@
+import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
+import { installSendPatch, type SimSdkSendHandler } from "../send-patch.js";
+
+/**
+ * An SDK client class: a constructable whose instances have a send method.
+ */
+type SimSdkClientConstructor = new (...arguments_: unknown[]) => object;
+
+interface SimSdkModuleClientInterceptorProperties {
+  readonly sendHandler: SimSdkSendHandler;
+  readonly defaultRegionName?: AwsRegionName | undefined;
+}
+
+/**
+ * Intercepts the SDK client classes exported by an AWS SDK package module.
+ *
+ * Client classes are wrapped so every instance constructed from the wrapped
+ * module gets a per-instance simulated send patch. The patch shadows send as
+ * an own property on the instance, so the real class prototype is never
+ * modified and nothing leaks to code using the module directly.
+ *
+ * All other exports, such as Command classes, error classes and constants,
+ * pass through untouched by identity, so instanceof checks and command
+ * construction behave exactly as with the real module.
+ */
+export class SimSdkModuleClientInterceptor {
+  private readonly sendHandler: SimSdkSendHandler;
+  private readonly defaultRegionName: AwsRegionName | undefined;
+
+  constructor(properties: SimSdkModuleClientInterceptorProperties) {
+    this.sendHandler = properties.sendHandler;
+    this.defaultRegionName = properties.defaultRegionName;
+  }
+
+  /**
+   * Build an intercepted copy of a module's exports.
+   *
+   * The source exports object is never mutated: the host module registry
+   * caches it process-wide, so mutation would leak interception into code
+   * importing the module normally.
+   */
+  interceptModule(moduleExports: object): object {
+    const intercepted: Record<string, unknown> = {};
+    for (const [exportName, exportValue] of Object.entries(moduleExports)) {
+      // eslint-disable-next-line security/detect-object-injection -- copying the module's own export names verbatim.
+      intercepted[exportName] = this.interceptExport(exportValue);
+    }
+    return intercepted;
+  }
+
+  private interceptExport(exportValue: unknown): unknown {
+    if (this.isClientClass(exportValue)) {
+      return this.wrapClientClass(exportValue);
+    }
+    return exportValue;
+  }
+
+  /**
+   * SDK v3 client classes inherit send from the smithy Client base class, so
+   * a prototype-chain check finds clients while Command classes and other
+   * function exports pass through.
+   */
+  private isClientClass(value: unknown): value is SimSdkClientConstructor {
+    if (typeof value !== "function") {
+      return false;
+    }
+    const prototype = (value as { prototype?: { send?: unknown } }).prototype;
+    return typeof prototype?.send === "function";
+  }
+
+  /**
+   * Wrap a client class so constructed instances are send-patched.
+   *
+   * Reflect.construct with the incoming new target preserves subclassing and
+   * instanceof against the real class.
+   */
+  private wrapClientClass(
+    clientClass: SimSdkClientConstructor,
+  ): SimSdkClientConstructor {
+    const sendHandler = this.sendHandler;
+    const configureArguments = (constructorArguments: unknown[]): unknown[] =>
+      this.regionDefaultedArguments(constructorArguments);
+
+    return new Proxy(clientClass, {
+      construct(
+        target: SimSdkClientConstructor,
+        constructorArguments: unknown[],
+        newTarget: Function, // eslint-disable-line @typescript-eslint/no-unsafe-function-type -- ProxyHandler construct trap signature.
+      ): object {
+        const instance = Reflect.construct(
+          target,
+          configureArguments(constructorArguments),
+          newTarget,
+        ) as object;
+        installSendPatch(instance, sendHandler);
+        return instance;
+      },
+    });
+  }
+
+  /**
+   * Default the client configuration region, as the real Lambda runtime does
+   * by supplying AWS_REGION to the SDK's environment region provider.
+   *
+   * An explicit region in the constructed configuration always wins.
+   */
+  private regionDefaultedArguments(constructorArguments: unknown[]): unknown[] {
+    if (this.defaultRegionName === undefined) {
+      return constructorArguments;
+    }
+
+    const [configuration, ...rest] = constructorArguments;
+    if (!this.isConfigurationObject(configuration)) {
+      return constructorArguments;
+    }
+
+    if (configuration?.["region"] !== undefined) {
+      return constructorArguments;
+    }
+
+    return [{ ...configuration, region: this.defaultRegionName }, ...rest];
+  }
+
+  private isConfigurationObject(
+    configuration: unknown,
+  ): configuration is Record<string, unknown> | undefined {
+    if (configuration === undefined) {
+      return true;
+    }
+    return typeof configuration === "object" && configuration !== null;
+  }
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -18,6 +18,7 @@ import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimLambda } from "../../lambda/index.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
+import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimSts } from "../../sts/sim-sts.js";
 
 interface SimAwsServiceFactoryProperties {
@@ -147,7 +148,10 @@ export class SimAwsServiceFactory {
    * Create simulated Lambda for an Account Region scope.
    *
    * S3-located function code is fetched from the same Account/Region scope's
-   * simulated S3, as real Lambda requires same-region code buckets.
+   * simulated S3, as real Lambda requires same-region code buckets. Function
+   * code running in the vm runtime is provided host-installed AWS SDK
+   * packages intercepted into this SimAws, as the real Lambda runtime
+   * provides the SDK.
    */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     const iam = this.createIam(scope);
@@ -158,6 +162,10 @@ export class SimAwsServiceFactory {
       background: this.background,
       runAsOwner: this.simAws,
       codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
+      vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
+        simAws: this.simAws,
+        regionName: scope.accountRegionScope.regionName,
+      }),
     });
   }
 

--- a/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
+++ b/src/service/cloudformation/bind/sim-cfn-exec-binding.type.ts
@@ -1,8 +1,16 @@
 import type { CloudFrontFunction } from "../../cloudfront/index.js";
+import type { SimLambdaHandler } from "../../lambda/function/sim-lambda-handler.type.js";
 
-// Later this will be expanded for other executable resources such as Lambdas.
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-type SimCfnExecutableResource = CloudFrontFunction.Handler | Function;
+/**
+ * A real in-process handler function that can back an executable
+ * CloudFormation Resource: a CloudFront Function handler or a Lambda handler.
+ * The plain Function member keeps room for other executable resource kinds.
+ */
+export type SimCfnExecutableResource =
+  | CloudFrontFunction.Handler
+  | SimLambdaHandler
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  | Function;
 
 export type SimCfnExecutableResourceBinding<
   H extends SimCfnExecutableResource = SimCfnExecutableResource,
@@ -38,3 +46,6 @@ export type SimCfnExecutableResourceBinding<
 
 export type SimCfnCfBinding =
   SimCfnExecutableResourceBinding<CloudFrontFunction.Handler>;
+
+export type SimCfnLambdaBinding =
+  SimCfnExecutableResourceBinding<SimLambdaHandler>;

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.iso.test.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.iso.test.ts
@@ -9,7 +9,7 @@ import type { CloudFrontFunction } from "../../../cloudfront/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCloudFrontFunction } from "../../../cloudfront/cff/sim-cloudfront-function.js";
 import { simCfnCffResourceFactory } from "../../resource/cfn/cloudfront/sim-cff-cfn.factory.js";
-import { SimCfnCffBindingFinder } from "./sim-cfn-exec-binding-finder.js";
+import { SimCfnExecBindingFinder } from "./sim-cfn-exec-binding-finder.js";
 
 describe("Sim CloudFormation executable binding finder", () => {
   it("finds a logicalId binding from CDK construct path metadata when deploying a template", async () => {
@@ -143,12 +143,15 @@ function handler(event) {
       logicalId: "RewriteFunction",
       handler: rewriteRequestToBoundHandler,
     };
-    const finder = new SimCfnCffBindingFinder({
+    const finder = new SimCfnExecBindingFinder({
       resource,
       bindings: [binding],
     });
 
-    assertIdentical(finder.findBinding("RewriteFunction48E73F66"), binding);
+    assertIdentical(
+      finder.findBinding({ functionName: "RewriteFunction48E73F66" }),
+      binding,
+    );
   });
 
   it("ignores invalid CDK path metadata when finding a binding directly", () => {
@@ -175,7 +178,7 @@ function handler(event) {
         logicalId: "RewriteFunction48E73F66",
         metadata: testCase.metadata,
       });
-      const finder = new SimCfnCffBindingFinder({
+      const finder = new SimCfnExecBindingFinder({
         resource,
         bindings: [
           {
@@ -185,7 +188,9 @@ function handler(event) {
         ],
       });
 
-      assertUndefined(finder.findBinding("RewriteFunction48E73F66"));
+      assertUndefined(
+        finder.findBinding({ functionName: "RewriteFunction48E73F66" }),
+      );
     }
   });
 });

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-finder.ts
@@ -1,51 +1,68 @@
 import type {
-  SimCfnCfBinding,
+  SimCfnExecutableResource,
   SimCfnExecutableResourceBinding,
 } from "../sim-cfn-exec-binding.type.js";
 import { cdkPathMetadataKeys } from "./sim-cfn-exec-binding-matcher.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
-interface SimCfnCffBindingFinderProperties {
+interface SimCfnExecBindingFinderProperties {
   readonly resource: SimCfnResource;
   readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
 }
 
 /**
- * Finds the executable binding that should replace CloudFormation FunctionCode.
+ * The resolved identifiers of the executable Resource a factory is creating,
+ * used to decide which binding targets it.
+ */
+export interface SimCfnExecBindingTargets {
+  readonly functionName: string;
+  readonly arn?: string | undefined;
+}
+
+/**
+ * Finds the executable binding that should replace CloudFormation function
+ * code.
  *
- * A CloudFront Function can be declared in a synthesized CloudFormation template,
- * while test code may provide an executable JavaScript handler through a binding.
- * This class keeps the matching rules in one place so the CreateFunction input
- * builder can stay focused on validating Resource properties and building the
- * command input.
+ * An executable resource such as a CloudFront Function or Lambda function can
+ * be declared in a synthesized CloudFormation template, while test code may
+ * provide a real in-process handler through a binding. This class keeps the
+ * matching rules in one place so resource factories can stay focused on
+ * validating Resource properties and building command input.
  *
  * Supported binding targets:
  *
  * - CloudFormation logical ID, for templates written directly or synthesized by CDK
  * - CDK construct ID, recovered from Resource Metadata path values
- * - resolved CloudFront Function name, for name-based bindings
+ * - resolved function name, for name-based bindings
+ * - resource ARN, when the creating factory supplies its ARN format
+ * - CDK construct path, matched against Resource Metadata
  */
-export class SimCfnCffBindingFinder {
+export class SimCfnExecBindingFinder<
+  H extends SimCfnExecutableResource = SimCfnExecutableResource,
+> {
   private readonly resource: SimCfnResource;
   private readonly bindings:
     readonly SimCfnExecutableResourceBinding[] | undefined;
 
-  constructor(properties: SimCfnCffBindingFinderProperties) {
+  constructor(properties: SimCfnExecBindingFinderProperties) {
     this.resource = properties.resource;
     this.bindings = properties.bindings;
   }
 
   /**
-   * Return the first binding that targets this CloudFront Function Resource.
+   * Return the first binding that targets this executable Resource.
    *
    * Logical ID matching is evaluated before function-name matching because the
-   * logical ID is stable even when the template omits the Function Name property
-   * and the simulator falls back to the Resource logical ID as the local name.
+   * logical ID is stable even when the template omits the function name
+   * property and the simulator falls back to the Resource logical ID as the
+   * local name.
    */
-  findBinding(functionName: string): SimCfnCfBinding | undefined {
+  findBinding(
+    targets: SimCfnExecBindingTargets,
+  ): SimCfnExecutableResourceBinding<H> | undefined {
     return this.bindings?.find((binding) =>
-      this.matchesBinding(binding, functionName),
-    ) as SimCfnCfBinding | undefined;
+      this.matchesBinding(binding, targets),
+    ) as SimCfnExecutableResourceBinding<H> | undefined;
   }
 
   /**
@@ -57,14 +74,22 @@ export class SimCfnCffBindingFinder {
    */
   private matchesBinding(
     binding: SimCfnExecutableResourceBinding,
-    functionName: string,
+    targets: SimCfnExecBindingTargets,
   ): boolean {
     if ("logicalId" in binding) {
       return this.resourceMatchesLogicalIdBinding(binding.logicalId);
     }
 
     if ("functionName" in binding) {
-      return binding.functionName === functionName;
+      return binding.functionName === targets.functionName;
+    }
+
+    if ("arn" in binding) {
+      return targets.arn !== undefined && binding.arn === targets.arn;
+    }
+
+    if ("cdkPath" in binding) {
+      return binding.cdkPath === this.cdkPath();
     }
 
     /* v8 ignore next */

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
@@ -37,7 +37,8 @@ export class SimCfnExecutableResourceBindingMatcher {
    * - `logicalId` checks the synthesized logical ID and the CDK construct ID.
    * - `functionName` checks the CloudFront Function Name property, falling
    *   back to the logical ID because CloudFront Functions can omit Name.
-   * - `arn` reconstructs the simulator's CloudFront Function ARN format.
+   * - `arn` reconstructs the simulator's CloudFront Function or Lambda
+   *   function ARN format.
    * - `cdkPath` checks CDK metadata emitted into the synthesized template.
    */
   matches(binding: SimCfnExecutableResourceBinding): boolean {
@@ -50,13 +51,13 @@ export class SimCfnExecutableResourceBindingMatcher {
     if ("functionName" in binding) {
       return this.#resources.some(
         (resource) =>
-          this.#cloudFrontFunctionName(resource) === binding.functionName,
+          this.#executableFunctionName(resource) === binding.functionName,
       );
     }
 
     if ("arn" in binding) {
       return this.#resources.some(
-        (resource) => this.#cloudFrontFunctionArn(resource) === binding.arn,
+        (resource) => this.#executableFunctionArn(resource) === binding.arn,
       );
     }
 
@@ -86,37 +87,62 @@ export class SimCfnExecutableResourceBindingMatcher {
     );
   }
 
-  #cloudFrontFunctionName(resource: SimCfnResource): string | undefined {
-    if (resource.type !== "AWS::CloudFront::Function") {
+  /**
+   * The name an executable function Resource resolves to when created.
+   *
+   * CloudFront Function Name and Lambda FunctionName are optional in CDK
+   * output. When no explicit name is present, the simulator identifies the
+   * function using its logical ID, matching the fallback used when the sim
+   * resource is created.
+   */
+  #executableFunctionName(resource: SimCfnResource): string | undefined {
+    const name = this.#functionNameProperty(resource);
+
+    if (name === undefined) {
       return undefined;
     }
 
-    const name = resource.properties["Name"];
-
-    /*
-     * CloudFront Function Name is optional in CDK output. When no explicit name
-     * is present, the simulator identifies the function using its logical ID,
-     * matching the fallback used when the sim Function resource is created.
-     */
-    return typeof name === "string" && name.length > 0
-      ? name
-      : resource.logicalId;
+    return name.length > 0 ? name : resource.logicalId;
   }
 
-  #cloudFrontFunctionArn(resource: SimCfnResource): string | undefined {
-    const functionName = this.#cloudFrontFunctionName(resource);
+  #functionNameProperty(resource: SimCfnResource): string | undefined {
+    const propertyName = this.#namePropertyForType(resource.type);
+    if (propertyName === undefined) {
+      return undefined;
+    }
 
-    /* v8 ignore if */
+    const name = resource.properties[propertyName];
+    return typeof name === "string" ? name : "";
+  }
+
+  #namePropertyForType(resourceType: string | undefined): string | undefined {
+    if (resourceType === "AWS::CloudFront::Function") {
+      return "Name";
+    }
+    if (resourceType === "AWS::Lambda::Function") {
+      return "FunctionName";
+    }
+    return undefined;
+  }
+
+  #executableFunctionArn(resource: SimCfnResource): string | undefined {
+    const functionName = this.#executableFunctionName(resource);
+
     if (functionName === undefined) {
       return undefined;
     }
 
     /*
-     * CloudFront Function ARNs do not contain a region component. The account
-     * still comes from the resource scope so bindings can validate exact ARNs
-     * when CDK associations use ARN-based references.
+     * CloudFront Function ARNs do not contain a region component, while
+     * Lambda function ARNs do. The account comes from the resource scope so
+     * bindings can validate exact ARNs when associations use ARN-based
+     * references.
      */
-    return `arn:aws:cloudfront::${resource.accountRegionScope.accountId}:function/${functionName}`;
+    const { accountId, regionName } = resource.accountRegionScope;
+    if (resource.type === "AWS::Lambda::Function") {
+      return `arn:aws:lambda:${regionName}:${accountId}:function:${functionName}`;
+    }
+    return `arn:aws:cloudfront::${accountId}:function/${functionName}`;
   }
 
   #cdkPath(resource: SimCfnResource): string | undefined {

--- a/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
+++ b/src/service/cloudformation/bind/validate/sim-cfn-exec-binding-matcher.ts
@@ -1,3 +1,4 @@
+import { simLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCfnExecutableResourceBinding } from "../sim-cfn-exec-binding.type.js";
 
@@ -35,8 +36,9 @@ export class SimCfnExecutableResourceBindingMatcher {
    * Each binding variant uses the most natural identifier available:
    *
    * - `logicalId` checks the synthesized logical ID and the CDK construct ID.
-   * - `functionName` checks the CloudFront Function Name property, falling
-   *   back to the logical ID because CloudFront Functions can omit Name.
+   * - `functionName` checks the CloudFront Function Name or Lambda
+   *   FunctionName property, falling back to the logical ID because both can
+   *   omit an explicit name.
    * - `arn` reconstructs the simulator's CloudFront Function or Lambda
    *   function ARN format.
    * - `cdkPath` checks CDK metadata emitted into the synthesized template.
@@ -111,6 +113,7 @@ export class SimCfnExecutableResourceBindingMatcher {
       return undefined;
     }
 
+    // eslint-disable-next-line security/detect-object-injection -- fixed per-type property names.
     const name = resource.properties[propertyName];
     return typeof name === "string" ? name : "";
   }
@@ -138,11 +141,10 @@ export class SimCfnExecutableResourceBindingMatcher {
      * bindings can validate exact ARNs when associations use ARN-based
      * references.
      */
-    const { accountId, regionName } = resource.accountRegionScope;
     if (resource.type === "AWS::Lambda::Function") {
-      return `arn:aws:lambda:${regionName}:${accountId}:function:${functionName}`;
+      return simLambdaFunctionArn(resource.accountRegionScope, functionName);
     }
-    return `arn:aws:cloudfront::${accountId}:function/${functionName}`;
+    return `arn:aws:cloudfront::${resource.accountRegionScope.accountId}:function/${functionName}`;
   }
 
   #cdkPath(resource: SimCfnResource): string | undefined {

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-s3-read.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-s3-read.loc.test.ts
@@ -1,0 +1,245 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and asset manifest to pass to sim CloudFormation.
+ */
+import { SimSdk } from "../../../../sdk/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const objectContent = "Hello from sim S3 via CDK";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The AWS SDK
+ * is provided by the simulated runtime, as on real Lambda, and calls run as
+ * the function's execution role.
+ */
+const readObjectHandlerSource = `
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+const s3Client = new S3Client({});
+exports.handler = async (event) => {
+  const output = await s3Client.send(
+    new GetObjectCommand({ Bucket: event.bucketName, Key: event.objectKey }),
+  );
+  const content = await output.Body.transformToString();
+  return { content, contentLength: content.length };
+};
+`;
+
+describe("Sim CDK Lambda deployment local integration", () => {
+  it("deploys a Lambda that reads a granted S3 object", async () => {
+    // Given a data file for the bucket deployment.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    await projectDirectory.writeFile("data/greeting.txt", objectContent);
+    const dataDirectory = projectDirectory.join("data");
+
+    // And a CDK stack with a bucket holding the data object and a Lambda
+    // function whose execution role is granted read access to the bucket.
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const dataBucket = new s3.Bucket(stack, "DataBucket");
+
+new s3deploy.BucketDeployment(stack, "DeployData", {
+  sources: [s3deploy.Source.asset(${JSON.stringify(dataDirectory)})],
+  destinationBucket: dataBucket,
+});
+
+const readerFunction = new lambda.Function(stack, "ReaderFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(readObjectHandlerSource)}),
+});
+
+dataBucket.grantRead(readerFunction);
+
+new cdk.CfnOutput(stack, "DataBucketName", {
+  value: dataBucket.bucketName,
+});
+new cdk.CfnOutput(stack, "ReaderFunctionName", {
+  value: readerFunction.functionName,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the Outputs should be available.
+    const bucketName = stack.outputs.get("DataBucketName")?.value;
+    const functionName = stack.outputs.get("ReaderFunctionName")?.value;
+    assertTypeString(bucketName);
+    assertTypeString(functionName);
+
+    // And invoking the deployed function reads the deployed S3 object as the
+    // granted execution role.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Payload: JSON.stringify({
+          bucketName,
+          objectKey: "greeting.txt",
+        }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    const result = JSON.parse(Buffer.from(invokeOutput.Payload).toString()) as {
+      content: string;
+      contentLength: number;
+    };
+    assertIdentical(result.content, objectContent);
+    assertIdentical(result.contentLength, objectContent.length);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("binds a real in-process handler over the synthesized template", async () => {
+    // Given a data file for the bucket deployment.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    await projectDirectory.writeFile("data/greeting.txt", objectContent);
+    const dataDirectory = projectDirectory.join("data");
+
+    // And a real in-process handler reading sim S3 through an intercepted
+    // SDK client, closing over test state so it can be stepped through in a
+    // debugger.
+    using simSdk = new SimSdk({ simAws });
+    const s3Client = new S3Client({ region: simAws.defaultRegionName });
+    simSdk.intercept(s3Client);
+    const observedEvents: unknown[] = [];
+    const boundHandler = async (event: {
+      bucketName: string;
+      objectKey: string;
+    }): Promise<{ content: string; source: string }> => {
+      observedEvents.push(event);
+      const output = await s3Client.send(
+        new GetObjectCommand({
+          Bucket: event.bucketName,
+          Key: event.objectKey,
+        }),
+      );
+      const content = (await output.Body?.transformToString()) ?? "";
+      return { content, source: "bound-handler" };
+    };
+
+    // And a CDK stack whose function has placeholder inline code that the
+    // binding will replace at deploy time.
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const dataBucket = new s3.Bucket(stack, "DataBucket");
+
+new s3deploy.BucketDeployment(stack, "DeployData", {
+  sources: [s3deploy.Source.asset(${JSON.stringify(dataDirectory)})],
+  destinationBucket: dataBucket,
+});
+
+const readerFunction = new lambda.Function(stack, "ReaderFunction", {
+  functionName: "cdk-bound-reader",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(
+    "exports.handler = async () => 'replaced by binding';",
+  ),
+});
+
+dataBucket.grantRead(readerFunction);
+
+new cdk.CfnOutput(stack, "DataBucketName", {
+  value: dataBucket.bucketName,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template with the handler bound by function name.
+    const stack = await simAws.cloudFormation().deployTemplateFile({
+      templatePath: path.join(cdkOutDirectory, "TestStack.template.json"),
+      bindings: [
+        {
+          functionName: "cdk-bound-reader",
+          handler: boundHandler,
+        },
+      ],
+    });
+    await simAws.backgroundTasksComplete();
+
+    const bucketName = stack.outputs.get("DataBucketName")?.value;
+    assertTypeString(bucketName);
+
+    // Then invoking the deployed function runs the bound handler in-process,
+    // reading the deployed S3 object as the granted execution role.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "cdk-bound-reader",
+        Payload: JSON.stringify({
+          bucketName,
+          objectKey: "greeting.txt",
+        }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    const result = JSON.parse(Buffer.from(invokeOutput.Payload).toString()) as {
+      content: string;
+      source: string;
+    };
+    assertIdentical(result.content, objectContent);
+    assertIdentical(result.source, "bound-handler");
+    assertArrayLength(observedEvents, 1);
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -6,7 +6,10 @@ import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
-import { SimCfnTemplateFileLoader } from "./sim-cfn-template-file-loader.js";
+import {
+  SimCfnTemplateFileLoader,
+  type SimCloudFormationDeployTemplateFileProps as SimCloudFormationDeployTemplateFileProperties,
+} from "./sim-cfn-template-file-loader.js";
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
@@ -25,11 +28,7 @@ export interface SimCloudFormationCreateStackProps {
   readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
 }
 
-export interface SimCloudFormationDeployTemplateFileProps {
-  readonly templatePath: string;
-  readonly stackName?: SimCloudFormationStackName | string | undefined;
-  readonly parameters?: Record<string, string> | undefined;
-}
+export type { SimCloudFormationDeployTemplateFileProps } from "./sim-cfn-template-file-loader.js";
 
 interface SimCloudFormationTemplateDeployerProperties {
   readonly simAws: SimAws;
@@ -82,7 +81,7 @@ export class SimCloudFormationTemplateDeployer {
    * template file.
    */
   async deployTemplateFile(
-    properties: SimCloudFormationDeployTemplateFileProps | string,
+    properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnStack> {
     return await this.deployTemplateWithContext(
       await this.templateFileLoader.load(properties),

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-cfn.ts
@@ -1,0 +1,41 @@
+import type { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLambdaFunctionCfnProperties {
+  readonly lambdaFunction: SimLambdaFunction;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::Lambda::Function Resource.
+ *
+ * Keeps Lambda function objects free of CloudFormation intrinsic-function
+ * concerns while exposing the correct Ref and Fn::GetAtt values.
+ */
+export class SimLambdaFunctionCfn implements SimCfnResourceValueAdapter {
+  private readonly lambdaFunction: SimLambdaFunction;
+
+  constructor(properties: SimLambdaFunctionCfnProperties) {
+    this.lambdaFunction = properties.lambdaFunction;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::Lambda::Function returns the function name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.lambdaFunction.name;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::Lambda::Function.
+   *
+   * AWS::Lambda::Function supports Fn::GetAtt for Arn.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Arn") {
+      return this.lambdaFunction.arn;
+    }
+
+    return `${this.lambdaFunction.arn}.${attributeName}`;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -14,6 +14,8 @@ import { SimIamManagedPolicyCfn } from "./iam/sim-iam-managed-policy-cfn.js";
 import type { SimIamManagedPolicy } from "../../../iam/policy/sim-iam-policy.js";
 import { SimIamRoleCfn } from "./iam/sim-iam-role-cfn.js";
 import type { SimIamRole } from "../../../iam/role/sim-iam-role.js";
+import { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import { SimLambdaFunctionCfn } from "./lambda/sim-lambda-function-cfn.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -82,6 +84,15 @@ export function simCfnResourceValueAdapter(
   if (properties.type === "AWS::IAM::Role") {
     return new SimIamRoleCfn({
       role: properties.simResource as SimIamRole,
+    });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::Function" &&
+    properties.simResource instanceof SimLambdaFunction
+  ) {
+    return new SimLambdaFunctionCfn({
+      lambdaFunction: properties.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -54,6 +54,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "IAM": {
       return scopedAws.iam().cfnResourceFactory();
     }
+    case "Lambda": {
+      return scopedAws.lambda().cfnResourceFactory();
+    }
     case "Route53": {
       return scopedAws.route53().cfnResourceFactory();
     }

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-binding-lookup.ts
@@ -1,0 +1,36 @@
+import type {
+  SimCfnCfBinding,
+  SimCfnExecutableResourceBinding,
+} from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { CloudFrontFunction } from "../../index.js";
+
+interface SimCfnCffBindingLookupProperties {
+  readonly resource: SimCfnResource;
+  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+  readonly cffName: string;
+}
+
+/**
+ * Find the executable binding targeting a CloudFront Function Resource,
+ * resolving the identifiers a binding can target: the function name and the
+ * simulator's CloudFront Function ARN, which has no region component.
+ */
+export function findSimCfnCffBinding(
+  properties: SimCfnCffBindingLookupProperties,
+): SimCfnCfBinding | undefined {
+  const bindingFinder = new SimCfnExecBindingFinder<CloudFrontFunction.Handler>(
+    {
+      resource: properties.resource,
+      bindings: properties.bindings,
+    },
+  );
+
+  const { accountId } = properties.resource.accountRegionScope;
+
+  return bindingFinder.findBinding({
+    functionName: properties.cffName,
+    arn: `arn:aws:cloudfront::${accountId}:function/${properties.cffName}`,
+  });
+}

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-create-input-builder.ts
@@ -10,7 +10,7 @@ import {
   simCfnCffFunctionConfig,
   type SimCfnCffFunctionConfig,
 } from "./sim-cfn-cff-function-config.js";
-import { SimCfnCffBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
+import { findSimCfnCffBinding } from "./sim-cfn-cff-binding-lookup.js";
 
 interface SimCfnCfFunctionCreateInputBuilderProperties {
   readonly resource: SimCfnResource;
@@ -64,11 +64,11 @@ export class SimCfnCffCreateInputBuilder {
   build(): SimCfnCfFunctionCreateInput {
     const functionCodeValue = this.functionCode();
     const cffName = this.cffName();
-    const bindingFinder = new SimCfnCffBindingFinder({
+    const binding = findSimCfnCffBinding({
       resource: this.resource,
       bindings: this.bindings,
+      cffName,
     });
-    const binding = bindingFinder.findBinding(cffName);
 
     return {
       Name: cffName,

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
@@ -1,0 +1,134 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIam } from "../../sim-iam.js";
+
+interface SimCfnIamPolicyCreatorProperties {
+  readonly iam: SimIam;
+}
+
+/**
+ * Creates simulated IAM inline role policies from AWS::IAM::Policy
+ * CloudFormation Resources.
+ *
+ * AWS::IAM::Policy is an inline policy put onto the referenced principals,
+ * which is how CDK grants such as bucket.grantRead(fn) attach permissions to
+ * a function's execution role (the "DefaultPolicy" resource). Only Roles are
+ * simulated; the policy has no standalone stored resource, so creation
+ * returns undefined and Ref resolution uses the default adapter.
+ */
+export class SimCfnIamPolicyCreator {
+  private readonly iam: SimIam;
+
+  constructor(properties: SimCfnIamPolicyCreatorProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Put the inline policy onto each referenced Role.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<undefined> {
+    this.rejectUnsimulatedPrincipals(resource, properties);
+
+    const policyName = this.policyName(resource, properties);
+    const policyDocument = this.policyDocument(resource, properties);
+    const roleNames = this.roleNames(resource, properties);
+
+    await Promise.all(
+      roleNames.map(async (roleName) =>
+        this.iam.putRolePolicy({
+          input: {
+            RoleName: roleName,
+            PolicyName: policyName,
+            PolicyDocument: policyDocument,
+          },
+        }),
+      ),
+    );
+
+    return undefined;
+  }
+
+  private policyName(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const policyName = properties["PolicyName"];
+
+    if (typeof policyName !== "string") {
+      throw new TypeError(
+        `Invalid AWS::IAM::Policy ${resource.logicalId}: PolicyName must be a string`,
+      );
+    }
+
+    return policyName;
+  }
+
+  private policyDocument(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const policyDocument = properties["PolicyDocument"];
+
+    if (
+      policyDocument === undefined ||
+      typeof policyDocument !== "object" ||
+      policyDocument === null ||
+      Array.isArray(policyDocument)
+    ) {
+      throw new TypeError(
+        `Invalid AWS::IAM::Policy ${resource.logicalId}: PolicyDocument must be an object`,
+      );
+    }
+
+    return JSON.stringify(policyDocument);
+  }
+
+  /**
+   * The Role names the policy attaches to. Role Refs are resolved to Role
+   * names before creation, so entries arrive as plain strings.
+   */
+  private roleNames(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): readonly string[] {
+    const roles = properties["Roles"];
+
+    if (!Array.isArray(roles) || roles.length === 0) {
+      throw new TypeError(
+        `Invalid AWS::IAM::Policy ${resource.logicalId}: Roles must be a non-empty array`,
+      );
+    }
+
+    return roles.map((roleName) => {
+      if (typeof roleName !== "string") {
+        throw new TypeError(
+          `Invalid AWS::IAM::Policy ${resource.logicalId}: Roles entries must be strings`,
+        );
+      }
+      return roleName;
+    });
+  }
+
+  /**
+   * IAM Users and Groups are not simulated as CloudFormation policy
+   * principals, and silently dropping a grant would be misleading, so their
+   * presence fails creation.
+   */
+  private rejectUnsimulatedPrincipals(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    for (const principalProperty of ["Users", "Groups"]) {
+      // eslint-disable-next-line security/detect-object-injection -- fixed property names.
+      if (properties[principalProperty] !== undefined) {
+        throw new TypeError(
+          `Invalid AWS::IAM::Policy ${resource.logicalId}: ` +
+            `${principalProperty} are not simulated`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
@@ -1,0 +1,174 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimIamCloudFormationResourceFactory } from "../sim-cfn-iam-resource-factory.js";
+import { SimCfnIamPolicyCreator } from "./sim-cfn-iam-policy-creator.js";
+
+const validPolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::data-bucket/*",
+    },
+  ],
+};
+
+async function policyCreationError(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const creator = new SimCfnIamPolicyCreator({ iam: simAws.iam() });
+  const resource = new SimCfnResource({
+    accountRegionScope: {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadPolicy",
+    template: {
+      Type: "AWS::IAM::Policy",
+      Properties: properties,
+    },
+  });
+
+  return await assertThrowsErrorAsync(async () =>
+    creator.create(resource, properties),
+  );
+}
+
+async function assertRejectsPolicy(
+  properties: SimCfnTemplateValueRecord,
+  expectedMessage: string,
+): Promise<void> {
+  const error = await policyCreationError(properties);
+
+  assertInstanceOf(error, TypeError);
+  assertIdentical(
+    error.message,
+    `Invalid AWS::IAM::Policy BadPolicy: ${expectedMessage}`,
+  );
+}
+
+describe("IAM CloudFormation Policy validation", () => {
+  it("rejects a missing or non-string PolicyName", async () => {
+    // Given Policy properties with a missing or malformed PolicyName.
+    // When creation is attempted, then each rejects naming the property and
+    // the logical ID.
+    await assertRejectsPolicy(
+      { PolicyDocument: validPolicyDocument, Roles: ["ReaderRole"] },
+      "PolicyName must be a string",
+    );
+    await assertRejectsPolicy(
+      {
+        PolicyName: 42,
+        PolicyDocument: validPolicyDocument,
+        Roles: ["ReaderRole"],
+      },
+      "PolicyName must be a string",
+    );
+  });
+
+  it("rejects a missing or malformed PolicyDocument", async () => {
+    // Given Policy properties with a missing or malformed PolicyDocument.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsPolicy(
+      { PolicyName: "BadPolicy", Roles: ["ReaderRole"] },
+      "PolicyDocument must be an object",
+    );
+    await assertRejectsPolicy(
+      { PolicyName: "BadPolicy", PolicyDocument: "{}", Roles: ["ReaderRole"] },
+      "PolicyDocument must be an object",
+    );
+    await assertRejectsPolicy(
+      { PolicyName: "BadPolicy", PolicyDocument: [], Roles: ["ReaderRole"] },
+      "PolicyDocument must be an object",
+    );
+  });
+
+  it("rejects missing, empty, or malformed Roles", async () => {
+    // Given Policy properties with missing or malformed Roles.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsPolicy(
+      { PolicyName: "BadPolicy", PolicyDocument: validPolicyDocument },
+      "Roles must be a non-empty array",
+    );
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Roles: [],
+      },
+      "Roles must be a non-empty array",
+    );
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Roles: [42],
+      },
+      "Roles entries must be strings",
+    );
+  });
+
+  it("rejects unsupported IAM resource types", async () => {
+    // Given an IAM CloudFormation Resource factory and an unsupported
+    // Resource type.
+    const simAws = new SimAws();
+    const factory = new SimIamCloudFormationResourceFactory(simAws.iam());
+    const resource = new SimCfnResource({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+      logicalId: "ExampleGroup",
+      template: {
+        Type: "AWS::IAM::Group",
+      },
+    });
+
+    // When creation is attempted, then it rejects with an unsupported
+    // Resource type error naming the type for diagnosis.
+    const error = await assertThrowsErrorAsync(async () =>
+      factory.create("Group", resource, { simAws, resources: new Map() }),
+    );
+
+    assertIdentical(
+      error.message,
+      "Unsupported sim IAM CloudFormation Resource Group",
+    );
+  });
+
+  it("rejects unsimulated Users and Groups principals", async () => {
+    // Given Policy properties naming Users or Groups, which sim IAM does not
+    // simulate as CloudFormation policy principals.
+    // When creation is attempted, then each rejects rather than silently
+    // dropping the grant.
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Roles: ["ReaderRole"],
+        Users: ["SomeUser"],
+      },
+      "Users are not simulated",
+    );
+    await assertRejectsPolicy(
+      {
+        PolicyName: "BadPolicy",
+        PolicyDocument: validPolicyDocument,
+        Roles: ["ReaderRole"],
+        Groups: ["SomeGroup"],
+      },
+      "Groups are not simulated",
+    );
+  });
+});

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
@@ -1,0 +1,126 @@
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimIamRoleName } from "../../role/sim-iam-role.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: {
+        Service: "lambda.amazonaws.com",
+      },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+const readPolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::data-bucket/*",
+    },
+  ],
+};
+
+describe("IAM CloudFormation Policy", () => {
+  it("puts the inline policy onto referenced Roles", async () => {
+    // Given a CloudFormation template with a Role and an AWS::IAM::Policy
+    // referencing it, as CDK grants attach permissions to execution roles.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-inline-policy-stack",
+      template: {
+        Resources: {
+          ReaderRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "ReaderRole",
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          ReaderDefaultPolicy: {
+            Type: "AWS::IAM::Policy",
+            Properties: {
+              PolicyName: "ReaderDefaultPolicy",
+              PolicyDocument: readPolicyDocument,
+              Roles: [
+                {
+                  Ref: "ReaderRole",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Then the Role carries the inline policy document.
+    const role = simAws.iam().roles.get("ReaderRole" as SimIamRoleName);
+
+    assertNonNullable(role);
+    const inlinePolicy = role.inlinePolicies.get("ReaderDefaultPolicy");
+    assertNonNullable(inlinePolicy);
+    assertIdentical(inlinePolicy, JSON.stringify(readPolicyDocument));
+
+    // And the Policy Resource completes without a standalone sim resource.
+    const policyResource = stack.getResource("ReaderDefaultPolicy");
+    assertNonNullable(policyResource);
+    assertIdentical(policyResource.simResource, undefined);
+  });
+
+  it("puts the inline policy onto multiple referenced Roles", async () => {
+    // Given a template attaching one policy to two Roles.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "iam-shared-policy-stack",
+      template: {
+        Resources: {
+          FirstRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          SecondRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          SharedPolicy: {
+            Type: "AWS::IAM::Policy",
+            Properties: {
+              PolicyName: "SharedPolicy",
+              PolicyDocument: readPolicyDocument,
+              Roles: [
+                {
+                  Ref: "FirstRole",
+                },
+                {
+                  Ref: "SecondRole",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // Then both Roles carry the inline policy.
+    for (const roleName of ["FirstRole", "SecondRole"]) {
+      const role = simAws.iam().roles.get(roleName as SimIamRoleName);
+      assertNonNullable(role);
+      assertNonNullable(role.inlinePolicies.get("SharedPolicy"));
+    }
+  });
+});

--- a/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
@@ -5,6 +5,7 @@ import type {
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimIam } from "../sim-iam.js";
 import { SimCfnIamManagedPolicyCreator } from "./managed-policy/sim-cfn-iam-managed-policy-creator.js";
+import { SimCfnIamPolicyCreator } from "./policy/sim-cfn-iam-policy-creator.js";
 import { SimCfnIamRoleCreator } from "./role/sim-cfn-iam-role-creator.js";
 
 /**
@@ -12,10 +13,12 @@ import { SimCfnIamRoleCreator } from "./role/sim-cfn-iam-role-creator.js";
  */
 export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourceFactory {
   private readonly managedPolicyCreator: SimCfnIamManagedPolicyCreator;
+  private readonly policyCreator: SimCfnIamPolicyCreator;
   private readonly roleCreator: SimCfnIamRoleCreator;
 
   constructor(iam: SimIam) {
     this.managedPolicyCreator = new SimCfnIamManagedPolicyCreator({ iam });
+    this.policyCreator = new SimCfnIamPolicyCreator({ iam });
     this.roleCreator = new SimCfnIamRoleCreator({ iam });
   }
 
@@ -33,6 +36,13 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
           resource,
           context.resolvedProperties ?? resource.properties,
         );
+      }
+      case "Policy": {
+        await this.policyCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+        return;
       }
       case "Role": {
         return await this.roleCreator.create(

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -117,6 +117,23 @@ module and export (`index.handler`, `src/app.handler`). ES module source is not 
 fails with a clear hint. The sandbox exposes common globals and an AWS-like `process.env` with the
 standard runtime variables.
 
+### Runtime-provided AWS SDK
+
+Like the real Lambda Node.js runtime, the simulated runtime provides AWS SDK v3 packages without
+them being bundled in the code archive: `require("@aws-sdk/client-s3")` (and other `@aws-sdk/*`
+packages installed in the host project) resolves to the real host module with its client classes
+intercepted into the owning simulated AWS environment. Calls the function code makes are routed
+per send with the function's execution role as the caller, so simulated IAM authorizes them just
+like real Lambda execution roles. A client constructed without a region defaults to the function's
+Account/Region scope, as the real runtime's `AWS_REGION` provides; an explicit region wins.
+
+The archive always takes precedence: a package bundled under the archive's `node_modules/` is used
+as-is, uninstrumented. Interception is per client instance (`function/code/vm/sdk/`,
+`src/sdk/module/`), so the host package's classes are never patched globally. A standalone
+`SimLambda` constructed outside `SimAws` has no simulated environment to route to; SDK requires
+fail with `Runtime.ImportModuleError` and guidance to wire a `vmSdkModuleProvider` or bundle the
+package.
+
 Note that the `vm` context is a namespacing convenience, not a security boundary: function code
 runs in-process with the same trust as the test suite itself, in keeping with the simulator's
 in-process, Docker-free design. Do not run untrusted code through the simulator.
@@ -164,10 +181,54 @@ account-scoped simulated IAM implementation when constructed through `SimAws`
 (`lambda:CreateFunction`, `lambda:GetFunction`, `lambda:InvokeFunction`), with the same
 allow-all fallback as other services for direct standalone construction.
 
+## CloudFormation
+
+`cfn/` owns `AWS::Lambda::*` resource creation, following the shared per-service factory pattern
+(see `src/service/cloudformation/README.md`). `SimLambdaCloudFormationResourceFactory` is exposed
+via `SimLambda.cfnResourceFactory()` and resolved by the generic CloudFormation engine, so
+deploying a template containing `AWS::Lambda::Function` creates a real `SimLambdaFunction`,
+reachable afterwards through `simAws.lambda()` and invokable via the SDK `InvokeCommand`.
+
+Supported `AWS::Lambda::Function` properties: `FunctionName` (defaults to the logical ID), `Role`
+(typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`), `Code`, `Handler`, `Runtime`,
+`Description`, `Timeout`, and `MemorySize`. Malformed property values fail AWS-style with a
+`TypeError` naming the property and logical ID.
+
+Template `Code` supports two source forms:
+
+- **Inline `ZipFile` source string** — packaged into a single-module `index.js` zip with
+  `makeLambdaCodeZip(...)`, mirroring how real CloudFormation packages inline source.
+- **`S3Bucket`/`S3Key`** — passed through to the CreateFunction handler, which fetches the code
+  zip from same-scope sim S3.
+
+The handler-reference stowaway trick stays SDK-only: template values are JSON, so a `Uint8Array`
+cannot appear in a template `Code.ZipFile`. Inline template code does not need it to reach AWS:
+the vm runtime provides `@aws-sdk/*` packages routed to the owning simulated environment (see
+"Runtime-provided AWS SDK" above), so a CDK `Code.fromInline` function can read sim S3 as its
+execution role.
+
+### Executable bindings
+
+Deploy-time `bindings` (shared with simulated CloudFront Functions — see
+`src/service/cloudformation/bind/`) let `deployTemplate`/`deployTemplateFile` back an
+`AWS::Lambda::Function` with a real in-process handler instead of template code. The
+`SimCfnLambdaFunctionCreator` swaps the bound handler in through the same stowaway code input the
+SDK path uses, so execution-role attribution and invocation behaviour are identical, tests can
+close over test state, and handlers can be stepped through in a debugger. Bindings target the
+logical ID (or CDK construct ID), the function name, or the function ARN; a bound function may
+omit template `Code` and `Handler`. Unbound functions keep their template code on the vm path.
+
+`Ref` on the function returns the function name and `Fn::GetAtt` exposes `Arn`, implemented by the
+`SimLambdaFunctionCfn` value adapter under
+`src/service/cloudformation/resource/cfn/lambda/`, keeping the function model free of
+CloudFormation concerns.
+
+Other `AWS::Lambda::*` resource types (`Version`, `Alias`, `Permission`, `EventSourceMapping`, ...)
+are not supported and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
+
 ## Not simulated yet
 
-- CloudFormation `AWS::Lambda::*` resource creation (no `cfn/` directory yet), including inline
-  template `ZipFile` source strings
+- `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime
 - container image functions (`Code.ImageUri`) — the simulator stays Docker-free
 - `UpdateFunctionCode`, versions, aliases and qualifiers

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-cdk-assets-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-cdk-assets-skip.ts
@@ -1,0 +1,56 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
+
+/**
+ * CDK bootstrap assets buckets are named cdk-{qualifier}-assets-{account}-{region}.
+ */
+const cdkBootstrapAssetsBucketPattern =
+  /^cdk-[a-z0-9]+-assets-\d{12}-[a-z0-9-]+$/u;
+
+/**
+ * Skips functions whose code lives in a missing CDK bootstrap assets bucket.
+ *
+ * CDK-synthesized templates include helper functions, such as the CDK
+ * BucketDeployment provider, whose code zip lives in the CDK bootstrap assets
+ * bucket. That bucket does not exist in sim AWS, and sim CloudFormation
+ * simulates the CDK custom resources directly instead of running their
+ * provider functions. The "Unsupported sim ... CloudFormation" wording marks
+ * the Resource as skipped rather than failing the stack.
+ */
+export class SimCfnLambdaCdkAssetsSkip {
+  /**
+   * Map a creation failure to a skip error, when the failure was a code
+   * fetch from a CDK bootstrap assets bucket that does not exist in sim S3.
+   */
+  findSkipError(
+    resource: SimCfnResource,
+    functionProperties: SimCfnLambdaFunctionProperties,
+    error: unknown,
+  ): Error | undefined {
+    if (!this.isMissingCdkBootstrapAssetsBucket(functionProperties, error)) {
+      return undefined;
+    }
+
+    const bucketName = functionProperties.code?.S3Bucket ?? "";
+
+    return new Error(
+      `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
+        `function code from missing CDK bootstrap assets bucket ${bucketName}`,
+    );
+  }
+
+  private isMissingCdkBootstrapAssetsBucket(
+    functionProperties: SimCfnLambdaFunctionProperties,
+    error: unknown,
+  ): boolean {
+    const bucketName = functionProperties.code?.S3Bucket;
+
+    return (
+      bucketName !== undefined &&
+      cdkBootstrapAssetsBucketPattern.test(bucketName) &&
+      error instanceof SimLambdaInvalidParameterValueException &&
+      error.message.includes("NoSuchBucket")
+    );
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -1,0 +1,49 @@
+import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import { SimCfnExecBindingFinder } from "../../../cloudformation/bind/validate/sim-cfn-exec-binding-finder.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.cmd.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { simLambdaFunctionArn } from "../../function/sim-lambda-function.js";
+import type { SimLambdaHandler } from "../../function/sim-lambda-handler.type.js";
+import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
+
+interface SimCfnLambdaCodeInputProperties {
+  readonly resource: SimCfnResource;
+  readonly functionProperties: SimCfnLambdaFunctionProperties;
+  readonly bindings?: readonly SimCfnExecutableResourceBinding[] | undefined;
+}
+
+/**
+ * The CreateFunction code input for an AWS::Lambda::Function Resource: an
+ * executable binding's real handler when one targets the Resource, otherwise
+ * the template code.
+ *
+ * The bound handler rides the same stowaway Code.ZipFile input the SDK path
+ * uses, so execution-role attribution and invocation behave identically. A
+ * bound function may omit template Code and Handler entirely, as the binding
+ * replaces the code wholesale. Bindings can target the logical ID (or CDK
+ * construct ID), the resolved function name, or the function ARN.
+ */
+export function simCfnLambdaCodeInput(
+  properties: SimCfnLambdaCodeInputProperties,
+): SimLambdaFunctionCode | undefined {
+  const { resource, functionProperties, bindings } = properties;
+
+  const bindingFinder = new SimCfnExecBindingFinder<SimLambdaHandler>({
+    resource,
+    bindings,
+  });
+  const binding = bindingFinder.findBinding({
+    functionName: functionProperties.functionName,
+    arn: simLambdaFunctionArn(
+      resource.accountRegionScope,
+      functionProperties.functionName,
+    ),
+  });
+
+  if (binding === undefined) {
+    return functionProperties.code;
+  }
+
+  return { ZipFile: makeLambdaZipFileInput(binding.handler) };
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-code-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-code-parser.ts
@@ -1,0 +1,73 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaFunctionCode } from "../../command/create-function/create-function.cmd.js";
+import { makeLambdaCodeZip } from "../../function/code/make-lambda-code-zip.js";
+import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
+
+/**
+ * Parses the AWS::Lambda::Function Code property into sim Lambda
+ * CreateFunction code input.
+ *
+ * Template values are JSON, so an inline Code.ZipFile is a source string,
+ * which real CloudFormation packages as a single-module zip. The existing
+ * makeLambdaCodeZip models exactly that. S3-located code passes through
+ * as-is for the CreateFunction handler to fetch from sim S3.
+ */
+export class SimCfnLambdaFunctionCodeParser {
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+
+  /**
+   * Parse the Code property for an AWS::Lambda::Function.
+   */
+  parse(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+  ): SimLambdaFunctionCode | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.propertyParser.invalidPropertyError(
+        resource,
+        "Code",
+        "an object",
+      );
+    }
+
+    return {
+      ZipFile: this.zipFileBytes(resource, value["ZipFile"]),
+      S3Bucket: this.propertyParser.optionalString(
+        resource,
+        value["S3Bucket"],
+        "Code.S3Bucket",
+      ),
+      S3Key: this.propertyParser.optionalString(
+        resource,
+        value["S3Key"],
+        "Code.S3Key",
+      ),
+      S3ObjectVersion: this.propertyParser.optionalString(
+        resource,
+        value["S3ObjectVersion"],
+        "Code.S3ObjectVersion",
+      ),
+    };
+  }
+
+  private zipFileBytes(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+  ): Uint8Array | undefined {
+    const zipFileSource = this.propertyParser.optionalString(
+      resource,
+      value,
+      "Code.ZipFile",
+    );
+    if (zipFileSource === undefined) {
+      return undefined;
+    }
+
+    return makeLambdaCodeZip(zipFileSource);
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -1,0 +1,81 @@
+import type { SimCfnExecutableResourceBinding } from "../../../cloudformation/bind/sim-cfn-exec-binding.type.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaCdkAssetsSkip } from "./sim-cfn-lambda-cdk-assets-skip.js";
+import { simCfnLambdaCodeInput } from "./sim-cfn-lambda-code-input.js";
+import {
+  simCfnLambdaCreateFunctionInput,
+  SimCfnLambdaFunctionPropertiesParser,
+} from "./sim-cfn-lambda-function-properties-parser.js";
+
+interface SimCfnLambdaFunctionCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates simulated Lambda functions from CloudFormation Resources.
+ */
+export class SimCfnLambdaFunctionCreator {
+  private readonly lambda: SimLambda;
+  private readonly propertiesParser =
+    new SimCfnLambdaFunctionPropertiesParser();
+  private readonly cdkAssetsSkip = new SimCfnLambdaCdkAssetsSkip();
+
+  constructor(properties: SimCfnLambdaFunctionCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Create a simulated Lambda function from an AWS::Lambda::Function Resource.
+   *
+   * When an executable binding targets this Resource, the binding's real
+   * in-process handler backs the function instead of the template code, so
+   * tests can step through their actual handler while still deploying it
+   * through CloudFormation.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    bindings?: readonly SimCfnExecutableResourceBinding[],
+  ): Promise<SimLambdaFunction> {
+    const functionProperties = this.propertiesParser.parse(
+      resource,
+      properties,
+    );
+    const code = simCfnLambdaCodeInput({
+      resource,
+      functionProperties,
+      bindings,
+    });
+
+    try {
+      await this.lambda.createFunction({
+        input: simCfnLambdaCreateFunctionInput(functionProperties, code),
+      });
+    } catch (error) {
+      const skipError = this.cdkAssetsSkip.findSkipError(
+        resource,
+        functionProperties,
+        error,
+      );
+      if (skipError !== undefined) {
+        throw skipError;
+      }
+
+      throw error;
+    }
+
+    const simFunction = this.lambda.getSimFunctionByName(
+      functionProperties.functionName,
+    );
+    assertDefined(
+      simFunction,
+      `Sim Lambda function ${functionProperties.functionName} after CloudFormation creation`,
+    );
+
+    return simFunction;
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -1,5 +1,7 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { makeSimRoleArn } from "../../../iam/role/arn/sim-iam-role-arn.js";
+import type { SimIamRoleName } from "../../../iam/role/sim-iam-role.js";
 import type {
   SimCreateFunctionCommandInput,
   SimLambdaFunctionCode,
@@ -59,11 +61,7 @@ export class SimCfnLambdaFunctionPropertiesParser {
   ): SimCfnLambdaFunctionProperties {
     return {
       functionName: this.functionName(resource, properties),
-      roleArn: this.propertyParser.requiredString(
-        resource,
-        properties["Role"],
-        "Role",
-      ),
+      roleArn: this.roleArn(resource, properties),
       code: this.codeParser.parse(resource, properties["Code"]),
       handlerName: this.propertyParser.optionalString(
         resource,
@@ -91,6 +89,35 @@ export class SimCfnLambdaFunctionPropertiesParser {
         "MemorySize",
       ),
     };
+  }
+
+  /**
+   * The execution Role, resolved to an ARN.
+   *
+   * A Ref to a same-stack AWS::IAM::Role resolves to the role name, so a
+   * plain name is mapped to the role's default-path ARN, equivalent to what
+   * Fn::GetAtt Role.Arn resolves to, keeping execution-role attribution
+   * correct. Direct ARN strings pass through unchanged.
+   */
+  private roleArn(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const role = this.propertyParser.requiredString(
+      resource,
+      properties["Role"],
+      "Role",
+    );
+
+    if (role.startsWith("arn:")) {
+      return role;
+    }
+
+    return makeSimRoleArn({
+      accountId: resource.accountRegionScope.accountId,
+      path: "/",
+      roleName: role as SimIamRoleName,
+    });
   }
 
   /**

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -1,0 +1,112 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimCreateFunctionCommandInput,
+  SimLambdaFunctionCode,
+} from "../../command/create-function/create-function.cmd.js";
+import { SimCfnLambdaFunctionCodeParser } from "./sim-cfn-lambda-function-code-parser.js";
+import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
+
+export interface SimCfnLambdaFunctionProperties {
+  readonly functionName: string;
+  readonly roleArn: string;
+  readonly code: SimLambdaFunctionCode | undefined;
+  readonly handlerName: string | undefined;
+  readonly runtimeName: string | undefined;
+  readonly description: string | undefined;
+  readonly timeoutSeconds: number | undefined;
+  readonly memorySizeMb: number | undefined;
+}
+
+/**
+ * Map parsed AWS::Lambda::Function properties onto the sim Lambda
+ * CreateFunction command input, with the code input resolved separately so
+ * executable bindings can replace template code.
+ */
+export function simCfnLambdaCreateFunctionInput(
+  functionProperties: SimCfnLambdaFunctionProperties,
+  code: SimLambdaFunctionCode | undefined,
+): SimCreateFunctionCommandInput {
+  return {
+    FunctionName: functionProperties.functionName,
+    Role: functionProperties.roleArn,
+    Code: code,
+    Handler: functionProperties.handlerName,
+    Runtime: functionProperties.runtimeName,
+    Description: functionProperties.description,
+    Timeout: functionProperties.timeoutSeconds,
+    MemorySize: functionProperties.memorySizeMb,
+  };
+}
+
+/**
+ * Parses and validates AWS::Lambda::Function CloudFormation properties into
+ * the shape the sim Lambda function creator needs.
+ *
+ * Keeping the property-shape validation here keeps the creator focused on
+ * orchestrating Lambda command calls.
+ */
+export class SimCfnLambdaFunctionPropertiesParser {
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+  private readonly codeParser = new SimCfnLambdaFunctionCodeParser();
+
+  /**
+   * Parse the resolved CloudFormation properties for an AWS::Lambda::Function.
+   */
+  parse(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnLambdaFunctionProperties {
+    return {
+      functionName: this.functionName(resource, properties),
+      roleArn: this.propertyParser.requiredString(
+        resource,
+        properties["Role"],
+        "Role",
+      ),
+      code: this.codeParser.parse(resource, properties["Code"]),
+      handlerName: this.propertyParser.optionalString(
+        resource,
+        properties["Handler"],
+        "Handler",
+      ),
+      runtimeName: this.propertyParser.optionalString(
+        resource,
+        properties["Runtime"],
+        "Runtime",
+      ),
+      description: this.propertyParser.optionalString(
+        resource,
+        properties["Description"],
+        "Description",
+      ),
+      timeoutSeconds: this.propertyParser.optionalNumber(
+        resource,
+        properties["Timeout"],
+        "Timeout",
+      ),
+      memorySizeMb: this.propertyParser.optionalNumber(
+        resource,
+        properties["MemorySize"],
+        "MemorySize",
+      ),
+    };
+  }
+
+  /**
+   * The function name defaults to the logical ID, as CloudFormation
+   * effectively names unnamed functions from it.
+   */
+  private functionName(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    return (
+      this.propertyParser.optionalString(
+        resource,
+        properties["FunctionName"],
+        "FunctionName",
+      ) ?? resource.logicalId
+    );
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-validation.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-validation.iso.test.ts
@@ -1,0 +1,165 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLambdaCloudFormationResourceFactory } from "../sim-cfn-lambda-resource-factory.js";
+
+/**
+ * Attempt a Function creation with the given properties and return the
+ * validation error it rejects with.
+ */
+async function functionCreationError(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const resource = new SimCfnResource({
+    accountRegionScope: {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadFunction",
+    template: {
+      Type: "AWS::Lambda::Function",
+      Properties: properties,
+    },
+  });
+  const factory = new SimLambdaCloudFormationResourceFactory(simAws.lambda());
+
+  try {
+    await factory.create("Function", resource, {
+      simAws,
+      resources: new Map(),
+    });
+  } catch (error) {
+    assertInstanceOf(error, Error);
+    return error;
+  }
+
+  throw new Error("Expected Function creation to reject");
+}
+
+const validProperties: SimCfnTemplateValueRecord = {
+  Role: "arn:aws:iam::111111111111:role/BadFunctionRole",
+  Code: {
+    ZipFile: "exports.handler = async () => 'ok';",
+  },
+  Handler: "index.handler",
+};
+
+async function assertRejectsProperty(
+  overrides: SimCfnTemplateValueRecord,
+  expectedMessage: string,
+): Promise<void> {
+  const error = await functionCreationError({
+    ...validProperties,
+    ...overrides,
+  });
+
+  assertInstanceOf(error, TypeError);
+  assertIdentical(
+    error.message,
+    `Invalid AWS::Lambda::Function BadFunction: ${expectedMessage}`,
+  );
+}
+
+describe("Lambda CloudFormation Function property validation", () => {
+  it("rejects a missing or non-string Role", async () => {
+    // Given Function properties without a Role, or with a non-string Role.
+    // When creation is attempted, then each rejects with an AWS-like
+    // diagnostic naming the property and the logical ID.
+    const missingRoleError = await functionCreationError({
+      Code: validProperties["Code"] ?? {},
+      Handler: "index.handler",
+    });
+
+    assertInstanceOf(missingRoleError, TypeError);
+    assertIdentical(
+      missingRoleError.message,
+      "Invalid AWS::Lambda::Function BadFunction: Role must be a string",
+    );
+
+    await assertRejectsProperty({ Role: 123 }, "Role must be a string");
+  });
+
+  it("rejects non-string string-typed properties", async () => {
+    // Given Function properties where string-typed values have other types.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsProperty(
+      { FunctionName: 42 },
+      "FunctionName must be a string",
+    );
+    await assertRejectsProperty(
+      { Handler: ["index.handler"] },
+      "Handler must be a string",
+    );
+    await assertRejectsProperty(
+      { Runtime: { name: "nodejs20.x" } },
+      "Runtime must be a string",
+    );
+    await assertRejectsProperty(
+      { Description: false },
+      "Description must be a string",
+    );
+  });
+
+  it("rejects a missing Code property with the AWS-like create error", async () => {
+    // Given Function properties without any Code.
+    // When creation is attempted, then the CreateFunction handler rejects it
+    // with its AWS-like required Code diagnostic.
+    const error = await functionCreationError({
+      Role: "arn:aws:iam::111111111111:role/BadFunctionRole",
+      Handler: "index.handler",
+    });
+
+    assertStringIncludes(error.message, "Code required");
+  });
+
+  it("rejects a malformed Code property", async () => {
+    // Given Function properties where Code is not an object.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsProperty(
+      { Code: "exports.handler = async () => 'ok';" },
+      "Code must be an object",
+    );
+    await assertRejectsProperty({ Code: [] }, "Code must be an object");
+    await assertRejectsProperty({ Code: null }, "Code must be an object");
+  });
+
+  it("rejects malformed Code source values", async () => {
+    // Given Function Code where source values have the wrong types.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsProperty(
+      { Code: { ZipFile: 123 } },
+      "Code.ZipFile must be a string",
+    );
+    await assertRejectsProperty(
+      { Code: { S3Bucket: 123, S3Key: "greeter.zip" } },
+      "Code.S3Bucket must be a string",
+    );
+    await assertRejectsProperty(
+      { Code: { S3Bucket: "code-bucket", S3Key: 123 } },
+      "Code.S3Key must be a string",
+    );
+    await assertRejectsProperty(
+      { Code: { S3Bucket: "code-bucket", S3Key: "k", S3ObjectVersion: 1 } },
+      "Code.S3ObjectVersion must be a string",
+    );
+  });
+
+  it("rejects non-number number-typed properties", async () => {
+    // Given Function properties where number-typed values have other types.
+    // When creation is attempted, then each rejects naming the property.
+    await assertRejectsProperty({ Timeout: "10" }, "Timeout must be a number");
+    await assertRejectsProperty(
+      { MemorySize: "256" },
+      "MemorySize must be a number",
+    );
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
@@ -1,0 +1,70 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Validates individual AWS::Lambda::Function CloudFormation property values,
+ * failing with a diagnostic naming the property and the logical ID.
+ */
+export class SimCfnLambdaPropertyParser {
+  /**
+   * Parse a property value that must be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.requiredString(resource, value, label);
+  }
+
+  /**
+   * Parse a property value that must be a number when present.
+   */
+  optionalNumber(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "number") {
+      throw this.invalidPropertyError(resource, label, "a number");
+    }
+
+    return value;
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid AWS::Lambda::Function ${resource.logicalId}: ${label} must be ${expected}`,
+    );
+  }
+}

--- a/src/service/lambda/cfn/sim-cfn-lambda-bindings.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-bindings.iso.test.ts
@@ -1,0 +1,326 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+describe("Lambda CloudFormation Function bindings", () => {
+  it("binds a real in-process handler by logical ID", async () => {
+    // Given a template function bound to a real handler that closes over
+    // test state, with template Code and Handler omitted entirely.
+    const simAws = new SimAws();
+    const observedEvents: unknown[] = [];
+
+    // When the template is deployed with the binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "bound-greeter-stack",
+      template: {
+        Resources: {
+          GreeterFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "bound-greeter",
+              Role: "arn:aws:iam::111111111111:role/BoundGreeterRole",
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "GreeterFunction",
+          handler: (event: { name: string }) => {
+            observedEvents.push(event);
+            return `Hello ${event.name} from bound handler`;
+          },
+        },
+      ],
+    });
+
+    // Then invoking the deployed function runs the bound handler in-process.
+    const output = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "bound-greeter",
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(output.StatusCode, 200);
+    assertIdentical(
+      parsePayload(output.Payload),
+      "Hello Yulin from bound handler",
+    );
+    assertArrayLength(observedEvents, 1);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("binds by function name, replacing template code", async () => {
+    // Given a template function with placeholder inline code and a binding
+    // targeting its FunctionName.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "name-bound-stack",
+      template: {
+        Resources: {
+          NamedFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "named-function",
+              Role: "arn:aws:iam::111111111111:role/NamedFunctionRole",
+              Handler: "index.handler",
+              Code: {
+                ZipFile: "exports.handler = async () => 'template code';",
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          functionName: "named-function",
+          handler: () => "bound instead of template code",
+        },
+      ],
+    });
+
+    // Then the bound handler replaces the template code.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "named-function" }));
+
+    assertIdentical(
+      parsePayload(output.Payload),
+      "bound instead of template code",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("binds by function ARN", async () => {
+    // Given a binding targeting the function's ARN in the deploy scope.
+    const simAws = new SimAws();
+    const functionArn =
+      `arn:aws:lambda:${simAws.defaultRegionName}:` +
+      `${simAws.defaultAccountId}:function:arn-bound-function`;
+
+    // When the template is deployed with the binding, alongside a
+    // non-executable resource the binding matcher must pass over.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "arn-bound-stack",
+      template: {
+        Resources: {
+          DataBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "arn-bound-data-bucket",
+            },
+          },
+          ArnBoundFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "arn-bound-function",
+              Role: "arn:aws:iam::111111111111:role/ArnBoundRole",
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          arn: functionArn,
+          handler: () => "bound by arn",
+        },
+      ],
+    });
+
+    // Then the bound handler backs the function.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "arn-bound-function" }));
+
+    assertIdentical(parsePayload(output.Payload), "bound by arn");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("binds by CDK construct ID from path metadata", async () => {
+    // Given a CDK-synthesized style template with a hashed logical ID and
+    // construct path metadata, and a binding using the readable construct ID.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "cdk-bound-stack",
+      template: {
+        Resources: {
+          ReaderFunction2A1B3C4D: {
+            Type: "AWS::Lambda::Function",
+            Metadata: {
+              "aws:cdk:path": "TestStack/ReaderFunction/Resource",
+            },
+            Properties: {
+              Role: "arn:aws:iam::111111111111:role/ReaderFunctionRole",
+              Handler: "index.handler",
+              Code: {
+                ZipFile: "exports.handler = async () => 'template code';",
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "ReaderFunction",
+          handler: () => "bound via construct id",
+        },
+      ],
+    });
+
+    // Then the bound handler backs the function created under the hashed
+    // logical ID.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "ReaderFunction2A1B3C4D" }));
+
+    assertIdentical(parsePayload(output.Payload), "bound via construct id");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("binds by CDK construct path", async () => {
+    // Given a binding targeting the full CDK construct path from synthesized
+    // template metadata.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "cdk-path-bound-stack",
+      template: {
+        Resources: {
+          PathBoundFunction9F8E7D6C: {
+            Type: "AWS::Lambda::Function",
+            Metadata: {
+              "aws:cdk:path": "TestStack/PathBoundFunction/Resource",
+            },
+            Properties: {
+              FunctionName: "path-bound-function",
+              Role: "arn:aws:iam::111111111111:role/PathBoundRole",
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          cdkPath: "TestStack/PathBoundFunction/Resource",
+          handler: () => "bound by cdk path",
+        },
+      ],
+    });
+
+    // Then the bound handler backs the function.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "path-bound-function" }));
+
+    assertIdentical(parsePayload(output.Payload), "bound by cdk path");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("leaves unbound functions on their template code", async () => {
+    // Given two template functions with only one bound.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the single binding.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "partially-bound-stack",
+      template: {
+        Resources: {
+          BoundFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "bound-function",
+              Role: "arn:aws:iam::111111111111:role/BoundRole",
+            },
+          },
+          UnboundFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "unbound-function",
+              Role: "arn:aws:iam::111111111111:role/UnboundRole",
+              Handler: "index.handler",
+              Code: {
+                ZipFile: "exports.handler = async () => 'vm template code';",
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "BoundFunction",
+          handler: () => "bound handler",
+        },
+      ],
+    });
+
+    // Then the bound function runs the binding and the unbound function
+    // still runs its template code in the vm.
+    const boundOutput = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "bound-function" }));
+    const unboundOutput = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "unbound-function" }));
+
+    assertIdentical(parsePayload(boundOutput.Payload), "bound handler");
+    assertIdentical(parsePayload(unboundOutput.Payload), "vm template code");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("rejects bindings that do not target any resource", async () => {
+    // Given a binding whose function name matches nothing in the template.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then binding validation rejects it with
+    // the unmatched target for diagnosis.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "unmatched-binding-stack",
+        template: {
+          Resources: {
+            SomeFunction: {
+              Type: "AWS::Lambda::Function",
+              Properties: {
+                FunctionName: "some-function",
+                Role: "arn:aws:iam::111111111111:role/SomeRole",
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            functionName: "no-such-function",
+            handler: () => "never runs",
+          },
+        ],
+      }),
+    );
+
+    assertStringIncludes(error.message, "no-such-function");
+    assertStringIncludes(error.message, "does not resolve to a Resource");
+  });
+});

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -113,6 +113,55 @@ describe("Lambda CloudFormation Function deployment", () => {
     await simAws.backgroundTasksComplete();
   });
 
+  it("resolves a Role name from Ref to the role's ARN", async () => {
+    // Given a template whose function references its Role with Ref, which
+    // resolves to the role name rather than the ARN Fn::GetAtt provides.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ref-role-stack",
+      template: {
+        Resources: {
+          RefRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "RefRole",
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          RefRoleFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "ref-role-function",
+              Role: {
+                Ref: "RefRole",
+              },
+              Code: {
+                ZipFile: "exports.handler = async () => 'ref role';",
+              },
+              Handler: "index.handler",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the function's execution Role is the role's ARN, keeping
+    // execution-role attribution correct.
+    const roleResource = stack.getResource("RefRole");
+    assertNonNullable(roleResource);
+    const role = roleResource.simResource as SimIamRole;
+
+    const simFunction = simAws
+      .lambda()
+      .getSimFunctionByName("ref-role-function");
+    assertNonNullable(simFunction);
+    assertIdentical(simFunction.roleArn, role.arn);
+
+    await simAws.backgroundTasksComplete();
+  });
+
   it("uses the function name for Ref and exposes Arn via Fn::GetAtt", async () => {
     // Given a CloudFormation template with a function, a dependent resource,
     // and Outputs that exercise Ref and Fn::GetAtt resolution.

--- a/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-deploy.iso.test.ts
@@ -1,0 +1,338 @@
+import { GetFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamRole } from "../../iam/role/sim-iam-role.js";
+import { makeLambdaCodeZip } from "../function/code/make-lambda-code-zip.js";
+import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: {
+        Service: "lambda.amazonaws.com",
+      },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+describe("Lambda CloudFormation Function deployment", () => {
+  it("creates an invokable function with a same-stack IAM Role", async () => {
+    // Given a CloudFormation template declaring an IAM Role and a Lambda
+    // function that references it via Fn::GetAtt, with inline ZipFile source.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: {
+        Resources: {
+          GreeterRole: {
+            Type: "AWS::IAM::Role",
+            Properties: {
+              RoleName: "GreeterRole",
+              AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            },
+          },
+          GreeterFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "greeter",
+              Role: {
+                "Fn::GetAtt": ["GreeterRole", "Arn"],
+              },
+              Code: {
+                ZipFile:
+                  "exports.handler = async (event) => 'Hello ' + event.name;",
+              },
+              Handler: "index.handler",
+              Runtime: "nodejs20.x",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the CloudFormation Resource is backed by a simulated function.
+    const roleResource = stack.getResource("GreeterRole");
+    const functionResource = stack.getResource("GreeterFunction");
+
+    assertNonNullable(roleResource);
+    assertNonNullable(functionResource);
+
+    const role = roleResource.simResource as SimIamRole | undefined;
+    const simFunction = functionResource.simResource as
+      SimLambdaFunction | undefined;
+
+    assertNonNullable(role);
+    assertNonNullable(simFunction);
+    assertIdentical(
+      simAws.lambda().getSimFunctionByName("greeter"),
+      simFunction,
+    );
+
+    // And the function's execution Role resolved to the same-stack Role ARN.
+    assertIdentical(simFunction.roleArn, role.arn);
+
+    // And the function is retrievable through the Lambda GetFunction API.
+    const retrievedFunction = await simAws
+      .lambda()
+      .getFunction(new GetFunctionCommand({ FunctionName: "greeter" }));
+
+    assertIdentical(retrievedFunction.Configuration.FunctionName, "greeter");
+    assertIdentical(retrievedFunction.Configuration.Role, role.arn);
+
+    // And the inline ZipFile source is invokable via the Lambda Invoke API.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "greeter",
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertNonNullable(invokeOutput.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(invokeOutput.Payload).toString()),
+      "Hello Yulin",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("uses the function name for Ref and exposes Arn via Fn::GetAtt", async () => {
+    // Given a CloudFormation template with a function, a dependent resource,
+    // and Outputs that exercise Ref and Fn::GetAtt resolution.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "function-ref-stack",
+      template: {
+        Resources: {
+          OutputFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "output-function",
+              Role: "arn:aws:iam::111111111111:role/OutputFunctionRole",
+              Code: {
+                ZipFile: "exports.handler = async () => 'output';",
+              },
+              Handler: "index.handler",
+            },
+          },
+          WaitHandle: {
+            Type: "AWS::CloudFormation::WaitConditionHandle",
+            Properties: {
+              FunctionName: {
+                Ref: "OutputFunction",
+              },
+              FunctionArn: {
+                "Fn::GetAtt": ["OutputFunction", "Arn"],
+              },
+              FunctionUnknownAttribute: {
+                "Fn::GetAtt": ["OutputFunction", "MemorySize"],
+              },
+            },
+          },
+        },
+        Outputs: {
+          FunctionName: {
+            Value: {
+              Ref: "OutputFunction",
+            },
+          },
+          FunctionArn: {
+            Value: {
+              "Fn::GetAtt": ["OutputFunction", "Arn"],
+            },
+          },
+        },
+      },
+    });
+
+    // Then Ref returns the function name and Fn::GetAtt returns the ARN.
+    const functionResource = stack.getResource("OutputFunction");
+    const waitHandleResource = stack.getResource("WaitHandle");
+
+    assertNonNullable(functionResource);
+    assertNonNullable(waitHandleResource);
+
+    const simFunction = functionResource.simResource as SimLambdaFunction;
+
+    assertIdentical(functionResource.refValue, "output-function");
+
+    const resolvedWaitHandleProperties = waitHandleResource.resolvedProperties({
+      simAws,
+      resources: stack.resources,
+    });
+
+    assertIdentical(
+      resolvedWaitHandleProperties["FunctionName"],
+      "output-function",
+    );
+    assertIdentical(
+      resolvedWaitHandleProperties["FunctionArn"],
+      simFunction.arn,
+    );
+
+    // And unsupported Fn::GetAtt attributes fall back to an ARN-derived value.
+    assertIdentical(
+      resolvedWaitHandleProperties["FunctionUnknownAttribute"],
+      `${simFunction.arn}.MemorySize`,
+    );
+
+    assertIdentical(
+      stack.outputs.get("FunctionName")?.value,
+      "output-function",
+    );
+    assertIdentical(stack.outputs.get("FunctionArn")?.value, simFunction.arn);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips functions coded from a missing CDK bootstrap assets bucket", async () => {
+    // Given a CDK-synthesized style template with a helper function whose
+    // code zip lives in the CDK bootstrap assets bucket, which does not exist
+    // in sim AWS.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cdk-assets-stack",
+      template: {
+        Resources: {
+          DeploymentProviderFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              Role: "arn:aws:iam::111111111111:role/ProviderRole",
+              Code: {
+                S3Bucket: "cdk-hnb659fds-assets-111111111111-eu-west-2",
+                S3Key: "asset.zip",
+              },
+              Handler: "index.handler",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the function Resource is skipped rather than failing the stack.
+    const functionResource = stack.getResource("DeploymentProviderFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(
+      functionResource.skippedReason,
+      "cdk-hnb659fds-assets-111111111111-eu-west-2",
+    );
+    assertUndefined(
+      simAws.lambda().getSimFunctionByName("DeploymentProviderFunction"),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails AWS-like when a non-CDK code bucket does not exist", async () => {
+    // Given a template with a function coded from a missing user bucket.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deploy fails with the AWS-like
+    // missing bucket diagnostic rather than being skipped.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "missing-code-bucket-stack",
+        template: {
+          Resources: {
+            MissingCodeFunction: {
+              Type: "AWS::Lambda::Function",
+              Properties: {
+                Role: "arn:aws:iam::111111111111:role/MissingCodeRole",
+                Code: {
+                  S3Bucket: "missing-code-bucket",
+                  S3Key: "greeter.zip",
+                },
+                Handler: "index.handler",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    assertStringIncludes(error.message, "NoSuchBucket");
+    assertUndefined(
+      simAws.lambda().getSimFunctionByName("MissingCodeFunction"),
+    );
+  });
+
+  it("creates a function from a code zip stored in sim S3", async () => {
+    // Given a code zip archive stored in sim S3, as SAM and CDK deploy.
+    const simAws = new SimAws();
+    const codeZip = makeLambdaCodeZip(
+      "exports.handler = async (event) => 'Hello ' + event.name + ' from S3';",
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "code-bucket" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "code-bucket",
+        Key: "artifacts/greeter.zip",
+        Body: codeZip,
+      }),
+    );
+
+    // When a template referencing the S3 code location is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "s3-code-stack",
+      template: {
+        Resources: {
+          S3Greeter: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "s3-greeter",
+              Role: "arn:aws:iam::111111111111:role/S3GreeterRole",
+              Code: {
+                S3Bucket: "code-bucket",
+                S3Key: "artifacts/greeter.zip",
+              },
+              Handler: "index.handler",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the stored code runs in the simulated runtime.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "s3-greeter",
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertNonNullable(invokeOutput.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(invokeOutput.Payload).toString()),
+      "Hello Yulin from S3",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
@@ -1,0 +1,206 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCloudFormationResourceCreateContext } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import {
+  DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+  DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
+  SimLambdaFunction,
+} from "../function/sim-lambda-function.js";
+import { SimLambdaCloudFormationResourceFactory } from "./sim-cfn-lambda-resource-factory.js";
+
+const accountRegionScope: SimAwsAccountRegionScope = {
+  accountId: "111111111111" as SimAwsAccountId,
+  regionName: "eu-west-2",
+};
+
+describe("SimLambdaCloudFormationResourceFactory", () => {
+  it("creates a Lambda function from inline ZipFile source", async () => {
+    // Given a Lambda CloudFormation Resource factory and a Function resource
+    // with inline ZipFile source, as real CloudFormation supports for small
+    // functions.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    const resource = new SimCfnResource({
+      accountRegionScope,
+      logicalId: "GreeterFunction",
+      template: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: "arn:aws:iam::111111111111:role/GreeterRole",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => 'Hello ' + event.name;",
+          },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Description: "Greets by name",
+          Timeout: 10,
+          MemorySize: 256,
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      resources: new Map(),
+    };
+    const factory = new SimLambdaCloudFormationResourceFactory(simLambda);
+
+    // When the Function resource type is created.
+    const created = await factory.create("Function", resource, context);
+
+    // Then the named function is created and returned with its configuration.
+    const storedFunction = simLambda.getSimFunctionByName("greeter");
+
+    assertNonNullable(storedFunction);
+    assertIdentical(created, storedFunction);
+    assertIdentical(
+      storedFunction.roleArn,
+      "arn:aws:iam::111111111111:role/GreeterRole",
+    );
+    assertIdentical(storedFunction.handlerName, "index.handler");
+    assertIdentical(storedFunction.runtimeName, "nodejs20.x");
+    assertIdentical(storedFunction.description, "Greets by name");
+    assertIdentical(storedFunction.timeoutSeconds, 10);
+    assertIdentical(storedFunction.memorySizeMb, 256);
+
+    // And the inline source code runs in the simulated runtime.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "greeter",
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(output.StatusCode, 200);
+    assertNonNullable(output.Payload);
+    assertIdentical(
+      JSON.parse(Buffer.from(output.Payload).toString()),
+      "Hello Yulin",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("defaults the function name and configuration values", async () => {
+    // Given a Function resource without FunctionName, Timeout or MemorySize.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    const resource = new SimCfnResource({
+      accountRegionScope,
+      logicalId: "DefaultNamedFunction",
+      template: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/DefaultRole",
+          Code: {
+            ZipFile: "exports.handler = async () => 'ok';",
+          },
+          Handler: "index.handler",
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      resources: new Map(),
+    };
+    const factory = new SimLambdaCloudFormationResourceFactory(simLambda);
+
+    // When the Function resource type is created.
+    const created = await factory.create("Function", resource, context);
+
+    // Then a function named from the logical ID is created with AWS-like
+    // default configuration.
+    const storedFunction = simLambda.getSimFunctionByName(
+      "DefaultNamedFunction",
+    );
+
+    assertNonNullable(storedFunction);
+    assertIdentical(created, storedFunction);
+    assertIdentical(
+      storedFunction.timeoutSeconds,
+      DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
+    );
+    assertIdentical(
+      storedFunction.memorySizeMb,
+      DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("returns a SimLambdaFunction as the backing sim resource", async () => {
+    // Given a Function resource created through the factory.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    const resource = new SimCfnResource({
+      accountRegionScope,
+      logicalId: "TypedFunction",
+      template: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/TypedRole",
+          Code: {
+            ZipFile: "exports.handler = async () => 'typed';",
+          },
+          Handler: "index.handler",
+        },
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      resources: new Map(),
+    };
+    const factory = new SimLambdaCloudFormationResourceFactory(simLambda);
+
+    // When the Function resource type is created.
+    const created = await factory.create("Function", resource, context);
+
+    // Then the returned sim resource is the simulated Lambda function model.
+    assertInstanceOf(created, SimLambdaFunction);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("rejects unsupported Lambda resource types", async () => {
+    // Given a Lambda CloudFormation Resource factory and an unsupported
+    // Resource type.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    const resource = new SimCfnResource({
+      accountRegionScope,
+      logicalId: "ExampleAlias",
+      template: {
+        Type: "AWS::Lambda::Alias",
+      },
+    });
+    const context: SimCloudFormationResourceCreateContext = {
+      simAws,
+      resources: new Map(),
+    };
+    const factory = new SimLambdaCloudFormationResourceFactory(simLambda);
+
+    // When creation is attempted, then it rejects with an unsupported Resource
+    // type error.
+    const error = await assertThrowsErrorAsync(async () =>
+      factory.create("Alias", resource, context),
+    );
+
+    // Then the unsupported Resource type name is included for diagnosis.
+    assertIdentical(
+      error.message,
+      "Unsupported sim Lambda CloudFormation Resource Alias",
+    );
+  });
+});

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -1,0 +1,42 @@
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type { SimLambda } from "../sim-lambda.js";
+import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
+
+/**
+ * CloudFormation Resource factory for simulated Lambda resources.
+ */
+export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly functionCreator: SimCfnLambdaFunctionCreator;
+
+  constructor(lambda: SimLambda) {
+    this.functionCreator = new SimCfnLambdaFunctionCreator({ lambda });
+  }
+
+  /**
+   * Create a simulated Lambda resource from a CloudFormation Resource.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Function": {
+        return await this.functionCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+          context.bindings,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Lambda CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -14,6 +14,7 @@ import { SimLambdaResourceConflictException } from "../../error/sim-lambda.error
 import type { SimLambdaExecutableCode } from "../../function/code/sim-lambda-executable-code.js";
 import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resolver.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
+import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import {
   DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
   SimLambdaFunction,
@@ -38,6 +39,7 @@ interface CreateFunctionCommandHandlerProperties {
   iam?: SimIamInterServiceAuthZ;
   background?: BackgroundScheduler;
   codeStore?: SimLambdaCodeStore | undefined;
+  vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 
 interface CreateFunctionCommandHandlerOptions {
@@ -68,13 +70,17 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       codeStore,
+      vmSdkModuleProvider,
     } = properties;
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
     this.runAsOwner = runAsOwner;
     this.authorizer = new CreateFunctionAuthorizer({ iam });
     this.background = background;
-    this.codeResolver = new SimLambdaCodeResolver({ codeStore });
+    this.codeResolver = new SimLambdaCodeResolver({
+      codeStore,
+      vmSdkModuleProvider,
+    });
   }
 
   /**

--- a/src/service/lambda/function/code/sim-lambda-code-resolver.ts
+++ b/src/service/lambda/function/code/sim-lambda-code-resolver.ts
@@ -1,20 +1,19 @@
-import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
-import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import type { SimLambdaCodeSource } from "./lambda-code-source.js";
 import {
   type SimLambdaExecutableCode,
   SimLambdaHandlerReferenceCode,
 } from "./sim-lambda-executable-code.js";
-import { SimLambdaVmZipCode } from "./sim-lambda-vm-zip-code.js";
+import { SimLambdaVmZipCodeFactory } from "./sim-lambda-vm-zip-code-factory.js";
 import {
   type SimLambdaCodeStore,
   SimLambdaNoCodeStore,
 } from "./store/sim-lambda-code-store.js";
+import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 
 interface SimLambdaCodeResolverProperties {
   readonly codeStore?: SimLambdaCodeStore | undefined;
+  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 
 /**
@@ -40,9 +39,13 @@ export interface SimLambdaCodeResolveContext {
  */
 export class SimLambdaCodeResolver {
   private readonly codeStore: SimLambdaCodeStore;
+  private readonly vmZipCodeFactory: SimLambdaVmZipCodeFactory;
 
   constructor(properties: SimLambdaCodeResolverProperties) {
     this.codeStore = properties.codeStore ?? new SimLambdaNoCodeStore();
+    this.vmZipCodeFactory = new SimLambdaVmZipCodeFactory({
+      vmSdkModuleProvider: properties.vmSdkModuleProvider,
+    });
   }
 
   /**
@@ -57,7 +60,7 @@ export class SimLambdaCodeResolver {
         return new SimLambdaHandlerReferenceCode(source.handlerFunction);
       }
       case "zip-bytes": {
-        return this.vmZipCode(source.zipBytes, context);
+        return this.vmZipCodeFactory.make(source.zipBytes, context);
       }
       case "s3-location": {
         const zipBytes = await this.codeStore.getZipBytes({
@@ -65,40 +68,8 @@ export class SimLambdaCodeResolver {
           objectKey: source.objectKey,
           caller: context.caller,
         });
-        return this.vmZipCode(zipBytes, context);
+        return this.vmZipCodeFactory.make(zipBytes, context);
       }
-    }
-  }
-
-  private vmZipCode(
-    zipBytes: Uint8Array,
-    context: SimLambdaCodeResolveContext,
-  ): SimLambdaVmZipCode {
-    assertDefined(
-      context.handlerName,
-      "CreateFunctionCommand.input.Handler required for zip function code",
-    );
-
-    return new SimLambdaVmZipCode({
-      archive: this.unzip(zipBytes),
-      handlerName: context.handlerName,
-      environment: {
-        functionName: context.functionName,
-        regionName: context.regionName,
-        memorySizeMb: context.memorySizeMb,
-      },
-    });
-  }
-
-  private unzip(zipBytes: Uint8Array): SimZipArchive {
-    try {
-      return SimZipArchive.fromBytes(zipBytes);
-    } catch (error) {
-      throw new SimLambdaInvalidParameterValueException(
-        "Could not unzip uploaded file. Please check your file, " +
-          "then try to upload again.",
-        { cause: error },
-      );
     }
   }
 }

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
@@ -1,0 +1,62 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaCodeResolveContext } from "./sim-lambda-code-resolver.js";
+import { SimLambdaVmZipCode } from "./sim-lambda-vm-zip-code.js";
+import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+
+interface SimLambdaVmZipCodeFactoryProperties {
+  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+}
+
+/**
+ * Builds executable vm zip code from code zip bytes.
+ *
+ * Zip validity is checked here, at function creation time, as real AWS
+ * validates the uploaded archive; import and handler problems surface later
+ * at invocation cold start.
+ */
+export class SimLambdaVmZipCodeFactory {
+  private readonly vmSdkModuleProvider:
+    SimLambdaVmSdkModuleProvider | undefined;
+
+  constructor(properties: SimLambdaVmZipCodeFactoryProperties) {
+    this.vmSdkModuleProvider = properties.vmSdkModuleProvider;
+  }
+
+  /**
+   * Build vm zip code for a function from its code zip bytes.
+   */
+  make(
+    zipBytes: Uint8Array,
+    context: SimLambdaCodeResolveContext,
+  ): SimLambdaVmZipCode {
+    assertDefined(
+      context.handlerName,
+      "CreateFunctionCommand.input.Handler required for zip function code",
+    );
+
+    return new SimLambdaVmZipCode({
+      archive: this.unzip(zipBytes),
+      handlerName: context.handlerName,
+      environment: {
+        functionName: context.functionName,
+        regionName: context.regionName,
+        memorySizeMb: context.memorySizeMb,
+      },
+      sdkModuleProvider: this.vmSdkModuleProvider,
+    });
+  }
+
+  private unzip(zipBytes: Uint8Array): SimZipArchive {
+    try {
+      return SimZipArchive.fromBytes(zipBytes);
+    } catch (error) {
+      throw new SimLambdaInvalidParameterValueException(
+        "Could not unzip uploaded file. Please check your file, " +
+          "then try to upload again.",
+        { cause: error },
+      );
+    }
+  }
+}

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
@@ -1,6 +1,10 @@
 import type { SimZipArchive } from "../../../../util/zip/zip-archive.js";
 import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
 import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+import {
+  SimLambdaNoVmSdkModuleProvider,
+  type SimLambdaVmSdkModuleProvider,
+} from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimLambdaExecutableCode } from "./sim-lambda-executable-code.js";
 import {
   makeSimLambdaVmContext,
@@ -12,6 +16,7 @@ interface SimLambdaVmZipCodeProperties {
   readonly archive: SimZipArchive;
   readonly handlerName: string;
   readonly environment: SimLambdaVmEnvironment;
+  readonly sdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 
 interface ParsedHandlerName {
@@ -59,12 +64,15 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
   }
 
   private coldStart(): SimLambdaHandler {
-    const { archive, handlerName, environment } = this.properties;
+    const { archive, handlerName, environment, sdkModuleProvider } =
+      this.properties;
     const parsedName = parseLambdaHandlerName(handlerName);
 
     const modules = new SimLambdaVmModules({
       archive,
       context: makeSimLambdaVmContext(environment),
+      sdkModuleProvider:
+        sdkModuleProvider ?? new SimLambdaNoVmSdkModuleProvider(),
     });
     const moduleExports = this.importHandlerModule(
       modules,

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.iso.test.ts
@@ -1,0 +1,38 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaRuntimeError } from "../../../../error/sim-lambda-runtime.error.js";
+import { SimLambdaNoVmSdkModuleProvider } from "./sim-lambda-vm-sdk-module-provider.js";
+
+describe("SimLambdaNoVmSdkModuleProvider", () => {
+  it("fails AWS SDK requires with wiring guidance", () => {
+    // Given a standalone provider with no simulated AWS environment.
+    const provider = new SimLambdaNoVmSdkModuleProvider();
+
+    // When an AWS SDK package is requested, then it fails with an AWS-like
+    // runtime import error explaining how to wire the provider.
+    const error = assertThrowsError(() =>
+      provider.provideModule("@aws-sdk/client-s3"),
+    );
+
+    assertInstanceOf(error, SimLambdaRuntimeError);
+    assertIdentical(error.name, "Runtime.ImportModuleError");
+    assertStringIncludes(error.message, "@aws-sdk/client-s3");
+    assertStringIncludes(error.message, "vmSdkModuleProvider");
+  });
+
+  it("declines non-SDK specifiers", () => {
+    // Given a standalone provider.
+    const provider = new SimLambdaNoVmSdkModuleProvider();
+
+    // When a non-SDK package is requested, then the provider declines so the
+    // archive resolution error is reported instead.
+    assertUndefined(provider.provideModule("left-pad"));
+  });
+});

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
@@ -1,0 +1,44 @@
+import { SimLambdaRuntimeError } from "../../../../error/sim-lambda-runtime.error.js";
+
+/**
+ * The package scope the real Lambda Node.js runtime provides without
+ * bundling: AWS SDK v3 client packages.
+ */
+export const awsSdkPackagePrefix = "@aws-sdk/";
+
+/**
+ * Provides host-backed modules to sim Lambda vm function code.
+ *
+ * The vm module system asks a provider for bare specifiers the code archive
+ * cannot resolve, mirroring how the real Lambda Node.js runtime provides the
+ * AWS SDK without it being bundled in the deployment package. A provider
+ * returns undefined for specifiers it does not serve, so the original
+ * archive resolution error is reported.
+ */
+export interface SimLambdaVmSdkModuleProvider {
+  provideModule(specifier: string): unknown;
+}
+
+/**
+ * Module provider used when no simulated AWS environment is wired up, such
+ * as for a standalone SimLambda constructed outside SimAws.
+ */
+export class SimLambdaNoVmSdkModuleProvider implements SimLambdaVmSdkModuleProvider {
+  /**
+   * Fail AWS SDK requires with an explanation of how to wire the provider.
+   */
+  provideModule(specifier: string): unknown {
+    if (!specifier.startsWith(awsSdkPackagePrefix)) {
+      return undefined;
+    }
+
+    throw new SimLambdaRuntimeError(
+      "Runtime.ImportModuleError",
+      `Cannot provide ${specifier} to sim Lambda function code: this ` +
+        "SimLambda has no simulated SDK module provider. Create the " +
+        "function through SimAws, construct SimLambda with a " +
+        "vmSdkModuleProvider, or bundle the package into the function code " +
+        "archive.",
+    );
+  }
+}

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
@@ -12,6 +12,15 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../../../aws/sim-aws.js";
 import { SimSdkLambdaVmModuleProvider } from "./sim-sdk-lambda-vm-module-provider.js";
 
+/**
+ * Build the error shape Node.js module resolution throws for a missing
+ * package.
+ */
+function makeModuleNotFoundError(specifier: string): Error {
+  const error = new Error(`Cannot find module '${specifier}'`);
+  return Object.assign(error, { code: "MODULE_NOT_FOUND" });
+}
+
 describe("SimSdkLambdaVmModuleProvider", () => {
   it("provides an intercepted AWS SDK package module", () => {
     // Given a provider for a simulated AWS environment.
@@ -57,11 +66,11 @@ describe("SimSdkLambdaVmModuleProvider", () => {
   });
 
   it("reports an uninstalled AWS SDK package helpfully", () => {
-    // Given a provider whose host require cannot find the package.
+    // Given a provider whose host require cannot resolve the package.
     const provider = new SimSdkLambdaVmModuleProvider({
       simAws: new SimAws(),
       requireModule: () => {
-        throw new Error("Cannot find module");
+        throw makeModuleNotFoundError("@aws-sdk/client-unknown");
       },
     });
 
@@ -73,6 +82,25 @@ describe("SimSdkLambdaVmModuleProvider", () => {
 
     assertStringIncludes(error.message, "@aws-sdk/client-unknown");
     assertStringIncludes(error.message, "not installed");
+  });
+
+  it("propagates installed-package initialization failures unchanged", () => {
+    // Given a provider whose host require resolves the package but the
+    // package throws while initializing.
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+      requireModule: () => {
+        throw new Error("boom during package initialization");
+      },
+    });
+
+    // When the package is requested, then the real initialization error is
+    // reported rather than a misleading not-installed message.
+    const error = assertThrowsError(() =>
+      provider.provideModule("@aws-sdk/client-s3"),
+    );
+
+    assertIdentical(error.message, "boom during package initialization");
   });
 
   it("rejects a host module that is not a module object", () => {

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
@@ -1,0 +1,92 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import { SimSdkLambdaVmModuleProvider } from "./sim-sdk-lambda-vm-module-provider.js";
+
+describe("SimSdkLambdaVmModuleProvider", () => {
+  it("provides an intercepted AWS SDK package module", () => {
+    // Given a provider for a simulated AWS environment.
+    const simAws = new SimAws();
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws,
+      regionName: "eu-west-2",
+    });
+
+    // When an AWS SDK client package is requested.
+    const provided = provider.provideModule("@aws-sdk/client-s3") as Record<
+      string,
+      unknown
+    >;
+
+    // Then a wrapped module is provided: the client class is intercepted
+    // while other exports pass through by identity.
+    assertNonNullable(provided);
+    assertFalse(provided["S3Client"] === S3Client);
+    assertIdentical(provided["GetObjectCommand"], GetObjectCommand);
+  });
+
+  it("caches provided modules per specifier", () => {
+    // Given a provider for a simulated AWS environment.
+    const provider = new SimSdkLambdaVmModuleProvider({ simAws: new SimAws() });
+
+    // When the same package is requested twice.
+    const first = provider.provideModule("@aws-sdk/client-s3");
+    const second = provider.provideModule("@aws-sdk/client-s3");
+
+    // Then the identical module object is returned, as repeated requires
+    // within one runtime observe one module instance.
+    assertIdentical(first, second);
+  });
+
+  it("declines non-SDK specifiers", () => {
+    // Given a provider for a simulated AWS environment.
+    const provider = new SimSdkLambdaVmModuleProvider({ simAws: new SimAws() });
+
+    // When a non-SDK package is requested, then the provider declines so the
+    // archive resolution error is reported instead.
+    assertUndefined(provider.provideModule("left-pad"));
+  });
+
+  it("reports an uninstalled AWS SDK package helpfully", () => {
+    // Given a provider whose host require cannot find the package.
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+      requireModule: () => {
+        throw new Error("Cannot find module");
+      },
+    });
+
+    // When the package is requested, then the failure explains how to make
+    // the package available.
+    const error = assertThrowsError(() =>
+      provider.provideModule("@aws-sdk/client-unknown"),
+    );
+
+    assertStringIncludes(error.message, "@aws-sdk/client-unknown");
+    assertStringIncludes(error.message, "not installed");
+  });
+
+  it("rejects a host module that is not a module object", () => {
+    // Given a provider whose host require returns a non-object.
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+      requireModule: () => "not-a-module",
+    });
+
+    // When the package is requested, then the malformed module is reported.
+    const error = assertThrowsError(() =>
+      provider.provideModule("@aws-sdk/client-s3"),
+    );
+
+    assertStringIncludes(error.message, "did not export a module object");
+  });
+});

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
@@ -1,0 +1,109 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { SimSdkModuleClientInterceptor } from "../../../../../../sdk/module/sim-sdk-module-client-interceptor.js";
+import { SimSdkCommandDispatcher } from "../../../../../../sdk/sim-sdk-command-dispatcher.js";
+import type { AwsRegionName } from "../../../../../aws/sim-aws-region.js";
+import type { SimAws } from "../../../../../aws/sim-aws.js";
+import {
+  awsSdkPackagePrefix,
+  type SimLambdaVmSdkModuleProvider,
+} from "./sim-lambda-vm-sdk-module-provider.js";
+
+const hostRequire = createRequire(import.meta.url);
+
+interface SimSdkLambdaVmModuleProviderProperties {
+  readonly simAws: SimAws;
+  readonly regionName?: AwsRegionName | undefined;
+  /**
+   * Host module require, injectable for tests. Defaults to requiring from
+   * this package's context with a working-directory fallback for consumer
+   * package layouts that do not hoist dependencies.
+   */
+  readonly requireModule?: ((specifier: string) => unknown) | undefined;
+}
+
+/**
+ * Provides host-installed AWS SDK v3 packages to sim Lambda vm function
+ * code, with client classes intercepted into the owning simulated AWS
+ * environment.
+ *
+ * Calls made by the function code are routed per send, so the ambient
+ * execution-role caller applies and simulated IAM authorizes them, just as
+ * the real Lambda runtime's bundled SDK operates as the execution role.
+ */
+export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvider {
+  private readonly interceptor: SimSdkModuleClientInterceptor;
+  private readonly requireModule: (specifier: string) => unknown;
+  private readonly providedModules = new Map<string, unknown>();
+
+  constructor(properties: SimSdkLambdaVmModuleProviderProperties) {
+    const dispatcher = new SimSdkCommandDispatcher(properties.simAws);
+    this.interceptor = new SimSdkModuleClientInterceptor({
+      sendHandler: (command, client): Promise<unknown> =>
+        dispatcher.dispatch(command, client, undefined),
+      defaultRegionName: properties.regionName,
+    });
+    this.requireModule = properties.requireModule ?? requireHostModule;
+  }
+
+  /**
+   * Provide an intercepted AWS SDK package module, or undefined for other
+   * specifiers.
+   */
+  provideModule(specifier: string): unknown {
+    if (!specifier.startsWith(awsSdkPackagePrefix)) {
+      return undefined;
+    }
+
+    const provided = this.providedModules.get(specifier);
+    if (provided !== undefined) {
+      return provided;
+    }
+
+    const intercepted = this.interceptor.interceptModule(
+      this.hostModuleExports(specifier),
+    );
+    this.providedModules.set(specifier, intercepted);
+    return intercepted;
+  }
+
+  private hostModuleExports(specifier: string): object {
+    let moduleExports: unknown;
+    try {
+      moduleExports = this.requireModule(specifier);
+    } catch {
+      throw new Error(
+        `Cannot provide ${specifier} to sim Lambda function code: the ` +
+          "package is not installed. Install it in your project, as the " +
+          "real Lambda runtime provides it, or bundle it into the function " +
+          "code archive.",
+      );
+    }
+
+    if (typeof moduleExports !== "object" || moduleExports === null) {
+      throw new Error(
+        `Cannot provide ${specifier} to sim Lambda function code: the host ` +
+          "module did not export a module object",
+      );
+    }
+    return moduleExports;
+  }
+}
+
+/**
+ * Require an AWS SDK package from the host.
+ *
+ * The packages are installed by the consuming project, as they are provided
+ * by the real Lambda runtime rather than by this package. Requiring from
+ * this module's context covers hoisted installs; the working-directory
+ * fallback covers stricter package layouts.
+ */
+function requireHostModule(specifier: string): unknown {
+  try {
+    return hostRequire(specifier);
+  } catch {
+    /* v8 ignore next 4 -- only reachable in consumer package layouts where
+       this package's own require context cannot see the SDK packages. */
+    return createRequire(path.join(process.cwd(), "package.json"))(specifier);
+  }
+}

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
@@ -71,12 +71,18 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
     let moduleExports: unknown;
     try {
       moduleExports = this.requireModule(specifier);
-    } catch {
+    } catch (error) {
+      // Only translate resolution failures: an installed package failing to
+      // initialize is a real error the function code should observe as-is.
+      if (!isModuleNotFoundError(error)) {
+        throw error;
+      }
       throw new Error(
         `Cannot provide ${specifier} to sim Lambda function code: the ` +
           "package is not installed. Install it in your project, as the " +
           "real Lambda runtime provides it, or bundle it into the function " +
           "code archive.",
+        { cause: error },
       );
     }
 
@@ -106,4 +112,16 @@ function requireHostModule(specifier: string): unknown {
        this package's own require context cannot see the SDK packages. */
     return createRequire(path.join(process.cwd(), "package.json"))(specifier);
   }
+}
+
+/**
+ * Whether an error is a Node.js module resolution failure, as opposed to an
+ * error thrown while a resolved module initializes.
+ */
+function isModuleNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "MODULE_NOT_FOUND" || error.code === "ERR_MODULE_NOT_FOUND")
+  );
 }

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
@@ -2,6 +2,7 @@ import { createRequire, isBuiltin } from "node:module";
 import path from "node:path";
 import vm from "node:vm";
 import type { SimZipArchive } from "../../../../../util/zip/zip-archive.js";
+import type { SimLambdaVmSdkModuleProvider } from "./sdk/sim-lambda-vm-sdk-module-provider.js";
 import { loadJsonModule } from "./sim-lambda-vm-json-module.js";
 import { SimLambdaVmModuleResolver } from "./sim-lambda-vm-module-resolver.js";
 import { userCodeSyntaxError } from "./sim-lambda-vm-syntax-error.js";
@@ -17,6 +18,7 @@ const hostRequire = createRequire(import.meta.url);
 interface SimLambdaVmModulesProperties {
   readonly archive: SimZipArchive;
   readonly context: vm.Context;
+  readonly sdkModuleProvider: SimLambdaVmSdkModuleProvider;
 }
 
 interface VmModule {
@@ -55,12 +57,34 @@ export class SimLambdaVmModules {
       return hostRequire(specifier);
     }
 
-    const filePath = this.resolver.resolveFilePath(specifier, fromDirectory);
+    let filePath: string;
+    try {
+      filePath = this.resolver.resolveFilePath(specifier, fromDirectory);
+    } catch (archiveError) {
+      return this.provideModule(specifier, archiveError);
+    }
+
     const loaded = this.modules.get(filePath);
     if (loaded !== undefined) {
       return loaded.exports;
     }
     return this.loadModule(filePath).exports;
+  }
+
+  /**
+   * Provide a runtime module the archive does not bundle, as the real Lambda
+   * runtime provides the AWS SDK.
+   *
+   * The archive always takes precedence: the provider is only consulted for
+   * specifiers the archive cannot resolve, and when it declines, the
+   * original archive resolution error is reported.
+   */
+  private provideModule(specifier: string, archiveError: unknown): unknown {
+    const provided = this.properties.sdkModuleProvider.provideModule(specifier);
+    if (provided === undefined) {
+      throw archiveError;
+    }
+    return provided;
   }
 
   private loadModule(filePath: string): VmModule {

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-bridge.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-bridge.iso.test.ts
@@ -1,0 +1,302 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../make-lambda-code-zip.js";
+import { SimLambda } from "../../../sim-lambda.js";
+
+const readObjectHandlerSource = `
+const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+const s3Client = new S3Client({});
+exports.handler = async (event) => {
+  const output = await s3Client.send(
+    new GetObjectCommand({ Bucket: event.bucketName, Key: event.objectKey }),
+  );
+  const content = await output.Body.transformToString();
+  return { content, contentLength: content.length };
+};
+`;
+
+async function createExecutionRole(
+  simAws: SimAws,
+  roleName: string,
+): Promise<string> {
+  const roleCreation = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  return roleCreation.Role.Arn;
+}
+
+async function allowGetObject(
+  simAws: SimAws,
+  roleName: string,
+  bucketName: string,
+): Promise<void> {
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "ReadCodeObject",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: `arn:aws:s3:::${bucketName}/*`,
+        },
+      }),
+    }),
+  );
+}
+
+async function putObject(
+  simAws: SimAws,
+  bucketName: string,
+  objectKey: string,
+  content: string,
+): Promise<void> {
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: bucketName,
+      Key: objectKey,
+      Body: content,
+    }),
+  );
+}
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+describe("Lambda vm runtime AWS SDK bridge", () => {
+  it("lets vm function code read sim S3 with the provided SDK", async () => {
+    // Given a sim S3 object and an execution role allowed to read it.
+    const simAws = new SimAws();
+    await putObject(simAws, "data-bucket", "greeting.txt", "Hello from S3");
+    const roleArn = await createExecutionRole(simAws, "ReaderRole");
+    await allowGetObject(simAws, "ReaderRole", "data-bucket");
+
+    // And a function whose zip code uses the runtime-provided AWS SDK.
+    const simLambda = simAws.lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reader",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(readObjectHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "reader",
+        Payload: JSON.stringify({
+          bucketName: "data-bucket",
+          objectKey: "greeting.txt",
+        }),
+      }),
+    );
+
+    // Then the handler read the object through simulated S3 as its
+    // execution role.
+    assertIdentical(output.StatusCode, 200);
+    assertUndefined(output.FunctionError);
+    const result = parsePayload(output.Payload) as {
+      content: string;
+      contentLength: number;
+    };
+    assertIdentical(result.content, "Hello from S3");
+    assertIdentical(result.contentLength, "Hello from S3".length);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("denies vm SDK calls the execution role has no permission for", async () => {
+    // Given a sim S3 object and an execution role with no S3 permissions.
+    const simAws = new SimAws();
+    await putObject(simAws, "data-bucket", "greeting.txt", "Hello from S3");
+    const roleArn = await createExecutionRole(simAws, "NoReadRole");
+
+    const simLambda = simAws.lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "denied-reader",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(readObjectHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "denied-reader",
+        Payload: JSON.stringify({
+          bucketName: "data-bucket",
+          objectKey: "greeting.txt",
+        }),
+      }),
+    );
+
+    // Then simulated IAM denied the in-handler read, reported AWS-style as
+    // an unhandled invocation error.
+    assertIdentical(output.StatusCode, 200);
+    assertIdentical(output.FunctionError, "Unhandled");
+    const errorDocument = parsePayload(output.Payload) as {
+      errorMessage: string;
+    };
+    assertStringIncludes(errorDocument.errorMessage, "s3:GetObject");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("prefers SDK packages bundled in the code archive", async () => {
+    // Given a function whose archive bundles its own @aws-sdk package.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    const bundledSdkZip = makeLambdaCodeZip({
+      "index.js":
+        'const sdk = require("@aws-sdk/client-s3");\n' +
+        "exports.handler = async () => sdk.stubMarker;",
+      "node_modules/@aws-sdk/client-s3/package.json":
+        '{ "name": "@aws-sdk/client-s3", "main": "index.js" }',
+      "node_modules/@aws-sdk/client-s3/index.js":
+        'exports.stubMarker = "bundled-stub";',
+    });
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "bundled-sdk",
+        Role: "arn:aws:iam::111111111111:role/BundledSdkRole",
+        Handler: "index.handler",
+        Code: { ZipFile: bundledSdkZip },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "bundled-sdk" }),
+    );
+
+    // Then the bundled package was used, not the host-provided one.
+    assertIdentical(parsePayload(output.Payload), "bundled-stub");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("passes SDK command classes through into the vm untouched", async () => {
+    // Given a function that constructs an SDK command without sending it.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "command-builder",
+        Role: "arn:aws:iam::111111111111:role/CommandBuilderRole",
+        Handler: "index.handler",
+        Code: {
+          ZipFile: makeLambdaCodeZip(
+            'const { GetObjectCommand } = require("@aws-sdk/client-s3");\n' +
+              "exports.handler = async () => {\n" +
+              '  const command = new GetObjectCommand({ Bucket: "b", Key: "k" });\n' +
+              "  return command.constructor.name;\n" +
+              "};",
+          ),
+        },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "command-builder" }),
+    );
+
+    // Then the real command class behaved normally inside the vm.
+    assertIdentical(parsePayload(output.Payload), "GetObjectCommand");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports missing SDK wiring for a standalone SimLambda", async () => {
+    // Given a standalone SimLambda with no simulated AWS environment.
+    const simLambda = new SimLambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "standalone-sdk",
+        Role: "arn:aws:iam::111111111111:role/StandaloneRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(readObjectHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "standalone-sdk" }),
+    );
+
+    // Then the import fails with guidance on wiring the SDK provider.
+    assertIdentical(output.FunctionError, "Unhandled");
+    const errorDocument = parsePayload(output.Payload) as {
+      errorType: string;
+      errorMessage: string;
+    };
+    assertIdentical(errorDocument.errorType, "Runtime.ImportModuleError");
+    assertStringIncludes(errorDocument.errorMessage, "vmSdkModuleProvider");
+  });
+
+  it("keeps reporting unbundled non-SDK packages with the archive error", async () => {
+    // Given a function requiring a package that is neither bundled nor an
+    // AWS SDK package.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "missing-package",
+        Role: "arn:aws:iam::111111111111:role/MissingPackageRole",
+        Handler: "index.handler",
+        Code: {
+          ZipFile: makeLambdaCodeZip(
+            'const leftPad = require("left-pad");\n' +
+              "exports.handler = async () => leftPad;",
+          ),
+        },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: "missing-package" }),
+    );
+
+    // Then the original archive resolution error is reported.
+    assertIdentical(output.FunctionError, "Unhandled");
+    const errorDocument = parsePayload(output.Payload) as {
+      errorType: string;
+      errorMessage: string;
+    };
+    assertIdentical(errorDocument.errorType, "Runtime.ImportModuleError");
+    assertStringIncludes(errorDocument.errorMessage, "left-pad");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -1,4 +1,9 @@
 export { SimLambda } from "./sim-lambda.js";
+export {
+  SimLambdaNoVmSdkModuleProvider,
+  type SimLambdaVmSdkModuleProvider,
+} from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+export { SimSdkLambdaVmModuleProvider } from "./function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 export { makeLambdaZipFileInput } from "./function/code/lambda-zip-file-input.js";
 export {
   makeLambdaCodeZip,

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -11,9 +11,16 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
 import { CreateFunctionCommandHandler } from "./command/create-function/create-function.handler.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
-import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
+import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type {
+  SimLambdaFunction,
+  SimLambdaFunctionMap,
+  SimLambdaFunctionName,
+} from "./function/sim-lambda-function.js";
 import type {
   SimCreateFunctionCommand,
   SimCreateFunctionCommandOutput,
@@ -40,6 +47,7 @@ interface SimLambdaProperties {
   readonly background?: BackgroundScheduler;
   readonly runAsOwner?: SimAwsRunAsOwner;
   readonly codeStore?: SimLambdaCodeStore;
+  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
 }
 
 /**
@@ -53,6 +61,11 @@ export class SimLambda {
   private readonly background: BackgroundScheduler;
   private readonly runAsOwner: SimAwsRunAsOwner;
   private readonly codeStore: SimLambdaCodeStore | undefined;
+  private readonly vmSdkModuleProvider:
+    SimLambdaVmSdkModuleProvider | undefined;
+  private readonly cfnFactory = new SimLambdaCloudFormationResourceFactory(
+    this,
+  );
   private readonly sdkRouter = new SimLambdaSdkCommandRouter(this);
 
   constructor(properties: SimLambdaProperties = {}) {
@@ -61,12 +74,14 @@ export class SimLambda {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       codeStore,
+      vmSdkModuleProvider,
     } = properties;
 
     this.accountRegionScope = accountRegionScope;
     this.iam = iam;
     this.background = background;
     this.codeStore = codeStore;
+    this.vmSdkModuleProvider = vmSdkModuleProvider;
     // Ambient execution-role callers are tracked per owning SimAws instance.
     // A standalone SimLambda is its own little universe, so it owns its own
     // ambient callers.
@@ -87,6 +102,7 @@ export class SimLambda {
       iam: this.iam,
       background: this.background,
       codeStore: this.codeStore,
+      vmSdkModuleProvider: this.vmSdkModuleProvider,
     });
     return await handler.handle(command, options);
   }
@@ -121,6 +137,22 @@ export class SimLambda {
       background: this.background,
     });
     return await handler.handle(command, options);
+  }
+
+  /**
+   * Get a simulated Lambda function instance by name.
+   */
+  getSimFunctionByName(
+    functionName: SimLambdaFunctionName | string,
+  ): SimLambdaFunction | undefined {
+    return this.functions.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return this.cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for `AWS::Lambda::Function`, including inline code, S3-backed code, configuration properties, references, and attributes.
  * Added deploy-time Lambda handler bindings by function name, ARN, logical ID, or CDK path.
  * Lambda handlers can now access simulated AWS SDK services with IAM permission enforcement.
  * Added simulated `AWS::IAM::Policy` support for attaching inline policies to roles.

* **Documentation**
  * Expanded CloudFormation, Lambda, and IAM documentation with supported features, limitations, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->