### PR TITLE
feat: validate sim ACM certificate via sim Route53

### DIFF
--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -325,8 +325,9 @@ console.log(issuedOutput.Certificate?.Status); // ISSUED
 ```
 
 Each domain on a certificate is validated separately, so a certificate with subject alternative
-names is issued only once every domain's record exists. Until then `DescribeCertificateCommand`
-reports `SUCCESS` for the domains already validated and `PENDING_VALIDATION` for the rest.
+names is issued only once every domain that needs DNS validation has its record. Domains no hosted
+zone covers need nothing published for them. Until then `DescribeCertificateCommand` reports
+`SUCCESS` for the domains already validated and `PENDING_VALIDATION` for the rest.
 
 Hosted zones are looked up across every simulated account, matching real ACM validating against
 public DNS. A certificate in one account can be validated by a hosted zone in another.
@@ -386,6 +387,8 @@ Two methods override the default for tests where the hosted zone heuristic guess
   without creating a hosted zone first.
 
 A standalone `new SimAcm()` has no sim Route53 at all, so it always issues certificates immediately.
+Calling `requireDnsValidation()` on one throws, because nothing could ever publish the record it
+would then wait for.
 
 ## Listing and filtering certificates
 

--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -12,12 +12,14 @@ Sim ACM currently supports:
 - Requesting certificates with `RequestCertificateCommand`
 - Describing certificates with `DescribeCertificateCommand`
 - Listing certificates with `ListCertificatesCommand`
-- DNS and EMAIL validation method shapes (but validation always succeeds regardless)
+- DNS validation against records in sim Route53
+- EMAIL validation method shapes (but validation always succeeds regardless)
 - Subject alternative names
 - Certificate tags, up to the ACM limit of 50 tags
 - Deterministic simulated certificate ARNs scoped to account and region
 - Deterministic DNS validation CNAME records
 - Background certificate issuance from `PENDING_VALIDATION` to `ISSUED`
+- Per-domain validation status for multi-domain certificates
 - CloudFormation resource:
   - `AWS::CertificateManager::Certificate`
 - CloudFormation `Ref` and `Fn::GetAtt` values for ACM certificates
@@ -199,6 +201,9 @@ to move them to `ISSUED`.
 
 If your test needs the issued state, wait for simulator background tasks to complete.
 
+Where a sim Route53 hosted zone covers the certificate domain, issuance waits for DNS validation
+first. See [DNS validation against sim Route53](#dns-validation-against-sim-route53) below.
+
 ```typescript sim-acm-background-issuance
 /**
  * Waiting for a simulated ACM certificate to be issued.
@@ -231,6 +236,156 @@ const describeOutput = await acm.describeCertificate(
 console.log(describeOutput.Certificate?.Status);
 console.log(describeOutput.Certificate?.IssuedAt);
 ```
+
+## DNS validation against sim Route53
+
+Real ACM issues a DNS validated certificate only once the CNAME it asks for is resolvable. Sim ACM
+does the same, but only where the simulation could actually answer for the domain: if a sim Route53
+hosted zone covers the certificate domain, the certificate waits for its validation record. With no
+covering hosted zone there is nothing to validate against, so the certificate is issued as soon as
+background tasks drain.
+
+That keeps certificates realistic when you are simulating Route53, without getting in the way when
+your DNS lives outside the simulation. Templates commonly reference hosted zones managed by another
+team or another tool, and those certificates keep working here.
+
+```typescript sim-acm-dns-validation
+/**
+ * Validating a simulated ACM certificate against a simulated Route53 record.
+ */
+
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const zoneOutput = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "acm-dns-validation",
+  }),
+);
+
+const requestOutput = await simAws.acm().requestCertificate(
+  new RequestCertificateCommand({
+    DomainName: "api.example.test",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+// A hosted zone covers the domain, so the certificate waits for its record.
+const pendingOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(pendingOutput.Certificate?.Status); // PENDING_VALIDATION
+
+const validationRecord =
+  pendingOutput.Certificate?.DomainValidationOptions?.[0]?.ResourceRecord;
+
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zoneOutput.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: validationRecord?.Name,
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: validationRecord?.Value ?? "" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const issuedOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(issuedOutput.Certificate?.Status); // ISSUED
+```
+
+Each domain on a certificate is validated separately, so a certificate with subject alternative
+names is issued only once every domain's record exists. Until then `DescribeCertificateCommand`
+reports `SUCCESS` for the domains already validated and `PENDING_VALIDATION` for the rest.
+
+Hosted zones are looked up across every simulated account, matching real ACM validating against
+public DNS. A certificate in one account can be validated by a hosted zone in another.
+
+### Skipping the validation record
+
+If you want a realistic hosted zone but not the certificate ceremony, `completeDnsValidation()`
+publishes the validation records for a pending certificate. The certificate is issued by the time it
+resolves.
+
+```typescript sim-acm-complete-dns-validation
+/**
+ * Completing simulated ACM DNS validation in one call.
+ */
+
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "acm-shortcut",
+  }),
+);
+
+const requestOutput = await simAws.acm().requestCertificate(
+  new RequestCertificateCommand({
+    DomainName: "api.example.test",
+  }),
+);
+
+await simAws.acm().completeDnsValidation(requestOutput.CertificateArn);
+
+const describeOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(describeOutput.Certificate?.Status); // ISSUED
+```
+
+### Overriding when validation is required
+
+Two methods override the default for tests where the hosted zone heuristic guesses wrong:
+
+- `simAws.acm().autoIssueCertificates()` never requires validation, for a test that has a hosted zone
+  for unrelated reasons and does not care about certificates.
+- `simAws.acm().requireDnsValidation()` always requires it, so the validation path can be exercised
+  without creating a hosted zone first.
+
+A standalone `new SimAcm()` has no sim Route53 at all, so it always issues certificates immediately.
 
 ## Listing and filtering certificates
 
@@ -497,6 +652,9 @@ Current documented limitations:
 - Certificate deletion is not supported.
 - Certificate renewal is not supported.
 - Imported certificates are not supported.
-- Real validation checks are not performed.
-- DNS validation records are generated for test use; they are not resolvable through real DNS.
+- EMAIL validation always succeeds; only DNS validation is really checked.
+- DNS validation is checked against sim Route53 only, never against real DNS.
+- Validation does not time out: a certificate whose record never appears stays `PENDING_VALIDATION`.
+- CloudFormation templates cannot create their own validation records yet, so
+  `DomainValidationOptions[].HostedZoneId` is ignored.
 - ACM is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/acm/sim-acm-complete-dns-validation.example.ts
+++ b/docs/services/acm/sim-acm-complete-dns-validation.example.ts
@@ -1,0 +1,36 @@
+/**
+ * Completing simulated ACM DNS validation in one call.
+ */
+
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "acm-shortcut",
+  }),
+);
+
+const requestOutput = await simAws.acm().requestCertificate(
+  new RequestCertificateCommand({
+    DomainName: "api.example.test",
+  }),
+);
+
+await simAws.acm().completeDnsValidation(requestOutput.CertificateArn);
+
+const describeOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(describeOutput.Certificate?.Status); // ISSUED

--- a/docs/services/acm/sim-acm-dns-validation.example.ts
+++ b/docs/services/acm/sim-acm-dns-validation.example.ts
@@ -1,0 +1,72 @@
+/**
+ * Validating a simulated ACM certificate against a simulated Route53 record.
+ */
+
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import {
+  ChangeResourceRecordSetsCommand,
+  CreateHostedZoneCommand,
+} from "@aws-sdk/client-route-53";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const zoneOutput = await simAws.route53().createHostedZone(
+  new CreateHostedZoneCommand({
+    Name: "example.test",
+    CallerReference: "acm-dns-validation",
+  }),
+);
+
+const requestOutput = await simAws.acm().requestCertificate(
+  new RequestCertificateCommand({
+    DomainName: "api.example.test",
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+// A hosted zone covers the domain, so the certificate waits for its record.
+const pendingOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(pendingOutput.Certificate?.Status); // PENDING_VALIDATION
+
+const validationRecord =
+  pendingOutput.Certificate?.DomainValidationOptions?.[0]?.ResourceRecord;
+
+await simAws.route53().changeResourceRecordSets(
+  new ChangeResourceRecordSetsCommand({
+    HostedZoneId: zoneOutput.HostedZone?.Id,
+    ChangeBatch: {
+      Changes: [
+        {
+          Action: "CREATE",
+          ResourceRecordSet: {
+            Name: validationRecord?.Name,
+            Type: "CNAME",
+            TTL: 300,
+            ResourceRecords: [{ Value: validationRecord?.Value ?? "" }],
+          },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const issuedOutput = await simAws.acm().describeCertificate(
+  new DescribeCertificateCommand({
+    CertificateArn: requestOutput.CertificateArn,
+  }),
+);
+
+console.log(issuedOutput.Certificate?.Status); // ISSUED

--- a/src/service/acm/README.md
+++ b/src/service/acm/README.md
@@ -93,8 +93,8 @@ record into the hosted zone covering it, settles the certificate, and throws
 ## RequestCertificate
 
 `RequestCertificateCommandHandler` validates the required inputs, sequences background work, creates
-a certificate, stores it in the service certificate map, and schedules certificate issuance as a
-background task.
+a certificate, stores it in the service certificate map, and schedules domain validation as a
+background task. Validation is what issues the certificate, once every domain has succeeded.
 
 Current behaviour:
 

--- a/src/service/acm/README.md
+++ b/src/service/acm/README.md
@@ -11,6 +11,7 @@ certificates. It is an in-memory service for tests and local development, not a 
 - `index.ts` exports the public ACM simulator API for `@kensio/yulin/acm`.
 - `certificate/` contains the simulated certificate model.
 - `command/` contains AWS SDK-style command handlers.
+- `validation/` contains domain validation against sim Route53.
 - `cfn/` contains CloudFormation support for `AWS::CertificateManager::Certificate`.
 - `error/` contains ACM-specific AWS-like errors.
 
@@ -49,8 +50,45 @@ AWS SDK classes from `src/`.
 Certificates start as `PENDING_VALIDATION` when requested. The `issue()` method changes status to
 `ISSUED` and records `issuedAt`.
 
+Domain validation options are `SimAcmDomainValidation` objects rather than plain data, because each
+domain on a certificate carries its own validation status. `isValidated` on the certificate is the
+gate issuance waits on, and `issue()` marks any still-pending domain successful so the per-domain
+statuses stay consistent with the certificate status.
+
 The model is small. Command handlers and output factories translate it into AWS-shaped responses
 where needed.
+
+## Domain validation
+
+Validation lives under `validation/`.
+
+`SimAcmCertificateValidation` owns issuance. `RequestCertificate` hands it each new certificate
+instead of scheduling `issue()` directly, and it evaluates the certificate as background work, then
+again whenever DNS records change, until every domain has succeeded.
+
+Whether a domain must be validated at all is decided per domain:
+
+- ACM with no `SimAcmDnsRecords` at all, which is a standalone `SimAcm`, validates nothing.
+- a domain not using `DNS` validation is not checked.
+- otherwise `SimAcmDnsValidationMode` decides. The default `auto` mode requires validation only
+  where a hosted zone covers the domain name, so certificates for domains the simulation is not
+  authoritative for are issued rather than left stuck. `always` and `never` are the overrides behind
+  `SimAcm.requireDnsValidation()` and `SimAcm.autoIssueCertificates()`.
+
+`SimAcmDnsRecords` is the port ACM depends on, and `SimRoute53AcmDnsRecords` implements it over the
+shared `SimRoute53Registry`. All DNS name handling stays in that adapter, because Route53 stores
+record names and values normalised and comparisons have to match. The registry spans simulated
+accounts, so a certificate in one account can validate against a hosted zone in another, as real ACM
+validates against public DNS.
+
+Re-evaluation is driven by record change notifications from Route53 rather than by polling. A
+polling loop that rescheduled itself would never let `BackgroundTasks.complete()` drain, since it
+drains until no tasks remain. Pushing instead means a certificate whose record never appears simply
+stays pending.
+
+`SimAcmDnsValidationCompleter` backs `SimAcm.completeDnsValidation()`: it publishes each validation
+record into the hosted zone covering it, settles the certificate, and throws
+`SimAcmDnsValidationFailed` naming the records that had nowhere to go.
 
 ## RequestCertificate
 
@@ -66,6 +104,9 @@ Current behaviour:
 - certificate ARNs are generated from the account, region, and a stable sequence number.
 - DNS validation records are deterministic CNAMEs derived from account, region, and domain.
 - the command returns the new `CertificateArn`.
+
+Issuance is not scheduled directly. The handler hands the certificate to `SimAcmCertificateValidation`,
+which issues it once every domain is validated. See the domain validation section below.
 
 `RequestCertificateFactory` owns the certificate-shaping rules: ARN generation, validation defaults,
 domain validation option creation, deterministic validation records, and tag copying.
@@ -129,7 +170,7 @@ Current uses:
 
 - commands sequence before reading or mutating certificate state.
 - requested certificates are inserted immediately.
-- issuance is scheduled as background work after creation.
+- domain validation is scheduled as background work after creation, and again on DNS record changes.
 
 Tests that need the final issued state should drain the simulator background tasks, for example
 through the broader `SimAws` background completion helper.
@@ -143,6 +184,8 @@ Current errors cover the behaviours implemented by the simulator:
 - invalid command arguments
 - too many tags
 - certificate not found
+- DNS validation that could not be completed, which is a simulator diagnostic rather than an AWS
+  error: real ACM leaves the certificate pending until it times out hours later.
 
 Validation that does not yet need an AWS-specific exception may use assertion-style errors. Add a
 specific ACM error class when caller-visible failure semantics matter.

--- a/src/service/acm/certificate/sim-acm-certificate.ts
+++ b/src/service/acm/certificate/sim-acm-certificate.ts
@@ -1,4 +1,8 @@
 import type { SimArn } from "../../aws/arn.js";
+import type {
+  SimAcmDomainValidation,
+  SimAcmValidationMethod,
+} from "./sim-acm-domain-validation.js";
 
 export type SimAcmCertificateStatus =
   | "EXPIRED"
@@ -8,23 +12,10 @@ export type SimAcmCertificateStatus =
   | "PENDING_VALIDATION"
   | "REVOKED"
   | "VALIDATION_TIMED_OUT";
-export type SimAcmValidationMethod = "DNS" | "EMAIL" | "HTTP";
 
 export interface SimAcmTag {
   readonly Key?: string | undefined;
   readonly Value?: string | undefined;
-}
-
-export interface SimAcmValidationRecord {
-  readonly name: string;
-  readonly type: "CNAME";
-  readonly value: string;
-}
-
-export interface SimAcmDomainValidationOption {
-  readonly domainName: string;
-  readonly validationMethod?: SimAcmValidationMethod | undefined;
-  readonly resourceRecord?: SimAcmValidationRecord | undefined;
 }
 
 interface SimAcmCertificateProperties {
@@ -34,7 +25,7 @@ interface SimAcmCertificateProperties {
   readonly status?: SimAcmCertificateStatus | undefined;
   readonly validationMethod?: SimAcmValidationMethod | undefined;
   readonly domainValidationOptions?:
-    readonly SimAcmDomainValidationOption[] | undefined;
+    readonly SimAcmDomainValidation[] | undefined;
   readonly createdAt?: Date | undefined;
   readonly issuedAt?: Date | undefined;
   readonly tags?: readonly SimAcmTag[] | undefined;
@@ -48,7 +39,7 @@ export class SimAcmCertificate {
   public readonly domainName: string;
   public readonly subjectAlternativeNames: readonly string[];
   public readonly validationMethod?: SimAcmValidationMethod | undefined;
-  public readonly domainValidationOptions: readonly SimAcmDomainValidationOption[];
+  public readonly domainValidationOptions: readonly SimAcmDomainValidation[];
   public readonly createdAt: Date;
   public readonly tags?: readonly SimAcmTag[] | undefined;
 
@@ -94,11 +85,33 @@ export class SimAcmCertificate {
   }
 
   /**
+   * Whether every domain name on this sim Certificate has been validated.
+   *
+   * ACM issues a certificate only once ownership of all of its domain names is
+   * proven, so this is the gate the validation flow waits on.
+   */
+  get isValidated(): boolean {
+    return this.domainValidationOptions.every(
+      (domainValidation) => domainValidation.hasSucceeded,
+    );
+  }
+
+  /**
    * Move the sim Certificate into ISSUED status.
+   *
+   * Issuing implies every domain name was validated, so any domain validation
+   * still pending is marked successful here. That keeps the per-domain
+   * statuses consistent with the certificate status for the paths that issue a
+   * certificate without waiting for DNS, such as EMAIL validation.
    */
   issue(): Promise<void> {
     this.#status = "ISSUED";
     this.#issuedAt = new Date();
+
+    for (const domainValidation of this.domainValidationOptions) {
+      domainValidation.succeed();
+    }
+
     return Promise.resolve();
   }
 }

--- a/src/service/acm/certificate/sim-acm-domain-validation.ts
+++ b/src/service/acm/certificate/sim-acm-domain-validation.ts
@@ -1,0 +1,75 @@
+export type SimAcmValidationMethod = "DNS" | "EMAIL" | "HTTP";
+
+export type SimAcmDomainValidationStatus =
+  "FAILED" | "PENDING_VALIDATION" | "SUCCESS";
+
+export interface SimAcmValidationRecord {
+  readonly name: string;
+  readonly type: "CNAME";
+  readonly value: string;
+}
+
+interface SimAcmDomainValidationProperties {
+  readonly domainName: string;
+  readonly validationMethod?: SimAcmValidationMethod | undefined;
+  readonly resourceRecord?: SimAcmValidationRecord | undefined;
+  readonly status?: SimAcmDomainValidationStatus | undefined;
+}
+
+/**
+ * Validation state for one domain name on a simulated ACM Certificate.
+ *
+ * ACM validates every domain on a certificate separately, so a certificate
+ * with subject alternative names can have some domains already validated while
+ * others are still waiting for their DNS record. The certificate is only
+ * issued once every domain has succeeded.
+ */
+export class SimAcmDomainValidation {
+  public readonly domainName: string;
+  public readonly validationMethod?: SimAcmValidationMethod | undefined;
+  public readonly resourceRecord?: SimAcmValidationRecord | undefined;
+
+  #status: SimAcmDomainValidationStatus;
+
+  constructor(properties: SimAcmDomainValidationProperties) {
+    const {
+      domainName,
+      validationMethod,
+      resourceRecord,
+      status = "PENDING_VALIDATION",
+    } = properties;
+
+    this.domainName = domainName;
+    this.validationMethod = validationMethod;
+    this.resourceRecord = resourceRecord;
+    this.#status = status;
+  }
+
+  /**
+   * Get the current validation status for this domain name.
+   */
+  get status(): SimAcmDomainValidationStatus {
+    return this.#status;
+  }
+
+  /**
+   * Whether this domain name is still waiting to be validated.
+   */
+  get isPending(): boolean {
+    return this.#status === "PENDING_VALIDATION";
+  }
+
+  /**
+   * Whether this domain name has been validated.
+   */
+  get hasSucceeded(): boolean {
+    return this.#status === "SUCCESS";
+  }
+
+  /**
+   * Record this domain name as validated.
+   */
+  succeed(): void {
+    this.#status = "SUCCESS";
+  }
+}

--- a/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.ts
+++ b/src/service/acm/cfn/property/sim-cfn-acm-cert-properties.ts
@@ -1,4 +1,4 @@
-import type { SimAcmValidationMethod } from "../../certificate/sim-acm-certificate.js";
+import type { SimAcmValidationMethod } from "../../certificate/sim-acm-domain-validation.js";
 import type {
   SimRequestCertificateDomainValidationOption,
   SimRequestCertificateTag,

--- a/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-cert.iso.test.ts
@@ -166,7 +166,7 @@ describe("Sim ACM CloudFormation Certificate", () => {
     const primaryValidation = certificate.DomainValidationOptions[0];
     assertIdentical(primaryValidation.DomainName, "example.test");
     assertIdentical(primaryValidation.ValidationMethod, "DNS");
-    assertIdentical(primaryValidation.ValidationStatus, "ISSUED");
+    assertIdentical(primaryValidation.ValidationStatus, "SUCCESS");
     assertStringStartsWith(
       primaryValidation.ResourceRecord?.Name,
       "_yulin-acm-",

--- a/src/service/acm/command/describe-certificate/describe-certificate.command.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate.command.ts
@@ -1,9 +1,10 @@
 import type { SimArn } from "../../../aws/arn.js";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimAcmCertificateStatus } from "../../certificate/sim-acm-certificate.js";
 import type {
-  SimAcmCertificateStatus,
+  SimAcmDomainValidationStatus,
   SimAcmValidationMethod,
-} from "../../certificate/sim-acm-certificate.js";
+} from "../../certificate/sim-acm-domain-validation.js";
 
 /**
  * Minimal structural sim ACM DescribeCertificate command.
@@ -53,7 +54,7 @@ export interface SimAcmCertificateDetail {
 export interface SimAcmCertificateDomainValidation {
   readonly DomainName?: string | undefined;
   readonly ValidationMethod?: SimAcmValidationMethod | undefined;
-  readonly ValidationStatus?: SimAcmCertificateStatus | undefined;
+  readonly ValidationStatus?: SimAcmDomainValidationStatus | undefined;
   readonly ResourceRecord?: SimAcmCertificateResourceRecord | undefined;
 }
 

--- a/src/service/acm/command/describe-certificate/describe-certificate.iso.test.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate.iso.test.ts
@@ -185,7 +185,7 @@ describe("ACM DescribeCertificateCommand", () => {
     assertArrayLength(describeOutput.Certificate.DomainValidationOptions, 1);
     assertIdentical(
       describeOutput.Certificate.DomainValidationOptions[0].ValidationStatus,
-      "ISSUED",
+      "SUCCESS",
     );
   });
 

--- a/src/service/acm/command/describe-certificate/sim-acm-cert-detail-factory.ts
+++ b/src/service/acm/command/describe-certificate/sim-acm-cert-detail-factory.ts
@@ -34,7 +34,7 @@ export class SimAcmCertificateDetailFactory {
         (option) => ({
           DomainName: option.domainName,
           ValidationMethod: option.validationMethod,
-          ValidationStatus: certificate.status,
+          ValidationStatus: option.status,
           ResourceRecord:
             option.resourceRecord === undefined
               ? undefined

--- a/src/service/acm/command/request-certificate/request-cert-factory.ts
+++ b/src/service/acm/command/request-certificate/request-cert-factory.ts
@@ -3,11 +3,13 @@ import type { SimArn } from "../../../aws/arn.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   SimAcmCertificate,
-  type SimAcmDomainValidationOption,
   type SimAcmTag,
+} from "../../certificate/sim-acm-certificate.js";
+import {
+  SimAcmDomainValidation,
   type SimAcmValidationMethod,
   type SimAcmValidationRecord,
-} from "../../certificate/sim-acm-certificate.js";
+} from "../../certificate/sim-acm-domain-validation.js";
 import type { SimRequestCertificateCommand } from "./request-certificate.command.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 
@@ -97,15 +99,26 @@ export class RequestCertificateFactory {
   private makeDomainValidationOption(
     domainName: string,
     validationMethod: SimAcmValidationMethod,
-  ): SimAcmDomainValidationOption {
-    return {
+  ): SimAcmDomainValidation {
+    return new SimAcmDomainValidation({
       domainName,
       validationMethod,
-      resourceRecord:
-        validationMethod === "DNS"
-          ? this.makeValidationRecord(domainName)
-          : undefined,
-    };
+      resourceRecord: this.makeResourceRecord(domainName, validationMethod),
+    });
+  }
+
+  /**
+   * Build the record ACM asks for, where the validation method has one.
+   */
+  private makeResourceRecord(
+    domainName: string,
+    validationMethod: SimAcmValidationMethod,
+  ): SimAcmValidationRecord | undefined {
+    if (validationMethod !== "DNS") {
+      return undefined;
+    }
+
+    return this.makeValidationRecord(domainName);
   }
 
   /**

--- a/src/service/acm/command/request-certificate/request-certificate.command.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.command.ts
@@ -1,6 +1,6 @@
 import type { SimArn } from "../../../aws/arn.js";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimAcmValidationMethod } from "../../certificate/sim-acm-certificate.js";
+import type { SimAcmValidationMethod } from "../../certificate/sim-acm-domain-validation.js";
 
 /**
  * Minimal structural sim ACM RequestCertificate command.

--- a/src/service/acm/command/request-certificate/request-certificate.handler.ts
+++ b/src/service/acm/command/request-certificate/request-certificate.handler.ts
@@ -18,12 +18,14 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAcmCertificateValidation } from "../../validation/sim-acm-certificate-validation.js";
 
 interface RequestCertificateCommandHandlerProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly certificates: Map<SimArn, SimAcmCertificate>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly validation?: SimAcmCertificateValidation;
 }
 
 interface RequestCertificateCommandHandlerOptions {
@@ -43,6 +45,7 @@ export class RequestCertificateCommandHandler implements CommandHandler<
   private readonly authorizer: RequestCertificateAuthorizer;
   private readonly background: BackgroundScheduler;
   private readonly certificateFactory: RequestCertificateFactory;
+  private readonly validation: SimAcmCertificateValidation;
   private readonly validator = new RequestCertificateValidator();
 
   constructor(properties: RequestCertificateCommandHandlerProperties) {
@@ -51,9 +54,11 @@ export class RequestCertificateCommandHandler implements CommandHandler<
       certificates,
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      validation = new SimAcmCertificateValidation({ background }),
     } = properties;
 
     this.certificates = certificates;
+    this.validation = validation;
     this.authorizer = new RequestCertificateAuthorizer({
       iam,
       resource: `arn:aws:acm:${accountRegionScope.regionName}:${accountRegionScope.accountId}:certificate/*`,
@@ -91,8 +96,8 @@ export class RequestCertificateCommandHandler implements CommandHandler<
 
     this.certificates.set(certificateArn, certificate);
 
-    // Schedule background task to issue the sim Certificate.
-    this.background.schedule(() => certificate.issue());
+    // Issuance waits on domain validation, which happens in the background.
+    this.validation.begin(certificate);
 
     return {
       $metadata: {},

--- a/src/service/acm/error/sim-acm.error.ts
+++ b/src/service/acm/error/sim-acm.error.ts
@@ -40,6 +40,22 @@ export class SimAcmResourceNotFoundException extends SimAcmError {
 }
 
 /**
+ * Simulated ACM DNS validation failure.
+ *
+ * This is a simulator diagnostic rather than an AWS error: real ACM leaves a
+ * certificate pending until validation times out hours later, which is no use
+ * in a test. The message names the records that could not be published so the
+ * missing Hosted Zone is obvious.
+ */
+export class SimAcmDnsValidationFailed extends SimAcmError {
+  public override readonly name = "DnsValidationFailed";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated ACM TooManyTagsException error.
  */
 export class SimAcmTooManyTagsException extends SimAcmError {

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -29,6 +29,9 @@ import {
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimAcmSdkCommandRouter } from "./sdk/sim-acm-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import { SimAcmCertificateValidation } from "./validation/sim-acm-certificate-validation.js";
+import { SimAcmDnsValidationCompleter } from "./validation/sim-acm-dns-validation-completer.js";
+import type { SimAcmDnsRecords } from "./validation/sim-acm-dns-records.js";
 
 export interface SimAcmRequestOptions {
   readonly caller?: SimAwsCaller;
@@ -38,6 +41,7 @@ interface SimAcmProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly dnsRecords?: SimAcmDnsRecords;
 }
 
 /**
@@ -49,6 +53,8 @@ export class SimAcm {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly background: BackgroundScheduler;
+  private readonly validation: SimAcmCertificateValidation;
+  private readonly dnsValidationCompleter: SimAcmDnsValidationCompleter;
   private readonly cfnFactory = new SimAcmCfnResourceFactory({
     acm: this,
   });
@@ -59,11 +65,52 @@ export class SimAcm {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      dnsRecords,
     } = properties;
 
     this.accountRegionScope = accountRegionScope;
     this.iam = iam;
     this.background = background;
+    this.validation = new SimAcmCertificateValidation({
+      background,
+      dnsRecords,
+    });
+    this.dnsValidationCompleter = new SimAcmDnsValidationCompleter({
+      certificates: this.certificates,
+      validation: this.validation,
+      dnsRecords,
+    });
+  }
+
+  /**
+   * Always require a DNS validation record before issuing a Certificate, even
+   * where no sim Route53 Hosted Zone covers the domain name.
+   */
+  requireDnsValidation(): this {
+    this.validation.alwaysRequireDnsValidation();
+    return this;
+  }
+
+  /**
+   * Never require a DNS validation record: issue every Certificate as soon as
+   * it is requested, whatever sim Route53 holds.
+   */
+  autoIssueCertificates(): this {
+    this.validation.neverRequireDnsValidation();
+    return this;
+  }
+
+  /**
+   * Create the DNS validation records a pending sim Certificate is waiting on.
+   *
+   * This is a simulator convenience for tests that want a realistic issuance
+   * flow without publishing each validation CNAME by hand. The Certificate is
+   * issued by the time this resolves.
+   */
+  async completeDnsValidation(
+    certificateArn: string | undefined,
+  ): Promise<void> {
+    await this.dnsValidationCompleter.complete(certificateArn);
   }
 
   /**
@@ -108,6 +155,7 @@ export class SimAcm {
       certificates: this.certificates,
       iam: this.iam,
       background: this.background,
+      validation: this.validation,
     });
     return await handler.handle(command, options);
   }

--- a/src/service/acm/validation/sim-acm-certificate-validation.ts
+++ b/src/service/acm/validation/sim-acm-certificate-validation.ts
@@ -1,0 +1,156 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAcmCertificate } from "../certificate/sim-acm-certificate.js";
+import type {
+  SimAcmDomainValidation,
+  SimAcmValidationRecord,
+} from "../certificate/sim-acm-domain-validation.js";
+import type { SimAcmDnsRecords } from "./sim-acm-dns-records.js";
+import { SimAcmDnsValidationMode } from "./sim-acm-dns-validation-mode.js";
+
+interface SimAcmCertificateValidationProperties {
+  readonly background: BackgroundScheduler;
+  readonly dnsRecords?: SimAcmDnsRecords | undefined;
+}
+
+/**
+ * Drives sim ACM Certificate issuance through domain validation.
+ *
+ * A requested Certificate is evaluated once as background work, and then again
+ * whenever DNS records change, until every domain name on it is validated. The
+ * re-evaluation is driven by DNS record changes rather than by polling, so
+ * draining simulator background tasks always terminates: a Certificate whose
+ * validation record never appears simply stays pending.
+ */
+export class SimAcmCertificateValidation {
+  private readonly background: BackgroundScheduler;
+  private readonly dnsRecords: SimAcmDnsRecords | undefined;
+  private readonly pendingCertificates = new Set<SimAcmCertificate>();
+  private mode = SimAcmDnsValidationMode.auto();
+  private listeningForRecordChanges = false;
+
+  constructor(properties: SimAcmCertificateValidationProperties) {
+    this.background = properties.background;
+    this.dnsRecords = properties.dnsRecords;
+  }
+
+  /**
+   * Always require a DNS validation record before issuing a Certificate.
+   */
+  alwaysRequireDnsValidation(): void {
+    this.mode = SimAcmDnsValidationMode.always();
+  }
+
+  /**
+   * Never require a DNS validation record before issuing a Certificate.
+   */
+  neverRequireDnsValidation(): void {
+    this.mode = SimAcmDnsValidationMode.never();
+  }
+
+  /**
+   * Begin validating a newly requested Certificate.
+   */
+  begin(certificate: SimAcmCertificate): void {
+    this.pendingCertificates.add(certificate);
+    this.listenForRecordChanges();
+    this.background.schedule(() => this.settle(certificate));
+  }
+
+  /**
+   * Validate whatever can be validated now, issuing the Certificate once every
+   * domain name on it has succeeded.
+   */
+  async settle(certificate: SimAcmCertificate): Promise<void> {
+    for (const domainValidation of certificate.domainValidationOptions) {
+      this.validateDomain(domainValidation);
+    }
+
+    if (!certificate.isValidated) {
+      return;
+    }
+
+    await certificate.issue();
+    this.pendingCertificates.delete(certificate);
+  }
+
+  /**
+   * Validate one domain name, if it is waiting and its record now exists.
+   */
+  private validateDomain(domainValidation: SimAcmDomainValidation): void {
+    if (!domainValidation.isPending) {
+      return;
+    }
+
+    const dnsRecords = this.dnsRecords;
+    if (dnsRecords === undefined) {
+      domainValidation.succeed();
+      return;
+    }
+
+    const requiredRecord = this.requiredDnsRecord(domainValidation, dnsRecords);
+    if (requiredRecord === undefined) {
+      domainValidation.succeed();
+      return;
+    }
+
+    if (dnsRecords.hasCname(requiredRecord.name, requiredRecord.value)) {
+      domainValidation.succeed();
+    }
+  }
+
+  /**
+   * The DNS record a domain name must publish before it can be validated.
+   *
+   * Undefined means this domain name does not need to prove anything through
+   * DNS: it is not using DNS validation, or nothing in the simulation is
+   * authoritative for it.
+   */
+  private requiredDnsRecord(
+    domainValidation: SimAcmDomainValidation,
+    dnsRecords: SimAcmDnsRecords,
+  ): SimAcmValidationRecord | undefined {
+    const resourceRecord = domainValidation.resourceRecord;
+
+    if (
+      resourceRecord === undefined ||
+      domainValidation.validationMethod !== "DNS"
+    ) {
+      return undefined;
+    }
+
+    const requiresValidation = this.mode.requiresValidation(
+      dnsRecords.hasAuthorityFor(domainValidation.domainName),
+    );
+
+    if (!requiresValidation) {
+      return undefined;
+    }
+
+    return resourceRecord;
+  }
+
+  /**
+   * Subscribe to DNS record changes the first time a Certificate needs them.
+   */
+  private listenForRecordChanges(): void {
+    const dnsRecords = this.dnsRecords;
+
+    if (this.listeningForRecordChanges || dnsRecords === undefined) {
+      return;
+    }
+
+    this.listeningForRecordChanges = true;
+    dnsRecords.onRecordChange(() => {
+      this.revalidatePendingCertificates();
+    });
+  }
+
+  /**
+   * Schedule another look at every Certificate still waiting to be issued.
+   */
+  private revalidatePendingCertificates(): void {
+    for (const certificate of this.pendingCertificates) {
+      this.background.schedule(() => this.settle(certificate));
+    }
+  }
+}

--- a/src/service/acm/validation/sim-acm-certificate-validation.ts
+++ b/src/service/acm/validation/sim-acm-certificate-validation.ts
@@ -35,8 +35,18 @@ export class SimAcmCertificateValidation {
 
   /**
    * Always require a DNS validation record before issuing a Certificate.
+   *
+   * With no sim Route53 to validate against there is no way to satisfy this,
+   * so it is rejected rather than silently issuing certificates anyway.
    */
   alwaysRequireDnsValidation(): void {
+    if (this.dnsRecords === undefined) {
+      throw new Error(
+        "Sim ACM cannot require DNS validation with no sim Route53 to validate against. " +
+          "Use SimAws, so ACM can see Hosted Zones, rather than a standalone SimAcm.",
+      );
+    }
+
     this.mode = SimAcmDnsValidationMode.always();
   }
 

--- a/src/service/acm/validation/sim-acm-dns-records.ts
+++ b/src/service/acm/validation/sim-acm-dns-records.ts
@@ -1,0 +1,39 @@
+export type SimAcmDnsRecordChangeListener = () => void;
+
+/**
+ * DNS records visible to simulated ACM when validating domain ownership.
+ *
+ * Real ACM proves domain ownership by looking for a CNAME in public DNS. This
+ * port is how sim ACM does the same against sim Route53 without depending on
+ * Route53's own types or name normalisation rules. A standalone SimAcm has no
+ * implementation of this at all, which is what makes it issue certificates
+ * without validating them.
+ */
+export interface SimAcmDnsRecords {
+  /**
+   * Whether the simulation holds DNS authority for a domain name.
+   *
+   * This is the signal sim ACM uses to decide whether a certificate should
+   * wait for validation: with no Hosted Zone covering the domain name there is
+   * nothing in the simulation that could answer for it.
+   */
+  hasAuthorityFor(domainName: string): boolean;
+
+  /**
+   * Whether a CNAME record with this name and value exists.
+   */
+  hasCname(name: string, value: string): boolean;
+
+  /**
+   * Create a CNAME record in the Hosted Zone covering its name.
+   *
+   * Returns false when no Hosted Zone covers the name, so the caller can
+   * report which records it could not create.
+   */
+  createCname(name: string, value: string): boolean;
+
+  /**
+   * Register a listener called whenever any DNS record changes.
+   */
+  onRecordChange(listener: SimAcmDnsRecordChangeListener): void;
+}

--- a/src/service/acm/validation/sim-acm-dns-validation-completer.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation-completer.ts
@@ -1,0 +1,106 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAcmCertificate } from "../certificate/sim-acm-certificate.js";
+import {
+  SimAcmDnsValidationFailed,
+  SimAcmInvalidArgumentsException,
+  SimAcmResourceNotFoundException,
+} from "../error/sim-acm.error.js";
+import type { SimAcmCertificateValidation } from "./sim-acm-certificate-validation.js";
+import type { SimAcmDnsRecords } from "./sim-acm-dns-records.js";
+
+interface SimAcmDnsValidationCompleterProperties {
+  readonly certificates: ReadonlyMap<SimArn, SimAcmCertificate>;
+  readonly validation: SimAcmCertificateValidation;
+  readonly dnsRecords?: SimAcmDnsRecords | undefined;
+}
+
+/**
+ * Creates the DNS validation records a pending sim Certificate is waiting for.
+ *
+ * This is the shortcut for users who want realistic DNS routing but not the
+ * certificate ceremony: it writes each validation CNAME into the Hosted Zone
+ * covering it, then settles the Certificate, so the Certificate is issued by
+ * the time the call returns.
+ */
+export class SimAcmDnsValidationCompleter {
+  private readonly certificates: ReadonlyMap<SimArn, SimAcmCertificate>;
+  private readonly validation: SimAcmCertificateValidation;
+  private readonly dnsRecords: SimAcmDnsRecords | undefined;
+
+  constructor(properties: SimAcmDnsValidationCompleterProperties) {
+    this.certificates = properties.certificates;
+    this.validation = properties.validation;
+    this.dnsRecords = properties.dnsRecords;
+  }
+
+  /**
+   * Publish the validation records for a Certificate and wait for issuance.
+   */
+  async complete(certificateArn: string | undefined): Promise<void> {
+    const certificate = this.findCertificate(certificateArn);
+    const uncreatedRecordNames = this.createValidationRecords(certificate);
+
+    await this.validation.settle(certificate);
+
+    if (certificate.status === "ISSUED") {
+      return;
+    }
+
+    throw new SimAcmDnsValidationFailed(
+      `Cannot complete DNS validation of sim ACM Certificate ${certificate.certificateArn}: ` +
+        `no sim Route53 Hosted Zone covers ${uncreatedRecordNames.join(", ")}`,
+    );
+  }
+
+  /**
+   * Resolve the Certificate this ARN refers to.
+   */
+  private findCertificate(
+    certificateArn: string | undefined,
+  ): SimAcmCertificate {
+    if (certificateArn === undefined) {
+      throw new SimAcmInvalidArgumentsException(
+        "SimAcm.completeDnsValidation requires a CertificateArn",
+      );
+    }
+
+    const certificate = this.certificates.get(certificateArn as SimArn);
+
+    if (certificate === undefined) {
+      throw new SimAcmResourceNotFoundException(
+        `No sim ACM Certificate found with ARN ${certificateArn}`,
+      );
+    }
+
+    return certificate;
+  }
+
+  /**
+   * Create each validation record, reporting the names that had nowhere to go.
+   */
+  private createValidationRecords(
+    certificate: SimAcmCertificate,
+  ): readonly string[] {
+    const dnsRecords = this.dnsRecords;
+
+    if (dnsRecords === undefined) {
+      return [];
+    }
+
+    const uncreatedRecordNames: string[] = [];
+
+    for (const domainValidation of certificate.domainValidationOptions) {
+      const resourceRecord = domainValidation.resourceRecord;
+
+      if (resourceRecord === undefined) {
+        continue;
+      }
+
+      if (!dnsRecords.createCname(resourceRecord.name, resourceRecord.value)) {
+        uncreatedRecordNames.push(resourceRecord.name);
+      }
+    }
+
+    return uncreatedRecordNames;
+  }
+}

--- a/src/service/acm/validation/sim-acm-dns-validation-mode.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation-mode.ts
@@ -1,0 +1,52 @@
+type SimAcmDnsValidationModeName = "always" | "auto" | "never";
+
+/**
+ * When sim ACM requires a DNS validation record before issuing a Certificate.
+ *
+ * The default is `auto`, which requires validation only for domain names the
+ * simulation actually holds DNS authority for. That keeps sim ACM realistic
+ * for users who are simulating Route53, without obstructing users whose DNS
+ * lives outside the simulation entirely.
+ */
+export class SimAcmDnsValidationMode {
+  private constructor(private readonly name: SimAcmDnsValidationModeName) {}
+
+  /**
+   * Require validation only where a Hosted Zone covers the domain name.
+   */
+  static auto(): SimAcmDnsValidationMode {
+    return new SimAcmDnsValidationMode("auto");
+  }
+
+  /**
+   * Always require validation, whether or not a Hosted Zone covers the domain.
+   */
+  static always(): SimAcmDnsValidationMode {
+    return new SimAcmDnsValidationMode("always");
+  }
+
+  /**
+   * Never require validation.
+   */
+  static never(): SimAcmDnsValidationMode {
+    return new SimAcmDnsValidationMode("never");
+  }
+
+  /**
+   * Whether a domain name needs its DNS validation record before the
+   * Certificate can be issued.
+   */
+  requiresValidation(hasDnsAuthority: boolean): boolean {
+    switch (this.name) {
+      case "always": {
+        return true;
+      }
+      case "never": {
+        return false;
+      }
+      case "auto": {
+        return hasDnsAuthority;
+      }
+    }
+  }
+}

--- a/src/service/acm/validation/sim-acm-dns-validation-overrides.iso.test.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation-overrides.iso.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimAcm } from "../sim-acm.js";
+import {
+  SimAcmDnsValidationFailed,
+  SimAcmInvalidArgumentsException,
+  SimAcmResourceNotFoundException,
+} from "../error/sim-acm.error.js";
+import {
+  certificateStatus,
+  createHostedZone,
+} from "./sim-acm-dns-validation.fixture.js";
+
+describe("Sim ACM DNS validation overrides", () => {
+  it("issues certificates without validation when auto issue is set", async () => {
+    // Given ACM told to issue certificates without validating them.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test");
+    simAws.acm().autoIssueCertificates();
+
+    // When a certificate is requested in the covered domain.
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the covering hosted zone is ignored and it is issued.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("requires validation with no hosted zone when always is set", async () => {
+    // Given ACM told to always require DNS validation.
+    const simAws = new SimAws();
+    simAws.acm().requireDnsValidation();
+
+    // When a certificate is requested with no hosted zone anywhere.
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then it waits for a validation record that nothing can publish.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+  });
+
+  it("reports the record that could not be published", async () => {
+    // Given a certificate that always requires validation, with no zone.
+    const simAws = new SimAws();
+    simAws.acm().requireDnsValidation();
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+    const certificateArn = requestOutput.CertificateArn;
+    assertNonNullable(certificateArn);
+
+    // When DNS validation is completed for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.acm().completeDnsValidation(certificateArn);
+    });
+
+    // Then the error names the record with nowhere to go.
+    assertInstanceOf(error, SimAcmDnsValidationFailed);
+    assertStringIncludes(error.message, "no sim Route53 Hosted Zone covers");
+    assertStringIncludes(error.message, "_yulin-acm-");
+  });
+
+  it("completes DNS validation for a pending certificate", async () => {
+    // Given a certificate pending validation in a covered domain.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test");
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+    assertNonNullable(requestOutput.CertificateArn);
+
+    // When DNS validation is completed for it.
+    await simAws.acm().completeDnsValidation(requestOutput.CertificateArn);
+
+    // Then the certificate is issued by the time the call returns.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("completes DNS validation on a standalone SimAcm with no Route53", async () => {
+    // Given a certificate on standalone ACM, with no simulated DNS.
+    const simAcm = new SimAcm();
+    const requestOutput = await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "api.example.test" }),
+    );
+    const certificateArn = requestOutput.CertificateArn;
+    assertNonNullable(certificateArn);
+
+    // When DNS validation is completed for it.
+    await simAcm.completeDnsValidation(certificateArn);
+
+    // Then there was nothing to publish and the certificate is issued.
+    const describeOutput = await simAcm.describeCertificate(
+      new DescribeCertificateCommand({ CertificateArn: certificateArn }),
+    );
+    assertIdentical(describeOutput.Certificate?.Status, "ISSUED");
+  });
+
+  it("completes DNS validation for a certificate with no DNS records", async () => {
+    // Given an EMAIL validated certificate, which asks for no DNS record.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test");
+    const requestOutput = await simAws.acm().requestCertificate(
+      new RequestCertificateCommand({
+        DomainName: "api.example.test",
+        ValidationMethod: "EMAIL",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    const certificateArn = requestOutput.CertificateArn;
+    assertNonNullable(certificateArn);
+
+    // When DNS validation is completed for it.
+    await simAws.acm().completeDnsValidation(certificateArn);
+
+    // Then it stays issued, with no records published on its behalf.
+    assertIdentical(await certificateStatus(simAws, certificateArn), "ISSUED");
+  });
+
+  it("throws completing DNS validation for an unknown certificate", async () => {
+    // Given ACM with no certificates.
+    const simAws = new SimAws();
+
+    // When DNS validation is completed for an ARN that does not exist.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .acm()
+        .completeDnsValidation(
+          "arn:aws:acm:us-east-1:111111111111:certificate/00000001",
+        );
+    });
+
+    // Then it reports the certificate as not found.
+    assertInstanceOf(error, SimAcmResourceNotFoundException);
+  });
+
+  it("throws completing DNS validation with no certificate ARN", async () => {
+    // Given ACM.
+    const simAws = new SimAws();
+
+    // When DNS validation is completed without an ARN.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.acm().completeDnsValidation(undefined);
+    });
+
+    // Then it reports the missing argument.
+    assertInstanceOf(error, SimAcmInvalidArgumentsException);
+  });
+});

--- a/src/service/acm/validation/sim-acm-dns-validation-overrides.iso.test.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation-overrides.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
+  assertThrowsError,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import {
@@ -166,6 +167,17 @@ describe("Sim ACM DNS validation overrides", () => {
 
     // Then it reports the certificate as not found.
     assertInstanceOf(error, SimAcmResourceNotFoundException);
+  });
+
+  it("rejects requiring DNS validation with no sim Route53", () => {
+    // Given standalone ACM, with no simulated DNS anywhere.
+    const simAcm = new SimAcm();
+
+    // When DNS validation is required.
+    const error = assertThrowsError(() => simAcm.requireDnsValidation());
+
+    // Then it explains that nothing could ever satisfy it.
+    assertStringIncludes(error.message, "no sim Route53 to validate against");
   });
 
   it("throws completing DNS validation with no certificate ARN", async () => {

--- a/src/service/acm/validation/sim-acm-dns-validation.fixture.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation.fixture.ts
@@ -1,0 +1,119 @@
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../aws/sim-aws.js";
+
+interface ValidationRecord {
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * Test support for the sim ACM DNS validation flow.
+ *
+ * These helpers drive the simulator through structural command shapes rather
+ * than real SDK command objects, because this is source rather than a test
+ * file. The colocated tests cover SDK-shaped input.
+ */
+
+/**
+ * Create a Hosted Zone, optionally owned by another simulated Account.
+ */
+export async function createHostedZone(
+  simAws: SimAws,
+  name: string,
+  accountId?: string,
+): Promise<string> {
+  const output = await simAws
+    .account(accountId)
+    .route53()
+    .createHostedZone({ input: { Name: name, CallerReference: name } });
+
+  assertNonNullable(output.HostedZone?.Id);
+
+  return output.HostedZone.Id;
+}
+
+/**
+ * Read the current status of a Certificate.
+ */
+export async function certificateStatus(
+  simAws: SimAws,
+  certificateArn: string | undefined,
+): Promise<string | undefined> {
+  const output = await simAws
+    .acm()
+    .describeCertificate({ input: { CertificateArn: certificateArn } });
+
+  return output.Certificate?.Status;
+}
+
+/**
+ * Read the per-domain validation statuses of a Certificate, in order.
+ */
+export async function domainValidationStatuses(
+  simAws: SimAws,
+  certificateArn: string | undefined,
+): Promise<readonly (string | undefined)[]> {
+  const output = await simAws
+    .acm()
+    .describeCertificate({ input: { CertificateArn: certificateArn } });
+  const validations = output.Certificate?.DomainValidationOptions;
+
+  assertNonNullable(validations);
+
+  return validations.map((validation) => validation.ValidationStatus);
+}
+
+/**
+ * Read the DNS validation records ACM is waiting for, in domain order.
+ */
+export async function validationRecords(
+  simAws: SimAws,
+  certificateArn: string | undefined,
+): Promise<readonly ValidationRecord[]> {
+  const output = await simAws
+    .acm()
+    .describeCertificate({ input: { CertificateArn: certificateArn } });
+  const validations = output.Certificate?.DomainValidationOptions;
+
+  assertNonNullable(validations);
+
+  return validations.map((validation) => {
+    const resourceRecord = validation.ResourceRecord;
+    assertNonNullable(resourceRecord?.Name);
+    assertNonNullable(resourceRecord.Value);
+
+    return { name: resourceRecord.Name, value: resourceRecord.Value };
+  });
+}
+
+/**
+ * Publish one CNAME into a Hosted Zone through the Route53 command path.
+ */
+export async function publishCname(
+  simAws: SimAws,
+  hostedZoneId: string,
+  record: ValidationRecord,
+  value = record.value,
+): Promise<void> {
+  await simAws.route53().changeResourceRecordSets({
+    input: {
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: record.name,
+              Type: "CNAME",
+              TTL: 300,
+              ResourceRecords: [{ Value: value }],
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await simAws.backgroundTasksComplete();
+}

--- a/src/service/acm/validation/sim-acm-dns-validation.iso.test.ts
+++ b/src/service/acm/validation/sim-acm-dns-validation.iso.test.ts
@@ -1,0 +1,253 @@
+import { describe, it } from "vitest";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import {
+  DescribeCertificateCommand,
+  RequestCertificateCommand,
+} from "@aws-sdk/client-acm";
+import { CreateHostedZoneCommand } from "@aws-sdk/client-route-53";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimAcm } from "../sim-acm.js";
+import { BackgroundTasks } from "../../../util/background/background.js";
+import {
+  certificateStatus,
+  createHostedZone,
+  domainValidationStatuses,
+  publishCname,
+  validationRecords,
+} from "./sim-acm-dns-validation.fixture.js";
+
+describe("Sim ACM DNS validation against sim Route53", () => {
+  it("issues a certificate immediately when no hosted zone covers the domain", async () => {
+    // Given a simulated AWS with no hosted zones at all.
+    const simAws = new SimAws();
+
+    // When a certificate is requested and background work drains.
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing in the simulation is authoritative, so it is issued.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("holds a certificate pending when a hosted zone covers the domain", async () => {
+    // Given a hosted zone covering the certificate domain.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test");
+
+    // When a certificate is requested and background work drains.
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then it waits for its validation record.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+  });
+
+  it("issues the certificate once its validation record is published", async () => {
+    // Given a pending certificate in a covered domain.
+    const simAws = new SimAws();
+    const hostedZoneId = await createHostedZone(simAws, "example.test");
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // When the validation CNAME is published in the hosted zone.
+    const [record] = await validationRecords(
+      simAws,
+      requestOutput.CertificateArn,
+    );
+    assertNonNullable(record);
+    await publishCname(simAws, hostedZoneId, record);
+
+    // Then the certificate is issued.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("keeps the certificate pending when the record value does not match", async () => {
+    // Given a pending certificate in a covered domain.
+    const simAws = new SimAws();
+    const hostedZoneId = await createHostedZone(simAws, "example.test");
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // When a CNAME with the right name but the wrong value is published.
+    const [record] = await validationRecords(
+      simAws,
+      requestOutput.CertificateArn,
+    );
+    assertNonNullable(record);
+    await publishCname(
+      simAws,
+      hostedZoneId,
+      record,
+      "wrong.acm-validations.aws.",
+    );
+
+    // Then the certificate is still waiting.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+  });
+
+  it("issues a multi-domain certificate only once every domain is validated", async () => {
+    // Given a pending certificate with a subject alternative name.
+    const simAws = new SimAws();
+    const hostedZoneId = await createHostedZone(simAws, "example.test");
+    const requestOutput = await simAws.acm().requestCertificate(
+      new RequestCertificateCommand({
+        DomainName: "api.example.test",
+        SubjectAlternativeNames: ["www.example.test"],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const [firstRecord, secondRecord] = await validationRecords(
+      simAws,
+      requestOutput.CertificateArn,
+    );
+    assertNonNullable(firstRecord);
+    assertNonNullable(secondRecord);
+
+    // When only the first domain's record is published.
+    await publishCname(simAws, hostedZoneId, firstRecord);
+
+    // Then the certificate is still pending, with per-domain statuses shown.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+    const partialStatuses = await domainValidationStatuses(
+      simAws,
+      requestOutput.CertificateArn,
+    );
+    assertIdentical(partialStatuses[0], "SUCCESS");
+    assertIdentical(partialStatuses[1], "PENDING_VALIDATION");
+
+    // When the remaining record is published.
+    await publishCname(simAws, hostedZoneId, secondRecord);
+
+    // Then the certificate is issued.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("validates against a hosted zone in another simulated account", async () => {
+    // Given a hosted zone owned by a different simulated account.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test", "222222222222");
+
+    // When a certificate is requested in the default account.
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then it waits, because ACM validates against DNS wherever it is hosted.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+
+    // And publishing the record in that other account's zone issues it.
+    await simAws.acm().completeDnsValidation(requestOutput.CertificateArn);
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("issues certificates from a standalone SimAcm with no Route53", async () => {
+    // Given ACM on its own, with no simulated DNS anywhere.
+    const background = new BackgroundTasks();
+    const simAcm = new SimAcm({ background });
+
+    // When a certificate is requested and background work drains.
+    const requestOutput = await simAcm.requestCertificate(
+      new RequestCertificateCommand({ DomainName: "api.example.test" }),
+    );
+    await background.complete();
+
+    // Then it is issued, because there is no DNS to validate against.
+    const describeOutput = await simAcm.describeCertificate(
+      new DescribeCertificateCommand({
+        CertificateArn: requestOutput.CertificateArn,
+      }),
+    );
+    assertIdentical(describeOutput.Certificate?.Status, "ISSUED");
+  });
+
+  it("issues an EMAIL validated certificate without any DNS record", async () => {
+    // Given a hosted zone covering the domain.
+    const simAws = new SimAws();
+    await createHostedZone(simAws, "example.test");
+
+    // When an EMAIL validated certificate is requested.
+    const requestOutput = await simAws.acm().requestCertificate(
+      new RequestCertificateCommand({
+        DomainName: "api.example.test",
+        ValidationMethod: "EMAIL",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it is issued, because EMAIL validation is not simulated through DNS.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "ISSUED",
+    );
+  });
+
+  it("waits for a hosted zone created after the certificate was requested", async () => {
+    // Given a certificate requested before any hosted zone exists.
+    const simAws = new SimAws();
+    const requestOutput = await simAws
+      .acm()
+      .requestCertificate(
+        new RequestCertificateCommand({ DomainName: "api.example.test" }),
+      );
+
+    // When a covering hosted zone is created before background work drains.
+    await simAws.route53().createHostedZone(
+      new CreateHostedZoneCommand({
+        Name: "example.test",
+        CallerReference: "late-zone",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the certificate waits for validation in that zone.
+    assertIdentical(
+      await certificateStatus(simAws, requestOutput.CertificateArn),
+      "PENDING_VALIDATION",
+    );
+  });
+});

--- a/src/service/acm/validation/sim-route53-acm-dns-records.ts
+++ b/src/service/acm/validation/sim-route53-acm-dns-records.ts
@@ -1,0 +1,96 @@
+import { normaliseSimRoute53Name } from "../../route53/local-name/sim-route53-local-name.js";
+import type { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
+import { SimRoute53HostedZoneRecordFinder } from "../../route53/resolve/sim-r53-zone-record-finder.js";
+import type {
+  SimAcmDnsRecordChangeListener,
+  SimAcmDnsRecords,
+} from "./sim-acm-dns-records.js";
+
+const validationRecordTtl = 300;
+
+interface SimRoute53AcmDnsRecordsProperties {
+  readonly route53Registry: SimRoute53Registry;
+}
+
+/**
+ * Sim Route53 as the DNS sim ACM validates Certificates against.
+ *
+ * All of the DNS name handling lives here rather than in ACM: Route53 stores
+ * record names and values normalised, so comparisons have to be normalised the
+ * same way for a trailing dot not to look like a mismatch.
+ *
+ * The registry spans simulated Accounts, which matches real ACM validating
+ * against public DNS. A Certificate in one Account can be validated by a
+ * Hosted Zone in another.
+ */
+export class SimRoute53AcmDnsRecords implements SimAcmDnsRecords {
+  private readonly route53Registry: SimRoute53Registry;
+
+  constructor(properties: SimRoute53AcmDnsRecordsProperties) {
+    this.route53Registry = properties.route53Registry;
+  }
+
+  /**
+   * Whether any Hosted Zone covers this domain name.
+   */
+  hasAuthorityFor(domainName: string): boolean {
+    return (
+      this.recordFinder().findZone(normaliseSimRoute53Name(domainName)) !==
+      undefined
+    );
+  }
+
+  /**
+   * Whether a CNAME with this name resolves to this value.
+   */
+  hasCname(name: string, value: string): boolean {
+    const record = this.recordFinder().findRecord(
+      normaliseSimRoute53Name(name),
+      "CNAME",
+    );
+
+    if (record === undefined) {
+      return false;
+    }
+
+    return record.values.includes(normaliseSimRoute53Name(value));
+  }
+
+  /**
+   * Create a CNAME in the Hosted Zone covering its name.
+   */
+  createCname(name: string, value: string): boolean {
+    const normalisedName = normaliseSimRoute53Name(name);
+    const hostedZone = this.recordFinder().findZone(normalisedName);
+
+    if (hostedZone === undefined) {
+      return false;
+    }
+
+    hostedZone.records.upsert({
+      name: normalisedName,
+      type: "CNAME",
+      values: [value],
+      ttl: validationRecordTtl,
+    });
+
+    return true;
+  }
+
+  /**
+   * Watch every registered Hosted Zone for record changes.
+   */
+  onRecordChange(listener: SimAcmDnsRecordChangeListener): void {
+    this.route53Registry.onRecordChange(listener);
+  }
+
+  /**
+   * Hosted zones are registered over time, so the finder is built per lookup
+   * rather than held, to always see the current set of zones.
+   */
+  private recordFinder(): SimRoute53HostedZoneRecordFinder {
+    return new SimRoute53HostedZoneRecordFinder(
+      this.route53Registry.hostedZones,
+    );
+  }
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -13,6 +13,7 @@ import { SimS3 } from "../../s3/sim-s3.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
 import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
 import { SimAcm } from "../../acm/sim-acm.js";
+import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
@@ -102,6 +103,11 @@ export class SimAwsServiceFactory {
       accountRegionScope: scope.accountRegionScope,
       iam,
       background: this.background,
+      // Certificates validate against Hosted Zones from any simulated Account,
+      // as real ACM validates against public DNS.
+      dnsRecords: new SimRoute53AcmDnsRecords({
+        route53Registry: this.route53Registry,
+      }),
     });
   }
 

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -150,6 +150,13 @@ The record store supports three mutation modes:
 - `upsert()` creates or replaces a name/type record
 - `delete()` removes by name/type and is tolerant of missing records
 
+The store also notifies listeners registered through `onChange()` after every mutation.
+`SimRoute53Registry` subscribes each hosted zone as it is registered and re-broadcasts through its
+own `onRecordChange()`, so other simulated services can watch DNS across every account without
+holding a reference to individual zones. Sim ACM uses this to validate certificates when their
+validation record appears. Pushing changes this way rather than having watchers poll is what keeps
+background task draining terminating.
+
 Reads are `get()` for one name/type pair and `list()` for the whole zone. Both return copies, so
 callers cannot mutate hosted-zone state through a returned record. `list()` returns records in map
 insertion order rather than DNS order, because the store is a lookup structure; callers that need
@@ -281,6 +288,11 @@ then a lookup for `www.sub.example.test` prefers records from `sub.example.test`
 This is an important Route53-like behaviour. It lets tests model overlapping hosted zones without
 requiring a global DNS tree. The implementation remains simple because hosted zones are still just
 entries in a map; most-specific selection is applied only during record lookup.
+
+`findZone()` answers the related but distinct question of which hosted zone covers a name at all,
+regardless of the records it currently holds. That is what a caller needs to decide where a new
+record should be written, or to establish that nothing in the simulation could ever answer for a
+name. Sim ACM uses it for both.
 
 ## CloudFormation support
 

--- a/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
+++ b/src/service/route53/hosted-zone/sim-route53-hosted-zone-records.ts
@@ -4,12 +4,15 @@ import type {
   SimRoute53RecordType,
 } from "../record/sim-route53-record.js";
 
+export type SimRoute53RecordChangeListener = () => void;
+
 /**
  * Stores and normalises records for a simulated Route53 Hosted Zone.
  * @internal
  */
 export class SimRoute53HostedZoneRecords {
   private readonly records = new Map<string, SimRoute53Record>();
+  private readonly changeListeners = new Set<SimRoute53RecordChangeListener>();
 
   /**
    * Current number of records in the hosted zone.
@@ -35,6 +38,7 @@ export class SimRoute53HostedZoneRecords {
     }
 
     this.records.set(key, normalisedRecord);
+    this.notifyChange();
   }
 
   /**
@@ -48,6 +52,7 @@ export class SimRoute53HostedZoneRecords {
       recordKey(normalisedRecord.name, normalisedRecord.type),
       normalisedRecord,
     );
+    this.notifyChange();
   }
 
   /**
@@ -56,6 +61,18 @@ export class SimRoute53HostedZoneRecords {
    */
   delete(name: string, type: SimRoute53RecordType): void {
     this.records.delete(recordKey(normaliseSimRoute53Name(name), type));
+    this.notifyChange();
+  }
+
+  /**
+   * Register a listener called whenever a record in this hosted zone changes.
+   *
+   * Other simulated services observe DNS this way rather than polling for it,
+   * which keeps background task draining deterministic.
+   * @internal
+   */
+  onChange(listener: SimRoute53RecordChangeListener): void {
+    this.changeListeners.add(listener);
   }
 
   /**
@@ -87,6 +104,12 @@ export class SimRoute53HostedZoneRecords {
       .values()
       .map((record) => copyRecord(record))
       .toArray();
+  }
+
+  private notifyChange(): void {
+    for (const listener of this.changeListeners) {
+      listener();
+    }
   }
 }
 

--- a/src/service/route53/registry/sim-route53-registry.ts
+++ b/src/service/route53/registry/sim-route53-registry.ts
@@ -1,5 +1,6 @@
 import type { SimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
 import type { SimRoute53HostedZone } from "../hosted-zone/sim-route53-hosted-zone.js";
+import type { SimRoute53RecordChangeListener } from "../hosted-zone/sim-route53-hosted-zone-records.js";
 
 /**
  * Simulated Route53 DNS registry across Account scopes.
@@ -15,6 +16,9 @@ export class SimRoute53Registry {
     SimRoute53HostedZone
   >();
 
+  private readonly recordChangeListeners =
+    new Set<SimRoute53RecordChangeListener>();
+
   /**
    * Register a Hosted Zone for global DNS-style resolution.
    */
@@ -23,6 +27,20 @@ export class SimRoute53Registry {
     hostedZone: SimRoute53HostedZone,
   ): void {
     this.hostedZonesById.set(hostedZoneId, hostedZone);
+    hostedZone.records.onChange(() => {
+      this.notifyRecordChange();
+    });
+  }
+
+  /**
+   * Register a listener called whenever a record changes in any registered
+   * Hosted Zone.
+   *
+   * Hosted zones come and go while other simulated services are already
+   * watching DNS, so listeners subscribe here rather than to one zone.
+   */
+  onRecordChange(listener: SimRoute53RecordChangeListener): void {
+    this.recordChangeListeners.add(listener);
   }
 
   /**
@@ -30,5 +48,11 @@ export class SimRoute53Registry {
    */
   get hostedZones(): ReadonlyMap<SimRoute53HostedZoneId, SimRoute53HostedZone> {
     return this.hostedZonesById;
+  }
+
+  private notifyRecordChange(): void {
+    for (const listener of this.recordChangeListeners) {
+      listener();
+    }
   }
 }

--- a/src/service/route53/resolve/sim-r53-zone-record-finder.ts
+++ b/src/service/route53/resolve/sim-r53-zone-record-finder.ts
@@ -41,6 +41,34 @@ export class SimRoute53HostedZoneRecordFinder {
     return bestRecord;
   }
 
+  /**
+   * Find the most-specific hosted zone whose name covers a record name.
+   *
+   * This answers whether the simulation is authoritative for a name at all,
+   * regardless of which records the zone currently holds, so it is the right
+   * lookup for creating a record or for deciding that nothing here could ever
+   * answer for a name.
+   */
+  findZone(name: string): SimRoute53HostedZone | undefined {
+    let bestHostedZone: SimRoute53HostedZone | undefined;
+    let bestZoneNameLength = -1;
+
+    for (const hostedZone of this.hostedZones.values()) {
+      const zoneName = this.zoneName(hostedZone);
+
+      if (!this.zoneContainsName(zoneName, name)) {
+        continue;
+      }
+
+      if (zoneName.length > bestZoneNameLength) {
+        bestHostedZone = hostedZone;
+        bestZoneNameLength = zoneName.length;
+      }
+    }
+
+    return bestHostedZone;
+  }
+
   private zoneName(hostedZone: SimRoute53HostedZone): string {
     return hostedZone.name.replaceAll(/\.+$/g, "");
   }


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS-based certificate validation using simulated Route53 hosted zones.
  * Certificates now report validation status for each domain and remain pending until required records are available.
  * Added shortcuts to complete DNS validation and controls for automatic or required validation.
  * Added examples demonstrating manual and one-step DNS validation workflows.

* **Documentation**
  * Expanded ACM and Route53 documentation with validation workflows, behavior details, and known limitations.

* **Bug Fixes**
  * Corrected per-domain validation statuses returned by certificate descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->