### PR TITLE
feat: sim Route53 ListResourceRecordSets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,6 @@ dmypy.json
 tmp/
 *.tmp
 *.tmp.*
+
+# Video demo project (see .claude/video/HOUSE-STYLE.md)
+/yulin-demo/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ test/.coverage/
 node_modules/
 pnpm-lock.yaml
 pnpm-workspace.yaml
+.claude/

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -459,8 +459,9 @@ expired sessions are rejected.
 
 Simulated services use sim IAM to authorize their own actions when used through `SimAws`. Route53
 commands such as `CreateHostedZoneCommand`, `GetHostedZoneCommand`,
-`ChangeResourceRecordSetsCommand`, and `ListHostedZonesByNameCommand` accept an optional caller,
-letting tests exercise real allow/deny behaviour across services.
+`ChangeResourceRecordSetsCommand`, `ListHostedZonesByNameCommand`, and
+`ListResourceRecordSetsCommand` accept an optional caller, letting tests exercise real allow/deny
+behaviour across services.
 
 ```typescript sim-iam-route53-authorization
 /**

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -15,6 +15,7 @@ Sim Route53 currently supports:
 - Getting Hosted Zones with `GetHostedZoneCommand`
 - Listing Hosted Zones by name with `ListHostedZonesByNameCommand`
 - Changing record sets with `ChangeResourceRecordSetsCommand`
+- Listing record sets in a Hosted Zone with `ListResourceRecordSetsCommand`
 - `CREATE`, `UPSERT`, and `DELETE` record changes
 - Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS`, and `SOA`
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
@@ -316,6 +317,85 @@ for (const hostedZone of hostedZones) {
 
 The simulator supports duplicate Hosted Zone names when they have different caller references or
 CloudFormation logical IDs.
+
+## Listing records in a Hosted Zone
+
+Use `ListResourceRecordSetsCommand` to read back the records a Hosted Zone holds, whether they were
+created through the SDK or by sim CloudFormation.
+
+```typescript sim-route53-list-resource-record-sets
+/**
+ * Listing the records in a simulated Route53 Hosted Zone.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const createOutput = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "records-listing-zone",
+  }),
+);
+
+const hostedZoneId = createOutput.HostedZone?.Id;
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "www.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const listOutput = await route53.listResourceRecordSets(
+  new ListResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+  }),
+);
+
+const recordSets = listOutput.ResourceRecordSets ?? [];
+for (const recordSet of recordSets) {
+  console.log(recordSet.Name, recordSet.Type, recordSet.ResourceRecords);
+}
+```
+
+Records are returned in Route53 DNS name order, which compares names from the rightmost label
+inwards. The zone apex comes first, then names are grouped by shared parent, so `example.test.`
+sorts before `api.example.test.`, which sorts before `b.api.example.test.` and then
+`www.example.test.`. Where one name holds several record types, the record type breaks the tie.
+
+Record names are returned with a trailing dot, as Route53 returns them.
+
+Paginate with `MaxItems`. When the listing is truncated, `IsTruncated` is `true` and
+`NextRecordName` and `NextRecordType` identify the first record of the next page, which you pass
+back as `StartRecordName` and `StartRecordType`. Marker names are normalised, so `www.example.test`
+and `WWW.EXAMPLE.TEST.` select the same starting point.
+
+Alias records are returned with an `AliasTarget` rather than `ResourceRecords`. The simulator stores
+an alias target as a record value plus an alias flag, so `AliasTarget.DNSName` is returned but
+`AliasTarget.HostedZoneId` is not — it is not part of the stored record.
 
 ## Local hostname resolution
 

--- a/docs/services/route53/sim-route53-list-resource-record-sets.example.ts
+++ b/docs/services/route53/sim-route53-list-resource-record-sets.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Listing the records in a simulated Route53 Hosted Zone.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const createOutput = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "records-listing-zone",
+  }),
+);
+
+const hostedZoneId = createOutput.HostedZone?.Id;
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "www.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const listOutput = await route53.listResourceRecordSets(
+  new ListResourceRecordSetsCommand({
+    HostedZoneId: hostedZoneId,
+  }),
+);
+
+const recordSets = listOutput.ResourceRecordSets ?? [];
+for (const recordSet of recordSets) {
+  console.log(recordSet.Name, recordSet.Type, recordSet.ResourceRecords);
+}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,6 +33,7 @@ export default defineConfig(
       "test/.coverage/",
       "node_modules/",
       "**/*.config.ts",
+      ".claude/",
     ],
   },
 

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -57,6 +57,7 @@ Supported command areas currently include:
 - `get-hosted-zone/`
 - `list-hosted-zones-by-name/`
 - `change-resource-record-sets/`
+- `list-resource-record-sets/`
 
 The command handlers follow the same broad pattern used by other sim services:
 
@@ -149,6 +150,11 @@ The record store supports three mutation modes:
 - `upsert()` creates or replaces a name/type record
 - `delete()` removes by name/type and is tolerant of missing records
 
+Reads are `get()` for one name/type pair and `list()` for the whole zone. Both return copies, so
+callers cannot mutate hosted-zone state through a returned record. `list()` returns records in map
+insertion order rather than DNS order, because the store is a lookup structure; callers that need
+Route53 ordering sort the result themselves.
+
 The simulator does not currently model routing policies, weighted records, health checks,
 multi-value answer records, DNSSEC, or alias-specific evaluation beyond converting alias targets
 into record values for supported routing scenarios.
@@ -179,6 +185,27 @@ records and CloudFormation alias-style records through the same simple record ab
 The actual mutation is scheduled through the hosted zone's synchronization mechanism. Tests or
 CloudFormation resource creation paths that need the record to exist immediately after a scheduled
 change should wait for hosted-zone synchronization or drain the broader simulator background tasks.
+
+## ListResourceRecordSets behaviour
+
+`ListResourceRecordSetsCommandHandler` returns one Hosted Zone's records in Route53 DNS name order.
+
+DNS name order compares names from the rightmost label inwards, which puts the zone apex first and
+groups names under a shared parent together. `compareSimRoute53RecordNames` implements that
+comparison; `compareSimRoute53Records` adds the record type as a tiebreak so records sharing a name
+still have a total ordering for pagination.
+
+Pagination mirrors `ListHostedZonesByName` but markers are a name and a record type rather than a
+name and a hosted-zone ID. `StartRecordName` is normalised the same way stored record names are, so
+absolute and relative forms select the same page.
+
+Records are converted to AWS-shaped `ResourceRecordSet` output in `record-set-output.ts`. Stored
+names gain their trailing dot back at this boundary. Alias records are returned with an
+`AliasTarget` rather than `ResourceRecords`, but the alias hosted-zone ID is not stored on the
+record, so `AliasTarget.HostedZoneId` is omitted rather than invented.
+
+Authorization uses the hosted-zone ARN, matching `ChangeResourceRecordSets`, and runs before the
+hosted-zone lookup so an unauthorized caller cannot learn whether a zone ID exists.
 
 ## Hosted-zone lookup and listing
 
@@ -399,6 +426,12 @@ Useful areas:
   - CREATE/UPSERT/DELETE behaviour
   - alias target conversion
   - scheduled synchronization
+
+- `command/list-resource-record-sets/*.iso.test.ts`
+  - DNS name ordering
+  - alias and standard record output shapes
+  - name/type pagination markers
+  - hosted-zone ARN authorization
 
 - `hosted-zone/*.ts` and related tests
   - record storage invariants

--- a/src/service/route53/command/change-resource-record-sets/change-res-rec-sets-zone.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-res-rec-sets-zone.ts
@@ -1,4 +1,4 @@
-import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import { findSimRoute53HostedZone } from "../../hosted-zone/find-sim-route53-hosted-zone.js";
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
 import type { SimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
 
@@ -9,13 +9,5 @@ export function getChangeResourceRecordSetsHostedZone(
   hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>,
   hostedZoneId: SimRoute53HostedZoneId,
 ): SimRoute53HostedZone {
-  const hostedZone = hostedZones.get(hostedZoneId);
-
-  if (hostedZone === undefined) {
-    throw new SimRoute53NoSuchHostedZone(
-      `No sim Route53 Hosted Zone with ID ${hostedZoneId}`,
-    );
-  }
-
-  return hostedZone;
+  return findSimRoute53HostedZone(hostedZones, hostedZoneId);
 }

--- a/src/service/route53/command/change-resource-record-sets/change-resource-record-sets.handler.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-resource-record-sets.handler.ts
@@ -5,6 +5,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import { simRoute53HostedZoneArn } from "../../hosted-zone/sim-route53-hosted-zone-arn.js";
 import {
   normalizeSimRoute53HostedZoneId,
   type SimRoute53HostedZoneId,
@@ -74,7 +75,7 @@ export class ChangeResourceRecordSetsCommandHandler implements CommandHandler<
     const hostedZoneId = normalizeSimRoute53HostedZoneId(
       command.input.HostedZoneId,
     );
-    const hostedZoneArn = `arn:aws:route53:::hostedzone/${hostedZoneId}`;
+    const hostedZoneArn = simRoute53HostedZoneArn(hostedZoneId);
 
     const changes = command.input.ChangeBatch?.Changes;
     assertDefined(

--- a/src/service/route53/command/get-hosted-zone/get-hosted-zone.handler.ts
+++ b/src/service/route53/command/get-hosted-zone/get-hosted-zone.handler.ts
@@ -3,6 +3,7 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../../util/background/background.js";
+import { simRoute53HostedZoneArn } from "../../hosted-zone/sim-route53-hosted-zone-arn.js";
 import {
   normalizeSimRoute53HostedZoneId,
   type SimRoute53HostedZoneId,
@@ -70,7 +71,7 @@ export class GetHostedZoneCommandHandler implements CommandHandler<
     options?: GetHostedZoneCommandHandlerOptions,
   ): Promise<SimGetHostedZoneCommandOutput> {
     const hostedZoneId = normalizeSimRoute53HostedZoneId(command.input.Id);
-    const hostedZoneArn = `arn:aws:route53:::hostedzone/${hostedZoneId}`;
+    const hostedZoneArn = simRoute53HostedZoneArn(hostedZoneId);
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();

--- a/src/service/route53/command/list-resource-record-sets/list-rec-sets-iam.iso.test.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-rec-sets-iam.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimRoute53 } from "../../sim-route53.js";
+import { makeSimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
+
+async function createRoleWithPolicy(
+  simAws: SimAws,
+  accountId: string,
+  roleName: string,
+  policyDocument: (roleArn: string) => object,
+): Promise<string> {
+  const simIam = simAws.account(accountId).iam();
+
+  const createRoleOutput = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  const roleArn = createRoleOutput.Role.Arn;
+  const policyDocumentJson = JSON.stringify(policyDocument(roleArn));
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "ListRecordSets",
+      PolicyDocument: policyDocumentJson,
+    }),
+  );
+
+  return roleArn;
+}
+
+describe("Route53 ListResourceRecordSetsCommand IAM authorization", () => {
+  it("allows the default Account root caller", async () => {
+    // Given a Hosted Zone in a known simulated AWS Account.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const route53 = simAws.account(accountId).route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "root-records.test",
+        CallerReference: "root-records-ref",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    // When record sets are listed without an explicit caller.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+    );
+
+    // Then IAM defaults to Account root and Route53 returns the listing.
+    assertArrayLength(output.ResourceRecordSets, 0);
+  });
+
+  it("allows a Role granted the specific Hosted Zone ARN", async () => {
+    // Given a Role allowed to list record sets in one Hosted Zone.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const route53 = simAws.account(accountId).route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "role-records.test",
+        CallerReference: "role-records-ref",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    const roleArn = await createRoleWithPolicy(
+      simAws,
+      accountId,
+      "RecordSetLister",
+      () => ({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "route53:ListResourceRecordSets",
+          Resource: `arn:aws:route53:::hostedzone/${hostedZoneId}`,
+        },
+      }),
+    );
+
+    // When the Role lists record sets in that Hosted Zone.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then IAM permits the request.
+    assertArrayLength(output.ResourceRecordSets, 0);
+  });
+
+  it("denies a Role granted a different Hosted Zone ARN", async () => {
+    // Given a Role allowed to list record sets in some other Hosted Zone.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const route53 = simAws.account(accountId).route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "other-zone-records.test",
+        CallerReference: "other-zone-records-ref",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+    const otherHostedZoneId = makeSimRoute53HostedZoneId();
+
+    const roleArn = await createRoleWithPolicy(
+      simAws,
+      accountId,
+      "OtherZoneRecordSetLister",
+      () => ({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "route53:ListResourceRecordSets",
+          Resource: `arn:aws:route53:::hostedzone/${otherHostedZoneId}`,
+        },
+      }),
+    );
+
+    // When the Role lists record sets in the Hosted Zone it was not granted.
+    const error = await assertThrowsErrorAsync(async () =>
+      route53.listResourceRecordSets(
+        new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then IAM denies the request against the requested Hosted Zone ARN.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "route53:ListResourceRecordSets");
+    assertIdentical(
+      error.resource,
+      `arn:aws:route53:::hostedzone/${hostedZoneId}`,
+    );
+  });
+
+  it("denies an unauthorized caller without revealing whether the zone exists", async () => {
+    // Given a simulated Route53 with no Hosted Zone for the requested ID.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const route53 = simAws.account(accountId).route53();
+    const unknownHostedZoneId = makeSimRoute53HostedZoneId();
+
+    // When an explicitly anonymous caller lists record sets for that ID.
+    const error = await assertThrowsErrorAsync(async () =>
+      route53.listResourceRecordSets(
+        new ListResourceRecordSetsCommand({
+          HostedZoneId: unknownHostedZoneId,
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then AccessDenied is returned rather than NoSuchHostedZone.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.caller.kind, "anonymous");
+    assertIdentical(error.$metadata.httpStatusCode, 403);
+  });
+
+  it("uses allow-all authorization when SimRoute53 is instantiated directly", async () => {
+    // Given standalone Route53 with no supplied IAM implementation.
+    const simRoute53 = new SimRoute53();
+
+    const createOutput = await simRoute53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "standalone-records.test",
+        CallerReference: "standalone-records-ref",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    // When an anonymous caller lists record sets through the standalone service.
+    const output = await simRoute53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+      { caller: { kind: "anonymous" } },
+    );
+
+    // Then the allow-all fallback permits the request.
+    assertArrayLength(output.ResourceRecordSets, 0);
+  });
+});

--- a/src/service/route53/command/list-resource-record-sets/list-rec-sets-paginate.iso.test.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-rec-sets-paginate.iso.test.ts
@@ -1,0 +1,237 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
+
+/**
+ * Build a Hosted Zone holding four records across three names, so pagination
+ * markers can be exercised against both the name and the record type.
+ *
+ * In DNS name order the records are:
+ *
+ * 1. markers.test    TXT
+ * 2. a.markers.test  A
+ * 3. a.markers.test  TXT
+ * 4. b.markers.test  A
+ */
+async function createMarkersZone(
+  simAws: SimAws,
+  callerReference: string,
+): Promise<string> {
+  const route53 = simAws.route53();
+
+  const createOutput = await route53.createHostedZone(
+    new CreateHostedZoneCommand({
+      Name: "markers.test",
+      CallerReference: callerReference,
+    }),
+  );
+  const hostedZoneId = createOutput.HostedZone?.Id;
+  assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+  await route53.changeResourceRecordSets(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "markers.test",
+              Type: "TXT",
+              TTL: 300,
+              ResourceRecords: [{ Value: "apex" }],
+            },
+          },
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "a.markers.test",
+              Type: "A",
+              TTL: 60,
+              ResourceRecords: [{ Value: "127.0.0.1" }],
+            },
+          },
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "a.markers.test",
+              Type: "TXT",
+              TTL: 300,
+              ResourceRecords: [{ Value: "a text" }],
+            },
+          },
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: "b.markers.test",
+              Type: "A",
+              TTL: 60,
+              ResourceRecords: [{ Value: "127.0.0.2" }],
+            },
+          },
+        ],
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return hostedZoneId;
+}
+
+describe("Route53 ListResourceRecordSetsCommand pagination", () => {
+  it("paginates records using MaxItems and returns the next marker", async () => {
+    // Given a Hosted Zone with more records than the requested page size.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "max-items-zone");
+
+    // When record sets are listed with a two-item page size.
+    const output = await simAws.route53().listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        MaxItems: 2,
+      }),
+    );
+
+    // Then only the first page is returned, marked with the next record.
+    assertArrayLength(output.ResourceRecordSets, 2);
+    assertIdentical(output.ResourceRecordSets[0].Name, "markers.test.");
+    assertIdentical(output.ResourceRecordSets[1].Name, "a.markers.test.");
+    assertIdentical(output.ResourceRecordSets[1].Type, "A");
+    assertTrue(output.IsTruncated);
+    assertIdentical(output.NextRecordName, "a.markers.test.");
+    assertIdentical(output.NextRecordType, "TXT");
+    assertIdentical(output.MaxItems, 2);
+  });
+
+  it("omits the next marker when the last page is returned", async () => {
+    // Given a Hosted Zone listed with a page size covering every record.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "last-page-zone");
+
+    // When record sets are listed with a page size larger than the record count.
+    const output = await simAws.route53().listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        MaxItems: 10,
+      }),
+    );
+
+    // Then the listing is complete and carries no continuation marker.
+    assertArrayLength(output.ResourceRecordSets, 4);
+    assertFalse(output.IsTruncated);
+    assertUndefined(output.NextRecordName);
+    assertUndefined(output.NextRecordType);
+  });
+
+  it("continues from a StartRecordName marker", async () => {
+    // Given a Hosted Zone with records before and after a name marker.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "start-name-zone");
+
+    // When record sets are listed from a StartRecordName.
+    const output = await simAws.route53().listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: "a.markers.test",
+      }),
+    );
+
+    // Then records before that name are skipped, keeping both of its types.
+    assertArrayLength(output.ResourceRecordSets, 3);
+    assertIdentical(output.ResourceRecordSets[0].Name, "a.markers.test.");
+    assertIdentical(output.ResourceRecordSets[0].Type, "A");
+    assertIdentical(output.ResourceRecordSets[1].Type, "TXT");
+    assertIdentical(output.ResourceRecordSets[2].Name, "b.markers.test.");
+  });
+
+  it("continues from a StartRecordName and StartRecordType marker", async () => {
+    // Given a Hosted Zone where one name holds more than one record type.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "start-type-zone");
+
+    // When record sets are listed from a name and type marker.
+    const output = await simAws.route53().listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: "a.markers.test",
+        StartRecordType: "TXT",
+      }),
+    );
+
+    // Then the earlier record type at the same name is skipped.
+    assertArrayLength(output.ResourceRecordSets, 2);
+    assertIdentical(output.ResourceRecordSets[0].Name, "a.markers.test.");
+    assertIdentical(output.ResourceRecordSets[0].Type, "TXT");
+    assertIdentical(output.ResourceRecordSets[1].Name, "b.markers.test.");
+  });
+
+  it("normalises a StartRecordName marker for case and trailing dots", async () => {
+    // Given a Hosted Zone listed from a marker in absolute, upper-case form.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "marker-format-zone");
+
+    // When record sets are listed from that marker.
+    const output = await simAws.route53().listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: "A.MARKERS.TEST.",
+      }),
+    );
+
+    // Then the marker matches the same records as its normalised form.
+    assertArrayLength(output.ResourceRecordSets, 3);
+    assertIdentical(output.ResourceRecordSets[0].Name, "a.markers.test.");
+  });
+
+  it("walks every record across successive pages", async () => {
+    // Given a Hosted Zone paged one record at a time.
+    const simAws = new SimAws();
+    const hostedZoneId = await createMarkersZone(simAws, "walk-pages-zone");
+    const route53 = simAws.route53();
+    const seenNames: string[] = [];
+
+    // When each page is followed using the returned continuation marker.
+    let startRecordName: string | undefined = undefined;
+    let startRecordType: SimRoute53RecordType | undefined = undefined;
+
+    for (let page = 0; page < 4; page += 1) {
+      // eslint-disable-next-line no-await-in-loop -- pagination is sequential: each page needs the previous page's marker
+      const output = await route53.listResourceRecordSets(
+        new ListResourceRecordSetsCommand({
+          HostedZoneId: hostedZoneId,
+          MaxItems: 1,
+          StartRecordName: startRecordName,
+          StartRecordType: startRecordType,
+        }),
+      );
+
+      assertArrayLength(output.ResourceRecordSets, 1);
+      seenNames.push(
+        `${output.ResourceRecordSets[0].Name ?? ""} ${output.ResourceRecordSets[0].Type ?? ""}`,
+      );
+      startRecordName = output.NextRecordName;
+      startRecordType = output.NextRecordType;
+    }
+
+    // Then every record is visited exactly once, in DNS name order.
+    assertIdentical(seenNames[0], "markers.test. TXT");
+    assertIdentical(seenNames[1], "a.markers.test. A");
+    assertIdentical(seenNames[2], "a.markers.test. TXT");
+    assertIdentical(seenNames[3], "b.markers.test. A");
+    assertUndefined(startRecordName);
+    assertUndefined(startRecordType);
+  });
+});

--- a/src/service/route53/command/list-resource-record-sets/list-record-sets-marker.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-record-sets-marker.ts
@@ -1,6 +1,9 @@
 import { normaliseSimRoute53Name } from "../../local-name/sim-route53-local-name.js";
 import type { SimRoute53Record } from "../../record/sim-route53-record.js";
-import { compareSimRoute53RecordNames } from "./list-record-sets-order.js";
+import {
+  compareOrdinal,
+  compareSimRoute53RecordNames,
+} from "./list-record-sets-order.js";
 
 interface RecordSetListMarkerProperties {
   readonly startRecordName?: string | undefined;
@@ -59,7 +62,9 @@ export function isRecordAtOrAfterMarker(
     return true;
   }
 
-  return record.type.localeCompare(marker.markerType) >= 0;
+  // Ordinal, matching how the sort orders record types, so the filter cannot
+  // disagree with the ordering the marker was produced from.
+  return compareOrdinal(record.type, marker.markerType) >= 0;
 }
 
 function normaliseMarkerName(name: string | undefined): string | undefined {

--- a/src/service/route53/command/list-resource-record-sets/list-record-sets-marker.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-record-sets-marker.ts
@@ -1,0 +1,71 @@
+import { normaliseSimRoute53Name } from "../../local-name/sim-route53-local-name.js";
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import { compareSimRoute53RecordNames } from "./list-record-sets-order.js";
+
+interface RecordSetListMarkerProperties {
+  readonly startRecordName?: string | undefined;
+  readonly startRecordType?: string | undefined;
+}
+
+export interface RecordSetListMarker {
+  readonly markerName?: string | undefined;
+  readonly markerType?: string | undefined;
+}
+
+/**
+ * Normalise ListResourceRecordSets marker inputs before pagination comparison.
+ *
+ * Marker names are normalised the same way stored record names are, so a
+ * caller can pass `www.example.test` or `www.example.test.` and get the same
+ * page back.
+ */
+export function normaliseRecordSetListMarker(
+  properties: RecordSetListMarkerProperties,
+): RecordSetListMarker {
+  return {
+    markerName: normaliseMarkerName(properties.startRecordName),
+    markerType: properties.startRecordType,
+  };
+}
+
+/**
+ * Whether a record is positioned at or after the requested marker.
+ *
+ * A marker name without a marker type starts at the first record of that name,
+ * which matches how Route53 treats `StartRecordName` on its own.
+ */
+export function isRecordAtOrAfterMarker(
+  record: SimRoute53Record,
+  marker: RecordSetListMarker,
+): boolean {
+  if (marker.markerName === undefined) {
+    return true;
+  }
+
+  const nameComparison = compareSimRoute53RecordNames(
+    record.name,
+    marker.markerName,
+  );
+
+  if (nameComparison > 0) {
+    return true;
+  }
+
+  if (nameComparison < 0) {
+    return false;
+  }
+
+  if (marker.markerType === undefined) {
+    return true;
+  }
+
+  return record.type.localeCompare(marker.markerType) >= 0;
+}
+
+function normaliseMarkerName(name: string | undefined): string | undefined {
+  if (name === undefined) {
+    return undefined;
+  }
+
+  return normaliseSimRoute53Name(name);
+}

--- a/src/service/route53/command/list-resource-record-sets/list-record-sets-order.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-record-sets-order.ts
@@ -1,6 +1,27 @@
 import type { SimRoute53Record } from "../../record/sim-route53-record.js";
 
 /**
+ * Compare two strings by code unit rather than by locale.
+ *
+ * Record ordering has to be reproducible wherever the simulator runs, and it
+ * has to agree exactly with the order the pagination marker filter applies.
+ * `localeCompare` depends on the runtime's default locale and on how the
+ * collator weights characters that are legal in DNS labels, hyphens in
+ * particular, so ordinal comparison is used throughout record ordering.
+ */
+export function compareOrdinal(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+/**
  * Compare two normalised Route53 record names in DNS name order.
  *
  * Route53 orders record sets by DNS name, which compares labels from the right
@@ -20,7 +41,8 @@ export function compareSimRoute53RecordNames(
   for (let index = 0; index < labelCount; index += 1) {
     // A missing label sorts first, which puts shorter names before the longer
     // names that extend them.
-    const comparison = (leftLabels[index] ?? "").localeCompare(
+    const comparison = compareOrdinal(
+      leftLabels[index] ?? "",
       rightLabels[index] ?? "",
     );
 
@@ -48,5 +70,5 @@ export function compareSimRoute53Records(
     return nameComparison;
   }
 
-  return left.type.localeCompare(right.type);
+  return compareOrdinal(left.type, right.type);
 }

--- a/src/service/route53/command/list-resource-record-sets/list-record-sets-order.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-record-sets-order.ts
@@ -1,0 +1,52 @@
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+
+/**
+ * Compare two normalised Route53 record names in DNS name order.
+ *
+ * Route53 orders record sets by DNS name, which compares labels from the right
+ * rather than lexically from the left. Starting at the trailing label groups
+ * every name in a zone together and puts the zone apex first, so
+ * `example.test` sorts before `a.example.test`, which sorts before
+ * `b.example.test`.
+ */
+export function compareSimRoute53RecordNames(
+  left: string,
+  right: string,
+): number {
+  const leftLabels = left.split(".").toReversed();
+  const rightLabels = right.split(".").toReversed();
+  const labelCount = Math.max(leftLabels.length, rightLabels.length);
+
+  for (let index = 0; index < labelCount; index += 1) {
+    // A missing label sorts first, which puts shorter names before the longer
+    // names that extend them.
+    const comparison = (leftLabels[index] ?? "").localeCompare(
+      rightLabels[index] ?? "",
+    );
+
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Compare two Route53 records by DNS name, then by record type.
+ *
+ * The record type breaks ties because one name can hold several record types,
+ * and pagination markers need a total ordering.
+ */
+export function compareSimRoute53Records(
+  left: SimRoute53Record,
+  right: SimRoute53Record,
+): number {
+  const nameComparison = compareSimRoute53RecordNames(left.name, right.name);
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.type.localeCompare(right.type);
+}

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets-authorizer.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets-authorizer.ts
@@ -1,0 +1,52 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface ListResourceRecordSetsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to a Route53 ListResourceRecordSets request.
+ *
+ * ListResourceRecordSets authorizes against the specific hosted zone ARN, the
+ * same resource ChangeResourceRecordSets uses. A policy can therefore grant
+ * read access to one hosted zone without exposing every zone in the Account.
+ *
+ * Authorization occurs before Route53 looks up the Hosted Zone. An unauthorized
+ * caller receives AccessDenied whether the requested ID exists or not, which
+ * prevents the operation from exposing hosted zone existence.
+ */
+export class ListResourceRecordSetsAuthorizer {
+  private static readonly action = "route53:ListResourceRecordSets";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: ListResourceRecordSetsAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may list resource record sets in the hosted zone
+   * identified by the ARN.
+   *
+   * The caller is passed through unchanged so sim IAM can apply the
+   * account-root fallback only for an omitted caller and preserve explicit
+   * anonymous callers.
+   */
+  authorize(hostedZoneArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: ListResourceRecordSetsAuthorizer.action,
+      resource: hostedZoneArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: ListResourceRecordSetsAuthorizer.action,
+        resource: hostedZoneArn,
+      });
+    }
+  }
+}

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.cmd.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.cmd.ts
@@ -1,0 +1,37 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import type { SimRoute53ResourceRecordSet } from "../change-resource-record-sets/change-resource-record-sets.cmd.js";
+
+type SimRoute53RecordType = SimRoute53Record["type"];
+
+/**
+ * Minimal structural sim Route53 ListResourceRecordSets command.
+ */
+export interface SimListResourceRecordSetsCommand {
+  readonly input: SimListResourceRecordSetsCommandInput;
+}
+
+/**
+ * Minimal structural sim Route53 ListResourceRecordSets input.
+ */
+export interface SimListResourceRecordSetsCommandInput {
+  readonly HostedZoneId?: string | undefined;
+  readonly StartRecordName?: string | undefined;
+  readonly StartRecordType?: string | undefined;
+  readonly MaxItems?: number | undefined;
+}
+
+/**
+ * Minimal structural sim Route53 ListResourceRecordSets output.
+ */
+export interface SimListResourceRecordSetsCommandOutput {
+  readonly ResourceRecordSets?:
+    readonly SimRoute53ResourceRecordSet[] | undefined;
+  readonly IsTruncated?: boolean | undefined;
+  readonly NextRecordName?: string | undefined;
+  // Narrower than a bare string so a returned marker can be fed straight back
+  // in as StartRecordType, which the AWS SDK types as an RRType union.
+  readonly NextRecordType?: SimRoute53RecordType | undefined;
+  readonly MaxItems?: number | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.handler.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.handler.ts
@@ -4,6 +4,8 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import { findSimRoute53HostedZone } from "../../hosted-zone/find-sim-route53-hosted-zone.js";
+import { simRoute53HostedZoneArn } from "../../hosted-zone/sim-route53-hosted-zone-arn.js";
+import { simRoute53AbsoluteName } from "../../local-name/sim-route53-local-name.js";
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
 import {
   normalizeSimRoute53HostedZoneId,
@@ -73,7 +75,7 @@ export class ListResourceRecordSetsCommandHandler implements CommandHandler<
     const hostedZoneId = normalizeSimRoute53HostedZoneId(
       command.input.HostedZoneId,
     );
-    const hostedZoneArn = `arn:aws:route53:::hostedzone/${hostedZoneId}`;
+    const hostedZoneArn = simRoute53HostedZoneArn(hostedZoneId);
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
@@ -105,5 +107,5 @@ function nextRecordName(name: string | undefined): string | undefined {
     return undefined;
   }
 
-  return `${name}.`;
+  return simRoute53AbsoluteName(name);
 }

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.handler.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.handler.ts
@@ -1,0 +1,109 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { findSimRoute53HostedZone } from "../../hosted-zone/find-sim-route53-hosted-zone.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import {
+  normalizeSimRoute53HostedZoneId,
+  type SimRoute53HostedZoneId,
+} from "../create-hosted-zone/sim-route53-zone-id.js";
+import type {
+  SimListResourceRecordSetsCommand,
+  SimListResourceRecordSetsCommandOutput,
+} from "./list-resource-record-sets.cmd.js";
+import { getRecordSetListPage } from "./list-resource-record-sets.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { ListResourceRecordSetsAuthorizer } from "./list-resource-record-sets-authorizer.js";
+
+interface ListResourceRecordSetsCommandHandlerProperties {
+  readonly hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface ListResourceRecordSetsCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Route53 ListResourceRecordSetsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/command/ListResourceRecordSetsCommand/
+ */
+export class ListResourceRecordSetsCommandHandler implements CommandHandler<
+  SimListResourceRecordSetsCommand,
+  SimListResourceRecordSetsCommandOutput
+> {
+  private readonly hostedZones: Map<
+    SimRoute53HostedZoneId,
+    SimRoute53HostedZone
+  >;
+  private readonly authorizer: ListResourceRecordSetsAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListResourceRecordSetsCommandHandlerProperties) {
+    const {
+      hostedZones,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.hostedZones = hostedZones;
+    this.authorizer = new ListResourceRecordSetsAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Handle listing the Route53 records in a Hosted Zone.
+   *
+   * The hosted zone ID is normalized before authorization because it is the
+   * resource identifier used in the IAM decision. Authorization happens before
+   * the hosted zone store is read so unauthorized callers cannot learn whether
+   * the requested ID exists.
+   */
+  async handle(
+    command: SimListResourceRecordSetsCommand,
+    options?: ListResourceRecordSetsCommandHandlerOptions,
+  ): Promise<SimListResourceRecordSetsCommandOutput> {
+    const hostedZoneId = normalizeSimRoute53HostedZoneId(
+      command.input.HostedZoneId,
+    );
+    const hostedZoneArn = `arn:aws:route53:::hostedzone/${hostedZoneId}`;
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    this.authorizer.authorize(hostedZoneArn, options?.caller);
+
+    const hostedZone = findSimRoute53HostedZone(this.hostedZones, hostedZoneId);
+
+    const page = getRecordSetListPage({
+      hostedZone,
+      maxItemsInput: command.input.MaxItems,
+      startRecordName: command.input.StartRecordName,
+      startRecordType: command.input.StartRecordType,
+    });
+
+    return {
+      ResourceRecordSets: page.resourceRecordSets,
+      IsTruncated: page.nextRecord !== undefined,
+      NextRecordName: nextRecordName(page.nextRecord?.name),
+      NextRecordType: page.nextRecord?.type,
+      MaxItems: page.maxItems,
+      $metadata: {},
+    };
+  }
+}
+
+function nextRecordName(name: string | undefined): string | undefined {
+  if (name === undefined) {
+    return undefined;
+  }
+
+  return `${name}.`;
+}

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.iso.test.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.iso.test.ts
@@ -1,0 +1,299 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectMatches,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import { makeSimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
+
+describe("Route53 ListResourceRecordSetsCommand", () => {
+  it("lists records sorted in DNS name order", async () => {
+    // Given a Hosted Zone holding records created out of DNS name order.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "dns-order-zone",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.test",
+                Type: "CNAME",
+                TTL: 300,
+                ResourceRecords: [{ Value: "api.example.test" }],
+              },
+            },
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "b.api.example.test",
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "127.0.0.1" }],
+              },
+            },
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "example.test",
+                Type: "TXT",
+                TTL: 900,
+                ResourceRecords: [{ Value: "hello world" }],
+              },
+            },
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "api.example.test",
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "127.0.0.1" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Hosted Zone's record sets are listed.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+    );
+
+    // Then records are ordered by DNS name, apex first, with trailing dots.
+    assertArrayLength(output.ResourceRecordSets, 4);
+    assertIdentical(output.ResourceRecordSets[0].Name, "example.test.");
+    assertIdentical(output.ResourceRecordSets[1].Name, "api.example.test.");
+    assertIdentical(output.ResourceRecordSets[2].Name, "b.api.example.test.");
+    assertIdentical(output.ResourceRecordSets[3].Name, "www.example.test.");
+    assertFalse(output.IsTruncated);
+    assertIdentical(output.MaxItems, 100);
+    assertObjectMatches(output.$metadata, {});
+  });
+
+  it("returns record type, TTL and values for a standard record", async () => {
+    // Given a Hosted Zone with a multi-value TXT record.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "values.test",
+        CallerReference: "values-zone",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "values.test",
+                Type: "TXT",
+                TTL: 120,
+                ResourceRecords: [
+                  { Value: "first value" },
+                  { Value: "second value" },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the record sets are listed.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+    );
+
+    // Then the record set carries its type, TTL and every stored value.
+    assertArrayLength(output.ResourceRecordSets, 1);
+    const recordSet = output.ResourceRecordSets[0];
+    assertIdentical(recordSet.Type, "TXT");
+    assertIdentical(recordSet.TTL, 120);
+    assertArrayLength(recordSet.ResourceRecords, 2);
+    assertIdentical(recordSet.ResourceRecords[0].Value, "first value");
+    assertIdentical(recordSet.ResourceRecords[1].Value, "second value");
+  });
+
+  it("returns an alias record as an AliasTarget rather than resource records", async () => {
+    // Given a Hosted Zone with an alias record pointing at a CloudFront hostname.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "alias.test",
+        CallerReference: "alias-zone",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "cdn.alias.test",
+                Type: "A",
+                AliasTarget: {
+                  HostedZoneId: "Z2FDTNDATAQYW2",
+                  DNSName: "d111111abcdef8.cloudfront.net",
+                  EvaluateTargetHealth: false,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the record sets are listed.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+    );
+
+    // Then the alias target is returned instead of resource records.
+    assertArrayLength(output.ResourceRecordSets, 1);
+    const recordSet = output.ResourceRecordSets[0];
+    assertIdentical(recordSet.Name, "cdn.alias.test.");
+    assertIdentical(
+      recordSet.AliasTarget?.DNSName,
+      "d111111abcdef8.cloudfront.net.",
+    );
+    assertIdentical(recordSet.AliasTarget.EvaluateTargetHealth, false);
+    assertUndefined(recordSet.ResourceRecords);
+  });
+
+  it("returns an empty listing for a Hosted Zone with no records", async () => {
+    // Given a newly created Hosted Zone.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "empty.test",
+        CallerReference: "empty-zone",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+    await simAws.backgroundTasksComplete();
+
+    // When its record sets are listed.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({ HostedZoneId: hostedZoneId }),
+    );
+
+    // Then the listing is empty and not truncated.
+    assertArrayLength(output.ResourceRecordSets, 0);
+    assertFalse(output.IsTruncated);
+  });
+
+  it("accepts a /hostedzone/ prefixed Hosted Zone ID", async () => {
+    // Given a Hosted Zone with one record.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "prefixed.test",
+        CallerReference: "prefixed-zone",
+      }),
+    );
+    const hostedZoneId = createOutput.HostedZone?.Id;
+    assertNonNullable(hostedZoneId, "Hosted Zone ID");
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "prefixed.test",
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "127.0.0.1" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the record sets are listed using the prefixed form of the ID.
+    const output = await route53.listResourceRecordSets(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: `/hostedzone/${hostedZoneId}`,
+      }),
+    );
+
+    // Then the same Hosted Zone is listed.
+    assertArrayLength(output.ResourceRecordSets, 1);
+    assertIdentical(output.ResourceRecordSets[0].Name, "prefixed.test.");
+  });
+
+  it("throws NoSuchHostedZone for an unknown Hosted Zone ID", async () => {
+    // Given a simulated Route53 with no Hosted Zones.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+    const unknownHostedZoneId = makeSimRoute53HostedZoneId();
+
+    // When record sets are listed for an ID that was never created.
+    const error = await assertThrowsErrorAsync(async () =>
+      route53.listResourceRecordSets(
+        new ListResourceRecordSetsCommand({
+          HostedZoneId: unknownHostedZoneId,
+        }),
+      ),
+    );
+
+    // Then Route53 reports the missing Hosted Zone with its ID.
+    assertInstanceOf(error, SimRoute53NoSuchHostedZone);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+    assertIdentical(
+      error.message,
+      `No sim Route53 Hosted Zone with ID ${unknownHostedZoneId}`,
+    );
+  });
+});

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets.ts
@@ -1,0 +1,48 @@
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import type { SimRoute53ResourceRecordSet } from "../change-resource-record-sets/change-resource-record-sets.cmd.js";
+import {
+  isRecordAtOrAfterMarker,
+  normaliseRecordSetListMarker,
+} from "./list-record-sets-marker.js";
+import { compareSimRoute53Records } from "./list-record-sets-order.js";
+import { toSimRoute53ResourceRecordSet } from "./record-set-output.js";
+
+interface RecordSetListPageProperties {
+  readonly hostedZone: SimRoute53HostedZone;
+  readonly maxItemsInput?: number | undefined;
+  readonly startRecordName?: string | undefined;
+  readonly startRecordType?: string | undefined;
+}
+
+interface RecordSetListPage {
+  readonly resourceRecordSets: SimRoute53ResourceRecordSet[];
+  readonly maxItems: number;
+  readonly nextRecord?: SimRoute53Record | undefined;
+}
+
+/**
+ * Build a sorted ListResourceRecordSets response page for one Hosted Zone.
+ */
+export function getRecordSetListPage(
+  properties: RecordSetListPageProperties,
+): RecordSetListPage {
+  const maxItems = properties.maxItemsInput ?? 100;
+  const marker = normaliseRecordSetListMarker({
+    startRecordName: properties.startRecordName,
+    startRecordType: properties.startRecordType,
+  });
+
+  const matchingRecords = properties.hostedZone.records
+    .list()
+    .toSorted(compareSimRoute53Records)
+    .filter((record) => isRecordAtOrAfterMarker(record, marker));
+
+  return {
+    resourceRecordSets: matchingRecords
+      .slice(0, maxItems)
+      .map((record) => toSimRoute53ResourceRecordSet(record)),
+    maxItems,
+    nextRecord: matchingRecords.at(maxItems),
+  };
+}

--- a/src/service/route53/command/list-resource-record-sets/record-set-output.ts
+++ b/src/service/route53/command/list-resource-record-sets/record-set-output.ts
@@ -1,0 +1,57 @@
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import type { SimRoute53ResourceRecordSet } from "../change-resource-record-sets/change-resource-record-sets.cmd.js";
+
+/**
+ * Convert a stored Route53 record into an AWS-shaped ResourceRecordSet.
+ *
+ * Stored record names are normalised without a trailing dot, so the trailing
+ * dot is added back here to match Route53 output.
+ */
+export function toSimRoute53ResourceRecordSet(
+  record: SimRoute53Record,
+): SimRoute53ResourceRecordSet {
+  if (record.alias === true) {
+    return toAliasResourceRecordSet(record);
+  }
+
+  return {
+    Name: absoluteRecordName(record.name),
+    Type: record.type,
+    TTL: record.ttl,
+    ResourceRecords: record.values.map((value) => ({ Value: value })),
+  };
+}
+
+/**
+ * Convert an alias record into a ResourceRecordSet carrying an AliasTarget.
+ *
+ * Alias records are stored as an ordinary record value plus an alias flag, so
+ * the alias target hosted zone ID is not available to return. Route53 would
+ * include `AliasTarget.HostedZoneId`; the simulator omits it rather than
+ * inventing a value.
+ */
+function toAliasResourceRecordSet(
+  record: SimRoute53Record,
+): SimRoute53ResourceRecordSet {
+  const aliasTargetName = record.values.at(0);
+
+  /* v8 ignore if -- alias records always store their target as a record value */
+  if (aliasTargetName === undefined) {
+    throw new Error(
+      `Sim Route53 alias record ${record.type} ${record.name} has no alias target value`,
+    );
+  }
+
+  return {
+    Name: absoluteRecordName(record.name),
+    Type: record.type,
+    AliasTarget: {
+      DNSName: absoluteRecordName(aliasTargetName),
+      EvaluateTargetHealth: false,
+    },
+  };
+}
+
+function absoluteRecordName(name: string): string {
+  return `${name}.`;
+}

--- a/src/service/route53/command/list-resource-record-sets/record-set-output.ts
+++ b/src/service/route53/command/list-resource-record-sets/record-set-output.ts
@@ -1,3 +1,4 @@
+import { simRoute53AbsoluteName } from "../../local-name/sim-route53-local-name.js";
 import type { SimRoute53Record } from "../../record/sim-route53-record.js";
 import type { SimRoute53ResourceRecordSet } from "../change-resource-record-sets/change-resource-record-sets.cmd.js";
 
@@ -15,7 +16,7 @@ export function toSimRoute53ResourceRecordSet(
   }
 
   return {
-    Name: absoluteRecordName(record.name),
+    Name: simRoute53AbsoluteName(record.name),
     Type: record.type,
     TTL: record.ttl,
     ResourceRecords: record.values.map((value) => ({ Value: value })),
@@ -43,15 +44,11 @@ function toAliasResourceRecordSet(
   }
 
   return {
-    Name: absoluteRecordName(record.name),
+    Name: simRoute53AbsoluteName(record.name),
     Type: record.type,
     AliasTarget: {
-      DNSName: absoluteRecordName(aliasTargetName),
+      DNSName: simRoute53AbsoluteName(aliasTargetName),
       EvaluateTargetHealth: false,
     },
   };
-}
-
-function absoluteRecordName(name: string): string {
-  return `${name}.`;
 }

--- a/src/service/route53/hosted-zone/find-sim-route53-hosted-zone.ts
+++ b/src/service/route53/hosted-zone/find-sim-route53-hosted-zone.ts
@@ -1,0 +1,24 @@
+import { SimRoute53NoSuchHostedZone } from "../error/sim-route53.error.js";
+import type { SimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+import type { SimRoute53HostedZone } from "./sim-route53-hosted-zone.js";
+
+/**
+ * Find a Hosted Zone by ID, or throw the Route53 NoSuchHostedZone error.
+ *
+ * Commands that operate on one hosted zone share this lookup so they report a
+ * missing zone identically, including the zone ID in the message.
+ */
+export function findSimRoute53HostedZone(
+  hostedZones: Map<SimRoute53HostedZoneId, SimRoute53HostedZone>,
+  hostedZoneId: SimRoute53HostedZoneId,
+): SimRoute53HostedZone {
+  const hostedZone = hostedZones.get(hostedZoneId);
+
+  if (hostedZone === undefined) {
+    throw new SimRoute53NoSuchHostedZone(
+      `No sim Route53 Hosted Zone with ID ${hostedZoneId}`,
+    );
+  }
+
+  return hostedZone;
+}

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone-arn.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone-arn.ts
@@ -1,0 +1,14 @@
+import type { SimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+
+/**
+ * Build the ARN for a Hosted Zone.
+ *
+ * Route53 is a global service, so hosted zone ARNs carry no region or account
+ * segments. Zone-scoped commands authorize against this ARN, so the format
+ * lives in one place rather than being repeated per command handler.
+ */
+export function simRoute53HostedZoneArn(
+  hostedZoneId: SimRoute53HostedZoneId,
+): string {
+  return `arn:aws:route53:::hostedzone/${hostedZoneId}`;
+}

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
@@ -71,11 +71,33 @@ export class SimRoute53HostedZoneRecords {
       return undefined;
     }
 
-    return {
-      ...record,
-      values: [...record.values],
-    };
+    return copyRecord(record);
   }
+
+  /**
+   * List every record in the hosted zone.
+   *
+   * Records are returned in insertion order. Callers that need Route53-style
+   * ordering sort the result themselves, because the store is a lookup
+   * structure rather than an ordered collection.
+   * @internal
+   */
+  list(): readonly SimRoute53Record[] {
+    return this.records
+      .values()
+      .map((record) => copyRecord(record))
+      .toArray();
+  }
+}
+
+/**
+ * Copy a stored record so callers cannot mutate hosted-zone state.
+ */
+function copyRecord(record: SimRoute53Record): SimRoute53Record {
+  return {
+    ...record,
+    values: [...record.values],
+  };
 }
 
 function normaliseRecord(record: SimRoute53Record): SimRoute53Record {

--- a/src/service/route53/local-name/sim-route53-local-name.ts
+++ b/src/service/route53/local-name/sim-route53-local-name.ts
@@ -10,6 +10,17 @@ export function normaliseSimRoute53Name(name: string): string {
 }
 
 /**
+ * Render a Route53 name in absolute form, with the trailing dot AWS returns.
+ *
+ * This is the inverse of the trailing-dot stripping `normaliseSimRoute53Name`
+ * applies, and belongs at output boundaries where stored names become
+ * AWS-shaped command output.
+ */
+export function simRoute53AbsoluteName(name: string): string {
+  return `${name}.`;
+}
+
+/**
  * Convert a Yulin-local Route53 name to a logical DNS name.
  */
 export function simRoute53LogicalName(localName: string): string | undefined {

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.iso.test.ts
@@ -5,6 +5,7 @@ import {
   DeleteHostedZoneCommand,
   GetHostedZoneCommand,
   ListHostedZonesByNameCommand,
+  ListResourceRecordSetsCommand,
   Route53Client,
 } from "@aws-sdk/client-route-53";
 import {
@@ -82,6 +83,52 @@ describe("simulated Route53 SDK Command routing", () => {
       .route53()
       .hostedZones.get(zoneCreation.HostedZone.Id);
     assertIdentical(hostedZone?.status, "INSYNC");
+  });
+
+  it("routes ListResourceRecordSetsCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new Route53Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const zoneCreation = await client.send(
+      new CreateHostedZoneCommand({
+        Name: "listed.example.com",
+        CallerReference: "sdk-intercept-ref-3",
+      }),
+    );
+    assertNonNullable(zoneCreation.HostedZone?.Id);
+
+    await client.send(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: zoneCreation.HostedZone.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "UPSERT",
+              ResourceRecordSet: {
+                Name: "www.listed.example.com",
+                Type: "A",
+                TTL: 300,
+                ResourceRecords: [{ Value: "192.0.2.20" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const listOutput = await client.send(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: zoneCreation.HostedZone.Id,
+      }),
+    );
+
+    assertIdentical(
+      listOutput.ResourceRecordSets?.[0]?.Name,
+      "www.listed.example.com.",
+    );
+    assertIdentical(listOutput.ResourceRecordSets[0].Type, "A");
   });
 
   it("rejects a Command simulated Route53 does not support", async () => {

--- a/src/service/route53/sdk/sim-route53-sdk-command-router.ts
+++ b/src/service/route53/sdk/sim-route53-sdk-command-router.ts
@@ -7,6 +7,7 @@ import type { SimChangeResourceRecordSetsCommand } from "../command/change-resou
 import type { SimCreateHostedZoneCommand } from "../command/create-hosted-zone/create-hosted-zone.cmd.js";
 import type { SimGetHostedZoneCommand } from "../command/get-hosted-zone/get-hosted-zone.cmd.js";
 import type { SimListHostedZonesByNameCommand } from "../command/list-hosted-zones-by-name/list-hosted-zones-by-name.cmd.js";
+import type { SimListResourceRecordSetsCommand } from "../command/list-resource-record-sets/list-resource-record-sets.cmd.js";
 import type { SimRoute53 } from "../sim-route53.js";
 
 /**
@@ -46,6 +47,14 @@ export class SimRoute53SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRoute53.listHostedZonesByName(
             command as SimListHostedZonesByNameCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListResourceRecordSetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simRoute53.listResourceRecordSets(
+            command as SimListResourceRecordSetsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -18,6 +18,11 @@ import type {
 } from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.cmd.js";
 import { ListHostedZonesByNameCommandHandler } from "./command/list-hosted-zones-by-name/list-hosted-zones-by-name.handler.js";
 import type {
+  SimListResourceRecordSetsCommand,
+  SimListResourceRecordSetsCommandOutput,
+} from "./command/list-resource-record-sets/list-resource-record-sets.cmd.js";
+import { ListResourceRecordSetsCommandHandler } from "./command/list-resource-record-sets/list-resource-record-sets.handler.js";
+import type {
   SimChangeResourceRecordSetsCommand,
   SimChangeResourceRecordSetsCommandOutput,
 } from "./command/change-resource-record-sets/change-resource-record-sets.cmd.js";
@@ -119,6 +124,21 @@ export class SimRoute53 {
     options?: SimRoute53RequestOptions,
   ): Promise<SimListHostedZonesByNameCommandOutput> {
     const handler = new ListHostedZonesByNameCommandHandler({
+      hostedZones: this.hostedZones,
+      iam: this.iam,
+      background: this.background,
+    });
+    return await handler.handle(command, options);
+  }
+
+  /**
+   * Handle a List Resource Record Sets command from the SDK.
+   */
+  async listResourceRecordSets(
+    command: SimListResourceRecordSetsCommand,
+    options?: SimRoute53RequestOptions,
+  ): Promise<SimListResourceRecordSetsCommandOutput> {
+    const handler = new ListResourceRecordSetsCommandHandler({
       hostedZones: this.hostedZones,
       iam: this.iam,
       background: this.background,


### PR DESCRIPTION
Part of #160. Does not resolve it — this is phase 1 of four, adding the record enumeration the DNS and HTTP views both depend on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing record sets in Route 53 hosted zones.
  * Supports DNS ordering, pagination, continuation markers, standard records, and alias records.
  * Added SDK command routing and examples for retrieving hosted-zone records.
  * Added IAM authorization checks for listing records, including caller-specific access behavior.

* **Documentation**
  * Expanded Route 53 documentation with usage examples, response formats, pagination details, and authorization guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->