### PR TITLE
feat: sim Route53 hosted zone summary at dns.sim-aws.localhost

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -21,6 +21,7 @@ Sim Route53 currently supports:
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
 - Alias records, with `AliasTarget.DNSName` stored as the record value
 - Local hostname resolution through `*.sim-aws.localhost`
+- A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
 - CloudFormation resources:
   - `AWS::Route53::HostedZone`
   - `AWS::Route53::RecordSet`
@@ -396,6 +397,50 @@ and `WWW.EXAMPLE.TEST.` select the same starting point.
 Alias records are returned with an `AliasTarget` rather than `ResourceRecords`. The simulator stores
 an alias target as a record value plus an alias flag, so `AliasTarget.DNSName` is returned but
 `AliasTarget.HostedZoneId` is not — it is not part of the stored record.
+
+## Inspecting hosted zones in a browser
+
+A served simulated AWS environment reports its Route53 state at `dns.sim-aws.localhost`, so you can
+see which hosted zones and records exist without writing code to read them back.
+
+```typescript sim-route53-zone-summary
+/**
+ * Inspecting simulated Route53 hosted zones in a browser.
+ */
+
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "browsable-zone",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+// Open this in a browser to see every hosted zone and record.
+console.log(`http://dns.sim-aws.localhost:${srv.port}/`);
+```
+
+The page lists each hosted zone with its ID, synchronization status and record count, then a table
+of that zone's records in Route53 DNS name order. Alias records show their target marked `(alias)`
+with an em dash in place of a TTL, because Route53 answers an alias using the TTL of whatever it
+points at.
+
+Hosted zones from every simulated Account appear, not just the default one, because Route53 name
+resolution is environment-wide even though the Route53 service object is Account-scoped.
+
+`dns.sim-aws.localhost` is where the summary is served, not a name it answers for. It is a built-in
+Yulin hostname, so it stays reachable whatever records your test creates, and it is unrelated to any
+hosted zone you might name `dns`.
 
 ## Local hostname resolution
 

--- a/docs/services/route53/sim-route53-zone-summary.example.ts
+++ b/docs/services/route53/sim-route53-zone-summary.example.ts
@@ -1,0 +1,24 @@
+/**
+ * Inspecting simulated Route53 hosted zones in a browser.
+ */
+
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "browsable-zone",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+// Open this in a browser to see every hosted zone and record.
+console.log(`http://dns.sim-aws.localhost:${srv.port}/`);

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceController } from "../sim-service-controller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
+import { SimRoute53ServiceController } from "../../../service/route53/serve/sim-route53-controller.js";
 import { SimS3ServiceController } from "../../../service/s3/serve/sim-s3-controller.js";
 
 /**
@@ -21,6 +22,9 @@ export class SimAwsServiceControllerFactory {
         return new SimCloudFrontServiceController({
           simAws: this.simAws,
         });
+      }
+      case "route53": {
+        return new SimRoute53ServiceController({ simAws: this.simAws });
       }
       default: {
         throw new Error(

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -2,7 +2,7 @@ import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
 
 export interface SimAwsServiceTarget {
-  readonly service: "s3" | "cloudFront";
+  readonly service: "s3" | "cloudFront" | "route53";
   readonly resourceName: string;
   // regionName is used for validation, not look-up
   readonly regionName?: AwsRegionName;

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -337,6 +337,26 @@ created record.
 CloudFormation-created records should follow the same validation, normalization, change scheduling,
 and status transitions as SDK-created records.
 
+## Hosted-zone summary serving
+
+`serve/` holds Route53's own localhost HTTP controller, which is unlike the S3 and CloudFront
+controllers in that it does not serve a simulated AWS resource. It serves Yulin's view of the
+simulated hosted zones so a developer running `serveSimAws` can inspect Route53 state in a browser.
+
+The hostname is `dns.sim-aws.localhost`, whose logical name is defined by `simRoute53DnsHostName`.
+`SimRoute53ServiceTargetResolver` recognises it ahead of the S3 and CloudFront hostnames, so it
+cannot be shadowed by hosted-zone records, in the same way the other built-in service hostnames
+cannot. That means the summary stays reachable whatever a test has created.
+
+The summary reads the hosted-zone model directly rather than issuing `ListResourceRecordSets`,
+because it is an environment-wide development view rather than an AWS API call: it is not scoped to
+one Account and it does not apply sim IAM authorization. Zones come from `SimRoute53Registry` via
+`SimRoute53.resolvableHostedZones()`, so zones created in any simulated Account appear.
+
+Rendering is split into `zone-summary/`, with the page structure in
+`sim-route53-zone-summary-page.ts` and escaping in `sim-route53-summary-html.ts`. Hosted-zone names
+and record values originate in user templates and test code, so everything rendered is escaped.
+
 ## Cross-service routing role
 
 Route53's main cross-service role is name indirection for the local serving path.

--- a/src/service/route53/resolve/sim-r53-service-target-resolver.ts
+++ b/src/service/route53/resolve/sim-r53-service-target-resolver.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { simRoute53LogicalName } from "../local-name/sim-route53-local-name.js";
+import { simRoute53DnsHostName } from "../serve/sim-route53-dns-host.js";
 
 const s3WebsiteServiceLabel = "s3-website";
 const cloudFrontServiceLabel = "cloudfront";
@@ -34,9 +35,30 @@ export class SimRoute53ServiceTargetResolver {
     }
 
     return (
+      this.route53DnsServiceTarget(logicalName) ??
       this.s3WebsiteServiceTarget(logicalName) ??
       this.cloudFrontServiceTarget(logicalName)
     );
+  }
+
+  /**
+   * Resolve Yulin's own Route53 introspection hostname.
+   *
+   * This is checked first so the hosted-zone summary stays reachable whatever
+   * records a test has created, in the same way the built-in service hostnames
+   * below cannot be shadowed by hosted-zone records.
+   */
+  private route53DnsServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    if (logicalName !== simRoute53DnsHostName) {
+      return undefined;
+    }
+
+    return {
+      service: "route53",
+      resourceName: simRoute53DnsHostName,
+    };
   }
 
   /**

--- a/src/service/route53/serve/sim-route53-controller.iso.test.ts
+++ b/src/service/route53/serve/sim-route53-controller.iso.test.ts
@@ -1,0 +1,280 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertTrue,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { compareOrdinal } from "../command/list-resource-record-sets/list-record-sets-order.js";
+
+const summaryUrl = "http://dns.sim-aws.localhost/";
+
+describe("Simulated Route53 hosted zone summary", () => {
+  it("reports that no hosted zones exist yet", async () => {
+    // Given a simulated AWS environment with no Route53 Hosted Zones.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+
+    // When the Route53 summary host is requested.
+    const response = await simAwsHttp.fetch(summaryUrl);
+
+    // Then the page says so rather than rendering an empty table.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(
+      response.headers.get("content-type"),
+      "text/html; charset=utf-8",
+    );
+    assertStringIncludes(
+      await response.text(),
+      "No simulated Route53 hosted zones exist yet.",
+    );
+  });
+
+  it("renders hosted zones and their records", async () => {
+    // Given a Hosted Zone holding a CNAME record.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "summary-zone",
+      }),
+    );
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.test",
+                Type: "CNAME",
+                TTL: 300,
+                ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then the zone, its status and its record are all shown.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    const body = await response.text();
+    assertStringIncludes(body, "example.test.");
+    assertStringIncludes(body, "INSYNC");
+    assertStringIncludes(body, "1 record(s)");
+    assertStringIncludes(body, "www.example.test.");
+    assertStringIncludes(body, "CNAME");
+    assertStringIncludes(body, "300");
+    assertStringIncludes(body, "my-site.s3-website.eu-west-2");
+  });
+
+  it("shows an alias record without a TTL and marked as an alias", async () => {
+    // Given a Hosted Zone holding an alias record.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "alias.test",
+        CallerReference: "summary-alias-zone",
+      }),
+    );
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "cdn.alias.test",
+                Type: "A",
+                AliasTarget: {
+                  HostedZoneId: "Z2FDTNDATAQYW2",
+                  DNSName: "d111111abcdef8.cloudfront.net",
+                  EvaluateTargetHealth: false,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then the alias target is shown with an em dash in place of a TTL.
+    const body = await response.text();
+    assertStringIncludes(body, "d111111abcdef8.cloudfront.net (alias)");
+    assertStringIncludes(body, "<td>—</td>");
+  });
+
+  it("reports a hosted zone that holds no records", async () => {
+    // Given a Hosted Zone with no records.
+    const simAws = new SimAws();
+
+    await simAws.route53().createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "bare.test",
+        CallerReference: "summary-bare-zone",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then the zone appears with an explanation rather than an empty table.
+    const body = await response.text();
+    assertStringIncludes(body, "bare.test.");
+    assertStringIncludes(body, "No records in this hosted zone.");
+  });
+
+  it("escapes hosted zone and record text", async () => {
+    // Given a record whose value contains HTML.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "escaping.test",
+        CallerReference: "summary-escaping-zone",
+      }),
+    );
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "escaping.test",
+                Type: "TXT",
+                TTL: 60,
+                ResourceRecords: [{ Value: "<script>alert('x')</script>" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then the value is escaped rather than rendered as markup.
+    const body = await response.text();
+    assertStringNotIncludes(body, "<script>");
+    assertStringIncludes(body, "&lt;script&gt;");
+    assertStringIncludes(body, "&#39;x&#39;");
+  });
+
+  it("lists hosted zones from every simulated Account", async () => {
+    // Given Hosted Zones created in two different simulated Accounts.
+    const simAws = new SimAws();
+
+    await simAws
+      .account("111111111111")
+      .route53()
+      .createHostedZone(
+        new CreateHostedZoneCommand({
+          Name: "first-account.test",
+          CallerReference: "first-account-zone",
+        }),
+      );
+
+    await simAws
+      .account("222222222222")
+      .route53()
+      .createHostedZone(
+        new CreateHostedZoneCommand({
+          Name: "second-account.test",
+          CallerReference: "second-account-zone",
+        }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then both zones appear, because DNS resolution is environment-wide.
+    const body = await response.text();
+    assertStringIncludes(body, "first-account.test.");
+    assertStringIncludes(body, "second-account.test.");
+  });
+
+  it("lists duplicate-named hosted zones in a stable order", async () => {
+    // Given two Hosted Zones sharing a DNS name, which Route53 permits when
+    // their caller references differ.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+
+    const firstOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "duplicate.test",
+        CallerReference: "first-duplicate-zone",
+      }),
+    );
+    const secondOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "duplicate.test",
+        CallerReference: "second-duplicate-zone",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const firstId = firstOutput.HostedZone?.Id ?? "";
+    const secondId = secondOutput.HostedZone?.Id ?? "";
+
+    // When the Route53 summary host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(summaryUrl);
+
+    // Then both zones are shown, ordered by ID because their names are equal.
+    const body = await response.text();
+    const [earlierId, laterId] = [firstId, secondId].toSorted(compareOrdinal);
+    assertNonNullable(earlierId, "earlier hosted zone ID");
+    assertNonNullable(laterId, "later hosted zone ID");
+    assertTrue(body.indexOf(earlierId) < body.indexOf(laterId));
+  });
+
+  it("responds HTTP 404 for any other path on the summary host", async () => {
+    // Given a simulated AWS environment served over HTTP.
+    const simAwsHttp = new SimAwsHttp();
+
+    // When a path other than the root is requested on the summary host.
+    const response = await simAwsHttp.fetch(
+      "http://dns.sim-aws.localhost/records.json",
+    );
+
+    // Then Route53 reports that nothing is served there.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertStringIncludes(
+      await response.text(),
+      "No simulated Route53 resource at /records.json",
+    );
+  });
+});

--- a/src/service/route53/serve/sim-route53-controller.loc.test.ts
+++ b/src/service/route53/serve/sim-route53-controller.loc.test.ts
@@ -1,0 +1,77 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  serveSimAws,
+  type SimAwsLocalServer,
+} from "../../../serve/http/local-server/sim-aws-local-server.js";
+
+describe("Simulated Route53 hosted zone summary over localhost", () => {
+  const simAws = new SimAws();
+  let server: SimAwsLocalServer;
+
+  beforeAll(async () => {
+    const route53 = simAws.route53();
+
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "served.test",
+        CallerReference: "served-summary-zone",
+      }),
+    );
+
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.served.test",
+                Type: "CNAME",
+                TTL: 300,
+                ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    server = await serveSimAws({ simAws });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("serves the hosted zone summary in a browser-viewable page", async () => {
+    // Given a served simulated AWS environment holding one Hosted Zone.
+    // When the summary host is requested over real localhost HTTP.
+    const response = await fetch(
+      `http://dns.sim-aws.localhost:${server.port}/`,
+    );
+
+    // Then the zone and its record are rendered as HTML.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertStringIncludes(
+      response.headers.get("content-type") ?? "",
+      "text/html",
+    );
+
+    const body = await response.text();
+    assertStringIncludes(body, "served.test.");
+    assertStringIncludes(body, "www.served.test.");
+    assertStringIncludes(body, "my-site.s3-website.eu-west-2");
+  });
+});

--- a/src/service/route53/serve/sim-route53-controller.ts
+++ b/src/service/route53/serve/sim-route53-controller.ts
@@ -1,0 +1,56 @@
+import { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimAwsServiceController,
+  SimAwsServiceTarget,
+} from "../../../serve/controller/sim-service-controller.js";
+import { SimRoute53ZoneSummaryPage } from "./zone-summary/sim-route53-zone-summary-page.js";
+
+interface SimRoute53ServiceControllerProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * Localhost HTTP controller for simulated Route53.
+ *
+ * Unlike the S3 and CloudFront controllers, this one does not serve a simulated
+ * AWS resource. It serves Yulin's own view of the simulated hosted zones, so a
+ * developer running `serveSimAws` can inspect Route53 state in a browser.
+ */
+export class SimRoute53ServiceController implements SimAwsServiceController {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimRoute53ServiceControllerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.simAws = simAws;
+  }
+
+  /**
+   * Handle an HTTP request routed to the simulated Route53 summary host.
+   */
+  handleRequest(
+    _target: SimAwsServiceTarget,
+    request: Request,
+  ): Promise<Response> {
+    const { pathname } = new URL(request.url);
+
+    if (pathname !== "/") {
+      return Promise.resolve(
+        new Response(`No simulated Route53 resource at ${pathname}\n`, {
+          status: 404,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+      );
+    }
+
+    const page = new SimRoute53ZoneSummaryPage(
+      this.simAws.route53().resolvableHostedZones(),
+    );
+
+    return Promise.resolve(
+      new Response(page.render(), {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+  }
+}

--- a/src/service/route53/serve/sim-route53-dns-host.ts
+++ b/src/service/route53/serve/sim-route53-dns-host.ts
@@ -1,0 +1,9 @@
+/**
+ * Logical name of Yulin's own simulated Route53 introspection host.
+ *
+ * Served locally, `dns.sim-aws.localhost` reports the simulated hosted zones
+ * and their records. It is a built-in Yulin hostname rather than a name held in
+ * any hosted zone, so it resolves the same way whatever records exist. That
+ * matters because it is where the server is, not something it answers for.
+ */
+export const simRoute53DnsHostName = "dns";

--- a/src/service/route53/serve/zone-summary/sim-route53-summary-html.ts
+++ b/src/service/route53/serve/zone-summary/sim-route53-summary-html.ts
@@ -1,0 +1,26 @@
+/**
+ * Escape text for inclusion in the hosted-zone summary page.
+ *
+ * Hosted-zone names and record values come from user templates and test code,
+ * so they cannot be trusted to be HTML-safe. Escaping keeps the page correct
+ * for names containing characters that would otherwise close a tag.
+ */
+export function escapeSimRoute53Html(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/**
+ * Render one table row from already-escaped or plain-text cell values.
+ */
+export function simRoute53TableRow(cells: readonly string[]): string {
+  const renderedCells = cells
+    .map((cell) => `<td>${escapeSimRoute53Html(cell)}</td>`)
+    .join("");
+
+  return `<tr>${renderedCells}</tr>`;
+}

--- a/src/service/route53/serve/zone-summary/sim-route53-summary-style.ts
+++ b/src/service/route53/serve/zone-summary/sim-route53-summary-style.ts
@@ -1,0 +1,16 @@
+/**
+ * Styling for the hosted-zone summary page.
+ *
+ * Kept inline in the page rather than served as a separate asset, so the
+ * summary stays a single response with no extra routes to handle.
+ */
+export const simRoute53SummaryStyle = `<style>
+body { font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5; }
+h1 { font-size: 1.4rem; }
+h2 { font-size: 1.1rem; margin-bottom: 0.25rem; }
+table { border-collapse: collapse; margin: 0.5rem 0 1.5rem; }
+th, td { border: 1px solid #ccc; padding: 0.25rem 0.75rem; text-align: left; }
+th { background: #f4f4f4; }
+.zone-meta { color: #555; font-size: 0.85rem; margin-top: 0; }
+.empty { color: #555; }
+</style>`;

--- a/src/service/route53/serve/zone-summary/sim-route53-zone-section.ts
+++ b/src/service/route53/serve/zone-summary/sim-route53-zone-section.ts
@@ -1,0 +1,87 @@
+import { compareSimRoute53Records } from "../../command/list-resource-record-sets/list-record-sets-order.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import { simRoute53AbsoluteName } from "../../local-name/sim-route53-local-name.js";
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import {
+  escapeSimRoute53Html,
+  simRoute53TableRow,
+} from "./sim-route53-summary-html.js";
+
+/**
+ * Renders one hosted zone and its records as a section of the summary page.
+ */
+export class SimRoute53ZoneSection {
+  /**
+   * Render the hosted zone heading, metadata and record table.
+   */
+  render(hostedZone: SimRoute53HostedZone): string {
+    const records = hostedZone.records
+      .list()
+      .toSorted(compareSimRoute53Records);
+
+    return [
+      `<h2>${escapeSimRoute53Html(hostedZone.name)}</h2>`,
+      this.renderMetadata(hostedZone, records.length),
+      this.renderRecords(records),
+    ].join("\n");
+  }
+
+  private renderMetadata(
+    hostedZone: SimRoute53HostedZone,
+    recordCount: number,
+  ): string {
+    const parts = [
+      hostedZone.id,
+      hostedZone.status,
+      `${String(recordCount)} record(s)`,
+    ].map((part) => escapeSimRoute53Html(part));
+
+    return `<p class="zone-meta">${parts.join(" — ")}</p>`;
+  }
+
+  private renderRecords(records: readonly SimRoute53Record[]): string {
+    if (records.length === 0) {
+      return '<p class="empty">No records in this hosted zone.</p>';
+    }
+
+    const rows = records.map((record) => this.renderRecordRow(record));
+
+    return [
+      "<table>",
+      "<tr><th>Name</th><th>Type</th><th>TTL</th><th>Value</th></tr>",
+      ...rows,
+      "</table>",
+    ].join("\n");
+  }
+
+  private renderRecordRow(record: SimRoute53Record): string {
+    return simRoute53TableRow([
+      simRoute53AbsoluteName(record.name),
+      record.type,
+      recordTtl(record),
+      recordValue(record),
+    ]);
+  }
+}
+
+/**
+ * Alias records carry no TTL, because Route53 answers them using the TTL of the
+ * target they point at.
+ */
+function recordTtl(record: SimRoute53Record): string {
+  if (record.ttl === undefined) {
+    return "—";
+  }
+
+  return String(record.ttl);
+}
+
+function recordValue(record: SimRoute53Record): string {
+  const value = record.values.join(", ");
+
+  if (record.alias === true) {
+    return `${value} (alias)`;
+  }
+
+  return value;
+}

--- a/src/service/route53/serve/zone-summary/sim-route53-zone-summary-page.ts
+++ b/src/service/route53/serve/zone-summary/sim-route53-zone-summary-page.ts
@@ -1,0 +1,78 @@
+import type { SimRoute53HostedZoneId } from "../../command/create-hosted-zone/sim-route53-zone-id.js";
+import { compareOrdinal } from "../../command/list-resource-record-sets/list-record-sets-order.js";
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import { simRoute53SummaryStyle } from "./sim-route53-summary-style.js";
+import { SimRoute53ZoneSection } from "./sim-route53-zone-section.js";
+
+/**
+ * Renders the simulated Route53 hosted-zone summary served at
+ * `dns.sim-aws.localhost`.
+ *
+ * The page reads the hosted-zone model directly rather than going through the
+ * ListResourceRecordSets command, because it is a local development view of the
+ * whole simulated environment rather than an AWS API call. It is not scoped to
+ * one Account and does not apply sim IAM authorization.
+ */
+export class SimRoute53ZoneSummaryPage {
+  private readonly hostedZones: ReadonlyMap<
+    SimRoute53HostedZoneId,
+    SimRoute53HostedZone
+  >;
+  private readonly zoneSection = new SimRoute53ZoneSection();
+
+  constructor(
+    hostedZones: ReadonlyMap<SimRoute53HostedZoneId, SimRoute53HostedZone>,
+  ) {
+    this.hostedZones = hostedZones;
+  }
+
+  /**
+   * Render the summary as a complete HTML document.
+   */
+  render(): string {
+    return [
+      "<!doctype html>",
+      '<html lang="en">',
+      "<head>",
+      '<meta charset="utf-8">',
+      "<title>Simulated Route53</title>",
+      simRoute53SummaryStyle,
+      "</head>",
+      "<body>",
+      "<h1>Simulated Route53</h1>",
+      this.renderHostedZones(),
+      "</body>",
+      "</html>",
+    ].join("\n");
+  }
+
+  private renderHostedZones(): string {
+    const hostedZones = this.sortedHostedZones();
+
+    if (hostedZones.length === 0) {
+      return '<p class="empty">No simulated Route53 hosted zones exist yet.</p>';
+    }
+
+    return hostedZones
+      .map((hostedZone) => this.zoneSection.render(hostedZone))
+      .join("\n");
+  }
+
+  /**
+   * Sort by hosted-zone name, then by ID because zone names are not unique.
+   */
+  private sortedHostedZones(): readonly SimRoute53HostedZone[] {
+    return this.hostedZones
+      .values()
+      .toArray()
+      .toSorted((left, right) => {
+        const nameComparison = compareOrdinal(left.name, right.name);
+
+        if (nameComparison !== 0) {
+          return nameComparison;
+        }
+
+        return compareOrdinal(left.id, right.id);
+      });
+  }
+}

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -162,6 +162,20 @@ export class SimRoute53 {
   }
 
   /**
+   * Get every Hosted Zone resolvable in this simulated AWS environment.
+   *
+   * Route53 service instances are Account-scoped, but DNS-style resolution is
+   * global, so the localhost serving layer reads zones from the shared registry
+   * rather than from one Account's hosted-zone map.
+   */
+  resolvableHostedZones(): ReadonlyMap<
+    SimRoute53HostedZoneId,
+    SimRoute53HostedZone
+  > {
+    return this.route53Registry.hostedZones;
+  }
+
+  /**
    * Resolve a Yulin-local HTTP hostname to a simulated AWS service target.
    */
   resolveHttpHost(hostname: string): SimAwsServiceTarget | undefined {


### PR DESCRIPTION
Part of #160. Does not resolve it — this is phase 2 of four, adding the HTTP view. Phases 3 and 4 add the DNS wire codec and the UDP server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a browser-based Route 53 hosted-zone summary at `dns.sim-aws.localhost`.
  - Displays hosted-zone IDs, status, record counts, records, aliases, and TTL information.
  - Includes hosted zones across the simulated environment, including multiple accounts.
  - Added support for serving Route 53 inspection pages through the simulator.

- **Documentation**
  - Added usage guidance and a TypeScript example for inspecting hosted zones in a browser.

- **Tests**
  - Added coverage for rendering, sorting, multiple accounts, empty zones, invalid paths, and HTML escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->