### PR TITLE
feat: sim Lambda handler env var isolation

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -489,9 +489,13 @@ The same applies to zip-packaged code in the vm runtime and to functions deploye
 `AWS::Lambda::Function` template with an `Environment` property, including ones backed by an
 [executable binding](#executable-bindings).
 
-As on real AWS, the environment variable names Lambda reserves for the runtime (`AWS_REGION`,
-`AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be declared, and are rejected with
-`InvalidParameterValueException`.
+Variable names are validated as on real AWS. A name must match the Lambda name pattern
+`[a-zA-Z]([a-zA-Z0-9_])+` — starting with a letter, at least two characters, and otherwise letters,
+digits and underscores — or it is rejected with `ValidationException`. The names Lambda reserves
+for the runtime (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be
+declared, and are rejected with `InvalidParameterValueException`. As on AWS, the pattern is checked
+first, so a reserved name that also breaks it, such as `_HANDLER`, is reported as the constraint
+violation.
 
 ### Read environment variables inside the handler
 

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -26,6 +26,8 @@ Sim Lambda currently supports:
 - A Node.js `vm` runtime for zip-packaged code: warm module state across invocations, relative
   requires between archived files, Node.js built-in modules, and AWS-like runtime environment
   variables
+- Per-function environment variables with `Environment.Variables`, isolated from the host process
+  and from other functions
 - Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated
   AWS environment
 - Execution roles: handlers run as their execution `Role`, evaluated against simulated IAM
@@ -427,6 +429,100 @@ console.log(dryRunOutput.StatusCode);
 `Event` invocation handler errors are dropped, as sim Lambda does not simulate asynchronous
 retries or failure destinations yet.
 
+## Environment variables
+
+A function can declare its own environment variables with `Environment.Variables`, as on real
+Lambda. While the function runs, its code reads those variables from `process.env`, alongside the
+AWS-provided runtime variables (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, and the rest).
+
+```typescript sim-lambda-environment-variables
+/**
+ * Giving a simulated Lambda function its own environment variables, read by
+ * a real in-process handler function.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "greeter",
+    Role: "arn:aws:iam::111111111111:role/GreeterRole",
+    Environment: {
+      Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { name: string }) => ({
+        // Read inside the handler, so this sees the function's own
+        // variables rather than the ones the test process happens to have.
+        message: `${process.env["GREETING"] ?? "Hi"} ${event.name}`,
+        tableName: process.env["TABLE_NAME"],
+        region: process.env["AWS_REGION"],
+      })),
+    },
+  }),
+);
+
+const invokeOutput = await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "greeter",
+    Payload: JSON.stringify({ name: "Yulin" }),
+  }),
+);
+
+if (invokeOutput.Payload === undefined) throw new Error("No invoke Payload");
+// {"message":"Hello Yulin","tableName":"widgets","region":"eu-west-2"}
+console.log(Buffer.from(invokeOutput.Payload).toString());
+```
+
+Each function gets only the variables it declares. Variables that happen to be set in the process
+running your tests are not visible to it, so a function cannot accidentally pass because your
+shell or CI environment had the right variable set. Two functions declaring the same variable name
+with different values each see their own, including when their invocations overlap.
+
+The same applies to zip-packaged code in the vm runtime and to functions deployed from an
+`AWS::Lambda::Function` template with an `Environment` property, including ones backed by an
+[executable binding](#executable-bindings).
+
+As on real AWS, the environment variable names Lambda reserves for the runtime (`AWS_REGION`,
+`AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be declared, and are rejected with
+`InvalidParameterValueException`.
+
+### Read environment variables inside the handler
+
+There is one thing to know about functions backed by a real in-process handler function. Because
+that handler is an ordinary function in your test process rather than code loaded into a sandbox,
+it only gets the function's own `process.env` while it is actually running.
+
+That means a variable read at module scope is read too early:
+
+```typescript
+// Evaluated when your test file imports this module, before any invocation,
+// so it sees the test process's environment, not the function's.
+const TABLE_NAME = process.env.TABLE_NAME;
+
+export const handler = async () => {
+  // Read during the invocation, so this sees the function's own value.
+  return { tableName: process.env.TABLE_NAME };
+};
+```
+
+Moving the read inside the handler is the fix, and is worth doing anyway for testability. Zip
+code in the vm runtime is unaffected, because it is imported at cold start, during an invocation.
+
+In practice this often does not come up: test suites commonly export the same variables they
+configure their functions with, and then a module-scope read gets the right value regardless. Sim
+Lambda warns on the console when that is not the case, in the two situations where the difference
+actually changes what your code sees:
+
+- a declared variable whose name the host process also sets, with a different value
+- two simulated functions declaring the same variable name with different values
+
 ## CloudFormation functions
 
 Sim CloudFormation can create Lambda functions from `AWS::Lambda::Function`, typically alongside a
@@ -606,7 +702,9 @@ Current documented limitations:
   syntax) is not supported yet.
 - Container image functions (`Code.ImageUri`) are not supported — the simulator stays Docker-free.
 - Lambda Layers are not simulated.
-- Environment variable configuration (`Environment.Variables`) is not applied.
+- Environment variables declared with `Environment.Variables` reach a real in-process handler
+  function only while it runs, so a variable read at module scope sees the host process value
+  instead. See [Environment variables](#environment-variables).
 - `Timeout` is recorded but does not interrupt handler execution.
 - `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.

--- a/docs/services/lambda/sim-lambda-environment-variables.example.ts
+++ b/docs/services/lambda/sim-lambda-environment-variables.example.ts
@@ -1,0 +1,42 @@
+/**
+ * Giving a simulated Lambda function its own environment variables, read by
+ * a real in-process handler function.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "greeter",
+    Role: "arn:aws:iam::111111111111:role/GreeterRole",
+    Environment: {
+      Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+    },
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: { name: string }) => ({
+        // Read inside the handler, so this sees the function's own
+        // variables rather than the ones the test process happens to have.
+        message: `${process.env["GREETING"] ?? "Hi"} ${event.name}`,
+        tableName: process.env["TABLE_NAME"],
+        region: process.env["AWS_REGION"],
+      })),
+    },
+  }),
+);
+
+const invokeOutput = await lambda.invoke(
+  new InvokeCommand({
+    FunctionName: "greeter",
+    Payload: JSON.stringify({ name: "Yulin" }),
+  }),
+);
+
+if (invokeOutput.Payload === undefined) throw new Error("No invoke Payload");
+// {"message":"Hello Yulin","tableName":"widgets","region":"eu-west-2"}
+console.log(Buffer.from(invokeOutput.Payload).toString());

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -288,6 +288,9 @@ export default defineConfig(
     rules: {
       "no-console": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
+      // Examples model real AWS-shaped data, such as UPPER_SNAKE_CASE Lambda
+      // environment variable names, rather than code identifier names.
+      "@typescript-eslint/naming-convention": "off",
     },
   },
 

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -114,8 +114,9 @@ Import and handler problems surface as invocation errors with the real runtime e
 archived files, Node.js built-ins from the host (as the real runtime provides them), and a minimal
 `node_modules` lookup for dependencies bundled into the archive. The `Handler` string selects the
 module and export (`index.handler`, `src/app.handler`). ES module source is not supported yet and
-fails with a clear hint. The sandbox exposes common globals and an AWS-like `process.env` with the
-standard runtime variables.
+fails with a clear hint. The sandbox exposes common globals and an AWS-like `process.env` holding
+the standard runtime variables and any declared for the function (see "Environment variables"
+below).
 
 ### Runtime-provided AWS SDK
 
@@ -161,6 +162,34 @@ callback, or using the legacy context `done`/`fail`/`succeed` methods.
   `BackgroundScheduler`; handler errors are dropped (failure destinations are not simulated yet).
 - `DryRun`: returns `204` without invoking the handler.
 
+### Environment variables
+
+`function/environment/` owns what a function runs with. `SimLambdaEnvironment` merges the
+AWS-provided runtime variables with the ones declared through `Environment.Variables`, and is built
+at creation time because vm zip code takes it into its sandbox. The reserved names real Lambda
+refuses to let function configuration override are rejected at CreateFunction
+(`command/create-function/create-function-environment.ts`), so the two sets can never collide.
+
+Zip code needs nothing special: the vm context already owns its `process` object. A function backed
+by a real in-process handler is the harder case, because that handler is a closure over its own
+module scope and reads the host `process.env` like any other code in the test run.
+`sim-lambda-process-env.ts` bridges that with `AsyncLocalStorage`: `process.env` is a plain
+configurable data property on `process`, so it is redefined once as a getter that resolves to the
+current invocation's variables while one is set, and to the untouched host environment object
+otherwise. The store follows the invocation across `await` points and keeps concurrent invocations
+apart, which swapping and restoring `process.env` around the handler call could not.
+
+This is the only place the simulator patches a process global, so it is deliberately narrow. The
+patch is only installed when a function actually declares variables, it is inert whenever no
+invocation is running, and it is never removed, since removing it would be unsafe while another
+invocation is in flight and buys nothing.
+
+The limitation it cannot reach is a read that already happened: a handler module doing
+`const TABLE = process.env.TABLE_NAME` at module scope is evaluated when the test file imports it,
+before any invocation. `SimLambdaEnvironmentConflicts` warns about that in the two cases where it
+changes what the code sees, and stays quiet otherwise (see the usage docs section on reading
+environment variables inside the handler).
+
 ### Execution role
 
 Creating a function requires an execution `Role` ARN, as on real AWS. While a handler runs,
@@ -191,8 +220,9 @@ reachable afterwards through `simAws.lambda()` and invokable via the SDK `Invoke
 
 Supported `AWS::Lambda::Function` properties: `FunctionName` (defaults to the logical ID), `Role`
 (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`), `Code`, `Handler`, `Runtime`,
-`Description`, `Timeout`, and `MemorySize`. Malformed property values fail AWS-style with a
-`TypeError` naming the property and logical ID.
+`Description`, `Timeout`, `MemorySize`, and `Environment`. Malformed property values fail AWS-style
+with a `TypeError` naming the property and logical ID, down to the individual variable for
+`Environment.Variables`.
 
 Template `Code` supports two source forms:
 
@@ -233,6 +263,7 @@ are not supported and are skipped by the CloudFormation engine with an "Unsuppor
 - container image functions (`Code.ImageUri`) — the simulator stays Docker-free
 - `UpdateFunctionCode`, versions, aliases and qualifiers
 - Lambda Layers
-- environment variable configuration (`Environment.Variables`)
+- environment variables reaching a real in-process handler's module scope (see "Environment
+  variables" above)
 - timeouts interrupting handler execution
 - asynchronous invocation retries and failure destinations

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -166,14 +166,17 @@ callback, or using the legacy context `done`/`fail`/`succeed` methods.
 
 `function/environment/` owns what a function runs with. `SimLambdaEnvironment` merges the
 AWS-provided runtime variables with the ones declared through `Environment.Variables`, and is built
-at creation time because vm zip code takes it into its sandbox. The reserved names real Lambda
-refuses to let function configuration override are rejected at CreateFunction
-(`command/create-function/create-function-environment.ts`), so the two sets can never collide.
+at creation time because vm zip code takes it into its sandbox. Name validation lives at
+CreateFunction (`command/create-function/create-function-environment.ts`) and follows AWS's two
+stages in order: the API name-pattern constraint (`ValidationException`), then the reserved names
+real Lambda refuses to let function configuration override
+(`InvalidParameterValueException`). Rejecting the reserved names means the AWS-provided runtime
+variables and the declared ones can never collide, so neither set needs to win over the other.
 
 Zip code needs nothing special: the vm context already owns its `process` object. A function backed
 by a real in-process handler is the harder case, because that handler is a closure over its own
 module scope and reads the host `process.env` like any other code in the test run.
-`sim-lambda-process-env.ts` bridges that with `AsyncLocalStorage`: `process.env` is a plain
+`sim-lambda-process-environment.ts` bridges that with `AsyncLocalStorage`: `process.env` is a plain
 configurable data property on `process`, so it is redefined once as a getter that resolves to the
 current invocation's variables while one is set, and to the untouched host environment object
 otherwise. The store follows the invocation across `await` points and keeps concurrent invocations

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-environment-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-environment-parser.ts
@@ -1,0 +1,47 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaFunctionEnvironment } from "../../command/create-function/create-function.command.js";
+import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
+
+/**
+ * Parses the nested AWS::Lambda::Function Environment property.
+ *
+ * Its own parser because Environment is the one function property with a
+ * shape of its own rather than a plain scalar: an object holding a map of
+ * variables, each of which has to be checked individually.
+ */
+export class SimCfnLambdaEnvironmentParser {
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+
+  /**
+   * Parse the Environment property into the declared function environment.
+   */
+  parse(
+    resource: SimCfnResource,
+    environment: SimCfnTemplateValue | undefined,
+  ): SimLambdaFunctionEnvironment | undefined {
+    if (environment === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(environment)) {
+      throw this.propertyParser.invalidPropertyError(
+        resource,
+        "Environment",
+        "an object",
+      );
+    }
+
+    const variables = this.propertyParser.optionalStringRecord(
+      resource,
+      environment["Variables"],
+      "Environment.Variables",
+    );
+    if (variables === undefined) {
+      return undefined;
+    }
+
+    return { Variables: variables };
+  }
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-environment.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-environment.iso.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const roleArn = "arn:aws:iam::111111111111:role/GreeterRole";
+
+/**
+ * Deploy a single AWS::Lambda::Function with the given extra properties.
+ */
+async function deployFunction(
+  simAws: SimAws,
+  properties: SimCfnTemplateValueRecord,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "greeter-stack",
+    template: {
+      Resources: {
+        GreeterFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: "greeter",
+            Role: roleArn,
+            Handler: "index.handler",
+            Runtime: "nodejs20.x",
+            ...properties,
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+}
+
+describe("Lambda CloudFormation Function environment", () => {
+  it("gives template code the variables declared in the template", async () => {
+    // Given a template declaring Environment.Variables on the function.
+    const simAws = new SimAws();
+    await deployFunction(simAws, {
+      Code: {
+        ZipFile:
+          "exports.handler = async () => ({" +
+          " greeting: process.env.GREETING," +
+          " tableName: process.env.TABLE_NAME," +
+          " region: process.env.AWS_REGION });",
+      },
+      Environment: {
+        Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+      },
+    });
+
+    // When the deployed function is invoked.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter", Payload: "{}" }));
+
+    // Then the vm runtime gave the code the declared variables alongside the
+    // AWS-provided ones.
+    assertNonNullable(output.Payload);
+    assertObjectEquals(
+      JSON.parse(Buffer.from(output.Payload).toString()) as unknown,
+      {
+        greeting: "Hello",
+        tableName: "widgets",
+        region: simAws.defaultRegionName,
+      },
+    );
+  });
+
+  it("gives a bound in-process handler the template's variables", async () => {
+    // Given a template function backed by a real in-process handler.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: {
+        Resources: {
+          GreeterFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "greeter",
+              Role: roleArn,
+              Environment: { Variables: { TABLE_NAME: "widgets" } },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "GreeterFunction",
+          handler: () => ({ tableName: process.env["TABLE_NAME"] }),
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // When the deployed function is invoked.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter", Payload: "{}" }));
+
+    // Then the bound handler read the template's variables, so a debuggable
+    // handler and template code behave the same way.
+    assertNonNullable(output.Payload);
+    assertObjectEquals(
+      JSON.parse(Buffer.from(output.Payload).toString()) as unknown,
+      { tableName: "widgets" },
+    );
+  });
+
+  it("accepts a template Environment with no Variables", async () => {
+    // Given an Environment property holding nothing.
+    const simAws = new SimAws();
+    await deployFunction(simAws, {
+      Code: {
+        ZipFile:
+          "exports.handler = async () => ({ region: process.env.AWS_REGION });",
+      },
+      Environment: {},
+    });
+
+    // When the deployed function is invoked.
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter", Payload: "{}" }));
+
+    // Then it runs with just the AWS-provided runtime variables.
+    assertNonNullable(output.Payload);
+    assertObjectEquals(
+      JSON.parse(Buffer.from(output.Payload).toString()) as unknown,
+      { region: simAws.defaultRegionName },
+    );
+  });
+
+  it("fails a template whose Environment is not an object", async () => {
+    // Given an Environment property that is not an object.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployFunction(simAws, {
+        Code: { ZipFile: "exports.handler = async () => null;" },
+        Environment: "TABLE_NAME=widgets",
+      });
+    });
+
+    // Then it fails naming the property and the logical ID.
+    assertStringIncludes(error.message, "GreeterFunction");
+    assertStringIncludes(error.message, "Environment must be an object");
+  });
+
+  it("fails a template whose Variables is not an object", async () => {
+    // Given a Variables property that is not an object.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployFunction(simAws, {
+        Code: { ZipFile: "exports.handler = async () => null;" },
+        Environment: { Variables: "TABLE_NAME=widgets" },
+      });
+    });
+
+    // Then it fails naming the nested property.
+    assertStringIncludes(
+      error.message,
+      "Environment.Variables must be an object",
+    );
+  });
+
+  it("fails a template with a non-string variable value", async () => {
+    // Given a variable whose value is a number rather than a string.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployFunction(simAws, {
+        Code: { ZipFile: "exports.handler = async () => null;" },
+        Environment: { Variables: { RETRY_COUNT: 3 } },
+      });
+    });
+
+    // Then it fails naming the individual variable.
+    assertStringIncludes(
+      error.message,
+      "Environment.Variables.RETRY_COUNT must be a string",
+    );
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -5,7 +5,9 @@ import type { SimIamRoleName } from "../../../iam/role/sim-iam-role.js";
 import type {
   SimCreateFunctionCommandInput,
   SimLambdaFunctionCode,
+  SimLambdaFunctionEnvironment,
 } from "../../command/create-function/create-function.command.js";
+import { SimCfnLambdaEnvironmentParser } from "./sim-cfn-lambda-environment-parser.js";
 import { SimCfnLambdaFunctionCodeParser } from "./sim-cfn-lambda-function-code-parser.js";
 import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
 
@@ -18,6 +20,7 @@ export interface SimCfnLambdaFunctionProperties {
   readonly description: string | undefined;
   readonly timeoutSeconds: number | undefined;
   readonly memorySizeMb: number | undefined;
+  readonly environment: SimLambdaFunctionEnvironment | undefined;
 }
 
 /**
@@ -38,6 +41,7 @@ export function simCfnLambdaCreateFunctionInput(
     Description: functionProperties.description,
     Timeout: functionProperties.timeoutSeconds,
     MemorySize: functionProperties.memorySizeMb,
+    Environment: functionProperties.environment,
   };
 }
 
@@ -51,6 +55,7 @@ export function simCfnLambdaCreateFunctionInput(
 export class SimCfnLambdaFunctionPropertiesParser {
   private readonly propertyParser = new SimCfnLambdaPropertyParser();
   private readonly codeParser = new SimCfnLambdaFunctionCodeParser();
+  private readonly environmentParser = new SimCfnLambdaEnvironmentParser();
 
   /**
    * Parse the resolved CloudFormation properties for an AWS::Lambda::Function.
@@ -87,6 +92,10 @@ export class SimCfnLambdaFunctionPropertiesParser {
         resource,
         properties["MemorySize"],
         "MemorySize",
+      ),
+      environment: this.environmentParser.parse(
+        resource,
+        properties["Environment"],
       ),
     };
   }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
@@ -53,6 +54,36 @@ export class SimCfnLambdaPropertyParser {
     }
 
     return value;
+  }
+
+  /**
+   * Parse a property value that must be a record of strings when present.
+   *
+   * CloudFormation has no typed map, so every value has to be checked: a
+   * template that puts a number or a nested object where a string belongs
+   * should fail here rather than reach the function as a non-string.
+   */
+  optionalStringRecord(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): Record<string, string> | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!isRecord(value)) {
+      throw this.invalidPropertyError(resource, label, "an object");
+    }
+
+    const entries: [string, string][] = Object.entries(value).map(
+      ([key, entryValue]) => [
+        key,
+        this.requiredString(resource, entryValue, `${label}.${key}`),
+      ],
+    );
+
+    return Object.fromEntries(entries);
   }
 
   /**

--- a/src/service/lambda/command/create-function/create-function-environment-names.ts
+++ b/src/service/lambda/command/create-function/create-function-environment-names.ts
@@ -1,0 +1,89 @@
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import { lambdaReservedVariableNames } from "./lambda-reserved-variable-names.js";
+
+/**
+ * The pattern real Lambda requires an environment variable name to match: a
+ * letter, then at least one more letter, digit or underscore.
+ *
+ * The trailing `+` is why a single-character name is rejected too, and why
+ * the reserved names starting with an underscore fail this before they ever
+ * reach the reserved-name check.
+ */
+const variableNamePattern = /^[a-zA-Z][a-zA-Z0-9_]+$/;
+
+/**
+ * The declared names failing a check, in a stable order for reporting.
+ */
+function namesFailing(
+  declared: ReadonlyMap<string, string>,
+  fails: (name: string) => boolean,
+): string[] {
+  return declared
+    .keys()
+    .filter(fails)
+    .toArray()
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Reject variable names that break the AWS name pattern.
+ */
+function requireMatchingVariableNames(
+  declared: ReadonlyMap<string, string>,
+): void {
+  const invalid = namesFailing(
+    declared,
+    (name) => !variableNamePattern.test(name),
+  );
+
+  if (invalid.length === 0) {
+    return;
+  }
+
+  throw new SimLambdaValidationException(
+    "1 validation error detected: Value at 'environment.variables' failed " +
+      "to satisfy constraint: Map keys must satisfy constraint: [Member " +
+      "must satisfy regular expression pattern: [a-zA-Z]([a-zA-Z0-9_])+]. " +
+      `Invalid keys used in this request: ${invalid.join(", ")}`,
+  );
+}
+
+/**
+ * Reject reserved variable names AWS-style, naming the offenders.
+ */
+function requireUnreservedVariableNames(
+  declared: ReadonlyMap<string, string>,
+): void {
+  const reserved = namesFailing(declared, (name) =>
+    lambdaReservedVariableNames.has(name),
+  );
+
+  if (reserved.length === 0) {
+    return;
+  }
+
+  throw new SimLambdaInvalidParameterValueException(
+    "Lambda was unable to configure your environment variables because " +
+      "the environment variables you have provided contains reserved keys " +
+      "that are currently not supported for modification. Reserved keys " +
+      `used in this request: ${reserved.join(", ")}`,
+  );
+}
+
+/**
+ * Validate the declared environment variable names.
+ *
+ * Applies AWS's two stages in its order: the API name-pattern constraint
+ * first, then the service-level reserved-name rule. The order is what a
+ * caller sees for a name breaking both, such as the reserved `_HANDLER`,
+ * which is also an illegal name shape.
+ */
+export function requireValidVariableNames(
+  declared: ReadonlyMap<string, string>,
+): void {
+  requireMatchingVariableNames(declared);
+  requireUnreservedVariableNames(declared);
+}

--- a/src/service/lambda/command/create-function/create-function-environment.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-environment.iso.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import {
+  CreateFunctionCommand,
+  GetFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+
+const roleArn = "arn:aws:iam::111111111111:role/GreeterRole";
+const code = {
+  ZipFile: makeLambdaZipFileInput(() => "Hello"),
+};
+
+describe("Lambda CreateFunctionCommand environment", () => {
+  it("reports the declared variables in the function configuration", async () => {
+    // Given a function created with environment variables.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+
+    const creation = await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: roleArn,
+        Code: code,
+        Environment: {
+          Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+        },
+      }),
+    );
+
+    // Then CreateFunction reports them back, as real Lambda does.
+    assertObjectEquals(creation.Environment, {
+      Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+    });
+
+    // And GetFunction reports them too.
+    await simAws.backgroundTasksComplete();
+    const fetched = await simLambda.getFunction(
+      new GetFunctionCommand({ FunctionName: "greeter" }),
+    );
+    assertObjectEquals(fetched.Configuration.Environment, {
+      Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+    });
+  });
+
+  it("leaves Environment off a function that declares none", async () => {
+    // Given a function created without environment variables.
+    const simLambda = new SimAws().lambda();
+
+    const creation = await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: roleArn,
+        Code: code,
+      }),
+    );
+
+    // Then the configuration omits Environment entirely, as AWS does.
+    assertUndefined(creation.Environment);
+  });
+
+  it("rejects the environment variable names AWS reserves", async () => {
+    // Given a function declaring a name reserved for the Lambda runtime.
+    const simLambda = new SimAws().lambda();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: roleArn,
+          Code: code,
+          Environment: {
+            Variables: { AWS_REGION: "us-east-1", TABLE_NAME: "widgets" },
+          },
+        }),
+      );
+    });
+
+    // Then it fails AWS-style, naming the reserved key.
+    assertInstanceOf(error, SimLambdaInvalidParameterValueException);
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "reserved keys");
+    assertStringIncludes(error.message, "AWS_REGION");
+  });
+
+  it("names every reserved key used in the request", async () => {
+    // Given a function declaring several reserved names at once.
+    const simLambda = new SimAws().lambda();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: roleArn,
+          Code: code,
+          Environment: {
+            Variables: {
+              LAMBDA_TASK_ROOT: "/var/task",
+              AWS_SESSION_TOKEN: "token",
+            },
+          },
+        }),
+      );
+    });
+
+    // Then all of them are reported, so one fix covers the lot.
+    assertStringIncludes(error.message, "AWS_SESSION_TOKEN, LAMBDA_TASK_ROOT");
+  });
+
+  it("accepts an Environment with no Variables", async () => {
+    // Given an Environment property with nothing in it.
+    const simLambda = new SimAws().lambda();
+
+    const creation = await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: roleArn,
+        Code: code,
+        Environment: {},
+      }),
+    );
+
+    // Then the function is created with no declared variables.
+    assertUndefined(creation.Environment);
+  });
+});

--- a/src/service/lambda/command/create-function/create-function-environment.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-environment.iso.test.ts
@@ -15,7 +15,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 
 const roleArn = "arn:aws:iam::111111111111:role/GreeterRole";
@@ -119,6 +122,104 @@ describe("Lambda CreateFunctionCommand environment", () => {
 
     // Then all of them are reported, so one fix covers the lot.
     assertStringIncludes(error.message, "AWS_SESSION_TOKEN, LAMBDA_TASK_ROOT");
+  });
+
+  it("rejects the metadata and concurrency runtime names", async () => {
+    // Given the reserved names Lambda provides for the metadata endpoint and
+    // managed instances, which are easy to miss in the reserved list.
+    const simLambda = new SimAws().lambda();
+
+    // When a function declaring them is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: roleArn,
+          Code: code,
+          Environment: {
+            Variables: {
+              AWS_LAMBDA_METADATA_API: "169.254.100.1:9001",
+              AWS_LAMBDA_METADATA_TOKEN: "token",
+              AWS_LAMBDA_MAX_CONCURRENCY: "1",
+            },
+          },
+        }),
+      );
+    });
+
+    // Then all three are reported as reserved.
+    assertStringIncludes(
+      error.message,
+      "AWS_LAMBDA_MAX_CONCURRENCY, AWS_LAMBDA_METADATA_API, " +
+        "AWS_LAMBDA_METADATA_TOKEN",
+    );
+  });
+
+  it("rejects variable names that break the AWS name pattern", async () => {
+    // Given names starting with a digit, holding a hyphen, and one character
+    // long, none of which real Lambda accepts.
+    const simLambda = new SimAws().lambda();
+
+    // When a function declaring them is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: roleArn,
+          Code: code,
+          Environment: {
+            Variables: { "1TABLE": "widgets", "MY-VAR": "x", A: "y" },
+          },
+        }),
+      );
+    });
+
+    // Then it fails as an AWS constraint violation, naming the offenders.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "regular expression pattern");
+    assertStringIncludes(error.message, "1TABLE, A, MY-VAR");
+  });
+
+  it("reports a reserved name that also breaks the pattern as invalid", async () => {
+    // Given _HANDLER, which is reserved and also starts with an underscore.
+    const simLambda = new SimAws().lambda();
+
+    // When a function declaring it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: roleArn,
+          Code: code,
+          Environment: { Variables: { _HANDLER: "index.handler" } },
+        }),
+      );
+    });
+
+    // Then the constraint violation wins, as it does on real AWS, where the
+    // API constraint is checked before the reserved-name rule.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "_HANDLER");
+  });
+
+  it("accepts a two-character name, the shortest AWS allows", async () => {
+    // Given the shortest name the AWS pattern permits.
+    const simLambda = new SimAws().lambda();
+
+    const creation = await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: roleArn,
+        Code: code,
+        Environment: { Variables: { A1: "widgets", table_name_2: "gadgets" } },
+      }),
+    );
+
+    // Then it is accepted, along with the other legal name shapes.
+    assertObjectEquals(creation.Environment, {
+      Variables: { A1: "widgets", table_name_2: "gadgets" },
+    });
   });
 
   it("accepts an Environment with no Variables", async () => {

--- a/src/service/lambda/command/create-function/create-function-environment.ts
+++ b/src/service/lambda/command/create-function/create-function-environment.ts
@@ -1,0 +1,72 @@
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionEnvironment } from "./create-function.command.js";
+
+/**
+ * The environment variable names real Lambda reserves for the runtime, and
+ * rejects at CreateFunction rather than letting function configuration
+ * override.
+ *
+ * Keeping the same rule here means the AWS-provided runtime variables and the
+ * declared ones can never collide, so neither needs to win over the other.
+ */
+const reservedVariableNames: ReadonlySet<string> = new Set([
+  "_HANDLER",
+  "_X_AMZN_TRACE_ID",
+  "AWS_ACCESS_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_DEFAULT_REGION",
+  "AWS_EXECUTION_ENV",
+  "AWS_LAMBDA_FUNCTION_MEMORY_SIZE",
+  "AWS_LAMBDA_FUNCTION_NAME",
+  "AWS_LAMBDA_FUNCTION_VERSION",
+  "AWS_LAMBDA_INITIALIZATION_TYPE",
+  "AWS_LAMBDA_LOG_GROUP_NAME",
+  "AWS_LAMBDA_LOG_STREAM_NAME",
+  "AWS_LAMBDA_RUNTIME_API",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "LAMBDA_RUNTIME_DIR",
+  "LAMBDA_TASK_ROOT",
+]);
+
+/**
+ * Validate the Environment input into the variables declared for a function.
+ */
+export function requireLambdaEnvironmentVariables(
+  environment: SimLambdaFunctionEnvironment | undefined,
+): ReadonlyMap<string, string> {
+  const variables = environment?.Variables;
+  if (variables === undefined) {
+    return new Map();
+  }
+
+  const declared = new Map(Object.entries(variables));
+  requireNoReservedVariableNames(declared);
+
+  return declared;
+}
+
+/**
+ * Reject reserved variable names AWS-style, naming the offenders.
+ */
+function requireNoReservedVariableNames(
+  declared: ReadonlyMap<string, string>,
+): void {
+  const reserved = declared
+    .keys()
+    .filter((name) => reservedVariableNames.has(name))
+    .toArray()
+    .toSorted((left, right) => left.localeCompare(right));
+
+  if (reserved.length === 0) {
+    return;
+  }
+
+  throw new SimLambdaInvalidParameterValueException(
+    "Lambda was unable to configure your environment variables because " +
+      "the environment variables you have provided contains reserved keys " +
+      "that are currently not supported for modification. Reserved keys " +
+      `used in this request: ${reserved.join(", ")}`,
+  );
+}

--- a/src/service/lambda/command/create-function/create-function-environment.ts
+++ b/src/service/lambda/command/create-function/create-function-environment.ts
@@ -1,34 +1,5 @@
-import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { requireValidVariableNames } from "./create-function-environment-names.js";
 import type { SimLambdaFunctionEnvironment } from "./create-function.command.js";
-
-/**
- * The environment variable names real Lambda reserves for the runtime, and
- * rejects at CreateFunction rather than letting function configuration
- * override.
- *
- * Keeping the same rule here means the AWS-provided runtime variables and the
- * declared ones can never collide, so neither needs to win over the other.
- */
-const reservedVariableNames: ReadonlySet<string> = new Set([
-  "_HANDLER",
-  "_X_AMZN_TRACE_ID",
-  "AWS_ACCESS_KEY",
-  "AWS_ACCESS_KEY_ID",
-  "AWS_DEFAULT_REGION",
-  "AWS_EXECUTION_ENV",
-  "AWS_LAMBDA_FUNCTION_MEMORY_SIZE",
-  "AWS_LAMBDA_FUNCTION_NAME",
-  "AWS_LAMBDA_FUNCTION_VERSION",
-  "AWS_LAMBDA_INITIALIZATION_TYPE",
-  "AWS_LAMBDA_LOG_GROUP_NAME",
-  "AWS_LAMBDA_LOG_STREAM_NAME",
-  "AWS_LAMBDA_RUNTIME_API",
-  "AWS_REGION",
-  "AWS_SECRET_ACCESS_KEY",
-  "AWS_SESSION_TOKEN",
-  "LAMBDA_RUNTIME_DIR",
-  "LAMBDA_TASK_ROOT",
-]);
 
 /**
  * Validate the Environment input into the variables declared for a function.
@@ -42,31 +13,7 @@ export function requireLambdaEnvironmentVariables(
   }
 
   const declared = new Map(Object.entries(variables));
-  requireNoReservedVariableNames(declared);
+  requireValidVariableNames(declared);
 
   return declared;
-}
-
-/**
- * Reject reserved variable names AWS-style, naming the offenders.
- */
-function requireNoReservedVariableNames(
-  declared: ReadonlyMap<string, string>,
-): void {
-  const reserved = declared
-    .keys()
-    .filter((name) => reservedVariableNames.has(name))
-    .toArray()
-    .toSorted((left, right) => left.localeCompare(right));
-
-  if (reserved.length === 0) {
-    return;
-  }
-
-  throw new SimLambdaInvalidParameterValueException(
-    "Lambda was unable to configure your environment variables because " +
-      "the environment variables you have provided contains reserved keys " +
-      "that are currently not supported for modification. Reserved keys " +
-      `used in this request: ${reserved.join(", ")}`,
-  );
 }

--- a/src/service/lambda/command/create-function/create-function-input.ts
+++ b/src/service/lambda/command/create-function/create-function-input.ts
@@ -3,6 +3,7 @@ import {
   requireLambdaCodeSource,
   type SimLambdaCodeSource,
 } from "../../function/code/lambda-code-source.js";
+import { requireLambdaEnvironmentVariables } from "./create-function-environment.js";
 import type { SimCreateFunctionCommand } from "./create-function.command.js";
 
 /**
@@ -17,6 +18,7 @@ export interface CreateFunctionInput {
   description: string | undefined;
   timeoutSeconds: number | undefined;
   memorySizeMb: number | undefined;
+  environmentVariables: ReadonlyMap<string, string>;
 }
 
 /**
@@ -42,5 +44,6 @@ export function requireCreateFunctionInput(
     description: input.Description,
     timeoutSeconds: input.Timeout,
     memorySizeMb: input.MemorySize,
+    environmentVariables: requireLambdaEnvironmentVariables(input.Environment),
   };
 }

--- a/src/service/lambda/command/create-function/create-function.command.ts
+++ b/src/service/lambda/command/create-function/create-function.command.ts
@@ -27,6 +27,13 @@ export interface SimLambdaFunctionCode {
 }
 
 /**
+ * Minimal structural sim Lambda function environment configuration.
+ */
+export interface SimLambdaFunctionEnvironment {
+  Variables?: Record<string, string> | undefined;
+}
+
+/**
  * Minimal structural sim Lambda CreateFunction input.
  */
 export interface SimCreateFunctionCommandInput {
@@ -38,6 +45,7 @@ export interface SimCreateFunctionCommandInput {
   readonly Description?: string | undefined;
   readonly Timeout?: number | undefined;
   readonly MemorySize?: number | undefined;
+  readonly Environment?: SimLambdaFunctionEnvironment | undefined;
 }
 
 /**

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -15,6 +15,8 @@ import type { SimLambdaExecutableCode } from "../../function/code/sim-lambda-exe
 import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resolver.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
+import { SimLambdaEnvironment } from "../../function/environment/sim-lambda-environment.js";
 import {
   DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
   SimLambdaFunction,
@@ -40,6 +42,7 @@ interface CreateFunctionCommandHandlerProperties {
   background?: BackgroundScheduler;
   codeStore?: SimLambdaCodeStore | undefined;
   vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  environmentConflicts?: SimLambdaEnvironmentConflicts;
 }
 
 interface CreateFunctionCommandHandlerOptions {
@@ -61,6 +64,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
   private readonly authorizer: CreateFunctionAuthorizer;
   private readonly background: BackgroundScheduler;
   private readonly codeResolver: SimLambdaCodeResolver;
+  private readonly environmentConflicts: SimLambdaEnvironmentConflicts;
 
   constructor(properties: CreateFunctionCommandHandlerProperties) {
     const {
@@ -71,6 +75,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       background = new BackgroundTasks(),
       codeStore,
       vmSdkModuleProvider,
+      environmentConflicts = new SimLambdaEnvironmentConflicts(),
     } = properties;
     this.accountRegionScope = accountRegionScope;
     this.functions = functions;
@@ -81,6 +86,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       codeStore,
       vmSdkModuleProvider,
     });
+    this.environmentConflicts = environmentConflicts;
   }
 
   /**
@@ -103,16 +109,25 @@ export class CreateFunctionCommandHandler implements CommandHandler<
 
     this.requireAvailableFunctionName(input.name, functionArn);
 
-    const code = await this.resolveCode(input, options?.caller);
+    const environment = this.makeEnvironment(input);
+    const code = await this.resolveCode(input, environment, options?.caller);
 
     // Re-check after resolving code: a concurrent create for the same name
     // may have completed while awaiting an S3 code fetch, and must not be
     // overwritten.
     this.requireAvailableFunctionName(input.name, functionArn);
 
+    // Compared against the functions that already exist, so this has to
+    // happen before the new one joins them.
+    this.environmentConflicts.check(
+      environment,
+      this.functions.values().map((existing) => existing.environment),
+    );
+
     const simFunction = new SimLambdaFunction({
       ...input,
       code,
+      environment,
       accountRegionScope: this.accountRegionScope,
       runAsOwner: this.runAsOwner,
     });
@@ -143,18 +158,32 @@ export class CreateFunctionCommandHandler implements CommandHandler<
   }
 
   /**
+   * Build the environment the new function will run with.
+   *
+   * Built before the function itself, because vm zip code takes the
+   * environment at creation to put in its sandbox.
+   */
+  private makeEnvironment(input: CreateFunctionInput): SimLambdaEnvironment {
+    return new SimLambdaEnvironment({
+      functionName: input.name,
+      regionName: this.accountRegionScope.regionName,
+      memorySizeMb: input.memorySizeMb ?? DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+      declaredVariables: input.environmentVariables,
+    });
+  }
+
+  /**
    * Resolve the validated code source into executable code, fetching
    * S3-located code as the creating caller.
    */
   private async resolveCode(
     input: CreateFunctionInput,
+    environment: SimLambdaEnvironment,
     caller: SimAwsCaller | undefined,
   ): Promise<SimLambdaExecutableCode> {
     return await this.codeResolver.resolve(input.codeSource, {
       handlerName: input.handlerName,
-      functionName: input.name,
-      regionName: this.accountRegionScope.regionName,
-      memorySizeMb: input.memorySizeMb ?? DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+      environment,
       caller,
     });
   }

--- a/src/service/lambda/command/create-function/lambda-reserved-variable-names.ts
+++ b/src/service/lambda/command/create-function/lambda-reserved-variable-names.ts
@@ -1,0 +1,35 @@
+/**
+ * The environment variable names real Lambda reserves for the runtime, and
+ * rejects at CreateFunction rather than letting function configuration
+ * override.
+ *
+ * Keeping the same rule here means the AWS-provided runtime variables and the
+ * declared ones can never collide, so neither needs to win over the other.
+ *
+ * Note that the two names starting with an underscore cannot match the AWS
+ * environment variable name pattern either, so in practice they are reported
+ * as an invalid name rather than a reserved one, as on real AWS.
+ */
+export const lambdaReservedVariableNames: ReadonlySet<string> = new Set([
+  "_HANDLER",
+  "_X_AMZN_TRACE_ID",
+  "AWS_ACCESS_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_DEFAULT_REGION",
+  "AWS_EXECUTION_ENV",
+  "AWS_LAMBDA_FUNCTION_MEMORY_SIZE",
+  "AWS_LAMBDA_FUNCTION_NAME",
+  "AWS_LAMBDA_FUNCTION_VERSION",
+  "AWS_LAMBDA_INITIALIZATION_TYPE",
+  "AWS_LAMBDA_LOG_GROUP_NAME",
+  "AWS_LAMBDA_LOG_STREAM_NAME",
+  "AWS_LAMBDA_MAX_CONCURRENCY",
+  "AWS_LAMBDA_METADATA_API",
+  "AWS_LAMBDA_METADATA_TOKEN",
+  "AWS_LAMBDA_RUNTIME_API",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "LAMBDA_RUNTIME_DIR",
+  "LAMBDA_TASK_ROOT",
+]);

--- a/src/service/lambda/error/sim-lambda.error.ts
+++ b/src/service/lambda/error/sim-lambda.error.ts
@@ -52,6 +52,22 @@ export class SimLambdaInvalidRequestContentException extends SimLambdaError {
 }
 
 /**
+ * Simulated Lambda ValidationException error.
+ *
+ * Real Lambda reports input that fails an API-level constraint this way, such
+ * as an environment variable name that does not match the required pattern.
+ * These constraints are checked before service-level rules like reserved
+ * environment variable names, so a name breaking both is reported here.
+ */
+export class SimLambdaValidationException extends SimLambdaError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Lambda InvalidParameterValueException error.
  *
  * Real Lambda reports function code problems this way, such as unreadable

--- a/src/service/lambda/function/code/sim-lambda-code-resolver.ts
+++ b/src/service/lambda/function/code/sim-lambda-code-resolver.ts
@@ -1,4 +1,5 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import type { SimLambdaCodeSource } from "./lambda-code-source.js";
 import {
   type SimLambdaExecutableCode,
@@ -18,14 +19,12 @@ interface SimLambdaCodeResolverProperties {
 
 /**
  * The function details a code source is resolved for: the handler identifier
- * selecting the module and export, the AWS-like execution environment for vm
- * code, and the creating caller for S3 code fetch authorization.
+ * selecting the module and export, the execution environment for vm code, and
+ * the creating caller for S3 code fetch authorization.
  */
 export interface SimLambdaCodeResolveContext {
   readonly handlerName: string | undefined;
-  readonly functionName: string;
-  readonly regionName: string;
-  readonly memorySizeMb: number;
+  readonly environment: SimLambdaEnvironment;
   readonly caller?: SimAwsCaller | undefined;
 }
 

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
@@ -10,6 +10,7 @@ import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
+import { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import { SimLambdaFunction } from "../sim-lambda-function.js";
 import {
   type LambdaCodeZipFiles,
@@ -37,11 +38,11 @@ function makeVmFunction(
     code: new SimLambdaVmZipCode({
       archive,
       handlerName,
-      environment: {
+      environment: new SimLambdaEnvironment({
         functionName: "vm-error-test",
         regionName: "eu-west-2",
         memorySizeMb: 128,
-      },
+      }),
     }),
   });
 }

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
@@ -39,11 +39,7 @@ export class SimLambdaVmZipCodeFactory {
     return new SimLambdaVmZipCode({
       archive: this.unzip(zipBytes),
       handlerName: context.handlerName,
-      environment: {
-        functionName: context.functionName,
-        regionName: context.regionName,
-        memorySizeMb: context.memorySizeMb,
-      },
+      environment: context.environment,
       sdkModuleProvider: this.vmSdkModuleProvider,
     });
   }

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.iso.test.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.iso.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import { SimLambdaFunction } from "../sim-lambda-function.js";
 import {
   type LambdaCodeZipFiles,
@@ -27,11 +28,11 @@ function makeVmFunction(
     code: new SimLambdaVmZipCode({
       archive,
       handlerName,
-      environment: {
+      environment: new SimLambdaEnvironment({
         functionName: "vm-test",
         regionName: "eu-west-2",
         memorySizeMb: 256,
-      },
+      }),
     }),
   });
 }

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
@@ -5,17 +5,15 @@ import {
   SimLambdaNoVmSdkModuleProvider,
   type SimLambdaVmSdkModuleProvider,
 } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import type { SimLambdaExecutableCode } from "./sim-lambda-executable-code.js";
-import {
-  makeSimLambdaVmContext,
-  type SimLambdaVmEnvironment,
-} from "./vm/sim-lambda-vm-context.js";
+import { makeSimLambdaVmContext } from "./vm/sim-lambda-vm-context.js";
 import { SimLambdaVmModules } from "./vm/sim-lambda-vm-modules.js";
 
 interface SimLambdaVmZipCodeProperties {
   readonly archive: SimZipArchive;
   readonly handlerName: string;
-  readonly environment: SimLambdaVmEnvironment;
+  readonly environment: SimLambdaEnvironment;
   readonly sdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -1,46 +1,27 @@
 import vm from "node:vm";
-
-/**
- * The AWS-like execution environment details exposed to sim Lambda function
- * code running in a vm context.
- */
-export interface SimLambdaVmEnvironment {
-  readonly functionName: string;
-  readonly regionName: string;
-  readonly memorySizeMb: number;
-}
-
-/**
- * Build the AWS-like standard runtime environment variables.
- */
-function runtimeEnvironmentVariables(
-  environment: SimLambdaVmEnvironment,
-): Record<string, string> {
-  return Object.fromEntries([
-    ["AWS_REGION", environment.regionName],
-    ["AWS_DEFAULT_REGION", environment.regionName],
-    ["AWS_LAMBDA_FUNCTION_NAME", environment.functionName],
-    ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE", String(environment.memorySizeMb)],
-    ["AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"],
-  ]);
-}
+import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environment.js";
 
 /**
  * Create the sandbox vm context that sim Lambda function code runs in.
  *
  * The context provides the common globals a Node.js Lambda runtime offers,
- * including an AWS-like process.env with the standard runtime variables.
- * Everything else must be part of the deployed function code archive, as on
- * real Lambda.
+ * including an AWS-like process.env holding the standard runtime variables
+ * and any variables declared for the function. Everything else must be part
+ * of the deployed function code archive, as on real Lambda.
+ *
+ * Zip code needs nothing like the process.env handling the in-process handler
+ * path does: this sandbox already owns its process object, so the host
+ * environment is invisible here whether or not the function declares
+ * variables of its own.
  */
 export function makeSimLambdaVmContext(
-  environment: SimLambdaVmEnvironment,
+  environment: SimLambdaEnvironment,
 ): vm.Context {
   return vm.createContext({
     console,
     Buffer,
     process: {
-      env: runtimeEnvironmentVariables(environment),
+      env: environment.variables(),
     },
     setTimeout,
     clearTimeout,

--- a/src/service/lambda/function/environment/sim-lambda-environment-conflicts.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment-conflicts.iso.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { assertArrayLength, assertStringIncludes } from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+import { SimLambdaEnvironmentConflicts } from "./sim-lambda-environment-conflicts.js";
+import { SimLambdaEnvironment } from "./sim-lambda-environment.js";
+
+function makeEnvironment(
+  functionName: string,
+  declaredVariables: Record<string, string>,
+): SimLambdaEnvironment {
+  return new SimLambdaEnvironment({
+    functionName,
+    regionName: "eu-west-2",
+    memorySizeMb: 128,
+    declaredVariables: new Map(Object.entries(declaredVariables)),
+  });
+}
+
+/**
+ * Collect the warnings a check emits, keeping them out of the test output.
+ */
+function warningsFrom(check: () => void): string[] {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* captured, not printed */
+  });
+
+  try {
+    check();
+    return warn.mock.calls.map((call) => String(call[0]));
+  } finally {
+    warn.mockRestore();
+  }
+}
+
+describe("sim Lambda environment conflicts", () => {
+  it("warns when the host process sets the name differently", () => {
+    // Given a host variable whose value differs from the declared one.
+    process.env["YULIN_CONFLICT"] = "host value";
+
+    try {
+      const environment = makeEnvironment("greeter", {
+        YULIN_CONFLICT: "declared value",
+      });
+
+      // When the new function's environment is checked.
+      const warnings = warningsFrom(() => {
+        new SimLambdaEnvironmentConflicts().check(environment, []);
+      });
+
+      // Then the mismatch is reported with the advice that resolves it.
+      assertArrayLength(warnings, 1);
+      assertStringIncludes(warnings[0], "greeter");
+      assertStringIncludes(warnings[0], "YULIN_CONFLICT");
+      assertStringIncludes(warnings[0], "inside the handler function");
+    } finally {
+      delete process.env["YULIN_CONFLICT"];
+    }
+  });
+
+  it("stays quiet when the host process sets the same value", () => {
+    // Given a host variable that agrees with the declared one.
+    process.env["YULIN_AGREES"] = "same value";
+
+    try {
+      const environment = makeEnvironment("greeter", {
+        YULIN_AGREES: "same value",
+      });
+
+      // When the new function's environment is checked.
+      const warnings = warningsFrom(() => {
+        new SimLambdaEnvironmentConflicts().check(environment, []);
+      });
+
+      // Then nothing is reported: a module-scope read gets the right value
+      // anyway, so there is no mismatch to explain.
+      assertArrayLength(warnings, 0);
+    } finally {
+      delete process.env["YULIN_AGREES"];
+    }
+  });
+
+  it("stays quiet when the host process does not set the name", () => {
+    // Given a declared variable the host process knows nothing about.
+    const environment = makeEnvironment("greeter", {
+      YULIN_UNSET_ON_HOST: "declared value",
+    });
+
+    // When the new function's environment is checked.
+    const warnings = warningsFrom(() => {
+      new SimLambdaEnvironmentConflicts().check(environment, []);
+    });
+
+    // Then there is nothing to report.
+    assertArrayLength(warnings, 0);
+  });
+
+  it("warns when another function declares the name differently", () => {
+    // Given an existing function declaring a different value for the name.
+    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
+    const environment = makeEnvironment("writer", { TABLE_NAME: "gadgets" });
+
+    // When the new function's environment is checked against it.
+    const warnings = warningsFrom(() => {
+      new SimLambdaEnvironmentConflicts().check(environment, [existing]);
+    });
+
+    // Then both function names are reported with the variable name.
+    assertArrayLength(warnings, 1);
+    assertStringIncludes(warnings[0], "reader");
+    assertStringIncludes(warnings[0], "writer");
+    assertStringIncludes(warnings[0], "TABLE_NAME");
+  });
+
+  it("stays quiet when functions agree on the value", () => {
+    // Given two functions declaring the same value for the same name.
+    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
+    const environment = makeEnvironment("writer", { TABLE_NAME: "widgets" });
+
+    // When the new function's environment is checked against it.
+    const warnings = warningsFrom(() => {
+      new SimLambdaEnvironmentConflicts().check(environment, [existing]);
+    });
+
+    // Then there is nothing to report.
+    assertArrayLength(warnings, 0);
+  });
+
+  it("stays quiet when another function declares nothing in common", () => {
+    // Given an existing function declaring an unrelated variable.
+    const existing = makeEnvironment("reader", { QUEUE_URL: "widgets" });
+    const environment = makeEnvironment("writer", { TABLE_NAME: "gadgets" });
+
+    // When the new function's environment is checked against it.
+    const warnings = warningsFrom(() => {
+      new SimLambdaEnvironmentConflicts().check(environment, [existing]);
+    });
+
+    // Then there is nothing to report.
+    assertArrayLength(warnings, 0);
+  });
+
+  it("reports each variable name only once", () => {
+    // Given a conflict that would be found again by a later function.
+    const conflicts = new SimLambdaEnvironmentConflicts();
+    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
+
+    // When two more functions are checked against it.
+    const warnings = warningsFrom(() => {
+      conflicts.check(makeEnvironment("writer", { TABLE_NAME: "gadgets" }), [
+        existing,
+      ]);
+      conflicts.check(makeEnvironment("deleter", { TABLE_NAME: "sprockets" }), [
+        existing,
+      ]);
+    });
+
+    // Then the same variable name is only reported the first time.
+    assertArrayLength(warnings, 1);
+  });
+});

--- a/src/service/lambda/function/environment/sim-lambda-environment-conflicts.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment-conflicts.ts
@@ -1,0 +1,111 @@
+import type { SimLambdaEnvironment } from "./sim-lambda-environment.js";
+import { simLambdaProcessEnvironment } from "./sim-lambda-process-environment.js";
+
+const moveTheReadAdvice =
+  "A read of process.env at module scope happens when the module is " +
+  "imported, before any invocation, so it sees the host value instead. " +
+  "Move the read inside the handler function.";
+
+/**
+ * Warns about declared environment variables whose value a handler module
+ * might not actually see.
+ *
+ * A sim Lambda function backed by a real in-process handler only gets its own
+ * process.env while the handler runs, so a variable read at module scope is
+ * read too early (see SimLambdaProcessEnv). That only changes what the code
+ * sees when the value read at module scope differs from the declared one, so
+ * these are the two conditions worth reporting: the host process sets the
+ * same name with a different value, or another simulated function declares
+ * the same name with a different value.
+ *
+ * Staying quiet when the values agree matters as much as warning when they do
+ * not. Test suites commonly export the same variables they configure their
+ * functions with, and in that case a module-scope read gets the right value
+ * anyway and there is nothing to report.
+ */
+export class SimLambdaEnvironmentConflicts {
+  /**
+   * Variable names already reported, so repeated function creation does not
+   * repeat the same warning.
+   */
+  private readonly warned = new Set<string>();
+
+  /**
+   * Check a new function's environment against the host process and against
+   * the functions that already exist.
+   */
+  check(
+    environment: SimLambdaEnvironment,
+    existingEnvironments: Iterable<SimLambdaEnvironment>,
+  ): void {
+    for (const [name, value] of environment.declaredVariables) {
+      this.checkHostProcess(environment, name, value);
+      this.checkOtherFunctions(environment, name, value, existingEnvironments);
+    }
+  }
+
+  /**
+   * Warn when the host process sets the same name with a different value.
+   */
+  private checkHostProcess(
+    environment: SimLambdaEnvironment,
+    name: string,
+    value: string,
+  ): void {
+    // Read-only lookup of a name the function itself declared.
+    // eslint-disable-next-line security/detect-object-injection
+    const hostValue = simLambdaProcessEnvironment.hostVariables()[name];
+    if (hostValue === undefined || hostValue === value) {
+      return;
+    }
+
+    this.warn(
+      `host:${name}`,
+      `Sim Lambda function "${environment.functionName}" declares ` +
+        `environment variable ${name}, which the host process also sets ` +
+        `with a different value. ${moveTheReadAdvice}`,
+    );
+  }
+
+  /**
+   * Warn when another simulated function declares the same name with a
+   * different value.
+   */
+  private checkOtherFunctions(
+    environment: SimLambdaEnvironment,
+    name: string,
+    value: string,
+    existingEnvironments: Iterable<SimLambdaEnvironment>,
+  ): void {
+    for (const existing of existingEnvironments) {
+      const existingValue = existing.declaredVariables.get(name);
+      if (existingValue === undefined || existingValue === value) {
+        continue;
+      }
+
+      this.warn(
+        `function:${name}`,
+        `Sim Lambda functions "${existing.functionName}" and ` +
+          `"${environment.functionName}" declare different values for ` +
+          `environment variable ${name}. ${moveTheReadAdvice}`,
+      );
+      return;
+    }
+  }
+
+  /**
+   * Report a conflict once per variable name.
+   *
+   * Warnings go to the console because that is where a test runner surfaces
+   * them next to the failing expectation they explain; the simulator has no
+   * logger of its own to route them through.
+   */
+  private warn(key: string, message: string): void {
+    if (this.warned.has(key)) {
+      return;
+    }
+    this.warned.add(key);
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  }
+}

--- a/src/service/lambda/function/environment/sim-lambda-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.iso.test.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import {
+  assertFalse,
+  assertIdentical,
+  assertMapSize,
+  assertObjectEquals,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimLambdaEnvironment } from "./sim-lambda-environment.js";
+
+describe("sim Lambda environment", () => {
+  it("provides the AWS runtime variables when nothing is declared", () => {
+    // Given an environment for a function that declares no variables.
+    const environment = new SimLambdaEnvironment({
+      functionName: "greeter",
+      regionName: "eu-west-2",
+      memorySizeMb: 256,
+    });
+
+    // When its variables are read.
+    const variables = environment.variables();
+
+    // Then only the AWS-provided runtime variables are there.
+    assertObjectEquals(variables, {
+      AWS_REGION: "eu-west-2",
+      AWS_DEFAULT_REGION: "eu-west-2",
+      AWS_LAMBDA_FUNCTION_NAME: "greeter",
+      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: "256",
+      AWS_LAMBDA_FUNCTION_VERSION: "$LATEST",
+    });
+    assertFalse(environment.hasDeclaredVariables);
+  });
+
+  it("merges declared variables with the AWS runtime variables", () => {
+    // Given an environment declaring variables of its own.
+    const environment = new SimLambdaEnvironment({
+      functionName: "greeter",
+      regionName: "eu-west-2",
+      memorySizeMb: 128,
+      declaredVariables: new Map([
+        ["TABLE_NAME", "widgets"],
+        ["GREETING", "Hello"],
+      ]),
+    });
+
+    // When its variables are read.
+    const variables = environment.variables();
+
+    // Then the declared variables sit alongside the AWS-provided ones.
+    assertIdentical(variables["TABLE_NAME"], "widgets");
+    assertIdentical(variables["GREETING"], "Hello");
+    assertIdentical(variables["AWS_LAMBDA_FUNCTION_NAME"], "greeter");
+    assertTrue(environment.hasDeclaredVariables);
+  });
+
+  it("reports the declared variables without the AWS-provided ones", () => {
+    // Given an environment declaring one variable.
+    const environment = new SimLambdaEnvironment({
+      functionName: "greeter",
+      regionName: "eu-west-2",
+      memorySizeMb: 128,
+      declaredVariables: new Map([["TABLE_NAME", "widgets"]]),
+    });
+
+    // When the declared variables are read.
+    const declared = environment.declaredVariables;
+
+    // Then the AWS-provided runtime variables are not among them.
+    assertMapSize(declared, 1);
+    assertIdentical(declared.get("TABLE_NAME"), "widgets");
+    assertIdentical(environment.functionName, "greeter");
+  });
+
+  it("reuses one variables object, as a warm execution environment does", () => {
+    // Given an environment that has already been read from.
+    const environment = new SimLambdaEnvironment({
+      functionName: "greeter",
+      regionName: "eu-west-2",
+      memorySizeMb: 128,
+      declaredVariables: new Map([["TABLE_NAME", "widgets"]]),
+    });
+    const variables = environment.variables();
+
+    // When function code writes to it, as it could to process.env.
+    variables["WRITTEN_AT_RUNTIME"] = "yes";
+
+    // Then the next read of the same environment still sees the write.
+    assertIdentical(environment.variables()["WRITTEN_AT_RUNTIME"], "yes");
+  });
+});

--- a/src/service/lambda/function/environment/sim-lambda-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.ts
@@ -1,0 +1,127 @@
+import { simLambdaProcessEnvironment } from "./sim-lambda-process-environment.js";
+
+/**
+ * The function details the AWS-provided runtime environment variables are
+ * built from.
+ */
+export interface SimLambdaEnvironmentDetails {
+  readonly functionName: string;
+  readonly regionName: string;
+  readonly memorySizeMb: number;
+}
+
+interface SimLambdaEnvironmentProperties extends SimLambdaEnvironmentDetails {
+  readonly declaredVariables?: ReadonlyMap<string, string> | undefined;
+}
+
+/**
+ * The environment a sim Lambda function runs with.
+ *
+ * Combines the AWS-provided runtime variables with the variables declared for
+ * the function through Environment.Variables. Declared variables cannot
+ * shadow the runtime ones: real Lambda rejects the reserved names at
+ * CreateFunction, so the two sets never collide by the time they get here.
+ */
+export class SimLambdaEnvironment {
+  private readonly details: SimLambdaEnvironmentDetails;
+  private readonly declared: ReadonlyMap<string, string>;
+
+  /**
+   * The merged variables, built once and then reused.
+   *
+   * Reusing one object gives the warm execution environment semantics of real
+   * Lambda: a write to process.env inside a handler is still visible to the
+   * next invocation of the same function, and is discarded when the function
+   * goes away.
+   */
+  #variables: Record<string, string> | undefined;
+
+  constructor(properties: SimLambdaEnvironmentProperties) {
+    const { declaredVariables, ...details } = properties;
+    this.details = details;
+    this.declared = declaredVariables ?? new Map();
+  }
+
+  /**
+   * Whether any variables were declared for this function.
+   *
+   * A function with no declared variables needs no environment of its own, so
+   * callers can leave the host process environment alone entirely.
+   */
+  get hasDeclaredVariables(): boolean {
+    return this.declared.size > 0;
+  }
+
+  /**
+   * The variables declared for this function, without the AWS-provided ones.
+   */
+  get declaredVariables(): ReadonlyMap<string, string> {
+    return this.declared;
+  }
+
+  /**
+   * The name of the function this environment belongs to.
+   */
+  get functionName(): string {
+    return this.details.functionName;
+  }
+
+  /**
+   * The declared variables as AWS reports them in function configuration.
+   *
+   * Real Lambda leaves Environment off the configuration entirely for a
+   * function that declares none.
+   */
+  configuration(): { Variables: Record<string, string> } | undefined {
+    if (!this.hasDeclaredVariables) {
+      return undefined;
+    }
+
+    return { Variables: Object.fromEntries(this.declared) };
+  }
+
+  /**
+   * Run function code with this environment applied to process.env.
+   *
+   * A function that declares nothing is left reading the host process
+   * environment, exactly as before: there is nothing of its own to give it,
+   * so there is no reason to touch process.env at all. Zip code running in a
+   * vm context takes its variables from the sandbox instead, and is
+   * unaffected either way.
+   */
+  async runWith<T>(run: () => Promise<T>): Promise<T> {
+    if (!this.hasDeclaredVariables) {
+      return await run();
+    }
+
+    return await simLambdaProcessEnvironment.run(this.variables(), run);
+  }
+
+  /**
+   * The complete process.env-shaped variables the function code sees.
+   */
+  variables(): Record<string, string> {
+    this.#variables ??= {
+      ...this.runtimeVariables(),
+      ...Object.fromEntries(this.declared),
+    };
+    return this.#variables;
+  }
+
+  /**
+   * The AWS-like standard runtime environment variables.
+   */
+  private runtimeVariables(): Record<string, string> {
+    const { functionName, regionName, memorySizeMb } = this.details;
+    // Built from entries rather than an object literal because AWS
+    // environment variable names are not code identifier names, and the
+    // project's naming rules treat object literal keys as if they were.
+    return Object.fromEntries([
+      ["AWS_REGION", regionName],
+      ["AWS_DEFAULT_REGION", regionName],
+      ["AWS_LAMBDA_FUNCTION_NAME", functionName],
+      ["AWS_LAMBDA_FUNCTION_MEMORY_SIZE", String(memorySizeMb)],
+      ["AWS_LAMBDA_FUNCTION_VERSION", "$LATEST"],
+    ]);
+  }
+}

--- a/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+async function createFunctionWithEnvironment(
+  simLambda: SimLambda,
+  functionName: string,
+  variables: Record<string, string> | undefined,
+  handlerFunction: SimLambdaHandler,
+): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(handlerFunction) },
+      ...(variables !== undefined && { Environment: { Variables: variables } }),
+    }),
+  );
+}
+
+async function invoke(
+  simLambda: SimLambda,
+  functionName: string,
+): Promise<unknown> {
+  const output = await simLambda.invoke(
+    new InvokeCommand({ FunctionName: functionName, Payload: "{}" }),
+  );
+  assertNonNullable(output.Payload);
+  return JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+}
+
+describe("sim Lambda in-process handler environment", () => {
+  it("gives the handler the variables declared for its function", async () => {
+    // Given a function declaring variables, backed by a real handler
+    // function running in this process.
+    const simLambda = new SimAws().lambda();
+    await createFunctionWithEnvironment(
+      simLambda,
+      "greeter",
+      { GREETING: "Hello", TABLE_NAME: "widgets" },
+      () => ({
+        greeting: process.env["GREETING"],
+        tableName: process.env["TABLE_NAME"],
+      }),
+    );
+
+    // When it is invoked.
+    const result = await invoke(simLambda, "greeter");
+
+    // Then the handler read its own declared variables from process.env.
+    assertObjectEquals(result, { greeting: "Hello", tableName: "widgets" });
+  });
+
+  it("gives the handler the AWS runtime variables too", async () => {
+    // Given a function declaring one variable of its own.
+    const simAws = new SimAws();
+    const simLambda = simAws.lambda();
+    await createFunctionWithEnvironment(
+      simLambda,
+      "greeter",
+      { TABLE_NAME: "widgets" },
+      () => ({
+        region: process.env["AWS_REGION"],
+        functionName: process.env["AWS_LAMBDA_FUNCTION_NAME"],
+        version: process.env["AWS_LAMBDA_FUNCTION_VERSION"],
+      }),
+    );
+
+    // When it is invoked.
+    const result = await invoke(simLambda, "greeter");
+
+    // Then the AWS-provided runtime variables are there as well.
+    assertObjectEquals(result, {
+      region: simAws.defaultRegionName,
+      functionName: "greeter",
+      version: "$LATEST",
+    });
+  });
+
+  it("hides host process variables the function does not declare", async () => {
+    // Given a variable set on the host process running the tests.
+    process.env["YULIN_TEST_HOST_ONLY"] = "host value";
+
+    try {
+      const simLambda = new SimAws().lambda();
+      await createFunctionWithEnvironment(
+        simLambda,
+        "greeter",
+        { TABLE_NAME: "widgets" },
+        () => ({ hostOnly: process.env["YULIN_TEST_HOST_ONLY"] ?? null }),
+      );
+
+      // When it is invoked.
+      const result = await invoke(simLambda, "greeter");
+
+      // Then the handler did not inherit it, as a real Lambda would not.
+      assertObjectEquals(result, { hostOnly: null });
+      assertIdentical(process.env["YULIN_TEST_HOST_ONLY"], "host value");
+    } finally {
+      delete process.env["YULIN_TEST_HOST_ONLY"];
+    }
+  });
+
+  it("leaves the host environment alone for a function declaring none", async () => {
+    // Given a function that declares no variables of its own.
+    process.env["YULIN_TEST_SHARED"] = "host value";
+
+    try {
+      const simLambda = new SimAws().lambda();
+      await createFunctionWithEnvironment(
+        simLambda,
+        "greeter",
+        undefined,
+        () => ({
+          shared: process.env["YULIN_TEST_SHARED"] ?? null,
+        }),
+      );
+
+      // When it is invoked.
+      const result = await invoke(simLambda, "greeter");
+
+      // Then it still reads the host process environment, as before: with
+      // nothing of its own to run with, there is nothing to substitute.
+      assertObjectEquals(result, { shared: "host value" });
+    } finally {
+      delete process.env["YULIN_TEST_SHARED"];
+    }
+  });
+
+  it("keeps concurrent invocations of two functions apart", async () => {
+    // Given two functions declaring different values for the same name.
+    const simLambda = new SimAws().lambda();
+    const readAfterDelay =
+      (milliseconds: number): SimLambdaHandler =>
+      async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, milliseconds);
+        });
+        return { tableName: process.env["TABLE_NAME"] };
+      };
+
+    await createFunctionWithEnvironment(
+      simLambda,
+      "reader",
+      { TABLE_NAME: "widgets" },
+      readAfterDelay(6),
+    );
+    await createFunctionWithEnvironment(
+      simLambda,
+      "writer",
+      { TABLE_NAME: "gadgets" },
+      readAfterDelay(2),
+    );
+
+    // When both are invoked at once, so their handlers interleave.
+    const [reader, writer] = await Promise.all([
+      invoke(simLambda, "reader"),
+      invoke(simLambda, "writer"),
+    ]);
+
+    // Then each saw only its own value.
+    assertObjectEquals(reader, { tableName: "widgets" });
+    assertObjectEquals(writer, { tableName: "gadgets" });
+  });
+
+  it("keeps a write by the handler out of the host environment", async () => {
+    // Given a handler that writes to process.env, as function code may.
+    const simLambda = new SimAws().lambda();
+    await createFunctionWithEnvironment(
+      simLambda,
+      "greeter",
+      { TABLE_NAME: "widgets" },
+      () => {
+        process.env["YULIN_TEST_WRITTEN"] = "written";
+        return { written: process.env["YULIN_TEST_WRITTEN"] };
+      },
+    );
+
+    // When it is invoked.
+    const result = await invoke(simLambda, "greeter");
+
+    // Then the handler saw its own write, and the host process did not.
+    assertObjectEquals(result, { written: "written" });
+    assertUndefined(process.env["YULIN_TEST_WRITTEN"]);
+  });
+});

--- a/src/service/lambda/function/environment/sim-lambda-process-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-process-environment.iso.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simLambdaProcessEnvironment } from "./sim-lambda-process-environment.js";
+
+/**
+ * Resolve after the given number of microtask-ish ticks, so a test can
+ * interleave two runs and prove they do not see each other's variables.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+describe("sim Lambda process env", () => {
+  it("gives the run its own process.env", async () => {
+    // Given a variable that only the run declares.
+    const variables = { TABLE_NAME: "widgets" };
+
+    // When process.env is read inside the run.
+    const insideRun = await simLambdaProcessEnvironment.run(variables, () =>
+      Promise.resolve(process.env["TABLE_NAME"]),
+    );
+
+    // Then the run saw its own value, and nothing outside it did.
+    assertIdentical(insideRun, "widgets");
+    assertUndefined(process.env["TABLE_NAME"]);
+  });
+
+  it("keeps the run's variables across an await", async () => {
+    // Given a run that reads process.env on both sides of an await.
+    const read = await simLambdaProcessEnvironment.run(
+      { TABLE_NAME: "widgets" },
+      async () => {
+        const before = process.env["TABLE_NAME"];
+        await tick(2);
+        return { before, after: process.env["TABLE_NAME"] };
+      },
+    );
+
+    // Then asynchronous context tracking carried the variables across it.
+    assertIdentical(read.before, "widgets");
+    assertIdentical(read.after, "widgets");
+  });
+
+  it("hides host variables the run does not declare", async () => {
+    // Given a variable set on the host process.
+    process.env["YULIN_HOST_ONLY"] = "host value";
+
+    try {
+      // When a run that does not declare it reads process.env.
+      const insideRun = await simLambdaProcessEnvironment.run({}, () =>
+        Promise.resolve(process.env["YULIN_HOST_ONLY"]),
+      );
+
+      // Then the run did not inherit it, as a real Lambda would not.
+      assertUndefined(insideRun);
+      assertIdentical(process.env["YULIN_HOST_ONLY"], "host value");
+    } finally {
+      delete process.env["YULIN_HOST_ONLY"];
+    }
+  });
+
+  it("keeps a write inside the run out of the host environment", async () => {
+    // Given a run that writes to process.env, as function code may.
+    await simLambdaProcessEnvironment.run({}, () => {
+      process.env["YULIN_WRITTEN_IN_RUN"] = "written";
+      return Promise.resolve();
+    });
+
+    // Then the host process environment is unchanged.
+    assertUndefined(process.env["YULIN_WRITTEN_IN_RUN"]);
+  });
+
+  it("isolates concurrent runs from each other", async () => {
+    // Given two overlapping runs declaring the same variable name.
+    const [first, second] = await Promise.all([
+      simLambdaProcessEnvironment.run({ TABLE_NAME: "widgets" }, async () => {
+        await tick(6);
+        return process.env["TABLE_NAME"];
+      }),
+      simLambdaProcessEnvironment.run({ TABLE_NAME: "gadgets" }, async () => {
+        await tick(2);
+        return process.env["TABLE_NAME"];
+      }),
+    ]);
+
+    // Then each run saw only its own value, despite interleaving.
+    assertIdentical(first, "widgets");
+    assertIdentical(second, "gadgets");
+  });
+
+  it("reports the host variables while a run is in progress", async () => {
+    // Given a variable set on the host process.
+    process.env["YULIN_HOST_LOOKUP"] = "host value";
+
+    try {
+      // When the host variables are read from inside a run.
+      const hostValue = await simLambdaProcessEnvironment.run(
+        { YULIN_HOST_LOOKUP: "run value" },
+        () =>
+          Promise.resolve(
+            simLambdaProcessEnvironment.hostVariables()["YULIN_HOST_LOOKUP"],
+          ),
+      );
+
+      // Then the host value is still reachable, past the run's own.
+      assertIdentical(hostValue, "host value");
+    } finally {
+      delete process.env["YULIN_HOST_LOOKUP"];
+    }
+  });
+
+  it("keeps process.env assignable", async () => {
+    // Given the patch is installed.
+    await simLambdaProcessEnvironment.run({}, () => Promise.resolve());
+    const hostVariables = process.env;
+
+    try {
+      // When something replaces process.env wholesale, as tooling may.
+      process.env = { ...hostVariables, YULIN_REPLACED: "replaced" };
+
+      // Then the replacement is what everything outside a run now reads.
+      assertIdentical(process.env["YULIN_REPLACED"], "replaced");
+    } finally {
+      process.env = hostVariables;
+    }
+  });
+});

--- a/src/service/lambda/function/environment/sim-lambda-process-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-process-environment.iso.test.ts
@@ -114,6 +114,34 @@ describe("sim Lambda process env", () => {
     }
   });
 
+  it("keeps a whole-object assignment inside the run", async () => {
+    // Given a variable set on the host process.
+    process.env["YULIN_HOST_SURVIVES"] = "host value";
+
+    try {
+      // When a run replaces process.env wholesale, as function code may.
+      const insideRun = await simLambdaProcessEnvironment.run(
+        { TABLE_NAME: "widgets" },
+        () => {
+          process.env = { REPLACED: "replaced" };
+          return Promise.resolve({
+            replaced: process.env["REPLACED"],
+            tableName: process.env["TABLE_NAME"],
+          });
+        },
+      );
+
+      // Then the run saw its own replacement, and the host environment came
+      // through the invocation untouched.
+      assertIdentical(insideRun.replaced, "replaced");
+      assertUndefined(insideRun.tableName);
+      assertIdentical(process.env["YULIN_HOST_SURVIVES"], "host value");
+      assertUndefined(process.env["REPLACED"]);
+    } finally {
+      delete process.env["YULIN_HOST_SURVIVES"];
+    }
+  });
+
   it("keeps process.env assignable", async () => {
     // Given the patch is installed.
     await simLambdaProcessEnvironment.run({}, () => Promise.resolve());

--- a/src/service/lambda/function/environment/sim-lambda-process-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-process-environment.ts
@@ -1,0 +1,83 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * The process.env a sim Lambda handler function sees while it runs.
+ *
+ * A handler backed by a real in-process function is a closure over its own
+ * module scope, so unlike zip code running in a vm context it has no sandbox
+ * to give it an environment of its own: it reads the host process.env like
+ * any other code in the test run. Node.js asynchronous context tracking
+ * bridges that gap. The function's variables are held in an
+ * AsyncLocalStorage store for the duration of the invocation, and process.env
+ * resolves to that store while it is set.
+ *
+ * The store follows the invocation across await points, and concurrent
+ * invocations of different functions each see their own variables, which a
+ * swap-and-restore around the handler call could not manage.
+ *
+ * The one thing this cannot reach is a read that already happened. A handler
+ * module doing `const TABLE = process.env.TABLE_NAME` at module scope is
+ * evaluated when the test file imports it, long before any invocation, so it
+ * captures the host value. Reads inside the handler body see the function's
+ * own variables. See SimLambdaEnvironmentConflicts, which warns when that
+ * distinction actually changes what the code sees.
+ */
+class SimLambdaProcessEnvironment {
+  private readonly storage = new AsyncLocalStorage<Record<string, string>>();
+  private hostEnvironment: NodeJS.ProcessEnv = process.env;
+  private installed = false;
+
+  /**
+   * Run an invocation with the given variables as its process.env.
+   */
+  async run<T>(
+    variables: Record<string, string>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    this.install();
+    return await this.storage.run(variables, run);
+  }
+
+  /**
+   * The host process environment, ignoring any invocation in progress.
+   */
+  hostVariables(): NodeJS.ProcessEnv {
+    return this.hostEnvironment;
+  }
+
+  /**
+   * Redefine process.env as an accessor backed by the invocation store.
+   *
+   * process.env is a plain configurable data property on process, so it can
+   * be replaced with a getter. Outside a sim Lambda invocation the getter
+   * hands back the untouched host environment object, so the patch is inert:
+   * anything that reads, writes, or stubs process.env normally is unaffected.
+   *
+   * Installed once and never removed. Removing it would be unsafe while
+   * another invocation is in flight, and there is nothing to gain: an
+   * installed patch with no invocation running behaves exactly like no patch
+   * at all.
+   */
+  private install(): void {
+    if (this.installed) {
+      return;
+    }
+
+    this.hostEnvironment = process.env;
+    Object.defineProperty(process, "env", {
+      configurable: true,
+      enumerable: true,
+      get: (): NodeJS.ProcessEnv =>
+        this.storage.getStore() ?? this.hostEnvironment,
+      set: (replacement: NodeJS.ProcessEnv): void => {
+        this.hostEnvironment = replacement;
+      },
+    });
+    this.installed = true;
+  }
+}
+
+/**
+ * Shared because it patches a process global: one patch, one store.
+ */
+export const simLambdaProcessEnvironment = new SimLambdaProcessEnvironment();

--- a/src/service/lambda/function/environment/sim-lambda-process-environment.ts
+++ b/src/service/lambda/function/environment/sim-lambda-process-environment.ts
@@ -70,10 +70,38 @@ class SimLambdaProcessEnvironment {
       get: (): NodeJS.ProcessEnv =>
         this.storage.getStore() ?? this.hostEnvironment,
       set: (replacement: NodeJS.ProcessEnv): void => {
-        this.hostEnvironment = replacement;
+        this.replaceVariables(replacement);
       },
     });
     this.installed = true;
+  }
+
+  /**
+   * Apply an assignment to process.env as a whole.
+   *
+   * Inside an invocation this has to stay invocation-local, like a write to a
+   * single variable does, or function code could wipe out the host
+   * environment for the rest of the test run. The store's object identity is
+   * fixed for the run, so the assignment is copied into it rather than
+   * swapping the reference. Outside an invocation it replaces the host
+   * environment, as an assignment to process.env normally would.
+   */
+  private replaceVariables(replacement: NodeJS.ProcessEnv): void {
+    const store = this.storage.getStore();
+    if (store === undefined) {
+      this.hostEnvironment = replacement;
+      return;
+    }
+
+    for (const name of Object.keys(store)) {
+      Reflect.deleteProperty(store, name);
+    }
+    for (const [name, value] of Object.entries(replacement)) {
+      if (value !== undefined) {
+        // eslint-disable-next-line security/detect-object-injection
+        store[name] = value;
+      }
+    }
   }
 }
 

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -7,6 +7,7 @@ import {
   type SimLambdaExecutableCode,
   SimLambdaHandlerReferenceCode,
 } from "./code/sim-lambda-executable-code.js";
+import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
 import {
@@ -58,6 +59,7 @@ export interface SimLambdaFunctionConfiguration {
   Handler?: string | undefined;
   Runtime?: string | undefined;
   Description?: string | undefined;
+  Environment?: { Variables: Record<string, string> } | undefined;
 }
 
 interface SimLambdaFunctionProperties {
@@ -72,6 +74,7 @@ interface SimLambdaFunctionProperties {
   description?: string | undefined;
   timeoutSeconds?: number | undefined;
   memorySizeMb?: number | undefined;
+  environment?: SimLambdaEnvironment | undefined;
   runAsOwner?: SimAwsRunAsOwner;
 }
 
@@ -92,6 +95,7 @@ export class SimLambdaFunction {
   public readonly description: string | undefined;
   public readonly timeoutSeconds: number;
   public readonly memorySizeMb: number;
+  public readonly environment: SimLambdaEnvironment;
 
   #state: SimLambdaFunctionState;
   private readonly code: SimLambdaExecutableCode;
@@ -111,6 +115,7 @@ export class SimLambdaFunction {
       description,
       timeoutSeconds = DEFAULT_SIM_LAMBDA_TIMEOUT_SECONDS,
       memorySizeMb = DEFAULT_SIM_LAMBDA_MEMORY_SIZE_MB,
+      environment,
       runAsOwner = this,
     } = properties;
     this.name = name as SimLambdaFunctionName;
@@ -123,6 +128,13 @@ export class SimLambdaFunction {
     this.description = description;
     this.timeoutSeconds = timeoutSeconds;
     this.memorySizeMb = memorySizeMb;
+    this.environment =
+      environment ??
+      new SimLambdaEnvironment({
+        functionName: name,
+        regionName: accountRegionScope.regionName,
+        memorySizeMb,
+      });
     this.runAsOwner = runAsOwner;
   }
 
@@ -163,6 +175,7 @@ export class SimLambdaFunction {
       Handler: this.handlerName,
       Runtime: this.runtimeName,
       Description: this.description,
+      Environment: this.environment.configuration(),
     };
   }
 
@@ -171,8 +184,9 @@ export class SimLambdaFunction {
    *
    * The handler runs with this function's execution Role as the ambient
    * simulated caller for the run-as owner, which is the owning SimAws
-   * instance when the function was created through one. Cold-start module
-   * imports also run as the execution Role, as on real Lambda.
+   * instance when the function was created through one, and with this
+   * function's own environment variables. Cold-start module imports also run
+   * as the execution Role and with the same environment, as on real Lambda.
    *
    * Resolves with the handler result, or rejects with the handler or
    * Runtime.* cold-start error.
@@ -189,10 +203,13 @@ export class SimLambdaFunction {
       this.runAsOwner,
       { kind: "arn", arn: this.roleArn },
       async () =>
-        await this.runner.run(
-          this.code.handlerFunction(),
-          event,
-          contextBuilder,
+        await this.environment.runWith(
+          async () =>
+            await this.runner.run(
+              this.code.handlerFunction(),
+              event,
+              contextBuilder,
+            ),
         ),
     );
   }

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -16,6 +16,7 @@ import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-res
 import { CreateFunctionCommandHandler } from "./command/create-function/create-function.handler.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
 import type {
   SimLambdaFunction,
   SimLambdaFunctionMap,
@@ -63,6 +64,12 @@ export class SimLambda {
   private readonly codeStore: SimLambdaCodeStore | undefined;
   private readonly vmSdkModuleProvider:
     SimLambdaVmSdkModuleProvider | undefined;
+  /**
+   * Shared across function creations so a conflicting environment variable is
+   * only reported once for this simulated Lambda.
+   */
+  private readonly environmentConflicts = new SimLambdaEnvironmentConflicts();
+
   private readonly cfnFactory = new SimLambdaCloudFormationResourceFactory(
     this,
   );
@@ -103,6 +110,7 @@ export class SimLambda {
       background: this.background,
       codeStore: this.codeStore,
       vmSdkModuleProvider: this.vmSdkModuleProvider,
+      environmentConflicts: this.environmentConflicts,
     });
     return await handler.handle(command, options);
   }


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-function Lambda environment variables via `CreateFunction` and CloudFormation `Environment.Variables`.
  * `process.env` now exposes configured variables with AWS-style runtime variables, isolated across functions and overlapping invocations.
  * In-process handlers see invocation-scoped values (including safe separation for concurrent runs) and environment writes don’t affect the host.

* **Documentation**
  * Expanded guidance on configuration, isolation behavior, reserved-name validation, and module-scope read limitations.

* **Tests**
  * Added coverage for validation and propagation across `CreateFunction`, CloudFormation, and environment conflict reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->