### PR TITLE
feat: sim Route53 real DNS queryable with dig

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -22,6 +22,7 @@ Sim Route53 currently supports:
 - Alias records, with `AliasTarget.DNSName` stored as the record value
 - Local hostname resolution through `*.sim-aws.localhost`
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
+- Real DNS answers over UDP, so records can be queried with `dig` or any DNS client
 - CloudFormation resources:
   - `AWS::Route53::HostedZone`
   - `AWS::Route53::RecordSet`
@@ -441,6 +442,125 @@ resolution is environment-wide even though the Route53 service object is Account
 `dns.sim-aws.localhost` is where the summary is served, not a name it answers for. It is a built-in
 Yulin hostname, so it stays reachable whatever records your test creates, and it is unrelated to any
 hosted zone you might name `dns`.
+
+## Querying simulated records with dig
+
+A served simulated environment answers real DNS queries over UDP, on the same port number the HTTP
+server took on TCP. UDP and TCP port namespaces are separate, so one number covers both.
+
+```typescript sim-route53-dns
+/**
+ * Querying simulated Route53 records with a DNS client.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const createOutput = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "dns-zone",
+  }),
+);
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: createOutput.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "www.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+console.log(`dig @127.0.0.1 -p ${srv.dnsPort} www.example.test`);
+```
+
+Running that `dig` command against the served simulator:
+
+```text
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 17691
+;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
+
+www.example.test.             300  IN  CNAME  my-site.s3-website.eu-west-2.
+my-site.s3-website.eu-west-2.  60  IN  A      127.0.0.1
+```
+
+The CNAME is followed and an address record is synthesised for the simulated S3 website, pointing at
+the address the local HTTP server listens on. A name that resolves to a simulated service therefore
+answers with somewhere you can actually make a request.
+
+Any DNS client works. Node's own resolver needs no extra dependency, which makes it convenient in
+tests:
+
+```typescript sim-route53-dns-resolver
+/**
+ * Resolving a simulated Route53 record with Node's DNS resolver.
+ */
+
+import { Resolver } from "node:dns/promises";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+const resolver = new Resolver({ timeout: 1000, tries: 1 });
+resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+
+// resolver.resolve4("www.example.test") now answers from simulated Route53.
+```
+
+### Ports
+
+DNS binds the same port number as HTTP, but that is a convenience rather than a guarantee: if the
+number is already held on UDP by something else, DNS binds an ephemeral port instead. Read
+`srv.dnsPort` rather than assuming it matches `srv.port`.
+
+Nothing binds port 53, which would need root. To resolve simulated names system-wide without naming a
+port, point your resolver at the simulator yourself — on macOS, a file such as `/etc/resolver/test`
+containing `nameserver 127.0.0.1` and `port <dnsPort>` makes the whole `.test` TLD resolve through it.
+That is a change to your machine, so Yulin does not make it for you.
+
+### What is answered
+
+- The record types sim Route53 stores: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`.
+- CNAME chains are followed, so an `A` query on a name holding a CNAME returns the CNAME and the
+  address it leads to together. Chains are bounded, and a cycle stops immediately.
+- Alias records are resolved to the address of whatever they point at, answered under the name that
+  holds the alias, which is how Route53 answers an alias. The alias record itself never appears.
+- A name in a zone holding no record of the queried type gives `NOERROR` with no answers, and a name
+  the zone does not hold gives `NXDOMAIN`. Both carry the zone `SOA` in the authority section, so a
+  resolver knows how long it may cache the negative answer. If the zone holds no `SOA` of its own,
+  one is synthesised.
+- A name held by no hosted zone is `REFUSED` rather than `NXDOMAIN`: the simulator answers only for
+  the zones it holds, and cannot claim a name exists nowhere.
+- Zones from every simulated Account are answered, because DNS resolution is environment-wide.
+
+Not modelled: EDNS0, the `ANY` query type, DNS over TCP, more than one question per query, recursion,
+and DNSSEC. Answers are always authoritative.
 
 ## Local hostname resolution
 

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -521,17 +521,61 @@ tests:
 
 import { Resolver } from "node:dns/promises";
 
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
 import { SimAws } from "@kensio/yulin";
 import { serveSimAws } from "@kensio/yulin/serve";
 
 const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const zone = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "resolver-zone",
+  }),
+);
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "A",
+            TTL: 60,
+            ResourceRecords: [{ Value: "192.0.2.10" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
 const srv = await serveSimAws({ simAws });
 
-const resolver = new Resolver({ timeout: 1000, tries: 1 });
-resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+try {
+  const resolver = new Resolver({ timeout: 1000, tries: 1 });
+  resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
 
-// resolver.resolve4("www.example.test") now answers from simulated Route53.
+  const addresses = await resolver.resolve4("api.example.test");
+
+  console.log(addresses); // [ '192.0.2.10' ]
+} finally {
+  srv.close();
+}
 ```
+
+A short timeout with a single try keeps a test failing quickly rather than
+hanging, should the record not be there.
 
 ### Ports
 

--- a/docs/services/route53/sim-route53-dns-resolver.example.ts
+++ b/docs/services/route53/sim-route53-dns-resolver.example.ts
@@ -4,13 +4,54 @@
 
 import { Resolver } from "node:dns/promises";
 
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
 import { SimAws } from "@kensio/yulin";
 import { serveSimAws } from "@kensio/yulin/serve";
 
 const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const zone = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "resolver-zone",
+  }),
+);
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zone.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "api.example.test",
+            Type: "A",
+            TTL: 60,
+            ResourceRecords: [{ Value: "192.0.2.10" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
 const srv = await serveSimAws({ simAws });
 
-const resolver = new Resolver({ timeout: 1000, tries: 1 });
-resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+try {
+  const resolver = new Resolver({ timeout: 1000, tries: 1 });
+  resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
 
-// resolver.resolve4("www.example.test") now answers from simulated Route53.
+  const addresses = await resolver.resolve4("api.example.test");
+
+  console.log(addresses); // [ '192.0.2.10' ]
+} finally {
+  srv.close();
+}

--- a/docs/services/route53/sim-route53-dns-resolver.example.ts
+++ b/docs/services/route53/sim-route53-dns-resolver.example.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolving a simulated Route53 record with Node's DNS resolver.
+ */
+
+import { Resolver } from "node:dns/promises";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+const resolver = new Resolver({ timeout: 1000, tries: 1 });
+resolver.setServers([`127.0.0.1:${srv.dnsPort}`]);
+
+// resolver.resolve4("www.example.test") now answers from simulated Route53.

--- a/docs/services/route53/sim-route53-dns.example.ts
+++ b/docs/services/route53/sim-route53-dns.example.ts
@@ -1,0 +1,46 @@
+/**
+ * Querying simulated Route53 records with a DNS client.
+ */
+
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const route53 = simAws.route53();
+
+const createOutput = await route53.createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "dns-zone",
+  }),
+);
+
+await route53.changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: createOutput.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: "www.example.test",
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const srv = await serveSimAws({ simAws });
+
+console.log(`dig @127.0.0.1 -p ${srv.dnsPort} www.example.test`);

--- a/src/serve/dns/sim-aws-dns-server.loc.test.ts
+++ b/src/serve/dns/sim-aws-dns-server.loc.test.ts
@@ -1,0 +1,208 @@
+import dgram from "node:dgram";
+import { Resolver } from "node:dns/promises";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import {
+  CreateBucketCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import {
+  serveSimAws,
+  type SimAwsLocalServer,
+} from "../http/local-server/sim-aws-local-server.js";
+import { SimAwsDnsServer } from "./sim-aws-dns-server.js";
+
+describe("Simulated AWS DNS server", () => {
+  const simAws = new SimAws();
+  let server: SimAwsLocalServer;
+  let resolver: Resolver;
+
+  beforeAll(async () => {
+    // A simulated S3 website, reachable at a hostname of its own.
+    const simS3 = simAws.region("eu-west-2").s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "my-site" }));
+    await simS3.putBucketWebsite(
+      new PutBucketWebsiteCommand({
+        Bucket: "my-site",
+        WebsiteConfiguration: { IndexDocument: { Suffix: "index.html" } },
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "my-site",
+        Key: "index.html",
+        Body: "<h1>Hello from Yulin</h1>",
+        ContentType: "text/html; charset=utf-8",
+      }),
+    );
+
+    // A Route53 name pointing at it, plus a name of a type it does not hold.
+    const route53 = simAws.route53();
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "dns-server-zone",
+      }),
+    );
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "www.example.test",
+                Type: "CNAME",
+                TTL: 300,
+                ResourceRecords: [{ Value: "my-site.s3-website.eu-west-2" }],
+              },
+            },
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "text.example.test",
+                Type: "TXT",
+                TTL: 300,
+                ResourceRecords: [{ Value: "hello from yulin" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    server = await serveSimAws({ simAws });
+
+    resolver = new Resolver({ timeout: 1000, tries: 1 });
+    resolver.setServers([`127.0.0.1:${server.dnsPort}`]);
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("resolves a simulated Route53 name with a real DNS client", async () => {
+    // Given a served simulated environment answering DNS on localhost.
+    // When Node's resolver, which speaks real DNS over UDP, resolves the name.
+    const addresses = await resolver.resolve4("www.example.test");
+
+    // Then it follows the CNAME to the simulated S3 website and gets the address
+    // the local HTTP server is listening on.
+    assertArrayEquals(addresses, ["127.0.0.1"]);
+  });
+
+  it("serves over HTTP what DNS pointed at, for the same name", async () => {
+    // Given the address DNS just answered with.
+    const addresses = await resolver.resolve4("www.example.test");
+    assertIdentical(addresses[0], "127.0.0.1");
+
+    // When the same name is requested over HTTP on the local server.
+    // The `.sim-aws.localhost` suffix and the port are still needed, because
+    // nothing has pointed this machine's resolver at the simulator; the DNS
+    // answer says which address serves the name, not how to reach it by name.
+    const response = await fetch(
+      `http://www.example.test.sim-aws.localhost:${server.port}/`,
+    );
+
+    // Then the simulated S3 website answers, so the DNS answer and the HTTP
+    // response describe the same thing.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertStringIncludes(await response.text(), "Hello from Yulin");
+  });
+
+  it("resolves a TXT record through the same server", async () => {
+    // Given a TXT record in the zone.
+    // When it is resolved.
+    const values = await resolver.resolveTxt("text.example.test");
+
+    // Then the stored value comes back through a real client.
+    assertArrayEquals(values.flat(), ["hello from yulin"]);
+  });
+
+  it("reports a name the zone does not hold as not found", async () => {
+    // Given a name in a served zone that holds no record.
+    // When it is resolved.
+    const error = await assertThrowsErrorAsync(async () =>
+      resolver.resolve4("missing.example.test"),
+    );
+
+    // Then the client sees a name error rather than a timeout.
+    assertInstanceOf(error, Error);
+    assertIdentical((error as NodeJS.ErrnoException).code, "ENOTFOUND");
+  });
+
+  it("answers DNS on the same port number the HTTP server took", () => {
+    // Given a served environment with both protocols up.
+    // When the two ports are compared.
+    // Then they are the same number, UDP and TCP having separate namespaces.
+    assertIdentical(server.dnsPort, server.port);
+  });
+
+  it("throws when the port is read before the server is listening", () => {
+    // Given a DNS server that has not been started.
+    const dnsServer = new SimAwsDnsServer({ simAws });
+
+    // When its port is read.
+    const error = assertThrowsError(() => dnsServer.port);
+
+    // Then it says so rather than reporting a meaningless port.
+    assertStringIncludes(error.message, "not yet listening");
+  });
+
+  it("ignores being closed before it was ever started", () => {
+    // Given a DNS server that has not been started.
+    const dnsServer = new SimAwsDnsServer({ simAws });
+
+    // When it is closed anyway, as a test teardown might.
+    dnsServer.close();
+
+    // Then nothing is thrown, so teardown does not have to track whether the
+    // server got as far as listening.
+    assertIdentical(true, true);
+  });
+
+  it("falls back to another port when the preferred one is taken on UDP", async () => {
+    // Given an unrelated process already holding a UDP port.
+    const occupier = dgram.createSocket("udp4");
+    await new Promise<void>((resolve) => {
+      occupier.bind(0, "127.0.0.1", resolve);
+    });
+    const occupiedPort = occupier.address().port;
+
+    // When a DNS server is asked to bind that same port.
+    const dnsServer = await new SimAwsDnsServer({ simAws }).listen(
+      occupiedPort,
+    );
+
+    try {
+      // Then it serves on a different port rather than failing to serve at all.
+      assertIdentical(dnsServer.port === String(occupiedPort), false);
+
+      const fallbackResolver = new Resolver({ timeout: 1000, tries: 1 });
+      fallbackResolver.setServers([`127.0.0.1:${dnsServer.port}`]);
+      assertArrayEquals(await fallbackResolver.resolve4("www.example.test"), [
+        "127.0.0.1",
+      ]);
+    } finally {
+      dnsServer.close();
+      occupier.close();
+    }
+  });
+});

--- a/src/serve/dns/sim-aws-dns-server.loc.test.ts
+++ b/src/serve/dns/sim-aws-dns-server.loc.test.ts
@@ -1,4 +1,5 @@
 import dgram from "node:dgram";
+import http from "node:http";
 import { Resolver } from "node:dns/promises";
 import {
   ChangeResourceRecordSetsCommand,
@@ -13,11 +14,9 @@ import {
   assertArrayEquals,
   assertIdentical,
   assertInstanceOf,
-  assertResponseStatus,
   assertStringIncludes,
   assertThrowsError,
   assertThrowsErrorAsync,
-  describeResponse,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { SimAws } from "../../service/aws/sim-aws.js";
@@ -26,6 +25,33 @@ import {
   type SimAwsLocalServer,
 } from "../http/local-server/sim-aws-local-server.js";
 import { SimAwsDnsServer } from "./sim-aws-dns-server.js";
+
+/**
+ * Request a path at a literal address, choosing the simulated host by Host
+ * header. `fetch` forbids setting Host, so the request is made with node:http.
+ */
+async function requestAt(
+  address: string,
+  port: string,
+  host: string,
+): Promise<{ statusCode: number | undefined; body: string }> {
+  return await new Promise((resolve, reject) => {
+    const request = http.request(
+      { hostname: address, port, path: "/", headers: { host } },
+      (response) => {
+        let body = "";
+        response.on("data", (chunk: Buffer) => {
+          body += chunk.toString("utf8");
+        });
+        response.on("end", () => {
+          resolve({ statusCode: response.statusCode, body });
+        });
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
 
 describe("Simulated AWS DNS server", () => {
   const simAws = new SimAws();
@@ -113,18 +139,20 @@ describe("Simulated AWS DNS server", () => {
     const addresses = await resolver.resolve4("www.example.test");
     assertIdentical(addresses[0], "127.0.0.1");
 
-    // When the same name is requested over HTTP on the local server.
-    // The `.sim-aws.localhost` suffix and the port are still needed, because
-    // nothing has pointed this machine's resolver at the simulator; the DNS
-    // answer says which address serves the name, not how to reach it by name.
-    const response = await fetch(
-      `http://www.example.test.sim-aws.localhost:${server.port}/`,
+    // When the site is requested at exactly the address DNS gave, rather than by
+    // resolving the hostname again. `sim-aws.localhost` resolves to both ::1 and
+    // 127.0.0.1, so going by name could reach a different socket than the one
+    // the DNS answer named, and hide a disagreement between the two.
+    const { statusCode, body } = await requestAt(
+      addresses[0],
+      server.port,
+      "www.example.test.sim-aws.localhost",
     );
 
-    // Then the simulated S3 website answers, so the DNS answer and the HTTP
-    // response describe the same thing.
-    assertResponseStatus(response, 200, await describeResponse(response));
-    assertStringIncludes(await response.text(), "Hello from Yulin");
+    // Then the simulated S3 website answers, so the address in the DNS answer is
+    // one that really serves the name.
+    assertIdentical(statusCode, 200);
+    assertStringIncludes(body, "Hello from Yulin");
   });
 
   it("resolves a TXT record through the same server", async () => {
@@ -146,13 +174,6 @@ describe("Simulated AWS DNS server", () => {
     // Then the client sees a name error rather than a timeout.
     assertInstanceOf(error, Error);
     assertIdentical((error as NodeJS.ErrnoException).code, "ENOTFOUND");
-  });
-
-  it("answers DNS on the same port number the HTTP server took", () => {
-    // Given a served environment with both protocols up.
-    // When the two ports are compared.
-    // Then they are the same number, UDP and TCP having separate namespaces.
-    assertIdentical(server.dnsPort, server.port);
   });
 
   it("throws when the port is read before the server is listening", () => {

--- a/src/serve/dns/sim-aws-dns-server.ts
+++ b/src/serve/dns/sim-aws-dns-server.ts
@@ -1,0 +1,100 @@
+import dgram from "node:dgram";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { simAwsLocalConf as simAwsLocalConfig } from "../http/local-server/sim-aws-local.conf.js";
+import { SimAwsDns } from "./sim-aws-dns.js";
+
+interface SimAwsDnsServerProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * Local DNS server for a simulated AWS environment.
+ *
+ * Answers real DNS queries over UDP, so simulated hosted zones can be inspected
+ * with an ordinary DNS client. UDP only: a resolver falls back to TCP for
+ * responses too large for a datagram, and the simulator's answers never are.
+ */
+export class SimAwsDnsServer {
+  private readonly dns: SimAwsDns;
+  private socket: dgram.Socket;
+  private listening = false;
+
+  constructor(properties: SimAwsDnsServerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.dns = new SimAwsDns({ simAws });
+    this.socket = this.createSocket();
+  }
+
+  /**
+   * Start answering DNS queries, preferring a given port number.
+   *
+   * UDP and TCP port namespaces are separate, so the number the HTTP server
+   * took on TCP is normally free on UDP and one number serves both protocols.
+   * That is a convenience rather than a guarantee: an unrelated process may
+   * already hold that UDP port, so binding falls back to an ephemeral port and
+   * reports it through `port` instead of failing to serve DNS at all.
+   */
+  async listen(preferredPort: number): Promise<this> {
+    try {
+      await this.bind(preferredPort);
+    } catch {
+      // The preferred number is free on TCP but held by something else on UDP.
+      // A socket whose bind failed cannot be reused, so it is replaced.
+      this.socket.close();
+      this.socket = this.createSocket();
+      await this.bind(0);
+    }
+
+    return this;
+  }
+
+  /**
+   * Get the UDP port on which this DNS server is listening.
+   */
+  get port(): string {
+    if (!this.listening) {
+      throw new Error(
+        "DNS server is not yet listening, cannot get port number",
+      );
+    }
+
+    return String(this.socket.address().port);
+  }
+
+  /**
+   * Stop answering DNS queries.
+   */
+  close(): void {
+    if (!this.listening) {
+      return;
+    }
+
+    this.listening = false;
+    this.socket.close();
+  }
+
+  private createSocket(): dgram.Socket {
+    const socket = dgram.createSocket("udp4");
+
+    socket.on("message", (message, remote) => {
+      socket.send(this.dns.handleQuery(message), remote.port, remote.address);
+    });
+
+    return socket;
+  }
+
+  private async bind(port: number): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => {
+        reject(error);
+      };
+
+      this.socket.once("error", onError);
+      this.socket.bind(port, simAwsLocalConfig.loopbackAddress, () => {
+        this.socket.off("error", onError);
+        this.listening = true;
+        resolve();
+      });
+    });
+  }
+}

--- a/src/serve/dns/sim-aws-dns-server.ts
+++ b/src/serve/dns/sim-aws-dns-server.ts
@@ -76,8 +76,25 @@ export class SimAwsDnsServer {
   private createSocket(): dgram.Socket {
     const socket = dgram.createSocket("udp4");
 
+    // A socket with no error listener throws on an 'error' event, which would
+    // take the process down. Nothing useful can be done about a datagram that
+    // failed to send to a client that may no longer be there, so the error is
+    // absorbed and the server keeps answering.
+    socket.on("error", () => {
+      // Nothing to do but keep serving.
+    });
+
     socket.on("message", (message, remote) => {
-      socket.send(this.dns.handleQuery(message), remote.port, remote.address);
+      // The send callback keeps a failure here from reaching the socket's error
+      // event as an unhandled one.
+      socket.send(
+        this.dns.handleQuery(message),
+        remote.port,
+        remote.address,
+        () => {
+          // Delivery failure is the client's problem, not the server's.
+        },
+      );
     });
 
     return socket;

--- a/src/serve/dns/sim-aws-dns.iso.test.ts
+++ b/src/serve/dns/sim-aws-dns.iso.test.ts
@@ -107,6 +107,48 @@ describe("Simulated AWS DNS", () => {
     assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.formatError);
   });
 
+  it("reports a query it decoded but could not answer as a server failure", async () => {
+    // Given an A record stored with a value that is not an address. Route53
+    // record changes do not validate address syntax, so this is reachable.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "unencodable-zone",
+      }),
+    );
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "api.example.test",
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "not-an-address" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When it is queried.
+    const response = new SimAwsDns({ simAws }).handleQuery(
+      buildQuery("api.example.test"),
+    );
+
+    // Then the failure is reported as the server's, not as a malformed query,
+    // so the resolver does not conclude it sent something wrong.
+    const view = responseView(response);
+    assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.serverFailure);
+  });
+
   it("reports an opcode other than a standard query as not implemented", () => {
     // Given an inverse query, which the simulator does not answer.
     const inverseQuery = buildQuery("api.example.test", 1);

--- a/src/serve/dns/sim-aws-dns.iso.test.ts
+++ b/src/serve/dns/sim-aws-dns.iso.test.ts
@@ -1,0 +1,122 @@
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { dnsRcodes } from "../../service/route53/dns/dns-rcode.js";
+import {
+  dnsInternetClass,
+  dnsRecordTypeNumber,
+} from "../../service/route53/dns/dns-record-type.js";
+import { concatenateBytes } from "../../service/route53/dns/wire/dns-bytes.js";
+import { dnsHeaderLength } from "../../service/route53/dns/wire/dns-header.js";
+import { encodeDnsName } from "../../service/route53/dns/wire/dns-name.js";
+import { SimAwsDns } from "./sim-aws-dns.js";
+
+const queryId = 0xab_cd;
+
+function buildQuery(name: string, opcode = 0): Uint8Array {
+  const header = new Uint8Array(dnsHeaderLength);
+  const view = new DataView(header.buffer);
+  view.setUint16(0, queryId);
+  view.setUint16(2, (opcode << 11) | 0x01_00);
+  view.setUint16(4, 1);
+
+  const question = new Uint8Array(4);
+  new DataView(question.buffer).setUint16(0, dnsRecordTypeNumber("A"));
+  new DataView(question.buffer).setUint16(2, dnsInternetClass);
+
+  return concatenateBytes([header, encodeDnsName(name), question]);
+}
+
+function responseView(response: Uint8Array): DataView {
+  return new DataView(
+    response.buffer,
+    response.byteOffset,
+    response.byteLength,
+  );
+}
+
+describe("Simulated AWS DNS", () => {
+  it("answers a query from the simulated hosted zones", async () => {
+    // Given a served environment holding an A record.
+    const simAws = new SimAws();
+    const route53 = simAws.route53();
+    const createOutput = await route53.createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "dns-protocol-zone",
+      }),
+    );
+    await route53.changeResourceRecordSets(
+      new ChangeResourceRecordSetsCommand({
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: [
+            {
+              Action: "CREATE",
+              ResourceRecordSet: {
+                Name: "api.example.test",
+                Type: "A",
+                TTL: 60,
+                ResourceRecords: [{ Value: "192.0.2.10" }],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a query datagram arrives.
+    const response = new SimAwsDns({ simAws }).handleQuery(
+      buildQuery("api.example.test"),
+    );
+
+    // Then the response echoes the query ID and carries one answer.
+    const view = responseView(response);
+    assertIdentical(view.getUint16(0), queryId);
+    assertIdentical(view.getUint16(6), 1);
+    assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.noError);
+  });
+
+  it("answers a datagram it cannot read with a format error", () => {
+    // Given a datagram that is not a valid DNS message.
+    const malformed = Uint8Array.of(0xab, 0xcd, 0xff);
+
+    // When it arrives.
+    const response = new SimAwsDns().handleQuery(malformed);
+
+    // Then the ID is echoed so the resolver can match the response, and the
+    // format error is reported rather than the server failing.
+    const view = responseView(response);
+    assertIdentical(view.getUint16(0), queryId);
+    assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.formatError);
+  });
+
+  it("answers a datagram too short to hold an ID", () => {
+    // Given a datagram with no readable ID at all.
+    // When it arrives.
+    const response = new SimAwsDns().handleQuery(Uint8Array.of(1));
+
+    // Then a format error is still returned rather than nothing.
+    const view = responseView(response);
+    assertIdentical(view.getUint16(0), 0);
+    assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.formatError);
+  });
+
+  it("reports an opcode other than a standard query as not implemented", () => {
+    // Given an inverse query, which the simulator does not answer.
+    const inverseQuery = buildQuery("api.example.test", 1);
+
+    // When it arrives.
+    const response = new SimAwsDns().handleQuery(inverseQuery);
+
+    // Then the opcode is reported unimplemented, with the question echoed.
+    const view = responseView(response);
+    assertIdentical(view.getUint16(2) & 0x0f, dnsRcodes.notImplemented);
+    assertIdentical(view.getUint16(4), 1);
+  });
+});

--- a/src/serve/dns/sim-aws-dns.ts
+++ b/src/serve/dns/sim-aws-dns.ts
@@ -1,6 +1,9 @@
 import { SimAws } from "../../service/aws/sim-aws.js";
 import { SimRoute53DnsAnswerer } from "../../service/route53/dns/answer/sim-route53-dns-answerer.js";
-import { decodeDnsQuery } from "../../service/route53/dns/dns-query.js";
+import {
+  decodeDnsQuery,
+  type DnsQuery,
+} from "../../service/route53/dns/dns-query.js";
 import { dnsRcodes } from "../../service/route53/dns/dns-rcode.js";
 import { encodeDnsResponse } from "../../service/route53/dns/dns-response.js";
 import { dnsStandardQueryOpcode } from "../../service/route53/dns/wire/dns-header-flags.js";
@@ -34,21 +37,31 @@ export class SimAwsDns {
   /**
    * Answer a DNS query datagram.
    *
-   * This never throws. A server on a socket has to answer whatever arrives, so
-   * a datagram that cannot be read becomes a format error and an unexpected
-   * failure becomes a server failure, rather than either taking the server down.
+   * This never throws: a server on a socket has to answer whatever arrives.
+   *
+   * The two failure modes are kept apart because they mean different things to a
+   * resolver. A datagram that cannot be decoded is the sender's problem and gets
+   * a format error. A datagram that decoded fine but could not be answered — an
+   * unencodable stored record value, say — is the server's problem and gets a
+   * server failure, so a resolver does not conclude it sent something malformed.
    */
   handleQuery(message: Uint8Array): Uint8Array {
+    let query;
+
     try {
-      return this.answerQuery(message);
+      query = decodeDnsQuery(message);
     } catch {
       return this.errorResponse(message, dnsRcodes.formatError);
     }
+
+    try {
+      return this.answerQuery(query);
+    } catch {
+      return this.errorResponse(message, dnsRcodes.serverFailure);
+    }
   }
 
-  private answerQuery(message: Uint8Array): Uint8Array {
-    const query = decodeDnsQuery(message);
-
+  private answerQuery(query: DnsQuery): Uint8Array {
     if (query.opcode !== dnsStandardQueryOpcode) {
       return encodeDnsResponse({
         id: query.id,

--- a/src/serve/dns/sim-aws-dns.ts
+++ b/src/serve/dns/sim-aws-dns.ts
@@ -1,0 +1,105 @@
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { SimRoute53DnsAnswerer } from "../../service/route53/dns/answer/sim-route53-dns-answerer.js";
+import { decodeDnsQuery } from "../../service/route53/dns/dns-query.js";
+import { dnsRcodes } from "../../service/route53/dns/dns-rcode.js";
+import { encodeDnsResponse } from "../../service/route53/dns/dns-response.js";
+import { dnsStandardQueryOpcode } from "../../service/route53/dns/wire/dns-header-flags.js";
+import { simAwsLocalConf as simAwsLocalConfig } from "../http/local-server/sim-aws-local.conf.js";
+
+interface SimAwsDnsProperties {
+  readonly simAws?: SimAws;
+  readonly serviceAddress?: string;
+}
+
+/**
+ * DNS interface for a simulated AWS environment.
+ *
+ * Turns a query datagram into a response datagram. Holding no socket keeps this
+ * testable without networking, in the same way `SimAwsHttp` handles a request
+ * without owning a listener.
+ */
+export class SimAwsDns {
+  private readonly simAws: SimAws;
+  private readonly serviceAddress: string;
+
+  constructor(properties: SimAwsDnsProperties = {}) {
+    const {
+      simAws = new SimAws(),
+      serviceAddress = simAwsLocalConfig.loopbackAddress,
+    } = properties;
+    this.simAws = simAws;
+    this.serviceAddress = serviceAddress;
+  }
+
+  /**
+   * Answer a DNS query datagram.
+   *
+   * This never throws. A server on a socket has to answer whatever arrives, so
+   * a datagram that cannot be read becomes a format error and an unexpected
+   * failure becomes a server failure, rather than either taking the server down.
+   */
+  handleQuery(message: Uint8Array): Uint8Array {
+    try {
+      return this.answerQuery(message);
+    } catch {
+      return this.errorResponse(message, dnsRcodes.formatError);
+    }
+  }
+
+  private answerQuery(message: Uint8Array): Uint8Array {
+    const query = decodeDnsQuery(message);
+
+    if (query.opcode !== dnsStandardQueryOpcode) {
+      return encodeDnsResponse({
+        id: query.id,
+        rcode: dnsRcodes.notImplemented,
+        recursionDesired: query.recursionDesired,
+        question: query.question,
+      });
+    }
+
+    const answerer = new SimRoute53DnsAnswerer({
+      hostedZones: this.simAws.route53().resolvableHostedZones(),
+      serviceAddress: this.serviceAddress,
+    });
+    const answer = answerer.answer(query.question);
+
+    return encodeDnsResponse({
+      id: query.id,
+      rcode: answer.rcode,
+      recursionDesired: query.recursionDesired,
+      question: query.question,
+      answers: answer.answers,
+      authority: answer.authority,
+    });
+  }
+
+  /**
+   * Answer a datagram that could not be handled, echoing its ID so the resolver
+   * can match the response to its outstanding query.
+   */
+  private errorResponse(
+    message: Uint8Array,
+    rcode: (typeof dnsRcodes)[keyof typeof dnsRcodes],
+  ): Uint8Array {
+    return encodeDnsResponse({
+      id: queryId(message),
+      rcode,
+      recursionDesired: false,
+    });
+  }
+}
+
+const queryIdLength = 2;
+
+function queryId(message: Uint8Array): number {
+  if (message.length < queryIdLength) {
+    return 0;
+  }
+
+  return new DataView(
+    message.buffer,
+    message.byteOffset,
+    message.byteLength,
+  ).getUint16(0);
+}

--- a/src/serve/http/local-server/sim-aws-local-request-handler.ts
+++ b/src/serve/http/local-server/sim-aws-local-request-handler.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { NodeFetchHttpAdapter } from "../node-fetch-http-adapter.js";
+import type { SimAwsHttp } from "../sim-aws-http.js";
+
+/**
+ * Bridges Node's HTTP server callbacks to the Fetch-shaped simulated AWS HTTP
+ * interface.
+ *
+ * Node hands over a request and a response object and expects nothing back,
+ * while `SimAwsHttp` takes a `Request` and returns a `Response`. Keeping that
+ * adaptation here leaves the local server owning only the socket lifecycle.
+ */
+export class SimAwsLocalRequestHandler {
+  private readonly simAwsHttp: SimAwsHttp;
+  private readonly nodeFetchHttpAdapter = new NodeFetchHttpAdapter();
+
+  constructor(simAwsHttp: SimAwsHttp) {
+    this.simAwsHttp = simAwsHttp;
+  }
+
+  /**
+   * Handle one Node HTTP request, reporting any failure on the response rather
+   * than letting it escape into an unhandled rejection.
+   */
+  handle(nodeRequest: IncomingMessage, nodeResponse: ServerResponse): void {
+    // eslint-disable-next-line unicorn/prefer-await
+    this.respond(nodeRequest, nodeResponse).catch((error: unknown) => {
+      this.respondWithError(error, nodeResponse);
+    });
+  }
+
+  private async respond(
+    nodeRequest: IncomingMessage,
+    nodeResponse: ServerResponse,
+  ): Promise<void> {
+    const request =
+      this.nodeFetchHttpAdapter.nodeRequestToFetchRequest(nodeRequest);
+    const response = await this.simAwsHttp.handleRequest(request);
+
+    await this.nodeFetchHttpAdapter.sendFetchResponse(nodeResponse, response);
+  }
+
+  private respondWithError(error: unknown, nodeResponse: ServerResponse): void {
+    /* v8 ignore if */
+    if (nodeResponse.writableEnded) {
+      return;
+    }
+
+    if (!nodeResponse.headersSent) {
+      nodeResponse.statusCode = 400;
+      nodeResponse.setHeader("content-type", "text/plain; charset=utf-8");
+    }
+
+    const message =
+      error instanceof Error ? error.message : "HTTP request processing failed";
+
+    nodeResponse.end(message);
+  }
+}

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -38,9 +38,15 @@ export class SimAwsLocalServer {
    * environment is inspectable with a DNS client without anything extra to
    * discover. It binds the same port number on UDP that HTTP took on TCP, which
    * is normally free because the two protocols have separate port namespaces.
+   *
+   * HTTP binds the loopback address rather than the hostname. `sim-aws.localhost`
+   * resolves to both `::1` and `127.0.0.1`, and binding the name takes whichever
+   * the resolver returns first, which is commonly `::1`. DNS answers with the
+   * IPv4 loopback address, so binding it explicitly is what makes the address in
+   * a DNS answer one that actually serves HTTP.
    */
   async listen(port: number = simAwsLocalConfig.defaultPort): Promise<this> {
-    this.server.listen(port, this.hostname);
+    this.server.listen(port, simAwsLocalConfig.loopbackAddress);
     await waitNodeServerListen(this.server);
     await this.dnsServer.listen(Number(this.port));
     return this;

--- a/src/serve/http/local-server/sim-aws-local-server.ts
+++ b/src/serve/http/local-server/sim-aws-local-server.ts
@@ -1,14 +1,11 @@
-import http, {
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from "node:http";
+import http, { type Server } from "node:http";
 import { SimAws } from "../../../service/aws/sim-aws.js";
 import { simAwsLocalConf as simAwsLocalConfig } from "./sim-aws-local.conf.js";
 import { SimAwsHttp } from "../sim-aws-http.js";
 import { SimAwsLocalUrl } from "../url/sim-aws-local-url.js";
-import { NodeFetchHttpAdapter } from "../node-fetch-http-adapter.js";
 import { waitNodeServerListen } from "./wait-node-server-listen.js";
+import { SimAwsLocalRequestHandler } from "./sim-aws-local-request-handler.js";
+import { SimAwsDnsServer } from "../../dns/sim-aws-dns-server.js";
 
 interface SimAwsLocalServerProperties {
   readonly simAws?: SimAws;
@@ -19,27 +16,33 @@ interface SimAwsLocalServerProperties {
  * Useful for local integration testing and local development.
  */
 export class SimAwsLocalServer {
-  private readonly simAwsHttp: SimAwsHttp;
-  private readonly nodeFetchHttpAdapter = new NodeFetchHttpAdapter();
+  private readonly requestHandler: SimAwsLocalRequestHandler;
   private readonly server: Server;
+  private readonly dnsServer: SimAwsDnsServer;
 
   constructor(properties: SimAwsLocalServerProperties = {}) {
     const { simAws = new SimAws() } = properties;
-    this.simAwsHttp = new SimAwsHttp({ simAws });
+    this.requestHandler = new SimAwsLocalRequestHandler(
+      new SimAwsHttp({ simAws }),
+    );
+    this.dnsServer = new SimAwsDnsServer({ simAws });
     this.server = http.createServer((request, response) => {
-      // eslint-disable-next-line unicorn/prefer-await
-      this.handleRequest(request, response).catch((error: unknown) => {
-        this.handleRequestError(error, response);
-      });
+      this.requestHandler.handle(request, response);
     });
   }
 
   /**
    * Start serving simulated AWS services on localhost.
+   *
+   * DNS comes up alongside HTTP rather than being opted into, so a served
+   * environment is inspectable with a DNS client without anything extra to
+   * discover. It binds the same port number on UDP that HTTP took on TCP, which
+   * is normally free because the two protocols have separate port namespaces.
    */
   async listen(port: number = simAwsLocalConfig.defaultPort): Promise<this> {
     this.server.listen(port, this.hostname);
     await waitNodeServerListen(this.server);
+    await this.dnsServer.listen(Number(this.port));
     return this;
   }
 
@@ -68,10 +71,22 @@ export class SimAwsLocalServer {
   }
 
   /**
+   * Get the UDP port on which DNS queries are answered.
+   *
+   * Usually the same number as `port`, but not guaranteed: if that number was
+   * already taken on UDP, DNS bound an ephemeral port instead. Read it rather
+   * than assuming the numbers match.
+   */
+  get dnsPort(): string {
+    return this.dnsServer.port;
+  }
+
+  /**
    * Stop serving simulated AWS services.
    */
   close(): void {
     this.server.close();
+    this.dnsServer.close();
   }
 
   /**
@@ -80,37 +95,6 @@ export class SimAwsLocalServer {
   localUrl(input: string | URL): URL {
     const simAwsLocalUrl = new SimAwsLocalUrl({ input, port: this.port });
     return simAwsLocalUrl.toURL();
-  }
-
-  private async handleRequest(
-    nodeRequest: IncomingMessage,
-    nodeResponse: ServerResponse,
-  ): Promise<void> {
-    const request =
-      this.nodeFetchHttpAdapter.nodeRequestToFetchRequest(nodeRequest);
-    const response = await this.simAwsHttp.handleRequest(request);
-
-    await this.nodeFetchHttpAdapter.sendFetchResponse(nodeResponse, response);
-  }
-
-  private handleRequestError(
-    error: unknown,
-    nodeResponse: ServerResponse,
-  ): void {
-    /* v8 ignore if */
-    if (nodeResponse.writableEnded) {
-      return;
-    }
-
-    if (!nodeResponse.headersSent) {
-      nodeResponse.statusCode = 400;
-      nodeResponse.setHeader("content-type", "text/plain; charset=utf-8");
-    }
-
-    const message =
-      error instanceof Error ? error.message : "HTTP request processing failed";
-
-    nodeResponse.end(message);
   }
 }
 

--- a/src/serve/http/local-server/sim-aws-local.conf.ts
+++ b/src/serve/http/local-server/sim-aws-local.conf.ts
@@ -4,4 +4,8 @@
 export const simAwsLocalConf = {
   hostname: "sim-aws.localhost",
   defaultPort: 0,
+  // The address the local servers bind, and the address DNS answers with for
+  // names that resolve to a simulated service, so a lookup and an HTTP request
+  // for the same name reach the same place.
+  loopbackAddress: "127.0.0.1",
 };

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -1,4 +1,6 @@
 export { SimAwsHttp } from "./http/sim-aws-http.js";
+export { SimAwsDns } from "./dns/sim-aws-dns.js";
+export { SimAwsDnsServer } from "./dns/sim-aws-dns-server.js";
 export {
   serveSimAws,
   SimAwsLocalServer,

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -364,13 +364,13 @@ from a real resolver and encode a response it will accept. It has no sockets and
 no knowledge of hosted zones, so it is exercised entirely by unit tests plus one
 localhost test against a real client.
 
-The scope is deliberately narrow, which is what keeps the codec small:
+The scope is narrow, which is what keeps the codec small:
 
 - Only the record types sim Route53 stores are encodable: `A`, `AAAA`, `CNAME`,
   `TXT`, `NS`, `SOA`. `dns-record-type.ts` maps those to and from wire type
   numbers, and returns `undefined` for any other query type so a caller answers
   with no records rather than guessing at an encoding it does not have.
-- **`ANY` (QTYPE 255) is a query type, not a record type**, so it deliberately
+- **`ANY` (QTYPE 255) is a query type, not a record type**, so it
   does not map to a stored record type. `dnsAnyQueryType` is exported for a
   caller that wants to recognise it, but what to _answer_ for `ANY` is answer
   semantics rather than wire format, and is not the codec's decision. Note that
@@ -399,6 +399,52 @@ front of the codec and queries it with Node's own `node:dns` resolver, which is
 c-ares. That proves the encoding against an independent implementation rather
 than against the codec's own decoder. Node's resolver is used rather than `dig`
 because it needs no external package and works the same on a laptop and in CI.
+
+## DNS answer semantics
+
+`dns/answer/` turns a decoded question into the records, response code and authority section that
+answer it. It is separate from `SimRoute53Resolver`, which resolves an HTTP hostname to
+a service target: an HTTP request only needs to know which simulated service handles a host, while a
+DNS answer needs record types, CNAME chains, and the difference between a name that does not exist
+and a name holding no record of the queried type.
+
+The pieces are small and each does one thing:
+
+- `sim-route53-dns-zone-finder.ts` picks the most specific hosted zone containing a name, the same
+  longest-suffix rule the HTTP record finder uses.
+- `sim-route53-dns-record-chase.ts` walks CNAME and alias records looking for the queried type,
+  bounded by both a visited-name set and a maximum depth.
+- `sim-route53-dns-service-target.ts` synthesises an address record for a name owned by a simulated
+  service. Those hostnames are recognised by shape rather than stored, so nothing holds an address
+  for them; answering with the address the local server listens on is what makes a DNS lookup and an
+  HTTP request for the same name describe the same thing.
+- `sim-route53-dns-soa.ts` supplies the SOA a negative answer carries, using the zone's own record
+  when it has one and synthesising a Route53-shaped default when it does not.
+- `sim-route53-dns-answerer.ts` composes those and decides the response code.
+
+Two distinctions carry most of the behaviour. A name the zone holds under another type is `NOERROR`
+with no answers; a name it does not hold is `NXDOMAIN`. A name held by no zone at all is `REFUSED`,
+because the simulator is authoritative only for its own zones and cannot say a name exists nowhere.
+
+**Aliases are followed, not answered.** An alias record stores a hostname rather than data of its own
+type, so encoding one as an address would fail. The chase follows it without adding it to the answer
+and records that the answer name should stay put, so the synthesised address appears under the name
+holding the alias. That matches Route53, where an alias is transparent.
+
+## DNS serving
+
+The socket lives in `src/serve/dns/`, mirroring how HTTP splits `SimAwsHttp` from
+`SimAwsLocalServer`. `SimAwsDns` turns a query datagram into a response datagram and holds no socket,
+so it is testable without networking; `SimAwsDnsServer` owns the UDP socket.
+
+`SimAwsDns.handleQuery` never throws. A server on a socket has to answer whatever arrives, so a
+datagram that cannot be read becomes a format error rather than taking the server down, and the query
+ID is echoed even then so the resolver can match the response.
+
+`serveSimAws` brings DNS up alongside HTTP rather than making it opt-in, binding the same port number
+on UDP that HTTP took on TCP. That is usually free, the two protocols having separate port
+namespaces, but it is not guaranteed: on collision the server binds an ephemeral port and reports it
+through `dnsPort`.
 
 ## Cross-service routing role
 

--- a/src/service/route53/dns/answer/dns-answerer-test-query.ts
+++ b/src/service/route53/dns/answer/dns-answerer-test-query.ts
@@ -1,0 +1,31 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
+import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import type { DnsQuestion } from "../wire/dns-question.js";
+import { SimRoute53DnsAnswerer } from "./sim-route53-dns-answerer.js";
+
+/**
+ * Build an answerer over every hosted zone in a simulated environment.
+ * @internal
+ */
+export function testAnswerer(simAws: SimAws): SimRoute53DnsAnswerer {
+  return new SimRoute53DnsAnswerer({
+    hostedZones: simAws.route53().resolvableHostedZones(),
+    serviceAddress: "127.0.0.1",
+  });
+}
+
+/**
+ * Build a question for a name and record type.
+ * @internal
+ */
+export function testQuestion(
+  name: string,
+  type: SimRoute53RecordType,
+): DnsQuestion {
+  return {
+    name,
+    type: dnsRecordTypeNumber(type),
+    class: dnsInternetClass,
+  };
+}

--- a/src/service/route53/dns/answer/dns-answerer-test-zone.ts
+++ b/src/service/route53/dns/answer/dns-answerer-test-zone.ts
@@ -1,0 +1,81 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
+import type { SimRoute53 } from "../../sim-route53.js";
+
+export interface TestRecord {
+  readonly name: string;
+  readonly type: SimRoute53RecordType;
+  readonly values: readonly string[];
+  /** Omitted entirely when null, which the SDK allows. */
+  readonly ttl?: number | null;
+  /** Store as an alias record, which carries a target instead of a TTL. */
+  readonly alias?: boolean;
+}
+
+/**
+ * Create a hosted zone holding the given records, through the normal command
+ * path so the records are normalised the way stored records always are.
+ *
+ * Commands are built as plain structural inputs rather than from the AWS SDK,
+ * because this is a shared helper rather than a test file, and runtime source
+ * does not import SDK packages.
+ * @internal
+ */
+export async function createTestZone(
+  simAws: SimAws,
+  zoneName: string,
+  records: readonly TestRecord[],
+  route53: SimRoute53 = simAws.route53(),
+): Promise<void> {
+  const createOutput = await route53.createHostedZone({
+    input: {
+      Name: zoneName,
+      CallerReference: `${zoneName}-dns-test`,
+    },
+  });
+
+  if (records.length > 0) {
+    await route53.changeResourceRecordSets({
+      input: {
+        HostedZoneId: createOutput.HostedZone?.Id,
+        ChangeBatch: {
+          Changes: records.map((record) => ({
+            Action: "CREATE" as const,
+            ResourceRecordSet: recordSet(record),
+          })),
+        },
+      },
+    });
+  }
+
+  await simAws.backgroundTasksComplete();
+}
+
+function recordSet(record: TestRecord): object {
+  if (record.alias === true) {
+    return {
+      Name: record.name,
+      Type: record.type,
+      AliasTarget: {
+        HostedZoneId: "Z2FDTNDATAQYW2",
+        DNSName: record.values.at(0),
+        EvaluateTargetHealth: false,
+      },
+    };
+  }
+
+  return {
+    Name: record.name,
+    Type: record.type,
+    TTL: storedTtl(record),
+    ResourceRecords: record.values.map((value) => ({ Value: value })),
+  };
+}
+
+function storedTtl(record: TestRecord): number | undefined {
+  if (record.ttl === null) {
+    return undefined;
+  }
+
+  return record.ttl ?? 300;
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-answerer.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-answerer.iso.test.ts
@@ -147,6 +147,33 @@ describe("Simulated Route53 DNS answers", () => {
     assertArrayEquals([...answer.answers[0].rdata], [127, 0, 0, 1]);
   });
 
+  it("answers an alias to another record under the alias owner's name", async () => {
+    // Given an alias pointing at another record in the same zone, which Route53
+    // supports alongside aliases to AWS resources.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "cdn.example.test",
+        type: "A",
+        values: ["origin.example.test"],
+        alias: true,
+      },
+      { name: "origin.example.test", type: "A", values: ["192.0.2.40"] },
+    ]);
+
+    // When the alias name is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("cdn.example.test", "A"),
+    );
+
+    // Then the target's address is answered under the queried name. Answering it
+    // under the target name would leave a resolver with a record it did not ask
+    // for and no CNAME explaining the change of name.
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].name, "cdn.example.test");
+    assertArrayEquals([...answer.answers[0].rdata], [192, 0, 2, 40]);
+  });
+
   it("answers from the most specific hosted zone holding the name", async () => {
     // Given overlapping zones that both contain the queried name.
     const simAws = new SimAws();

--- a/src/service/route53/dns/answer/sim-route53-dns-answerer.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-answerer.iso.test.ts
@@ -1,0 +1,188 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { dnsRcodes } from "../dns-rcode.js";
+import { dnsRecordTypeNumber } from "../dns-record-type.js";
+import { testAnswerer, testQuestion } from "./dns-answerer-test-query.js";
+import { createTestZone } from "./dns-answerer-test-zone.js";
+
+describe("Simulated Route53 DNS answers", () => {
+  it("answers a record held directly at the queried name", async () => {
+    // Given a zone with an A record.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"], ttl: 120 },
+    ]);
+
+    // When the name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("api.example.test", "A"),
+    );
+
+    // Then the record is answered with its own TTL and no authority section.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].name, "api.example.test");
+    assertIdentical(answer.answers[0].ttl, 120);
+    assertArrayEquals([...answer.answers[0].rdata], [192, 0, 2, 10]);
+    assertArrayLength(answer.authority, 0);
+  });
+
+  it("returns one resource record per stored value", async () => {
+    // Given a record holding several values.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "many.example.test", type: "TXT", values: ["one", "two"] },
+    ]);
+
+    // When the name is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("many.example.test", "TXT"),
+    );
+
+    // Then each value is its own record, the wire format having no multi-value
+    // record.
+    assertArrayLength(answer.answers, 2);
+  });
+
+  it("follows a CNAME to the record the query asked for", async () => {
+    // Given a CNAME pointing at a name that holds an A record.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "www.example.test",
+        type: "CNAME",
+        values: ["origin.example.test"],
+      },
+      { name: "origin.example.test", type: "A", values: ["192.0.2.20"] },
+    ]);
+
+    // When the CNAME name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.test", "A"),
+    );
+
+    // Then both the CNAME and the address it leads to are answered together.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 2);
+    assertIdentical(answer.answers[0].type, dnsRecordTypeNumber("CNAME"));
+    assertIdentical(answer.answers[1].type, dnsRecordTypeNumber("A"));
+    assertIdentical(answer.answers[1].name, "origin.example.test");
+  });
+
+  it("answers a CNAME query with the CNAME itself rather than chasing it", async () => {
+    // Given a CNAME whose target holds an A record.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "www.example.test",
+        type: "CNAME",
+        values: ["origin.example.test"],
+      },
+      { name: "origin.example.test", type: "A", values: ["192.0.2.20"] },
+    ]);
+
+    // When the name is queried for CNAME.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.test", "CNAME"),
+    );
+
+    // Then only the CNAME is answered, because that is what was asked for.
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].type, dnsRecordTypeNumber("CNAME"));
+  });
+
+  it("synthesises an address for a name pointing at a simulated service", async () => {
+    // Given a CNAME pointing at a simulated S3 website hostname, which no zone
+    // holds an address record for.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "www.example.test",
+        type: "CNAME",
+        values: ["my-site.s3-website.eu-west-2"],
+      },
+    ]);
+
+    // When the name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.test", "A"),
+    );
+
+    // Then the CNAME is followed by an address record for the local server, so a
+    // DNS lookup and an HTTP request for the name reach the same place.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 2);
+    assertIdentical(answer.answers[1].name, "my-site.s3-website.eu-west-2");
+    assertArrayEquals([...answer.answers[1].rdata], [127, 0, 0, 1]);
+  });
+
+  it("resolves an alias record under the name that holds it", async () => {
+    // Given an alias record pointing at a simulated CloudFront distribution,
+    // which is how Route53 usually fronts one.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "cdn.example.test",
+        type: "A",
+        values: ["d111111abcdef8.cloudfront.net"],
+        alias: true,
+      },
+    ]);
+
+    // When the alias name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("cdn.example.test", "A"),
+    );
+
+    // Then the address is answered under the queried name, the alias itself
+    // never appearing, which is how Route53 answers an alias.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].name, "cdn.example.test");
+    assertArrayEquals([...answer.answers[0].rdata], [127, 0, 0, 1]);
+  });
+
+  it("answers from the most specific hosted zone holding the name", async () => {
+    // Given overlapping zones that both contain the queried name.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "www.sub.example.test", type: "A", values: ["192.0.2.1"] },
+    ]);
+    await createTestZone(simAws, "sub.example.test", [
+      { name: "www.sub.example.test", type: "A", values: ["192.0.2.2"] },
+    ]);
+
+    // When the name is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.sub.example.test", "A"),
+    );
+
+    // Then the record from the longer zone name wins.
+    assertArrayLength(answer.answers, 1);
+    assertArrayEquals([...answer.answers[0].rdata], [192, 0, 2, 2]);
+  });
+
+  it("answers records from any simulated Account", async () => {
+    // Given a zone created in a non-default Account.
+    const simAws = new SimAws();
+    await createTestZone(
+      simAws,
+      "other-account.test",
+      [{ name: "api.other-account.test", type: "A", values: ["192.0.2.30"] }],
+      simAws.account("111111111111").route53(),
+    );
+
+    // When the name is queried through the environment-wide registry.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("api.other-account.test", "A"),
+    );
+
+    // Then it is answered, because DNS resolution spans Accounts.
+    assertArrayLength(answer.answers, 1);
+  });
+});

--- a/src/service/route53/dns/answer/sim-route53-dns-answerer.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-answerer.ts
@@ -1,0 +1,130 @@
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import { dnsRcodes, type DnsRcode } from "../dns-rcode.js";
+import {
+  dnsInternetClass,
+  simRoute53RecordTypeFromNumber,
+} from "../dns-record-type.js";
+import type { DnsQuestion } from "../wire/dns-question.js";
+import type { DnsResourceRecord } from "../wire/dns-resource-record.js";
+import { simRoute53DnsAnswerRecords } from "./sim-route53-dns-record-answer.js";
+import { SimRoute53DnsRecordChase } from "./sim-route53-dns-record-chase.js";
+import { SimRoute53DnsServiceTarget } from "./sim-route53-dns-service-target.js";
+import { simRoute53DnsSoaRecord } from "./sim-route53-dns-soa.js";
+import { SimRoute53DnsZoneFinder } from "./sim-route53-dns-zone-finder.js";
+
+export interface SimRoute53DnsAnswer {
+  readonly rcode: DnsRcode;
+  readonly answers: readonly DnsResourceRecord[];
+  readonly authority: readonly DnsResourceRecord[];
+}
+
+interface SimRoute53DnsAnswererProperties {
+  readonly hostedZones: ReadonlyMap<string, SimRoute53HostedZone>;
+  /** Address returned for names that resolve to a simulated service. */
+  readonly serviceAddress: string;
+}
+
+/**
+ * Answer DNS questions from the simulated hosted zones.
+ *
+ * This is the DNS counterpart of `SimRoute53Resolver`, which resolves an HTTP
+ * hostname to a service target. The two are deliberately separate: an HTTP
+ * request only needs to know which simulated service handles a host, while a
+ * DNS answer needs record types, CNAME chains and the difference between a name
+ * that does not exist and a name holding no record of the queried type.
+ */
+export class SimRoute53DnsAnswerer {
+  private readonly zoneFinder: SimRoute53DnsZoneFinder;
+  private readonly chase: SimRoute53DnsRecordChase;
+  private readonly serviceTarget: SimRoute53DnsServiceTarget;
+
+  constructor(properties: SimRoute53DnsAnswererProperties) {
+    this.zoneFinder = new SimRoute53DnsZoneFinder(properties.hostedZones);
+    this.chase = new SimRoute53DnsRecordChase(this.zoneFinder);
+    this.serviceTarget = new SimRoute53DnsServiceTarget(
+      properties.serviceAddress,
+    );
+  }
+
+  /**
+   * Answer one question.
+   *
+   * A name held by no hosted zone is refused rather than reported as missing,
+   * because the simulator is authoritative only for the zones it holds and
+   * "refused" says so, where NXDOMAIN would claim the name exists nowhere.
+   */
+  answer(question: DnsQuestion): SimRoute53DnsAnswer {
+    if (question.class !== dnsInternetClass) {
+      return refused();
+    }
+
+    const hostedZone = this.zoneFinder.find(question.name);
+
+    if (hostedZone === undefined) {
+      return refused();
+    }
+
+    const recordType = simRoute53RecordTypeFromNumber(question.type);
+
+    // A query type the simulator cannot encode is answered as no data rather
+    // than as an error, which is what a resolver expects for a type a zone
+    // simply does not hold.
+    if (recordType === undefined) {
+      return this.negative(hostedZone, dnsRcodes.noError, []);
+    }
+
+    const chased = this.chase.chase(question.name, recordType);
+    const answers = [
+      ...chased.records.flatMap((record) => simRoute53DnsAnswerRecords(record)),
+      ...this.serviceTarget.answersFor(
+        chased.finalName,
+        chased.answerName,
+        recordType,
+      ),
+    ];
+
+    if (answers.length > 0) {
+      return { rcode: dnsRcodes.noError, answers, authority: [] };
+    }
+
+    return this.negative(hostedZone, this.negativeRcode(chased.finalName), []);
+  }
+
+  /**
+   * A name the zone holds under some other record type is a no-data answer; a
+   * name it does not hold at all does not exist.
+   */
+  private negativeRcode(name: string): DnsRcode {
+    const hostedZone = this.zoneFinder.find(name);
+
+    if (hostedZone === undefined) {
+      return dnsRcodes.nameError;
+    }
+
+    const nameExists = hostedZone.records
+      .list()
+      .some((record) => record.name === name);
+
+    if (nameExists) {
+      return dnsRcodes.noError;
+    }
+
+    return dnsRcodes.nameError;
+  }
+
+  private negative(
+    hostedZone: SimRoute53HostedZone,
+    rcode: DnsRcode,
+    answers: readonly DnsResourceRecord[],
+  ): SimRoute53DnsAnswer {
+    return {
+      rcode,
+      answers,
+      authority: [simRoute53DnsSoaRecord(hostedZone)],
+    };
+  }
+}
+
+function refused(): SimRoute53DnsAnswer {
+  return { rcode: dnsRcodes.refused, answers: [], authority: [] };
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-answerer.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-answerer.ts
@@ -70,7 +70,7 @@ export class SimRoute53DnsAnswerer {
     // than as an error, which is what a resolver expects for a type a zone
     // simply does not hold.
     if (recordType === undefined) {
-      return this.negative(hostedZone, dnsRcodes.noError, []);
+      return this.negative(hostedZone, dnsRcodes.noError);
     }
 
     const chased = this.chase.chase(question.name, recordType);
@@ -87,42 +87,47 @@ export class SimRoute53DnsAnswerer {
       return { rcode: dnsRcodes.noError, answers, authority: [] };
     }
 
-    return this.negative(hostedZone, this.negativeRcode(chased.finalName), []);
-  }
+    // A CNAME can lead into another hosted zone, and the SOA a resolver caches
+    // the negative answer against has to come from whichever zone is
+    // authoritative for the name the chase ended at.
+    const finalZone = this.zoneFinder.find(chased.finalName);
 
-  /**
-   * A name the zone holds under some other record type is a no-data answer; a
-   * name it does not hold at all does not exist.
-   */
-  private negativeRcode(name: string): DnsRcode {
-    const hostedZone = this.zoneFinder.find(name);
-
-    if (hostedZone === undefined) {
-      return dnsRcodes.nameError;
+    if (finalZone === undefined) {
+      return this.negative(hostedZone, dnsRcodes.nameError);
     }
 
-    const nameExists = hostedZone.records
-      .list()
-      .some((record) => record.name === name);
-
-    if (nameExists) {
-      return dnsRcodes.noError;
-    }
-
-    return dnsRcodes.nameError;
+    return this.negative(finalZone, negativeRcode(finalZone, chased.finalName));
   }
 
   private negative(
     hostedZone: SimRoute53HostedZone,
     rcode: DnsRcode,
-    answers: readonly DnsResourceRecord[],
   ): SimRoute53DnsAnswer {
     return {
       rcode,
-      answers,
+      answers: [],
       authority: [simRoute53DnsSoaRecord(hostedZone)],
     };
   }
+}
+
+/**
+ * A name the zone holds under some other record type is a no-data answer; a
+ * name it does not hold at all does not exist.
+ */
+function negativeRcode(
+  hostedZone: SimRoute53HostedZone,
+  name: string,
+): DnsRcode {
+  const nameExists = hostedZone.records
+    .list()
+    .some((record) => record.name === name);
+
+  if (nameExists) {
+    return dnsRcodes.noError;
+  }
+
+  return dnsRcodes.nameError;
 }
 
 function refused(): SimRoute53DnsAnswer {

--- a/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
@@ -260,6 +260,35 @@ describe("Simulated Route53 DNS negative answers", () => {
     assertArrayLength(answer.answers, 0);
   });
 
+  it("takes the negative answer SOA from the zone the chase ended in", async () => {
+    // Given an alias crossing from one hosted zone into another, landing on a
+    // name the second zone does not hold. An alias rather than a CNAME, because
+    // a CNAME is itself an answer and so never reaches the negative path.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "cdn.example.test",
+        type: "A",
+        values: ["gone.other.test"],
+        alias: true,
+      },
+    ]);
+    await createTestZone(simAws, "other.test", [
+      { name: "kept.other.test", type: "A", values: ["192.0.2.50"] },
+    ]);
+
+    // When the alias name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("cdn.example.test", "A"),
+    );
+
+    // Then the SOA comes from the zone authoritative for where the chase ended,
+    // which is what a resolver caches the negative answer against.
+    assertArrayLength(answer.authority, 1);
+    assertIdentical(answer.authority[0].name, "other.test");
+    assertIdentical(answer.rcode, dnsRcodes.nameError);
+  });
+
   it("uses a stored SOA record when the zone holds one", async () => {
     // Given a zone with its own SOA record at the apex.
     const simAws = new SimAws();

--- a/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-negative.iso.test.ts
@@ -1,0 +1,286 @@
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { dnsRcodes } from "../dns-rcode.js";
+import { dnsAnyQueryType, dnsRecordTypeNumber } from "../dns-record-type.js";
+import { testAnswerer, testQuestion } from "./dns-answerer-test-query.js";
+import { createTestZone } from "./dns-answerer-test-zone.js";
+
+describe("Simulated Route53 DNS negative answers", () => {
+  it("reports no data for a name holding no record of the queried type", async () => {
+    // Given a name that exists with an A record but no TXT record.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"] },
+    ]);
+
+    // When it is queried for TXT.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("api.example.test", "TXT"),
+    );
+
+    // Then the name is reported to exist, holding nothing of that type, with the
+    // zone SOA telling a resolver how long it may cache that.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 0);
+    assertArrayLength(answer.authority, 1);
+    assertIdentical(answer.authority[0].name, "example.test");
+    assertIdentical(answer.authority[0].type, dnsRecordTypeNumber("SOA"));
+  });
+
+  it("reports a name the zone does not hold as non-existent", async () => {
+    // Given a zone that does not hold the queried name.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"] },
+    ]);
+
+    // When a different name in that zone is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("missing.example.test", "A"),
+    );
+
+    // Then it is a name error, distinguishing it from a name with no such type.
+    assertIdentical(answer.rcode, dnsRcodes.nameError);
+    assertArrayLength(answer.answers, 0);
+    assertArrayLength(answer.authority, 1);
+  });
+
+  it("refuses a name held by no hosted zone", async () => {
+    // Given a simulated environment with one unrelated zone.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", []);
+
+    // When a name outside every zone is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("elsewhere.invalid", "A"),
+    );
+
+    // Then it is refused rather than reported missing, because the simulator is
+    // authoritative only for the zones it holds and cannot say the name does not
+    // exist anywhere.
+    assertIdentical(answer.rcode, dnsRcodes.refused);
+    assertArrayLength(answer.answers, 0);
+    assertArrayLength(answer.authority, 0);
+  });
+
+  it("refuses a query in a class other than internet", async () => {
+    // Given a zone holding the queried name.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"] },
+    ]);
+
+    // When it is queried in the CHAOS class.
+    const answer = testAnswerer(simAws).answer({
+      name: "api.example.test",
+      type: dnsRecordTypeNumber("A"),
+      class: 3,
+    });
+
+    // Then it is refused, the simulator modelling no class but internet.
+    assertIdentical(answer.rcode, dnsRcodes.refused);
+  });
+
+  it("reports no data for a query type it cannot encode, such as ANY", async () => {
+    // Given a zone holding the queried name.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"] },
+    ]);
+
+    // When it is queried with the ANY query type.
+    const answer = testAnswerer(simAws).answer({
+      name: "api.example.test",
+      type: dnsAnyQueryType,
+      class: 1,
+    });
+
+    // Then it is answered as no data rather than as an error, which is what a
+    // resolver expects for a type a zone does not hold.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 0);
+    assertArrayLength(answer.authority, 1);
+  });
+
+  it("stops a CNAME cycle instead of following it forever", async () => {
+    // Given two CNAME records pointing at each other.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "a.example.test", type: "CNAME", values: ["b.example.test"] },
+      { name: "b.example.test", type: "CNAME", values: ["a.example.test"] },
+    ]);
+
+    // When one of them is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("a.example.test", "A"),
+    );
+
+    // Then the chase stops, returning the CNAMEs it followed.
+    assertArrayLength(answer.answers, 2);
+  });
+
+  it("stops a CNAME chain that is longer than the depth limit", async () => {
+    // Given a chain of CNAMEs longer than the simulator follows.
+    const simAws = new SimAws();
+    const chain = Array.from({ length: 12 }, (_, index) => ({
+      name: `c${String(index)}.example.test`,
+      type: "CNAME" as const,
+      values: [`c${String(index + 1)}.example.test`],
+    }));
+    await createTestZone(simAws, "example.test", chain);
+
+    // When the head of the chain is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("c0.example.test", "A"),
+    );
+
+    // Then the chase stops at the depth limit rather than following it all.
+    assertArrayLength(answer.answers, 9);
+  });
+
+  it("reports no data for a CNAME query on a name holding no CNAME", async () => {
+    // Given a name that holds only an A record.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "api.example.test", type: "A", values: ["192.0.2.10"] },
+    ]);
+
+    // When it is queried for CNAME.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("api.example.test", "CNAME"),
+    );
+
+    // Then the name exists holding nothing of that type, and nothing is chased.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 0);
+  });
+
+  it("returns just the CNAME when it leads outside every zone", async () => {
+    // Given a CNAME pointing at a name in no hosted zone, which is also not a
+    // simulated service hostname.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "www.example.test", type: "CNAME", values: ["nowhere.invalid"] },
+    ]);
+
+    // When the CNAME name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.test", "A"),
+    );
+
+    // Then the CNAME alone is returned without error: the simulator is not
+    // authoritative for where it leads, so it cannot report that name missing.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 1);
+  });
+
+  it("reports an alias leading outside every zone as non-existent", async () => {
+    // Given an alias record pointing at a name nothing answers for. Unlike a
+    // CNAME, an alias never appears in the answer, so there is nothing to return.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "cdn.example.test",
+        type: "A",
+        values: ["nowhere.invalid"],
+        alias: true,
+      },
+    ]);
+
+    // When the alias name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("cdn.example.test", "A"),
+    );
+
+    // Then it is a name error with no answers at all.
+    assertIdentical(answer.rcode, dnsRcodes.nameError);
+    assertArrayLength(answer.answers, 0);
+  });
+
+  it("gives an alias record a default TTL, having none of its own", async () => {
+    // Given an alias record, which Route53 stores without a TTL.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "cdn.example.test",
+        type: "A",
+        values: ["d111111abcdef8.cloudfront.net"],
+        alias: true,
+      },
+    ]);
+
+    // When it is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("cdn.example.test", "A"),
+    );
+
+    // Then it is answered with a default TTL rather than none at all.
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].ttl, 60);
+  });
+
+  it("gives a record stored without a TTL a default one", async () => {
+    // Given a record created without a TTL, which the SDK allows.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "api.example.test",
+        type: "A",
+        values: ["192.0.2.10"],
+        ttl: null,
+      },
+    ]);
+
+    // When it is queried.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("api.example.test", "A"),
+    );
+
+    // Then it is answered with a default TTL rather than an invalid one.
+    assertArrayLength(answer.answers, 1);
+    assertIdentical(answer.answers[0].ttl, 60);
+  });
+
+  it("stops at a CNAME holding no target value", async () => {
+    // Given a CNAME record created with no values at all.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      { name: "www.example.test", type: "CNAME", values: [] },
+    ]);
+
+    // When the name is queried for A.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("www.example.test", "A"),
+    );
+
+    // Then the chase stops rather than following an absent target, and the name
+    // is reported to exist holding nothing of that type.
+    assertIdentical(answer.rcode, dnsRcodes.noError);
+    assertArrayLength(answer.answers, 0);
+  });
+
+  it("uses a stored SOA record when the zone holds one", async () => {
+    // Given a zone with its own SOA record at the apex.
+    const simAws = new SimAws();
+    await createTestZone(simAws, "example.test", [
+      {
+        name: "example.test",
+        type: "SOA",
+        values: ["ns1.example.test. admin.example.test. 7 7200 900 1209600 60"],
+      },
+    ]);
+
+    // When a missing name produces a negative answer.
+    const answer = testAnswerer(simAws).answer(
+      testQuestion("missing.example.test", "A"),
+    );
+
+    // Then the stored SOA is used rather than a synthesised one, so its serial
+    // appears in the authority record.
+    assertArrayLength(answer.authority, 1);
+    const rdata = answer.authority[0].rdata;
+    const view = new DataView(rdata.buffer, rdata.byteOffset, rdata.byteLength);
+    assertIdentical(view.getUint32(rdata.byteLength - 20), 7);
+  });
+});

--- a/src/service/route53/dns/answer/sim-route53-dns-record-answer.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-record-answer.ts
@@ -1,0 +1,30 @@
+import type { SimRoute53Record } from "../../record/sim-route53-record.js";
+import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import { encodeDnsRdata } from "../rdata/dns-rdata.js";
+import type { DnsResourceRecord } from "../wire/dns-resource-record.js";
+
+/**
+ * TTL used for a record stored without one, which is every alias record: Route53
+ * answers an alias using the TTL of whatever it points at, and the simulator has
+ * no such target to read.
+ */
+const defaultRecordTtl = 60;
+
+/**
+ * Convert a stored record into the resource records that answer for it.
+ *
+ * One stored record can hold several values — a TXT record with two strings, or
+ * a name with several addresses — and each becomes its own resource record,
+ * because the wire format has no notion of a multi-valued record.
+ */
+export function simRoute53DnsAnswerRecords(
+  record: SimRoute53Record,
+): readonly DnsResourceRecord[] {
+  return record.values.map((value) => ({
+    name: record.name,
+    type: dnsRecordTypeNumber(record.type),
+    class: dnsInternetClass,
+    ttl: record.ttl ?? defaultRecordTtl,
+    rdata: encodeDnsRdata(record.type, value),
+  }));
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-record-chase.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-record-chase.ts
@@ -53,9 +53,16 @@ export class SimRoute53DnsRecordChase {
       }
       visitedNames.add(currentName);
 
-      const step = this.followName(currentName, recordType, records);
+      const step = this.followName(currentName, recordType);
 
       if (step === undefined) {
+        return { records, finalName: currentName, answerName };
+      }
+
+      if (step.record !== undefined) {
+        // Answered under the name the query reached through visible records, so
+        // a record found behind an alias still carries the alias owner's name.
+        records.push({ ...step.record, name: answerName });
         return { records, finalName: currentName, answerName };
       }
 
@@ -63,6 +70,7 @@ export class SimRoute53DnsRecordChase {
         answerName = step.nextName;
       }
 
+      records.push(...step.emit);
       currentName = step.nextName;
     }
 
@@ -76,7 +84,6 @@ export class SimRoute53DnsRecordChase {
   private followName(
     name: string,
     recordType: SimRoute53RecordType,
-    records: SimRoute53Record[],
   ): ChaseStep | undefined {
     const hostedZone = this.zoneFinder.find(name);
 
@@ -90,11 +97,10 @@ export class SimRoute53DnsRecordChase {
       // An alias record holds a hostname rather than data of its own type, so
       // it is followed rather than answered, and stays out of the answer.
       if (exactRecord.alias === true) {
-        return followedTo(exactRecord.values.at(0), false);
+        return followedTo(exactRecord.values.at(0), false, []);
       }
 
-      records.push(exactRecord);
-      return undefined;
+      return { record: exactRecord, nextName: name, visible: false, emit: [] };
     }
 
     // A CNAME query wants the CNAME itself, so there is nothing to follow.
@@ -108,24 +114,28 @@ export class SimRoute53DnsRecordChase {
       return undefined;
     }
 
-    records.push(cname);
-    return followedTo(cname.values.at(0), true);
+    return followedTo(cname.values.at(0), true, [cname]);
   }
 }
 
 interface ChaseStep {
+  /** Set when the chase found the record it was looking for. */
+  readonly record?: SimRoute53Record | undefined;
   readonly nextName: string;
   /** Whether the followed record appears in the answer, as a CNAME does. */
   readonly visible: boolean;
+  /** Records the followed step contributes to the answer. */
+  readonly emit: readonly SimRoute53Record[];
 }
 
 function followedTo(
   nextName: string | undefined,
   visible: boolean,
+  emit: readonly SimRoute53Record[],
 ): ChaseStep | undefined {
   if (nextName === undefined) {
     return undefined;
   }
 
-  return { nextName, visible };
+  return { nextName, visible, emit };
 }

--- a/src/service/route53/dns/answer/sim-route53-dns-record-chase.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-record-chase.ts
@@ -1,0 +1,131 @@
+import type {
+  SimRoute53Record,
+  SimRoute53RecordType,
+} from "../../record/sim-route53-record.js";
+import type { SimRoute53DnsZoneFinder } from "./sim-route53-dns-zone-finder.js";
+
+const maxCnameDepth = 8;
+
+export interface SimRoute53DnsChase {
+  /** Records to place in the answer section, in the order they were followed. */
+  readonly records: readonly SimRoute53Record[];
+  /** The name the chase stopped at, which is where a negative answer applies. */
+  readonly finalName: string;
+  /**
+   * The name a synthesised address record should carry.
+   *
+   * Following a CNAME moves it to the target, because that is where the address
+   * lives. Following an alias leaves it alone: Route53 answers an alias under
+   * the name that holds it, the alias itself never appearing in the answer.
+   */
+  readonly answerName: string;
+}
+
+/**
+ * Follow CNAME records looking for a record of the queried type.
+ *
+ * A resolver asking for an A record at a name held by a CNAME expects the CNAME
+ * and the record it leads to in the same answer, so the chain is walked here
+ * rather than leaving the resolver to ask again.
+ *
+ * The walk is bounded twice over: visited names stop a cycle immediately, and a
+ * maximum depth stops a chain that is merely too long.
+ */
+export class SimRoute53DnsRecordChase {
+  private readonly zoneFinder: SimRoute53DnsZoneFinder;
+
+  constructor(zoneFinder: SimRoute53DnsZoneFinder) {
+    this.zoneFinder = zoneFinder;
+  }
+
+  /**
+   * Collect the records answering a query for one name and record type.
+   */
+  chase(name: string, recordType: SimRoute53RecordType): SimRoute53DnsChase {
+    const records: SimRoute53Record[] = [];
+    const visitedNames = new Set<string>();
+    let currentName = name;
+    let answerName = name;
+
+    for (let depth = 0; depth <= maxCnameDepth; depth += 1) {
+      if (visitedNames.has(currentName)) {
+        return { records, finalName: currentName, answerName };
+      }
+      visitedNames.add(currentName);
+
+      const step = this.followName(currentName, recordType, records);
+
+      if (step === undefined) {
+        return { records, finalName: currentName, answerName };
+      }
+
+      if (step.visible) {
+        answerName = step.nextName;
+      }
+
+      currentName = step.nextName;
+    }
+
+    return { records, finalName: currentName, answerName };
+  }
+
+  /**
+   * Take one step: collect a matching record and stop, or report the name to
+   * continue from.
+   */
+  private followName(
+    name: string,
+    recordType: SimRoute53RecordType,
+    records: SimRoute53Record[],
+  ): ChaseStep | undefined {
+    const hostedZone = this.zoneFinder.find(name);
+
+    if (hostedZone === undefined) {
+      return undefined;
+    }
+
+    const exactRecord = hostedZone.records.get(name, recordType);
+
+    if (exactRecord !== undefined) {
+      // An alias record holds a hostname rather than data of its own type, so
+      // it is followed rather than answered, and stays out of the answer.
+      if (exactRecord.alias === true) {
+        return followedTo(exactRecord.values.at(0), false);
+      }
+
+      records.push(exactRecord);
+      return undefined;
+    }
+
+    // A CNAME query wants the CNAME itself, so there is nothing to follow.
+    if (recordType === "CNAME") {
+      return undefined;
+    }
+
+    const cname = hostedZone.records.get(name, "CNAME");
+
+    if (cname === undefined) {
+      return undefined;
+    }
+
+    records.push(cname);
+    return followedTo(cname.values.at(0), true);
+  }
+}
+
+interface ChaseStep {
+  readonly nextName: string;
+  /** Whether the followed record appears in the answer, as a CNAME does. */
+  readonly visible: boolean;
+}
+
+function followedTo(
+  nextName: string | undefined,
+  visible: boolean,
+): ChaseStep | undefined {
+  if (nextName === undefined) {
+    return undefined;
+  }
+
+  return { nextName, visible };
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-service-target.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-service-target.ts
@@ -1,0 +1,59 @@
+import { simRoute53LocalName } from "../../local-name/sim-route53-local-name.js";
+import { SimRoute53ServiceTargetResolver } from "../../resolve/sim-r53-service-target-resolver.js";
+import type { SimRoute53RecordType } from "../../record/sim-route53-record.js";
+import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import { encodeDnsRdata } from "../rdata/dns-rdata.js";
+import type { DnsResourceRecord } from "../wire/dns-resource-record.js";
+
+const serviceTargetTtl = 60;
+
+/**
+ * Synthesise the address record for a name owned by a simulated service.
+ *
+ * A CNAME pointing at a simulated S3 website or CloudFront hostname has no
+ * address record behind it, because those hostnames are recognised by shape
+ * rather than stored in a hosted zone. Answering with the address the local
+ * server listens on is what makes a DNS lookup and an HTTP request for the same
+ * name describe the same thing.
+ */
+export class SimRoute53DnsServiceTarget {
+  private readonly resolver = new SimRoute53ServiceTargetResolver();
+  private readonly serviceAddress: string;
+
+  constructor(serviceAddress: string) {
+    this.serviceAddress = serviceAddress;
+  }
+
+  /**
+   * Address records for a name owned by a simulated service, if it is one.
+   *
+   * `targetName` is the hostname to recognise; `answerName` is the name the
+   * record is answered under. They differ for an alias record, which Route53
+   * answers under the name holding it rather than under the target.
+   */
+  answersFor(
+    targetName: string,
+    answerName: string,
+    recordType: SimRoute53RecordType,
+  ): readonly DnsResourceRecord[] {
+    if (recordType !== "A") {
+      return [];
+    }
+
+    const target = this.resolver.resolve(simRoute53LocalName(targetName));
+
+    if (target === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        name: answerName,
+        type: dnsRecordTypeNumber("A"),
+        class: dnsInternetClass,
+        ttl: serviceTargetTtl,
+        rdata: encodeDnsRdata("A", this.serviceAddress),
+      },
+    ];
+  }
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-soa.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-soa.ts
@@ -1,0 +1,41 @@
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+import { dnsInternetClass, dnsRecordTypeNumber } from "../dns-record-type.js";
+import { encodeDnsRdata } from "../rdata/dns-rdata.js";
+import type { DnsResourceRecord } from "../wire/dns-resource-record.js";
+import { simRoute53ZoneName } from "./sim-route53-dns-zone-finder.js";
+
+const negativeAnswerTtl = 900;
+
+/**
+ * Build the SOA record a negative answer carries in its authority section.
+ *
+ * A resolver reads the SOA's minimum field to learn how long it may cache the
+ * absence of a record, so NXDOMAIN and NODATA answers both carry one. When the
+ * zone holds its own SOA record that is used; otherwise one is synthesised, so
+ * a zone created without an explicit SOA still produces well-formed negative
+ * answers rather than a bare header.
+ */
+export function simRoute53DnsSoaRecord(
+  hostedZone: SimRoute53HostedZone,
+): DnsResourceRecord {
+  const zoneName = simRoute53ZoneName(hostedZone);
+  const storedSoa = hostedZone.records.get(zoneName, "SOA");
+
+  return {
+    name: zoneName,
+    type: dnsRecordTypeNumber("SOA"),
+    class: dnsInternetClass,
+    ttl: negativeAnswerTtl,
+    rdata: encodeDnsRdata("SOA", soaValue(zoneName, storedSoa?.values.at(0))),
+  };
+}
+
+function soaValue(zoneName: string, storedValue: string | undefined): string {
+  if (storedValue !== undefined) {
+    return storedValue;
+  }
+
+  // Shaped like a Route53 default SOA: primary name server, responsible
+  // mailbox, then serial, refresh, retry, expire and minimum.
+  return `ns.${zoneName}. hostmaster.${zoneName}. 1 7200 900 1209600 86400`;
+}

--- a/src/service/route53/dns/answer/sim-route53-dns-zone-finder.ts
+++ b/src/service/route53/dns/answer/sim-route53-dns-zone-finder.ts
@@ -1,0 +1,51 @@
+import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
+
+/**
+ * Find the hosted zone that answers for a DNS name.
+ *
+ * Route53 picks the most specific zone whose name contains the queried name, so
+ * a query for `www.sub.example.test` is answered by `sub.example.test` when both
+ * that zone and `example.test` exist. Zones are only entries in a map, so the
+ * longest matching zone name wins rather than there being a real DNS tree.
+ */
+export class SimRoute53DnsZoneFinder {
+  private readonly hostedZones: ReadonlyMap<string, SimRoute53HostedZone>;
+
+  constructor(hostedZones: ReadonlyMap<string, SimRoute53HostedZone>) {
+    this.hostedZones = hostedZones;
+  }
+
+  /**
+   * Find the most specific hosted zone containing a name, if any holds it.
+   */
+  find(name: string): SimRoute53HostedZone | undefined {
+    let bestZone: SimRoute53HostedZone | undefined;
+    let bestZoneNameLength = -1;
+
+    for (const hostedZone of this.hostedZones.values()) {
+      const zoneName = simRoute53ZoneName(hostedZone);
+
+      if (
+        zoneContainsName(zoneName, name) &&
+        zoneName.length > bestZoneNameLength
+      ) {
+        bestZone = hostedZone;
+        bestZoneNameLength = zoneName.length;
+      }
+    }
+
+    return bestZone;
+  }
+}
+
+/**
+ * Hosted-zone names are stored absolute, with a trailing dot, while record and
+ * question names are not.
+ */
+export function simRoute53ZoneName(hostedZone: SimRoute53HostedZone): string {
+  return hostedZone.name.replaceAll(/\.+$/gu, "");
+}
+
+function zoneContainsName(zoneName: string, name: string): boolean {
+  return name === zoneName || name.endsWith(`.${zoneName}`);
+}


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UDP-based DNS support for simulated Route53 records.
  * Simulated servers now provide DNS alongside HTTP, including CNAME, alias, A, TXT, and negative responses.
  * Added automatic DNS port selection when the preferred port is unavailable.
  * Added Node.js and `dig` examples for querying simulated records.

* **Documentation**
  * Expanded Route53 DNS documentation with querying instructions, response behavior, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->