### PR TITLE
feat: sim CloudFormation upload sim Lambda asset into sim S3

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -961,10 +961,30 @@ Supported function properties:
 - `Timeout`
 - `MemorySize`
 
-A function whose `Code` points at a missing CDK bootstrap assets bucket
-(`cdk-*-assets-*`) is skipped with a diagnostic rather than failing the stack, so CDK-synthesized
-templates deploy without their asset staging. Code in any other missing bucket fails the deploy
-AWS-style with a `NoSuchBucket` diagnostic.
+Code in a missing bucket fails the deploy AWS-style with a `NoSuchBucket` diagnostic.
+
+### CDK asset code
+
+`lambda.Code.fromAsset(...)` and the constructs built on it stage function code as a directory in
+the CDK cloud assembly, and synthesize a `Code.S3Bucket`/`S3Key` pointing at the CDK bootstrap
+staging bucket. Deploying a synthesized template file with `deployTemplateFile` publishes the cloud
+assembly's assets into that bucket in sim S3 before creating any resource, mirroring the way a real
+`cdk deploy` runs `cdk-assets` before CloudFormation. Asset-bundled functions then resolve their
+code through the ordinary sim S3 fetch and run their real handler modules.
+
+Asset code runs under the same rules as any other sim Lambda code: modules are evaluated as
+CommonJS in a vm, so everything the handler imports has to be in the asset, and only Node.js
+runtimes are simulated.
+
+Two cases are skipped with a diagnostic rather than failing the stack:
+
+- A function declaring a non-Node.js `Runtime`, such as the Python provider function CDK
+  synthesizes for `BucketDeployment`. Sim CloudFormation simulates that custom resource directly,
+  so its provider never needs to run. Bind a real in-process handler to simulate a function whose
+  runtime Yulin cannot run.
+- A CDK-shaped template deployed without its cloud assembly, such as a template object passed
+  inline to `deployTemplate`, where there is no asset to publish and the staging bucket does not
+  exist.
 
 ## Function URLs in templates
 

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -965,12 +965,16 @@ Code in a missing bucket fails the deploy AWS-style with a `NoSuchBucket` diagno
 
 ### CDK asset code
 
-`lambda.Code.fromAsset(...)` and the constructs built on it stage function code as a directory in
-the CDK cloud assembly, and synthesize a `Code.S3Bucket`/`S3Key` pointing at the CDK bootstrap
-staging bucket. Deploying a synthesized template file with `deployTemplateFile` publishes the cloud
-assembly's assets into that bucket in sim S3 before creating any resource, mirroring the way a real
+`lambda.Code.fromAsset(...)` and the constructs built on it stage function code in the CDK cloud
+assembly, and synthesize a `Code.S3Bucket`/`S3Key` pointing at the CDK bootstrap staging bucket.
+Deploying a synthesized template file with `deployTemplateFile` publishes the cloud assembly's
+assets into that bucket in sim S3 before creating any resource, mirroring the way a real
 `cdk deploy` runs `cdk-assets` before CloudFormation. Asset-bundled functions then resolve their
 code through the ordinary sim S3 fetch and run their real handler modules.
+
+Both shapes of staged asset are published. A handler directory is zipped on the way into sim S3,
+as `cdk-assets` zips it on the way to a real bucket. An asset that is already an archive, such as
+`Code.fromAsset("handler.zip")` or a bundler's archived output, is published as it stands.
 
 Asset code runs under the same rules as any other sim Lambda code: modules are evaluated as
 CommonJS in a vm, so everything the handler imports has to be in the asset, and only Node.js

--- a/src/service/cloudformation/cdk/assets/sim-cdk-asset-bytes.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-asset-bytes.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { readFile, readdir } from "node:fs/promises";
+import { SimZipArchiveBuilder } from "../../../../util/zip/zip-archive-builder.js";
+
+/**
+ * Read the publishable bytes for one CDK cloud assembly file asset.
+ *
+ * CDK stages two shapes of file asset in a cloud assembly. A "file" asset is
+ * already a single file on disk, such as the stack template JSON or a prebuilt
+ * layer zip, and publishes byte for byte. A "zip" asset is a directory that the
+ * real `cdk-assets` publisher zips on its way to the staging bucket, so the
+ * simulated publisher zips it here, in memory.
+ */
+export async function readSimCdkAssetBytes(
+  sourcePath: string,
+  packaging: string | undefined,
+): Promise<Uint8Array> {
+  if (packaging === "zip") {
+    return await zipSimCdkAssetDirectory(sourcePath);
+  }
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return await readFile(sourcePath);
+}
+
+/**
+ * Zip a CDK asset directory into Lambda-readable archive bytes.
+ *
+ * Entries are sorted so the same asset directory always produces the same
+ * archive bytes, as a content-addressed CDK asset should.
+ */
+async function zipSimCdkAssetDirectory(
+  directoryPath: string,
+): Promise<Uint8Array> {
+  const archivePaths = await assetArchivePaths(directoryPath);
+  const files = await Promise.all(
+    archivePaths.map(async (archivePath) => ({
+      archivePath,
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      content: await readFile(path.join(directoryPath, archivePath)),
+    })),
+  );
+
+  const builder = new SimZipArchiveBuilder();
+  for (const file of files) {
+    builder.addFile(file.archivePath, file.content);
+  }
+
+  return builder.toBytes();
+}
+
+/**
+ * The archive-relative paths of every file in a CDK asset directory, in a
+ * stable order and using zip forward-slash separators.
+ */
+async function assetArchivePaths(
+  directoryPath: string,
+): Promise<readonly string[]> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const entries = await readdir(directoryPath, {
+    recursive: true,
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) =>
+      path
+        .relative(directoryPath, path.join(entry.parentPath, entry.name))
+        .split(path.sep)
+        .join("/"),
+    )
+    .toSorted((left, right) => left.localeCompare(right));
+}

--- a/src/service/cloudformation/cdk/assets/sim-cdk-asset-publications.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-asset-publications.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
+import type { SimCdkAssetsManifest } from "../sim-cdk-out-context.js";
+
+type SimCdkFileAsset = NonNullable<SimCdkAssetsManifest["files"]>[string];
+type SimCdkAssetDestination = NonNullable<
+  SimCdkFileAsset["destinations"]
+>[string];
+
+/**
+ * One asset publication: a cloud assembly source to read, and the staging
+ * Bucket location to publish it to.
+ */
+export interface SimCdkAssetPublication {
+  readonly sourcePath: string;
+  readonly packaging: string | undefined;
+  readonly bucketName: string;
+  readonly objectKey: string;
+}
+
+interface SimCdkAssetPublicationsProperties {
+  readonly templateDirectoryPath: string;
+  readonly pseudoParameters: SimCfnPseudoParameters;
+}
+
+/**
+ * Works out what a CDK assets manifest asks to be published, and where.
+ *
+ * Manifest entries that cannot name both a readable source inside the cloud
+ * assembly and a resolvable staging Bucket location are left out rather than
+ * failing a Stack deployment before any Resource is created. What is left out
+ * simply stays unpublished, and the Resource referencing it reports the
+ * missing object through the ordinary sim S3 lookup.
+ */
+export class SimCdkAssetPublications {
+  private readonly properties: SimCdkAssetPublicationsProperties;
+
+  constructor(properties: SimCdkAssetPublicationsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * The publishable entries of an assets manifest.
+   */
+  resolve(
+    assetsManifest: SimCdkAssetsManifest | undefined,
+  ): readonly SimCdkAssetPublication[] {
+    return Object.values(assetsManifest?.files ?? {}).flatMap((fileAsset) =>
+      this.fileAssetPublications(fileAsset),
+    );
+  }
+
+  private fileAssetPublications(
+    fileAsset: SimCdkFileAsset,
+  ): readonly SimCdkAssetPublication[] {
+    const sourcePath = this.assetSourcePath(fileAsset.source?.path);
+    if (sourcePath === undefined) {
+      return [];
+    }
+
+    return Object.values(fileAsset.destinations ?? {}).flatMap(
+      (destination) => {
+        const location = this.stagingLocation(destination);
+
+        return location === undefined
+          ? []
+          : [
+              {
+                sourcePath,
+                packaging: fileAsset.source?.packaging,
+                ...location,
+              },
+            ];
+      },
+    );
+  }
+
+  private stagingLocation(
+    destination: SimCdkAssetDestination,
+  ): { bucketName: string; objectKey: string } | undefined {
+    const bucketName = this.resolvedBucketName(destination.bucketName);
+    const { objectKey } = destination;
+
+    if (bucketName === undefined || objectKey === undefined) {
+      return undefined;
+    }
+
+    return { bucketName, objectKey };
+  }
+
+  /**
+   * Resolve a manifest Bucket name, which is literal for a Stack synthesized
+   * with an explicit environment and pseudo-parameter templated otherwise.
+   *
+   * The same pseudo parameters resolve the template's own `Fn::Sub` Bucket
+   * name, so the published location and the location a Resource fetches from
+   * agree by construction. A name still holding a variable afterwards cannot
+   * name a real Bucket, so nothing is published to it.
+   */
+  private resolvedBucketName(
+    bucketName: string | undefined,
+  ): string | undefined {
+    if (bucketName === undefined) {
+      return undefined;
+    }
+
+    const resolved = bucketName.replaceAll(
+      /\$\{([^}]+)\}/gu,
+      (match: string, parameterName: string) => {
+        const value = this.properties.pseudoParameters.value(parameterName);
+
+        return typeof value === "string" ? value : match;
+      },
+    );
+
+    return resolved.includes("${") ? undefined : resolved;
+  }
+
+  /**
+   * Resolve an asset source path inside the cloud assembly directory.
+   *
+   * Asset paths come from a file on disk, so a path escaping the assembly
+   * directory is not published, mirroring the containment check the CDK
+   * BucketDeployment source resolver applies before mounting a directory.
+   */
+  private assetSourcePath(sourcePath: string | undefined): string | undefined {
+    if (sourcePath === undefined) {
+      return undefined;
+    }
+
+    const directoryPath = path.resolve(this.properties.templateDirectoryPath);
+    const resolvedSourcePath = path.resolve(directoryPath, sourcePath);
+
+    if (!resolvedSourcePath.startsWith(`${directoryPath}${path.sep}`)) {
+      return undefined;
+    }
+
+    return resolvedSourcePath;
+  }
+}

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
@@ -1,0 +1,263 @@
+import path from "node:path";
+import { buffer } from "node:stream/consumers";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import type { SimCdkAssetsManifest } from "../sim-cdk-out-context.js";
+import { SimCdkAssetsPublisher } from "./sim-cdk-assets-publisher.js";
+
+const defaultScope = { accountId: "888888888888", regionName: "us-east-1" };
+
+/**
+ * A CDK pseudo-parameter reference, as an environment-agnostic Stack's assets
+ * manifest templates its staging Bucket name with.
+ */
+function pseudoParameter(name: string): string {
+  return `\${${name}}`;
+}
+
+/**
+ * Publish a manifest against a temporary cloud assembly directory.
+ */
+async function publish(
+  simAws: SimAws,
+  templateDirectoryPath: string,
+  assetsManifest: SimCdkAssetsManifest,
+): Promise<void> {
+  await new SimCdkAssetsPublisher({
+    simAws,
+    accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+    stackName: "TestStack",
+    cdkOutContext: { templateDirectoryPath, assetsManifest },
+  }).publish();
+}
+
+/**
+ * Read a published object body back out of sim S3.
+ */
+async function publishedObjectBytes(
+  simAws: SimAws,
+  bucketName: string,
+  objectKey: string,
+): Promise<Uint8Array> {
+  const output = await simAws
+    .s3()
+    .getObject({ input: { Bucket: bucketName, Key: objectKey } });
+  assertNonNullable(output.Body);
+
+  return await buffer(output.Body);
+}
+
+describe("SimCdkAssetsPublisher", () => {
+  it("zips a staged asset directory into the staging Bucket", async () => {
+    // Given a cloud assembly with a multi-file zip-packaged asset directory.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile(
+      ["asset.abc123", "index.js"],
+      "exports.handler = async () => 'asset';",
+    );
+    await cdkOutDirectory.writeFile(
+      ["asset.abc123", "lib", "helper.js"],
+      "exports.help = () => 'helped';",
+    );
+
+    // When the assembly's assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        abc123: {
+          source: { path: "asset.abc123", packaging: "zip" },
+          destinations: {
+            "current_account-current_region": {
+              bucketName:
+                `cdk-hnb659fds-assets-${pseudoParameter("AWS::AccountId")}` +
+                `-${pseudoParameter("AWS::Region")}`,
+              objectKey: "abc123.zip",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the staging Bucket is created with the pseudo parameters resolved
+    // against the deploying scope.
+    const bucketName = `cdk-hnb659fds-assets-${defaultScope.accountId}-${defaultScope.regionName}`;
+    assertNonNullable(simAws.s3().getSimBucketByName(bucketName));
+
+    // And the whole directory was zipped, preserving archive paths.
+    const archive = SimZipArchive.fromBytes(
+      await publishedObjectBytes(simAws, bucketName, "abc123.zip"),
+    );
+    assertIdentical(
+      archive.file("index.js").toString(),
+      "exports.handler = async () => 'asset';",
+    );
+    assertIdentical(
+      archive.file("lib/helper.js").toString(),
+      "exports.help = () => 'helped';",
+    );
+  });
+
+  it("publishes a file-packaged asset byte for byte", async () => {
+    // Given a cloud assembly with an already-zipped file asset.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("TestStack.template.json", '{"a":1}');
+
+    // When the assembly's assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        def456: {
+          source: { path: "TestStack.template.json", packaging: "file" },
+          destinations: {
+            "current_account-current_region": {
+              bucketName: "staging-bucket",
+              objectKey: "def456.json",
+            },
+          },
+        },
+      },
+    });
+
+    // Then the file content is published unchanged, not zipped.
+    const objectBytes = await publishedObjectBytes(
+      simAws,
+      "staging-bucket",
+      "def456.json",
+    );
+    assertIdentical(Buffer.from(objectBytes).toString(), '{"a":1}');
+  });
+
+  it("publishes several assets and destinations into one staging Bucket", async () => {
+    // Given two assets sharing a staging Bucket, one with two destinations.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("first.txt", "first");
+    await cdkOutDirectory.writeFile("second.txt", "second");
+
+    // When the assembly's assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        first: {
+          source: { path: "first.txt", packaging: "file" },
+          destinations: {
+            one: { bucketName: "staging-bucket", objectKey: "first.txt" },
+            two: { bucketName: "staging-bucket", objectKey: "first-copy.txt" },
+          },
+        },
+        second: {
+          source: { path: "second.txt", packaging: "file" },
+          destinations: {
+            one: { bucketName: "staging-bucket", objectKey: "second.txt" },
+          },
+        },
+      },
+    });
+
+    // Then the Bucket is reused rather than recreated, and holds every object.
+    const listed = await simAws
+      .s3()
+      .listObjects({ input: { Bucket: "staging-bucket" } });
+    assertArrayLength(listed.Contents ?? [], 3);
+  });
+
+  it("skips a Bucket name it cannot fully resolve", async () => {
+    // Given a Bucket name templated with something that is not a supported
+    // CloudFormation pseudo parameter, so it cannot name a real Bucket.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("asset.txt", "content");
+
+    // When the assembly's assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        abc: {
+          source: { path: "asset.txt", packaging: "file" },
+          destinations: {
+            one: {
+              bucketName:
+                `staging-${pseudoParameter("Unknown")}` +
+                `-${pseudoParameter("AWS::Region")}`,
+              objectKey: "abc.txt",
+            },
+          },
+        },
+      },
+    });
+
+    // Then publishing declines rather than failing the Stack deployment with
+    // an invalid Bucket name.
+    const listed = await simAws.s3().listBuckets({ input: {} });
+    assertArrayLength(listed.Buckets ?? [], 0);
+  });
+
+  it("does nothing without a cloud assembly", async () => {
+    // Given a Stack deployed from an inline template, so no CDK out context.
+    const simAws = new SimAws();
+
+    // When publishing runs anyway.
+    await new SimCdkAssetsPublisher({
+      simAws,
+      accountRegionScope: simAws.accountRegionScope().accountRegionScope,
+      stackName: "TestStack",
+    }).publish();
+
+    // Then no staging Bucket is created.
+    const listed = await simAws.s3().listBuckets({ input: {} });
+    assertArrayLength(listed.Buckets ?? [], 0);
+  });
+
+  it("skips assets the cloud assembly does not describe or contain", async () => {
+    // Given assets that cannot be published: no source path, no destinations,
+    // a source path escaping the assembly, a source file that is not there,
+    // and destinations missing a Bucket name or object key.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("present.txt", "present");
+
+    // When the assembly's assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        noSourcePath: {
+          source: { packaging: "file" },
+          destinations: { one: { bucketName: "b", objectKey: "k" } },
+        },
+        noDestinations: {
+          source: { path: "present.txt", packaging: "file" },
+          destinations: {},
+        },
+        escapingPath: {
+          source: {
+            path: path.join("..", "outside.txt"),
+            packaging: "file",
+          },
+          destinations: { one: { bucketName: "b", objectKey: "k" } },
+        },
+        missingFile: {
+          source: { path: "absent.txt", packaging: "file" },
+          destinations: { one: { bucketName: "b", objectKey: "k" } },
+        },
+        noBucketName: {
+          source: { path: "present.txt", packaging: "file" },
+          destinations: { one: { objectKey: "k" } },
+        },
+        noObjectKey: {
+          source: { path: "present.txt", packaging: "file" },
+          destinations: { one: { bucketName: "b" } },
+        },
+      },
+    });
+
+    // Then nothing was published, and the Stack deployment is left to report
+    // the missing code through the ordinary sim S3 lookup.
+    assertUndefined(simAws.s3().getSimBucketByName("b"));
+  });
+});

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
@@ -4,9 +4,11 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
@@ -259,5 +261,79 @@ describe("SimCdkAssetsPublisher", () => {
     // Then nothing was published, and the Stack deployment is left to report
     // the missing code through the ordinary sim S3 lookup.
     assertUndefined(simAws.s3().getSimBucketByName("b"));
+  });
+
+  it("publishes into a staging Bucket another Stack created concurrently", async () => {
+    // Given a staging Bucket that appears between the publisher checking for
+    // it and its own CreateBucket landing, as it can when two Stacks sharing
+    // one staging Bucket deploy concurrently.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("asset.txt", "content");
+
+    const s3 = simAws.s3();
+    await s3.createBucket({ input: { Bucket: "shared-staging-bucket" } });
+
+    const findBucket = s3.getSimBucketByName.bind(s3);
+    let checkedBeforeCreate = false;
+    vi.spyOn(s3, "getSimBucketByName").mockImplementation((bucketName) => {
+      if (checkedBeforeCreate) {
+        return findBucket(bucketName);
+      }
+      checkedBeforeCreate = true;
+
+      return undefined;
+    });
+
+    // When the assets are published.
+    await publish(simAws, cdkOutDirectory.path(), {
+      files: {
+        abc: {
+          source: { path: "asset.txt", packaging: "file" },
+          destinations: {
+            one: { bucketName: "shared-staging-bucket", objectKey: "abc.txt" },
+          },
+        },
+      },
+    });
+
+    // Then losing the race to create the Bucket is not a failure, and the
+    // asset is published into the Bucket that won.
+    const objectBytes = await publishedObjectBytes(
+      simAws,
+      "shared-staging-bucket",
+      "abc.txt",
+    );
+    assertIdentical(Buffer.from(objectBytes).toString(), "content");
+  });
+
+  it("reports a staging Bucket name already taken in another scope", async () => {
+    // Given the staging Bucket name already in use in another Region, which
+    // sim S3 refuses because Bucket names are globally unique.
+    const simAws = new SimAws();
+    const cdkOutDirectory = new TemporaryDirectory();
+    await cdkOutDirectory.writeFile("asset.txt", "content");
+
+    await simAws
+      .accountRegionScope(undefined, "eu-west-2")
+      .s3()
+      .createBucket({ input: { Bucket: "taken-staging-bucket" } });
+
+    // When publishing tries to create it in the deploying scope.
+    const error = await assertThrowsErrorAsync(async () => {
+      await publish(simAws, cdkOutDirectory.path(), {
+        files: {
+          abc: {
+            source: { path: "asset.txt", packaging: "file" },
+            destinations: {
+              one: { bucketName: "taken-staging-bucket", objectKey: "abc.txt" },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the failure is reported rather than mistaken for a lost race.
+    assertStringIncludes(error.message, "taken-staging-bucket");
   });
 });

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
@@ -1,0 +1,136 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimS3 } from "../../../s3/sim-s3.js";
+import { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
+import type { SimCdkOutContext } from "../sim-cdk-out-context.js";
+import {
+  type SimCdkAssetPublication,
+  SimCdkAssetPublications,
+} from "./sim-cdk-asset-publications.js";
+import { readSimCdkAssetBytes } from "./sim-cdk-asset-bytes.js";
+
+interface SimCdkAssetsPublisherProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stackName?: string | undefined;
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
+}
+
+/**
+ * Publishes a CDK cloud assembly's file assets into simulated S3.
+ *
+ * A real `cdk deploy` runs in two phases: `cdk-assets` publishes every staged
+ * file asset to the bootstrap staging bucket, and only then does CloudFormation
+ * process a template whose `Code.S3Bucket`/`S3Key` already point at those
+ * objects. Sim CloudFormation mirrors that ordering, so an asset-bundled
+ * Lambda function resolves its code through the ordinary sim S3 fetch with no
+ * Lambda-specific asset handling.
+ *
+ * Publishing is byte movement only; nothing here runs asset code. Functions
+ * sim Lambda cannot run, such as a CDK BucketDeployment provider written in
+ * Python, are declined later by the Lambda resource creator on their Runtime.
+ */
+export class SimCdkAssetsPublisher {
+  private readonly properties: SimCdkAssetsPublisherProperties;
+
+  constructor(properties: SimCdkAssetsPublisherProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Publish every publishable file asset in the cloud assembly to its staging
+   * Bucket.
+   *
+   * Does nothing when the Stack was not deployed from a synthesized CDK
+   * template, so inline templates keep their existing behavior.
+   */
+  async publish(): Promise<void> {
+    const { cdkOutContext, accountRegionScope, stackName } = this.properties;
+    const templateDirectoryPath = cdkOutContext?.templateDirectoryPath;
+
+    if (cdkOutContext === undefined || templateDirectoryPath === undefined) {
+      return;
+    }
+
+    const publications = new SimCdkAssetPublications({
+      templateDirectoryPath,
+      pseudoParameters: new SimCfnPseudoParameters({
+        accountRegionScope,
+        stackName,
+      }),
+    }).resolve(cdkOutContext.assetsManifest);
+
+    for (const publication of publications) {
+      // eslint-disable-next-line no-await-in-loop -- assets sharing a staging Bucket must not race to create it
+      await this.publishAsset(publication);
+    }
+  }
+
+  private async publishAsset(
+    publication: SimCdkAssetPublication,
+  ): Promise<void> {
+    const assetBytes = await this.readAssetBytes(publication);
+    if (assetBytes === undefined) {
+      return;
+    }
+
+    const s3 = this.stagingS3();
+    await this.ensureBucket(s3, publication.bucketName);
+    await s3.putObject({
+      input: {
+        Bucket: publication.bucketName,
+        Key: publication.objectKey,
+        Body: assetBytes,
+      },
+    });
+  }
+
+  /**
+   * Create the staging Bucket if this is the first asset published into it,
+   * standing in for the CDK bootstrap stack that provisions it for real.
+   */
+  private async ensureBucket(s3: SimS3, bucketName: string): Promise<void> {
+    if (s3.getSimBucketByName(bucketName) !== undefined) {
+      return;
+    }
+
+    await s3.createBucket({ input: { Bucket: bucketName } });
+  }
+
+  private stagingS3(): SimS3 {
+    const { simAws, accountRegionScope } = this.properties;
+
+    return simAws
+      .accountRegionScope(
+        accountRegionScope.accountId,
+        accountRegionScope.regionName,
+      )
+      .s3();
+  }
+
+  /**
+   * Read asset bytes, treating an asset the cloud assembly references but does
+   * not contain as unpublishable rather than as a Stack deployment failure.
+   */
+  private async readAssetBytes(
+    publication: SimCdkAssetPublication,
+  ): Promise<Uint8Array | undefined> {
+    try {
+      return await readSimCdkAssetBytes(
+        publication.sourcePath,
+        publication.packaging,
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return undefined;
+      }
+
+      /* v8 ignore next */
+      throw error;
+    }
+  }
+}

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
@@ -88,13 +88,26 @@ export class SimCdkAssetsPublisher {
   /**
    * Create the staging Bucket if this is the first asset published into it,
    * standing in for the CDK bootstrap stack that provisions it for real.
+   *
+   * Stacks deployed concurrently share one staging Bucket, and creating it is
+   * not atomic: sim S3 reaches a sequencing point before registering the
+   * Bucket, so both can pass the check above and the loser is refused. A
+   * Bucket that exists by the time the failure lands is the outcome this
+   * wanted, whoever created it. Anything else, such as the name already being
+   * taken in another scope, is a real failure and is reported.
    */
   private async ensureBucket(s3: SimS3, bucketName: string): Promise<void> {
     if (s3.getSimBucketByName(bucketName) !== undefined) {
       return;
     }
 
-    await s3.createBucket({ input: { Bucket: bucketName } });
+    try {
+      await s3.createBucket({ input: { Bucket: bucketName } });
+    } catch (error) {
+      if (s3.getSimBucketByName(bucketName) === undefined) {
+        throw error;
+      }
+    }
   }
 
   private stagingS3(): SimS3 {

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
@@ -8,6 +8,7 @@ import {
   assertUndefined,
 } from "@kensio/smartass";
 import path from "node:path";
+import { buffer } from "node:stream/consumers";
 import { describe, it } from "vitest";
 
 /**
@@ -266,11 +267,18 @@ app.synth();
     assertIdentical(invokeOutput.StatusCode, 200);
     assertUndefined(invokeOutput.FunctionError);
 
-    // And the bucket deployment itself still works, as it is simulated
-    // directly rather than by running the skipped provider.
+    // And the bucket deployment itself still delivered its objects, as it is
+    // simulated directly rather than by running the skipped provider.
     const bucketName = stack.outputs.get("DataBucketName")?.value;
     assertTypeString(bucketName);
     assertNonNullable(simAws.s3().getSimBucketByName(bucketName));
+
+    const deployedObject = await simAws
+      .s3()
+      .getObject({ input: { Bucket: bucketName, Key: "greeting.txt" } });
+    assertNonNullable(deployedObject.Body);
+    const deployedBytes = await buffer(deployedObject.Body);
+    assertIdentical(deployedBytes.toString(), "Hello from sim S3");
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-asset-code.loc.test.ts
@@ -1,0 +1,277 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and asset manifest to pass to sim CloudFormation.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * A multi-module handler directory, as `Code.fromAsset` bundles one: CDK
+ * stages the directory in the cloud assembly, and the asset publisher has to
+ * zip it whole for the local `require` to resolve.
+ */
+async function writeHandlerDirectory(
+  projectDirectory: TemporaryDirectory,
+): Promise<string> {
+  await projectDirectory.writeFile(
+    "handler/index.js",
+    `const { greet } = require("./lib/greeter");
+exports.handler = async (event) => ({ message: greet(event.name) });
+`,
+  );
+  await projectDirectory.writeFile(
+    "handler/lib/greeter.js",
+    `exports.greet = (name) => "Hello " + name + " from a CDK asset";\n`,
+  );
+
+  return projectDirectory.join("handler");
+}
+
+describe("Sim CDK Lambda asset code local integration", () => {
+  it("runs an asset function from a Stack with an explicit environment", async () => {
+    // Given a CDK stack whose function code is a staged asset directory, for
+    // a Stack synthesized with an explicit account and region, so the asset
+    // bucket name is synthesized literally.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const handlerDirectory = await writeHandlerDirectory(projectDirectory);
+
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const assetFunction = new lambda.Function(stack, "AssetFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromAsset(${JSON.stringify(handlerDirectory)}),
+});
+
+new cdk.CfnOutput(stack, "AssetFunctionName", {
+  value: assetFunction.functionName,
+});
+
+app.synth();
+      `,
+    );
+
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function is deployed rather than skipped, with its asset code.
+    const functionResource = stack.getResource("AssetFunctionA633A7D1");
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+
+    const functionName = stack.outputs.get("AssetFunctionName")?.value;
+    assertTypeString(functionName);
+
+    // And invoking it runs the real asset code, including its local require.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    const result = JSON.parse(Buffer.from(invokeOutput.Payload).toString()) as {
+      message: string;
+    };
+    assertIdentical(result.message, "Hello Yulin from a CDK asset");
+
+    // And the asset was published into the CDK staging Bucket in sim S3, as a
+    // real `cdk deploy` publishes it before CloudFormation runs. The Bucket
+    // is named as the template names it, in the scope the Stack deployed
+    // into, which is where the function's code fetch looks for it.
+    assertNonNullable(
+      simAws
+        .s3()
+        .getSimBucketByName("cdk-hnb659fds-assets-111111111111-eu-west-2"),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("runs an asset function from an environment-agnostic Stack", async () => {
+    // Given the same asset function in a Stack synthesized without an
+    // environment, so the asset bucket name is a pseudo-parameter Fn::Sub
+    // that only resolves against the deploying account and region.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const handlerDirectory = await writeHandlerDirectory(projectDirectory);
+
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack");
+
+const assetFunction = new lambda.Function(stack, "AssetFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromAsset(${JSON.stringify(handlerDirectory)}),
+});
+
+new cdk.CfnOutput(stack, "AssetFunctionName", {
+  value: assetFunction.functionName,
+});
+
+app.synth();
+      `,
+    );
+
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const functionName = stack.outputs.get("AssetFunctionName")?.value;
+    assertTypeString(functionName);
+
+    // Then the published location and the template's Fn::Sub code location
+    // agree, so the function runs its asset code.
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    const result = JSON.parse(Buffer.from(invokeOutput.Payload).toString()) as {
+      message: string;
+    };
+    assertIdentical(result.message, "Hello Yulin from a CDK asset");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("skips a CDK BucketDeployment provider function on its runtime", async () => {
+    // Given a CDK stack using BucketDeployment, which synthesizes a Python
+    // provider function into the stack alongside the user's own function.
+    const simAws = new SimAws();
+    const projectDirectory = new TemporaryDirectory();
+    const handlerDirectory = await writeHandlerDirectory(projectDirectory);
+    await projectDirectory.writeFile("data/greeting.txt", "Hello from sim S3");
+    const dataDirectory = projectDirectory.join("data");
+
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack");
+
+const dataBucket = new s3.Bucket(stack, "DataBucket");
+
+new s3deploy.BucketDeployment(stack, "DeployData", {
+  sources: [s3deploy.Source.asset(${JSON.stringify(dataDirectory)})],
+  destinationBucket: dataBucket,
+});
+
+const assetFunction = new lambda.Function(stack, "AssetFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromAsset(${JSON.stringify(handlerDirectory)}),
+});
+
+new cdk.CfnOutput(stack, "AssetFunctionName", {
+  value: assetFunction.functionName,
+});
+new cdk.CfnOutput(stack, "DataBucketName", { value: dataBucket.bucketName });
+
+app.synth();
+      `,
+    );
+
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the provider function is skipped, because sim Lambda simulates
+    // Node.js runtimes and sim CloudFormation simulates the BucketDeployment
+    // custom resource directly instead of running its provider.
+    const providerResource = stack.resources
+      .values()
+      .find(
+        (resource) =>
+          resource.type === "AWS::Lambda::Function" &&
+          resource.logicalId.startsWith("CustomCDKBucketDeployment"),
+      );
+    assertNonNullable(providerResource);
+    assertTrue(providerResource.skipped);
+    assertNonNullable(providerResource.skippedReason);
+    assertStringIncludes(providerResource.skippedReason, "python");
+
+    // And the user's own asset function still deploys and runs.
+    const functionName = stack.outputs.get("AssetFunctionName")?.value;
+    assertTypeString(functionName);
+
+    const invokeOutput = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Payload: JSON.stringify({ name: "Yulin" }),
+      }),
+    );
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+
+    // And the bucket deployment itself still works, as it is simulated
+    // directly rather than by running the skipped provider.
+    const bucketName = stack.outputs.get("DataBucketName")?.value;
+    assertTypeString(bucketName);
+    assertNonNullable(simAws.s3().getSimBucketByName(bucketName));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/cdk/sim-cdk-out-context.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-out-context.ts
@@ -13,6 +13,7 @@ export interface SimCdkAssetsManifest {
       readonly destinations?: Record<
         string,
         {
+          readonly bucketName?: string | undefined;
           readonly objectKey?: string | undefined;
         }
       >;

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -11,6 +11,7 @@ import { SimCfnStackResourceCreator } from "./deploy/sim-cfn-stack-resource-crea
 import { makeSimCfnStackResourceMap } from "./resource-map/sim-cfn-stack-resource-map.js";
 import { SimCfnStackDeploymentLifecycle } from "./deploy/sim-cfn-stack-deployment-lifecycle.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
+import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js";
 import type { SimCfnExecutableResourceBinding } from "../bind/sim-cfn-exec-binding.type.js";
 import type { SimCfnStackOutput } from "./output/sim-cfn-stack-output.js";
 import { SimCfnStackOutputResolver } from "./output/sim-cfn-stack-output-resolver.js";
@@ -58,6 +59,7 @@ export class SimCfnStack {
   public outputs = new Map<string, SimCfnStackOutput>();
 
   private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly cfnTemplate: SimCfnTemplate;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings:
@@ -76,6 +78,7 @@ export class SimCfnStack {
     } = properties;
 
     this.simAws = simAws;
+    this.accountRegionScope = accountRegionScope;
     this.stackName = stackName;
     this.cfnTemplate = template;
     this.cdkOutContext = cdkOutContext;
@@ -132,8 +135,19 @@ export class SimCfnStack {
   /**
    * Delegate resource dependency ordering and creation to the resource
    * creator.
+   *
+   * CDK cloud assembly assets are published into sim S3 first, as a real
+   * `cdk deploy` publishes them before CloudFormation processes the template
+   * that references them.
    */
   private async createResources(): Promise<void> {
+    await new SimCdkAssetsPublisher({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
+      stackName: this.stackName,
+      cdkOutContext: this.cdkOutContext,
+    }).publish();
+
     const resourceCreator = new SimCfnStackResourceCreator({
       simAws: this.simAws,
       resources: this.resources,

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-cdk-assets-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-cdk-assets-skip.ts
@@ -11,12 +11,14 @@ const cdkBootstrapAssetsBucketPattern =
 /**
  * Skips functions whose code lives in a missing CDK bootstrap assets bucket.
  *
- * CDK-synthesized templates include helper functions, such as the CDK
- * BucketDeployment provider, whose code zip lives in the CDK bootstrap assets
- * bucket. That bucket does not exist in sim AWS, and sim CloudFormation
- * simulates the CDK custom resources directly instead of running their
- * provider functions. The "Unsupported sim ... CloudFormation" wording marks
- * the Resource as skipped rather than failing the stack.
+ * Deploying from a synthesized template file publishes the cloud assembly's
+ * assets into that bucket in sim S3 first, so asset-bundled function code is
+ * normally found there. This skip covers what is left: a CDK-shaped template
+ * deployed without its cloud assembly, such as a template object passed
+ * inline, where there is no asset to publish and nothing to fetch.
+ *
+ * The "Unsupported sim ... CloudFormation" wording marks the Resource as
+ * skipped rather than failing the stack.
  */
 export class SimCfnLambdaCdkAssetsSkip {
   /**
@@ -36,7 +38,10 @@ export class SimCfnLambdaCdkAssetsSkip {
 
     return new Error(
       `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
-        `function code from missing CDK bootstrap assets bucket ${bucketName}`,
+        `function code from missing CDK bootstrap assets bucket ${bucketName}. ` +
+        `Deploy from a synthesized CDK template file so its cloud assembly ` +
+        `assets can be published, or bind a real in-process handler to this ` +
+        `function.`,
     );
   }
 

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-code-input.ts
@@ -14,6 +14,15 @@ interface SimCfnLambdaCodeInputProperties {
 }
 
 /**
+ * The code a Resource's function will be created with, and whether an
+ * executable binding supplied it.
+ */
+export interface SimCfnLambdaCodeInput {
+  readonly code: SimLambdaFunctionCode | undefined;
+  readonly bound: boolean;
+}
+
+/**
  * The CreateFunction code input for an AWS::Lambda::Function Resource: an
  * executable binding's real handler when one targets the Resource, otherwise
  * the template code.
@@ -26,7 +35,7 @@ interface SimCfnLambdaCodeInputProperties {
  */
 export function simCfnLambdaCodeInput(
   properties: SimCfnLambdaCodeInputProperties,
-): SimLambdaFunctionCode | undefined {
+): SimCfnLambdaCodeInput {
   const { resource, functionProperties, bindings } = properties;
 
   const bindingFinder = new SimCfnExecBindingFinder<SimLambdaHandler>({
@@ -42,8 +51,11 @@ export function simCfnLambdaCodeInput(
   });
 
   if (binding === undefined) {
-    return functionProperties.code;
+    return { code: functionProperties.code, bound: false };
   }
 
-  return { ZipFile: makeLambdaZipFileInput(binding.handler) };
+  return {
+    code: { ZipFile: makeLambdaZipFileInput(binding.handler) },
+    bound: true,
+  };
 }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -6,6 +6,7 @@ import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaCdkAssetsSkip } from "./sim-cfn-lambda-cdk-assets-skip.js";
 import { simCfnLambdaCodeInput } from "./sim-cfn-lambda-code-input.js";
+import { SimCfnLambdaRuntimeSkip } from "./sim-cfn-lambda-runtime-skip.js";
 import {
   simCfnLambdaCreateFunctionInput,
   SimCfnLambdaFunctionPropertiesParser,
@@ -23,6 +24,7 @@ export class SimCfnLambdaFunctionCreator {
   private readonly propertiesParser =
     new SimCfnLambdaFunctionPropertiesParser();
   private readonly cdkAssetsSkip = new SimCfnLambdaCdkAssetsSkip();
+  private readonly runtimeSkip = new SimCfnLambdaRuntimeSkip();
 
   constructor(properties: SimCfnLambdaFunctionCreatorProperties) {
     this.lambda = properties.lambda;
@@ -45,11 +47,20 @@ export class SimCfnLambdaFunctionCreator {
       resource,
       properties,
     );
-    const code = simCfnLambdaCodeInput({
+    const { code, bound } = simCfnLambdaCodeInput({
       resource,
       functionProperties,
       bindings,
     });
+
+    const runtimeSkipError = this.runtimeSkip.findSkipError(
+      resource,
+      functionProperties,
+      bound,
+    );
+    if (runtimeSkipError !== undefined) {
+      throw runtimeSkipError;
+    }
 
     try {
       await this.lambda.createFunction({

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.iso.test.ts
@@ -1,0 +1,125 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const pythonFunctionTemplate = {
+  Resources: {
+    ReportFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "report",
+        Role: "arn:aws:iam::111111111111:role/ReportRole",
+        Handler: "index.handler",
+        Runtime: "python3.13",
+        Code: { ZipFile: "def handler(event, context): return 'report'" },
+      },
+    },
+  },
+};
+
+describe("Lambda CloudFormation Function runtime support", () => {
+  it("skips a function declaring a runtime sim Lambda does not simulate", async () => {
+    // Given a template with a Python function, as CDK synthesizes for its
+    // BucketDeployment provider.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "report-stack",
+      template: pythonFunctionTemplate,
+    });
+
+    // Then the Resource is skipped rather than failing the stack, saying why.
+    const functionResource = stack.getResource("ReportFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertNonNullable(functionResource.skippedReason);
+    assertStringIncludes(functionResource.skippedReason, "python3.13");
+    assertStringIncludes(functionResource.skippedReason, "Node.js");
+
+    // And no simulated function is created for it.
+    assertUndefined(simAws.lambda().getSimFunctionByName("report"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a function with an unsimulated runtime when a handler is bound", async () => {
+    // Given the same Python function, with a real in-process handler bound to
+    // it, which replaces the template code wholesale.
+    const simAws = new SimAws();
+
+    // When the template is deployed with the binding.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "report-stack",
+      template: pythonFunctionTemplate,
+      bindings: [
+        {
+          functionName: "report",
+          handler: (): { source: string } => ({ source: "bound-handler" }),
+        },
+      ],
+    });
+
+    // Then the Resource deploys, because the bound handler is what runs.
+    const functionResource = stack.getResource("ReportFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+
+    const invokeOutput = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "report" }));
+
+    assertIdentical(invokeOutput.StatusCode, 200);
+    assertUndefined(invokeOutput.FunctionError);
+    assertNonNullable(invokeOutput.Payload);
+    assertStringIncludes(
+      Buffer.from(invokeOutput.Payload).toString(),
+      "bound-handler",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys a function that declares no runtime", async () => {
+    // Given a template function with inline code and no Runtime property, as
+    // a minimal hand-written template has.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: {
+        Resources: {
+          GreeterFunction: {
+            Type: "AWS::Lambda::Function",
+            Properties: {
+              FunctionName: "greeter",
+              Role: "arn:aws:iam::111111111111:role/GreeterRole",
+              Handler: "index.handler",
+              Code: { ZipFile: "exports.handler = async () => 'hello';" },
+            },
+          },
+        },
+      },
+    });
+
+    // Then it deploys, as the runtime gate only declines a declared runtime.
+    const functionResource = stack.getResource("GreeterFunction");
+
+    assertNonNullable(functionResource);
+    assertUndefined(functionResource.skippedReason);
+    assertNonNullable(simAws.lambda().getSimFunctionByName("greeter"));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
@@ -1,0 +1,56 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
+
+/**
+ * Sim Lambda runs handler modules in a Node.js vm, so it simulates the
+ * Node.js managed runtimes.
+ */
+const nodeJsRuntimePrefix = "nodejs";
+
+/**
+ * Skips template functions declaring a runtime sim Lambda does not simulate.
+ *
+ * Yulin is a Node.js simulator: function code is evaluated as CommonJS modules
+ * in a vm, so a Python, Java, Go or container function cannot run whatever its
+ * code says. CDK synthesizes such functions into a user's stack without being
+ * asked to. The CDK BucketDeployment provider, for instance, is a Python
+ * function, and sim CloudFormation simulates that custom resource directly
+ * rather than running its provider.
+ *
+ * Declining those functions on their Runtime keeps the reason honest, and
+ * keeps their code from being loaded at all. A function with an executable
+ * binding is exempt, because the binding replaces the code with a real
+ * in-process handler, which is exactly how to simulate a function whose real
+ * runtime Yulin cannot run.
+ *
+ * The "Unsupported sim ... CloudFormation" wording marks the Resource as
+ * skipped rather than failing the stack.
+ */
+export class SimCfnLambdaRuntimeSkip {
+  /**
+   * A skip error when this function's runtime is not simulated, otherwise
+   * undefined.
+   */
+  findSkipError(
+    resource: SimCfnResource,
+    functionProperties: SimCfnLambdaFunctionProperties,
+    bound: boolean,
+  ): Error | undefined {
+    const { runtimeName } = functionProperties;
+
+    if (
+      bound ||
+      runtimeName === undefined ||
+      runtimeName.startsWith(nodeJsRuntimePrefix)
+    ) {
+      return undefined;
+    }
+
+    return new Error(
+      `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
+        `sim Lambda simulates Node.js runtimes, and this function declares ` +
+        `Runtime ${runtimeName}. Bind a real in-process handler to this ` +
+        `function to simulate it.`,
+    );
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CDK Lambda asset code is now published to simulated S3 during synthesized deployments and can be executed by simulated Lambda functions.
  - ZIP and file-based assets are supported, including multiple assets sharing a staging bucket.
  - Non-Node.js Lambda runtimes are clearly marked as skipped unless a real handler binding is provided.

- **Bug Fixes**
  - Improved diagnostics for missing buckets, unavailable cloud assemblies, and unsupported runtimes.

- **Documentation**
  - Clarified CDK asset deployment behavior, skipped scenarios, and `NoSuchBucket` errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->