### PR TITLE
feat: sim Lambda Function URLs

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -19,6 +19,9 @@ Sim Lambda currently supports:
 - Fetching function configuration with `GetFunctionCommand`
 - Invoking functions with `InvokeCommand`, including the `RequestResponse`, `Event`, and `DryRun`
   invocation types
+- Function URLs, created with `CreateFunctionUrlConfigCommand` and served over real HTTP on
+  localhost with `serveSimAws`, so application code can call a simulated function the way it calls
+  a deployed one
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
@@ -32,11 +35,11 @@ Sim Lambda currently supports:
   AWS environment
 - Execution roles: handlers run as their execution `Role`, evaluated against simulated IAM
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
-  `lambda:GetFunction`, `lambda:InvokeFunction`)
+  `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
 - AWS-like validation and errors, such as `ResourceConflictException` for duplicate function names
   and `Could not unzip uploaded file` for invalid zip bytes
-- CloudFormation resource `AWS::Lambda::Function`, with `Ref`/`Fn::GetAtt` support and deploy-time
-  executable bindings
+- CloudFormation resources `AWS::Lambda::Function` and `AWS::Lambda::Url`, with `Ref`/`Fn::GetAtt`
+  support and deploy-time executable bindings
 
 Real `LambdaClient` instances can also be routed into sim Lambda with
 [SDK interception](../../sdk/ "Simulated AWS SDK interception docs").
@@ -429,6 +432,132 @@ console.log(dryRunOutput.StatusCode);
 `Event` invocation handler errors are dropped, as sim Lambda does not simulate asynchronous
 retries or failure destinations yet.
 
+## Function URLs
+
+A Function URL is an HTTP endpoint for one function. Creating one with
+`CreateFunctionUrlConfigCommand` returns an AWS-shaped endpoint:
+
+```text
+https://<url-id>.lambda-url.<region>.on.aws/
+```
+
+Serving that URL with `serveSimAws` is the point of the feature: application code, a frontend dev
+server, or curl can make real HTTP requests to a simulated Lambda function, alongside the other
+simulated services on the same local server. Pass the Function URL through `srv.localUrl(...)`,
+which keeps the endpoint's hostname but sends the request to the local server, in the same way it
+adapts simulated S3 website and CloudFront URLs.
+
+```typescript sim-lambda-function-url
+/**
+ * Serving a simulated Lambda Function URL on localhost.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  type SimLambdaFunctionUrlEvent,
+  makeLambdaZipFileInput,
+} from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "greeter",
+    Role: "arn:aws:iam::111111111111:role/GreeterRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaFunctionUrlEvent) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `Hello ${event.queryStringParameters?.["name"] ?? "world"}`,
+      })),
+    },
+  }),
+);
+
+const urlConfig = await lambda.createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "greeter",
+    AuthType: "NONE",
+  }),
+);
+
+// https://<url-id>.lambda-url.us-east-1.on.aws/
+console.log(urlConfig.FunctionUrl);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(
+    srv.localUrl(`${urlConfig.FunctionUrl}greet?name=Yulin`),
+  );
+
+  console.log(response.status);
+  console.log(await response.text());
+} finally {
+  srv.close();
+}
+```
+
+On localhost the endpoint hostname becomes
+`<url-id>.lambda-url.<region>.sim-aws.localhost:<port>`, dropping the `.on.aws` tail the way
+simulated S3 endpoints drop `.amazonaws.com`. Requests are routed by that hostname, so a Function
+URL created in a non-default account or region reaches the right function without any extra
+configuration.
+
+### The invocation event and the response
+
+The handler receives the API Gateway HTTP API payload format 2.0 event that real Function URLs
+send, which is the only format they use:
+
+```json
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/greet",
+  "rawQueryString": "name=Yulin",
+  "headers": { "host": "...", "user-agent": "..." },
+  "queryStringParameters": { "name": "Yulin" },
+  "cookies": ["session=abc"],
+  "requestContext": {
+    "http": { "method": "GET", "path": "/greet", "sourceIp": "127.0.0.1" }
+  },
+  "isBase64Encoded": false
+}
+```
+
+Cookies arrive in their own `cookies` field rather than in `headers`, and a request body arrives on
+`body` as text or, for binary content types, as base64 with `isBase64Encoded` set.
+
+A handler can answer in either of the two shapes real Lambda accepts:
+
+- a structured response, recognised by its `statusCode`, whose `headers`, `body`, `cookies` (sent
+  as `set-cookie` headers) and `isBase64Encoded` control the HTTP response
+- any other value, which becomes a `200` JSON response, as in
+  `return { greeting: "hello" }`
+
+If the handler throws, the endpoint answers `502` with an AWS-like error document rather than the
+handler's error, which stays visible to the test as the thrown error would be through
+`InvokeCommand`.
+
+### Managing a Function URL
+
+`GetFunctionUrlConfigCommand` reads the configuration back, `UpdateFunctionUrlConfigCommand`
+changes the `AuthType` or `InvokeMode` while keeping the same endpoint, and
+`DeleteFunctionUrlConfigCommand` removes it, after which the hostname stops resolving and returns
+`404`. `ListFunctionUrlConfigsCommand` lists what a function has, which is either nothing or one
+configuration, since a function has at most one Function URL.
+
+A URL created with `AuthType: "AWS_IAM"` is stored and reported, but the simulator does not verify
+SigV4 signatures, so serving one refuses every request with `403`. Use `AuthType: "NONE"` for URLs
+a test needs to call.
+
 ## Environment variables
 
 A function can declare its own environment variables with `Environment.Variables`, as on real
@@ -632,6 +761,90 @@ A function whose `Code` points at a missing CDK bootstrap assets bucket
 templates deploy without their asset staging. Code in any other missing bucket fails the deploy
 AWS-style with a `NoSuchBucket` diagnostic.
 
+## Function URLs in templates
+
+`AWS::Lambda::Url` creates a Function URL for a deployed function, which is what CDK's
+`Function.addFunctionUrl(...)` emits. `TargetFunctionArn` accepts either an `Fn::GetAtt` ARN or a
+`Ref` to the function, and `Fn::GetAtt` on the URL exposes `FunctionUrl` and `FunctionArn`.
+
+```typescript sim-lambda-cloudformation-function-url
+/**
+ * Deploying a simulated Lambda Function URL from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "GreeterRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => " +
+              "({ statusCode: 200, body: 'Hello ' + event.rawPath });",
+          },
+        },
+      },
+      GreeterUrl: {
+        Type: "AWS::Lambda::Url",
+        Properties: {
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "NONE",
+        },
+      },
+    },
+    Outputs: {
+      GreeterFunctionUrl: {
+        Value: { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const functionUrl = stack.outputs.get("GreeterFunctionUrl")?.value as string;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl(`${functionUrl}hello`));
+
+  console.log(await response.text());
+} finally {
+  srv.close();
+}
+```
+
+CDK templates work the same way: synth the app, deploy the template file, and read
+`functionUrl.url` from the stack outputs. Note that CDK pairs a public Function URL with an
+`AWS::Lambda::Permission`, which is not simulated and is skipped with a diagnostic rather than
+failing the deployment.
+
 ## Executable bindings
 
 Deploy-time `bindings` let a template function be backed by a real in-process handler instead of
@@ -699,8 +912,15 @@ deploy with the unmatched target named for diagnosis.
 
 Current documented limitations:
 
-- Only `CreateFunctionCommand`, `GetFunctionCommand`, and `InvokeCommand` are supported —
-  no `UpdateFunctionCode`, `DeleteFunction`, or function listing yet.
+- Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, and the Function URL config
+  commands are supported — no `UpdateFunctionCode`, `DeleteFunction`, or function listing yet.
+- Function URLs with `AuthType: "AWS_IAM"` are stored and reported, but SigV4 signatures are not
+  verified, so serving one refuses every request with `403`.
+- The Function URL `Cors` configuration is not simulated, including OPTIONS preflight handling.
+- `InvokeMode: "RESPONSE_STREAM"` is accepted and reported, but responses are always served
+  buffered.
+- A function has at most one Function URL, and qualified (version or alias) Function URLs are not
+  simulated.
 - Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
@@ -712,9 +932,12 @@ Current documented limitations:
 - `Timeout` is recorded but does not interrupt handler execution.
 - `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
-- CloudFormation resource types other than `AWS::Lambda::Function` (`Version`, `Alias`,
-  `Permission`, `EventSourceMapping`, ...) are skipped with an "Unsupported" diagnostic.
+- CloudFormation resource types other than `AWS::Lambda::Function` and `AWS::Lambda::Url`
+  (`Version`, `Alias`, `Permission`, `EventSourceMapping`, ...) are skipped with an "Unsupported"
+  diagnostic.
 - The `vm` context is a namespacing convenience, not a security boundary: function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.
-- Lambda is not served as an HTTP API by `serveSimAws`.
+- Only Function URLs are served over HTTP by `serveSimAws`; the Lambda control-plane API itself is
+  not served, so SDK commands go through `SimAws` or [SDK interception](../../sdk/) rather than
+  over the local server.

--- a/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-function-url.example.ts
@@ -1,0 +1,70 @@
+/**
+ * Deploying a simulated Lambda Function URL from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "greeter-stack",
+  template: {
+    Resources: {
+      GreeterRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "GreeterRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => " +
+              "({ statusCode: 200, body: 'Hello ' + event.rawPath });",
+          },
+        },
+      },
+      GreeterUrl: {
+        Type: "AWS::Lambda::Url",
+        Properties: {
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "NONE",
+        },
+      },
+    },
+    Outputs: {
+      GreeterFunctionUrl: {
+        Value: { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const functionUrl = stack.outputs.get("GreeterFunctionUrl")?.value as string;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl(`${functionUrl}hello`));
+
+  console.log(await response.text());
+} finally {
+  srv.close();
+}

--- a/docs/services/lambda/sim-lambda-function-url.example.ts
+++ b/docs/services/lambda/sim-lambda-function-url.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Serving a simulated Lambda Function URL on localhost.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  type SimLambdaFunctionUrlEvent,
+  makeLambdaZipFileInput,
+} from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "greeter",
+    Role: "arn:aws:iam::111111111111:role/GreeterRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaFunctionUrlEvent) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `Hello ${event.queryStringParameters?.["name"] ?? "world"}`,
+      })),
+    },
+  }),
+);
+
+const urlConfig = await lambda.createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "greeter",
+    AuthType: "NONE",
+  }),
+);
+
+// https://<url-id>.lambda-url.us-east-1.on.aws/
+console.log(urlConfig.FunctionUrl);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(
+    srv.localUrl(`${urlConfig.FunctionUrl}greet?name=Yulin`),
+  );
+
+  console.log(response.status);
+  console.log(await response.text());
+} finally {
+  srv.close();
+}

--- a/src/serve/controller/container/sim-aws-service-controller-container.iso.test.ts
+++ b/src/serve/controller/container/sim-aws-service-controller-container.iso.test.ts
@@ -6,6 +6,7 @@ import {
   assertThrowsError,
 } from "@kensio/smartass";
 import { SimAws } from "../../../service/aws/sim-aws.js";
+import { SimLambdaServiceController } from "../../../service/lambda/serve/sim-lambda-controller.js";
 import { SimS3ServiceController } from "../../../service/s3/serve/sim-s3-controller.js";
 import { SimAwsServiceControllerContainer } from "./sim-aws-service-controller-container.js";
 
@@ -18,6 +19,16 @@ describe("SimAwsServiceControllerContainer", () => {
     const controller = container.controllerForService("s3");
 
     assertInstanceOf(controller, SimS3ServiceController);
+  });
+
+  it("returns Lambda service controller", () => {
+    const simAws = new SimAws();
+
+    const container = new SimAwsServiceControllerContainer({ simAws });
+
+    const controller = container.controllerForService("lambda");
+
+    assertInstanceOf(controller, SimLambdaServiceController);
   });
 
   it("returns same controller for same service", () => {

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceController } from "../sim-service-controller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
+import { SimLambdaServiceController } from "../../../service/lambda/serve/sim-lambda-controller.js";
 import { SimRoute53ServiceController } from "../../../service/route53/serve/sim-route53-controller.js";
 import { SimS3ServiceController } from "../../../service/s3/serve/sim-s3-controller.js";
 
@@ -22,6 +23,9 @@ export class SimAwsServiceControllerFactory {
         return new SimCloudFrontServiceController({
           simAws: this.simAws,
         });
+      }
+      case "lambda": {
+        return new SimLambdaServiceController({ simAws: this.simAws });
       }
       case "route53": {
         return new SimRoute53ServiceController({ simAws: this.simAws });

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -2,7 +2,7 @@ import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
 
 export interface SimAwsServiceTarget {
-  readonly service: "s3" | "cloudFront" | "route53";
+  readonly service: "s3" | "cloudFront" | "lambda" | "route53";
   readonly resourceName: string;
   // regionName is used for validation, not look-up
   readonly regionName?: AwsRegionName;

--- a/src/serve/http/url/sim-aws-local-url.iso.test.ts
+++ b/src/serve/http/url/sim-aws-local-url.iso.test.ts
@@ -27,6 +27,20 @@ describe("Simulated AWS local URL", () => {
     );
   });
 
+  it("replaces an AWS Lambda Function URL suffix with the local hostname suffix", () => {
+    const url = new SimAwsLocalUrl({
+      input:
+        "https://2sn5f1tes4o11qsj5ue6cb5ndltmgute.lambda-url.eu-west-2.on.aws/hello",
+      port: "12345",
+    });
+
+    assertIdentical(
+      url.toString(),
+      "http://2sn5f1tes4o11qsj5ue6cb5ndltmgute.lambda-url.eu-west-2" +
+        ".sim-aws.localhost:12345/hello",
+    );
+  });
+
   it("adds the local hostname suffix to other hostnames", () => {
     const url = new SimAwsLocalUrl({
       input: "https://www.example.test/foo/",

--- a/src/serve/http/url/sim-aws-local-url.ts
+++ b/src/serve/http/url/sim-aws-local-url.ts
@@ -50,15 +50,28 @@ export class SimAwsLocalUrl {
       return hostname;
     }
 
-    const s3AwsHostname =
-      /^(?<prefix>.+\.(?:s3|s3-website)\.[^.]+)\.amazonaws\.com$/.exec(
-        hostname,
-      );
+    const awsHostnamePrefix = this.awsHostnamePrefix(hostname);
 
-    if (s3AwsHostname?.groups?.["prefix"] !== undefined) {
-      return `${s3AwsHostname.groups["prefix"]}${SimAwsLocalUrl.localhostSuffix}`;
+    if (awsHostnamePrefix !== undefined) {
+      return `${awsHostnamePrefix}${SimAwsLocalUrl.localhostSuffix}`;
     }
 
     return `${hostname}${SimAwsLocalUrl.localhostSuffix}`;
+  }
+
+  /**
+   * Get the part of a real AWS service hostname that identifies the resource,
+   * dropping the AWS domain the local suffix replaces.
+   *
+   * Returns undefined for hostnames that are not AWS service endpoints, such
+   * as a CloudFront alternate domain name, which are used as they are.
+   */
+  private awsHostnamePrefix(hostname: string): string | undefined {
+    const awsHostname =
+      /^(?<prefix>.+\.(?:s3|s3-website)\.[^.]+)\.amazonaws\.com$/.exec(
+        hostname,
+      ) ?? /^(?<prefix>.+\.lambda-url\.[^.]+)\.on\.aws$/.exec(hostname);
+
+    return awsHostname?.groups?.["prefix"];
   }
 }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -19,6 +19,7 @@ import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimLambda } from "../../lambda/index.js";
+import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimSts } from "../../sts/sim-sts.js";
@@ -59,6 +60,16 @@ export class SimAwsServiceFactory {
    * instance so cross-account services can resolve Account-owned IAM state.
    */
   public readonly iamRegistry = new SimIamRegistry();
+
+  /**
+   * Shared simulated Lambda Function URL registry.
+   *
+   * This maps Function URL ids to the Accounts that own them, so the
+   * localhost serving layer can route a Function URL request to the right
+   * Account/Region scope from the request hostname alone.
+   * @internal
+   */
+  public readonly lambdaUrlRegistry = new SimLambdaUrlRegistry();
 
   private readonly simAws: SimAws;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
@@ -182,6 +193,7 @@ export class SimAwsServiceFactory {
       iam,
       background: this.background,
       runAsOwner: this.simAws,
+      urlRegistry: this.lambdaUrlRegistry,
       codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
       vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
         simAws: this.simAws,

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -17,6 +17,7 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimCloudFrontRegistry } from "../cloudfront/registry/sim-cloud-front-registry.js";
+import type { SimLambdaUrlRegistry } from "../lambda/registry/sim-lambda-url-registry.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
@@ -174,6 +175,18 @@ export class SimAws {
    */
   cloudFrontRegistry(): SimCloudFrontRegistry {
     return this.serviceFactory.cloudFrontRegistry;
+  }
+
+  /**
+   * Get the shared simulated Lambda Function URL registry.
+   *
+   * This is intended for Lambda controller wiring, so serving a Function URL
+   * request resolves the owning Account from the same registry the Function
+   * URL commands register ids in.
+   * @internal
+   */
+  lambdaUrlRegistry(): SimLambdaUrlRegistry {
+    return this.serviceFactory.lambdaUrlRegistry;
   }
 
   /**

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-function-url.loc.test.ts
@@ -1,0 +1,161 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed Function URL over real localhost
+ * HTTP.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The handler
+ * returns a structured Function URL response, reading the query string from
+ * the payload format 2.0 event.
+ */
+const greeterHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: "Hello " + (event.queryStringParameters?.name || "world"),
+});
+`;
+
+describe("Sim CDK Lambda Function URL deployment local integration", () => {
+  it("serves a CDK-deployed Function URL over localhost", async () => {
+    // Given a CDK stack with a Lambda function that has a public Function URL.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const greeterFunction = new lambda.Function(stack, "GreeterFunction", {
+  functionName: "cdk-greeter",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(greeterHandlerSource)}),
+});
+
+const greeterUrl = greeterFunction.addFunctionUrl({
+  authType: lambda.FunctionUrlAuthType.NONE,
+});
+
+new cdk.CfnOutput(stack, "GreeterFunctionUrl", {
+  value: greeterUrl.url,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation and serve it.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the CDK Function URL output is the deployed endpoint.
+    const functionUrl = stack.outputs.get("GreeterFunctionUrl")?.value;
+    assertTypeString(functionUrl);
+    assertIdentical(
+      functionUrl,
+      simAws.lambda().getSimFunctionUrl("cdk-greeter")?.url,
+    );
+
+    // And fetching that endpoint on localhost runs the deployed function.
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const response = await fetch(
+        srv.localUrl(`${functionUrl}greet?name=CDK`),
+      );
+
+      assertIdentical(response.status, 200);
+      assertIdentical(response.headers.get("content-type"), "text/plain");
+      assertIdentical(await response.text(), "Hello CDK");
+    } finally {
+      srv.close();
+    }
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips the AWS::Lambda::Permission CDK adds for a public URL", async () => {
+    // Given a CDK stack with a public Function URL, which CDK pairs with an
+    // AWS::Lambda::Permission granting lambda:InvokeFunctionUrl to everyone.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const greeterFunction = new lambda.Function(stack, "GreeterFunction", {
+  functionName: "cdk-greeter",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline("exports.handler = async () => 'ok';"),
+});
+
+greeterFunction.addFunctionUrl({
+  authType: lambda.FunctionUrlAuthType.NONE,
+});
+
+app.synth();
+      `,
+    );
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the template is deployed.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the unsupported permission Resource is skipped with a diagnostic
+    // rather than failing the deployment, and the Function URL still works.
+    const permissionResource = stack.resources
+      .values()
+      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    assertNonNullable(permissionResource);
+    assertTrue(permissionResource.skipped);
+    assertStringIncludes(
+      permissionResource.skippedReason ?? "",
+      "Unsupported sim Lambda CloudFormation Resource Permission",
+    );
+    assertNonNullable(simAws.lambda().getSimFunctionUrl("cdk-greeter"));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-url-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-function-url-cfn.ts
@@ -1,0 +1,46 @@
+import type { SimLambdaFunctionUrl } from "../../../../lambda/function/url/sim-lambda-function-url.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLambdaFunctionUrlCfnProperties {
+  readonly functionUrl: SimLambdaFunctionUrl;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::Lambda::Url Resource.
+ *
+ * The endpoint itself is what templates almost always want from this
+ * Resource, through Fn::GetAtt FunctionUrl, which is what CDK's
+ * `FunctionUrl.url` resolves to.
+ */
+export class SimLambdaFunctionUrlCfn implements SimCfnResourceValueAdapter {
+  private readonly functionUrl: SimLambdaFunctionUrl;
+
+  constructor(properties: SimLambdaFunctionUrlCfnProperties) {
+    this.functionUrl = properties.functionUrl;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::Lambda::Url returns the endpoint URL.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.functionUrl.url;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::Lambda::Url.
+   *
+   * AWS::Lambda::Url supports Fn::GetAtt for FunctionUrl and FunctionArn.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "FunctionUrl") {
+      return this.functionUrl.url;
+    }
+
+    if (attributeName === "FunctionArn") {
+      return this.functionUrl.functionArn;
+    }
+
+    return `${this.functionUrl.url}.${attributeName}`;
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -16,6 +16,8 @@ import { SimIamRoleCfn } from "./iam/sim-iam-role-cfn.js";
 import type { SimIamRole } from "../../../iam/role/sim-iam-role.js";
 import { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
 import { SimLambdaFunctionCfn } from "./lambda/sim-lambda-function-cfn.js";
+import { SimLambdaFunctionUrl } from "../../../lambda/function/url/sim-lambda-function-url.js";
+import { SimLambdaFunctionUrlCfn } from "./lambda/sim-lambda-function-url-cfn.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -93,6 +95,15 @@ export function simCfnResourceValueAdapter(
   ) {
     return new SimLambdaFunctionCfn({
       lambdaFunction: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::Url" &&
+    properties.simResource instanceof SimLambdaFunctionUrl
+  ) {
+    return new SimLambdaFunctionUrlCfn({
+      functionUrl: properties.simResource,
     });
   }
 

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -49,6 +49,9 @@ Current command areas include:
 - `create-function/`
 - `get-function/`
 - `invoke/`
+- `create-function-url-config/`, `get-function-url-config/`,
+  `update-function-url-config/`, `delete-function-url-config/`,
+  `list-function-url-configs/`
 
 The main `SimLambda` class delegates command execution to handlers rather than keeping command
 handling logic inline.
@@ -206,12 +209,68 @@ execution roles.
 A standalone `SimLambda` (constructed directly rather than through `SimAws`) is its own run-as
 owner, keeping its ambient callers isolated.
 
+## Function URLs
+
+`function/url/` owns Function URLs: `SimLambdaFunctionUrl` is the stored resource and
+`SimLambdaFunctionUrlStore` holds one per function for an Account/Region scope. Creating one
+allocates a URL id and builds the AWS-shaped endpoint from it:
+
+```text
+https://<url-id>.lambda-url.<region>.on.aws/
+```
+
+The URL id is the routing key, so it is allocated from `SimLambdaUrlRegistry` (`registry/`), which
+maps ids to the Accounts that own them across one `SimAws` instance. A served request carries its
+region in the hostname but not its Account, and Lambda state is per Account/Region, so without that
+registry a Function URL host could not be resolved to a function. `SimCloudFrontRegistry` has the
+same shape for a different reason: CloudFront is not region-scoped, whereas this registry exists
+purely for the hostname-to-Account hop.
+
+### Serving
+
+`serve/` is the localhost HTTP side, reached through `serveSimAws` like the S3 and CloudFront
+controllers. Routing goes through simulated Route53: `<url-id>.lambda-url.<region>` is a terminal
+service target, with `SimAwsLocalUrl` dropping the real `.on.aws` tail exactly as it drops
+`.amazonaws.com` from S3 endpoints, giving:
+
+```text
+http://<url-id>.lambda-url.<region>.sim-aws.localhost:<port>/
+```
+
+`SimLambdaUrlRouter` turns that target back into a Function URL and function, then
+`SimLambdaServiceController` converts the request into a payload format 2.0 event
+(`serve/event/`) and the handler result back into a response (`serve/response/`). Payload format
+2.0 is the only format real Function URLs use, so there is no version to choose. Text bodies cross
+as strings and everything else as base64, in both directions, decided by content type in
+`SimLambdaUrlBodyEncoding`. A handler returning a structured result (one carrying `statusCode`)
+controls the response, including `cookies` becoming `set-cookie` headers; any other return value
+becomes a 200 JSON response, as on AWS.
+
+A Function URL request is not attributed to a simulated principal: a `NONE` auth URL is invokable
+by anyone on AWS, so the controller invokes the function directly rather than through the Invoke
+command's IAM path. The function still runs as its execution Role.
+
+`AWS_IAM` URLs are stored and reported, but SigV4 signatures are not verified, so a served request
+to one is refused with 403 `{"Message":"Forbidden"}` rather than admitted unauthenticated. The
+endpoint's own error responses (403, 404 for an unknown or deleted URL, 502 for a handler error)
+are AWS-shaped JSON documents, though the exact wording is an approximation.
+
+### CloudFormation
+
+`cfn/url/` creates `AWS::Lambda::Url`, which is what CDK's `Function.addFunctionUrl()` emits.
+`TargetFunctionArn` accepts both an `Fn::GetAtt` ARN and a `Ref` function name, dropping any
+version or alias qualifier. `Fn::GetAtt` exposes `FunctionUrl` and `FunctionArn`, and `Ref`
+returns the endpoint URL, implemented by the `SimLambdaFunctionUrlCfn` value adapter alongside the
+function's own adapter.
+
 ## IAM authorization
 
 Command handlers authorize with per-command authorizers against the function ARN, using the
 account-scoped simulated IAM implementation when constructed through `SimAws`
-(`lambda:CreateFunction`, `lambda:GetFunction`, `lambda:InvokeFunction`), with the same
-allow-all fallback as other services for direct standalone construction.
+(`lambda:CreateFunction`, `lambda:GetFunction`, `lambda:InvokeFunction`, and the
+`lambda:*FunctionUrlConfig*` actions), with the same allow-all fallback as other services for
+direct standalone construction. The Function URL commands share one `FunctionUrlAuthorizer` taking
+the action as a constructor value, since only the action name varies between them.
 
 ## CloudFormation
 
@@ -261,7 +320,11 @@ are not supported and are skipped by the CloudFormation engine with an "Unsuppor
 
 ## Not simulated yet
 
-- `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`
+- `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function` and
+  `AWS::Lambda::Url`
+- Function URL SigV4 verification, so `AWS_IAM` URLs refuse every served request
+- Function URL `Cors` configuration and OPTIONS preflight handling
+- `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime
 - container image functions (`Code.ImageUri`) — the simulator stays Docker-free
 - `UpdateFunctionCode`, versions, aliases and qualifiers

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
@@ -3,8 +3,8 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
- * Validates individual AWS::Lambda::Function CloudFormation property values,
- * failing with a diagnostic naming the property and the logical ID.
+ * Validates individual AWS::Lambda::* CloudFormation property values, failing
+ * with a diagnostic naming the Resource type, the property and the logical ID.
  */
 export class SimCfnLambdaPropertyParser {
   /**
@@ -95,7 +95,8 @@ export class SimCfnLambdaPropertyParser {
     expected: string,
   ): TypeError {
     return new TypeError(
-      `Invalid AWS::Lambda::Function ${resource.logicalId}: ${label} must be ${expected}`,
+      `Invalid ${resource.type ?? "AWS::Lambda::Function"} ` +
+        `${resource.logicalId}: ${label} must be ${expected}`,
     );
   }
 }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -5,15 +5,18 @@ import type {
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimLambda } from "../sim-lambda.js";
 import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
+import { SimCfnLambdaUrlCreator } from "./url/sim-cfn-lambda-url-creator.js";
 
 /**
  * CloudFormation Resource factory for simulated Lambda resources.
  */
 export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceResourceFactory {
   private readonly functionCreator: SimCfnLambdaFunctionCreator;
+  private readonly urlCreator: SimCfnLambdaUrlCreator;
 
   constructor(lambda: SimLambda) {
     this.functionCreator = new SimCfnLambdaFunctionCreator({ lambda });
+    this.urlCreator = new SimCfnLambdaUrlCreator({ lambda });
   }
 
   /**
@@ -30,6 +33,12 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
           resource,
           context.resolvedProperties ?? resource.properties,
           context.bindings,
+        );
+      }
+      case "Url": {
+        return await this.urlCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
         );
       }
       default: {

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
@@ -1,0 +1,70 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimLambdaFunctionUrl,
+  SimLambdaFunctionUrlAuthType,
+  SimLambdaFunctionUrlInvokeMode,
+} from "../../function/url/sim-lambda-function-url.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaUrlFunctionName } from "./sim-cfn-lambda-url-target.js";
+
+interface SimCfnLambdaUrlCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates simulated Lambda Function URLs from CloudFormation Resources.
+ *
+ * This is the resource CDK's `Function.addFunctionUrl()` emits, so a deployed
+ * template is the usual way a Function URL comes into existence outside a
+ * direct SDK call.
+ */
+export class SimCfnLambdaUrlCreator {
+  private readonly lambda: SimLambda;
+  private readonly propertyParser = new SimCfnLambdaPropertyParser();
+
+  constructor(properties: SimCfnLambdaUrlCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Create a simulated Function URL from an AWS::Lambda::Url Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLambdaFunctionUrl> {
+    const targetFunctionArn = this.propertyParser.requiredString(
+      resource,
+      properties["TargetFunctionArn"],
+      "TargetFunctionArn",
+    );
+    const functionName = simCfnLambdaUrlFunctionName(targetFunctionArn);
+
+    await this.lambda.createFunctionUrlConfig({
+      input: {
+        FunctionName: functionName,
+        AuthType: this.propertyParser.requiredString(
+          resource,
+          properties["AuthType"],
+          "AuthType",
+        ) as SimLambdaFunctionUrlAuthType,
+        InvokeMode: this.propertyParser.optionalString(
+          resource,
+          properties["InvokeMode"],
+          "InvokeMode",
+        ) as SimLambdaFunctionUrlInvokeMode | undefined,
+      },
+    });
+
+    const functionUrl = this.lambda.getSimFunctionUrl(functionName);
+    assertDefined(
+      functionUrl,
+      `Sim Lambda Function URL for ${functionName} after CloudFormation creation`,
+    );
+
+    return functionUrl;
+  }
+}

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-target.iso.test.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-target.iso.test.ts
@@ -1,0 +1,41 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfnLambdaUrlFunctionName } from "./sim-cfn-lambda-url-target.js";
+
+describe("AWS::Lambda::Url target function name", () => {
+  it("takes the function name out of a function ARN", () => {
+    // Given a TargetFunctionArn from Fn::GetAtt on the function.
+    const targetFunctionArn =
+      "arn:aws:lambda:eu-west-2:111111111111:function:greeter";
+
+    // When the target function name is read.
+    const functionName = simCfnLambdaUrlFunctionName(targetFunctionArn);
+
+    // Then it is the function the ARN names.
+    assertIdentical(functionName, "greeter");
+  });
+
+  it("drops a version or alias qualifier", () => {
+    // Given a qualified function ARN.
+    const targetFunctionArn =
+      "arn:aws:lambda:eu-west-2:111111111111:function:greeter:live";
+
+    // When the target function name is read.
+    const functionName = simCfnLambdaUrlFunctionName(targetFunctionArn);
+
+    // Then the qualifier is dropped, as qualified URLs are not simulated.
+    assertIdentical(functionName, "greeter");
+  });
+
+  it("accepts a bare function name", () => {
+    // Given a TargetFunctionArn from a Ref, which is the function name.
+    const targetFunctionArn = "greeter";
+
+    // When the target function name is read.
+    const functionName = simCfnLambdaUrlFunctionName(targetFunctionArn);
+
+    // Then it is used as it is.
+    assertIdentical(functionName, "greeter");
+  });
+});

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-target.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-target.ts
@@ -1,0 +1,24 @@
+const functionArnSeparator = ":function:";
+
+/**
+ * Get the function name an AWS::Lambda::Url TargetFunctionArn names.
+ *
+ * Templates reach this property in two ways: `Fn::GetAtt` on the function,
+ * giving a full ARN, or `Ref`, giving the function name. Both are accepted,
+ * as both are valid template ways to point at the same function. A version or
+ * alias qualifier on the ARN is dropped, as qualified Function URLs are not
+ * simulated.
+ */
+export function simCfnLambdaUrlFunctionName(targetFunctionArn: string): string {
+  const separatorIndex = targetFunctionArn.indexOf(functionArnSeparator);
+
+  if (separatorIndex === -1) {
+    return targetFunctionArn;
+  }
+
+  const nameAndQualifier = targetFunctionArn.slice(
+    separatorIndex + functionArnSeparator.length,
+  );
+
+  return nameAndQualifier.split(":", 1)[0] ?? nameAndQualifier;
+}

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url.iso.test.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url.iso.test.ts
@@ -1,0 +1,206 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertTypeString,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLambdaFunctionUrl } from "../../function/url/sim-lambda-function-url.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+function greeterTemplate(
+  urlProperties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      GreeterRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "GreeterRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      GreeterFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "greeter",
+          Role: { "Fn::GetAtt": ["GreeterRole", "Arn"] },
+          Code: {
+            ZipFile:
+              "exports.handler = async (event) => " +
+              "({ statusCode: 200, body: 'Hello ' + event.rawPath });",
+          },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+        },
+      },
+      GreeterUrl: {
+        Type: "AWS::Lambda::Url",
+        Properties: urlProperties,
+      },
+    },
+    Outputs: {
+      FunctionUrl: {
+        Value: { "Fn::GetAtt": ["GreeterUrl", "FunctionUrl"] },
+      },
+      FunctionArn: {
+        Value: { "Fn::GetAtt": ["GreeterUrl", "FunctionArn"] },
+      },
+      UnsupportedAttribute: {
+        Value: { "Fn::GetAtt": ["GreeterUrl", "Nonsense"] },
+      },
+      UrlRef: {
+        Value: { Ref: "GreeterUrl" },
+      },
+    },
+  };
+}
+
+describe("Lambda CloudFormation Function URL deployment", () => {
+  it("creates a servable Function URL from AWS::Lambda::Url", async () => {
+    // Given a template with a function and a Function URL targeting it.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+        AuthType: "NONE",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Resource is backed by a simulated Function URL that serves the
+    // deployed function.
+    const urlResource = stack.getResource("GreeterUrl");
+    assertNonNullable(urlResource);
+    const functionUrl = urlResource.simResource;
+    assertInstanceOf(functionUrl, SimLambdaFunctionUrl);
+
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({ input: `${functionUrl.url}hello` }).toString(),
+    );
+    assertIdentical(await response.text(), "Hello /hello");
+  });
+
+  it("resolves Fn::GetAtt FunctionUrl and FunctionArn", async () => {
+    // Given a deployed stack with a Function URL.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+        AuthType: "NONE",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the stack outputs are read.
+    const output = stack.outputs.get("FunctionUrl")?.value;
+
+    // Then the endpoint URL is what Fn::GetAtt FunctionUrl resolved to.
+    assertTypeString(output);
+    assertTrue(
+      /^https:\/\/[a-z0-9]{32}\.lambda-url\.us-east-1\.on\.aws\/$/.test(output),
+      `Unexpected Function URL output ${output}`,
+    );
+
+    // And Ref resolves to the same endpoint.
+    assertIdentical(stack.outputs.get("UrlRef")?.value, output);
+
+    // And Fn::GetAtt FunctionArn resolves to the target function.
+    assertIdentical(
+      stack.outputs.get("FunctionArn")?.value,
+      simAws.lambda().getSimFunctionUrl("greeter")?.functionArn,
+    );
+
+    // And an attribute AWS::Lambda::Url does not have resolves to a
+    // recognisable placeholder rather than failing the deployment.
+    assertIdentical(
+      stack.outputs.get("UnsupportedAttribute")?.value,
+      `${output}.Nonsense`,
+    );
+  });
+
+  it("accepts a Ref to the function as the target", async () => {
+    // Given a template pointing at the function by Ref, which is its name.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        TargetFunctionArn: { Ref: "GreeterFunction" },
+        AuthType: "NONE",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Function URL belongs to the named function.
+    const functionUrl = simAws.lambda().getSimFunctionUrl("greeter");
+    assertNonNullable(functionUrl);
+    assertStringIncludes(functionUrl.functionArn, ":function:greeter");
+  });
+
+  it("carries the template auth type and invoke mode", async () => {
+    // Given a template with a non-default Function URL configuration.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+        AuthType: "AWS_IAM",
+        InvokeMode: "RESPONSE_STREAM",
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the created Function URL has that configuration.
+    const functionUrl = simAws.lambda().getSimFunctionUrl("greeter");
+    assertNonNullable(functionUrl);
+    assertIdentical(functionUrl.authType, "AWS_IAM");
+    assertIdentical(functionUrl.invokeMode, "RESPONSE_STREAM");
+  });
+
+  it("fails the Resource when TargetFunctionArn is missing", async () => {
+    // Given a template whose Function URL names no target function.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "greeter-stack",
+        template: greeterTemplate({ AuthType: "NONE" }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the failure names the Resource type, property and logical ID.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Url GreeterUrl: TargetFunctionArn must be a string",
+    );
+  });
+});

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.command.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.command.ts
@@ -1,0 +1,36 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateFunctionUrlConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimLambdaFunctionUrlAuthType,
+  SimLambdaFunctionUrlConfiguration,
+  SimLambdaFunctionUrlInvokeMode,
+} from "../../function/url/sim-lambda-function-url.js";
+
+/**
+ * Minimal structural sim Lambda CreateFunctionUrlConfig command.
+ */
+export interface SimCreateFunctionUrlConfigCommand {
+  readonly input: SimCreateFunctionUrlConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda CreateFunctionUrlConfig input.
+ *
+ * The Cors block real Lambda accepts here is not simulated, so it is left out
+ * rather than accepted and ignored.
+ */
+export interface SimCreateFunctionUrlConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly AuthType?: SimLambdaFunctionUrlAuthType | undefined;
+  readonly InvokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda CreateFunctionUrlConfig output.
+ */
+export interface SimCreateFunctionUrlConfigCommandOutput extends SimLambdaFunctionUrlConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.handler.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.handler.ts
@@ -1,0 +1,97 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import { FunctionUrlInputParser } from "../function-url/function-url-input.js";
+import type {
+  SimCreateFunctionUrlConfigCommand,
+  SimCreateFunctionUrlConfigCommandOutput,
+} from "./create-function-url-config.command.js";
+
+interface CreateFunctionUrlConfigCommandHandlerProperties {
+  functionUrls: SimLambdaFunctionUrlStore;
+  functions: SimLambdaFunctionLookup;
+  iam?: SimIamInterServiceAuthZ;
+  background?: BackgroundScheduler;
+}
+
+interface CreateFunctionUrlConfigCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda CreateFunctionUrlConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateFunctionUrlConfigCommand/
+ */
+export class CreateFunctionUrlConfigCommandHandler implements CommandHandler<
+  SimCreateFunctionUrlConfigCommand,
+  SimCreateFunctionUrlConfigCommandOutput
+> {
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly inputParser = new FunctionUrlInputParser();
+
+  constructor(properties: CreateFunctionUrlConfigCommandHandlerProperties) {
+    const {
+      functionUrls,
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functionUrls = functionUrls;
+    this.functions = functions;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam,
+      action: "lambda:CreateFunctionUrlConfig",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Create the Function URL for a sim Lambda function.
+   */
+  async handle(
+    command: SimCreateFunctionUrlConfigCommand,
+    options?: CreateFunctionUrlConfigCommandHandlerOptions,
+  ): Promise<SimCreateFunctionUrlConfigCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "CreateFunctionUrlConfigCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName;
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+
+    const functionUrl = this.functionUrls.create({
+      simFunction: this.functions.require(functionName),
+      authType: this.inputParser.requireAuthType(command.input.AuthType),
+      invokeMode: this.inputParser.parseOptionalInvokeMode(
+        command.input.InvokeMode,
+      ),
+    });
+
+    return {
+      $metadata: {},
+      ...functionUrl.configuration(),
+    };
+  }
+}

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.iso.test.ts
@@ -1,0 +1,275 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimLambdaResourceConflictException,
+  SimLambdaResourceNotFoundException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createGreeter(simLambda: SimLambda): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+    }),
+  );
+}
+
+describe("Lambda CreateFunctionUrlConfigCommand", () => {
+  it("creates a Function URL in the AWS endpoint format", async () => {
+    // Given a sim Lambda function.
+    const simAws = new SimAws();
+    await createGreeter(simAws.lambda());
+
+    // When a Function URL is created for it.
+    const output = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // Then the URL has the AWS shape, naming the region it lives in.
+    assertTrue(
+      /^https:\/\/[a-z0-9]{32}\.lambda-url\.us-east-1\.on\.aws\/$/.test(
+        output.FunctionUrl,
+      ),
+      `Unexpected Function URL ${output.FunctionUrl}`,
+    );
+    assertIdentical(output.AuthType, "NONE");
+    assertIdentical(output.InvokeMode, "BUFFERED");
+    assertIdentical(
+      output.FunctionArn,
+      `arn:aws:lambda:us-east-1:${simAws.defaultAccountId}:function:greeter`,
+    );
+  });
+
+  it("keeps the same Function URL when read back", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+    const created = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // When the Function URL config is read back.
+    const read = await simLambda.getFunctionUrlConfig(
+      new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then it is the same URL.
+    assertIdentical(read.FunctionUrl, created.FunctionUrl);
+  });
+
+  it("gives each function its own Function URL", async () => {
+    // Given two sim Lambda functions.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "other",
+        Role: "arn:aws:iam::111111111111:role/OtherRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "other") },
+      }),
+    );
+
+    // When both get a Function URL.
+    const greeterUrl = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+    const otherUrl = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "other",
+        AuthType: "NONE",
+      }),
+    );
+
+    // Then the URLs differ.
+    assertTrue(
+      greeterUrl.FunctionUrl !== otherUrl.FunctionUrl,
+      "Expected distinct Function URLs",
+    );
+  });
+
+  it("accepts an AWS_IAM Function URL and a RESPONSE_STREAM invoke mode", async () => {
+    // Given a sim Lambda function.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+
+    // When a Function URL is created with non-default configuration.
+    const output = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+        InvokeMode: "RESPONSE_STREAM",
+      }),
+    );
+
+    // Then the configuration is reported back.
+    assertIdentical(output.AuthType, "AWS_IAM");
+    assertIdentical(output.InvokeMode, "RESPONSE_STREAM");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a Function URL is created for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "missing",
+          AuthType: "NONE",
+        }),
+      ),
+    );
+
+    // Then it fails the way AWS reports an unknown function.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:missing");
+  });
+
+  it("throws when the function already has a Function URL", async () => {
+    // Given a function that already has a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // When a second Function URL is created for it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      ),
+    );
+
+    // Then it conflicts, as it does on AWS.
+    assertInstanceOf(error, SimLambdaResourceConflictException);
+    assertStringIncludes(error.message, "FunctionUrlConfig exists");
+  });
+
+  it("throws on a missing AuthType", async () => {
+    // Given a sim Lambda function.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+
+    // When a Function URL is created without an AuthType, which the SDK types
+    // as required but a plain JavaScript caller can still omit.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.createFunctionUrlConfig({ input: { FunctionName: "greeter" } }),
+    );
+
+    // Then the required value is reported as a validation failure.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "'authType'");
+  });
+
+  it("throws on an unknown AuthType", async () => {
+    // Given a sim Lambda function.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+
+    // When a Function URL is created with an AuthType AWS does not have.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.createFunctionUrlConfig({
+        input: { FunctionName: "greeter", AuthType: "OPEN_SESAME" as "NONE" },
+      }),
+    );
+
+    // Then the enum member is reported as a validation failure.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "OPEN_SESAME");
+  });
+
+  it("throws on an unknown InvokeMode", async () => {
+    // Given a sim Lambda function.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+
+    // When a Function URL is created with an InvokeMode AWS does not have.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.createFunctionUrlConfig({
+        input: {
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          InvokeMode: "FIREHOSE" as "BUFFERED",
+        },
+      }),
+    );
+
+    // Then the enum member is reported as a validation failure.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "'invokeMode'");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When a Function URL is created without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: undefined,
+          AuthType: "NONE",
+        }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "CreateFunctionUrlConfigCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller creates a Function URL.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:CreateFunctionUrlConfig");
+  });
+});

--- a/src/service/lambda/command/delete-function-url-config/delete-function-url-config.command.ts
+++ b/src/service/lambda/command/delete-function-url-config/delete-function-url-config.command.ts
@@ -1,0 +1,29 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteFunctionUrlConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionUrlConfig command.
+ */
+export interface SimDeleteFunctionUrlConfigCommand {
+  readonly input: SimDeleteFunctionUrlConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionUrlConfig input.
+ */
+export interface SimDeleteFunctionUrlConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda DeleteFunctionUrlConfig output.
+ *
+ * Real Lambda answers this operation with no content beyond the response
+ * metadata.
+ */
+export interface SimDeleteFunctionUrlConfigCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/delete-function-url-config/delete-function-url-config.handler.ts
+++ b/src/service/lambda/command/delete-function-url-config/delete-function-url-config.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import type {
+  SimDeleteFunctionUrlConfigCommand,
+  SimDeleteFunctionUrlConfigCommandOutput,
+} from "./delete-function-url-config.command.js";
+
+interface DeleteFunctionUrlConfigCommandHandlerProperties {
+  functionUrls: SimLambdaFunctionUrlStore;
+  functions: SimLambdaFunctionLookup;
+  iam?: SimIamInterServiceAuthZ;
+  background?: BackgroundScheduler;
+}
+
+interface DeleteFunctionUrlConfigCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda DeleteFunctionUrlConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/DeleteFunctionUrlConfigCommand/
+ */
+export class DeleteFunctionUrlConfigCommandHandler implements CommandHandler<
+  SimDeleteFunctionUrlConfigCommand,
+  SimDeleteFunctionUrlConfigCommandOutput
+> {
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteFunctionUrlConfigCommandHandlerProperties) {
+    const {
+      functionUrls,
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functionUrls = functionUrls;
+    this.functions = functions;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam,
+      action: "lambda:DeleteFunctionUrlConfig",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Delete the Function URL for a sim Lambda function.
+   */
+  async handle(
+    command: SimDeleteFunctionUrlConfigCommand,
+    options?: DeleteFunctionUrlConfigCommandHandlerOptions,
+  ): Promise<SimDeleteFunctionUrlConfigCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "DeleteFunctionUrlConfigCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName;
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+    this.functionUrls.delete(this.functions.require(functionName));
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   assertIdentical,
   assertInstanceOf,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertUndefined,
@@ -17,7 +18,6 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-import type { SimLambdaFunctionUrlId } from "../../function/url/sim-lambda-function-url.js";
 import { SimLambda } from "../../sim-lambda.js";
 
 async function createGreeterWithUrl(simLambda: SimLambda): Promise<void> {
@@ -62,7 +62,7 @@ describe("Lambda DeleteFunctionUrlConfigCommand", () => {
     const simLambda = new SimLambda();
     await createGreeterWithUrl(simLambda);
     const functionUrl = simLambda.getSimFunctionUrl("greeter");
-    const urlId = functionUrl?.urlId ?? ("" as SimLambdaFunctionUrlId);
+    assertNonNullable(functionUrl);
 
     // When the Function URL is deleted.
     await simLambda.deleteFunctionUrlConfig(
@@ -70,7 +70,7 @@ describe("Lambda DeleteFunctionUrlConfigCommand", () => {
     );
 
     // Then its id no longer finds anything to serve.
-    assertUndefined(simLambda.getSimFunctionUrlById(urlId));
+    assertUndefined(simLambda.getSimFunctionUrlById(functionUrl.urlId));
   });
 
   it("allows a new Function URL after deleting the old one", async () => {

--- a/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
@@ -1,0 +1,175 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  DeleteFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambdaFunctionUrlId } from "../../function/url/sim-lambda-function-url.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createGreeterWithUrl(simLambda: SimLambda): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+    }),
+  );
+
+  await simLambda.createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "greeter",
+      AuthType: "NONE",
+    }),
+  );
+}
+
+describe("Lambda DeleteFunctionUrlConfigCommand", () => {
+  it("deletes a Function URL so it can no longer be read", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeterWithUrl(simLambda);
+
+    // When the Function URL is deleted.
+    await simLambda.deleteFunctionUrlConfig(
+      new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then reading it back fails as a missing resource.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.getFunctionUrlConfig(
+        new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+      ),
+    );
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+  });
+
+  it("stops the deleted URL id resolving to a Function URL", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeterWithUrl(simLambda);
+    const functionUrl = simLambda.getSimFunctionUrl("greeter");
+    const urlId = functionUrl?.urlId ?? ("" as SimLambdaFunctionUrlId);
+
+    // When the Function URL is deleted.
+    await simLambda.deleteFunctionUrlConfig(
+      new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then its id no longer finds anything to serve.
+    assertUndefined(simLambda.getSimFunctionUrlById(urlId));
+  });
+
+  it("allows a new Function URL after deleting the old one", async () => {
+    // Given a function whose Function URL has been deleted.
+    const simLambda = new SimLambda();
+    await createGreeterWithUrl(simLambda);
+    await simLambda.deleteFunctionUrlConfig(
+      new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // When a new Function URL is created.
+    const output = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // Then the function is reachable again, at a new URL.
+    assertStringIncludes(output.FunctionUrl, ".lambda-url.");
+  });
+
+  it("throws when the function has no Function URL", async () => {
+    // Given a function without a Function URL.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // When its Function URL is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .deleteFunctionUrlConfig(
+          new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+        ),
+    );
+
+    // Then it fails as a missing resource.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function URL config not found");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a Function URL is deleted for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .deleteFunctionUrlConfig(
+          new DeleteFunctionUrlConfigCommand({ FunctionName: "missing" }),
+        ),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When a Function URL is deleted without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.deleteFunctionUrlConfig(
+        new DeleteFunctionUrlConfigCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "DeleteFunctionUrlConfigCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller deletes a Function URL.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .deleteFunctionUrlConfig(
+          new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:DeleteFunctionUrlConfig");
+  });
+});

--- a/src/service/lambda/command/function-url/function-url-authorizer.ts
+++ b/src/service/lambda/command/function-url/function-url-authorizer.ts
@@ -1,0 +1,49 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface FunctionUrlAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly action: string;
+}
+
+/**
+ * Applies IAM authorization to a Lambda Function URL config request.
+ *
+ * AWS maps each of the FunctionUrlConfig API operations to the IAM action of
+ * the same name, always against the function ARN the config belongs to. The
+ * action varies but nothing else does, so one authorizer serves all of them
+ * rather than a near-identical class per command.
+ */
+export class FunctionUrlAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly action: string;
+
+  constructor(properties: FunctionUrlAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.action = properties.action;
+  }
+
+  /**
+   * Ensure the caller may perform this Function URL action on the function.
+   *
+   * The caller is passed through unchanged so sim IAM can distinguish an
+   * omitted caller, which defaults to Account root, from an explicit
+   * anonymous caller.
+   */
+  authorize(functionArn: string, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action: this.action,
+      resource: functionArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: this.action,
+        resource: functionArn,
+      });
+    }
+  }
+}

--- a/src/service/lambda/command/function-url/function-url-input.ts
+++ b/src/service/lambda/command/function-url/function-url-input.ts
@@ -1,0 +1,72 @@
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import type {
+  SimLambdaFunctionUrlAuthType,
+  SimLambdaFunctionUrlInvokeMode,
+} from "../../function/url/sim-lambda-function-url.js";
+
+const authTypes: readonly string[] = ["NONE", "AWS_IAM"];
+const invokeModes: readonly string[] = ["BUFFERED", "RESPONSE_STREAM"];
+
+/**
+ * Validates the enumerated values in Function URL config command input.
+ *
+ * The command types constrain these already, but templates and plain
+ * JavaScript callers reach the same handlers, so the values are checked at
+ * runtime and reported the way real Lambda reports a bad enum member.
+ */
+export class FunctionUrlInputParser {
+  /**
+   * Parse a required AuthType, as CreateFunctionUrlConfig requires one.
+   */
+  requireAuthType(value: string | undefined): SimLambdaFunctionUrlAuthType {
+    if (value === undefined) {
+      throw new SimLambdaValidationException(
+        "1 validation error detected: Value null at 'authType' failed to satisfy constraint: Member must not be null",
+      );
+    }
+
+    return this.parseAuthType(value);
+  }
+
+  /**
+   * Parse an optional AuthType, as UpdateFunctionUrlConfig allows omitting it.
+   */
+  parseOptionalAuthType(
+    value: string | undefined,
+  ): SimLambdaFunctionUrlAuthType | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.parseAuthType(value);
+  }
+
+  /**
+   * Parse an optional InvokeMode, which defaults to BUFFERED on real Lambda.
+   */
+  parseOptionalInvokeMode(
+    value: string | undefined,
+  ): SimLambdaFunctionUrlInvokeMode | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!invokeModes.includes(value)) {
+      throw new SimLambdaValidationException(
+        `1 validation error detected: Value '${value}' at 'invokeMode' failed to satisfy constraint: Member must satisfy enum value set: [${invokeModes.join(", ")}]`,
+      );
+    }
+
+    return value as SimLambdaFunctionUrlInvokeMode;
+  }
+
+  private parseAuthType(value: string): SimLambdaFunctionUrlAuthType {
+    if (!authTypes.includes(value)) {
+      throw new SimLambdaValidationException(
+        `1 validation error detected: Value '${value}' at 'authType' failed to satisfy constraint: Member must satisfy enum value set: [${authTypes.join(", ")}]`,
+      );
+    }
+
+    return value as SimLambdaFunctionUrlAuthType;
+  }
+}

--- a/src/service/lambda/command/function-url/sim-lambda-function-url-commands.ts
+++ b/src/service/lambda/command/function-url/sim-lambda-function-url-commands.ts
@@ -1,0 +1,117 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { CreateFunctionUrlConfigCommandHandler } from "../create-function-url-config/create-function-url-config.handler.js";
+import type {
+  SimCreateFunctionUrlConfigCommand,
+  SimCreateFunctionUrlConfigCommandOutput,
+} from "../create-function-url-config/create-function-url-config.command.js";
+import { DeleteFunctionUrlConfigCommandHandler } from "../delete-function-url-config/delete-function-url-config.handler.js";
+import type {
+  SimDeleteFunctionUrlConfigCommand,
+  SimDeleteFunctionUrlConfigCommandOutput,
+} from "../delete-function-url-config/delete-function-url-config.command.js";
+import { GetFunctionUrlConfigCommandHandler } from "../get-function-url-config/get-function-url-config.handler.js";
+import type {
+  SimGetFunctionUrlConfigCommand,
+  SimGetFunctionUrlConfigCommandOutput,
+} from "../get-function-url-config/get-function-url-config.command.js";
+import { ListFunctionUrlConfigsCommandHandler } from "../list-function-url-configs/list-function-url-configs.handler.js";
+import type {
+  SimListFunctionUrlConfigsCommand,
+  SimListFunctionUrlConfigsCommandOutput,
+} from "../list-function-url-configs/list-function-url-configs.command.js";
+import { UpdateFunctionUrlConfigCommandHandler } from "../update-function-url-config/update-function-url-config.handler.js";
+import type {
+  SimUpdateFunctionUrlConfigCommand,
+  SimUpdateFunctionUrlConfigCommandOutput,
+} from "../update-function-url-config/update-function-url-config.command.js";
+
+interface SimLambdaFunctionUrlCommandsProperties {
+  readonly functionUrls: SimLambdaFunctionUrlStore;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface SimLambdaFunctionUrlCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The Function URL config commands of one simulated Lambda scope.
+ *
+ * These five commands share the same collaborators and differ only in the
+ * handler they run, so grouping them here keeps the SimLambda facade a thin
+ * delegation rather than five near-identical wiring blocks.
+ */
+export class SimLambdaFunctionUrlCommands {
+  private readonly properties: SimLambdaFunctionUrlCommandsProperties;
+
+  constructor(properties: SimLambdaFunctionUrlCommandsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Create the Function URL for a function.
+   */
+  async create(
+    command: SimCreateFunctionUrlConfigCommand,
+    options?: SimLambdaFunctionUrlCommandOptions,
+  ): Promise<SimCreateFunctionUrlConfigCommandOutput> {
+    return await new CreateFunctionUrlConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * Get a function's Function URL configuration.
+   */
+  async get(
+    command: SimGetFunctionUrlConfigCommand,
+    options?: SimLambdaFunctionUrlCommandOptions,
+  ): Promise<SimGetFunctionUrlConfigCommandOutput> {
+    return await new GetFunctionUrlConfigCommandHandler(this.properties).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Update a function's Function URL configuration.
+   */
+  async update(
+    command: SimUpdateFunctionUrlConfigCommand,
+    options?: SimLambdaFunctionUrlCommandOptions,
+  ): Promise<SimUpdateFunctionUrlConfigCommandOutput> {
+    return await new UpdateFunctionUrlConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * Delete a function's Function URL.
+   */
+  async delete(
+    command: SimDeleteFunctionUrlConfigCommand,
+    options?: SimLambdaFunctionUrlCommandOptions,
+  ): Promise<SimDeleteFunctionUrlConfigCommandOutput> {
+    return await new DeleteFunctionUrlConfigCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+
+  /**
+   * List a function's Function URL configurations.
+   */
+  async list(
+    command: SimListFunctionUrlConfigsCommand,
+    options?: SimLambdaFunctionUrlCommandOptions,
+  ): Promise<SimListFunctionUrlConfigsCommandOutput> {
+    return await new ListFunctionUrlConfigsCommandHandler(
+      this.properties,
+    ).handle(command, options);
+  }
+}

--- a/src/service/lambda/command/get-function-url-config/get-function-url-config.command.ts
+++ b/src/service/lambda/command/get-function-url-config/get-function-url-config.command.ts
@@ -1,0 +1,27 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetFunctionUrlConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionUrlConfiguration } from "../../function/url/sim-lambda-function-url.js";
+
+/**
+ * Minimal structural sim Lambda GetFunctionUrlConfig command.
+ */
+export interface SimGetFunctionUrlConfigCommand {
+  readonly input: SimGetFunctionUrlConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda GetFunctionUrlConfig input.
+ */
+export interface SimGetFunctionUrlConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda GetFunctionUrlConfig output.
+ */
+export interface SimGetFunctionUrlConfigCommandOutput extends SimLambdaFunctionUrlConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/get-function-url-config/get-function-url-config.handler.ts
+++ b/src/service/lambda/command/get-function-url-config/get-function-url-config.handler.ts
@@ -1,0 +1,88 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import type {
+  SimGetFunctionUrlConfigCommand,
+  SimGetFunctionUrlConfigCommandOutput,
+} from "./get-function-url-config.command.js";
+
+interface GetFunctionUrlConfigCommandHandlerProperties {
+  functionUrls: SimLambdaFunctionUrlStore;
+  functions: SimLambdaFunctionLookup;
+  iam?: SimIamInterServiceAuthZ;
+  background?: BackgroundScheduler;
+}
+
+interface GetFunctionUrlConfigCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda GetFunctionUrlConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/GetFunctionUrlConfigCommand/
+ */
+export class GetFunctionUrlConfigCommandHandler implements CommandHandler<
+  SimGetFunctionUrlConfigCommand,
+  SimGetFunctionUrlConfigCommandOutput
+> {
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetFunctionUrlConfigCommandHandlerProperties) {
+    const {
+      functionUrls,
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functionUrls = functionUrls;
+    this.functions = functions;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam,
+      action: "lambda:GetFunctionUrlConfig",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Get the Function URL configuration for a sim Lambda function.
+   */
+  async handle(
+    command: SimGetFunctionUrlConfigCommand,
+    options?: GetFunctionUrlConfigCommandHandlerOptions,
+  ): Promise<SimGetFunctionUrlConfigCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "GetFunctionUrlConfigCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName;
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+    const simFunction = this.functions.require(functionName);
+
+    return {
+      $metadata: {},
+      ...this.functionUrls.require(simFunction).configuration(),
+    };
+  }
+}

--- a/src/service/lambda/command/get-function-url-config/get-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/get-function-url-config/get-function-url-config.iso.test.ts
@@ -1,0 +1,126 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createGreeter(simLambda: SimLambda): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+    }),
+  );
+}
+
+describe("Lambda GetFunctionUrlConfigCommand", () => {
+  it("gets an existing Function URL configuration", async () => {
+    // Given a function with an AWS_IAM Function URL.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // When the configuration is read.
+    const output = await simLambda.getFunctionUrlConfig(
+      new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then the stored configuration is reported, with both timestamps.
+    assertIdentical(output.AuthType, "AWS_IAM");
+    assertIdentical(output.InvokeMode, "BUFFERED");
+    assertIdentical(output.CreationTime, output.LastModifiedTime);
+  });
+
+  it("throws when the function has no Function URL", async () => {
+    // Given a function without a Function URL.
+    const simAws = new SimAws();
+    await createGreeter(simAws.lambda());
+
+    // When its Function URL config is read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .getFunctionUrlConfig(
+          new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+        ),
+    );
+
+    // Then it fails as a missing resource, naming the function.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, ":function:greeter");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a Function URL config is read for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .getFunctionUrlConfig(
+          new GetFunctionUrlConfigCommand({ FunctionName: "missing" }),
+        ),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When a Function URL config is read without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.getFunctionUrlConfig(
+        new GetFunctionUrlConfigCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "GetFunctionUrlConfigCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller reads a Function URL config.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .getFunctionUrlConfig(
+          new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:GetFunctionUrlConfig");
+  });
+});

--- a/src/service/lambda/command/list-function-url-configs/list-function-url-configs.command.ts
+++ b/src/service/lambda/command/list-function-url-configs/list-function-url-configs.command.ts
@@ -1,0 +1,28 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionUrlConfigsCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionUrlConfiguration } from "../../function/url/sim-lambda-function-url.js";
+
+/**
+ * Minimal structural sim Lambda ListFunctionUrlConfigs command.
+ */
+export interface SimListFunctionUrlConfigsCommand {
+  readonly input: SimListFunctionUrlConfigsCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctionUrlConfigs input.
+ */
+export interface SimListFunctionUrlConfigsCommandInput {
+  readonly FunctionName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda ListFunctionUrlConfigs output.
+ */
+export interface SimListFunctionUrlConfigsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  FunctionUrlConfigs: SimLambdaFunctionUrlConfiguration[];
+}

--- a/src/service/lambda/command/list-function-url-configs/list-function-url-configs.handler.ts
+++ b/src/service/lambda/command/list-function-url-configs/list-function-url-configs.handler.ts
@@ -1,0 +1,93 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import type {
+  SimListFunctionUrlConfigsCommand,
+  SimListFunctionUrlConfigsCommandOutput,
+} from "./list-function-url-configs.command.js";
+
+interface ListFunctionUrlConfigsCommandHandlerProperties {
+  functionUrls: SimLambdaFunctionUrlStore;
+  functions: SimLambdaFunctionLookup;
+  iam?: SimIamInterServiceAuthZ;
+  background?: BackgroundScheduler;
+}
+
+interface ListFunctionUrlConfigsCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda ListFunctionUrlConfigsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/ListFunctionUrlConfigsCommand/
+ */
+export class ListFunctionUrlConfigsCommandHandler implements CommandHandler<
+  SimListFunctionUrlConfigsCommand,
+  SimListFunctionUrlConfigsCommandOutput
+> {
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListFunctionUrlConfigsCommandHandlerProperties) {
+    const {
+      functionUrls,
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functionUrls = functionUrls;
+    this.functions = functions;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam,
+      action: "lambda:ListFunctionUrlConfigs",
+    });
+    this.background = background;
+  }
+
+  /**
+   * List the Function URL configurations for a sim Lambda function.
+   *
+   * A function has at most one Function URL, so this returns either no
+   * configurations or one.
+   */
+  async handle(
+    command: SimListFunctionUrlConfigsCommand,
+    options?: ListFunctionUrlConfigsCommandHandlerOptions,
+  ): Promise<SimListFunctionUrlConfigsCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "ListFunctionUrlConfigsCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName;
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+    this.functions.require(functionName);
+
+    return {
+      $metadata: {},
+      FunctionUrlConfigs: this.functionUrls
+        .allForFunction(functionName)
+        .map((functionUrl) => functionUrl.configuration()),
+    };
+  }
+}

--- a/src/service/lambda/command/list-function-url-configs/list-function-url-configs.iso.test.ts
+++ b/src/service/lambda/command/list-function-url-configs/list-function-url-configs.iso.test.ts
@@ -1,0 +1,124 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  ListFunctionUrlConfigsCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createGreeter(simLambda: SimLambda): Promise<void> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+    }),
+  );
+}
+
+describe("Lambda ListFunctionUrlConfigsCommand", () => {
+  it("lists the Function URL a function has", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+    const created = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // When its Function URL configs are listed.
+    const output = await simLambda.listFunctionUrlConfigs(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then the one configuration is listed.
+    assertArrayLength(output.FunctionUrlConfigs, 1);
+    const config = output.FunctionUrlConfigs[0];
+    assertNonNullable(config);
+    assertIdentical(config.FunctionUrl, created.FunctionUrl);
+  });
+
+  it("lists nothing for a function without a Function URL", async () => {
+    // Given a function without a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeter(simLambda);
+
+    // When its Function URL configs are listed.
+    const output = await simLambda.listFunctionUrlConfigs(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then the list is empty rather than an error.
+    assertArrayLength(output.FunctionUrlConfigs, 0);
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When Function URL configs are listed for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .listFunctionUrlConfigs(
+          new ListFunctionUrlConfigsCommand({ FunctionName: "missing" }),
+        ),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When Function URL configs are listed without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.listFunctionUrlConfigs(
+        new ListFunctionUrlConfigsCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "ListFunctionUrlConfigsCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller lists Function URL configs.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .lambda()
+        .listFunctionUrlConfigs(
+          new ListFunctionUrlConfigsCommand({ FunctionName: "greeter" }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:ListFunctionUrlConfigs");
+  });
+});

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.command.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.command.ts
@@ -1,0 +1,36 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionUrlConfigCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimLambdaFunctionUrlAuthType,
+  SimLambdaFunctionUrlConfiguration,
+  SimLambdaFunctionUrlInvokeMode,
+} from "../../function/url/sim-lambda-function-url.js";
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionUrlConfig command.
+ */
+export interface SimUpdateFunctionUrlConfigCommand {
+  readonly input: SimUpdateFunctionUrlConfigCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionUrlConfig input.
+ *
+ * Omitted values leave that part of the configuration as it is, as on real
+ * Lambda.
+ */
+export interface SimUpdateFunctionUrlConfigCommandInput {
+  readonly FunctionName?: string | undefined;
+  readonly AuthType?: SimLambdaFunctionUrlAuthType | undefined;
+  readonly InvokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+}
+
+/**
+ * Minimal structural sim Lambda UpdateFunctionUrlConfig output.
+ */
+export interface SimUpdateFunctionUrlConfigCommandOutput extends SimLambdaFunctionUrlConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.handler.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.handler.ts
@@ -1,0 +1,98 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaFunctionUrlStore } from "../../function/url/sim-lambda-function-url-store.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import { FunctionUrlInputParser } from "../function-url/function-url-input.js";
+import type {
+  SimUpdateFunctionUrlConfigCommand,
+  SimUpdateFunctionUrlConfigCommandOutput,
+} from "./update-function-url-config.command.js";
+
+interface UpdateFunctionUrlConfigCommandHandlerProperties {
+  functionUrls: SimLambdaFunctionUrlStore;
+  functions: SimLambdaFunctionLookup;
+  iam?: SimIamInterServiceAuthZ;
+  background?: BackgroundScheduler;
+}
+
+interface UpdateFunctionUrlConfigCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda UpdateFunctionUrlConfigCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/UpdateFunctionUrlConfigCommand/
+ */
+export class UpdateFunctionUrlConfigCommandHandler implements CommandHandler<
+  SimUpdateFunctionUrlConfigCommand,
+  SimUpdateFunctionUrlConfigCommandOutput
+> {
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly inputParser = new FunctionUrlInputParser();
+
+  constructor(properties: UpdateFunctionUrlConfigCommandHandlerProperties) {
+    const {
+      functionUrls,
+      functions,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+    this.functionUrls = functionUrls;
+    this.functions = functions;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam,
+      action: "lambda:UpdateFunctionUrlConfig",
+    });
+    this.background = background;
+  }
+
+  /**
+   * Update the Function URL configuration for a sim Lambda function.
+   */
+  async handle(
+    command: SimUpdateFunctionUrlConfigCommand,
+    options?: UpdateFunctionUrlConfigCommandHandlerOptions,
+  ): Promise<SimUpdateFunctionUrlConfigCommandOutput> {
+    assertDefined(
+      command.input.FunctionName,
+      "UpdateFunctionUrlConfigCommand.input.FunctionName required",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const functionName = command.input.FunctionName;
+    this.authorizer.authorize(
+      this.functions.functionArn(functionName),
+      options?.caller,
+    );
+    const simFunction = this.functions.require(functionName);
+
+    const functionUrl = this.functionUrls.require(simFunction);
+    functionUrl.update({
+      authType: this.inputParser.parseOptionalAuthType(command.input.AuthType),
+      invokeMode: this.inputParser.parseOptionalInvokeMode(
+        command.input.InvokeMode,
+      ),
+    });
+
+    return {
+      $metadata: {},
+      ...functionUrl.configuration(),
+    };
+  }
+}

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  UpdateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimLambdaResourceNotFoundException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+
+async function createGreeterWithUrl(simLambda: SimLambda): Promise<string> {
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+    }),
+  );
+
+  const created = await simLambda.createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "greeter",
+      AuthType: "NONE",
+    }),
+  );
+
+  return created.FunctionUrl;
+}
+
+describe("Lambda UpdateFunctionUrlConfigCommand", () => {
+  it("updates the auth type without changing the URL", async () => {
+    // Given a function with a public Function URL.
+    const simLambda = new SimLambda();
+    const functionUrl = await createGreeterWithUrl(simLambda);
+
+    // When the auth type is updated.
+    const output = await simLambda.updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // Then the new auth type applies to the same URL.
+    assertIdentical(output.AuthType, "AWS_IAM");
+    assertIdentical(output.FunctionUrl, functionUrl);
+  });
+
+  it("leaves omitted values as they are", async () => {
+    // Given a Function URL with a non-default invoke mode.
+    const simLambda = new SimLambda();
+    await createGreeterWithUrl(simLambda);
+    await simLambda.updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        InvokeMode: "RESPONSE_STREAM",
+      }),
+    );
+
+    // When only the auth type is updated.
+    const output = await simLambda.updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // Then the invoke mode is untouched.
+    assertIdentical(output.AuthType, "AWS_IAM");
+    assertIdentical(output.InvokeMode, "RESPONSE_STREAM");
+  });
+
+  it("throws when the function has no Function URL", async () => {
+    // Given a function without a Function URL.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // When its Function URL config is updated.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionUrlConfig(
+        new UpdateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "AWS_IAM",
+        }),
+      ),
+    );
+
+    // Then it fails as a missing resource.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function URL config not found");
+  });
+
+  it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
+    const simAws = new SimAws();
+
+    // When a Function URL config is updated for a missing function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionUrlConfig(
+        new UpdateFunctionUrlConfigCommand({
+          FunctionName: "missing",
+          AuthType: "NONE",
+        }),
+      ),
+    );
+
+    // Then the missing function is what gets reported.
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+    assertStringIncludes(error.message, "Function not found");
+  });
+
+  it("throws on an unknown auth type", async () => {
+    // Given a function with a Function URL.
+    const simLambda = new SimLambda();
+    await createGreeterWithUrl(simLambda);
+
+    // When it is updated to an auth type AWS does not have.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionUrlConfig({
+        input: { FunctionName: "greeter", AuthType: "OPEN_SESAME" as "NONE" },
+      }),
+    );
+
+    // Then the enum member is reported as a validation failure.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(error.message, "OPEN_SESAME");
+  });
+
+  it("throws on an undefined function name", async () => {
+    // Given a standalone sim Lambda.
+    const simLambda = new SimLambda();
+
+    // When a Function URL config is updated without naming a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simLambda.updateFunctionUrlConfig(
+        new UpdateFunctionUrlConfigCommand({ FunctionName: undefined }),
+      ),
+    );
+
+    // Then the missing input is reported.
+    assertStringIncludes(
+      error.message,
+      "UpdateFunctionUrlConfigCommand.input.FunctionName required",
+    );
+  });
+
+  it("denies an explicitly anonymous caller through sim IAM", async () => {
+    // Given a simulated AWS with sim IAM in play.
+    const simAws = new SimAws();
+
+    // When an anonymous caller updates a Function URL config.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionUrlConfig(
+        new UpdateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then the request is denied for the matching IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:UpdateFunctionUrlConfig");
+  });
+});

--- a/src/service/lambda/function/url/sim-lambda-function-lookup.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-lookup.ts
@@ -1,0 +1,57 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
+import {
+  type SimLambdaFunction,
+  type SimLambdaFunctionArn,
+  type SimLambdaFunctionMap,
+  type SimLambdaFunctionName,
+  simLambdaFunctionArn,
+} from "../sim-lambda-function.js";
+
+interface SimLambdaFunctionLookupProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly functions: SimLambdaFunctionMap;
+}
+
+/**
+ * Finds functions by name in one Account/Region scope, failing the way AWS
+ * does when the name belongs to no function.
+ *
+ * Commands that act on something belonging to a function, such as its
+ * Function URL, need this check before they can say anything about the thing
+ * itself.
+ */
+export class SimLambdaFunctionLookup {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly functions: SimLambdaFunctionMap;
+
+  constructor(properties: SimLambdaFunctionLookupProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.functions = properties.functions;
+  }
+
+  /**
+   * Build the ARN a function has, or would have, in this scope.
+   */
+  functionArn(functionName: string): SimLambdaFunctionArn {
+    return simLambdaFunctionArn(this.accountRegionScope, functionName);
+  }
+
+  /**
+   * Get a function by name, or fail as AWS does when there is no such
+   * function.
+   */
+  require(functionName: string): SimLambdaFunction {
+    const simFunction = this.functions.get(
+      functionName as SimLambdaFunctionName,
+    );
+
+    if (simFunction === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function not found: ${this.functionArn(functionName)}`,
+      );
+    }
+
+    return simFunction;
+  }
+}

--- a/src/service/lambda/function/url/sim-lambda-function-url-factory.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-factory.ts
@@ -1,0 +1,64 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaUrlRegistry } from "../../registry/sim-lambda-url-registry.js";
+import type { SimLambdaFunction } from "../sim-lambda-function.js";
+import {
+  SimLambdaFunctionUrl,
+  type SimLambdaFunctionUrlAuthType,
+  type SimLambdaFunctionUrlInvokeMode,
+} from "./sim-lambda-function-url.js";
+
+interface SimLambdaFunctionUrlFactoryProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly urlRegistry: SimLambdaUrlRegistry;
+}
+
+interface MakeSimLambdaFunctionUrlProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
+  readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+}
+
+/**
+ * Builds Function URLs, taking their ids from the cross-Account registry.
+ *
+ * Allocating and registering the id belong together: an id that is not
+ * registered names a URL the serving layer cannot route to.
+ */
+export class SimLambdaFunctionUrlFactory {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly urlRegistry: SimLambdaUrlRegistry;
+
+  constructor(properties: SimLambdaFunctionUrlFactoryProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.urlRegistry = properties.urlRegistry;
+  }
+
+  /**
+   * Make a registered Function URL for a function.
+   */
+  make(properties: MakeSimLambdaFunctionUrlProperties): SimLambdaFunctionUrl {
+    const { simFunction, authType, invokeMode } = properties;
+    const urlId = this.urlRegistry.allocateFunctionUrlId();
+
+    this.urlRegistry.registerFunctionUrl(
+      urlId,
+      this.accountRegionScope.accountId,
+    );
+
+    return new SimLambdaFunctionUrl({
+      urlId,
+      functionName: simFunction.name,
+      functionArn: simFunction.arn,
+      accountRegionScope: this.accountRegionScope,
+      authType,
+      invokeMode,
+    });
+  }
+
+  /**
+   * Forget a Function URL id, so its hostname stops resolving.
+   */
+  forget(functionUrl: SimLambdaFunctionUrl): void {
+    this.urlRegistry.deregisterFunctionUrl(functionUrl.urlId);
+  }
+}

--- a/src/service/lambda/function/url/sim-lambda-function-url-host.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-host.ts
@@ -1,0 +1,40 @@
+/**
+ * The DNS label real Lambda uses for Function URL endpoints, sitting between
+ * the URL id and the region:
+ *
+ *   <url-id>.lambda-url.<region>.on.aws
+ */
+export const lambdaFunctionUrlHostLabel = "lambda-url";
+
+/**
+ * The real AWS domain Function URL endpoints live under.
+ */
+export const lambdaFunctionUrlDomain = "on.aws";
+
+interface SimLambdaFunctionUrlHostProperties {
+  readonly urlId: string;
+  readonly regionName: string;
+}
+
+/**
+ * Build the real AWS endpoint hostname for a Function URL.
+ */
+export function simLambdaFunctionUrlHost(
+  properties: SimLambdaFunctionUrlHostProperties,
+): string {
+  return `${simLambdaFunctionUrlLogicalHost(properties)}.${lambdaFunctionUrlDomain}`;
+}
+
+/**
+ * Build the logical hostname for a Function URL: the AWS endpoint hostname
+ * without the real AWS domain.
+ *
+ * This is the form Yulin serves on localhost, where the `.on.aws` tail is
+ * replaced by the local suffix, in the same way S3 endpoint hostnames drop
+ * `.amazonaws.com`.
+ */
+export function simLambdaFunctionUrlLogicalHost(
+  properties: SimLambdaFunctionUrlHostProperties,
+): string {
+  return `${properties.urlId}.${lambdaFunctionUrlHostLabel}.${properties.regionName}`;
+}

--- a/src/service/lambda/function/url/sim-lambda-function-url-store.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-store.ts
@@ -1,0 +1,118 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimLambdaResourceConflictException,
+  SimLambdaResourceNotFoundException,
+} from "../../error/sim-lambda.error.js";
+import type { SimLambdaUrlRegistry } from "../../registry/sim-lambda-url-registry.js";
+import type {
+  SimLambdaFunction,
+  SimLambdaFunctionName,
+} from "../sim-lambda-function.js";
+import { SimLambdaFunctionUrlFactory } from "./sim-lambda-function-url-factory.js";
+import type {
+  SimLambdaFunctionUrl,
+  SimLambdaFunctionUrlAuthType,
+  SimLambdaFunctionUrlId,
+  SimLambdaFunctionUrlInvokeMode,
+  SimLambdaFunctionUrlMap,
+} from "./sim-lambda-function-url.js";
+
+interface SimLambdaFunctionUrlStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly urlRegistry: SimLambdaUrlRegistry;
+}
+
+interface CreateSimLambdaFunctionUrlProperties {
+  readonly simFunction: SimLambdaFunction;
+  readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
+  readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+}
+
+/**
+ * Function URL state for one Account/Region scope of simulated Lambda.
+ *
+ * Each function has at most one Function URL, so URLs are held by function
+ * name.
+ */
+export class SimLambdaFunctionUrlStore {
+  private readonly functionUrls: SimLambdaFunctionUrlMap = new Map();
+  private readonly factory: SimLambdaFunctionUrlFactory;
+
+  constructor(properties: SimLambdaFunctionUrlStoreProperties) {
+    this.factory = new SimLambdaFunctionUrlFactory(properties);
+  }
+
+  /**
+   * Get a function's Function URL, if it has one.
+   */
+  get(functionName: string): SimLambdaFunctionUrl | undefined {
+    return this.functionUrls.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
+   * Get a function's Function URL, or fail as AWS does when it has none.
+   */
+  require(simFunction: SimLambdaFunction): SimLambdaFunctionUrl {
+    const functionUrl = this.get(simFunction.name);
+
+    if (functionUrl === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `Function URL config not found for function: ${simFunction.arn}`,
+      );
+    }
+
+    return functionUrl;
+  }
+
+  /**
+   * Get every Function URL a function has, which is either none or one.
+   */
+  allForFunction(functionName: string): readonly SimLambdaFunctionUrl[] {
+    const functionUrl = this.get(functionName);
+
+    if (functionUrl === undefined) {
+      return [];
+    }
+
+    return [functionUrl];
+  }
+
+  /**
+   * Find a Function URL by the id in its hostname.
+   */
+  byUrlId(urlId: SimLambdaFunctionUrlId): SimLambdaFunctionUrl | undefined {
+    return this.functionUrls
+      .values()
+      .find((functionUrl) => functionUrl.urlId === urlId);
+  }
+
+  /**
+   * Create a Function URL for a function that does not have one.
+   */
+  create(
+    properties: CreateSimLambdaFunctionUrlProperties,
+  ): SimLambdaFunctionUrl {
+    const { simFunction } = properties;
+
+    if (this.get(simFunction.name) !== undefined) {
+      throw new SimLambdaResourceConflictException(
+        `FunctionUrlConfig exists for this Lambda function: ${simFunction.arn}`,
+      );
+    }
+
+    const functionUrl = this.factory.make(properties);
+    this.functionUrls.set(simFunction.name, functionUrl);
+
+    return functionUrl;
+  }
+
+  /**
+   * Delete a function's Function URL, so its hostname stops resolving.
+   */
+  delete(simFunction: SimLambdaFunction): void {
+    const functionUrl = this.require(simFunction);
+
+    this.functionUrls.delete(functionUrl.functionName);
+    this.factory.forget(functionUrl);
+  }
+}

--- a/src/service/lambda/function/url/sim-lambda-function-url.iso.test.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url.iso.test.ts
@@ -1,0 +1,79 @@
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaFunctionName } from "../sim-lambda-function.js";
+import {
+  makeSimLambdaFunctionUrlId,
+  SimLambdaFunctionUrl,
+} from "./sim-lambda-function-url.js";
+
+const accountRegionScope: SimAwsAccountRegionScope = {
+  accountId: "111111111111" as SimAwsAccountId,
+  regionName: "eu-west-2",
+};
+
+function makeFunctionUrl(): SimLambdaFunctionUrl {
+  return new SimLambdaFunctionUrl({
+    urlId: makeSimLambdaFunctionUrlId(),
+    functionName: "greeter" as SimLambdaFunctionName,
+    functionArn: "arn:aws:lambda:eu-west-2:111111111111:function:greeter",
+    accountRegionScope,
+  });
+}
+
+describe("Sim Lambda Function URL", () => {
+  it("builds the AWS endpoint URL for its scope", () => {
+    // Given a Function URL in eu-west-2.
+    const functionUrl = makeFunctionUrl();
+
+    // When its endpoint is read.
+    const url = functionUrl.url;
+
+    // Then the URL names the region and ends with a trailing slash.
+    assertIdentical(
+      url,
+      `https://${functionUrl.urlId}.lambda-url.eu-west-2.on.aws/`,
+    );
+    assertStringIncludes(functionUrl.hostname, ".lambda-url.eu-west-2.on.aws");
+  });
+
+  it("defaults to a public buffered endpoint", () => {
+    // Given a Function URL created without configuration.
+    const functionUrl = makeFunctionUrl();
+
+    // When its configuration is read.
+    const configuration = functionUrl.configuration();
+
+    // Then it takes the AWS defaults.
+    assertIdentical(configuration.AuthType, "NONE");
+    assertIdentical(configuration.InvokeMode, "BUFFERED");
+    assertIdentical(configuration.CreationTime, configuration.LastModifiedTime);
+  });
+
+  it("keeps values that an update omits", () => {
+    // Given a Function URL with a non-default invoke mode.
+    const functionUrl = makeFunctionUrl();
+    functionUrl.update({ invokeMode: "RESPONSE_STREAM" });
+
+    // When only the auth type is updated.
+    functionUrl.update({ authType: "AWS_IAM" });
+
+    // Then both values are in place.
+    assertIdentical(functionUrl.authType, "AWS_IAM");
+    assertIdentical(functionUrl.invokeMode, "RESPONSE_STREAM");
+  });
+
+  it("keeps its endpoint across updates", () => {
+    // Given a Function URL.
+    const functionUrl = makeFunctionUrl();
+    const url = functionUrl.url;
+
+    // When it is updated.
+    functionUrl.update({ authType: "AWS_IAM" });
+
+    // Then the endpoint is unchanged, as it is on AWS.
+    assertIdentical(functionUrl.url, url);
+  });
+});

--- a/src/service/lambda/function/url/sim-lambda-function-url.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url.ts
@@ -1,0 +1,160 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../../util/brand.type.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaFunctionName } from "../sim-lambda-function.js";
+import { simLambdaFunctionUrlHost } from "./sim-lambda-function-url-host.js";
+
+/**
+ * The id AWS allocates for one Function URL, which is the leading DNS label of
+ * the URL it hands out.
+ */
+export type SimLambdaFunctionUrlId = Brand<string, "SimLambdaFunctionUrlId">;
+
+/**
+ * Function URL authentication types.
+ *
+ * NONE makes the URL publicly invokable. AWS_IAM requires SigV4-signed
+ * requests, which the simulator stores and reports but does not authenticate.
+ */
+export type SimLambdaFunctionUrlAuthType = "NONE" | "AWS_IAM";
+
+/**
+ * Function URL invocation modes. Only BUFFERED responses are simulated.
+ */
+export type SimLambdaFunctionUrlInvokeMode = "BUFFERED" | "RESPONSE_STREAM";
+
+/**
+ * Allocate a Function URL id in the shape real Lambda uses: 32 lowercase
+ * alphanumeric characters, forming one DNS label.
+ */
+export function makeSimLambdaFunctionUrlId(): SimLambdaFunctionUrlId {
+  return faker.helpers.fromRegExp(/[a-z0-9]{32}/) as SimLambdaFunctionUrlId;
+}
+
+interface SimLambdaFunctionUrlProperties {
+  readonly urlId: SimLambdaFunctionUrlId;
+  readonly functionName: SimLambdaFunctionName;
+  readonly functionArn: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
+  readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+}
+
+/**
+ * Minimal structural Function URL configuration, as returned by the
+ * CreateFunctionUrlConfig, GetFunctionUrlConfig and UpdateFunctionUrlConfig
+ * commands.
+ */
+export interface SimLambdaFunctionUrlConfiguration {
+  FunctionUrl: string;
+  FunctionArn: string;
+  AuthType: SimLambdaFunctionUrlAuthType;
+  InvokeMode: SimLambdaFunctionUrlInvokeMode;
+  CreationTime: string;
+  LastModifiedTime: string;
+}
+
+/**
+ * Simulated Lambda Function URL resource.
+ *
+ * A Function URL is the HTTP endpoint for one function. The id is the routing
+ * key: it is the leading label of the endpoint hostname, so the localhost
+ * serving layer can find the function from nothing but the request Host.
+ */
+export class SimLambdaFunctionUrl {
+  public readonly urlId: SimLambdaFunctionUrlId;
+  public readonly functionName: SimLambdaFunctionName;
+  public readonly functionArn: string;
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
+  public readonly creationTime: string;
+
+  #authType: SimLambdaFunctionUrlAuthType;
+  #invokeMode: SimLambdaFunctionUrlInvokeMode;
+  #lastModifiedTime: string;
+
+  constructor(properties: SimLambdaFunctionUrlProperties) {
+    const {
+      urlId,
+      functionName,
+      functionArn,
+      accountRegionScope,
+      authType = "NONE",
+      invokeMode = "BUFFERED",
+    } = properties;
+
+    this.urlId = urlId;
+    this.functionName = functionName;
+    this.functionArn = functionArn;
+    this.accountRegionScope = accountRegionScope;
+    this.#authType = authType;
+    this.#invokeMode = invokeMode;
+    this.creationTime = new Date().toISOString();
+    this.#lastModifiedTime = this.creationTime;
+  }
+
+  /**
+   * Get the authentication type for this Function URL.
+   */
+  get authType(): SimLambdaFunctionUrlAuthType {
+    return this.#authType;
+  }
+
+  /**
+   * Get the invocation mode for this Function URL.
+   */
+  get invokeMode(): SimLambdaFunctionUrlInvokeMode {
+    return this.#invokeMode;
+  }
+
+  /**
+   * Get the endpoint hostname for this Function URL.
+   */
+  get hostname(): string {
+    return simLambdaFunctionUrlHost({
+      urlId: this.urlId,
+      regionName: this.accountRegionScope.regionName,
+    });
+  }
+
+  /**
+   * Get the endpoint URL for this Function URL, with the trailing slash real
+   * Lambda includes.
+   */
+  get url(): string {
+    return `https://${this.hostname}/`;
+  }
+
+  /**
+   * Apply an update to this Function URL's configuration.
+   *
+   * Omitted values are left as they are, as real UpdateFunctionUrlConfig does.
+   */
+  update(properties: {
+    readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
+    readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  }): void {
+    this.#authType = properties.authType ?? this.#authType;
+    this.#invokeMode = properties.invokeMode ?? this.#invokeMode;
+    this.#lastModifiedTime = new Date().toISOString();
+  }
+
+  /**
+   * Get the AWS-like configuration for this Function URL.
+   */
+  configuration(): SimLambdaFunctionUrlConfiguration {
+    return {
+      FunctionUrl: this.url,
+      FunctionArn: this.functionArn,
+      AuthType: this.#authType,
+      InvokeMode: this.#invokeMode,
+      CreationTime: this.creationTime,
+      LastModifiedTime: this.#lastModifiedTime,
+    };
+  }
+}
+
+export type SimLambdaFunctionUrlMap = Map<
+  SimLambdaFunctionName,
+  SimLambdaFunctionUrl
+>;

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -14,3 +14,7 @@ export type {
   SimLambdaContext,
   SimLambdaHandler,
 } from "./function/sim-lambda-handler.type.js";
+export type {
+  SimLambdaFunctionUrlEvent,
+  SimLambdaFunctionUrlResult,
+} from "./serve/event/sim-lambda-url-event.type.js";

--- a/src/service/lambda/registry/sim-lambda-url-registry.iso.test.ts
+++ b/src/service/lambda/registry/sim-lambda-url-registry.iso.test.ts
@@ -1,0 +1,78 @@
+import {
+  assertIdentical,
+  assertSetSize,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimLambdaFunctionUrlId } from "../function/url/sim-lambda-function-url.js";
+import { SimLambdaUrlRegistry } from "./sim-lambda-url-registry.js";
+
+const accountId = "111111111111" as SimAwsAccountId;
+
+describe("Sim Lambda URL registry", () => {
+  it("allocates URL ids that are one DNS label", () => {
+    // Given a Function URL registry.
+    const registry = new SimLambdaUrlRegistry();
+
+    // When a URL id is allocated.
+    const urlId = registry.allocateFunctionUrlId();
+
+    // Then it is a single lowercase alphanumeric label.
+    assertTrue(/^[a-z0-9]{32}$/.test(urlId), `Unexpected URL id ${urlId}`);
+  });
+
+  it("allocates distinct URL ids", () => {
+    // Given a Function URL registry.
+    const registry = new SimLambdaUrlRegistry();
+
+    // When several URL ids are allocated.
+    const urlIds = new Set(
+      Array.from({ length: 20 }, () => registry.allocateFunctionUrlId()),
+    );
+
+    // Then they are all different.
+    assertSetSize(urlIds, 20);
+  });
+
+  it("resolves a registered URL id to its account", () => {
+    // Given a registered Function URL id.
+    const registry = new SimLambdaUrlRegistry();
+    const urlId = registry.allocateFunctionUrlId();
+    registry.registerFunctionUrl(urlId, accountId);
+
+    // When the owning account is looked up.
+    const owner = registry.accountIdForFunctionUrl(urlId);
+
+    // Then the account that registered it is returned.
+    assertIdentical(owner, accountId);
+  });
+
+  it("does not resolve an unregistered URL id", () => {
+    // Given a Function URL registry.
+    const registry = new SimLambdaUrlRegistry();
+
+    // When an unknown URL id is looked up.
+    const owner = registry.accountIdForFunctionUrl(
+      "unknown" as SimLambdaFunctionUrlId,
+    );
+
+    // Then nothing is found.
+    assertUndefined(owner);
+  });
+
+  it("forgets a deregistered URL id", () => {
+    // Given a registered Function URL id.
+    const registry = new SimLambdaUrlRegistry();
+    const urlId = registry.allocateFunctionUrlId();
+    registry.registerFunctionUrl(urlId, accountId);
+
+    // When it is deregistered.
+    registry.deregisterFunctionUrl(urlId);
+
+    // Then it no longer resolves to an account.
+    assertUndefined(registry.accountIdForFunctionUrl(urlId));
+  });
+});

--- a/src/service/lambda/registry/sim-lambda-url-registry.ts
+++ b/src/service/lambda/registry/sim-lambda-url-registry.ts
@@ -1,0 +1,61 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import {
+  makeSimLambdaFunctionUrlId,
+  type SimLambdaFunctionUrlId,
+} from "../function/url/sim-lambda-function-url.js";
+
+/**
+ * Simulated Lambda cross-Account registry of Function URL ids.
+ *
+ * A served Function URL request carries its region in the hostname, but not
+ * the Account. Simulated Lambda state is per Account/Region, so the serving
+ * layer needs a way to get from a URL id to the Account that owns it. This
+ * registry is that lookup, which is why URL ids are allocated here and are
+ * unique across every Account and Region of one simulated AWS environment.
+ */
+export class SimLambdaUrlRegistry {
+  private readonly functionUrlAccountIds = new Map<
+    SimLambdaFunctionUrlId,
+    SimAwsAccountId
+  >();
+
+  /**
+   * Allocate a Function URL id that is unique in this simulated AWS.
+   */
+  allocateFunctionUrlId(): SimLambdaFunctionUrlId {
+    let urlId = makeSimLambdaFunctionUrlId();
+
+    while (this.functionUrlAccountIds.has(urlId)) {
+      /* v8 ignore next -- does not happen in practice */
+      urlId = makeSimLambdaFunctionUrlId();
+    }
+
+    return urlId;
+  }
+
+  /**
+   * Register a Function URL id to the Account that owns it.
+   */
+  registerFunctionUrl(
+    urlId: SimLambdaFunctionUrlId,
+    accountId: SimAwsAccountId,
+  ): void {
+    this.functionUrlAccountIds.set(urlId, accountId);
+  }
+
+  /**
+   * Forget a Function URL id, so its hostname stops resolving.
+   */
+  deregisterFunctionUrl(urlId: SimLambdaFunctionUrlId): void {
+    this.functionUrlAccountIds.delete(urlId);
+  }
+
+  /**
+   * Get the Account that owns a Function URL id, if it is registered.
+   */
+  accountIdForFunctionUrl(
+    urlId: SimLambdaFunctionUrlId,
+  ): SimAwsAccountId | undefined {
+    return this.functionUrlAccountIds.get(urlId);
+  }
+}

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -4,8 +4,13 @@ import {
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
+import type { SimCreateFunctionUrlConfigCommand } from "../command/create-function-url-config/create-function-url-config.command.js";
+import type { SimDeleteFunctionUrlConfigCommand } from "../command/delete-function-url-config/delete-function-url-config.command.js";
 import type { SimGetFunctionCommand } from "../command/get-function/get-function.command.js";
+import type { SimGetFunctionUrlConfigCommand } from "../command/get-function-url-config/get-function-url-config.command.js";
 import type { SimInvokeCommand } from "../command/invoke/invoke.command.js";
+import type { SimListFunctionUrlConfigsCommand } from "../command/list-function-url-configs/list-function-url-configs.command.js";
+import type { SimUpdateFunctionUrlConfigCommand } from "../command/update-function-url-config/update-function-url-config.command.js";
 import type { SimLambda } from "../sim-lambda.js";
 
 /**
@@ -37,6 +42,46 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLambda.invoke(
             command as SimInvokeCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateFunctionUrlConfigCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.createFunctionUrlConfig(
+            command as SimCreateFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetFunctionUrlConfigCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.getFunctionUrlConfig(
+            command as SimGetFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateFunctionUrlConfigCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.updateFunctionUrlConfig(
+            command as SimUpdateFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteFunctionUrlConfigCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.deleteFunctionUrlConfig(
+            command as SimDeleteFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListFunctionUrlConfigsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.listFunctionUrlConfigs(
+            command as SimListFunctionUrlConfigsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/lambda/sdk/sim-lambda-url-sdk-routing.iso.test.ts
+++ b/src/service/lambda/sdk/sim-lambda-url-sdk-routing.iso.test.ts
@@ -1,0 +1,105 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  DeleteFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+  LambdaClient,
+  ListFunctionUrlConfigsCommand,
+  UpdateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { SimLambdaResourceNotFoundException } from "../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+describe("simulated Lambda Function URL SDK Command routing", () => {
+  it("round-trips Function URL Commands through an intercepted client", async () => {
+    // Given an intercepted Lambda client with a function.
+    using simSdk = new SimSdk();
+    const client = new LambdaClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateFunctionCommand({
+        FunctionName: "intercepted",
+        Role: "arn:aws:iam::111111111111:role/InterceptedRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // When the Function URL Commands are sent through the client.
+    const created = await client.send(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "intercepted",
+        AuthType: "NONE",
+      }),
+    );
+    const read = await client.send(
+      new GetFunctionUrlConfigCommand({ FunctionName: "intercepted" }),
+    );
+    const updated = await client.send(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "intercepted",
+        AuthType: "AWS_IAM",
+      }),
+    );
+    const listed = await client.send(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "intercepted" }),
+    );
+
+    // Then each reaches the simulated Lambda in the client's Region scope.
+    assertNonNullable(created.FunctionUrl);
+    assertIdentical(read.FunctionUrl, created.FunctionUrl);
+    assertIdentical(updated.AuthType, "AWS_IAM");
+    assertArrayLength(listed.FunctionUrlConfigs ?? [], 1);
+    assertIdentical(
+      simSdk.simAws
+        .region("eu-west-2")
+        .lambda()
+        .getSimFunctionUrl("intercepted")?.url,
+      created.FunctionUrl,
+    );
+  });
+
+  it("routes a Function URL deletion through an intercepted client", async () => {
+    // Given an intercepted client with a function that has a Function URL.
+    using simSdk = new SimSdk();
+    const client = new LambdaClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateFunctionCommand({
+        FunctionName: "intercepted",
+        Role: "arn:aws:iam::111111111111:role/InterceptedRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+    await client.send(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "intercepted",
+        AuthType: "NONE",
+      }),
+    );
+
+    // When the Function URL is deleted through the client.
+    await client.send(
+      new DeleteFunctionUrlConfigCommand({ FunctionName: "intercepted" }),
+    );
+
+    // Then it is gone from the simulated Lambda.
+    const error = await assertThrowsErrorAsync(async () => {
+      await client.send(
+        new GetFunctionUrlConfigCommand({ FunctionName: "intercepted" }),
+      );
+    });
+    assertInstanceOf(error, SimLambdaResourceNotFoundException);
+  });
+});

--- a/src/service/lambda/serve/event/sim-lambda-url-body-encoding.iso.test.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-body-encoding.iso.test.ts
@@ -1,0 +1,65 @@
+import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaUrlBodyEncoding } from "./sim-lambda-url-body-encoding.js";
+
+describe("Sim Lambda Function URL body encoding", () => {
+  it("treats text media types as text", () => {
+    // Given the body encoding rules.
+    const encoding = new SimLambdaUrlBodyEncoding();
+
+    // When text-ish content types are checked.
+    // Then each is treated as text the handler receives as a string.
+    assertTrue(encoding.isText("text/plain; charset=utf-8"));
+    assertTrue(encoding.isText("application/json"));
+    assertTrue(encoding.isText("APPLICATION/XML"));
+    assertTrue(encoding.isText("application/vnd.api+json"));
+    assertTrue(encoding.isText("image/svg+xml"));
+  });
+
+  it("treats other media types as binary", () => {
+    // Given the body encoding rules.
+    const encoding = new SimLambdaUrlBodyEncoding();
+
+    // When binary content types are checked.
+    // Then each is treated as binary, including a missing content type.
+    assertFalse(encoding.isText("application/octet-stream"));
+    assertFalse(encoding.isText("image/png"));
+    assertFalse(encoding.isText(null));
+  });
+
+  it("encodes binary request bodies as base64", () => {
+    // Given some bytes that are not text.
+    const encoding = new SimLambdaUrlBodyEncoding();
+    const bytes = new Uint8Array([0, 1, 2]);
+
+    // When they are encoded for the handler event.
+    const body = encoding.encode(bytes, "application/octet-stream");
+
+    // Then the handler receives base64.
+    assertIdentical(body, Buffer.from(bytes).toString("base64"));
+  });
+
+  it("passes text request bodies through as UTF-8", () => {
+    // Given UTF-8 bytes with a text content type.
+    const encoding = new SimLambdaUrlBodyEncoding();
+    const bytes = new TextEncoder().encode("héllo");
+
+    // When they are encoded for the handler event.
+    const body = encoding.encode(bytes, "text/plain");
+
+    // Then the handler receives the decoded string.
+    assertIdentical(body, "héllo");
+  });
+
+  it("returns response bodies unchanged when not base64", () => {
+    // Given a plain handler response body.
+    const encoding = new SimLambdaUrlBodyEncoding();
+
+    // When it is decoded for the client.
+    const body = encoding.decode("hello", false);
+
+    // Then it is used as it is.
+    assertIdentical(body, "hello");
+  });
+});

--- a/src/service/lambda/serve/event/sim-lambda-url-body-encoding.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-body-encoding.ts
@@ -1,0 +1,61 @@
+const textContentTypes: ReadonlySet<string> = new Set([
+  "application/javascript",
+  "application/json",
+  "application/x-www-form-urlencoded",
+  "application/xml",
+]);
+
+/**
+ * Decides how a Function URL request or response body crosses the boundary
+ * between HTTP bytes and the string a handler event carries.
+ *
+ * Real Lambda passes text bodies through as UTF-8 strings and base64-encodes
+ * everything else, telling the handler which happened with isBase64Encoded.
+ */
+export class SimLambdaUrlBodyEncoding {
+  /**
+   * Whether a content type's body is passed to the handler as text.
+   *
+   * An absent content type is treated as binary, as Lambda does, because
+   * nothing says the bytes are decodable text.
+   */
+  isText(contentType: string | null): boolean {
+    if (contentType === null) {
+      return false;
+    }
+
+    const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+
+    if (mediaType.startsWith("text/")) {
+      return true;
+    }
+
+    if (mediaType.endsWith("+json") || mediaType.endsWith("+xml")) {
+      return true;
+    }
+
+    return textContentTypes.has(mediaType);
+  }
+
+  /**
+   * Encode request body bytes for the handler event.
+   */
+  encode(bytes: Uint8Array, contentType: string | null): string {
+    if (this.isText(contentType)) {
+      return new TextDecoder().decode(bytes);
+    }
+
+    return Buffer.from(bytes).toString("base64");
+  }
+
+  /**
+   * Decode a handler's response body into the bytes sent to the client.
+   */
+  decode(body: string, isBase64Encoded: boolean): Uint8Array | string {
+    if (isBase64Encoded) {
+      return new Uint8Array(Buffer.from(body, "base64"));
+    }
+
+    return body;
+  }
+}

--- a/src/service/lambda/serve/event/sim-lambda-url-event-builder.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-event-builder.ts
@@ -6,6 +6,7 @@ import type {
   SimLambdaFunctionUrlEvent,
   SimLambdaFunctionUrlRequestContext,
 } from "./sim-lambda-url-event.type.js";
+import { simLambdaUrlEventTime } from "./sim-lambda-url-event-time.js";
 import { SimLambdaUrlRequestParts } from "./sim-lambda-url-request-parts.js";
 
 /**
@@ -84,7 +85,7 @@ export class SimLambdaUrlEventBuilder {
       requestId: randomUUID(),
       routeKey: "$default",
       stage: "$default",
-      time: now.toISOString(),
+      time: simLambdaUrlEventTime(now),
       timeEpoch: now.getTime(),
     };
   }

--- a/src/service/lambda/serve/event/sim-lambda-url-event-builder.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-event-builder.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimLambdaFunctionUrl } from "../../function/url/sim-lambda-function-url.js";
+import { SimLambdaUrlBodyEncoding } from "./sim-lambda-url-body-encoding.js";
+import type {
+  SimLambdaFunctionUrlEvent,
+  SimLambdaFunctionUrlRequestContext,
+} from "./sim-lambda-url-event.type.js";
+import { SimLambdaUrlRequestParts } from "./sim-lambda-url-request-parts.js";
+
+/**
+ * Builds the payload format 2.0 event a Function URL invocation passes to the
+ * function handler.
+ *
+ * Real Function URLs only speak payload format 2.0, so there is no version to
+ * choose. Request headers are passed through as received, including the local
+ * Host, while the requestContext describes the AWS-shaped endpoint the URL
+ * identifies.
+ */
+export class SimLambdaUrlEventBuilder {
+  private readonly bodyEncoding = new SimLambdaUrlBodyEncoding();
+  private readonly requestParts = new SimLambdaUrlRequestParts();
+
+  /**
+   * Build the invocation event for one Function URL request.
+   */
+  async build(
+    request: Request,
+    functionUrl: SimLambdaFunctionUrl,
+  ): Promise<SimLambdaFunctionUrlEvent> {
+    const url = new URL(request.url);
+    const bytes = new Uint8Array(await request.arrayBuffer());
+    const hasBody = bytes.length > 0;
+    const contentType = request.headers.get("content-type");
+
+    const event: SimLambdaFunctionUrlEvent = {
+      version: "2.0",
+      routeKey: "$default",
+      rawPath: url.pathname,
+      rawQueryString: url.search.replace(/^\?/, ""),
+      headers: this.requestParts.headers(request),
+      requestContext: this.requestContext(request, url, functionUrl),
+      isBase64Encoded: hasBody && !this.bodyEncoding.isText(contentType),
+    };
+
+    const cookies = this.requestParts.cookies(request);
+    if (cookies.length > 0) {
+      event.cookies = cookies;
+    }
+
+    const queryStringParameters = this.requestParts.queryStringParameters(url);
+    if (Object.keys(queryStringParameters).length > 0) {
+      event.queryStringParameters = queryStringParameters;
+    }
+
+    if (hasBody) {
+      event.body = this.bodyEncoding.encode(bytes, contentType);
+    }
+
+    return event;
+  }
+
+  private requestContext(
+    request: Request,
+    url: URL,
+    functionUrl: SimLambdaFunctionUrl,
+  ): SimLambdaFunctionUrlRequestContext {
+    const now = new Date();
+
+    return {
+      // Function URLs report the caller as anonymous when the request was not
+      // authenticated, which is every request the simulator serves.
+      accountId: "anonymous",
+      apiId: functionUrl.urlId,
+      domainName: functionUrl.hostname,
+      domainPrefix: functionUrl.urlId,
+      http: {
+        method: request.method,
+        path: url.pathname,
+        protocol: "HTTP/1.1",
+        sourceIp: "127.0.0.1",
+        userAgent: request.headers.get("user-agent") ?? "",
+      },
+      requestId: randomUUID(),
+      routeKey: "$default",
+      stage: "$default",
+      time: now.toISOString(),
+      timeEpoch: now.getTime(),
+    };
+  }
+}

--- a/src/service/lambda/serve/event/sim-lambda-url-event-time.iso.test.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-event-time.iso.test.ts
@@ -1,0 +1,28 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simLambdaUrlEventTime } from "./sim-lambda-url-event-time.js";
+
+describe("Sim Lambda Function URL event time", () => {
+  it("formats the time as real Function URL events carry it", () => {
+    // Given an instant.
+    const at = new Date("2020-03-12T19:03:58.390Z");
+
+    // When it is formatted for the event request context.
+    const time = simLambdaUrlEventTime(at);
+
+    // Then it is the Common Log Format stamp, not an ISO-8601 one.
+    assertIdentical(time, "12/Mar/2020:19:03:58 +0000");
+  });
+
+  it("formats in UTC, whatever the host timezone offset", () => {
+    // Given an instant late in the UTC day.
+    const at = new Date("2024-01-01T23:07:05Z");
+
+    // When it is formatted.
+    const time = simLambdaUrlEventTime(at);
+
+    // Then the UTC date and time are used, with the fixed +0000 offset.
+    assertIdentical(time, "01/Jan/2024:23:07:05 +0000");
+  });
+});

--- a/src/service/lambda/serve/event/sim-lambda-url-event-time.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-event-time.ts
@@ -1,0 +1,42 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function twoDigits(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/**
+ * Format the time payload format 2.0 carries in requestContext.time.
+ *
+ * This is the Common Log Format stamp real Function URL events use, such as
+ * `12/Mar/2020:19:03:58 +0000`, always in UTC. The event's timeEpoch field is
+ * the same instant in milliseconds, for handlers that want to compute with it.
+ */
+export function simLambdaUrlEventTime(at: Date): string {
+  const month = months[at.getUTCMonth()];
+  assertDefined(month, `Month name for ${at.toISOString()}`);
+
+  const year = String(at.getUTCFullYear());
+  const date = `${twoDigits(at.getUTCDate())}/${month}/${year}`;
+  const time = [
+    twoDigits(at.getUTCHours()),
+    twoDigits(at.getUTCMinutes()),
+    twoDigits(at.getUTCSeconds()),
+  ].join(":");
+
+  return `${date}:${time} +0000`;
+}

--- a/src/service/lambda/serve/event/sim-lambda-url-event.type.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-event.type.ts
@@ -1,0 +1,72 @@
+/**
+ * Lambda Function URL invocation event, in the API Gateway HTTP API payload
+ * format 2.0 that real Function URLs use.
+ *
+ * This is a minimal structural equivalent of the `aws-lambda` typings
+ * package's `LambdaFunctionURLEvent`, so handlers typed against that package
+ * can be invoked unchanged.
+ */
+export interface SimLambdaFunctionUrlEvent {
+  version: "2.0";
+  routeKey: "$default";
+  rawPath: string;
+  rawQueryString: string;
+  cookies?: string[];
+  headers: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+  requestContext: SimLambdaFunctionUrlRequestContext;
+  body?: string;
+  isBase64Encoded: boolean;
+}
+
+/**
+ * The requestContext block of a Function URL invocation event.
+ */
+export interface SimLambdaFunctionUrlRequestContext {
+  accountId: string;
+  apiId: string;
+  domainName: string;
+  domainPrefix: string;
+  http: SimLambdaFunctionUrlHttpContext;
+  requestId: string;
+  routeKey: "$default";
+  stage: "$default";
+  time: string;
+  timeEpoch: number;
+}
+
+/**
+ * The requestContext.http block of a Function URL invocation event.
+ */
+export interface SimLambdaFunctionUrlHttpContext {
+  method: string;
+  path: string;
+  protocol: string;
+  sourceIp: string;
+  userAgent: string;
+}
+
+/**
+ * Structured handler result for a Function URL invocation.
+ *
+ * A handler may also return any other value, in which case real Lambda infers
+ * a 200 JSON response from it.
+ */
+export interface SimLambdaFunctionUrlResult extends SimLambdaFunctionUrlResultBody {
+  statusCode?: number | undefined;
+}
+
+/**
+ * A handler result that carries a status code, which is what makes real
+ * Lambda treat it as an HTTP response rather than a value to JSON-encode.
+ */
+export interface SimLambdaFunctionUrlStructuredResult extends SimLambdaFunctionUrlResultBody {
+  statusCode: number;
+}
+
+interface SimLambdaFunctionUrlResultBody {
+  headers?: Record<string, string | number | boolean> | undefined;
+  cookies?: string[] | undefined;
+  body?: string | undefined;
+  isBase64Encoded?: boolean | undefined;
+}

--- a/src/service/lambda/serve/event/sim-lambda-url-request-parts.ts
+++ b/src/service/lambda/serve/event/sim-lambda-url-request-parts.ts
@@ -1,0 +1,57 @@
+/**
+ * Reads the parts of an HTTP request that payload format 2.0 delivers in its
+ * own event fields rather than as raw request data.
+ *
+ * Keeping this separate leaves the event builder to assemble the event from
+ * parts, without also owning the header, cookie and query conventions.
+ */
+export class SimLambdaUrlRequestParts {
+  /**
+   * Collect request headers, which payload format 2.0 delivers as single
+   * lowercased values.
+   *
+   * Cookies are left out because they travel in their own event field.
+   */
+  headers(request: Request): Record<string, string> {
+    // Fetch API header names are already lowercased, which is the case
+    // payload format 2.0 delivers them in, and repeats are already joined.
+    const headers = new Map<string, string>();
+    request.headers.forEach((value, name) => {
+      headers.set(name, value);
+    });
+    headers.delete("cookie");
+
+    return Object.fromEntries(headers);
+  }
+
+  /**
+   * Collect the request cookies as the separate list the event carries.
+   */
+  cookies(request: Request): string[] {
+    const cookieHeader = request.headers.get("cookie");
+
+    if (cookieHeader === null || cookieHeader.length === 0) {
+      return [];
+    }
+
+    return cookieHeader
+      .split(";")
+      .map((cookie) => cookie.trim())
+      .filter((cookie) => cookie.length > 0);
+  }
+
+  /**
+   * Collect query string parameters, joining repeated keys with commas as
+   * payload format 2.0 does.
+   */
+  queryStringParameters(url: URL): Record<string, string> {
+    const keys = new Set(url.searchParams.keys());
+
+    return Object.fromEntries(
+      [...keys].map((key): [string, string] => [
+        key,
+        url.searchParams.getAll(key).join(","),
+      ]),
+    );
+  }
+}

--- a/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
+++ b/src/service/lambda/serve/response/sim-lambda-url-error-response.ts
@@ -1,0 +1,40 @@
+/**
+ * The error responses a Function URL endpoint returns itself, before or
+ * instead of the function producing one.
+ *
+ * Real Lambda answers these with a small JSON document rather than the
+ * handler's output, so client code that reads the body of a failed Function
+ * URL call sees the same shape here.
+ */
+export class SimLambdaUrlErrorResponse {
+  /**
+   * No Function URL is served at this hostname.
+   */
+  notFound(): Response {
+    return this.jsonResponse(404, "Not Found");
+  }
+
+  /**
+   * The Function URL requires authentication the simulator cannot verify.
+   */
+  forbidden(): Response {
+    return this.jsonResponse(403, "Forbidden");
+  }
+
+  /**
+   * The function failed to handle the invocation.
+   */
+  internalServerError(): Response {
+    return this.jsonResponse(502, "Internal Server Error");
+  }
+
+  private jsonResponse(status: number, message: string): Response {
+    return Response.json(
+      { Message: message },
+      {
+        status,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+}

--- a/src/service/lambda/serve/response/sim-lambda-url-response-builder.ts
+++ b/src/service/lambda/serve/response/sim-lambda-url-response-builder.ts
@@ -1,0 +1,82 @@
+import { SimLambdaUrlBodyEncoding } from "../event/sim-lambda-url-body-encoding.js";
+import type {
+  SimLambdaFunctionUrlResult,
+  SimLambdaFunctionUrlStructuredResult,
+} from "../event/sim-lambda-url-event.type.js";
+
+const jsonContentType = "application/json";
+
+/**
+ * Turns a Function URL handler result into the HTTP response the client sees.
+ *
+ * Real Lambda accepts two shapes here: a structured response carrying a
+ * statusCode, or any other value, which it wraps in a 200 JSON response. Both
+ * are supported so handlers written either way behave as they would on AWS.
+ */
+export class SimLambdaUrlResponseBuilder {
+  private readonly bodyEncoding = new SimLambdaUrlBodyEncoding();
+
+  /**
+   * Build the HTTP response for one handler result.
+   */
+  build(result: unknown): Response {
+    if (this.isStructuredResult(result)) {
+      return this.structuredResponse(result);
+    }
+
+    return Response.json(result ?? null, {
+      status: 200,
+      headers: { "content-type": jsonContentType },
+    });
+  }
+
+  /**
+   * Whether the handler returned a structured HTTP response rather than a
+   * value to be JSON-encoded.
+   */
+  private isStructuredResult(
+    result: unknown,
+  ): result is SimLambdaFunctionUrlStructuredResult {
+    return (
+      typeof result === "object" &&
+      result !== null &&
+      "statusCode" in result &&
+      typeof (result as SimLambdaFunctionUrlResult).statusCode === "number"
+    );
+  }
+
+  private structuredResponse(
+    result: SimLambdaFunctionUrlStructuredResult,
+  ): Response {
+    const headers = new Headers();
+    const resultHeaders = Object.entries(result.headers ?? {});
+    const resultCookies = result.cookies ?? [];
+
+    for (const [name, value] of resultHeaders) {
+      headers.set(name, String(value));
+    }
+
+    for (const cookie of resultCookies) {
+      headers.append("set-cookie", cookie);
+    }
+
+    if (!headers.has("content-type")) {
+      headers.set("content-type", jsonContentType);
+    }
+
+    const body = this.bodyEncoding.decode(
+      result.body ?? "",
+      result.isBase64Encoded ?? false,
+    );
+
+    return new Response(
+      // An empty body is sent as no body at all, so statuses that must not
+      // carry one, such as 204, stay valid responses.
+      body.length === 0 ? null : body,
+      {
+        status: result.statusCode,
+        headers,
+      },
+    );
+  }
+}

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -1,0 +1,75 @@
+import type {
+  SimAwsServiceController,
+  SimAwsServiceTarget,
+} from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimLambdaUrlEventBuilder } from "./event/sim-lambda-url-event-builder.js";
+import { SimLambdaUrlErrorResponse } from "./response/sim-lambda-url-error-response.js";
+import { SimLambdaUrlResponseBuilder } from "./response/sim-lambda-url-response-builder.js";
+import {
+  type SimLambdaFunctionUrlRoute,
+  SimLambdaUrlRouter,
+} from "./sim-lambda-url-router.js";
+
+interface SimLambdaServiceControllerProperties {
+  readonly simAws?: SimAws;
+  readonly router?: SimLambdaUrlRouter;
+}
+
+/**
+ * Localhost HTTP controller for simulated Lambda Function URLs.
+ *
+ * A Function URL is invoked without an SDK caller: on real AWS a NONE auth
+ * URL is invokable by anyone, so the request is not attributed to a simulated
+ * principal. The function itself still runs as its execution Role, as it does
+ * for any other invocation.
+ */
+export class SimLambdaServiceController implements SimAwsServiceController {
+  private readonly router: SimLambdaUrlRouter;
+  private readonly eventBuilder = new SimLambdaUrlEventBuilder();
+  private readonly responseBuilder = new SimLambdaUrlResponseBuilder();
+  private readonly errorResponse = new SimLambdaUrlErrorResponse();
+
+  constructor(properties: SimLambdaServiceControllerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.router = properties.router ?? new SimLambdaUrlRouter({ simAws });
+  }
+
+  /**
+   * Handle an HTTP request routed to a simulated Lambda Function URL.
+   */
+  async handleRequest(
+    target: SimAwsServiceTarget,
+    request: Request,
+  ): Promise<Response> {
+    const route = this.router.route(target);
+
+    if (route === undefined) {
+      return this.errorResponse.notFound();
+    }
+
+    // SigV4 signatures are not verified, so an IAM-authenticated URL has no
+    // way to admit a request. Refusing is the safe direction: it matches what
+    // an unsigned request to a real AWS_IAM Function URL gets.
+    if (route.functionUrl.authType === "AWS_IAM") {
+      return this.errorResponse.forbidden();
+    }
+
+    return await this.invoke(route, request);
+  }
+
+  private async invoke(
+    route: SimLambdaFunctionUrlRoute,
+    request: Request,
+  ): Promise<Response> {
+    const event = await this.eventBuilder.build(request, route.functionUrl);
+
+    try {
+      return this.responseBuilder.build(await route.simFunction.invoke(event));
+    } catch {
+      // Real Function URLs report an unhandled function error as a bad
+      // gateway, with the error itself only visible in the function's logs.
+      return this.errorResponse.internalServerError();
+    }
+  }
+}

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -62,13 +62,15 @@ export class SimLambdaServiceController implements SimAwsServiceController {
     route: SimLambdaFunctionUrlRoute,
     request: Request,
   ): Promise<Response> {
-    const event = await this.eventBuilder.build(request, route.functionUrl);
-
     try {
+      const event = await this.eventBuilder.build(request, route.functionUrl);
+
       return this.responseBuilder.build(await route.simFunction.invoke(event));
     } catch {
       // Real Function URLs report an unhandled function error as a bad
       // gateway, with the error itself only visible in the function's logs.
+      // Reading the request body can fail the same way, so building the event
+      // is inside this too.
       return this.errorResponse.internalServerError();
     }
   }

--- a/src/service/lambda/serve/sim-lambda-url-router.ts
+++ b/src/service/lambda/serve/sim-lambda-url-router.ts
@@ -1,0 +1,66 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
+import type {
+  SimLambdaFunctionUrl,
+  SimLambdaFunctionUrlId,
+} from "../function/url/sim-lambda-function-url.js";
+import type { SimLambdaUrlRegistry } from "../registry/sim-lambda-url-registry.js";
+
+export interface SimLambdaFunctionUrlRoute {
+  readonly functionUrl: SimLambdaFunctionUrl;
+  readonly simFunction: SimLambdaFunction;
+}
+
+interface SimLambdaUrlRouterProperties {
+  readonly simAws?: SimAws;
+  readonly urlRegistry?: SimLambdaUrlRegistry;
+}
+
+/**
+ * Routes a served Function URL request to the function behind it.
+ *
+ * The request hostname gives the URL id and the region, but not the Account.
+ * The registry supplies that missing hop, and the Account/Region scope it
+ * names owns the Function URL and the function.
+ */
+export class SimLambdaUrlRouter {
+  private readonly simAws: SimAws;
+  private readonly urlRegistry: SimLambdaUrlRegistry;
+
+  constructor(properties: SimLambdaUrlRouterProperties = {}) {
+    this.simAws = properties.simAws ?? new SimAws();
+    this.urlRegistry =
+      properties.urlRegistry ?? this.simAws.lambdaUrlRegistry();
+  }
+
+  /**
+   * Find the Function URL and function a request target addresses.
+   */
+  route(target: SimAwsServiceTarget): SimLambdaFunctionUrlRoute | undefined {
+    const urlId = target.resourceName as SimLambdaFunctionUrlId;
+    const accountId = this.urlRegistry.accountIdForFunctionUrl(urlId);
+
+    if (accountId === undefined) {
+      return undefined;
+    }
+
+    const lambda = this.simAws
+      .accountRegionScope(accountId, target.regionName)
+      .lambda();
+    const functionUrl = lambda.getSimFunctionUrlById(urlId);
+
+    if (functionUrl === undefined) {
+      return undefined;
+    }
+
+    const simFunction = lambda.getSimFunctionByName(functionUrl.functionName);
+
+    /* v8 ignore if -- defensive check: a URL cannot outlive its function */
+    if (simFunction === undefined) {
+      return undefined;
+    }
+
+    return { functionUrl, simFunction };
+  }
+}

--- a/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  DeleteFunctionUrlConfigCommand,
+  UpdateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
+
+async function serveFunction(
+  simAws: SimAws,
+  handler: SimLambdaHandler,
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "greeter",
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  const created = await simAws.lambda().createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "greeter",
+      AuthType: "NONE",
+    }),
+  );
+
+  return created.FunctionUrl;
+}
+
+function localUrl(functionUrl: string): string {
+  return new SimAwsLocalUrl({ input: functionUrl }).toString();
+}
+
+describe("Serving sim Lambda Function URL failures", () => {
+  it("returns 404 for a Function URL host that is not registered", async () => {
+    // Given a simulated AWS with no Function URLs.
+    const simAws = new SimAws();
+
+    // When an invented Function URL host is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        "https://sn5f1tes4o11qsj5ue6cb5ndltmguteq.lambda-url.us-east-1.on.aws/",
+      ),
+    );
+
+    // Then the endpoint reports it as not found, AWS-style.
+    assertIdentical(response.status, 404);
+    assertObjectEquals(await response.json(), { Message: "Not Found" });
+  });
+
+  it("returns 404 once the Function URL has been deleted", async () => {
+    // Given a served Function URL that is then deleted.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => "hello");
+    await simAws
+      .lambda()
+      .deleteFunctionUrlConfig(
+        new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+      );
+
+    // When the deleted Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the hostname no longer serves anything.
+    assertIdentical(response.status, 404);
+  });
+
+  it("returns 404 when the host names a different region", async () => {
+    // Given a Function URL in the default region.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => "hello");
+
+    // When the same URL id is requested in another region.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl.replace("us-east-1", "eu-west-2")),
+    );
+
+    // Then it does not resolve, because Function URLs are region-scoped.
+    assertIdentical(response.status, 404);
+  });
+
+  it("refuses an AWS_IAM Function URL request", async () => {
+    // Given a Function URL that requires IAM authentication.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => "hello");
+    await simAws.lambda().updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // When it is requested without a signature.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the request is forbidden, as an unsigned request is on AWS.
+    assertIdentical(response.status, 403);
+    assertObjectEquals(await response.json(), { Message: "Forbidden" });
+  });
+
+  it("returns 502 when the handler throws", async () => {
+    // Given a function whose handler fails.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => {
+      throw new Error("handler exploded");
+    });
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the endpoint reports a bad gateway, keeping the error out of the
+    // response body as real Lambda does.
+    assertIdentical(response.status, 502);
+    assertObjectEquals(await response.json(), {
+      Message: "Internal Server Error",
+    });
+  });
+});

--- a/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
@@ -1,0 +1,299 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
+import type { SimLambdaFunctionUrlEvent } from "./event/sim-lambda-url-event.type.js";
+
+/**
+ * Create a function backed by a real in-process handler and give it a public
+ * Function URL, returning the local URL that reaches it.
+ */
+async function serveFunction(
+  simAws: SimAws,
+  handler: SimLambdaHandler,
+  functionName = "greeter",
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/GreeterRole",
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  const created = await simAws.lambda().createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: functionName,
+      AuthType: "NONE",
+    }),
+  );
+
+  return created.FunctionUrl;
+}
+
+function localUrl(functionUrl: string, path = ""): string {
+  return new SimAwsLocalUrl({ input: `${functionUrl}${path}` }).toString();
+}
+
+describe("Serving a sim Lambda Function URL", () => {
+  it("invokes the function and returns its structured response", async () => {
+    // Given a function served at a Function URL.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => ({
+      statusCode: 201,
+      headers: { "content-type": "text/plain", "x-greeting": "hello" },
+      body: "Hello from a sim Lambda",
+    }));
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the handler's status, headers and body are what the client sees.
+    assertIdentical(response.status, 201);
+    assertIdentical(response.headers.get("content-type"), "text/plain");
+    assertIdentical(response.headers.get("x-greeting"), "hello");
+    assertIdentical(await response.text(), "Hello from a sim Lambda");
+  });
+
+  it("wraps a plain handler result in a JSON response", async () => {
+    // Given a function returning a plain value.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => ({
+      greeting: "hello",
+    }));
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then Lambda's 200 JSON inference applies.
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-type"), "application/json");
+    assertIdentical(await response.text(), '{"greeting":"hello"}');
+  });
+
+  it("passes a payload format 2.0 event to the handler", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(
+      simAws,
+      (event: SimLambdaFunctionUrlEvent) => event,
+    );
+
+    // When the Function URL is requested with a query and a cookie.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl, "hello/world?name=yulin&name=again"),
+      { headers: { cookie: "session=abc; theme=dark", "X-Test": "yes" } },
+    );
+
+    // Then the event carries the payload format 2.0 request details.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.version, "2.0");
+    assertIdentical(event.rawPath, "/hello/world");
+    assertIdentical(event.rawQueryString, "name=yulin&name=again");
+    assertIdentical(event.queryStringParameters?.["name"], "yulin,again");
+    assertIdentical(event.headers["x-test"], "yes");
+    assertIdentical(event.requestContext.http.method, "GET");
+    assertIdentical(event.requestContext.http.path, "/hello/world");
+    assertFalse(event.isBase64Encoded);
+  });
+
+  it("delivers cookies in their own event field", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(
+      simAws,
+      (event: SimLambdaFunctionUrlEvent) => event,
+    );
+
+    // When the Function URL is requested with cookies.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      { headers: { cookie: "session=abc; theme=dark" } },
+    );
+
+    // Then the cookies are listed separately and not left in the headers.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertNonNullable(event.cookies);
+    assertArrayEquals(event.cookies, ["session=abc", "theme=dark"]);
+    assertUndefined(event.headers["cookie"]);
+  });
+
+  it("names the AWS endpoint in the event request context", async () => {
+    // Given a function served at a Function URL.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(
+      simAws,
+      (event: SimLambdaFunctionUrlEvent) => event,
+    );
+
+    // When the Function URL is requested on localhost.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the request context describes the AWS-shaped endpoint.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(`https://${event.requestContext.domainName}/`, functionUrl);
+    assertIdentical(
+      event.requestContext.apiId,
+      event.requestContext.domainPrefix,
+    );
+    assertIdentical(event.requestContext.accountId, "anonymous");
+  });
+
+  it("passes a text request body through as a string", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(
+      simAws,
+      (event: SimLambdaFunctionUrlEvent) => event,
+    );
+
+    // When JSON is posted to the Function URL.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"name":"yulin"}',
+      },
+    );
+
+    // Then the handler receives the body as text.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.body, '{"name":"yulin"}');
+    assertFalse(event.isBase64Encoded);
+    assertIdentical(event.requestContext.http.method, "POST");
+  });
+
+  it("base64-encodes a binary request body", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(
+      simAws,
+      (event: SimLambdaFunctionUrlEvent) => event,
+    );
+
+    // When binary content is posted to the Function URL.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new Uint8Array([1, 2, 3]),
+      },
+    );
+
+    // Then the handler receives base64, flagged as such.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.body, Buffer.from([1, 2, 3]).toString("base64"));
+    assertTrue(event.isBase64Encoded);
+  });
+
+  it("decodes a base64 handler response body", async () => {
+    // Given a function returning base64-encoded bytes.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => ({
+      statusCode: 200,
+      headers: { "content-type": "application/octet-stream" },
+      body: Buffer.from([7, 8, 9]).toString("base64"),
+      isBase64Encoded: true,
+    }));
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the client receives the decoded bytes.
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    assertArrayEquals([...bytes], [7, 8, 9]);
+  });
+
+  it("sends handler cookies as set-cookie headers", async () => {
+    // Given a function returning cookies.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => ({
+      statusCode: 200,
+      cookies: ["session=abc; Path=/", "theme=dark"],
+      body: "ok",
+    }));
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then each cookie is its own set-cookie header.
+    assertArrayEquals(response.headers.getSetCookie(), [
+      "session=abc; Path=/",
+      "theme=dark",
+    ]);
+  });
+
+  it("returns a bodiless response when the handler sends no body", async () => {
+    // Given a function returning no content.
+    const simAws = new SimAws();
+    const functionUrl = await serveFunction(simAws, () => ({
+      statusCode: 204,
+    }));
+
+    // When the Function URL is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the status is passed through without a body.
+    assertIdentical(response.status, 204);
+    assertIdentical(await response.text(), "");
+  });
+
+  it("routes same-named functions in different accounts separately", async () => {
+    // Given two accounts with a same-named function, each with a Function URL.
+    const simAws = new SimAws();
+    const firstUrl = await serveFunction(simAws, () => "first account");
+    const secondLambda = simAws.account("222222222222").lambda();
+    await secondLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::222222222222:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "second account") },
+      }),
+    );
+    const secondCreated = await secondLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+    const secondUrl = secondCreated.FunctionUrl;
+
+    // When each Function URL is requested.
+    const http = new SimAwsHttp({ simAws });
+    const firstResponse = await http.fetch(localUrl(firstUrl));
+    const secondResponse = await http.fetch(localUrl(secondUrl));
+
+    // Then each reaches its own account's function.
+    assertIdentical(await firstResponse.text(), '"first account"');
+    assertIdentical(await secondResponse.text(), '"second account"');
+  });
+});

--- a/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
@@ -158,6 +158,12 @@ describe("Serving a sim Lambda Function URL", () => {
       event.requestContext.domainPrefix,
     );
     assertIdentical(event.requestContext.accountId, "anonymous");
+    assertTrue(
+      /^\d{2}\/[A-Z][a-z]{2}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000$/.test(
+        event.requestContext.time,
+      ),
+      `Unexpected request context time ${event.requestContext.time}`,
+    );
   });
 
   it("passes a text request body through as a string", async () => {

--- a/src/service/lambda/serve/sim-lambda-url-serve.loc.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.loc.test.ts
@@ -1,0 +1,56 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+describe("Serving a sim Lambda Function URL on localhost", () => {
+  it("invokes the function over real localhost HTTP", async () => {
+    // Given a sim Lambda function with a public Function URL, served on
+    // localhost alongside the other simulated services.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: { queryStringParameters?: { name?: string } }) => ({
+              statusCode: 200,
+              headers: { "content-type": "text/plain" },
+              body: `Hello ${event.queryStringParameters?.name ?? "world"}`,
+            }),
+          ),
+        },
+      }),
+    );
+
+    const created = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the Function URL is fetched over localhost.
+      const response = await fetch(
+        srv.localUrl(`${created.FunctionUrl}greet?name=Yulin`),
+      );
+
+      // Then the function handled the real HTTP request.
+      assertIdentical(response.status, 200);
+      assertIdentical(response.headers.get("content-type"), "text/plain");
+      assertIdentical(await response.text(), "Hello Yulin");
+    } finally {
+      srv.close();
+    }
+  });
+});

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -36,6 +36,34 @@ import type {
   SimInvokeCommand,
   SimInvokeCommandOutput,
 } from "./command/invoke/invoke.command.js";
+import type {
+  SimCreateFunctionUrlConfigCommand,
+  SimCreateFunctionUrlConfigCommandOutput,
+} from "./command/create-function-url-config/create-function-url-config.command.js";
+import type {
+  SimGetFunctionUrlConfigCommand,
+  SimGetFunctionUrlConfigCommandOutput,
+} from "./command/get-function-url-config/get-function-url-config.command.js";
+import type {
+  SimUpdateFunctionUrlConfigCommand,
+  SimUpdateFunctionUrlConfigCommandOutput,
+} from "./command/update-function-url-config/update-function-url-config.command.js";
+import type {
+  SimDeleteFunctionUrlConfigCommand,
+  SimDeleteFunctionUrlConfigCommandOutput,
+} from "./command/delete-function-url-config/delete-function-url-config.command.js";
+import type {
+  SimListFunctionUrlConfigsCommand,
+  SimListFunctionUrlConfigsCommandOutput,
+} from "./command/list-function-url-configs/list-function-url-configs.command.js";
+import { SimLambdaFunctionUrlCommands } from "./command/function-url/sim-lambda-function-url-commands.js";
+import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
+import { SimLambdaFunctionUrlStore } from "./function/url/sim-lambda-function-url-store.js";
+import type {
+  SimLambdaFunctionUrl,
+  SimLambdaFunctionUrlId,
+} from "./function/url/sim-lambda-function-url.js";
+import { SimLambdaUrlRegistry } from "./registry/sim-lambda-url-registry.js";
 import { SimLambdaSdkCommandRouter } from "./sdk/sim-lambda-sdk-command-router.js";
 
 export interface SimLambdaRequestOptions {
@@ -49,6 +77,7 @@ interface SimLambdaProperties {
   readonly runAsOwner?: SimAwsRunAsOwner;
   readonly codeStore?: SimLambdaCodeStore;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
+  readonly urlRegistry?: SimLambdaUrlRegistry;
 }
 
 /**
@@ -56,6 +85,9 @@ interface SimLambdaProperties {
  */
 export class SimLambda {
   private readonly functions: SimLambdaFunctionMap = new Map();
+  private readonly functionUrls: SimLambdaFunctionUrlStore;
+  private readonly functionLookup: SimLambdaFunctionLookup;
+  private readonly functionUrlCommands: SimLambdaFunctionUrlCommands;
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly iam: SimIamInterServiceAuthZ;
@@ -82,9 +114,27 @@ export class SimLambda {
       background = new BackgroundTasks(),
       codeStore,
       vmSdkModuleProvider,
+      // A standalone SimLambda is not reachable over HTTP, so its own
+      // registry is enough; a SimAws-created one shares the environment-wide
+      // registry the serving layer routes with.
+      urlRegistry = new SimLambdaUrlRegistry(),
     } = properties;
 
     this.accountRegionScope = accountRegionScope;
+    this.functionLookup = new SimLambdaFunctionLookup({
+      accountRegionScope,
+      functions: this.functions,
+    });
+    this.functionUrls = new SimLambdaFunctionUrlStore({
+      accountRegionScope,
+      urlRegistry,
+    });
+    this.functionUrlCommands = new SimLambdaFunctionUrlCommands({
+      functionUrls: this.functionUrls,
+      functions: this.functionLookup,
+      iam,
+      background,
+    });
     this.iam = iam;
     this.background = background;
     this.codeStore = codeStore;
@@ -148,12 +198,83 @@ export class SimLambda {
   }
 
   /**
+   * Handle a Create Function Url Config Command from the SDK.
+   */
+  async createFunctionUrlConfig(
+    command: SimCreateFunctionUrlConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<SimCreateFunctionUrlConfigCommandOutput> {
+    return await this.functionUrlCommands.create(command, options);
+  }
+
+  /**
+   * Handle a Get Function Url Config Command from the SDK.
+   */
+  async getFunctionUrlConfig(
+    command: SimGetFunctionUrlConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<SimGetFunctionUrlConfigCommandOutput> {
+    return await this.functionUrlCommands.get(command, options);
+  }
+
+  /**
+   * Handle an Update Function Url Config Command from the SDK.
+   */
+  async updateFunctionUrlConfig(
+    command: SimUpdateFunctionUrlConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<SimUpdateFunctionUrlConfigCommandOutput> {
+    return await this.functionUrlCommands.update(command, options);
+  }
+
+  /**
+   * Handle a Delete Function Url Config Command from the SDK.
+   */
+  async deleteFunctionUrlConfig(
+    command: SimDeleteFunctionUrlConfigCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<SimDeleteFunctionUrlConfigCommandOutput> {
+    return await this.functionUrlCommands.delete(command, options);
+  }
+
+  /**
+   * Handle a List Function Url Configs Command from the SDK.
+   */
+  async listFunctionUrlConfigs(
+    command: SimListFunctionUrlConfigsCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<SimListFunctionUrlConfigsCommandOutput> {
+    return await this.functionUrlCommands.list(command, options);
+  }
+
+  /**
    * Get a simulated Lambda function instance by name.
    */
   getSimFunctionByName(
     functionName: SimLambdaFunctionName | string,
   ): SimLambdaFunction | undefined {
     return this.functions.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
+   * Get a simulated Lambda function's Function URL, if it has one.
+   */
+  getSimFunctionUrl(
+    functionName: SimLambdaFunctionName | string,
+  ): SimLambdaFunctionUrl | undefined {
+    return this.functionUrls.get(functionName);
+  }
+
+  /**
+   * Get a simulated Lambda Function URL by the id in its hostname.
+   *
+   * This is how the localhost serving layer finds the Function URL a request
+   * was addressed to, once the registry has named the owning Account.
+   */
+  getSimFunctionUrlById(
+    urlId: SimLambdaFunctionUrlId,
+  ): SimLambdaFunctionUrl | undefined {
+    return this.functionUrls.byUrlId(urlId);
   }
 
   /**

--- a/src/service/route53/resolve/sim-r53-service-target-resolver.ts
+++ b/src/service/route53/resolve/sim-r53-service-target-resolver.ts
@@ -1,5 +1,6 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { lambdaFunctionUrlHostLabel } from "../../lambda/function/url/sim-lambda-function-url-host.js";
 import { simRoute53LogicalName } from "../local-name/sim-route53-local-name.js";
 import { simRoute53DnsHostName } from "../serve/sim-route53-dns-host.js";
 
@@ -37,7 +38,8 @@ export class SimRoute53ServiceTargetResolver {
     return (
       this.route53DnsServiceTarget(logicalName) ??
       this.s3WebsiteServiceTarget(logicalName) ??
-      this.cloudFrontServiceTarget(logicalName)
+      this.cloudFrontServiceTarget(logicalName) ??
+      this.lambdaFunctionUrlServiceTarget(logicalName)
     );
   }
 
@@ -134,6 +136,44 @@ export class SimRoute53ServiceTargetResolver {
     return {
       service: "cloudFront",
       resourceName: distroId,
+    };
+  }
+
+  /**
+   * Resolve Lambda Function URL hostnames.
+   *
+   * Simulated Function URL hostnames use:
+   *
+   *   <url-id>.lambda-url.<region>
+   *
+   * The real AWS endpoint ends `.on.aws`, which the local URL rewriting drops
+   * in the same way it drops `.amazonaws.com` from S3 endpoints. The URL id is
+   * one DNS label, so the label count here is exact.
+   */
+  private lambdaFunctionUrlServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length !== 3) {
+      return undefined;
+    }
+
+    const [urlId, service, regionName] = labels;
+
+    if (service !== lambdaFunctionUrlHostLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    /* v8 ignore if -- defensive check */
+    if (urlId === undefined || urlId.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "lambda",
+      resourceName: urlId,
+      regionName: regionName as AwsRegionName,
     };
   }
 }


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Lambda Function URL support, including creation, retrieval, updates, deletion, and listing.
  * Added CloudFormation support for `AWS::Lambda::Url`, including references and stack outputs.
  * Function URLs can be invoked through local HTTP endpoints with payload format 2.0 events, query parameters, cookies, headers, and binary bodies.
  * Added support for public and IAM-protected URL configurations, with AWS-style error responses.
  * Added routing across accounts and regions with unique Function URL endpoints.
* **Documentation**
  * Expanded Lambda documentation with Function URL behavior, authorization, CloudFormation coverage, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->