### PR TITLE
fix: clean build output before packing, verify the real tarball

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,3 +59,20 @@ jobs:
           cache: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:check
+
+  pack:
+    name: Pack
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.17.0
+          cache: true
+      - run: pnpm install --frozen-lockfile
+      # Packs the tarball, installs it into a throwaway project and imports
+      # every export subpath, so an incomplete dist/ cannot be published.
+      - run: pnpm verify:pack

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "tsBuildInfoFile": "../tsconfig.docs.tsbuildinfo",
     "paths": {
       "@kensio/yulin": ["../src/index.ts"],
       "@kensio/yulin/cloudformation": [

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -289,6 +289,7 @@ export default defineConfig(
     files: ["scripts/**/*.mts"],
     rules: {
       "no-await-in-loop": "off",
+      "no-console": "off",
       "security/detect-non-literal-fs-filename": "off",
     },
   },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf ./dist/ ./*.tsbuildinfo",
+    "build": "pnpm clean && tsc -p tsconfig.build.json",
     "build:check": "tsc -p tsconfig.json --noEmit",
+    "prepack": "pnpm build",
+    "verify:pack": "pnpm tsx scripts/mts/verify-pack.mts",
     "fmt": "eslint --fix . && prettier --write .",
     "lint": "eslint . && prettier --check .",
     "test": "vitest run",

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -1,0 +1,284 @@
+#!/usr/bin/env -S pnpm tsx
+
+/**
+ * Packs the package exactly as `pnpm publish` would, installs the resulting
+ * tarball into a throwaway project outside the repository, and imports every
+ * export subpath from it.
+ *
+ * This catches publishes where `dist/` is stale or incomplete, which a local
+ * build alone cannot detect because the repository working tree still has the
+ * files that the tarball is missing.
+ */
+
+import { execa } from "execa";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const projectRoot = path.resolve(import.meta.dirname, "../..");
+
+/** Build artefacts that must never be published. */
+const forbiddenTarballEntries = [
+  ".tsbuildinfo",
+  "/dist-hidden/",
+  "/node_modules/",
+];
+
+interface PackageManifest {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportTarget>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+}
+
+type ExportTarget =
+  string | { readonly import: string; readonly types: string };
+
+interface Subpath {
+  /** Specifier a consumer would import, e.g. `@kensio/yulin/s3`. */
+  readonly specifier: string;
+  /** Package-relative path to the declaration file. */
+  readonly types: string;
+}
+
+interface ImportResult {
+  readonly specifier: string;
+  readonly ok: boolean;
+  readonly exportCount: number;
+  readonly error?: string;
+}
+
+async function main(): Promise<void> {
+  const manifest = await readManifest();
+  const subpaths = collectSubpaths(manifest);
+
+  const workDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "yulin-verify-pack-"),
+  );
+
+  try {
+    console.log(`Packing ${manifest.name} …`);
+    const tarballPath = await pack(workDirectory);
+
+    await assertTarballHygiene(tarballPath);
+
+    const consumerDirectory = path.join(workDirectory, "consumer");
+    await createConsumer(consumerDirectory, tarballPath, manifest);
+
+    const results = await importSubpaths(consumerDirectory, subpaths);
+    const missingTypes = await findMissingTypes(
+      consumerDirectory,
+      manifest,
+      subpaths,
+    );
+
+    report(results, missingTypes);
+  } finally {
+    await rm(workDirectory, { recursive: true, force: true });
+  }
+}
+
+async function readManifest(): Promise<PackageManifest> {
+  const raw = await readFile(path.join(projectRoot, "package.json"), "utf8");
+
+  return JSON.parse(raw) as PackageManifest;
+}
+
+/** Every importable export subpath, excluding plain file exports. */
+function collectSubpaths(manifest: PackageManifest): readonly Subpath[] {
+  const subpaths: Subpath[] = [];
+
+  for (const [key, target] of Object.entries(manifest.exports)) {
+    if (typeof target === "string") {
+      continue;
+    }
+
+    const suffix = key === "." ? "" : key.slice(1);
+
+    subpaths.push({
+      specifier: `${manifest.name}${suffix}`,
+      types: target.types,
+    });
+  }
+
+  return subpaths;
+}
+
+/**
+ * Runs the real pack, which triggers the `prepack` hook and therefore a clean
+ * rebuild.
+ */
+async function pack(destination: string): Promise<string> {
+  const { stdout } = await execa(
+    "npm",
+    ["pack", "--pack-destination", destination, "--json"],
+    { cwd: projectRoot },
+  );
+
+  const [entry] = JSON.parse(stdout) as readonly {
+    readonly filename: string;
+  }[];
+
+  if (entry === undefined) {
+    throw new Error("npm pack produced no tarball");
+  }
+
+  return path.join(destination, entry.filename);
+}
+
+async function assertTarballHygiene(tarballPath: string): Promise<void> {
+  const { stdout } = await execa("tar", ["tzf", tarballPath]);
+  const entries = stdout.split("\n");
+
+  const offenders = entries.filter((entry) =>
+    forbiddenTarballEntries.some((forbidden) => entry.includes(forbidden)),
+  );
+
+  if (offenders.length > 0) {
+    throw new Error(
+      `Tarball contains build artefacts that must not be published:\n${offenders.join("\n")}`,
+    );
+  }
+
+  console.log(`Tarball is clean (${String(entries.length)} entries).`);
+}
+
+/**
+ * A bare ESM project outside the repository, so module resolution cannot fall
+ * back to the repository's own `node_modules` or source tree.
+ */
+async function createConsumer(
+  consumerDirectory: string,
+  tarballPath: string,
+  manifest: PackageManifest,
+): Promise<void> {
+  await mkdir(consumerDirectory, { recursive: true });
+
+  await writeFile(
+    path.join(consumerDirectory, "package.json"),
+    `${JSON.stringify({ name: "yulin-verify-pack", version: "0.0.0", private: true, type: "module" }, undefined, 2)}\n`,
+    "utf8",
+  );
+
+  // Optional peers are installed so that subpaths depending on them are
+  // exercised rather than skipped.
+  const peers = Object.keys(manifest.peerDependencies ?? {});
+
+  await execa("npm", ["install", "--silent", tarballPath, ...peers], {
+    cwd: consumerDirectory,
+  });
+
+  console.log(`Installed tarball into ${consumerDirectory}.`);
+}
+
+/** Declaration files an export target points at but the tarball does not have. */
+async function findMissingTypes(
+  consumerDirectory: string,
+  manifest: PackageManifest,
+  subpaths: readonly Subpath[],
+): Promise<readonly string[]> {
+  const packageDirectory = path.join(
+    consumerDirectory,
+    "node_modules",
+    manifest.name,
+  );
+  const missing: string[] = [];
+
+  for (const subpath of subpaths) {
+    if (!(await isFile(path.join(packageDirectory, subpath.types)))) {
+      missing.push(`${subpath.specifier} -> ${subpath.types}`);
+    }
+  }
+
+  return missing;
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const entry = await stat(filePath);
+
+    return entry.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Imports each subpath in a child process running inside the consumer. */
+async function importSubpaths(
+  consumerDirectory: string,
+  subpaths: readonly Subpath[],
+): Promise<readonly ImportResult[]> {
+  const specifiers = subpaths.map((subpath) => subpath.specifier);
+  const runnerPath = path.join(consumerDirectory, "import-subpaths.mjs");
+
+  await writeFile(runnerPath, importRunnerSource(specifiers), "utf8");
+
+  const { stdout } = await execa("node", [runnerPath], {
+    cwd: consumerDirectory,
+  });
+
+  return JSON.parse(stdout) as readonly ImportResult[];
+}
+
+function importRunnerSource(specifiers: readonly string[]): string {
+  return `const specifiers = ${JSON.stringify(specifiers, undefined, 2)};
+const results = [];
+
+for (const specifier of specifiers) {
+  try {
+    const module = await import(specifier);
+    results.push({
+      specifier,
+      ok: true,
+      exportCount: Object.keys(module).length,
+    });
+  } catch (error) {
+    results.push({
+      specifier,
+      ok: false,
+      exportCount: 0,
+      error: \`\${error.code ?? ""} \${error.message}\`.trim().split("\\n")[0],
+    });
+  }
+}
+
+process.stdout.write(JSON.stringify(results));
+`;
+}
+
+function report(
+  results: readonly ImportResult[],
+  missingTypes: readonly string[],
+): void {
+  for (const result of results) {
+    console.log(
+      result.ok
+        ? `  ok   ${result.specifier} (${String(result.exportCount)} exports)`
+        : `  FAIL ${result.specifier} — ${result.error ?? "unknown error"}`,
+    );
+  }
+
+  for (const missing of missingTypes) {
+    console.log(`  FAIL ${missing} — declaration file missing from tarball`);
+  }
+
+  const failures = results.filter((result) => !result.ok).length;
+
+  if (failures > 0 || missingTypes.length > 0) {
+    throw new Error(
+      `Packed tarball is not publishable: ${String(failures)} of ${String(results.length)} export subpaths failed to import, ${String(missingTypes.length)} declaration file(s) missing.`,
+    );
+  }
+
+  console.log(
+    `\nAll ${String(results.length)} export subpaths import from the tarball, with declarations.`,
+  );
+}
+
+await main();

--- a/scripts/sh/publish.sh
+++ b/scripts/sh/publish.sh
@@ -2,12 +2,15 @@
 
 set -Eeuo pipefail
 
+RELEASE_TYPE="${1:-minor}"
+
 pnpm install
 pnpm lint
 pnpm test:coverage
 pnpm build
-pnpm pack --dry-run
-pnpm version minor
+# Verifies the real tarball in a throwaway install, not just the local dist/.
+pnpm verify:pack
+pnpm version "${RELEASE_TYPE}"
 pnpm login
 pnpm publish --access public
 git push

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "allowUnusedLabels": false,
     "exactOptionalPropertyTypes": true,
     "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "noCheck": false,
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## The bug

A clean `npm install @kensio/yulin@0.34.0` cannot import the package:

```
import { SimAws } from "@kensio/yulin"
// ERR_MODULE_NOT_FOUND: dist/index.js
```

Confirmed against the registry tarball, not just locally — 9 of the 13 export
targets are missing from the published 0.34.0, and it carries 1,631
`dist/dist-hidden/**` entries plus 5 `tsbuildinfo` files:

| | subpaths |
|---|---|
| broken | `.`, `./cloudformation`, `./cloudfront`, `./cloudfront/globals`, `./dynamodb`, `./eslint`, `./s3`, `./route53`, `./serve` |
| resolves | `./iam`, `./lambda`, `./sdk`, `./package.json` |

The three that work are exactly the areas that changed for the release, which is
the tell: everything else was served from stale incremental state.

## Root cause

`tsc -p tsconfig.build.json` is incremental and keeps its state in
`tsconfig.build.tsbuildinfo` **at the repository root**, outside `dist/`. When
that state disagrees with what is actually on disk, tsc emits nothing and exits
0. Deleting `dist/` by hand makes it worse rather than better:

```
$ rm -rf dist && pnpm build && ls dist
ls: dist: No such file or directory     # exit 0, zero files emitted
```

Nothing cleared the tree between builds — no clean script, no `prepack` — so
`files: ["dist"]` packed whatever happened to be lying around, including a
complete-but-stale older build under `dist/dist-hidden/` (it still contains
`service/organizations`, which is no longer in `src`).

Separately, `build:check` wrote `dist/tsconfig.tsbuildinfo`, which is how a
tsbuildinfo ended up published inside the tarball.

## The fix

- `clean` script, run as the first step of `build`, removing `dist/` **and** the
  tsbuildinfo files that drive the stale state. Removing `dist/` alone is not
  enough, per the repro above.
- `prepack` hook so `pnpm pack` and `pnpm publish` always rebuild.
- Explicit `tsBuildInfoFile` per tsconfig, so nothing writes into `dist/`.
  `tsconfig.build.json` needs its own path rather than inheriting the base one,
  otherwise it would share incremental state with `build:check`.
- New `pnpm verify:pack`: packs, installs the tarball into a throwaway project
  outside the repo, and imports every export subpath, checking declarations too.
  Wired into a new `Pack` CI job and into `publish.sh`.
- `publish.sh` release type is now a parameter — it was hardcoded to `minor`.

## Can this recur in CI?

No, and it never originated there. There is **no release automation at all** —
no publish workflow, no `NPM_TOKEN`, nothing under `.github/` that publishes.
Releases are run by hand via `scripts/sh/publish.sh` from a local workspace, and
that workspace accumulates `dist/` and tsbuildinfo state across releases. So the
failure is local-only in origin but would have recurred on every release from
that working copy. The new `prepack` hook closes it wherever the pack happens,
and the `Pack` CI job now catches it on PRs regardless.

## Verification

`pnpm check` passes. `pnpm verify:pack` on this branch:

```
Tarball is clean (1903 entries).
  ok   @kensio/yulin (1 exports)
  ok   @kensio/yulin/cloudformation (1 exports)
  ok   @kensio/yulin/cloudfront (3 exports)
  ok   @kensio/yulin/cloudfront/globals (0 exports)
  ok   @kensio/yulin/dynamodb (1 exports)
  ok   @kensio/yulin/eslint (1 exports)
  ok   @kensio/yulin/iam (1 exports)
  ok   @kensio/yulin/lambda (5 exports)
  ok   @kensio/yulin/s3 (1 exports)
  ok   @kensio/yulin/route53 (1 exports)
  ok   @kensio/yulin/sdk (12 exports)
  ok   @kensio/yulin/serve (3 exports)

All 12 export subpaths import from the tarball, with declarations.
```

The guard was also tested negatively: with `dist/index.js`, `dist/index.d.ts`
and `dist/service/s3/index.js` deleted and `prepack` suppressed, `verify:pack`
reproduces the exact reported `ERR_MODULE_NOT_FOUND` and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release scripts now accept an optional release type, defaulting to a minor release.
* **Bug Fixes**
  * Package publication now verifies the packed package in a temporary project, checking imports and declaration files before release.
* **Chores**
  * Builds now clean generated artifacts first, improving consistency.
  * Automated workflows include package validation before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->