### PR TITLE
fix: require both Accounts to allow a cross-Account request

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -874,9 +874,11 @@ The caller's Account is resolved from the principal ARN, so it has to be an Acco
 `SimAws` instance for its policies to count. An Account the simulation was never told about grants
 nothing, which is also what a principal ARN that was never given any permissions means on AWS.
 
-A standalone `SimIam` has no simulation around it and so no other Account to ask: a caller from
-outside its own Account is always denied. Its Account ID is available as `simIam.accountId`, which
-is what a test naming its own principals should build their ARNs from.
+A standalone `SimIam` has no simulation around it and so no other Account to ask: a principal whose
+ARN belongs to another Account is always denied, however permissive the resource policy. Anonymous
+and service-principal callers are not affected — they have no Account either way, so a resource
+policy still allows them. The Account ID is available as `simIam.accountId`, which is what a test
+naming its own principals should build their ARNs from.
 
 ## Standalone SimIam
 

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -99,15 +99,20 @@ denied for every action.
 ## Authorization decisions
 
 `authorize(...)` returns a decision object rather than throwing, so tests can assert on exactly why
-a request was allowed or denied. The decision models the common IAM evaluation union:
+a request was allowed or denied. The decision models the common IAM evaluation rules:
 
 - A matching explicit `Deny` statement in any evaluated policy wins
-- Otherwise a matching `Allow` in an identity policy or resource policy allows the request
+- Otherwise, within one Account, a matching `Allow` in an identity policy or resource policy allows
+  the request
+- Across Accounts, a matching `Allow` is needed from each side — see
+  [Cross-Account requests](#cross-account-requests)
 - Otherwise the request is implicitly denied
 
 The decision exposes `value` (`"Allow"`, `"ExplicitDeny"`, or `"ImplicitDeny"`), the convenience
 flags `isAllowed`, `isDenied`, `isExplicitDeny`, and `isImplicitDeny`, the matching
-`allowStatements` and `explicitDenyStatements`, and the resolved `caller` for diagnostics.
+`allowStatements` and `explicitDenyStatements`, and the resolved `caller` for diagnostics. The
+matching Allows are also available per side as `identityAllowStatements` and
+`resourceAllowStatements`, which is what a cross-Account denial is best read from.
 
 If the caller is omitted, authorization defaults to the root principal of the Account owning the
 sim IAM instance, which is allowed within its own Account. An explicit `{ kind: "anonymous" }`
@@ -770,8 +775,108 @@ console.log(secondUserOutput.User.Arn);
 ```
 
 Principals from one Account get no implicit access to another Account's resources: authorizing a
-caller from a different simulated Account results in an implicit deny unless a supplied resource
-policy allows it.
+caller from a different simulated Account results in an implicit deny unless both Accounts allow the
+request.
+
+## Cross-Account requests
+
+A request whose caller belongs to a different Account from the resource is decided in both
+Accounts, as it is on AWS:
+
+- The resource's Account must allow it through a resource policy, such as an S3 Bucket policy or a
+  Lambda permission
+- The caller's Account must allow it through an identity policy on that principal
+
+Either one on its own is denied. A resource policy naming another Account's principal delegates to
+that Account rather than granting on its behalf, and an Account cannot grant its own principals
+access to somebody else's resource. An explicit `Deny` on either side denies. Callers with no
+identity side — a service principal, or an anonymous request — are unaffected, and are still allowed
+by a resource policy alone.
+
+```typescript sim-iam-cross-account
+/**
+ * A cross-Account request needs an allow from both Accounts.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const partnerRoleArn = "arn:aws:iam::222222222222:role/Reader";
+
+// The Bucket's Account grants the partner Account's Role.
+const bucketPolicy = {
+  document: {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: partnerRoleArn },
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::reports-bucket/*",
+    },
+  },
+} as const;
+
+const request = {
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+  caller: { kind: "arn", arn: partnerRoleArn },
+  resourcePolicies: [bucketPolicy],
+} as const;
+
+const beforeIdentityPolicy = simAws
+  .account("111111111111")
+  .iam()
+  .authorize(request);
+
+// false: the partner Account has not allowed its Role to read anything.
+console.log(beforeIdentityPolicy.isAllowed);
+console.log(beforeIdentityPolicy.resourceAllowStatements.length); // 1
+console.log(beforeIdentityPolicy.identityAllowStatements.length); // 0
+
+// The partner Account allows its own Role.
+const partnerIam = simAws.account("222222222222").iam();
+
+await partnerIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Reader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::222222222222:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await partnerIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reader",
+    PolicyName: "ReadReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports-bucket/*",
+      },
+    }),
+  }),
+);
+
+// true: both Accounts now allow the request.
+console.log(simAws.account("111111111111").iam().authorize(request).isAllowed);
+```
+
+The caller's Account is resolved from the principal ARN, so it has to be an Account of the same
+`SimAws` instance for its policies to count. An Account the simulation was never told about grants
+nothing, which is also what a principal ARN that was never given any permissions means on AWS.
+
+A standalone `SimIam` has no simulation around it and so no other Account to ask: a caller from
+outside its own Account is always denied. Its Account ID is available as `simIam.accountId`, which
+is what a test naming its own principals should build their ARNs from.
 
 ## Standalone SimIam
 
@@ -828,5 +933,6 @@ full IAM feature set. Notable gaps:
 - The resolved caller is evaluated by Lambda Function URLs with `AuthType: "AWS_IAM"`, but not yet
   by the other services that serve HTTP: served S3 objects and CloudFront responses perform no
   authorization
-- A cross-account call is allowed by the target's resource policy alone. Real AWS also requires the
-  caller's own Account to allow the action, and that second side is not evaluated
+- The identity side of a cross-Account request comes from the caller's Account in the same `SimAws`
+  instance. A caller whose Account is not part of the simulation is denied rather than assumed to be
+  permitted

--- a/docs/services/iam/sim-iam-cross-account.example.ts
+++ b/docs/services/iam/sim-iam-cross-account.example.ts
@@ -1,0 +1,74 @@
+/**
+ * A cross-Account request needs an allow from both Accounts.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const partnerRoleArn = "arn:aws:iam::222222222222:role/Reader";
+
+// The Bucket's Account grants the partner Account's Role.
+const bucketPolicy = {
+  document: {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: partnerRoleArn },
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::reports-bucket/*",
+    },
+  },
+} as const;
+
+const request = {
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+  caller: { kind: "arn", arn: partnerRoleArn },
+  resourcePolicies: [bucketPolicy],
+} as const;
+
+const beforeIdentityPolicy = simAws
+  .account("111111111111")
+  .iam()
+  .authorize(request);
+
+// false: the partner Account has not allowed its Role to read anything.
+console.log(beforeIdentityPolicy.isAllowed);
+console.log(beforeIdentityPolicy.resourceAllowStatements.length); // 1
+console.log(beforeIdentityPolicy.identityAllowStatements.length); // 0
+
+// The partner Account allows its own Role.
+const partnerIam = simAws.account("222222222222").iam();
+
+await partnerIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Reader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::222222222222:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await partnerIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reader",
+    PolicyName: "ReadReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports-bucket/*",
+      },
+    }),
+  }),
+);
+
+// true: both Accounts now allow the request.
+console.log(simAws.account("111111111111").iam().authorize(request).isAllowed);

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -26,7 +26,8 @@ Sim Lambda currently supports:
   resolved from the request and reporting it to the handler as
   `requestContext.authorizer.iam`
 - Function resource-based policies with `AddPermissionCommand`, `RemovePermissionCommand` and
-  `GetPolicyCommand`, evaluated alongside identity policies, including cross-account invocation
+  `GetPolicyCommand`, evaluated alongside identity policies, including cross-account invocation,
+  which also needs the caller's own Account to allow the action
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
@@ -673,9 +674,10 @@ try {
 
 A function's resource-based policy is the other half of Lambda authorization. An identity policy
 says what a principal may do; a resource policy says who may act on the function. Either one is
-enough to allow a call within the same Account, and a resource policy is the _only_ thing that can
-allow a principal from another Account, because that principal's own policies live somewhere the
-function's Account never sees.
+enough to allow a call within the same Account. A principal from another Account needs both: the
+grant on the function, and an identity policy in its own Account allowing the action, which is how
+AWS decides a cross-Account request. See
+[Cross-Account requests](../iam/README.md#cross-account-requests).
 
 `AddPermissionCommand` grants a statement, `RemovePermissionCommand` revokes it by `StatementId`,
 and `GetPolicyCommand` returns the assembled document. `AddPermission` is a shorthand for writing a
@@ -1143,9 +1145,9 @@ Current documented limitations:
 
 - Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, and the Function URL config
   commands are supported — no `UpdateFunctionCode`, `DeleteFunction`, or function listing yet.
-- A cross-account call is allowed by the function's resource policy alone. Real AWS also requires
-  the caller's own Account to allow the action, and the simulator does not evaluate that second
-  side, so a cross-account grant is more permissive here than on AWS.
+- A cross-account grant is only half of what admits a call: the caller's own Account has to allow
+  the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
+  found. A caller from an Account the simulation knows nothing about is denied.
 - Only the `lambda:FunctionUrlAuthType` condition key is given a value at request time.
   `SourceArn`, `SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the
   statement so `GetPolicy` reports the grant that was made, but nothing supplies a value for them,

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -108,6 +108,9 @@ export class SimAwsAccountServiceCache {
         const iam = new SimIam({
           accountRegionScope: scope.accountRegionScope,
           background: this.background,
+          // A cross-Account request is decided in both Accounts, so this IAM
+          // needs to be able to reach the IAM of the caller's own Account.
+          iamResolver: this.iamRegistry,
           // Access keys are indexed simulation-wide as they are issued, so a
           // signed request naming only a key id can be traced to this Account.
           credentialRegistry: new SimIamCredentialRegistry({

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
@@ -1,7 +1,8 @@
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { assertIdentical, assertTypeString } from "@kensio/smartass";
 import path from "node:path";
 import { describe, it } from "vitest";
+
+import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 
 /**
  * Slower local integration test. Calls the real CDK CLI to synth the output
@@ -29,36 +30,13 @@ const otherAccountId = "222222222222";
  * that Account's own identity policy.
  */
 async function grantOtherAccountRole(simAws: SimAws): Promise<void> {
-  const iam = simAws.account(otherAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Anything",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${otherAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Anything",
-      PolicyName: "InvokeUrl",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "lambda:InvokeFunctionUrl",
-          Resource: "*",
-        },
-      }),
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: otherAccountId,
+    roleName: "Anything",
+    policyName: "InvokeUrl",
+    action: "lambda:InvokeFunctionUrl",
+  });
 }
 
 describe("Sim CDK Lambda grantInvokeUrl local integration", () => {

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
@@ -1,3 +1,4 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { assertIdentical, assertTypeString } from "@kensio/smartass";
 import path from "node:path";
 import { describe, it } from "vitest";
@@ -22,6 +23,43 @@ import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js"
 const accountId = "888888888888";
 
 const otherAccountId = "222222222222";
+
+/**
+ * The calling Role in the other Account, allowed to invoke Function URLs by
+ * that Account's own identity policy.
+ */
+async function grantOtherAccountRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.account(otherAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Anything",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${otherAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Anything",
+      PolicyName: "InvokeUrl",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunctionUrl",
+          Resource: "*",
+        },
+      }),
+    }),
+  );
+}
 
 describe("Sim CDK Lambda grantInvokeUrl local integration", () => {
   it("deploys grantInvokeUrl grants that admit the granted principals", async () => {
@@ -85,6 +123,11 @@ app.synth();
     const functionUrl = stack.outputs.get("ReporterFunctionUrl")?.value;
     assertTypeString(functionUrl);
 
+    // And the other Account allows its own Role to invoke Function URLs. That
+    // is the side a CDK app in this Account cannot write, and a cross-account
+    // call needs an allow from each Account.
+    await grantOtherAccountRole(simAws);
+
     const srv = await serveSimAws({ simAws });
     const invokeAs = async (arn: string): Promise<Response> =>
       await fetch(srv.localUrl(functionUrl), {
@@ -100,8 +143,7 @@ app.synth();
       assertIdentical(await grantedRole.text(), "reported");
 
       // And so does a principal in the Account granted by the deployed
-      // AWS::Lambda::Permission, which is the only way a cross-account call
-      // can be allowed at all.
+      // AWS::Lambda::Permission, now that its own Account allows it too.
       const grantedAccount = await invokeAs(
         `arn:aws:iam::${otherAccountId}:role/Anything`,
       );

--- a/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
@@ -1,0 +1,76 @@
+interface SimIamAllowSidesProperties {
+  readonly identity: boolean;
+  readonly resource: boolean;
+}
+
+/**
+ * Which sides of a policy evaluation produced a matching Allow.
+ *
+ * Identity-based policies are the caller's side of a request; resource-based
+ * policies are the resource's side. AWS combines the two differently depending
+ * on whether the caller and the resource belong to the same Account, so the
+ * sides are kept apart rather than counted together.
+ */
+export class SimIamAllowSides {
+  private readonly identityAllowed: boolean;
+  private readonly resourceAllowed: boolean;
+
+  constructor(properties: SimIamAllowSidesProperties) {
+    this.identityAllowed = properties.identity;
+    this.resourceAllowed = properties.resource;
+  }
+
+  /**
+   * Whether an identity-based policy allowed the request.
+   */
+  get identity(): boolean {
+    return this.identityAllowed;
+  }
+
+  /**
+   * Whether a resource-based policy allowed the request.
+   */
+  get resource(): boolean {
+    return this.resourceAllowed;
+  }
+}
+
+/**
+ * Which sides of an authorization must allow a request for it to be allowed.
+ */
+export interface SimIamAllowRequirement {
+  isSatisfiedBy(allows: SimIamAllowSides): boolean;
+}
+
+/**
+ * The same-Account rule: an Allow from either side is enough.
+ *
+ * Within one Account an identity policy can allow a request with no resource
+ * policy involved, and a resource policy can allow it with no identity policy
+ * involved.
+ */
+export class SimIamEitherSideAllowRequirement implements SimIamAllowRequirement {
+  /**
+   * Whether either side of the evaluation allowed the request.
+   */
+  isSatisfiedBy(allows: SimIamAllowSides): boolean {
+    return allows.identity || allows.resource;
+  }
+}
+
+/**
+ * The cross-Account rule: both sides must allow.
+ *
+ * AWS decides a cross-Account request in both Accounts. The caller's Account
+ * allows the action through an identity policy, and the resource's Account
+ * allows it through a resource policy. Neither side can grant access to the
+ * other Account's principals or resources on its own.
+ */
+export class SimIamBothSidesAllowRequirement implements SimIamAllowRequirement {
+  /**
+   * Whether both sides of the evaluation allowed the request.
+   */
+  isSatisfiedBy(allows: SimIamAllowSides): boolean {
+    return allows.identity && allows.resource;
+  }
+}

--- a/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
@@ -1,0 +1,83 @@
+import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import { SimIamAllowSides } from "./sim-iam-allow-requirement.js";
+
+/**
+ * The matching Allow statements found for one authorization, kept per side.
+ *
+ * Which side an Allow came from decides whether it counts: a cross-Account
+ * request needs one from each. Trust policies are resource policies on an IAM
+ * Role, so they count as the resource side, and are additionally kept apart for
+ * the AssumeRole rule that an identity policy cannot substitute for a Role's
+ * trust.
+ */
+export class SimIamAllowStatements {
+  private readonly identityStatements: SimIamPolicyDocumentStatement[] = [];
+  private readonly resourceStatements: SimIamPolicyDocumentStatement[] = [];
+  private readonly trustStatements: SimIamPolicyDocumentStatement[] = [];
+
+  /**
+   * Record a matching Allow against the policy side it came from.
+   */
+  record(
+    policy: SimIamAuthZPolicySource,
+    statement: SimIamPolicyDocumentStatement,
+  ): void {
+    if (policy.sourceType === "trust") {
+      this.trustStatements.push(statement);
+    }
+
+    this.sideStatements(policy).push(statement);
+  }
+
+  /**
+   * Every matching Allow statement, identity side first.
+   */
+  get all(): readonly SimIamPolicyDocumentStatement[] {
+    return [...this.identityStatements, ...this.resourceStatements];
+  }
+
+  /**
+   * Matching Allow statements from identity-based policies.
+   */
+  get identity(): readonly SimIamPolicyDocumentStatement[] {
+    return this.identityStatements;
+  }
+
+  /**
+   * Matching Allow statements from resource-based policies.
+   */
+  get resource(): readonly SimIamPolicyDocumentStatement[] {
+    return this.resourceStatements;
+  }
+
+  /**
+   * Matching Allow statements originating from trust policies.
+   */
+  get trust(): readonly SimIamPolicyDocumentStatement[] {
+    return this.trustStatements;
+  }
+
+  /**
+   * Which sides produced a matching Allow.
+   */
+  get sides(): SimIamAllowSides {
+    return new SimIamAllowSides({
+      identity: this.identityStatements.length > 0,
+      resource: this.resourceStatements.length > 0,
+    });
+  }
+
+  /**
+   * The list an Allow from this policy source belongs in.
+   */
+  private sideStatements(
+    policy: SimIamAuthZPolicySource,
+  ): SimIamPolicyDocumentStatement[] {
+    if (policy.sourceType === "resource" || policy.sourceType === "trust") {
+      return this.resourceStatements;
+    }
+
+    return this.identityStatements;
+  }
+}

--- a/src/service/iam/authorize/caller-account/sim-iam-caller-account-resolver.ts
+++ b/src/service/iam/authorize/caller-account/sim-iam-caller-account-resolver.ts
@@ -1,0 +1,58 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamAccountResolver } from "../../registry/sim-iam-account-resolver.js";
+import type { SimIamCallerAccount } from "./sim-iam-caller-account.js";
+import { SimIamCrossAccountCaller } from "./sim-iam-cross-account-caller.js";
+import { SimIamSameAccountCaller } from "./sim-iam-same-account-caller.js";
+
+interface SimIamCallerAccountResolverProperties {
+  /**
+   * The Account evaluating the request, which owns the target resource.
+   */
+  readonly accountId: SimAwsAccountId;
+
+  /**
+   * Resolves the IAM state of other Accounts in the same simulation.
+   *
+   * A standalone SimIam has no wider simulation to look in, so it has no
+   * resolver and no other Account's identity policies to find.
+   */
+  readonly iamResolver?: SimIamAccountResolver | undefined;
+}
+
+/**
+ * Works out which Account owns the caller of an authorization request.
+ *
+ * The answer decides how the request is evaluated, so it is made once, here,
+ * from the resolved caller. A caller with no Account in its ARN — a service
+ * principal or an anonymous request — has no identity side and is treated as
+ * belonging to the evaluating Account, which leaves it to be allowed by a
+ * resource policy alone.
+ */
+export class SimIamCallerAccountResolver {
+  private readonly accountId: SimAwsAccountId;
+  private readonly iamResolver?: SimIamAccountResolver | undefined;
+
+  constructor(properties: SimIamCallerAccountResolverProperties) {
+    this.accountId = properties.accountId;
+    this.iamResolver = properties.iamResolver;
+  }
+
+  /**
+   * Resolve the caller's Account relative to the Account owning the resource.
+   */
+  resolve(caller: SimAwsResolvedCaller): SimIamCallerAccount {
+    const callerAccountId = caller.accountId;
+
+    if (callerAccountId === undefined || callerAccountId === this.accountId) {
+      return new SimIamSameAccountCaller();
+    }
+
+    return new SimIamCrossAccountCaller({
+      principal: caller.identityPolicyPrincipal,
+      callerAccountIam: this.iamResolver?.findIamForAccount(
+        callerAccountId as SimAwsAccountId,
+      ),
+    });
+  }
+}

--- a/src/service/iam/authorize/caller-account/sim-iam-caller-account.ts
+++ b/src/service/iam/authorize/caller-account/sim-iam-caller-account.ts
@@ -1,0 +1,22 @@
+import type { SimIamAllowRequirement } from "../allow/sim-iam-allow-requirement.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+
+/**
+ * What the Account owning the caller contributes to an authorization request.
+ *
+ * The Account evaluating a request owns the resource. Whether the caller
+ * belongs to that same Account decides two things at once: which identity
+ * policies are in scope, and how an Allow from each side is combined. Both
+ * answers come from here so they cannot disagree.
+ */
+export interface SimIamCallerAccount {
+  /**
+   * Identity policies contributed by the caller's own Account.
+   */
+  readonly identityPolicies: readonly SimIamAuthZPolicySource[];
+
+  /**
+   * How identity and resource Allows combine for this caller.
+   */
+  readonly allowRequirement: SimIamAllowRequirement;
+}

--- a/src/service/iam/authorize/caller-account/sim-iam-cross-account-caller.ts
+++ b/src/service/iam/authorize/caller-account/sim-iam-cross-account-caller.ts
@@ -1,0 +1,46 @@
+import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  type SimIamAllowRequirement,
+  SimIamBothSidesAllowRequirement,
+} from "../allow/sim-iam-allow-requirement.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import type { SimIamAccountIdentityPolicies } from "../identity/sim-iam-account-identity-policies.js";
+import type { SimIamCallerAccount } from "./sim-iam-caller-account.js";
+
+interface SimIamCrossAccountCallerProperties {
+  /**
+   * The identity whose policies apply to the request, in the caller's Account.
+   */
+  readonly principal: SimAwsPrincipal;
+
+  /**
+   * Simulated IAM of the Account owning the caller, when the simulation has it.
+   */
+  readonly callerAccountIam?: SimIamAccountIdentityPolicies | undefined;
+}
+
+/**
+ * A caller belonging to a different Account from the resource.
+ *
+ * AWS decides such a request in both Accounts, so the identity policies of the
+ * caller's own Account are pulled in and both sides are then required to allow.
+ * A resource policy naming another Account's principal delegates to that
+ * Account rather than granting on its own behalf.
+ *
+ * An Account the simulation knows nothing about contributes no identity
+ * policies, which denies the request. That matches AWS for the case it
+ * represents: a principal ARN that was never given any permissions.
+ */
+export class SimIamCrossAccountCaller implements SimIamCallerAccount {
+  readonly identityPolicies: readonly SimIamAuthZPolicySource[];
+
+  readonly allowRequirement: SimIamAllowRequirement =
+    new SimIamBothSidesAllowRequirement();
+
+  constructor(properties: SimIamCrossAccountCallerProperties) {
+    this.identityPolicies =
+      properties.callerAccountIam?.identityPolicySourcesFor(
+        properties.principal,
+      ) ?? [];
+  }
+}

--- a/src/service/iam/authorize/caller-account/sim-iam-same-account-caller.ts
+++ b/src/service/iam/authorize/caller-account/sim-iam-same-account-caller.ts
@@ -1,0 +1,23 @@
+import {
+  type SimIamAllowRequirement,
+  SimIamEitherSideAllowRequirement,
+} from "../allow/sim-iam-allow-requirement.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import type { SimIamCallerAccount } from "./sim-iam-caller-account.js";
+
+/**
+ * A caller decided entirely within the Account that owns the resource.
+ *
+ * This covers a principal belonging to that Account, and callers with no
+ * identity side at all: a service principal or an anonymous request, which AWS
+ * allows on a resource policy alone.
+ *
+ * The Account's own IAM state already holds every identity policy in scope, so
+ * nothing is contributed here.
+ */
+export class SimIamSameAccountCaller implements SimIamCallerAccount {
+  readonly identityPolicies: readonly SimIamAuthZPolicySource[] = [];
+
+  readonly allowRequirement: SimIamAllowRequirement =
+    new SimIamEitherSideAllowRequirement();
+}

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
 
-interface SimIamAuthZCallerContext {
+export interface SimIamAuthZCallerContext {
   readonly caller: SimAwsResolvedCaller;
   readonly rootPolicySources: readonly SimIamAuthZPolicySource[];
 }

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -1,8 +1,12 @@
 import type { SimArn } from "../../../aws/arn.js";
+import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import type {
   SimAwsCaller,
   SimAwsPrincipal,
 } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamCallerAccountResolver } from "../caller-account/sim-iam-caller-account-resolver.js";
+import type { SimIamAccountResolver } from "../../registry/sim-iam-account-resolver.js";
 import type {
   SimIamConditionValue,
   SimIamPolicy,
@@ -15,7 +19,10 @@ import type {
   SimIamAuthZPolicySourceType,
 } from "./sim-iam-auth-z-context.js";
 import { SimIamAuthZIdentityPolicyCoordinator } from "./identity-policy-source/sim-iam-auth-z-id-pol-coordinator.js";
-import { SimIamAuthZCallerContextBuilder } from "./sim-iam-auth-z-caller-context-builder.js";
+import {
+  SimIamAuthZCallerContextBuilder,
+  type SimIamAuthZCallerContext,
+} from "./sim-iam-auth-z-caller-context-builder.js";
 import type {
   SimAwsCredentialIdentityResolver,
   SimAwsResolvedCaller,
@@ -69,6 +76,24 @@ export interface SimIamAuthorizationInput {
   readonly resourcePolicies?: readonly SimIamResourcePolicyInput[] | undefined;
 }
 
+interface SimIamAuthZContextBuilderProperties {
+  /**
+   * The Account whose IAM is evaluating the request.
+   */
+  readonly accountId: SimAwsAccountId;
+
+  readonly policies: ReadonlyMap<SimArn, SimIamPolicy>;
+  readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
+  readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
+  readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+
+  /**
+   * Resolves other Accounts' IAM in the same simulation, for the identity side
+   * of a cross-Account request.
+   */
+  readonly iamResolver?: SimIamAccountResolver | undefined;
+}
+
 /**
  * Builds the authorization context consumed by SimIamAuthorizer.
  *
@@ -80,6 +105,11 @@ export interface SimIamAuthorizationInput {
  * SimIamAuthZIdentityPolicySourceBuilder. That helper owns the details of
  * finding a principal role, reading inline policies from the role, resolving
  * attached managed policy ARNs, and parsing stored policy documents.
+ *
+ * Whose identity policies are in scope depends on which Account owns the
+ * caller, which SimIamCallerAccountResolver decides. A caller from another
+ * Account brings that Account's identity policies with it, along with the rule
+ * that both sides must then allow the request.
  *
  * Resource policies are supplied by the service that owns the target resource.
  * They are passed through the authorization input rather than loaded from the
@@ -93,22 +123,21 @@ export interface SimIamAuthorizationInput {
 export class SimIamAuthZContextBuilder {
   private readonly callerContextBuilder: SimIamAuthZCallerContextBuilder;
   private readonly identityPolicyCoordinator: SimIamAuthZIdentityPolicyCoordinator;
+  private readonly callerAccountResolver: SimIamCallerAccountResolver;
 
-  constructor(
-    policies: ReadonlyMap<SimArn, SimIamPolicy>,
-    roles: ReadonlyMap<SimIamRoleName, SimIamRole>,
-    users: ReadonlyMap<SimIamUsername, SimIamUser>,
-    defaultCallerPrincipal: SimAwsPrincipal,
-    credentialIdentityResolver: SimAwsCredentialIdentityResolver,
-  ) {
+  constructor(properties: SimIamAuthZContextBuilderProperties) {
     this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
-      defaultCallerPrincipal,
-      credentialIdentityResolver,
+      makeSimAwsAccountRootPrincipal(properties.accountId),
+      properties.credentialIdentityResolver,
     );
     this.identityPolicyCoordinator = new SimIamAuthZIdentityPolicyCoordinator({
-      policies,
-      roles,
-      users,
+      policies: properties.policies,
+      roles: properties.roles,
+      users: properties.users,
+    });
+    this.callerAccountResolver = new SimIamCallerAccountResolver({
+      accountId: properties.accountId,
+      iamResolver: properties.iamResolver,
     });
   }
 
@@ -117,20 +146,52 @@ export class SimIamAuthZContextBuilder {
    */
   build(input: SimIamAuthorizationInput): SimIamAuthZContext {
     const callerContext = this.callerContextBuilder.build(input.caller);
+    const callerAccount = this.callerAccountResolver.resolve(
+      callerContext.caller,
+    );
 
     return {
       identityPolicies: [
-        ...this.identityPolicyCoordinator.build(
-          callerContext.caller.identityPolicyArn,
-        ),
-        ...callerContext.rootPolicySources,
+        ...this.ownIdentityPolicySources(callerContext),
+        ...callerAccount.identityPolicies,
       ],
       resourcePolicies: this.resourcePolicySources(input),
+      allowRequirement: callerAccount.allowRequirement,
       action: input.action,
       resource: input.resource,
       conditionContext: this.conditionContext(input, callerContext.caller),
       caller: callerContext.caller,
     };
+  }
+
+  /**
+   * Identity policy sources this Account applies to one of its own principals.
+   *
+   * This is the identity side of a request within one Account, and is also what
+   * another Account's IAM asks for when it is deciding a cross-Account request
+   * against a principal belonging to this one.
+   */
+  identityPolicySourcesFor(
+    principal: SimAwsPrincipal,
+  ): readonly SimIamAuthZPolicySource[] {
+    return this.ownIdentityPolicySources(
+      this.callerContextBuilder.build(principal),
+    );
+  }
+
+  /**
+   * Combine stored identity policies with any implied by the caller itself,
+   * such as the unrestricted access held by this Account's root principal.
+   */
+  private ownIdentityPolicySources(
+    callerContext: SimIamAuthZCallerContext,
+  ): readonly SimIamAuthZPolicySource[] {
+    return [
+      ...this.identityPolicyCoordinator.build(
+        callerContext.caller.identityPolicyArn,
+      ),
+      ...callerContext.rootPolicySources,
+    ];
   }
 
   /**

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -1,4 +1,5 @@
 import { StaticFactory } from "@kensio/part-factory";
+import { SimIamEitherSideAllowRequirement } from "../allow/sim-iam-allow-requirement.js";
 import type {
   SimIamAuthZContext,
   SimIamAuthZResourcePolicySource,
@@ -10,6 +11,7 @@ import type {
 export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   identityPolicies: [],
   resourcePolicies: [],
+  allowRequirement: new SimIamEitherSideAllowRequirement(),
   action: "s3:GetObject",
   resource: "arn:aws:s3:::test-bucket/test-key",
   conditionContext: {},

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
@@ -4,6 +4,7 @@ import type {
   SimIamPolicyDocument,
 } from "../../policy/sim-iam-policy.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamAllowRequirement } from "../allow/sim-iam-allow-requirement.js";
 
 export type SimIamAuthZPolicySourceType =
   | "identity-inline"
@@ -48,6 +49,15 @@ export interface SimIamAuthZContext {
    * Resource policies are not gathered from IAM's managed policy store.
    */
   readonly resourcePolicies: readonly SimIamAuthZPolicySource[];
+
+  /**
+   * How an Allow from each policy side combines into the final decision.
+   *
+   * Within one Account either side is enough. A cross-Account request needs
+   * both, because each Account only speaks for its own principals and
+   * resources.
+   */
+  readonly allowRequirement: SimIamAllowRequirement;
 
   readonly action: string;
   readonly resource: string;

--- a/src/service/iam/authorize/identity/sim-iam-account-identity-policies.ts
+++ b/src/service/iam/authorize/identity/sim-iam-account-identity-policies.ts
@@ -1,0 +1,16 @@
+import type { SimAwsPrincipal } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+
+/**
+ * Identity-based policy discovery for principals belonging to one Account.
+ *
+ * This is the capability one Account's IAM needs from another Account's IAM to
+ * decide a cross-Account request: the policies the caller's own Account applies
+ * to its own principal. SimIam implements it, so a resource-owning Account can
+ * ask the caller's Account without depending on the whole service facade.
+ */
+export interface SimIamAccountIdentityPolicies {
+  identityPolicySourcesFor(
+    principal: SimAwsPrincipal,
+  ): readonly SimIamAuthZPolicySource[];
+}

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
@@ -184,8 +184,7 @@ describe("sim IAM ForAllValues:StringEquals authorization", () => {
   it("matches the principal ARN derived from the caller", () => {
     // Given a policy accepting the caller ARN as one of its principal values.
     const simIam = new SimIam();
-    const callerPrincipalArn =
-      "arn:aws:iam::123456789012:role/application/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/application/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -196,7 +195,7 @@ describe("sim IAM ForAllValues:StringEquals authorization", () => {
           Condition: {
             "ForAllValues:StringEquals": {
               "aws:PrincipalArn": [
-                "arn:aws:iam::123456789012:role/OtherRole",
+                `arn:aws:iam::${simIam.accountId}:role/OtherRole`,
                 callerPrincipalArn,
               ],
             },

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
@@ -184,8 +184,7 @@ describe("sim IAM ForAllValues:StringLike authorization", () => {
   it("matches a pattern against the principal ARN derived from the caller", () => {
     // Given a policy accepting app roles from a particular account.
     const simIam = new SimIam();
-    const callerPrincipalArn =
-      "arn:aws:iam::123456789012:role/application/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/application/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -195,8 +194,7 @@ describe("sim IAM ForAllValues:StringLike authorization", () => {
           Resource: "arn:aws:s3:::example-bucket/example-key.txt",
           Condition: {
             "ForAllValues:StringLike": {
-              "aws:PrincipalArn":
-                "arn:aws:iam::123456789012:role/application/*",
+              "aws:PrincipalArn": `arn:aws:iam::${simIam.accountId}:role/application/*`,
             },
           },
         },

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.iso.test.ts
@@ -256,8 +256,7 @@ describe("sim IAM ForAnyValue:StringEquals authorization", () => {
   it("matches the principal ARN derived from the caller", () => {
     // Given a policy accepting the caller ARN among several principal values.
     const simIam = new SimIam();
-    const callerPrincipalArn =
-      "arn:aws:iam::123456789012:role/application/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/application/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -268,7 +267,7 @@ describe("sim IAM ForAnyValue:StringEquals authorization", () => {
           Condition: {
             "ForAnyValue:StringEquals": {
               "aws:PrincipalArn": [
-                "arn:aws:iam::123456789012:role/OtherRole",
+                `arn:aws:iam::${simIam.accountId}:role/OtherRole`,
                 callerPrincipalArn,
               ],
             },

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.iso.test.ts
@@ -256,8 +256,7 @@ describe("sim IAM ForAnyValue:StringLike authorization", () => {
   it("matches a pattern against the principal ARN derived from the caller", () => {
     // Given a policy accepting app roles from a particular account.
     const simIam = new SimIam();
-    const callerPrincipalArn =
-      "arn:aws:iam::123456789012:role/application/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/application/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -269,7 +268,7 @@ describe("sim IAM ForAnyValue:StringLike authorization", () => {
             "ForAnyValue:StringLike": {
               "aws:PrincipalArn": [
                 "arn:aws:iam::210987654321:role/*",
-                "arn:aws:iam::123456789012:role/application/*",
+                `arn:aws:iam::${simIam.accountId}:role/application/*`,
               ],
             },
           },

--- a/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.iso.test.ts
@@ -116,7 +116,7 @@ describe("sim IAM StringEquals authorization", () => {
   it("allows a specified principal when its context value matches", () => {
     // Given a resource policy for a specific principal with a StringEquals condition.
     const simIam = new SimIam();
-    const callerPrincipalArn = "arn:aws:iam::123456789012:role/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -151,7 +151,7 @@ describe("sim IAM StringEquals authorization", () => {
   it("supplies the principal ARN condition value from the caller", () => {
     // Given a policy conditioned on an IAM-known property of the principal.
     const simIam = new SimIam();
-    const callerPrincipalArn = "arn:aws:iam::123456789012:role/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {

--- a/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.iso.test.ts
@@ -187,8 +187,7 @@ describe("sim IAM StringLike authorization", () => {
   it("matches a pattern against the principal ARN supplied by IAM", () => {
     // Given a policy accepting role principals from a particular account.
     const simIam = new SimIam();
-    const callerPrincipalArn =
-      "arn:aws:iam::123456789012:role/application/TestRole";
+    const callerPrincipalArn = `arn:aws:iam::${simIam.accountId}:role/application/TestRole`;
     const policy = simIamAuthZResourcePolicySourceFactory.make({
       document: {
         Statement: {
@@ -198,8 +197,7 @@ describe("sim IAM StringLike authorization", () => {
           Resource: "arn:aws:s3:::example-bucket/example-key.txt",
           Condition: {
             StringLike: {
-              "aws:PrincipalArn":
-                "arn:aws:iam::123456789012:role/application/*",
+              "aws:PrincipalArn": `arn:aws:iam::${simIam.accountId}:role/application/*`,
             },
           },
         },

--- a/src/service/iam/authorize/sim-iam-account-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-account-auth-z.ts
@@ -1,12 +1,15 @@
-import { makeSimAwsAccountRootPrincipal } from "../../aws/caller/sim-aws-account-root-principal.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimArn } from "../../aws/arn.js";
 import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "../role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
+import type { SimIamAccountResolver } from "../registry/sim-iam-account-resolver.js";
 import { SimIamAuthorizer } from "./sim-iam-authorizer.js";
 import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthZPolicySource } from "./context/sim-iam-auth-z-context.js";
+import type { SimIamAccountIdentityPolicies } from "./identity/sim-iam-account-identity-policies.js";
 import type { SimIamPolicyDecision } from "./sim-iam-decision.js";
 
 interface SimIamAccountAuthZProperties {
@@ -15,6 +18,15 @@ interface SimIamAccountAuthZProperties {
   readonly roles: Map<SimIamRoleName, SimIamRole>;
   readonly users: Map<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+
+  /**
+   * Resolves other Accounts' IAM in the same simulation.
+   *
+   * A cross-Account request is decided in both Accounts, so the caller's own
+   * Account has to be reachable for its identity policies to count. A
+   * standalone SimIam has no simulation around it and so no resolver.
+   */
+  readonly iamResolver?: SimIamAccountResolver | undefined;
 }
 
 /**
@@ -25,7 +37,7 @@ interface SimIamAccountAuthZProperties {
  * the owning sim Account. An explicit anonymous caller suppresses that
  * fallback and is evaluated without identity policies.
  */
-export class SimIamAccountAuthZ {
+export class SimIamAccountAuthZ implements SimIamAccountIdentityPolicies {
   private readonly properties: SimIamAccountAuthZProperties;
 
   constructor(properties: SimIamAccountAuthZProperties) {
@@ -37,15 +49,32 @@ export class SimIamAccountAuthZ {
    * request caller.
    */
   authorize(input: SimIamAuthorizationInput): SimIamPolicyDecision {
-    const simIamAuthorizer = new SimIamAuthorizer({
+    return this.authorizer().authorize(input);
+  }
+
+  /**
+   * Identity policies this Account applies to one of its own principals.
+   */
+  identityPolicySourcesFor(
+    principal: SimAwsPrincipal,
+  ): readonly SimIamAuthZPolicySource[] {
+    return this.authorizer().identityPolicySourcesFor(principal);
+  }
+
+  /**
+   * Make an authorizer over this Account's current IAM state.
+   *
+   * The state maps are shared by reference, so a fresh authorizer sees every
+   * Role, User, and Policy created since the last request.
+   */
+  private authorizer(): SimIamAuthorizer {
+    return new SimIamAuthorizer({
+      accountId: this.properties.accountId,
       policies: this.properties.policies,
       roles: this.properties.roles,
       users: this.properties.users,
-      defaultCallerPrincipal: makeSimAwsAccountRootPrincipal(
-        this.properties.accountId,
-      ),
       credentialIdentityResolver: this.properties.credentialIdentityResolver,
+      iamResolver: this.properties.iamResolver,
     });
-    return simIamAuthorizer.authorize(input);
   }
 }

--- a/src/service/iam/authorize/sim-iam-auth-z-cross-account.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-cross-account.iso.test.ts
@@ -1,4 +1,4 @@
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
 import {
   assertArrayLength,
   assertFalse,
@@ -7,6 +7,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { createSimIamRoleWithPolicy } from "../../../../test/iam/create-role-with-policy.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimIamPolicyDocument } from "../policy/sim-iam-policy.js";
 import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
@@ -41,36 +42,15 @@ async function callerRole(
   simAws: SimAws,
   effect: "Allow" | "Deny",
 ): Promise<void> {
-  const iam = simAws.account(callerAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Caller",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Caller",
-      PolicyName: "ReadReports",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: effect,
-          Action: "s3:GetObject",
-          Resource: objectArn,
-        },
-      }),
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: callerAccountId,
+    roleName: "Caller",
+    policyName: "ReadReports",
+    action: "s3:GetObject",
+    resource: objectArn,
+    effect,
+  });
 }
 
 /**

--- a/src/service/iam/authorize/sim-iam-auth-z-cross-account.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-cross-account.iso.test.ts
@@ -1,0 +1,296 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimIamPolicyDocument } from "../policy/sim-iam-policy.js";
+import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
+
+const ownerAccountId = "111111111111";
+const callerAccountId = "222222222222";
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
+const objectArn = "arn:aws:s3:::reports-bucket/summary.csv";
+
+/**
+ * A resource policy on the object granting the other Account's Role.
+ */
+function grantingResourcePolicy(
+  effect: "Allow" | "Deny",
+): SimIamPolicyDocument {
+  return {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: effect,
+      Principal: { AWS: callerRoleArn },
+      Action: "s3:GetObject",
+      Resource: objectArn,
+    },
+  };
+}
+
+/**
+ * Create the calling Role in its own Account, with an inline policy of the
+ * given effect for reading the object.
+ */
+async function callerRole(
+  simAws: SimAws,
+  effect: "Allow" | "Deny",
+): Promise<void> {
+  const iam = simAws.account(callerAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Caller",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Caller",
+      PolicyName: "ReadReports",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: effect,
+          Action: "s3:GetObject",
+          Resource: objectArn,
+        },
+      }),
+    }),
+  );
+}
+
+/**
+ * Authorize the other Account's Role against the resource-owning Account.
+ */
+function authorizeCaller(
+  simAws: SimAws,
+  resourcePolicy: SimIamPolicyDocument,
+  callerArn: string = callerRoleArn,
+): ReturnType<ReturnType<SimAws["iam"]>["authorize"]> {
+  return simAws
+    .account(ownerAccountId)
+    .iam()
+    .authorize({
+      action: "s3:GetObject",
+      resource: objectArn,
+      caller: { kind: "arn", arn: callerArn },
+      resourcePolicies: [{ document: resourcePolicy }],
+    });
+}
+
+describe("sim IAM cross-Account authorization", () => {
+  it("denies a caller allowed only by the resource policy", () => {
+    // Given a resource policy granting a Role in another Account, with nothing
+    // in that Account allowing it
+    const simAws = new SimAws();
+    simAws.account(callerAccountId).iam();
+
+    // When the request is authorized
+    const decision = authorizeCaller(simAws, grantingResourcePolicy("Allow"));
+
+    // Then it is implicitly denied: a resource policy delegates to the caller's
+    // Account rather than granting on its behalf
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.isDenied);
+    assertArrayLength(decision.resourceAllowStatements, 1);
+    assertArrayLength(decision.identityAllowStatements, 0);
+  });
+
+  it("allows a caller both Accounts allow", async () => {
+    // Given the same resource policy, and an identity policy for the Role in
+    // its own Account
+    const simAws = new SimAws();
+    await callerRole(simAws, "Allow");
+
+    // When the request is authorized
+    const decision = authorizeCaller(simAws, grantingResourcePolicy("Allow"));
+
+    // Then it is allowed, with a matching Allow from each side, as real AWS
+    // requires for a cross-Account request
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.identityAllowStatements, 1);
+    assertArrayLength(decision.resourceAllowStatements, 1);
+    assertArrayLength(decision.allowStatements, 2);
+  });
+
+  it("denies when the resource policy explicitly denies", async () => {
+    // Given a Role its own Account allows, denied by the resource policy
+    const simAws = new SimAws();
+    await callerRole(simAws, "Allow");
+
+    // When the request is authorized
+    const decision = authorizeCaller(simAws, grantingResourcePolicy("Deny"));
+
+    // Then the explicit Deny wins, as it does on either side
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertArrayLength(decision.explicitDenyStatements, 1);
+  });
+
+  it("denies when the caller's own Account explicitly denies", async () => {
+    // Given a Role granted by the resource policy, denied by its own Account
+    const simAws = new SimAws();
+    await callerRole(simAws, "Deny");
+
+    // When the request is authorized
+    const decision = authorizeCaller(simAws, grantingResourcePolicy("Allow"));
+
+    // Then the caller's Account denies the request the resource policy invited
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertArrayLength(decision.explicitDenyStatements, 1);
+  });
+
+  it("denies a caller from an Account the simulation knows nothing about", () => {
+    // Given a resource policy granting a principal in an Account that was
+    // never created in this simulation
+    const simAws = new SimAws();
+
+    // When the request is authorized
+    const decision = authorizeCaller(simAws, grantingResourcePolicy("Allow"));
+
+    // Then it is denied: an Account with no IAM state grants nothing, which is
+    // what a principal ARN nobody gave permissions to means on AWS
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("allows the other Account's root principal", () => {
+    // Given a resource policy granting the whole of another Account
+    const simAws = new SimAws();
+    simAws.account(callerAccountId).iam();
+    const rootArn = `arn:aws:iam::${callerAccountId}:root`;
+
+    // When that Account's root principal calls
+    const decision = authorizeCaller(
+      simAws,
+      {
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: callerAccountId },
+          Action: "s3:GetObject",
+          Resource: objectArn,
+        },
+      },
+      rootArn,
+    );
+
+    // Then it is allowed: the root principal carries its own Account's
+    // unrestricted access, so both sides allow the request
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.identityAllowStatements, 1);
+  });
+
+  it("allows an anonymous caller on a resource policy alone", () => {
+    // Given a resource policy open to anyone
+    const simAws = new SimAws();
+    const publicPolicy: SimIamPolicyDocument = {
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: "*",
+        Action: "s3:GetObject",
+        Resource: objectArn,
+      },
+    };
+
+    // When an anonymous request is authorized
+    const decision = simAws
+      .account(ownerAccountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: objectArn,
+        caller: { kind: "anonymous" },
+        resourcePolicies: [{ document: publicPolicy }],
+      });
+
+    // Then the resource policy is enough on its own: an anonymous caller has no
+    // Account to ask, as on AWS
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.isDenied);
+  });
+
+  it("allows a service principal on a resource policy alone", () => {
+    // Given a resource policy granting an AWS service
+    const simAws = new SimAws();
+    const servicePolicy: SimIamPolicyDocument = {
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "cloudfront.amazonaws.com" },
+        Action: "s3:GetObject",
+        Resource: objectArn,
+      },
+    };
+
+    // When that service calls
+    const decision = simAws
+      .account(ownerAccountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: objectArn,
+        caller: { kind: "service", service: "cloudfront.amazonaws.com" },
+        resourcePolicies: [{ document: servicePolicy }],
+      });
+
+    // Then the resource policy is enough on its own: a service principal has no
+    // identity policies anywhere
+    assertTrue(decision.isAllowed);
+  });
+
+  it("leaves same-Account authorization on a resource policy alone", async () => {
+    // Given a Role in the resource's own Account, with no identity policies
+    const simAws = new SimAws();
+    const iam = simAws.account(ownerAccountId).iam();
+    const roleCreation = await iam.createRole(
+      new CreateRoleCommand({
+        RoleName: "OwnAccountReader",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${ownerAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When a resource policy granting it is authorized
+    const decision = iam.authorize({
+      action: "s3:GetObject",
+      resource: objectArn,
+      caller: { kind: "arn", arn: roleCreation.Role.Arn },
+      resourcePolicies: [
+        {
+          document: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: { AWS: roleCreation.Role.Arn },
+              Action: "s3:GetObject",
+              Resource: objectArn,
+            },
+          },
+        },
+      ],
+    });
+
+    // Then either side allowing is still enough within one Account
+    assertTrue(decision.isAllowed);
+  });
+});

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -9,13 +9,18 @@ import { SimIamPolicyDecision } from "./sim-iam-decision.js";
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
 import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamAccountResolver } from "../registry/sim-iam-account-resolver.js";
+import type { SimIamAuthZPolicySource } from "./context/sim-iam-auth-z-context.js";
+import type { SimIamAccountIdentityPolicies } from "./identity/sim-iam-account-identity-policies.js";
 
 interface SimIamAuthorizerProperties {
+  readonly accountId: SimAwsAccountId;
   readonly policies: ReadonlyMap<SimArn, SimIamPolicy>;
   readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
-  readonly defaultCallerPrincipal: SimAwsPrincipal;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+  readonly iamResolver?: SimIamAccountResolver | undefined;
 }
 
 /**
@@ -26,17 +31,18 @@ interface SimIamAuthorizerProperties {
  * each SimIamPolicyDecision instance keeps the state and diagnostics for one
  * evaluated authorization attempt.
  */
-export class SimIamAuthorizer {
+export class SimIamAuthorizer implements SimIamAccountIdentityPolicies {
   private readonly contextBuilder: SimIamAuthZContextBuilder;
 
   constructor(properties: SimIamAuthorizerProperties) {
-    this.contextBuilder = new SimIamAuthZContextBuilder(
-      properties.policies,
-      properties.roles,
-      properties.users,
-      properties.defaultCallerPrincipal,
-      properties.credentialIdentityResolver,
-    );
+    this.contextBuilder = new SimIamAuthZContextBuilder({
+      accountId: properties.accountId,
+      policies: properties.policies,
+      roles: properties.roles,
+      users: properties.users,
+      credentialIdentityResolver: properties.credentialIdentityResolver,
+      iamResolver: properties.iamResolver,
+    });
   }
 
   /**
@@ -44,5 +50,14 @@ export class SimIamAuthorizer {
    */
   authorize(input: SimIamAuthorizationInput): SimIamPolicyDecision {
     return new SimIamPolicyDecision(this.contextBuilder.build(input));
+  }
+
+  /**
+   * Identity policies this Account applies to one of its own principals.
+   */
+  identityPolicySourcesFor(
+    principal: SimAwsPrincipal,
+  ): readonly SimIamAuthZPolicySource[] {
+    return this.contextBuilder.identityPolicySourcesFor(principal);
   }
 }

--- a/src/service/iam/authorize/sim-iam-decision.ts
+++ b/src/service/iam/authorize/sim-iam-decision.ts
@@ -6,6 +6,7 @@ import type {
 import { SimIamPolicyDocumentParser } from "../policy/parse/sim-iam-document-parser.js";
 import { SimIamPolicyStatementMatcher } from "./match/sim-iam-policy-statement-matcher.js";
 import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import { SimIamAllowStatements } from "./allow/sim-iam-allow-statements.js";
 
 export const SimIamPolicyDecisionValue = {
   ExplicitDeny: "ExplicitDeny",
@@ -24,10 +25,11 @@ export type SimIamPolicyDecisionValue =
  * evaluate permissions boundaries, evaluate SCPs, or enforce service command
  * access.
  *
- * The simulator currently models the common IAM authorization union:
+ * The simulator currently models the common IAM authorization rules:
  *
  * - an explicit Deny in any evaluated policy wins;
- * - an Allow in an identity policy or resource policy allows the request;
+ * - the Allows found must satisfy the request's allow requirement, which is
+ *   either side within one Account and both sides across Accounts;
  * - otherwise the request is implicitly denied.
  *
  * Resource policies are expected to be supplied by the service that owns the
@@ -39,9 +41,7 @@ export class SimIamPolicyDecision {
   private readonly statementMatcher: SimIamPolicyStatementMatcher;
   private readonly explicitDenyStatementRecords: SimIamPolicyDocumentStatement[] =
     [];
-  private readonly allowStatementRecords: SimIamPolicyDocumentStatement[] = [];
-  private readonly trustAllowStatementRecords: SimIamPolicyDocumentStatement[] =
-    [];
+  private readonly allows = new SimIamAllowStatements();
 
   constructor(
     request: SimIamAuthZContext,
@@ -72,7 +72,7 @@ export class SimIamPolicyDecision {
       return SimIamPolicyDecisionValue.ExplicitDeny;
     }
 
-    if (this.allowStatementRecords.length > 0) {
+    if (this.request.allowRequirement.isSatisfiedBy(this.allows.sides)) {
       return SimIamPolicyDecisionValue.Allow;
     }
 
@@ -113,7 +113,7 @@ export class SimIamPolicyDecision {
    * An identity-policy Allow cannot substitute for the target role's trust.
    */
   get isAllowedByTrustPolicy(): boolean {
-    return this.trustAllowStatementRecords.length > 0;
+    return this.allows.trust.length > 0;
   }
 
   /**
@@ -124,17 +124,35 @@ export class SimIamPolicyDecision {
   }
 
   /**
-   * Matching Allow statements.
+   * Matching Allow statements, from both policy sides.
+   *
+   * A statement appearing here did match the request. It does not follow that
+   * the request was allowed: a cross-Account request needs a matching Allow
+   * from each side.
    */
   get allowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.allowStatementRecords;
+    return this.allows.all;
+  }
+
+  /**
+   * Matching Allow statements from identity-based policies.
+   */
+  get identityAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
+    return this.allows.identity;
+  }
+
+  /**
+   * Matching Allow statements from resource-based policies.
+   */
+  get resourceAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
+    return this.allows.resource;
   }
 
   /**
    * Matching Allow statements originating from trust policies.
    */
   get trustAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.trustAllowStatementRecords;
+    return this.allows.trust;
   }
 
   private evaluate(): void {
@@ -159,11 +177,7 @@ export class SimIamPolicyDecision {
         continue;
       }
 
-      this.allowStatementRecords.push(statement.source);
-
-      if (policy.sourceType === "trust") {
-        this.trustAllowStatementRecords.push(statement.source);
-      }
+      this.allows.record(policy, statement.source);
     }
   }
 }

--- a/src/service/iam/command/sim-iam-command-handlers.ts
+++ b/src/service/iam/command/sim-iam-command-handlers.ts
@@ -1,0 +1,68 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimArn } from "../../aws/arn.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamActionAuthorizer } from "../authorize/sim-iam-action-authorizer.js";
+import type { SimIamInterServiceAuthZ } from "../authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamCredentialRegistry } from "../credential/sim-iam-credential-registry.js";
+import type { SimIamUserCredentialGenerator } from "../credential/user/sim-iam-user-credential-generator.js";
+import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
+import type { SimIamRole, SimIamRoleName } from "../role/sim-iam-role.js";
+import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
+import { SimIamPolicyCommandHandlers } from "./policy/sim-iam-policy-command-handlers.js";
+import { SimIamRoleCommandHandlers } from "./role/sim-iam-role-command-handlers.js";
+import { SimIamUserCommandHandlers } from "./user/sim-iam-user-command-handlers.js";
+
+interface SimIamCommandHandlersProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  readonly roles: Map<SimIamRoleName, SimIamRole>;
+  readonly users: Map<SimIamUsername, SimIamUser>;
+  readonly credentialRegistry: SimIamCredentialRegistry;
+  readonly userCredentialGenerator: SimIamUserCredentialGenerator;
+  readonly background: BackgroundScheduler;
+
+  /**
+   * IAM itself, which authorizes its own control-plane commands.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * The command handlers of one simulated IAM Account, grouped by resource.
+ *
+ * Every group authorizes against the same IAM and mutates the same Account
+ * state, so they are wired together here rather than one at a time in the
+ * service facade. That keeps SimIam what it should be: state maps plus
+ * delegation.
+ */
+export class SimIamCommandHandlers {
+  readonly roles: SimIamRoleCommandHandlers;
+  readonly users: SimIamUserCommandHandlers;
+  readonly policies: SimIamPolicyCommandHandlers;
+
+  constructor(properties: SimIamCommandHandlersProperties) {
+    const authorizer = new SimIamActionAuthorizer({ iam: properties.iam });
+
+    this.roles = new SimIamRoleCommandHandlers({
+      accountId: properties.accountId,
+      roles: properties.roles,
+      background: properties.background,
+      authorizer,
+    });
+    this.users = new SimIamUserCommandHandlers({
+      accountId: properties.accountId,
+      users: properties.users,
+      credentialRegistry: properties.credentialRegistry,
+      credentialGenerator: properties.userCredentialGenerator,
+      background: properties.background,
+      authorizer,
+    });
+    this.policies = new SimIamPolicyCommandHandlers({
+      accountId: properties.accountId,
+      policies: properties.policies,
+      users: properties.users,
+      background: properties.background,
+      authorizer,
+    });
+  }
+}

--- a/src/service/iam/registry/sim-iam-account-resolver.ts
+++ b/src/service/iam/registry/sim-iam-account-resolver.ts
@@ -13,4 +13,13 @@ export interface SimIamAccountResolver {
    * registered for the requested Account.
    */
   iamForAccount(accountId: SimAwsAccountId): SimIam;
+
+  /**
+   * Find simulated IAM for an Account, without requiring it to exist.
+   *
+   * An Account with no IAM registered is a legitimate answer rather than a
+   * fault: a request can name a principal in an Account the simulation was
+   * never told about, and that Account grants it nothing.
+   */
+  findIamForAccount(accountId: SimAwsAccountId): SimIam | undefined;
 }

--- a/src/service/iam/registry/sim-iam-registry.ts
+++ b/src/service/iam/registry/sim-iam-registry.ts
@@ -43,12 +43,19 @@ export class SimIamRegistry implements SimIamAccountResolver {
    * rely on receiving a usable account-scoped service.
    */
   iamForAccount(accountId: SimAwsAccountId): SimIam {
-    const iam = this.iamByAccountId.get(accountId);
+    const iam = this.findIamForAccount(accountId);
 
     if (iam === undefined) {
       throw new Error(`Sim IAM is not registered for Account ${accountId}`);
     }
 
     return iam;
+  }
+
+  /**
+   * Find the registered IAM facade belonging to an Account, if there is one.
+   */
+  findIamForAccount(accountId: SimAwsAccountId): SimIam | undefined {
+    return this.iamByAccountId.get(accountId);
   }
 }

--- a/src/service/iam/sim-iam-account-parts.ts
+++ b/src/service/iam/sim-iam-account-parts.ts
@@ -1,0 +1,118 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimArn } from "../aws/arn.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { SimIamAccountAuthZ } from "./authorize/sim-iam-account-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCommandHandlers } from "./command/sim-iam-command-handlers.js";
+import { SimIamCredentialRegistry } from "./credential/sim-iam-credential-registry.js";
+import {
+  SimIamRandomSessionCredentialGenerator,
+  type SimIamSessionCredentialGenerator,
+} from "./credential/session/sim-iam-session-cred-gen.js";
+import { SimIamSessionManager } from "./credential/session/sim-iam-session-manager.js";
+import {
+  SimIamRandomUserCredentialGenerator,
+  type SimIamUserCredentialGenerator,
+} from "./credential/user/sim-iam-user-credential-generator.js";
+import type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
+import type { SimIamAccountResolver } from "./registry/sim-iam-account-resolver.js";
+import type { SimIamRole, SimIamRoleName } from "./role/sim-iam-role.js";
+import type { SimIamUser, SimIamUsername } from "./user/sim-iam-user.js";
+
+export interface SimIamProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly background?: BackgroundScheduler;
+  readonly credentialRegistry?: SimIamCredentialRegistry;
+  readonly sessionCredentialGenerator?: SimIamSessionCredentialGenerator;
+  readonly userCredentialGenerator?: SimIamUserCredentialGenerator;
+
+  /**
+   * Resolves the IAM of other Accounts in the same simulation.
+   *
+   * A cross-Account request is decided in both Accounts, so deciding one needs
+   * a way to reach the caller's own Account. A standalone SimIam has no
+   * simulation around it and so leaves this out.
+   */
+  readonly iamResolver?: SimIamAccountResolver;
+}
+
+/**
+ * The state and collaborators of one simulated IAM Account.
+ *
+ * SimIam is the SDK-facing facade. This class is what it is a facade over: the
+ * Account's stored Roles, Users and Policies, the credential registry and
+ * session manager, and the authorization and command-handling collaborators
+ * that work on them. Keeping the construction and defaulting rules here leaves
+ * the facade as state plus delegation.
+ */
+export class SimIamAccountParts {
+  readonly accountId: SimAwsAccountId;
+  readonly background: BackgroundScheduler;
+  readonly credentials: SimIamCredentialRegistry;
+  readonly sessionManager: SimIamSessionManager;
+  readonly accountAuthZ: SimIamAccountAuthZ;
+
+  readonly policies = new Map<SimArn, SimIamManagedPolicy>();
+  readonly roles = new Map<SimIamRoleName, SimIamRole>();
+  readonly users = new Map<SimIamUsername, SimIamUser>();
+
+  private readonly userCredentialGenerator: SimIamUserCredentialGenerator;
+
+  constructor(properties: SimIamProperties) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      background = new BackgroundTasks(),
+      sessionCredentialGenerator = new SimIamRandomSessionCredentialGenerator(),
+      userCredentialGenerator = new SimIamRandomUserCredentialGenerator(),
+    } = properties;
+
+    // The scheduler is this simulation's clock, so session expiry is judged in
+    // the same time as every other simulated timestamp.
+    const credentialRegistry =
+      properties.credentialRegistry ??
+      new SimIamCredentialRegistry({ clock: background });
+
+    this.accountId = accountRegionScope.accountId;
+    this.background = background;
+    this.credentials = credentialRegistry;
+    this.userCredentialGenerator = userCredentialGenerator;
+    this.sessionManager = new SimIamSessionManager({
+      accountId: this.accountId,
+      roles: this.roles,
+      credentialRegistry,
+      credentialGenerator: sessionCredentialGenerator,
+    });
+    this.accountAuthZ = new SimIamAccountAuthZ({
+      accountId: this.accountId,
+      policies: this.policies,
+      roles: this.roles,
+      users: this.users,
+      credentialIdentityResolver: credentialRegistry,
+      iamResolver: properties.iamResolver,
+    });
+  }
+
+  /**
+   * Make the command handlers for this Account.
+   *
+   * IAM authorizes its own control-plane commands, so the handlers need the
+   * service facade the commands arrive at and cannot be built before it.
+   */
+  commandHandlers(iam: SimIamInterServiceAuthZ): SimIamCommandHandlers {
+    return new SimIamCommandHandlers({
+      accountId: this.accountId,
+      policies: this.policies,
+      roles: this.roles,
+      users: this.users,
+      credentialRegistry: this.credentials,
+      userCredentialGenerator: this.userCredentialGenerator,
+      background: this.background,
+      iam,
+    });
+  }
+}

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -1,6 +1,5 @@
 import type { SimArn } from "../aws/arn.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
 import type {
   SimCreatePolicyCommand,
   SimCreatePolicyCommandOutput,
@@ -14,10 +13,6 @@ import type {
   SimListPoliciesCommand,
   SimListPoliciesCommandOutput,
 } from "./command/policy/list-policies/list-policies.command.js";
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
 import type {
   SimCreateRoleCommand,
   SimCreateRoleCommandOutput,
@@ -31,7 +26,6 @@ import type {
   SimListRolesCommand,
   SimListRolesCommandOutput,
 } from "./command/role/list-roles/list-roles.command.js";
-import { SimIamRoleCommandHandlers } from "./command/role/sim-iam-role-command-handlers.js";
 import type { SimIamAuthorizationInput } from "./authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamPolicyDecision } from "./authorize/sim-iam-decision.js";
 import type {
@@ -42,17 +36,6 @@ import type {
   SimAttachRolePolicyCommand,
   SimAttachRolePolicyCommandOutput,
 } from "./command/role/attach-role-policy/attach-role-policy.command.js";
-import { SimIamCredentialRegistry } from "./credential/sim-iam-credential-registry.js";
-import {
-  SimIamRandomSessionCredentialGenerator,
-  type SimIamSessionCredentialGenerator,
-} from "./credential/session/sim-iam-session-cred-gen.js";
-import { SimIamSessionManager } from "./credential/session/sim-iam-session-manager.js";
-import {
-  SimIamRandomUserCredentialGenerator,
-  type SimIamUserCredentialGenerator,
-} from "./credential/user/sim-iam-user-credential-generator.js";
-import type { SimIamUser, SimIamUsername } from "./user/sim-iam-user.js";
 import type {
   SimCreateUserCommand,
   SimCreateUserCommandOutput,
@@ -61,10 +44,6 @@ import type {
   SimCreateAccessKeyCommand,
   SimCreateAccessKeyCommandOutput,
 } from "./command/user/create-access-key/create-access-key.command.js";
-import { SimIamUserCommandHandlers } from "./command/user/sim-iam-user-command-handlers.js";
-import { SimIamPolicyCommandHandlers } from "./command/policy/sim-iam-policy-command-handlers.js";
-import { SimIamActionAuthorizer } from "./authorize/sim-iam-action-authorizer.js";
-import { SimIamAccountAuthZ } from "./authorize/sim-iam-account-auth-z.js";
 import type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";
 import type {
   SimPutUserPolicyCommand,
@@ -73,16 +52,19 @@ import type {
 import { SimIamCloudFormationResourceFactory } from "./cfn/sim-cfn-iam-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamAccountIdentityPolicies } from "./authorize/identity/sim-iam-account-identity-policies.js";
+import type { SimIamAuthZPolicySource } from "./authorize/context/sim-iam-auth-z-context.js";
+import type { SimAwsPrincipal } from "../aws/caller/sim-aws-caller.js";
 import { SimIamSdkCommandRouter } from "./sdk/sim-iam-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
-
-interface SimIamProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly background?: BackgroundScheduler;
-  readonly credentialRegistry?: SimIamCredentialRegistry;
-  readonly sessionCredentialGenerator?: SimIamSessionCredentialGenerator;
-  readonly userCredentialGenerator?: SimIamUserCredentialGenerator;
-}
+import type { SimIamCredentialRegistry } from "./credential/sim-iam-credential-registry.js";
+import type { SimIamSessionManager } from "./credential/session/sim-iam-session-manager.js";
+import type { SimIamAccountAuthZ } from "./authorize/sim-iam-account-auth-z.js";
+import type { SimIamCommandHandlers } from "./command/sim-iam-command-handlers.js";
+import {
+  SimIamAccountParts,
+  type SimIamProperties,
+} from "./sim-iam-account-parts.js";
 
 /**
  * Simulated IAM service facade. Handles SDK commands. Emulates AWS behaviour
@@ -92,7 +74,17 @@ interface SimIamProperties {
  * scope for consistency with the other service factories, but memoises one
  * service facade per Account.
  */
-export class SimIam implements SimIamInterServiceAuthZ {
+export class SimIam
+  implements SimIamInterServiceAuthZ, SimIamAccountIdentityPolicies
+{
+  /**
+   * The simulated AWS Account this IAM belongs to.
+   *
+   * A standalone SimIam generates one, so this is how a test naming its own
+   * principals finds out which Account they should belong to.
+   */
+  public readonly accountId: SimAwsAccountId;
+
   /**
    * Manage temporary sessions belonging to this simulated IAM Account.
    */
@@ -100,70 +92,25 @@ export class SimIam implements SimIamInterServiceAuthZ {
 
   public readonly credentials: SimIamCredentialRegistry;
 
-  public readonly policies = new Map<SimArn, SimIamManagedPolicy>();
-  public readonly roles = new Map<SimIamRoleName, SimIamRole>();
-  private readonly users = new Map<SimIamUsername, SimIamUser>();
+  public readonly policies: Map<SimArn, SimIamManagedPolicy>;
+  public readonly roles: Map<SimIamRoleName, SimIamRole>;
 
-  private readonly background: BackgroundScheduler;
   private readonly cfnFactory: SimCfnServiceResourceFactory;
-  private readonly roleCommands: SimIamRoleCommandHandlers;
-  private readonly userCommands: SimIamUserCommandHandlers;
-  private readonly policyCommands: SimIamPolicyCommandHandlers;
+  private readonly commands: SimIamCommandHandlers;
   private readonly accountAuthZ: SimIamAccountAuthZ;
   private readonly sdkRouter = new SimIamSdkCommandRouter(this);
 
   constructor(properties: SimIamProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      background = new BackgroundTasks(),
-      sessionCredentialGenerator = new SimIamRandomSessionCredentialGenerator(),
-      userCredentialGenerator = new SimIamRandomUserCredentialGenerator(),
-    } = properties;
+    const parts = new SimIamAccountParts(properties);
 
-    // The scheduler is this simulation's clock, so session expiry is judged in
-    // the same time as every other simulated timestamp.
-    const credentialRegistry =
-      properties.credentialRegistry ??
-      new SimIamCredentialRegistry({ clock: background });
-
-    this.background = background;
-    this.credentials = credentialRegistry;
-    this.sessionManager = new SimIamSessionManager({
-      accountId: accountRegionScope.accountId,
-      roles: this.roles,
-      credentialRegistry,
-      credentialGenerator: sessionCredentialGenerator,
-    });
+    this.accountId = parts.accountId;
+    this.policies = parts.policies;
+    this.roles = parts.roles;
+    this.credentials = parts.credentials;
+    this.sessionManager = parts.sessionManager;
+    this.accountAuthZ = parts.accountAuthZ;
+    this.commands = parts.commandHandlers(this);
     this.cfnFactory = new SimIamCloudFormationResourceFactory(this);
-    this.accountAuthZ = new SimIamAccountAuthZ({
-      accountId: accountRegionScope.accountId,
-      policies: this.policies,
-      roles: this.roles,
-      users: this.users,
-      credentialIdentityResolver: credentialRegistry,
-    });
-    const authorizer = new SimIamActionAuthorizer({ iam: this });
-    this.roleCommands = new SimIamRoleCommandHandlers({
-      accountId: accountRegionScope.accountId,
-      roles: this.roles,
-      background: this.background,
-      authorizer,
-    });
-    this.userCommands = new SimIamUserCommandHandlers({
-      accountId: accountRegionScope.accountId,
-      users: this.users,
-      credentialRegistry,
-      credentialGenerator: userCredentialGenerator,
-      background: this.background,
-      authorizer,
-    });
-    this.policyCommands = new SimIamPolicyCommandHandlers({
-      accountId: accountRegionScope.accountId,
-      policies: this.policies,
-      users: this.users,
-      background: this.background,
-      authorizer,
-    });
   }
 
   /**
@@ -175,13 +122,28 @@ export class SimIam implements SimIamInterServiceAuthZ {
   }
 
   /**
+   * Identity-based policies this Account applies to one of its own principals.
+   *
+   * This is how another Account's IAM asks this Account what it grants a
+   * principal of its own, which is the caller's side of a cross-Account
+   * request. Real AWS requires that side to allow the action as well as the
+   * resource's own resource-based policy.
+   * @internal
+   */
+  identityPolicySourcesFor(
+    principal: SimAwsPrincipal,
+  ): readonly SimIamAuthZPolicySource[] {
+    return this.accountAuthZ.identityPolicySourcesFor(principal);
+  }
+
+  /**
    * Handle a Create Policy Command from the SDK.
    */
   async createPolicy(
     command: SimCreatePolicyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimCreatePolicyCommandOutput> {
-    return await this.policyCommands.createPolicy(command, options);
+    return await this.commands.policies.createPolicy(command, options);
   }
 
   /**
@@ -191,7 +153,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimGetPolicyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimGetPolicyCommandOutput> {
-    return await this.policyCommands.getPolicy(command, options);
+    return await this.commands.policies.getPolicy(command, options);
   }
 
   /**
@@ -201,7 +163,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimListPoliciesCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimListPoliciesCommandOutput> {
-    return await this.policyCommands.listPolicies(command, options);
+    return await this.commands.policies.listPolicies(command, options);
   }
 
   /**
@@ -211,7 +173,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimPutRolePolicyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimPutRolePolicyCommandOutput> {
-    return await this.roleCommands.putRolePolicy(command, options);
+    return await this.commands.roles.putRolePolicy(command, options);
   }
 
   /**
@@ -221,7 +183,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimPutUserPolicyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimPutUserPolicyCommandOutput> {
-    return await this.policyCommands.putUserPolicy(command, options);
+    return await this.commands.policies.putUserPolicy(command, options);
   }
 
   /**
@@ -231,7 +193,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimCreateRoleCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimCreateRoleCommandOutput> {
-    return await this.roleCommands.createRole(command, options);
+    return await this.commands.roles.createRole(command, options);
   }
 
   /**
@@ -241,7 +203,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimAttachRolePolicyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimAttachRolePolicyCommandOutput> {
-    return await this.roleCommands.attachRolePolicy(command, options);
+    return await this.commands.roles.attachRolePolicy(command, options);
   }
 
   /**
@@ -251,7 +213,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimGetRoleCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimGetRoleCommandOutput> {
-    return await this.roleCommands.getRole(command, options);
+    return await this.commands.roles.getRole(command, options);
   }
 
   /**
@@ -261,7 +223,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimListRolesCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimListRolesCommandOutput> {
-    return await this.roleCommands.listRoles(command, options);
+    return await this.commands.roles.listRoles(command, options);
   }
 
   /**
@@ -271,7 +233,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimCreateUserCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimCreateUserCommandOutput> {
-    return await this.userCommands.createUser(command, options);
+    return await this.commands.users.createUser(command, options);
   }
 
   /**
@@ -281,7 +243,7 @@ export class SimIam implements SimIamInterServiceAuthZ {
     command: SimCreateAccessKeyCommand,
     options?: SimIamRequestOptions,
   ): Promise<SimCreateAccessKeyCommandOutput> {
-    return await this.userCommands.createAccessKey(command, options);
+    return await this.commands.users.createAccessKey(command, options);
   }
 
   /**

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -71,8 +71,8 @@ statements keyed by `StatementId`, which is how `AddPermission` and `RemovePermi
 them. `AddPermission` is a shorthand for writing a policy statement, so the permission holds the
 parts it was given and expands them into a statement on demand, rather than storing a statement
 nothing can address. The policy belongs to the function because it survives exactly as long as the
-function does, and because it is the only thing that can allow a principal from another Account,
-whose own policies this Account never sees.
+function does, and because it is this Account's half of admitting a principal from another Account:
+the other half is that Account's own identity policy, which IAM asks it for.
 
 `SimLambdaFunction` is the stored simulated resource: name, execution role ARN, scope, AWS-like
 configuration metadata, and the real handler function reference that backs it. A new function
@@ -272,11 +272,11 @@ assumed-role session is judged against the Role behind it; a request that carrie
 anonymous, owns no policies, and is denied by the same evaluation.
 
 Authorization is evaluated by the IAM of the Account that owns the function, against two policy
-sources: identity policies, which that IAM finds itself and which therefore only exist for a caller
-in the same Account, and the function's own resource policy, passed in by
-`command/authorize/sim-lambda-resource-policies.ts`. A caller from another Account has no identity
-policies here — its own Account's are not consulted — so a resource policy is the only thing that
-can allow it. The URL's auth type travels with the request as the `lambda:FunctionUrlAuthType`
+sources: identity policies belonging to the caller, and the function's own resource policy, passed
+in by `command/authorize/sim-lambda-resource-policies.ts`. For a caller from another Account, IAM
+resolves that Account through the simulation's IAM registry and reads its identity policies from
+there, then requires an allow from both sides — a resource policy on its own is not enough, exactly
+as on AWS. The URL's auth type travels with the request as the `lambda:FunctionUrlAuthType`
 condition value, which is what a Function URL grant conditions on.
 
 Only an authorized `AWS_IAM` invocation is given a caller to describe in its event, which is what
@@ -354,8 +354,6 @@ are not supported and are skipped by the CloudFormation engine with an "Unsuppor
 
 - `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function` and
   `AWS::Lambda::Url`
-- cross-account Function URL invocation, which needs a Lambda resource-based policy; `AWS_IAM`
-  URLs evaluate identity policies in the function's own Account only
 - Function URL `Cors` configuration and OPTIONS preflight handling
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
@@ -1,3 +1,4 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { GetPolicyCommand } from "@aws-sdk/client-lambda";
 import { assertTypeString } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
@@ -13,7 +14,48 @@ import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimLambdaPermission } from "../../function/policy/sim-lambda-permission.js";
 import { SimCfnLambdaPermissionCreator } from "./sim-cfn-lambda-permission-creator.js";
 
-const callerRoleArn = "arn:aws:iam::222222222222:role/Caller";
+const callerAccountId = "222222222222";
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
+
+/**
+ * The calling Role in its own Account, allowed to invoke Function URLs there.
+ *
+ * A cross-Account call needs an allow from the caller's Account as well as the
+ * grant on the function, so a template grant can only be shown to take effect
+ * with this side in place too.
+ */
+async function allowedCallerRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.account(callerAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Caller",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Caller",
+      PolicyName: "InvokeUrl",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunctionUrl",
+          Resource: "*",
+        },
+      }),
+    }),
+  );
+}
 
 function greeterTemplate(
   permissionProperties: SimCfnTemplateValueRecord,
@@ -93,7 +135,8 @@ describe("Lambda CloudFormation Permission deployment", () => {
   });
 
   it("takes effect for a request to the deployed Function URL", async () => {
-    // Given the same template deployed, with the URL requiring IAM auth
+    // Given the same template deployed, with the URL requiring IAM auth, and
+    // the granted Role allowed to invoke Function URLs by its own Account
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "greeter-stack",
@@ -105,6 +148,7 @@ describe("Lambda CloudFormation Permission deployment", () => {
       }),
     });
     await stack.waitForDeployComplete();
+    await allowedCallerRole(simAws);
     const functionUrl = stack.outputs.get("FunctionUrl")?.value;
     assertTypeString(functionUrl);
     const url = new SimAwsLocalUrl({ input: functionUrl }).toString();

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
@@ -1,8 +1,8 @@
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { GetPolicyCommand } from "@aws-sdk/client-lambda";
 import { assertTypeString } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
+import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -25,36 +25,13 @@ const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
  * with this side in place too.
  */
 async function allowedCallerRole(simAws: SimAws): Promise<void> {
-  const iam = simAws.account(callerAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Caller",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Caller",
-      PolicyName: "InvokeUrl",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "lambda:InvokeFunctionUrl",
-          Resource: "*",
-        },
-      }),
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: callerAccountId,
+    roleName: "Caller",
+    policyName: "InvokeUrl",
+    action: "lambda:InvokeFunctionUrl",
+  });
 }
 
 function greeterTemplate(

--- a/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
@@ -3,13 +3,17 @@ import {
   CreateFunctionCommand,
   InvokeCommand,
 } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 
-const callerRoleArn = "arn:aws:iam::222222222222:role/Caller";
+const ownerAccountId = "888888888888";
+const callerAccountId = "222222222222";
+const ownAccountRoleArn = `arn:aws:iam::${ownerAccountId}:role/Caller`;
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
 
 async function serveGreeter(): Promise<SimAws> {
   const simAws = new SimAws();
@@ -17,12 +21,62 @@ async function serveGreeter(): Promise<SimAws> {
   await simAws.lambda().createFunction(
     new CreateFunctionCommand({
       FunctionName: "greeter",
-      Role: "arn:aws:iam::888888888888:role/GreeterRole",
+      Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
       Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
     }),
   );
 
   return simAws;
+}
+
+/**
+ * Grant a principal `lambda:InvokeFunction` on the function itself.
+ */
+async function grantInvoke(simAws: SimAws, principal: string): Promise<void> {
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: "greeter",
+      StatementId: "AllowInvoke",
+      Action: "lambda:InvokeFunction",
+      Principal: principal,
+    }),
+  );
+}
+
+/**
+ * The calling Role, in its own Account, allowed to invoke by that Account.
+ */
+async function allowedCallerRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.account(callerAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Caller",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Caller",
+      PolicyName: "Invoke",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunction",
+          Resource: "*",
+        },
+      }),
+    }),
+  );
 }
 
 describe("Invoking a function through its resource policy", () => {
@@ -39,17 +93,43 @@ describe("Invoking a function through its resource policy", () => {
     ).rejects.toThrow(SimIamAccessDenied);
   });
 
-  it("allows a caller the function's resource policy grants", async () => {
-    // Given the same principal granted lambda:InvokeFunction on the function
+  it("allows a same-Account caller the function's resource policy grants", async () => {
+    // Given a principal in the function's own Account granted the invocation
     const simAws = await serveGreeter();
-    await simAws.lambda().addPermission(
-      new AddPermissionCommand({
-        FunctionName: "greeter",
-        StatementId: "AllowInvoke",
-        Action: "lambda:InvokeFunction",
-        Principal: callerRoleArn,
+    await grantInvoke(simAws, ownAccountRoleArn);
+
+    // When they invoke it
+    const output = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "greeter" }), {
+        caller: { kind: "arn", arn: ownAccountRoleArn },
+      });
+
+    // Then the grant is enough on its own within one Account, which is what
+    // AddPermission is for
+    expect(output.StatusCode).toBe(200);
+  });
+
+  it("refuses a cross-Account caller its own Account does not allow", async () => {
+    // Given a principal from another Account granted only by this function
+    const simAws = await serveGreeter();
+    await grantInvoke(simAws, callerRoleArn);
+
+    // When they invoke it
+    // Then it is denied: AWS also requires the caller's own Account to allow
+    // the action, and nothing there does
+    await expect(
+      simAws.lambda().invoke(new InvokeCommand({ FunctionName: "greeter" }), {
+        caller: { kind: "arn", arn: callerRoleArn },
       }),
-    );
+    ).rejects.toThrow(SimIamAccessDenied);
+  });
+
+  it("allows a cross-Account caller both Accounts allow", async () => {
+    // Given the same grant, plus an identity policy in the caller's Account
+    const simAws = await serveGreeter();
+    await grantInvoke(simAws, callerRoleArn);
+    await allowedCallerRole(simAws);
 
     // When they invoke it
     const output = await simAws
@@ -58,7 +138,7 @@ describe("Invoking a function through its resource policy", () => {
         caller: { kind: "arn", arn: callerRoleArn },
       });
 
-    // Then the grant is enough on its own, which is what AddPermission is for
+    // Then both sides allow it, as real AWS requires for a cross-Account call
     expect(output.StatusCode).toBe(200);
   });
 });

--- a/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
@@ -3,9 +3,9 @@ import {
   CreateFunctionCommand,
   InvokeCommand,
 } from "@aws-sdk/client-lambda";
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
 
+import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
@@ -47,36 +47,13 @@ async function grantInvoke(simAws: SimAws, principal: string): Promise<void> {
  * The calling Role, in its own Account, allowed to invoke by that Account.
  */
 async function allowedCallerRole(simAws: SimAws): Promise<void> {
-  const iam = simAws.account(callerAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Caller",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Caller",
-      PolicyName: "Invoke",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "lambda:InvokeFunction",
-          Resource: "*",
-        },
-      }),
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: callerAccountId,
+    roleName: "Caller",
+    policyName: "Invoke",
+    action: "lambda:InvokeFunction",
+  });
 }
 
 describe("Invoking a function through its resource policy", () => {

--- a/src/service/lambda/serve/sim-lambda-url-cross-account.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-cross-account.iso.test.ts
@@ -6,13 +6,12 @@ import {
 } from "@aws-sdk/client-lambda";
 import {
   CreateAccessKeyCommand,
-  CreateRoleCommand,
   CreateUserCommand,
-  PutRolePolicyCommand,
   PutUserPolicyCommand,
 } from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
 
+import { createSimIamRoleWithPolicy } from "../../../../test/iam/create-role-with-policy.js";
 import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
 import type { SignAwsRequestCredentials } from "../../../../test/sigv4/sign-aws-request.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
@@ -99,29 +98,13 @@ async function grantInvokeUrl(
  * alongside the resource policy on the function.
  */
 async function allowedCallerRole(simAws: SimAws): Promise<void> {
-  const iam = simAws.account(callerAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Caller",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Caller",
-      PolicyName: "InvokeUrl",
-      PolicyDocument: invokeUrlPolicyDocument,
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: callerAccountId,
+    roleName: "Caller",
+    policyName: "InvokeUrl",
+    action: "lambda:InvokeFunctionUrl",
+  });
 }
 
 /**

--- a/src/service/lambda/serve/sim-lambda-url-cross-account.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-cross-account.iso.test.ts
@@ -6,7 +6,9 @@ import {
 } from "@aws-sdk/client-lambda";
 import {
   CreateAccessKeyCommand,
+  CreateRoleCommand,
   CreateUserCommand,
+  PutRolePolicyCommand,
   PutUserPolicyCommand,
 } from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
@@ -22,6 +24,15 @@ import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.j
 const ownerAccountId = "111111111111";
 const callerAccountId = "222222222222";
 const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
+
+const invokeUrlPolicyDocument = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Action: "lambda:InvokeFunctionUrl",
+    Resource: "*",
+  },
+});
 
 interface CrossAccountFunction {
   readonly simAws: SimAws;
@@ -81,6 +92,39 @@ async function grantInvokeUrl(
 }
 
 /**
+ * The calling Role in its own Account, allowed to invoke Function URLs by that
+ * Account's own identity policy.
+ *
+ * This is the caller's half of a cross-Account request, which AWS requires
+ * alongside the resource policy on the function.
+ */
+async function allowedCallerRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.account(callerAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Caller",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Caller",
+      PolicyName: "InvokeUrl",
+      PolicyDocument: invokeUrlPolicyDocument,
+    }),
+  );
+}
+
+/**
  * A signing User in the caller's own Account, allowed to invoke the URL by
  * that Account's own identity policy.
  */
@@ -94,14 +138,7 @@ async function callerAccountUser(
     new PutUserPolicyCommand({
       UserName: "Caller",
       PolicyName: "InvokeUrl",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "lambda:InvokeFunctionUrl",
-          Resource: "*",
-        },
-      }),
+      PolicyDocument: invokeUrlPolicyDocument,
     }),
   );
 
@@ -125,13 +162,29 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       headers: { [simAwsCallerHeaderName]: callerRoleArn },
     });
 
-    // Then it is refused: the owning Account has no policies for a principal
-    // it did not create, so nothing can allow the call
+    // Then it is refused: neither Account allows the call
     expect(response.status).toBe(403);
   });
 
-  it("invokes for a principal from another Account that was granted the URL", async () => {
-    // Given the other Account's Role granted permission on the function
+  it("invokes for a principal both Accounts allow", async () => {
+    // Given the other Account's Role granted permission on the function, and
+    // allowed to invoke Function URLs by its own Account
+    const { simAws, url } = await serveOwnedFunction();
+    await grantInvokeUrl(simAws);
+    await allowedCallerRole(simAws);
+
+    // When that Role calls the URL
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { [simAwsCallerHeaderName]: callerRoleArn },
+    });
+
+    // Then it is admitted, which is the only way a cross-account call can be
+    // allowed: an allow from each side
+    expect(response.status).toBe(200);
+  });
+
+  it("refuses a principal its own Account does not allow", async () => {
+    // Given only the function's own grant to the other Account's Role
     const { simAws, url } = await serveOwnedFunction();
     await grantInvokeUrl(simAws);
 
@@ -140,15 +193,33 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       headers: { [simAwsCallerHeaderName]: callerRoleArn },
     });
 
-    // Then the resource policy is what admits it, which is the only way a
-    // cross-account call can be allowed at all
-    expect(response.status).toBe(200);
+    // Then it is refused: a resource policy delegates to the caller's Account
+    // rather than granting on its behalf, and nothing there allows the action
+    expect(response.status).toBe(403);
+  });
+
+  it("refuses a principal the function's Account did not grant", async () => {
+    // Given a Role its own Account allows to invoke any Function URL, with no
+    // grant on the function
+    const { simAws, url } = await serveOwnedFunction();
+    await allowedCallerRole(simAws);
+
+    // When that Role calls the URL
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { [simAwsCallerHeaderName]: callerRoleArn },
+    });
+
+    // Then it is refused: an Account cannot grant itself access to another
+    // Account's function
+    expect(response.status).toBe(403);
   });
 
   it("refuses again once the permission is removed", async () => {
-    // Given a granted permission that is then revoked
+    // Given a granted permission that is then revoked, with the caller's own
+    // Account still allowing the action
     const { simAws, url } = await serveOwnedFunction();
     await grantInvokeUrl(simAws);
+    await allowedCallerRole(simAws);
     await simAws
       .account(ownerAccountId)
       .lambda()
@@ -169,7 +240,8 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
   });
 
   it("admits a signed cross-account request", async () => {
-    // Given a User in the other Account holding an access key, granted the URL
+    // Given a User in the other Account holding an access key, allowed to
+    // invoke by its own Account and granted the URL by the function's
     const { simAws, url } = await serveOwnedFunction();
     const credentials = await callerAccountUser(simAws);
     await simAws
@@ -191,13 +263,15 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       signed.request,
     );
 
-    // Then the signature identifies them and the resource policy admits them
+    // Then the signature identifies them and both Accounts admit them
     expect(response.status).toBe(200);
   });
 
   it("does not let an Invoke grant open the Function URL", async () => {
-    // Given the other Account's Role granted only the Invoke API action
+    // Given the other Account's Role granted only the Invoke API action, while
+    // its own Account allows it to invoke Function URLs
     const { simAws, url } = await serveOwnedFunction();
+    await allowedCallerRole(simAws);
     await simAws
       .account(ownerAccountId)
       .lambda()
@@ -224,6 +298,7 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
     // Given a grant conditioned on the URL being public, not IAM-authenticated
     const { simAws, url } = await serveOwnedFunction();
     await grantInvokeUrl(simAws, "NONE");
+    await allowedCallerRole(simAws);
 
     // When the Role calls the AWS_IAM URL
     const response = await new SimAwsHttp({ simAws }).fetch(url, {
@@ -239,6 +314,7 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
     // Given the same grant, conditioned on the auth type the URL actually has
     const { simAws, url } = await serveOwnedFunction();
     await grantInvokeUrl(simAws, "AWS_IAM");
+    await allowedCallerRole(simAws);
 
     // When the Role calls the URL
     const response = await new SimAwsHttp({ simAws }).fetch(url, {

--- a/src/service/s3/command/get-object/get-object-cross-account.iso.test.ts
+++ b/src/service/s3/command/get-object/get-object-cross-account.iso.test.ts
@@ -1,4 +1,3 @@
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateBucketCommand,
   GetObjectCommand,
@@ -13,6 +12,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3 } from "../../sim-s3.js";
@@ -61,36 +61,14 @@ async function grantingBucket(simAws: SimAws): Promise<SimS3> {
  * The reading Role in its own Account, allowed to read the Object there.
  */
 async function allowedReaderRole(simAws: SimAws): Promise<void> {
-  const iam = simAws.account(callerAccountId).iam();
-
-  await iam.createRole(
-    new CreateRoleCommand({
-      RoleName: "Reader",
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-
-  await iam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: "Reader",
-      PolicyName: "ReadSharedReports",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "s3:GetObject",
-          Resource: "arn:aws:s3:::shared-reports/*",
-        },
-      }),
-    }),
-  );
+  await createSimIamRoleWithPolicy({
+    simAws,
+    accountId: callerAccountId,
+    roleName: "Reader",
+    policyName: "ReadSharedReports",
+    action: "s3:GetObject",
+    resource: "arn:aws:s3:::shared-reports/*",
+  });
 }
 
 describe("S3 GetObjectCommand cross-Account Bucket policy", () => {

--- a/src/service/s3/command/get-object/get-object-cross-account.iso.test.ts
+++ b/src/service/s3/command/get-object/get-object-cross-account.iso.test.ts
@@ -1,0 +1,138 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3 } from "../../sim-s3.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+const ownerAccountId = "111111111111";
+const callerAccountId = "222222222222";
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Reader`;
+
+/**
+ * A Bucket in one Account holding one Object, with a Bucket policy granting the
+ * other Account's Role read access to it.
+ */
+async function grantingBucket(simAws: SimAws): Promise<SimS3> {
+  const simS3 = simAws.account(ownerAccountId).s3();
+
+  await simS3.createBucket(
+    new CreateBucketCommand({ Bucket: "shared-reports" }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "shared-reports",
+      Key: "summary.csv",
+      Body: "period,total\n2026-07,42\n",
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "shared-reports",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: callerRoleArn },
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::shared-reports/*",
+        },
+      }),
+    }),
+  );
+
+  return simS3;
+}
+
+/**
+ * The reading Role in its own Account, allowed to read the Object there.
+ */
+async function allowedReaderRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.account(callerAccountId).iam();
+
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Reader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Reader",
+      PolicyName: "ReadSharedReports",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::shared-reports/*",
+        },
+      }),
+    }),
+  );
+}
+
+describe("S3 GetObjectCommand cross-Account Bucket policy", () => {
+  it("refuses a Role its own Account does not allow", async () => {
+    // Given a Bucket policy granting another Account's Role, with nothing in
+    // that Account allowing it
+    const simAws = new SimAws();
+    const simS3 = await grantingBucket(simAws);
+    simAws.account(callerAccountId).iam();
+
+    // When that Role reads the Object
+    // Then it is denied: real AWS requires the caller's Account to allow the
+    // action as well as the Bucket policy
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simS3.getObject(
+          new GetObjectCommand({
+            Bucket: "shared-reports",
+            Key: "summary.csv",
+          }),
+          { caller: { kind: "arn", arn: callerRoleArn } },
+        ),
+    );
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("reads the Object when both Accounts allow it", async () => {
+    // Given the same Bucket policy, and an identity policy for the Role in its
+    // own Account
+    const simAws = new SimAws();
+    const simS3 = await grantingBucket(simAws);
+    await allowedReaderRole(simAws);
+
+    // When that Role reads the Object
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "shared-reports", Key: "summary.csv" }),
+      { caller: { kind: "arn", arn: callerRoleArn } },
+    );
+
+    // Then the read succeeds, with an allow from each Account
+    assertNonNullable(output.Body);
+    const body = await simS3BodyToBuffer(output.Body);
+    assertIdentical(body.toString("utf8"), "period,total\n2026-07,42\n");
+  });
+});

--- a/test/iam/create-role-with-policy.ts
+++ b/test/iam/create-role-with-policy.ts
@@ -1,0 +1,82 @@
+/**
+ * Creates a simulated IAM Role with one inline policy statement.
+ *
+ * Cross-Account tests all need the caller's own half of the request: a Role in
+ * the caller's Account whose identity policy allows the action. Every such test
+ * was building the same Role and trust policy, so the setup lives here instead.
+ *
+ * This lives under `test/` for the same reasons as `test/sigv4/`: several test
+ * files share it, and eslint rejects a test file that exports helpers alongside
+ * its own `describe` calls. `test/**` is type-checked with everything else,
+ * excluded from the published build, not collected as a suite, and not counted
+ * in coverage.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+
+export interface CreateSimIamRoleWithPolicyInput {
+  readonly simAws: SimAws;
+
+  /**
+   * The Account the Role belongs to, which is the Account whose policies decide
+   * the caller's side of a request.
+   */
+  readonly accountId: string;
+
+  readonly roleName: string;
+  readonly policyName: string;
+  readonly action: string;
+
+  /**
+   * The resource the statement covers, defaulting to every resource.
+   */
+  readonly resource?: string;
+
+  /**
+   * The statement's effect, so a test can give the Role a Deny to prove that an
+   * explicit Deny on the caller's side denies the request.
+   */
+  readonly effect?: "Allow" | "Deny";
+}
+
+/**
+ * Create the Role and put its inline policy, returning the Role ARN.
+ */
+export async function createSimIamRoleWithPolicy(
+  input: CreateSimIamRoleWithPolicyInput,
+): Promise<string> {
+  const iam = input.simAws.account(input.accountId).iam();
+
+  const roleCreation = await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: input.roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${input.accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: input.roleName,
+      PolicyName: input.policyName,
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: input.effect ?? "Allow",
+          Action: input.action,
+          Resource: input.resource ?? "*",
+        },
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}


### PR DESCRIPTION
Sim IAM decided a cross-Account request entirely in the Account owning the resource, so a resource policy alone admitted a principal from another Account. Real AWS requires an allow from each side, and the divergence failed open: a test passed here and got a 403 on AWS.

IAM now resolves the caller's own Account through the IAM registry and requires an Allow from both sides when the caller and resource belong to different Accounts. An explicit Deny on either side still denies, callers with no identity side are unaffected, and same-Account authorization is unchanged. Cross-Account tests granting only a resource policy now fail and have been updated to grant both sides.

Resolves https://github.com/KensioSoftware/yulin/issues/187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-account IAM authorization support requiring both the resource owner’s policy and the caller’s identity policy to allow access.
  * Extended cross-account authorization to Lambda invocations, Function URLs, and S3 object access.
  * Added examples demonstrating cross-account permission evaluation.

* **Bug Fixes**
  * Requests from caller accounts not present in the simulation are now denied consistently.

* **Documentation**
  * Updated IAM and Lambda documentation to clarify cross-account authorization rules, decision details, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->