### PR TITLE
feat: resolve simulated IAM principal for HTTP requests

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -560,19 +560,21 @@ that check the only symptom would be a signature mismatch with nothing to act on
 ### What the simulator reports back
 
 Every served response carries the simulator's own account of the request in headers, leaving the
-response body the shape the real service returns:
+response body the shape the real service returns. Which headers appear depends on whether the
+request was accepted:
 
-| Header                   | Meaning                                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------- |
-| `x-sim-aws-caller`       | The principal the request was attributed to, in the same form the request header accepts |
-| `x-sim-aws-auth`         | How that was decided: `caller-header`, `sigv4`, `none`, or `rejected`                    |
-| `x-sim-aws-error`        | On a refusal, the AWS error code, such as `SignatureDoesNotMatch`                        |
-| `x-sim-aws-error-detail` | On a refusal, what the simulator can say about why                                       |
+| Header                   | On an accepted request                                                                   | On a refused request                                |
+| ------------------------ | ---------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `x-sim-aws-caller`       | The principal the request was attributed to, in the same form the request header accepts | Absent — there is no principal to report            |
+| `x-sim-aws-auth`         | How that was decided: `caller-header`, `sigv4`, or `none`                                | `rejected`                                          |
+| `x-sim-aws-error`        | Absent                                                                                   | The AWS error code, such as `SignatureDoesNotMatch` |
+| `x-sim-aws-error-detail` | Absent                                                                                   | What the simulator can say about why                |
 
 A refused request is answered as real AWS answers it: `403` with `{"Message":"Forbidden"}` for a
-rejected signature, and `400` for an `x-sim-aws-caller` value that names no principal form. Real
-AWS has nowhere in that body to explain itself and neither does this, which is why the detail goes
-in `x-sim-aws-error-detail` where it changes nothing for a client parsing the response.
+rejected signature, and `400` for a signature too incomplete to parse or an `x-sim-aws-caller`
+value that names no principal form. Real AWS has nowhere in that body to explain itself and neither
+does this, which is why the detail goes in `x-sim-aws-error-detail` where it changes nothing for a
+client parsing the response.
 
 ## Authorizing other simulated services
 

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -22,6 +22,8 @@ Sim IAM currently supports:
 - Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
   service-supplied resource policies, and policy conditions with explicit-deny precedence
 - IAM authorization at simulated service boundaries, such as Route53 actions
+- Resolving the caller of an HTTP request into simulated AWS, from an `x-sim-aws-caller` header or
+  a verified SigV4 signature, defaulting to anonymous
 - Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
   policies
 - CloudFormation resources:
@@ -455,6 +457,123 @@ the derived `aws:PrincipalArn` come from the underlying Role. A caller that the 
 not allow is denied the assume request, session credentials require their session token, and
 expired sessions are rejected.
 
+## Callers of HTTP requests
+
+An in-process SDK call can be told who its caller is. A request arriving over HTTP — through
+`serveSimAws`, or through `SimAwsHttp.fetch(...)` in the same process — carries no such thing, so
+sim IAM works the caller out from the request itself, in a fixed order:
+
+1. An `x-sim-aws-caller` header naming the principal directly.
+2. An `Authorization: AWS4-HMAC-SHA256` header, verified as a SigV4 signature.
+3. Neither, giving **anonymous**.
+
+The last step matters. Sim IAM treats an omitted in-process caller as the Account root with
+unrestricted access, which is a convenience inside a test. Over HTTP the same default would make
+every unauthenticated request an administrator, so a served request that says nothing about who
+sent it is anonymous instead, and never the Account root.
+
+### Naming the caller directly
+
+`x-sim-aws-caller` names the principal outright. It is the path for local development and for
+tooling that will not sign requests: a curl one-liner can be a Role without holding any credentials.
+
+```bash
+curl -H 'x-sim-aws-caller: arn:aws:iam::111111111111:role/Reporter' \
+  http://abc123.lambda-url.us-east-1.sim-aws.localhost:4566/
+```
+
+The value is one of three forms:
+
+| Value            | Principal                                                    |
+| ---------------- | ------------------------------------------------------------ |
+| An ARN           | That IAM User, Role, or assumed-role session                 |
+| `service:<name>` | An AWS service principal, such as `service:s3.amazonaws.com` |
+| `anonymous`      | Explicitly anonymous                                         |
+
+The header is always enabled and not configurable, it takes precedence over a valid signature, and
+it does not check that the ARN exists — naming a principal is not claiming it was created, exactly
+as `runAs` behaves. It is stripped before the request reaches the simulated service, so a Lambda
+handler echoing `event.headers` never sees simulator control metadata.
+
+```typescript sim-iam-served-request-caller
+/**
+ * Naming the caller of an HTTP request into simulated AWS.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "reporter",
+    Role: "arn:aws:iam::111111111111:role/ReporterRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+  }),
+);
+
+const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "reporter",
+    AuthType: "NONE",
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl(urlConfig.FunctionUrl), {
+    headers: { "x-sim-aws-caller": "arn:aws:iam::111111111111:role/Reporter" },
+  });
+
+  // arn:aws:iam::111111111111:role/Reporter
+  console.log(response.headers.get("x-sim-aws-caller"));
+  // caller-header
+  console.log(response.headers.get("x-sim-aws-auth"));
+} finally {
+  srv.close();
+}
+```
+
+### Signed requests
+
+A request signed with credentials from `CreateAccessKeyCommand` or from an STS `AssumeRoleCommand`
+session is verified as a SigV4 signature and resolves to the signing principal, with the same
+identity `resolveCredentials` returns in process.
+
+Sign the URL you actually call. Serving rewrites AWS endpoint hostnames to local ones — a Function
+URL is served at `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>` — and the `host` header is
+part of what a signature covers, so a signature made against the real AWS hostname will not verify
+against the local one.
+
+A signature whose credential scope names a different service or Region than the endpoint it reached
+is refused before anything else is checked, and says so. The scope feeds the signing key, so without
+that check the only symptom would be a signature mismatch with nothing to act on.
+
+### What the simulator reports back
+
+Every served response carries the simulator's own account of the request in headers, leaving the
+response body the shape the real service returns:
+
+| Header                   | Meaning                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| `x-sim-aws-caller`       | The principal the request was attributed to, in the same form the request header accepts |
+| `x-sim-aws-auth`         | How that was decided: `caller-header`, `sigv4`, `none`, or `rejected`                    |
+| `x-sim-aws-error`        | On a refusal, the AWS error code, such as `SignatureDoesNotMatch`                        |
+| `x-sim-aws-error-detail` | On a refusal, what the simulator can say about why                                       |
+
+A refused request is answered as real AWS answers it: `403` with `{"Message":"Forbidden"}` for a
+rejected signature, and `400` for an `x-sim-aws-caller` value that names no principal form. Real
+AWS has nowhere in that body to explain itself and neither does this, which is why the detail goes
+in `x-sim-aws-error-detail` where it changes nothing for a client parsing the response.
+
 ## Authorizing other simulated services
 
 Simulated services use sim IAM to authorize their own actions when used through `SimAws`. Route53
@@ -696,3 +815,12 @@ full IAM feature set. Notable gaps:
 - Deleting and detaching resources (Roles, Users, Policies, access keys) is not yet supported
 - Only the condition operators listed above are supported; a statement using an unsupported
   operator fails closed and does not match, rather than silently allowing
+- Signature age is deliberately not enforced: `X-Amz-Date` must be present, well formed, and agree
+  with the credential scope date, but is never compared to a clock, so a client stamping real time
+  is not locked out of a simulation keeping a different one. Session expiry _is_ enforced, against
+  simulated time
+- Presigned query-string authentication (`X-Amz-Algorithm` in the query), S3 `aws-chunked`
+  streaming signatures, and SigV4A are not verified
+- The resolved caller of a served request is reported back but is not yet evaluated by the services
+  that serve it: served S3 objects perform no authorization, and Lambda Function URLs with
+  `AuthType: "AWS_IAM"` still refuse every request

--- a/docs/services/iam/sim-iam-served-request-caller.example.ts
+++ b/docs/services/iam/sim-iam-served-request-caller.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Naming the caller of an HTTP request into simulated AWS.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "reporter",
+    Role: "arn:aws:iam::111111111111:role/ReporterRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) },
+  }),
+);
+
+const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "reporter",
+    AuthType: "NONE",
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  const response = await fetch(srv.localUrl(urlConfig.FunctionUrl), {
+    headers: { "x-sim-aws-caller": "arn:aws:iam::111111111111:role/Reporter" },
+  });
+
+  // arn:aws:iam::111111111111:role/Reporter
+  console.log(response.headers.get("x-sim-aws-caller"));
+  // caller-header
+  console.log(response.headers.get("x-sim-aws-auth"));
+} finally {
+  srv.close();
+}

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -554,9 +554,11 @@ changes the `AuthType` or `InvokeMode` while keeping the same endpoint, and
 `404`. `ListFunctionUrlConfigsCommand` lists what a function has, which is either nothing or one
 configuration, since a function has at most one Function URL.
 
-A URL created with `AuthType: "AWS_IAM"` is stored and reported, but the simulator does not verify
-SigV4 signatures, so serving one refuses every request with `403`. Use `AuthType: "NONE"` for URLs
-a test needs to call.
+A URL created with `AuthType: "AWS_IAM"` is stored and reported, but nothing yet evaluates
+`lambda:InvokeFunctionUrl` against the caller of a request, so serving one refuses every request
+with `403`. Use `AuthType: "NONE"` for URLs a test needs to call. The caller of a served request is
+resolved either way — see
+[callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs.
 
 ## Environment variables
 
@@ -914,8 +916,9 @@ Current documented limitations:
 
 - Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, and the Function URL config
   commands are supported — no `UpdateFunctionCode`, `DeleteFunction`, or function listing yet.
-- Function URLs with `AuthType: "AWS_IAM"` are stored and reported, but SigV4 signatures are not
-  verified, so serving one refuses every request with `403`.
+- Function URLs with `AuthType: "AWS_IAM"` are stored and reported, and the caller of a served
+  request is resolved, but `lambda:InvokeFunctionUrl` is not evaluated against it, so serving one
+  refuses every request with `403`.
 - The Function URL `Cors` configuration is not simulated, including OPTIONS preflight handling.
 - `InvokeMode: "RESPONSE_STREAM"` is accepted and reported, but responses are always served
   buffered.

--- a/src/serve/controller/sim-aws-service-signing-name.ts
+++ b/src/serve/controller/sim-aws-service-signing-name.ts
@@ -1,0 +1,28 @@
+import type { SimAwsServiceTarget } from "./sim-service-controller.js";
+
+/**
+ * The SigV4 signing name of each simulated service a request can be routed to.
+ *
+ * Service targets use the simulator's own naming, which follows the SDK client
+ * names, while a credential scope names the service the way the signer does.
+ * They agree for most services and not for CloudFront, so the two vocabularies
+ * are mapped here rather than assumed to be the same string.
+ */
+export function simAwsServiceSigningName(
+  service: SimAwsServiceTarget["service"],
+): string {
+  switch (service) {
+    case "cloudFront": {
+      return "cloudfront";
+    }
+    case "s3": {
+      return "s3";
+    }
+    case "lambda": {
+      return "lambda";
+    }
+    case "route53": {
+      return "route53";
+    }
+  }
+}

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -1,11 +1,46 @@
 import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import type { SimAws } from "../../service/aws/sim-aws.js";
+import { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-caller.js";
 
 export interface SimAwsServiceTarget {
   readonly service: "s3" | "cloudFront" | "lambda" | "route53";
   readonly resourceName: string;
   // regionName is used for validation, not look-up
   readonly regionName?: AwsRegionName;
+}
+
+interface SimAwsServiceRequestProperties {
+  readonly target: SimAwsServiceTarget;
+  readonly request: Request;
+  readonly caller?: SimAwsRequestCaller | undefined;
+  readonly body?: Uint8Array | undefined;
+}
+
+/**
+ * One HTTP request, routed to a simulated service and attributed to a
+ * principal.
+ *
+ * Controllers are handed this rather than a bare request because everything
+ * they need has already been settled once at the boundary: which resource the
+ * hostname names, who is asking, and the request body, buffered so that both
+ * signature verification and the controller can read the same bytes.
+ *
+ * The request carries no simulator control headers, so a Lambda handler
+ * echoing `event.headers` sees the request as its client sent it.
+ */
+export class SimAwsServiceRequest {
+  public readonly target: SimAwsServiceTarget;
+  public readonly request: Request;
+  public readonly caller: SimAwsRequestCaller;
+  public readonly body?: Uint8Array | undefined;
+
+  constructor(properties: SimAwsServiceRequestProperties) {
+    this.target = properties.target;
+    this.request = properties.request;
+    // An unattributed request is anonymous, never the Account root.
+    this.caller = properties.caller ?? SimAwsRequestCaller.anonymous();
+    this.body = properties.body;
+  }
 }
 
 /**
@@ -22,8 +57,5 @@ export interface SimAwsServiceController {
   /**
    * Handle an HTTP request routed to this simulated AWS service.
    */
-  handleRequest(
-    target: SimAwsServiceTarget,
-    request: Request,
-  ): Promise<Response>;
+  handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response>;
 }

--- a/src/serve/http/request/sim-aws-received-request.ts
+++ b/src/serve/http/request/sim-aws-received-request.ts
@@ -1,0 +1,62 @@
+import { simAwsCallerHeaderName } from "../../../service/iam/request/sim-aws-caller-header.js";
+
+/**
+ * Header names that are instructions to the simulator rather than part of the
+ * request being simulated.
+ */
+const controlHeaderNames = [simAwsCallerHeaderName];
+
+/**
+ * An HTTP request as it arrived at the simulated AWS boundary.
+ *
+ * The body is read exactly once, here, because a request body is a stream that
+ * cannot be consumed twice and two things need it: the SigV4 payload hash, and
+ * whatever the simulated service builds from the request. Everything
+ * downstream is handed the same bytes.
+ */
+export class SimAwsReceivedRequest {
+  /**
+   * The request body, or undefined when the request carried none.
+   */
+  public readonly body?: Uint8Array | undefined;
+
+  private readonly received: Request;
+
+  private constructor(received: Request, body: Uint8Array | undefined) {
+    this.received = received;
+    this.body = body;
+  }
+
+  /**
+   * Take a request in, buffering its body.
+   */
+  static async receive(request: Request): Promise<SimAwsReceivedRequest> {
+    const body =
+      request.body === null
+        ? undefined
+        : new Uint8Array(await request.arrayBuffer());
+
+    return new SimAwsReceivedRequest(request, body);
+  }
+
+  /**
+   * The request as the simulated service should see it.
+   *
+   * Simulator control headers are stripped, so a Lambda handler echoing
+   * `event.headers` never sees them, and the buffered body is reattached so
+   * the service can read it as usual.
+   */
+  forService(): Request {
+    const headers = new Headers(this.received.headers);
+
+    for (const name of controlHeaderNames) {
+      headers.delete(name);
+    }
+
+    return new Request(this.received.url, {
+      method: this.received.method,
+      headers,
+      ...(this.body !== undefined && { body: this.body }),
+    });
+  }
+}

--- a/src/serve/http/request/sim-aws-request-authenticator.ts
+++ b/src/serve/http/request/sim-aws-request-authenticator.ts
@@ -1,0 +1,60 @@
+import type { SimAws } from "../../../service/aws/sim-aws.js";
+import { simAwsServiceSigningName } from "../../controller/sim-aws-service-signing-name.js";
+import {
+  SimAwsServiceRequest,
+  type SimAwsServiceTarget,
+} from "../../controller/sim-service-controller.js";
+import { SimAwsReceivedRequest } from "./sim-aws-received-request.js";
+
+interface SimAwsRequestAuthenticatorProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * Turns a received HTTP request into a request a simulated service can serve.
+ *
+ * This is where the serving layer meets simulated IAM: the body is buffered
+ * once, the principal is resolved by IAM, and the result is the request a
+ * controller is given. Controllers therefore never see an unattributed
+ * request, and never have to decide for themselves what an unsigned one means.
+ */
+export class SimAwsRequestAuthenticator {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsRequestAuthenticatorProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Authenticate a request routed to a simulated service.
+   *
+   * The request handed to IAM is the one received, headers and all. A signature
+   * covers the host header as it arrived, and serving rewrites AWS hostnames to
+   * localhost ones, so reconstructing the real AWS hostname here would break
+   * every signature made against the URL actually called.
+   *
+   * Throws a SimAwsRequestAuthFailure when the request states an identity that
+   * cannot be accepted.
+   */
+  async authenticate(
+    target: SimAwsServiceTarget,
+    request: Request,
+  ): Promise<SimAwsServiceRequest> {
+    const received = await SimAwsReceivedRequest.receive(request);
+
+    const caller = this.simAws.resolveRequestCaller(request, {
+      body: received.body,
+      expectedScope: {
+        serviceName: simAwsServiceSigningName(target.service),
+        regionName: target.regionName,
+      },
+    });
+
+    return new SimAwsServiceRequest({
+      target,
+      request: received.forService(),
+      caller,
+      body: received.body,
+    });
+  }
+}

--- a/src/serve/http/response/sim-aws-auth-failure-response.ts
+++ b/src/serve/http/response/sim-aws-auth-failure-response.ts
@@ -2,6 +2,7 @@ import {
   SimAwsInvalidCallerHeader,
   type SimAwsRequestAuthFailure,
 } from "../../../service/iam/request/error/sim-aws-request-auth.error.js";
+import { SimIamIncompleteSignature } from "../../../service/iam/sigv4/error/sim-iam-sigv4.error.js";
 import { SimAwsResponseHints } from "./sim-aws-response-hints.js";
 
 /**
@@ -26,14 +27,27 @@ export class SimAwsAuthFailureResponse {
   }
 
   private rejectedResponse(failure: SimAwsRequestAuthFailure): Response {
-    // A malformed simulator control header is a mistake in driving Yulin
-    // rather than a failed AWS authentication, so it is a bad request. Every
-    // SigV4 rejection is a 403, as it is on real AWS.
-    if (failure instanceof SimAwsInvalidCallerHeader) {
+    if (this.isBadRequest(failure)) {
       return this.jsonResponse(400, "Bad Request", failure.code);
     }
 
     return this.jsonResponse(403, "Forbidden", failure.code);
+  }
+
+  /**
+   * Whether the request was malformed rather than unauthenticated.
+   *
+   * A caller header the simulator cannot read is a mistake in driving Yulin
+   * rather than a failed AWS authentication. A signature too incomplete to
+   * parse is the one SigV4 rejection real AWS also answers with a 400, because
+   * nothing was presented that could have been authenticated; every other SigV4
+   * rejection is a 403.
+   */
+  private isBadRequest(failure: SimAwsRequestAuthFailure): boolean {
+    return (
+      failure instanceof SimAwsInvalidCallerHeader ||
+      failure instanceof SimIamIncompleteSignature
+    );
   }
 
   private jsonResponse(

--- a/src/serve/http/response/sim-aws-auth-failure-response.ts
+++ b/src/serve/http/response/sim-aws-auth-failure-response.ts
@@ -1,0 +1,55 @@
+import {
+  SimAwsInvalidCallerHeader,
+  type SimAwsRequestAuthFailure,
+} from "../../../service/iam/request/error/sim-aws-request-auth.error.js";
+import { SimAwsResponseHints } from "./sim-aws-response-hints.js";
+
+/**
+ * The response a request refused at the authentication boundary gets.
+ *
+ * The body is the small JSON document AWS answers a rejected request with, and
+ * nothing more: real AWS does not explain itself here, and neither does this.
+ * Everything the simulator can say about the refusal goes into `x-sim-aws-*`
+ * headers, where it helps without changing the shape of the response any
+ * client is written against.
+ */
+export class SimAwsAuthFailureResponse {
+  private readonly hints = new SimAwsResponseHints();
+
+  /**
+   * Build the HTTP response for a failed request authentication.
+   */
+  build(failure: SimAwsRequestAuthFailure): Response {
+    const rejected = this.rejectedResponse(failure);
+
+    return this.hints.stampAuthFailure(rejected, failure);
+  }
+
+  private rejectedResponse(failure: SimAwsRequestAuthFailure): Response {
+    // A malformed simulator control header is a mistake in driving Yulin
+    // rather than a failed AWS authentication, so it is a bad request. Every
+    // SigV4 rejection is a 403, as it is on real AWS.
+    if (failure instanceof SimAwsInvalidCallerHeader) {
+      return this.jsonResponse(400, "Bad Request", failure.code);
+    }
+
+    return this.jsonResponse(403, "Forbidden", failure.code);
+  }
+
+  private jsonResponse(
+    status: number,
+    message: string,
+    errorType: string,
+  ): Response {
+    return Response.json(
+      { Message: message },
+      {
+        status,
+        headers: {
+          "content-type": "application/json",
+          "x-amzn-errortype": errorType,
+        },
+      },
+    );
+  }
+}

--- a/src/serve/http/response/sim-aws-response-hints.ts
+++ b/src/serve/http/response/sim-aws-response-hints.ts
@@ -1,0 +1,64 @@
+import type { SimAwsRequestAuthFailure } from "../../../service/iam/request/error/sim-aws-request-auth.error.js";
+import { simAwsCallerHeaderName } from "../../../service/iam/request/sim-aws-caller-header.js";
+import type { SimAwsRequestCaller } from "../../../service/iam/request/sim-aws-request-caller.js";
+
+/**
+ * How the caller was established, reported back on the response.
+ */
+export const simAwsAuthHeaderName = "x-sim-aws-auth";
+
+/**
+ * The AWS error code a rejected request was refused with.
+ */
+export const simAwsErrorHeaderName = "x-sim-aws-error";
+
+/**
+ * Why the request was refused, in more detail than the AWS response body has
+ * anywhere to put it.
+ */
+export const simAwsErrorDetailHeaderName = "x-sim-aws-error-detail";
+
+/**
+ * Stamps the simulator's own account of a request onto its response.
+ *
+ * These hints go in headers, never in the body, so that a response stays the
+ * shape the real service returns and client code parsing it is unaffected.
+ * That matters most where AWS is least forthcoming: a Function URL rejects a
+ * bad signature with nothing but `{"Message":"Forbidden"}`, which is faithful
+ * and useless to debug against, so the detail is carried alongside instead.
+ */
+export class SimAwsResponseHints {
+  /**
+   * Report who the simulator decided the caller was, and how.
+   */
+  stampCaller(response: Response, caller: SimAwsRequestCaller): Response {
+    response.headers.set(simAwsCallerHeaderName, caller.toHeaderValue());
+    response.headers.set(simAwsAuthHeaderName, caller.authMethod);
+
+    return response;
+  }
+
+  /**
+   * Report that the request was refused before it reached a service, and why.
+   */
+  stampAuthFailure(
+    response: Response,
+    failure: SimAwsRequestAuthFailure,
+  ): Response {
+    response.headers.set(simAwsAuthHeaderName, "rejected");
+    response.headers.set(simAwsErrorHeaderName, failure.code);
+    response.headers.set(
+      simAwsErrorDetailHeaderName,
+      singleLine(failure.message),
+    );
+
+    return response;
+  }
+}
+
+/**
+ * Flatten a message into something a header value can hold.
+ */
+function singleLine(message: string): string {
+  return message.replaceAll(/\s+/g, " ").trim();
+}

--- a/src/serve/http/sim-aws-http-caller.iso.test.ts
+++ b/src/serve/http/sim-aws-http-caller.iso.test.ts
@@ -179,6 +179,25 @@ describe("The caller of a served simulated AWS request", () => {
     );
   });
 
+  it("refuses a signature too incomplete to parse as a bad request", async () => {
+    // Given a request whose Authorization header states the algorithm but not
+    // the parts a signature is made of
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+
+    // When it is served
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { authorization: "AWS4-HMAC-SHA256 SignedHeaders=host" },
+    });
+
+    // Then it is a 400, as real AWS answers IncompleteSignature: nothing was
+    // presented that could have been authenticated in the first place
+    expect(response.status).toBe(400);
+    expect(response.headers.get(simAwsErrorHeaderName)).toBe(
+      "IncompleteSignature",
+    );
+  });
+
   it("refuses a caller header it cannot read as a principal", async () => {
     // Given a Function URL served on localhost
     const simAws = new SimAws();

--- a/src/serve/http/sim-aws-http-caller.iso.test.ts
+++ b/src/serve/http/sim-aws-http-caller.iso.test.ts
@@ -1,0 +1,202 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { describe, expect, it } from "vitest";
+
+import { signAwsRequest } from "../../../test/sigv4/sign-aws-request.js";
+import { createSigner } from "../../../test/sigv4/sim-signer.js";
+import { SimAws } from "../../service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../service/lambda/function/code/lambda-zip-file-input.js";
+import { simAwsCallerHeaderName } from "../../service/iam/request/sim-aws-caller-header.js";
+import type { SimLambdaFunctionUrlEvent } from "../../service/lambda/serve/event/sim-lambda-url-event.type.js";
+import { SimAwsHttp } from "./sim-aws-http.js";
+import {
+  simAwsAuthHeaderName,
+  simAwsErrorDetailHeaderName,
+  simAwsErrorHeaderName,
+} from "./response/sim-aws-response-hints.js";
+import { SimAwsLocalUrl } from "./url/sim-aws-local-url.js";
+
+/**
+ * A Function URL served on localhost whose handler echoes the headers it was
+ * given, so a test can see the request exactly as the simulated service does.
+ */
+async function serveHeaderEcho(simAws: SimAws): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "echo",
+      Role: "arn:aws:iam::888888888888:role/EchoRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput(
+          (event: SimLambdaFunctionUrlEvent) => event.headers,
+        ),
+      },
+    }),
+  );
+
+  const created = await simAws.lambda().createFunctionUrlConfig(
+    new CreateFunctionUrlConfigCommand({
+      FunctionName: "echo",
+      AuthType: "NONE",
+    }),
+  );
+
+  return new SimAwsLocalUrl({ input: created.FunctionUrl }).toString();
+}
+
+describe("The caller of a served simulated AWS request", () => {
+  it("attributes an unauthenticated request to anonymous", async () => {
+    // Given a Function URL served on localhost
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+
+    // When it is requested without any identity
+    const response = await new SimAwsHttp({ simAws }).fetch(url);
+
+    // Then the simulator reports the caller as anonymous, not the Account
+    // root, which is what an omitted in-process caller would have meant
+    expect(response.headers.get(simAwsCallerHeaderName)).toBe("anonymous");
+    expect(response.headers.get(simAwsAuthHeaderName)).toBe("none");
+  });
+
+  it("attributes a request to the principal its caller header names", async () => {
+    // Given a Function URL served on localhost
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+    const arn = "arn:aws:iam::111111111111:role/Reporter";
+
+    // When it is requested with a caller header, as a curl one-liner can
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { [simAwsCallerHeaderName]: arn },
+    });
+
+    // Then the request is attributed to that Role
+    expect(response.headers.get(simAwsCallerHeaderName)).toBe(arn);
+    expect(response.headers.get(simAwsAuthHeaderName)).toBe("caller-header");
+  });
+
+  it("reports a service principal in the form the header accepts", async () => {
+    // Given a Function URL served on localhost
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+
+    // When it is requested as an AWS service principal
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { [simAwsCallerHeaderName]: "service:s3.amazonaws.com" },
+    });
+
+    // Then what the simulator reports back can be sent straight back in
+    expect(response.headers.get(simAwsCallerHeaderName)).toBe(
+      "service:s3.amazonaws.com",
+    );
+  });
+
+  it("hides the caller header from the simulated service", async () => {
+    // Given a Function URL whose handler echoes the headers it receives
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+
+    // When it is requested with a caller header
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: {
+        [simAwsCallerHeaderName]: "arn:aws:iam::111111111111:role/Reporter",
+        "x-application": "kept",
+      },
+    });
+
+    // Then the handler never saw the simulator's control metadata, only the
+    // request its client actually sent
+    const seen = new Map(
+      Object.entries((await response.json()) as Record<string, string>),
+    );
+    expect(seen.has(simAwsCallerHeaderName)).toBe(false);
+    expect(seen.get("x-application")).toBe("kept");
+  });
+
+  it("attributes a request to the principal that signed it", async () => {
+    // Given a Function URL served on localhost, and a user holding an access
+    // key in the same simulation
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+    const credentials = await createSigner(simAws.iam());
+
+    // When the localhost URL that is actually called is signed and requested
+    const signed = await signAwsRequest({ url, credentials });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then the signature over the local hostname verifies, and the signing
+    // user is who the request is from
+    expect(response.status).toBe(200);
+    expect(response.headers.get(simAwsCallerHeaderName)).toBe(
+      "arn:aws:iam::888888888888:user/Signer",
+    );
+    expect(response.headers.get(simAwsAuthHeaderName)).toBe("sigv4");
+  });
+
+  it("refuses a request whose signature does not match", async () => {
+    // Given a signed request whose path is altered after signing
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+    const credentials = await createSigner(simAws.iam());
+    const signed = await signAwsRequest({ url, credentials });
+    const tampered = new Request(`${url}elsewhere`, {
+      headers: signed.request.headers,
+    });
+
+    // When it is served
+    const response = await new SimAwsHttp({ simAws }).handleRequest(tampered);
+
+    // Then it is refused with the body real AWS returns, and the simulator's
+    // account of why goes in headers where it changes nothing for a client
+    expect(response.status).toBe(403);
+    expect(await response.json()).toStrictEqual({ Message: "Forbidden" });
+    expect(response.headers.get(simAwsErrorHeaderName)).toBe(
+      "SignatureDoesNotMatch",
+    );
+    expect(response.headers.get(simAwsAuthHeaderName)).toBe("rejected");
+  });
+
+  it("says so when a signature names the wrong service", async () => {
+    // Given a request signed for S3 and sent to a Lambda Function URL
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+    const credentials = await createSigner(simAws.iam());
+    const signed = await signAwsRequest({ url, credentials, service: "s3" });
+
+    // When it is served
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then the refusal explains the credential scope, rather than leaving a
+    // bare signature mismatch to be worked out from first principles
+    expect(response.status).toBe(403);
+    expect(response.headers.get(simAwsErrorDetailHeaderName)).toContain(
+      "signed for service s3",
+    );
+  });
+
+  it("refuses a caller header it cannot read as a principal", async () => {
+    // Given a Function URL served on localhost
+    const simAws = new SimAws();
+    const url = await serveHeaderEcho(simAws);
+
+    // When it is requested with a caller header naming no principal form
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { [simAwsCallerHeaderName]: "Reporter" },
+    });
+
+    // Then it is a bad request: this is a mistake in driving the simulator
+    // rather than a failed AWS authentication
+    expect(response.status).toBe(400);
+    expect(response.headers.get(simAwsErrorHeaderName)).toBe(
+      "InvalidRequestCaller",
+    );
+    expect(response.headers.get(simAwsErrorDetailHeaderName)).toContain(
+      "must be an ARN",
+    );
+  });
+});

--- a/src/serve/http/sim-aws-http.ts
+++ b/src/serve/http/sim-aws-http.ts
@@ -1,5 +1,10 @@
 import { SimAwsServiceControllerContainer } from "../controller/container/sim-aws-service-controller-container.js";
 import { SimAws } from "../../service/aws/sim-aws.js";
+import type { SimAwsServiceTarget } from "../controller/sim-service-controller.js";
+import { isSimAwsRequestAuthFailure } from "../../service/iam/request/error/sim-aws-request-auth.error.js";
+import { SimAwsRequestAuthenticator } from "./request/sim-aws-request-authenticator.js";
+import { SimAwsAuthFailureResponse } from "./response/sim-aws-auth-failure-response.js";
+import { SimAwsResponseHints } from "./response/sim-aws-response-hints.js";
 
 interface SimAwsHttpProperties {
   readonly simAws?: SimAws;
@@ -11,11 +16,15 @@ interface SimAwsHttpProperties {
 export class SimAwsHttp {
   private readonly simAws: SimAws;
   private readonly controllers: SimAwsServiceControllerContainer;
+  private readonly authenticator: SimAwsRequestAuthenticator;
+  private readonly authFailureResponse = new SimAwsAuthFailureResponse();
+  private readonly hints = new SimAwsResponseHints();
 
   constructor(properties: SimAwsHttpProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.simAws = simAws;
     this.controllers = new SimAwsServiceControllerContainer({ simAws });
+    this.authenticator = new SimAwsRequestAuthenticator({ simAws });
   }
 
   /**
@@ -61,9 +70,12 @@ export class SimAwsHttp {
         });
       }
 
-      const controller = this.controllers.controllerForService(target.service);
-      return await controller.handleRequest(target, request);
+      return await this.serveTarget(target, request);
     } catch (error) {
+      if (isSimAwsRequestAuthFailure(error)) {
+        return this.authFailureResponse.build(error);
+      }
+
       /* v8 ignore next */
       return new Response(
         error instanceof Error
@@ -72,6 +84,29 @@ export class SimAwsHttp {
         { status: 500 },
       );
     }
+  }
+
+  /**
+   * Authenticate a request and hand it to the service it is routed to.
+   *
+   * Every served request passes through the same authentication boundary,
+   * whichever service answers it, and every response says who the simulator
+   * decided the caller was.
+   */
+  private async serveTarget(
+    target: SimAwsServiceTarget,
+    request: Request,
+  ): Promise<Response> {
+    const serviceRequest = await this.authenticator.authenticate(
+      target,
+      request,
+    );
+    const controller = this.controllers.controllerForService(target.service);
+
+    return this.hints.stampCaller(
+      await controller.handleRequest(serviceRequest),
+      serviceRequest.caller,
+    );
   }
 
   private hostnameFromRequest(request: Request): string | undefined {

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -5,3 +5,13 @@ export {
   serveSimAws,
   SimAwsLocalServer,
 } from "./http/local-server/sim-aws-local-server.js";
+export {
+  type SimAwsServiceController,
+  SimAwsServiceRequest,
+  type SimAwsServiceTarget,
+} from "./controller/sim-service-controller.js";
+export {
+  simAwsAuthHeaderName,
+  simAwsErrorDetailHeaderName,
+  simAwsErrorHeaderName,
+} from "./http/response/sim-aws-response-hints.js";

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -21,6 +21,7 @@ import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimIamAccessKeyRegistry } from "../../iam/registry/sim-iam-access-key-registry.js";
 import { SimIamGlobalCredentialResolver } from "../../iam/registry/sim-iam-global-credential-resolver.js";
 import { SimIamSigV4Verifier } from "../../iam/sigv4/sim-iam-sigv4-verifier.js";
+import { SimAwsRequestCallerResolver } from "../../iam/request/sim-aws-request-caller-resolver.js";
 import { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
@@ -82,6 +83,18 @@ export class SimAwsServiceFactory {
       accessKeys: this.accessKeyRegistry,
       iam: this.iamRegistry,
     }),
+  });
+
+  /**
+   * Resolves the principal behind an HTTP request into this simulation.
+   *
+   * This is the single request authentication boundary: everything arriving
+   * over HTTP, including the in-process `SimAwsHttp.fetch()` path, gets its
+   * caller from here.
+   * @internal
+   */
+  public readonly requestCallers = new SimAwsRequestCallerResolver({
+    signedRequests: this.signedRequests,
   });
 
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -33,6 +33,23 @@ import { simAwsRunAsContext } from "./caller/sim-aws-run-as-context.js";
 import type { SimClock } from "../../util/clock/sim-clock.js";
 import type { SimIamCredentialIdentity } from "../iam/credential/sim-aws-credentials.js";
 import { simIamSigV4SignedRequest } from "../iam/sigv4/sim-iam-sigv4-signed-request.js";
+import type { SimIamSigV4ExpectedScope } from "../iam/sigv4/sim-iam-sigv4-expected-scope.js";
+import type { SimAwsRequestCaller } from "../iam/request/sim-aws-request-caller.js";
+
+/**
+ * Everything caller resolution needs besides the request itself.
+ */
+export interface SimAwsRequestCallerOptions {
+  /**
+   * The request body, already buffered by whoever received the request.
+   */
+  readonly body?: Uint8Array | undefined;
+  /**
+   * The service and Region a signature should have been scoped to, when the
+   * receiving endpoint is known.
+   */
+  readonly expectedScope?: SimIamSigV4ExpectedScope | undefined;
+}
 
 interface SimAwsProperties {
   readonly defaultAccountId?: SimAwsAccountId;
@@ -119,6 +136,28 @@ export class SimAws {
   ): SimIamCredentialIdentity {
     return this.serviceFactory.signedRequests.verify(
       simIamSigV4SignedRequest(request, body),
+    );
+  }
+
+  /**
+   * Work out which simulated principal an HTTP request is made by.
+   *
+   * This is the request authentication boundary every served request passes
+   * through, exposed so it can be used directly. An `x-sim-aws-caller` header
+   * names a principal outright, an AWS4-HMAC-SHA256 signature is verified, and
+   * a request offering neither is anonymous rather than the Account root.
+   *
+   * The body is passed separately for the same reason it is on
+   * `verifySignedRequest`: a request body can only be read once, and whoever
+   * serves the request needs the same bytes.
+   */
+  resolveRequestCaller(
+    request: Request,
+    options: SimAwsRequestCallerOptions = {},
+  ): SimAwsRequestCaller {
+    return this.serviceFactory.requestCallers.resolve(
+      simIamSigV4SignedRequest(request, options.body),
+      options.expectedScope,
     );
   }
 

--- a/src/service/cloudfront/controller/sim-cf-controller-viewer-request-cff.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-viewer-request-cff.iso.test.ts
@@ -12,6 +12,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "./sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
 import { makeAwsRegionName } from "../../aws/sim-aws-region.js";
 import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
@@ -82,13 +83,15 @@ describe("Simulated CloudFront local HTTP controller CFF", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+        ),
+      }),
     );
 
     assertResponseStatus(response, 204);
@@ -181,13 +184,15 @@ describe("Simulated CloudFront local HTTP controller CFF", () => {
         simAws,
       });
       await cfController.handleRequest(
-        {
-          service: "cloudFront",
-          resourceName: "",
-        },
-        new Request(
-          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-        ),
+        new SimAwsServiceRequest({
+          target: {
+            service: "cloudFront",
+            resourceName: "",
+          },
+          request: new Request(
+            `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+          ),
+        }),
       );
     });
 

--- a/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
@@ -11,6 +11,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "./sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
 import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
 import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -95,13 +96,15 @@ describe("Simulated CloudFront local HTTP controller CFF", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+        ),
+      }),
     );
 
     assertResponseStatus(response, 200);

--- a/src/service/cloudfront/controller/sim-cloudfront-controller.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-controller.ts
@@ -1,6 +1,6 @@
 import type {
   SimAwsServiceController,
-  SimAwsServiceTarget,
+  SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimCloudFrontRequestPipeline } from "./sim-cloudfront-request-pipeline.js";
 import {
@@ -30,14 +30,11 @@ export class SimCloudFrontServiceController implements SimAwsServiceController {
   /**
    * Handle one incoming request for the simulated CloudFront service.
    *
-   * The `_target` is part of the shared service-controller interface, but
-   * CloudFront routing is host-based, so the request itself contains the
-   * information needed to find the Distribution.
+   * The service request carries the resolved target and caller, but CloudFront
+   * routing is host-based and a Distribution has no IAM authorization of its
+   * own, so only the request itself is needed to find and serve it.
    */
-  async handleRequest(
-    _target: SimAwsServiceTarget,
-    request: Request,
-  ): Promise<Response> {
-    return this.pipeline.handle(request);
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    return this.pipeline.handle(serviceRequest.request);
   }
 }

--- a/src/service/cloudfront/controller/sim-cloudfront-request-handling.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-handling.iso.test.ts
@@ -10,6 +10,7 @@ import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "./sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 
 describe("Simulated CloudFront local HTTP controller request handling", () => {
@@ -73,14 +74,16 @@ describe("Simulated CloudFront local HTTP controller request handling", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/api/users.json`,
-        { method: "HEAD" },
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/api/users.json`,
+          { method: "HEAD" },
+        ),
+      }),
     );
 
     assertResponseStatus(response, 200, await describeResponse(response));
@@ -138,14 +141,16 @@ describe("Simulated CloudFront local HTTP controller request handling", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-        { method: "POST" },
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+          { method: "POST" },
+        ),
+      }),
     );
 
     assertResponseStatus(response, 405, await describeResponse(response));
@@ -206,13 +211,15 @@ describe("Simulated CloudFront local HTTP controller request handling", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/missing.html`,
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/missing.html`,
+        ),
+      }),
     );
 
     assertResponseStatus(response, 404, await describeResponse(response));
@@ -251,18 +258,20 @@ describe("Simulated CloudFront local HTTP controller request handling", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-        {
-          headers: {
-            host: `${distributionId}.cloudfront.net.sim-aws.localhost`,
-          },
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
         },
-      ),
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+          {
+            headers: {
+              host: `${distributionId}.cloudfront.net.sim-aws.localhost`,
+            },
+          },
+        ),
+      }),
     );
 
     assertResponseStatus(response, 501, await describeResponse(response));

--- a/src/service/cloudfront/controller/sim-cloudfront-routing.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-routing.iso.test.ts
@@ -10,16 +10,21 @@ import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "./sim-cloudfront-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 
 describe("Simulated CloudFront local HTTP controller routing", () => {
   it("responds HTTP 404 when no Distribution matches the request host", async () => {
     const cfController = new SimCloudFrontServiceController();
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request("http://unknown.cloudfront.net.sim-aws.localhost/index.html"),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          "http://unknown.cloudfront.net.sim-aws.localhost/index.html",
+        ),
+      }),
     );
 
     assertResponseStatus(response, 404, await describeResponse(response));
@@ -76,18 +81,20 @@ describe("Simulated CloudFront local HTTP controller routing", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
-        {
-          headers: {
-            host: `${distributionId}.cloudfront.net.sim-aws.localhost`,
-          },
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
         },
-      ),
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/index.html`,
+          {
+            headers: {
+              host: `${distributionId}.cloudfront.net.sim-aws.localhost`,
+            },
+          },
+        ),
+      }),
     );
 
     assertResponseStatus(response, 200, await describeResponse(response));
@@ -172,13 +179,15 @@ describe("Simulated CloudFront local HTTP controller routing", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/page.html`,
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/page.html`,
+        ),
+      }),
     );
 
     assertResponseStatus(response, 200, await describeResponse(response));
@@ -285,13 +294,15 @@ describe("Simulated CloudFront local HTTP controller routing", () => {
       simAws,
     });
     const response = await cfController.handleRequest(
-      {
-        service: "cloudFront",
-        resourceName: "",
-      },
-      new Request(
-        `http://${distributionId}.cloudfront.net.sim-aws.localhost/assets/images/logo.png`,
-      ),
+      new SimAwsServiceRequest({
+        target: {
+          service: "cloudFront",
+          resourceName: "",
+        },
+        request: new Request(
+          `http://${distributionId}.cloudfront.net.sim-aws.localhost/assets/images/logo.png`,
+        ),
+      }),
     );
 
     assertResponseStatus(response, 200, await describeResponse(response));

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -2,6 +2,7 @@ export { SimIam } from "./sim-iam.js";
 export type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";
 export type { SimIamCredentialIdentity } from "./credential/sim-aws-credentials.js";
 export {
+  SimIamCredentialScopeMismatch,
   SimIamExpiredToken,
   SimIamIncompleteSignature,
   SimIamInvalidClientTokenId,
@@ -9,3 +10,18 @@ export {
   SimIamSigV4Error,
   type SimIamSigV4ErrorCode,
 } from "./sigv4/error/sim-iam-sigv4.error.js";
+export type { SimIamSigV4ExpectedScope } from "./sigv4/sim-iam-sigv4-expected-scope.js";
+export {
+  simAwsCallerHeaderName,
+  simAwsCallerHeaderPrincipal,
+  simAwsCallerHeaderValue,
+} from "./request/sim-aws-caller-header.js";
+export {
+  type SimAwsRequestAuthMethod,
+  SimAwsRequestCaller,
+} from "./request/sim-aws-request-caller.js";
+export {
+  isSimAwsRequestAuthFailure,
+  SimAwsInvalidCallerHeader,
+  type SimAwsRequestAuthFailure,
+} from "./request/error/sim-aws-request-auth.error.js";

--- a/src/service/iam/request/error/sim-aws-request-auth.error.ts
+++ b/src/service/iam/request/error/sim-aws-request-auth.error.ts
@@ -1,0 +1,41 @@
+import { SimIamSigV4Error } from "../../sigv4/error/sim-iam-sigv4.error.js";
+
+/**
+ * Raised when the `x-sim-aws-caller` header does not name a principal the
+ * simulator understands.
+ *
+ * This is a simulator control header rather than anything real AWS defines, so
+ * a bad value is the caller's mistake in using Yulin, not a failed AWS
+ * authentication. Saying exactly what the grammar is beats silently falling
+ * back to anonymous and leaving a test wondering why its principal vanished.
+ */
+export class SimAwsInvalidCallerHeader extends Error {
+  public readonly code = "InvalidRequestCaller";
+
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+/**
+ * Every way a request can fail to be attributed to a principal.
+ *
+ * A rejected signature and an unusable caller header are both authentication
+ * failures at the same boundary, so whoever turns one into an HTTP response
+ * handles them together.
+ */
+export type SimAwsRequestAuthFailure =
+  SimIamSigV4Error | SimAwsInvalidCallerHeader;
+
+/**
+ * Whether an error is a request authentication failure.
+ */
+export function isSimAwsRequestAuthFailure(
+  error: unknown,
+): error is SimAwsRequestAuthFailure {
+  return (
+    error instanceof SimIamSigV4Error ||
+    error instanceof SimAwsInvalidCallerHeader
+  );
+}

--- a/src/service/iam/request/sim-aws-caller-header.ts
+++ b/src/service/iam/request/sim-aws-caller-header.ts
@@ -1,0 +1,76 @@
+import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import { SimAwsInvalidCallerHeader } from "./error/sim-aws-request-auth.error.js";
+
+/**
+ * The header naming the principal a request into simulated AWS is made by.
+ *
+ * The same name is used on the way back out, as the simulator's own statement
+ * of who it decided the caller was.
+ *
+ * This is the convenience path for local development and for tooling that will
+ * not sign requests: a curl one-liner can be a Role without holding any
+ * credentials. It is deliberately always enabled and not configurable, because
+ * a simulator whose auth boundary can be half-configured is a simulator whose
+ * tests do not mean what they look like.
+ */
+export const simAwsCallerHeaderName = "x-sim-aws-caller";
+
+const anonymousValue = "anonymous";
+const servicePrefix = "service:";
+const arnPrefix = "arn:";
+
+/**
+ * Read a caller header value as the principal it names.
+ *
+ * No existence check is made on an ARN, matching how `runAs` already behaves:
+ * naming a principal is not the same as proving it exists, and IAM
+ * authorization will simply find no policies for a principal nothing created.
+ */
+export function simAwsCallerHeaderPrincipal(value: string): SimAwsPrincipal {
+  const trimmed = value.trim();
+
+  if (trimmed === anonymousValue) {
+    return { kind: "anonymous" };
+  }
+
+  if (trimmed.startsWith(servicePrefix)) {
+    return servicePrincipal(trimmed.slice(servicePrefix.length));
+  }
+
+  if (trimmed.startsWith(arnPrefix)) {
+    return { kind: "arn", arn: trimmed };
+  }
+
+  throw new SimAwsInvalidCallerHeader(
+    `${simAwsCallerHeaderName} value ${value} must be an ARN, ` +
+      `${anonymousValue}, or ${servicePrefix}<name>`,
+  );
+}
+
+/**
+ * Write a principal in the form this header accepts, so what the simulator
+ * reports back can be sent straight back in.
+ */
+export function simAwsCallerHeaderValue(principal: SimAwsPrincipal): string {
+  switch (principal.kind) {
+    case "arn": {
+      return principal.arn;
+    }
+    case "service": {
+      return `${servicePrefix}${principal.service}`;
+    }
+    case "anonymous": {
+      return anonymousValue;
+    }
+  }
+}
+
+function servicePrincipal(service: string): SimAwsPrincipal {
+  if (service.length === 0) {
+    throw new SimAwsInvalidCallerHeader(
+      `${simAwsCallerHeaderName} value ${servicePrefix} names no service`,
+    );
+  }
+
+  return { kind: "service", service };
+}

--- a/src/service/iam/request/sim-aws-request-caller-resolver.ts
+++ b/src/service/iam/request/sim-aws-request-caller-resolver.ts
@@ -1,0 +1,94 @@
+import { simIamSigV4Algorithm } from "../sigv4/sim-iam-sigv4-authorization.js";
+import type { SimIamSigV4ExpectedScope } from "../sigv4/sim-iam-sigv4-expected-scope.js";
+import type { SimIamSigV4SignedRequest } from "../sigv4/sim-iam-sigv4-signed-request.js";
+import type { SimIamSigV4Verifier } from "../sigv4/sim-iam-sigv4-verifier.js";
+import {
+  simAwsCallerHeaderName,
+  simAwsCallerHeaderPrincipal,
+} from "./sim-aws-caller-header.js";
+import { SimAwsRequestCaller } from "./sim-aws-request-caller.js";
+
+interface SimAwsRequestCallerResolverProperties {
+  readonly signedRequests: SimIamSigV4Verifier;
+}
+
+/**
+ * The one place an HTTP request into simulated AWS becomes a principal.
+ *
+ * Resolution runs in a fixed order:
+ *
+ * 1. an `x-sim-aws-caller` header naming the principal directly;
+ * 2. an `Authorization: AWS4-HMAC-SHA256` header, verified as a signature;
+ * 3. neither, giving anonymous.
+ *
+ * The header wins over a signature so that a developer can override the
+ * identity of a request their tooling already signs, without having to stop it
+ * signing. Nothing else is worth resolving after an explicit statement of who
+ * the caller is.
+ *
+ * Anonymous is the floor, and deliberately not the Account root. Simulated IAM
+ * treats an omitted in-process caller as the root principal with unrestricted
+ * access, which is convenient inside a test and would be a serious mistake over
+ * HTTP: every unauthenticated request would arrive as an administrator.
+ */
+export class SimAwsRequestCallerResolver {
+  private readonly signedRequests: SimIamSigV4Verifier;
+
+  constructor(properties: SimAwsRequestCallerResolverProperties) {
+    this.signedRequests = properties.signedRequests;
+  }
+
+  /**
+   * Resolve the principal behind a request as received.
+   *
+   * Throws a SimAwsRequestAuthFailure when the request states an identity that
+   * cannot be accepted. Stating none is not a failure; it is anonymous.
+   */
+  resolve(
+    request: SimIamSigV4SignedRequest,
+    expectedScope?: SimIamSigV4ExpectedScope,
+  ): SimAwsRequestCaller {
+    const named = request.headers.get(simAwsCallerHeaderName);
+
+    if (named !== null) {
+      return new SimAwsRequestCaller({
+        principal: simAwsCallerHeaderPrincipal(named),
+        authMethod: "caller-header",
+      });
+    }
+
+    if (!this.carriesSignature(request)) {
+      return SimAwsRequestCaller.anonymous();
+    }
+
+    return this.signedCaller(request, expectedScope);
+  }
+
+  /**
+   * Whether the request offers a SigV4 signature to verify.
+   *
+   * Only an AWS4-HMAC-SHA256 header counts. An Authorization header of any
+   * other scheme belongs to the application: a bearer token sent to a Function
+   * URL with NONE auth is the handler's business, and treating it as a broken
+   * signature would refuse a request real AWS delivers.
+   */
+  private carriesSignature(request: SimIamSigV4SignedRequest): boolean {
+    return (
+      request.headers.get("authorization")?.startsWith(simIamSigV4Algorithm) ===
+      true
+    );
+  }
+
+  private signedCaller(
+    request: SimIamSigV4SignedRequest,
+    expectedScope: SimIamSigV4ExpectedScope | undefined,
+  ): SimAwsRequestCaller {
+    const identity = this.signedRequests.verify(request, { expectedScope });
+
+    return new SimAwsRequestCaller({
+      principal: identity.principal,
+      identityPolicyPrincipal: identity.identityPolicyPrincipal,
+      authMethod: "sigv4",
+    });
+  }
+}

--- a/src/service/iam/request/sim-aws-request-caller-sigv4.iso.test.ts
+++ b/src/service/iam/request/sim-aws-request-caller-sigv4.iso.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import {
+  signerEndpoint,
+  simulationWithSigner,
+} from "../../../../test/sigv4/sim-signer.js";
+import { SimIamCredentialScopeMismatch } from "../sigv4/error/sim-iam-sigv4.error.js";
+import { simAwsCallerHeaderName } from "./sim-aws-caller-header.js";
+
+const lambdaScope = { serviceName: "lambda", regionName: "us-east-1" };
+
+describe("Resolving the caller of a signed request", () => {
+  it("resolves the principal that signed the request", async () => {
+    // Given a request signed with an access key belonging to an IAM user
+    const { simAws, credentials, userArn } = await simulationWithSigner();
+    const signed = await signAwsRequest({ url: signerEndpoint, credentials });
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(signed.request, {
+      body: signed.body,
+      expectedScope: lambdaScope,
+    });
+
+    // Then the signature is what attributes the request
+    expect(caller.principal).toStrictEqual({ kind: "arn", arn: userArn });
+    expect(caller.authMethod).toBe("sigv4");
+  });
+
+  it("prefers the caller header over a valid signature", async () => {
+    // Given a correctly signed request that also names a different principal
+    const { simAws, credentials } = await simulationWithSigner();
+    const named = "arn:aws:iam::111111111111:role/Reporter";
+    const signed = await signAwsRequest({
+      url: signerEndpoint,
+      credentials,
+      headers: { [simAwsCallerHeaderName]: named },
+    });
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(signed.request, {
+      body: signed.body,
+      expectedScope: lambdaScope,
+    });
+
+    // Then the named principal wins: a developer overriding the identity of a
+    // request their tooling already signs should not have to stop it signing
+    expect(caller.principal).toStrictEqual({ kind: "arn", arn: named });
+    expect(caller.authMethod).toBe("caller-header");
+  });
+
+  it("reports a signature scoped to the wrong service", async () => {
+    // Given a request signed for S3 but sent to a Lambda Function URL
+    const { simAws, credentials } = await simulationWithSigner();
+    const signed = await signAwsRequest({
+      url: signerEndpoint,
+      credentials,
+      service: "s3",
+    });
+
+    // When its caller is resolved
+    // Then the mismatch is named, rather than surfacing as an unexplained
+    // signature failure: the scope feeds the signing key, so nothing else
+    // could tell the two apart
+    expect(() =>
+      simAws.resolveRequestCaller(signed.request, {
+        body: signed.body,
+        expectedScope: lambdaScope,
+      }),
+    ).toThrow(SimIamCredentialScopeMismatch);
+  });
+
+  it("reports a signature scoped to the wrong Region", async () => {
+    // Given a request signed for one Region and sent to another
+    const { simAws, credentials } = await simulationWithSigner();
+    const signed = await signAwsRequest({
+      url: signerEndpoint,
+      credentials,
+      region: "eu-west-2",
+    });
+
+    // When its caller is resolved
+    // Then the Region is named in the failure
+    expect(() =>
+      simAws.resolveRequestCaller(signed.request, {
+        body: signed.body,
+        expectedScope: lambdaScope,
+      }),
+    ).toThrow(/signed for Region eu-west-2/);
+  });
+
+  it("accepts any Region when the endpoint names none", async () => {
+    // Given a request signed for a Region, sent to an endpoint that is not
+    // Region-specific, as a CloudFront hostname is not
+    const { simAws, credentials, userArn } = await simulationWithSigner();
+    const signed = await signAwsRequest({
+      url: signerEndpoint,
+      credentials,
+      region: "eu-west-2",
+    });
+
+    // When its caller is resolved with only the service expected
+    const caller = simAws.resolveRequestCaller(signed.request, {
+      body: signed.body,
+      expectedScope: { serviceName: "lambda" },
+    });
+
+    // Then there is nothing for the Region to disagree with
+    expect(caller.principal).toStrictEqual({ kind: "arn", arn: userArn });
+  });
+});

--- a/src/service/iam/request/sim-aws-request-caller.iso.test.ts
+++ b/src/service/iam/request/sim-aws-request-caller.iso.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimAwsInvalidCallerHeader } from "./error/sim-aws-request-auth.error.js";
+import { simAwsCallerHeaderName } from "./sim-aws-caller-header.js";
+
+const endpoint = "http://abc123.lambda-url.us-east-1.sim-aws.localhost/";
+
+function requestNaming(caller: string): Request {
+  return new Request(endpoint, {
+    headers: { [simAwsCallerHeaderName]: caller },
+  });
+}
+
+describe("Resolving the caller of a request into simulated AWS", () => {
+  it("resolves a request carrying no identity to anonymous", () => {
+    // Given a simulation and a request stating nothing about who sent it
+    const simAws = new SimAws();
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(new Request(endpoint));
+
+    // Then it is anonymous, and emphatically not the Account root: in process
+    // an omitted caller is the root principal with unrestricted access, and
+    // over HTTP that would make every unauthenticated request an administrator
+    expect(caller.principal).toStrictEqual({ kind: "anonymous" });
+    expect(caller.authMethod).toBe("none");
+  });
+
+  it("resolves an IAM ARN named by the caller header", () => {
+    // Given a request naming a Role directly
+    const simAws = new SimAws();
+    const arn = "arn:aws:iam::111111111111:role/Reporter";
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(requestNaming(arn));
+
+    // Then that Role is who the request is from
+    expect(caller.principal).toStrictEqual({ kind: "arn", arn });
+    expect(caller.authMethod).toBe("caller-header");
+  });
+
+  it("resolves a service principal named by the caller header", () => {
+    // Given a request naming an AWS service as its caller
+    const simAws = new SimAws();
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(
+      requestNaming("service:lambda.amazonaws.com"),
+    );
+
+    // Then the service principal is what comes back
+    expect(caller.principal).toStrictEqual({
+      kind: "service",
+      service: "lambda.amazonaws.com",
+    });
+  });
+
+  it("resolves anonymous named by the caller header", () => {
+    // Given a request stating outright that it is anonymous
+    const simAws = new SimAws();
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(requestNaming("anonymous"));
+
+    // Then it is anonymous, and says so as a stated identity rather than an
+    // absent one
+    expect(caller.principal).toStrictEqual({ kind: "anonymous" });
+    expect(caller.authMethod).toBe("caller-header");
+  });
+
+  it("does not check that a named ARN exists", () => {
+    // Given a request naming a Role no simulation ever created
+    const simAws = new SimAws();
+    const arn = "arn:aws:iam::111111111111:role/NeverCreated";
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(requestNaming(arn));
+
+    // Then it is accepted, as runAs accepts one: naming a principal is not
+    // claiming it exists, and IAM will simply find no policies for it
+    expect(caller.principal).toStrictEqual({ kind: "arn", arn });
+  });
+
+  it("refuses a caller header value naming nothing it understands", () => {
+    // Given a request whose caller header is not one of the three forms
+    const simAws = new SimAws();
+
+    // When its caller is resolved
+    // Then the grammar is spelled out rather than the value ignored
+    expect(() =>
+      simAws.resolveRequestCaller(requestNaming("Reporter")),
+    ).toThrow(SimAwsInvalidCallerHeader);
+  });
+
+  it("refuses a caller header naming an empty service", () => {
+    // Given a request whose caller header claims a service but names none
+    const simAws = new SimAws();
+
+    // When its caller is resolved
+    // Then it is refused rather than read as a service called ""
+    expect(() =>
+      simAws.resolveRequestCaller(requestNaming("service:")),
+    ).toThrow(SimAwsInvalidCallerHeader);
+  });
+
+  it("leaves an Authorization header of another scheme to the application", () => {
+    // Given a request carrying a bearer token, as a Function URL with NONE
+    // auth is entitled to receive
+    const simAws = new SimAws();
+    const request = new Request(endpoint, {
+      headers: { authorization: "Bearer some-application-token" },
+    });
+
+    // When its caller is resolved
+    const caller = simAws.resolveRequestCaller(request);
+
+    // Then it is anonymous rather than a broken signature: that header is the
+    // handler's business, not the simulator's
+    expect(caller.principal).toStrictEqual({ kind: "anonymous" });
+    expect(caller.authMethod).toBe("none");
+  });
+});

--- a/src/service/iam/request/sim-aws-request-caller.ts
+++ b/src/service/iam/request/sim-aws-request-caller.ts
@@ -1,0 +1,59 @@
+import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import { simAwsCallerHeaderValue } from "./sim-aws-caller-header.js";
+
+/**
+ * How a request's principal was established.
+ *
+ * This is reported back to the client, because "who does the simulator think
+ * you are" is much less useful without "and why".
+ */
+export type SimAwsRequestAuthMethod = "caller-header" | "sigv4" | "none";
+
+interface SimAwsRequestCallerProperties {
+  readonly principal: SimAwsPrincipal;
+  readonly identityPolicyPrincipal?: SimAwsPrincipal | undefined;
+  readonly authMethod: SimAwsRequestAuthMethod;
+}
+
+/**
+ * The principal a request into simulated AWS is attributed to.
+ *
+ * An unauthenticated request is anonymous and never the Account root. In
+ * process an omitted caller means "whoever owns this simulation", which is a
+ * convenience; over HTTP the same default would hand administrator rights to
+ * anyone who could reach the port, so the boundary refuses to make that
+ * assumption.
+ *
+ * For an assumed-role session the effective principal is the session while
+ * `identityPolicyPrincipal` is the Role whose policies apply, exactly as
+ * `SimIamCredentialIdentity` distinguishes them.
+ */
+export class SimAwsRequestCaller {
+  public readonly principal: SimAwsPrincipal;
+  public readonly identityPolicyPrincipal: SimAwsPrincipal;
+  public readonly authMethod: SimAwsRequestAuthMethod;
+
+  constructor(properties: SimAwsRequestCallerProperties) {
+    this.principal = properties.principal;
+    this.identityPolicyPrincipal =
+      properties.identityPolicyPrincipal ?? properties.principal;
+    this.authMethod = properties.authMethod;
+  }
+
+  /**
+   * The caller of a request that carried no identity at all.
+   */
+  static anonymous(): SimAwsRequestCaller {
+    return new SimAwsRequestCaller({
+      principal: { kind: "anonymous" },
+      authMethod: "none",
+    });
+  }
+
+  /**
+   * The principal in the form the `x-sim-aws-caller` header accepts.
+   */
+  toHeaderValue(): string {
+    return simAwsCallerHeaderValue(this.principal);
+  }
+}

--- a/src/service/iam/sigv4/error/sim-iam-sigv4.error.ts
+++ b/src/service/iam/sigv4/error/sim-iam-sigv4.error.ts
@@ -54,6 +54,23 @@ export class SimIamExpiredToken extends SimIamSigV4Error {
 }
 
 /**
+ * Raised when a signature was made for a different service or Region than the
+ * endpoint it arrived at.
+ *
+ * The scope is an input to the signing key, so this would otherwise surface as
+ * a bare signature mismatch with nothing to act on. Checking it first turns the
+ * least diagnosable SigV4 failure into the most obvious one, which matters
+ * because rewritten local hostnames make it an easy mistake to make. The AWS
+ * error code stays the one real AWS answers with, so client handling is
+ * unchanged; the detail is what the simulator adds.
+ */
+export class SimIamCredentialScopeMismatch extends SimIamSigV4Error {
+  constructor(message: string) {
+    super("SignatureDoesNotMatch", message);
+  }
+}
+
+/**
  * Raised when the request does not reproduce the signature it carries.
  *
  * The message says which part of the canonical request the simulator built, so

--- a/src/service/iam/sigv4/sim-iam-sigv4-expected-scope.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-expected-scope.ts
@@ -1,0 +1,80 @@
+import { SimIamCredentialScopeMismatch } from "./error/sim-iam-sigv4.error.js";
+import type { SimIamSigV4CredentialScope } from "./sim-iam-sigv4-credential-scope.js";
+
+/**
+ * The service and Region a signature is expected to have been scoped to.
+ *
+ * The Region is optional because not every simulated endpoint is
+ * Region-specific: a CloudFront hostname names no Region, so there is nothing
+ * to disagree with.
+ */
+export interface SimIamSigV4ExpectedScope {
+  readonly serviceName: string;
+  readonly regionName?: string | undefined;
+}
+
+/**
+ * Check a signature's scope against the endpoint it reached, when that
+ * endpoint is known.
+ *
+ * Verification is also done standalone, by a test asking only whether a
+ * signature is sound, and then there is no endpoint to compare against.
+ */
+export function simIamSigV4CheckExpectedScope(
+  expected: SimIamSigV4ExpectedScope | undefined,
+  scope: SimIamSigV4CredentialScope,
+): void {
+  if (expected !== undefined) {
+    new SimIamSigV4ScopeExpectation(expected).check(scope);
+  }
+}
+
+/**
+ * Checks that a signature was made for the endpoint it arrived at.
+ *
+ * Real AWS makes this check too, and the reason it is worth making here is
+ * diagnostic. A wrong service or Region changes the signing key, so without
+ * this the only symptom is a signature that does not match, with no hint that
+ * the credentials and the request body were fine all along.
+ */
+export class SimIamSigV4ScopeExpectation {
+  private readonly expected: SimIamSigV4ExpectedScope;
+
+  constructor(expected: SimIamSigV4ExpectedScope) {
+    this.expected = expected;
+  }
+
+  /**
+   * Refuse a scope naming a service or Region other than the expected one.
+   */
+  check(scope: SimIamSigV4CredentialScope): void {
+    this.checkServiceName(scope.serviceName);
+    this.checkRegionName(scope.regionName);
+  }
+
+  private checkServiceName(signed: string): void {
+    if (signed === this.expected.serviceName) {
+      return;
+    }
+
+    throw new SimIamCredentialScopeMismatch(
+      `Request is signed for service ${signed}, but reached simulated ` +
+        `${this.expected.serviceName}. Its credential scope should name ` +
+        `service ${this.expected.serviceName}.`,
+    );
+  }
+
+  private checkRegionName(signed: string): void {
+    const expected = this.expected.regionName;
+
+    if (expected === undefined || signed === expected) {
+      return;
+    }
+
+    throw new SimIamCredentialScopeMismatch(
+      `Request is signed for Region ${signed}, but reached simulated ` +
+        `${this.expected.serviceName} in ${expected}. Its credential scope ` +
+        `should name Region ${expected}.`,
+    );
+  }
+}

--- a/src/service/iam/sigv4/sim-iam-sigv4-signature-check.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-signature-check.ts
@@ -1,0 +1,51 @@
+import { SimIamSigV4CanonicalRequest } from "./canonical/sim-iam-sigv4-canonical-request.js";
+import { SimIamSignatureDoesNotMatch } from "./error/sim-iam-sigv4.error.js";
+import type { SimIamSigV4Authorization } from "./sim-iam-sigv4-authorization.js";
+import { simIamSigV4SignaturesMatch } from "./sim-iam-sigv4-signature-match.js";
+import type { SimIamSigV4SignedRequest } from "./sim-iam-sigv4-signed-request.js";
+import {
+  simIamSigV4Signature,
+  simIamSigV4StringToSign,
+} from "./sim-iam-sigv4-signing-key.js";
+
+interface SimIamSigV4SignatureCheckInput {
+  readonly signedRequest: SimIamSigV4SignedRequest;
+  readonly authorization: SimIamSigV4Authorization;
+  readonly signingKey: Buffer;
+  readonly amzDate: string;
+}
+
+/**
+ * Rebuild the signature the request should carry, and refuse it otherwise.
+ *
+ * The canonical request travels with the failure, because a mismatch is
+ * otherwise undiagnosable: the only way to see which byte differed is to have
+ * the bytes the simulator signed over.
+ */
+export function simIamSigV4CheckSignature(
+  input: SimIamSigV4SignatureCheckInput,
+): void {
+  const { signedRequest, authorization, signingKey, amzDate } = input;
+
+  const canonicalRequest = new SimIamSigV4CanonicalRequest(
+    signedRequest,
+    authorization.signedHeaderNames,
+  ).toString();
+
+  const expected = simIamSigV4Signature(
+    signingKey,
+    simIamSigV4StringToSign({
+      amzDate,
+      scope: authorization.scope,
+      canonicalRequest,
+    }),
+  );
+
+  if (!simIamSigV4SignaturesMatch(expected, authorization.signature)) {
+    throw new SimIamSignatureDoesNotMatch(
+      `Request signature does not match the signature the simulator ` +
+        `calculated for access key ${authorization.accessKeyId}`,
+      canonicalRequest,
+    );
+  }
+}

--- a/src/service/iam/sigv4/sim-iam-sigv4-signing-credentials.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-signing-credentials.ts
@@ -1,0 +1,32 @@
+import type {
+  SimIamSigningCredential,
+  SimIamSigningCredentialResolver,
+} from "../credential/sim-iam-signing-credential.js";
+import type { SimIamSigV4Authorization } from "./sim-iam-sigv4-authorization.js";
+import { simIamSigV4CredentialFailure } from "./sim-iam-sigv4-credential-failure.js";
+import type { SimIamSigV4SignedRequest } from "./sim-iam-sigv4-signed-request.js";
+
+/**
+ * Find the signing key the request claims to have been signed with.
+ *
+ * A signed request never presents its secret, so this asks for the key the
+ * named access key would have derived rather than for the secret itself, and
+ * the signature comparison settles whether the signer really held it. Any
+ * rejection is restated in the vocabulary a signed request is answered in.
+ */
+export function simIamSigV4SigningCredential(
+  credentials: SimIamSigningCredentialResolver,
+  signedRequest: SimIamSigV4SignedRequest,
+  authorization: SimIamSigV4Authorization,
+  now: Date | undefined,
+): SimIamSigningCredential {
+  return simIamSigV4CredentialFailure(authorization.accessKeyId, () =>
+    credentials.signingCredentialFor({
+      accessKeyId: authorization.accessKeyId,
+      sessionToken:
+        signedRequest.headers.get("x-amz-security-token") ?? undefined,
+      scope: authorization.scope,
+      now,
+    }),
+  );
+}

--- a/src/service/iam/sigv4/sim-iam-sigv4-verifier.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-verifier.ts
@@ -1,16 +1,12 @@
 import type { SimIamCredentialIdentity } from "../credential/sim-aws-credentials.js";
 import type { SimIamSigningCredentialResolver } from "../credential/sim-iam-signing-credential.js";
-import { SimIamSigV4CanonicalRequest } from "./canonical/sim-iam-sigv4-canonical-request.js";
-import { SimIamSignatureDoesNotMatch } from "./error/sim-iam-sigv4.error.js";
 import { SimIamSigV4Authorization } from "./sim-iam-sigv4-authorization.js";
-import { simIamSigV4CredentialFailure } from "./sim-iam-sigv4-credential-failure.js";
-import { simIamSigV4SignaturesMatch } from "./sim-iam-sigv4-signature-match.js";
+import { simIamSigV4CheckExpectedScope } from "./sim-iam-sigv4-expected-scope.js";
+import { simIamSigV4CheckSignature } from "./sim-iam-sigv4-signature-check.js";
 import { simIamSigV4RequestDate } from "./sim-iam-sigv4-request-date.js";
 import type { SimIamSigV4SignedRequest } from "./sim-iam-sigv4-signed-request.js";
-import {
-  simIamSigV4Signature,
-  simIamSigV4StringToSign,
-} from "./sim-iam-sigv4-signing-key.js";
+import { simIamSigV4SigningCredential } from "./sim-iam-sigv4-signing-credentials.js";
+import type { SimIamSigV4VerifyOptions } from "./sim-iam-sigv4-verify-options.js";
 
 interface SimIamSigV4VerifierProperties {
   readonly credentials: SimIamSigningCredentialResolver;
@@ -43,49 +39,33 @@ export class SimIamSigV4Verifier {
    */
   verify(
     signedRequest: SimIamSigV4SignedRequest,
-    now?: Date,
+    options: SimIamSigV4VerifyOptions = {},
   ): SimIamCredentialIdentity {
     const authorization = SimIamSigV4Authorization.parse(
       signedRequest.headers.get("authorization"),
     );
+
+    // Checked before anything else can fail on it, so a signature made for the
+    // wrong endpoint says so rather than looking like a bad secret.
+    simIamSigV4CheckExpectedScope(options.expectedScope, authorization.scope);
+
     const amzDate = simIamSigV4RequestDate(
       signedRequest.headers,
       authorization.scope,
     );
-
-    const { signingKey, identity } = simIamSigV4CredentialFailure(
-      authorization.accessKeyId,
-      () =>
-        this.credentials.signingCredentialFor({
-          accessKeyId: authorization.accessKeyId,
-          sessionToken:
-            signedRequest.headers.get("x-amz-security-token") ?? undefined,
-          scope: authorization.scope,
-          now,
-        }),
-    );
-
-    const canonicalRequest = new SimIamSigV4CanonicalRequest(
+    const { signingKey, identity } = simIamSigV4SigningCredential(
+      this.credentials,
       signedRequest,
-      authorization.signedHeaderNames,
-    ).toString();
-
-    const expected = simIamSigV4Signature(
-      signingKey,
-      simIamSigV4StringToSign({
-        amzDate,
-        scope: authorization.scope,
-        canonicalRequest,
-      }),
+      authorization,
+      options.now,
     );
 
-    if (!simIamSigV4SignaturesMatch(expected, authorization.signature)) {
-      throw new SimIamSignatureDoesNotMatch(
-        `Request signature does not match the signature the simulator ` +
-          `calculated for access key ${authorization.accessKeyId}`,
-        canonicalRequest,
-      );
-    }
+    simIamSigV4CheckSignature({
+      signedRequest,
+      authorization,
+      signingKey,
+      amzDate,
+    });
 
     return identity;
   }

--- a/src/service/iam/sigv4/sim-iam-sigv4-verify-options.ts
+++ b/src/service/iam/sigv4/sim-iam-sigv4-verify-options.ts
@@ -1,0 +1,17 @@
+import type { SimIamSigV4ExpectedScope } from "./sim-iam-sigv4-expected-scope.js";
+
+/**
+ * Anything verifying a signature needs beyond the request itself.
+ */
+export interface SimIamSigV4VerifyOptions {
+  /**
+   * The service and Region the signature should have been scoped to. Omitted
+   * when nothing about the receiving endpoint is known, as when a test verifies
+   * a signature on its own.
+   */
+  readonly expectedScope?: SimIamSigV4ExpectedScope | undefined;
+  /**
+   * Simulated time that credential expiry is judged against.
+   */
+  readonly now?: Date | undefined;
+}

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -1,6 +1,6 @@
 import type {
   SimAwsServiceController,
-  SimAwsServiceTarget,
+  SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimLambdaUrlEventBuilder } from "./event/sim-lambda-url-event-builder.js";
@@ -43,24 +43,23 @@ export class SimLambdaServiceController implements SimAwsServiceController {
   /**
    * Handle an HTTP request routed to a simulated Lambda Function URL.
    */
-  async handleRequest(
-    target: SimAwsServiceTarget,
-    request: Request,
-  ): Promise<Response> {
-    const route = this.router.route(target);
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    const route = this.router.route(serviceRequest.target);
 
     if (route === undefined) {
       return this.errorResponse.notFound();
     }
 
-    // SigV4 signatures are not verified, so an IAM-authenticated URL has no
-    // way to admit a request. Refusing is the safe direction: it matches what
-    // an unsigned request to a real AWS_IAM Function URL gets.
+    // The request now arrives with a resolved principal, but nothing yet
+    // evaluates lambda:InvokeFunctionUrl against it, so an IAM-authenticated
+    // URL still has no way to admit a request. Refusing is the safe direction:
+    // it matches what an unauthorized request to a real AWS_IAM Function URL
+    // gets.
     if (route.functionUrl.authType === "AWS_IAM") {
       return this.errorResponse.forbidden();
     }
 
-    return await this.invoke(route, request);
+    return await this.invoke(route, serviceRequest.request);
   }
 
   private async invoke(

--- a/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
@@ -13,6 +13,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
@@ -322,12 +323,14 @@ describe("Serving a sim Lambda Function URL", () => {
     // When the Function URL is invoked through it
     const url = new URL(localUrl(functionUrl));
     const response = await controller.handleRequest(
-      {
-        service: "lambda",
-        resourceName: url.hostname.split(".", 1)[0] ?? "",
-        regionName: simAws.defaultRegionName,
-      },
-      new Request(url),
+      new SimAwsServiceRequest({
+        target: {
+          service: "lambda",
+          resourceName: url.hostname.split(".", 1)[0] ?? "",
+          regionName: simAws.defaultRegionName,
+        },
+        request: new Request(url),
+      }),
     );
 
     // Then the event carries the router's simulated time, not the real time

--- a/src/service/route53/serve/sim-route53-controller.ts
+++ b/src/service/route53/serve/sim-route53-controller.ts
@@ -1,7 +1,7 @@
 import { SimAws } from "../../aws/sim-aws.js";
 import type {
   SimAwsServiceController,
-  SimAwsServiceTarget,
+  SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimRoute53ZoneSummaryPage } from "./zone-summary/sim-route53-zone-summary-page.js";
 
@@ -27,11 +27,8 @@ export class SimRoute53ServiceController implements SimAwsServiceController {
   /**
    * Handle an HTTP request routed to the simulated Route53 summary host.
    */
-  handleRequest(
-    _target: SimAwsServiceTarget,
-    request: Request,
-  ): Promise<Response> {
-    const { pathname } = new URL(request.url);
+  handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    const { pathname } = new URL(serviceRequest.request.url);
 
     if (pathname !== "/") {
       return Promise.resolve(

--- a/src/service/s3/serve/sim-s3-controller.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-controller.iso.test.ts
@@ -5,19 +5,25 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimS3ServiceController } from "./sim-s3-controller.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 
 describe("Simulated S3 local HTTP controller", () => {
   const simS3ServiceController = new SimS3ServiceController();
 
   it("responds HTTP 400 for missing S3 Bucket name", async () => {
     const response = await simS3ServiceController.handleRequest(
-      {
-        service: "s3",
-        resourceName: "",
-        regionName: "eu-west-2",
-      },
-      new Request("http://s3-website.eu-west-2.localhost/index.html", {
-        method: "GET",
+      new SimAwsServiceRequest({
+        target: {
+          service: "s3",
+          resourceName: "",
+          regionName: "eu-west-2",
+        },
+        request: new Request(
+          "http://s3-website.eu-west-2.localhost/index.html",
+          {
+            method: "GET",
+          },
+        ),
       }),
     );
 
@@ -27,12 +33,17 @@ describe("Simulated S3 local HTTP controller", () => {
 
   it("responds HTTP 400 for missing S3 Bucket region", async () => {
     const response = await simS3ServiceController.handleRequest(
-      {
-        service: "s3",
-        resourceName: "foo-site",
-      },
-      new Request("http://foo-site.s3-website.localhost/index.html", {
-        method: "GET",
+      new SimAwsServiceRequest({
+        target: {
+          service: "s3",
+          resourceName: "foo-site",
+        },
+        request: new Request(
+          "http://foo-site.s3-website.localhost/index.html",
+          {
+            method: "GET",
+          },
+        ),
       }),
     );
 

--- a/src/service/s3/serve/sim-s3-controller.ts
+++ b/src/service/s3/serve/sim-s3-controller.ts
@@ -1,7 +1,7 @@
 import { SimAws } from "../../aws/sim-aws.js";
 import type {
   SimAwsServiceController,
-  SimAwsServiceTarget,
+  SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimS3RequestRouter } from "./sim-s3-request-router.js";
 import { SimS3GetObjectController } from "./sim-s3-get-object-controller.js";
@@ -26,10 +26,8 @@ export class SimS3ServiceController implements SimAwsServiceController {
   /**
    * Handle an HTTP request routed to a simulated S3 Bucket.
    */
-  async handleRequest(
-    target: SimAwsServiceTarget,
-    request: Request,
-  ): Promise<Response> {
+  async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    const { target, request } = serviceRequest;
     const route = this.s3Router.route(target, request);
 
     if (route.action === "failure") {


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Served HTTP requests now identify callers as anonymous, via an explicit caller header, or through verified SigV4 credentials.
  * Added caller and authentication details to response headers.
  * Added validation for signing service and region, with clearer authentication error responses.
  * Request bodies and simulator control headers are handled consistently across supported services.

* **Documentation**
  * Expanded IAM guidance with caller resolution precedence, supported formats, response signals, and limitations.
  * Clarified Lambda Function URL behavior for `AWS_IAM` authentication.
  * Added an HTTP caller attribution example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->