### PR TITLE
feat: simulated clock time inside sim Lambda handlers

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -863,6 +863,20 @@ actually changes what your code sees:
 - a declared variable whose name the host process also sets, with a different value
 - two simulated functions declaring the same variable name with different values
 
+## The time inside a handler
+
+A function runs on its simulation's clock, and so does the function code: `Date.now()` and
+`new Date()` inside a handler report simulated time rather than the host's. Freezing the clock
+gives an invocation a constant `Date.now()`, and advancing it changes what the next invocation
+reads. `context.getRemainingTimeInMillis()` counts down against the same clock, so a frozen clock
+leaves a handler with a constant budget rather than one draining in real time.
+
+Zip code gets this from its own vm sandbox. A real in-process handler gets it from a substituted
+global `Date` that reports the invocation's clock while an invocation is running and the host clock
+otherwise, so a time read at module scope is read too early, exactly as it is for environment
+variables. See [simulated time](../../time/README.md) for the whole picture, including where real
+AWS puts the time on the event.
+
 ## CloudFormation functions
 
 Sim CloudFormation can create Lambda functions from `AWS::Lambda::Function`, typically alongside a
@@ -1171,6 +1185,10 @@ Current documented limitations:
   function only while it runs, so a variable read at module scope sees the host process value
   instead. See [Environment variables](#environment-variables).
 - `Timeout` is recorded but does not interrupt handler execution.
+- Timers inside a handler are host timers: `setTimeout` waits in real time, and advancing the
+  simulation's clock does not release a sleeping handler.
+- A time read at module scope, like an environment variable read there, is read before any
+  invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
 - `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
 - CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url` and

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -156,6 +156,93 @@ Nothing in the simulator schedules work on the clock yet, so today advancing mos
 timestamps and expiry checks see. The mechanism is there for scheduled behaviour to hook into as
 it arrives.
 
+## Time inside a simulated Lambda handler
+
+A simulated Lambda function runs on its simulation's clock, and that reaches the JavaScript clock
+the function code itself reads. `Date.now()` and `new Date()` inside a handler report simulated
+time, so code stamping an expiry or building a date-partitioned key can be tested against a clock
+the test controls:
+
+```typescript sim-clock-lambda-handler
+/**
+ * A simulated Lambda handler reading the simulation's clock.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "stamper",
+    Role: "arn:aws:iam::111111111111:role/StamperRole",
+    Code: {
+      // The handler asks JavaScript for the time, not the simulator.
+      ZipFile: makeLambdaZipFileInput(() => ({ at: new Date().toISOString() })),
+    },
+  }),
+);
+
+const first = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "stamper" }),
+);
+console.log(Buffer.from(first.Payload!).toString()); // {"at":"2026-07-26T09:00:00.000Z"}
+
+await simAws.clock().advanceBy({ hours: 2 });
+
+const second = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "stamper" }),
+);
+console.log(Buffer.from(second.Payload!).toString()); // {"at":"2026-07-26T11:00:00.000Z"}
+```
+
+How that is arranged depends on where the function code runs, which is worth knowing because one
+of the two touches a process global:
+
+- **Zip code** runs in a vm sandbox owning its own globals, so it is handed a `Date` bound to the
+  simulation's clock. Nothing outside the sandbox is affected.
+- **A real in-process handler function** is a closure over the module scope it was written in, and
+  reads the global `Date` like everything else in the test run. So the global is substituted for
+  one reporting the invocation's clock while an invocation is running, and the host clock
+  otherwise, tracked with `AsyncLocalStorage` so concurrent invocations of different simulations
+  stay apart. It is installed on the first in-process invocation and never removed, but with no
+  invocation running it behaves exactly as the host's own `Date` does.
+
+Only the current time comes from the clock. `new Date("2020-03-12")`, `Date.parse(...)`,
+`Date.UTC(...)` and `instanceof Date` all behave as they always did.
+
+One thing to watch: under a frozen clock `Date.now()` returns the same number for the whole
+invocation, so handler code that waits for it to change never finishes. `resume()` before invoking
+if the code under test polls the clock.
+
+### Where real AWS gets the time
+
+Real Lambda has no current-time API. The context object carries no timestamp, only
+`getRemainingTimeInMillis()`, and no environment variable holds one, so handler code reading
+`new Date()` is reading the machine clock. What AWS does provide is the time on the event:
+
+| Event source              | Field                                             |
+| ------------------------- | ------------------------------------------------- |
+| EventBridge               | `time`                                            |
+| Function URL, API Gateway | `requestContext.timeEpoch`, `requestContext.time` |
+| S3 notification           | `Records[].eventTime`                             |
+| SNS                       | `Records[].Sns.Timestamp`                         |
+| SQS                       | `Records[].attributes.SentTimestamp`              |
+
+For a scheduled invocation AWS's advice is to use the event's `time` rather than the system clock,
+because a retry or a delayed delivery runs later than the time the work was for. Simulated Lambda
+follows the same rule where it builds events: a Function URL request carries simulated time in
+`requestContext.time` and `requestContext.timeEpoch`.
+
+Handler code that takes a clock as a dependency stays the most testable option, on real AWS and
+here, and needs none of the machinery above.
+
 ## Time over HTTP
 
 A simulation served over HTTP, through `serveSimAws` or `SimAwsHttp.fetch(...)`, stamps every
@@ -178,7 +265,12 @@ runs on a clock a test can control: `await simSdk.simAws.clock().advanceBy({ hou
 - A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that
   scheduler brings its own clock. `simAws.clock()` throws a diagnostic error rather than silently
   controlling nothing.
-- Simulated time does not affect JavaScript's own clock: `Date.now()` and `new Date()` inside code
-  under test — including inside a simulated Lambda handler — still report real time.
+- Simulated time reaches JavaScript's own clock inside a simulated Lambda invocation, and nowhere
+  else. `Date.now()` and `new Date()` in code under test that is not running as a simulated Lambda
+  function still report real time.
+- Timers are not simulated. `setTimeout` inside a handler is a host timer, so a sleeping handler
+  waits in real time and advancing the clock does not release it.
+- A time already read cannot be reached. A handler module doing `const startedAt = Date.now()` at
+  module scope read it when the test file imported the module, long before any invocation.
 - Advancing time does not re-evaluate simulated state that was already computed, such as an ACM
   certificate that has finished validating. It changes what is read from the clock next.

--- a/docs/time/sim-clock-lambda-handler.example.ts
+++ b/docs/time/sim-clock-lambda-handler.example.ts
@@ -1,0 +1,36 @@
+/**
+ * A simulated Lambda handler reading the simulation's clock.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "stamper",
+    Role: "arn:aws:iam::111111111111:role/StamperRole",
+    Code: {
+      // The handler asks JavaScript for the time, not the simulator.
+      ZipFile: makeLambdaZipFileInput(() => ({ at: new Date().toISOString() })),
+    },
+  }),
+);
+
+const first = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "stamper" }),
+);
+console.log(Buffer.from(first.Payload!).toString()); // {"at":"2026-07-26T09:00:00.000Z"}
+
+await simAws.clock().advanceBy({ hours: 2 });
+
+const second = await lambda.invoke(
+  new InvokeCommand({ FunctionName: "stamper" }),
+);
+console.log(Buffer.from(second.Payload!).toString()); // {"at":"2026-07-26T11:00:00.000Z"}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -210,6 +210,32 @@ before any invocation. `SimLambdaEnvironmentConflicts` warns about that in the t
 changes what the code sees, and stays quiet otherwise (see the usage docs section on reading
 environment variables inside the handler).
 
+### The clock function code reads
+
+A function is given its simulation's clock, and the code it runs reads that clock rather than the
+host's when it asks JavaScript for the time. `makeSimClockDate` (`src/util/clock/`) builds the
+substitute: a `Proxy` over the host `Date` whose no-argument construction and `now()` read a
+`SimClock`, and which passes everything else through. A Proxy rather than a subclass because
+`Date.prototype` and `instanceof` have to keep meaning what they meant; a second Date identity
+would quietly stop dates built elsewhere being recognised as dates.
+
+Where it is installed follows the same split as environment variables, for the same reason.
+Sandboxed zip code is simply handed the substitute as the sandbox's `Date`
+(`makeSimLambdaVmContext`), touching nothing outside. A real in-process handler is a closure over
+its own module scope, so `sim-lambda-process-clock.ts` substitutes the global `Date` and resolves
+it through an `AsyncLocalStorage` store holding the invocation's clock, reporting the host time
+whenever no invocation is running.
+
+Two details in there are load-bearing. The store is read outside itself
+(`AsyncLocalStorage.exit`) when consulting the invocation's clock, because a simulation's clock is
+usually built on `new Date()` and would otherwise re-enter the substitute forever. And the patch is
+installed lazily, on the first invocation of an in-process handler, so a test run using only zip
+code never has its `Date` replaced at all: `Date` is a much busier global than `process.env`, so
+`SimLambdaExecutableCode.runsInHostScope` decides which invocations need it.
+
+`getRemainingTimeInMillis()` reads the same clock (`sim-lambda-invoke-context-builder.ts`), so a
+stopped clock leaves a handler with a constant budget.
+
 ### Execution role
 
 Creating a function requires an execution `Role` ARN, as on real AWS. While a handler runs,
@@ -361,6 +387,7 @@ are not supported and are skipped by the CloudFormation engine with an "Unsuppor
 - `UpdateFunctionCode`, versions, aliases and qualifiers
 - Lambda Layers
 - environment variables reaching a real in-process handler's module scope (see "Environment
-  variables" above)
+  variables" above), and the same limitation for a time read there
+- timers: `setTimeout` inside a handler is a host timer, not one the simulation's clock releases
 - timeouts interrupting handler execution
 - asynchronous invocation retries and failure destinations

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -85,6 +85,9 @@ export class CreateFunctionCommandHandler implements CommandHandler<
     this.codeResolver = new SimLambdaCodeResolver({
       codeStore,
       vmSdkModuleProvider,
+      // The background scheduler is this simulation's clock, and the same one
+      // the created function is given.
+      clock: background,
     });
     this.environmentConflicts = environmentConflicts;
   }

--- a/src/service/lambda/function/code/sim-lambda-code-resolver.ts
+++ b/src/service/lambda/function/code/sim-lambda-code-resolver.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
 import type { SimLambdaCodeSource } from "./lambda-code-source.js";
@@ -15,6 +16,11 @@ import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-mo
 interface SimLambdaCodeResolverProperties {
   readonly codeStore?: SimLambdaCodeStore | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  /**
+   * Clock vm zip code reports as the current time. A handler reference needs
+   * none: it runs in the host scope, where the invocation bridges the clock.
+   */
+  readonly clock?: SimClock | undefined;
 }
 
 /**
@@ -44,6 +50,7 @@ export class SimLambdaCodeResolver {
     this.codeStore = properties.codeStore ?? new SimLambdaNoCodeStore();
     this.vmZipCodeFactory = new SimLambdaVmZipCodeFactory({
       vmSdkModuleProvider: properties.vmSdkModuleProvider,
+      clock: properties.clock,
     });
   }
 

--- a/src/service/lambda/function/code/sim-lambda-executable-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-executable-code.ts
@@ -8,6 +8,17 @@ import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
  * at invocation time rather than at function creation.
  */
 export interface SimLambdaExecutableCode {
+  /**
+   * Whether this code runs in the host process's own global scope rather than
+   * in a sandbox of its own.
+   *
+   * Code in the host scope reads the host globals, so an invocation has to
+   * bridge process.env and Date to give it the function's environment and the
+   * simulation's time. Sandboxed code already has both and needs neither
+   * global touched.
+   */
+  readonly runsInHostScope: boolean;
+
   handlerFunction(): SimLambdaHandler;
 }
 
@@ -15,6 +26,12 @@ export interface SimLambdaExecutableCode {
  * Executable code backed directly by a real handler function reference.
  */
 export class SimLambdaHandlerReferenceCode implements SimLambdaExecutableCode {
+  /**
+   * A referenced handler is a closure over the module scope it was written
+   * in, which is the host process's.
+   */
+  readonly runsInHostScope = true;
+
   constructor(private readonly handler: SimLambdaHandler) {}
 
   /**

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-factory.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
@@ -7,6 +8,7 @@ import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-mo
 
 interface SimLambdaVmZipCodeFactoryProperties {
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  readonly clock?: SimClock | undefined;
 }
 
 /**
@@ -19,9 +21,11 @@ interface SimLambdaVmZipCodeFactoryProperties {
 export class SimLambdaVmZipCodeFactory {
   private readonly vmSdkModuleProvider:
     SimLambdaVmSdkModuleProvider | undefined;
+  private readonly clock: SimClock | undefined;
 
   constructor(properties: SimLambdaVmZipCodeFactoryProperties) {
     this.vmSdkModuleProvider = properties.vmSdkModuleProvider;
+    this.clock = properties.clock;
   }
 
   /**
@@ -41,6 +45,7 @@ export class SimLambdaVmZipCodeFactory {
       handlerName: context.handlerName,
       environment: context.environment,
       sdkModuleProvider: this.vmSdkModuleProvider,
+      clock: this.clock,
     });
   }
 

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
@@ -1,3 +1,4 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimZipArchive } from "../../../../util/zip/zip-archive.js";
 import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
 import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
@@ -15,6 +16,11 @@ interface SimLambdaVmZipCodeProperties {
   readonly handlerName: string;
   readonly environment: SimLambdaEnvironment;
   readonly sdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
+  /**
+   * Clock the sandbox's Date reports, so function code asking JavaScript for
+   * the time gets the simulation's time.
+   */
+  readonly clock?: SimClock | undefined;
 }
 
 interface ParsedHandlerName {
@@ -49,6 +55,12 @@ export function parseLambdaHandlerName(handlerName: string): ParsedHandlerName {
  * invocations like a warm execution environment.
  */
 export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
+  /**
+   * The sandbox owns its own globals, so the handler needs nothing bridged
+   * from the host process to run with the simulation's environment and time.
+   */
+  readonly runsInHostScope = false;
+
   #handler: SimLambdaHandler | undefined;
 
   constructor(private readonly properties: SimLambdaVmZipCodeProperties) {}
@@ -62,13 +74,13 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
   }
 
   private coldStart(): SimLambdaHandler {
-    const { archive, handlerName, environment, sdkModuleProvider } =
+    const { archive, handlerName, environment, sdkModuleProvider, clock } =
       this.properties;
     const parsedName = parseLambdaHandlerName(handlerName);
 
     const modules = new SimLambdaVmModules({
       archive,
-      context: makeSimLambdaVmContext(environment),
+      context: makeSimLambdaVmContext(environment, clock),
       sdkModuleProvider:
         sdkModuleProvider ?? new SimLambdaNoVmSdkModuleProvider(),
     });

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-clock.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-clock.iso.test.ts
@@ -1,0 +1,111 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../make-lambda-code-zip.js";
+
+const instant = new Date("2026-01-01T00:00:00.000Z");
+
+/**
+ * Captured before anything runs, to prove zip code never reaches it.
+ */
+const hostDate = Date;
+
+/**
+ * A simulation stopped at a known instant, with a zip code function that
+ * reports the time JavaScript gives it.
+ */
+async function makeStamperSimulation(): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "stamper",
+      Role: "arn:aws:iam::111111111111:role/StamperRole",
+      Handler: "index.handler",
+      Code: {
+        ZipFile: makeLambdaCodeZip(`
+          exports.handler = async () => ({
+            built: new Date().toISOString(),
+            read: Date.now(),
+            stated: new Date("2020-03-12T19:03:58.000Z").toISOString(),
+            isADate: new Date() instanceof Date,
+          });
+        `),
+      },
+    }),
+  );
+
+  return simAws;
+}
+
+async function invokeStamper(simAws: SimAws): Promise<Record<string, unknown>> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: "stamper" }));
+
+  assertNonNullable(output.Payload);
+
+  return JSON.parse(Buffer.from(output.Payload).toString()) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("sim Lambda vm code clock", () => {
+  it("gives zip function code the simulation's time", async () => {
+    // Given a simulation stopped at a known instant.
+    const simAws = await makeStamperSimulation();
+
+    // When function code in the vm sandbox asks JavaScript for the time.
+    const stamped = await invokeStamper(simAws);
+
+    // Then it gets the simulation's time, both ways of asking.
+    assertIdentical(stamped["built"], "2026-01-01T00:00:00.000Z");
+    assertIdentical(stamped["read"], instant.getTime());
+  });
+
+  it("leaves the rest of Date alone in the sandbox", async () => {
+    // Given a simulation stopped at a known instant.
+    const simAws = await makeStamperSimulation();
+
+    // When function code builds a date from an instant it states itself.
+    const stamped = await invokeStamper(simAws);
+
+    // Then only the current time comes from the clock, and dates are still
+    // recognisable as dates.
+    assertIdentical(stamped["stated"], "2020-03-12T19:03:58.000Z");
+    assertTrue(stamped["isADate"]);
+  });
+
+  it("moves with the simulation's clock between invocations", async () => {
+    // Given a function that has already reported the time once.
+    const simAws = await makeStamperSimulation();
+    const before = await invokeStamper(simAws);
+
+    // When the simulation's clock is advanced.
+    await simAws.clock().advanceBy({ hours: 1, minutes: 30 });
+
+    // Then the next invocation reports the advanced time, rather than the
+    // time the sandbox was built at.
+    const after = await invokeStamper(simAws);
+    assertIdentical(before["built"], "2026-01-01T00:00:00.000Z");
+    assertIdentical(after["built"], "2026-01-01T01:30:00.000Z");
+  });
+
+  it("leaves the host process's own Date alone", async () => {
+    // Given a simulation whose function code has run.
+    const simAws = await makeStamperSimulation();
+    await invokeStamper(simAws);
+
+    // When the host process reads its own Date.
+    // Then nothing was substituted for it: the sandbox owns its globals, so
+    // sandboxed code needs no global patched to see simulated time.
+    assertIdentical(Date, hostDate);
+  });
+});

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -1,4 +1,9 @@
 import vm from "node:vm";
+import { makeSimClockDate } from "../../../../../util/clock/sim-clock-date.js";
+import {
+  type SimClock,
+  SimRealClock,
+} from "../../../../../util/clock/sim-clock.js";
 import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environment.js";
 
 /**
@@ -9,13 +14,14 @@ import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environm
  * and any variables declared for the function. Everything else must be part
  * of the deployed function code archive, as on real Lambda.
  *
- * Zip code needs nothing like the process.env handling the in-process handler
- * path does: this sandbox already owns its process object, so the host
- * environment is invisible here whether or not the function declares
- * variables of its own.
+ * Zip code needs nothing like the process.env and Date handling the
+ * in-process handler path does: this sandbox already owns its globals, so
+ * both the host environment and the host clock are invisible here, and
+ * nothing outside the sandbox is touched to arrange that.
  */
 export function makeSimLambdaVmContext(
   environment: SimLambdaEnvironment,
+  clock: SimClock = new SimRealClock(),
 ): vm.Context {
   return vm.createContext({
     console,
@@ -23,6 +29,9 @@ export function makeSimLambdaVmContext(
     process: {
       env: environment.variables(),
     },
+    // Function code asking JavaScript for the time gets the simulation's
+    // time, so a frozen or advanced clock reaches the code under test.
+    Date: makeSimClockDate(clock),
     setTimeout,
     clearTimeout,
     setInterval,

--- a/src/service/lambda/function/invoke/sim-lambda-process-clock.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-clock.iso.test.ts
@@ -1,0 +1,124 @@
+import { assertIdentical, assertNumberBetween } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimControllableClock } from "../../../../util/clock/sim-controllable-clock.js";
+import { simLambdaProcessClock } from "./sim-lambda-process-clock.js";
+
+const instant = new Date("2026-01-01T00:00:00.000Z");
+const laterInstant = new Date("2026-06-01T12:00:00.000Z");
+
+/**
+ * Resolve after a real pause, so a test can interleave two runs and prove
+ * they do not see each other's time.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * How far a reading is from the untouched host clock.
+ */
+function driftFromHost(milliseconds: number): number {
+  const hostDate = simLambdaProcessClock.hostDateConstructor();
+
+  return Math.abs(milliseconds - new hostDate().getTime());
+}
+
+describe("sim Lambda process clock", () => {
+  it("gives the run the simulation's time", async () => {
+    // Given a simulation stopped at a known instant.
+    const clock = new SimFixedClock(instant);
+
+    // When the time is read inside the run.
+    const insideRun = await simLambdaProcessClock.run(clock, () =>
+      Promise.resolve({ from: Date.now(), built: new Date().toISOString() }),
+    );
+
+    // Then both ways of asking got the simulation's time.
+    assertIdentical(insideRun.from, instant.getTime());
+    assertIdentical(insideRun.built, "2026-01-01T00:00:00.000Z");
+  });
+
+  it("leaves the host clock alone outside a run", async () => {
+    // Given a run that has installed the substitute Date.
+    await simLambdaProcessClock.run(new SimFixedClock(instant), () =>
+      Promise.resolve(),
+    );
+
+    // When the time is read with no run in progress.
+    const outsideRun = Date.now();
+
+    // Then it is the host's time: an installed substitute with nothing
+    // running behaves exactly like no substitute at all.
+    assertNumberBetween(driftFromHost(outsideRun), 0, 1000);
+  });
+
+  it("keeps the run's time across an await", async () => {
+    // Given a run reading the time on both sides of an await.
+    const read = await simLambdaProcessClock.run(
+      new SimFixedClock(instant),
+      async () => {
+        const before = Date.now();
+        await tick(2);
+        return { before, after: Date.now() };
+      },
+    );
+
+    // Then asynchronous context tracking carried the clock across it.
+    assertIdentical(read.before, instant.getTime());
+    assertIdentical(read.after, instant.getTime());
+  });
+
+  it("keeps concurrent runs apart", async () => {
+    // Given two runs of different simulations, overlapping in time.
+    const [first, second] = await Promise.all([
+      simLambdaProcessClock.run(new SimFixedClock(instant), async () => {
+        await tick(5);
+        return Date.now();
+      }),
+      simLambdaProcessClock.run(new SimFixedClock(laterInstant), () =>
+        Promise.resolve(Date.now()),
+      ),
+    ]);
+
+    // Then each read its own simulation's clock.
+    assertIdentical(first, instant.getTime());
+    assertIdentical(second, laterInstant.getTime());
+  });
+
+  it("follows a clock that moves between runs", async () => {
+    // Given a controllable clock stopped at a known instant.
+    const clock = new SimControllableClock();
+    clock.setTo(instant);
+    const before = await simLambdaProcessClock.run(clock, () =>
+      Promise.resolve(Date.now()),
+    );
+
+    // When it is advanced between two runs.
+    clock.advanceBy({ hours: 2 });
+    const after = await simLambdaProcessClock.run(clock, () =>
+      Promise.resolve(Date.now()),
+    );
+
+    // Then the second run saw the advanced time.
+    assertIdentical(before, instant.getTime());
+    assertIdentical(after, instant.getTime() + 2 * 60 * 60 * 1000);
+  });
+
+  it("does not re-enter a clock that reads the host clock", async () => {
+    // Given a clock that is running rather than frozen, so answering what
+    // time it is means asking the host clock, through the very Date the run
+    // has substituted.
+    const clock = new SimControllableClock();
+
+    // When the time is read inside the run.
+    const insideRun = await simLambdaProcessClock.run(clock, () =>
+      Promise.resolve(Date.now()),
+    );
+
+    // Then the read terminated, with the host's time.
+    assertNumberBetween(driftFromHost(insideRun), 0, 1000);
+  });
+});

--- a/src/service/lambda/function/invoke/sim-lambda-process-clock.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-clock.ts
@@ -1,0 +1,111 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { makeSimClockDate } from "../../../../util/clock/sim-clock-date.js";
+
+/**
+ * The clock the substitute Date reads.
+ *
+ * An invocation in progress lends its own clock; anything else in the process
+ * carries on reading the host clock, which is what keeps the substitute inert
+ * outside a sim Lambda invocation.
+ */
+class SimLambdaAmbientClock implements SimClock {
+  constructor(
+    private readonly storage: AsyncLocalStorage<SimClock>,
+    private readonly hostDate: DateConstructor,
+  ) {}
+
+  /**
+   * Get the time the code running right now should see.
+   */
+  now(): Date {
+    const invocationClock = this.storage.getStore();
+
+    if (invocationClock === undefined) {
+      return new this.hostDate();
+    }
+
+    // Read outside the store, because a simulation's clock is itself often
+    // built on `new Date()`. Left inside it, that read would come straight
+    // back here and never terminate.
+    return this.storage.exit(() => invocationClock.now());
+  }
+}
+
+/**
+ * The time a sim Lambda handler function sees while it runs.
+ *
+ * A handler backed by a real in-process function is a closure over its own
+ * module scope, so it reads the global Date like any other code in the test
+ * run. Zip code has a vm sandbox with a Date of its own and needs none of
+ * this. Node.js asynchronous context tracking bridges the gap for the
+ * in-process case, exactly as it does for process.env: the invocation's clock
+ * is held in an AsyncLocalStorage store, and Date resolves to it while it is
+ * set.
+ *
+ * The store follows the invocation across await points, so concurrent
+ * invocations of functions belonging to different simulations each read their
+ * own time.
+ *
+ * What this cannot reach is a time already read. A handler module doing
+ * `const startedAt = Date.now()` at module scope is evaluated when the test
+ * file imports it, long before any invocation.
+ */
+class SimLambdaProcessClock {
+  private readonly storage = new AsyncLocalStorage<SimClock>();
+  private hostDate: DateConstructor = Date;
+  private installed = false;
+
+  /**
+   * Run an invocation with the given clock as its sense of the current time.
+   */
+  async run<T>(clock: SimClock, run: () => Promise<T>): Promise<T> {
+    this.install();
+    return await this.storage.run(clock, run);
+  }
+
+  /**
+   * The host Date constructor, ignoring any invocation in progress.
+   */
+  hostDateConstructor(): DateConstructor {
+    return this.hostDate;
+  }
+
+  /**
+   * Replace the global Date with one backed by the invocation store.
+   *
+   * Installed on the first invocation of an in-process handler rather than at
+   * import, so a test run that never uses one is left completely alone. Date
+   * is a far busier global than process.env, and a substitute that is only
+   * ever built when something actually needs it is easier to reason about.
+   *
+   * With no invocation running the substitute reports the host time, so an
+   * installed patch behaves exactly like no patch at all. It is never removed:
+   * removing it would be unsafe while another invocation is in flight, and
+   * there is nothing to gain.
+   */
+  private install(): void {
+    if (this.installed) {
+      return;
+    }
+
+    this.hostDate = Date;
+    // Defined rather than assigned, to keep Date the configurable, writable,
+    // non-enumerable global property it already was: anything else replacing
+    // it, a test framework's fake timers included, has to find what it
+    // expects.
+    Object.defineProperty(globalThis, "Date", {
+      configurable: true,
+      writable: true,
+      value: makeSimClockDate(
+        new SimLambdaAmbientClock(this.storage, this.hostDate),
+      ),
+    });
+    this.installed = true;
+  }
+}
+
+/**
+ * Shared because it patches a process global: one patch, one store.
+ */
+export const simLambdaProcessClock = new SimLambdaProcessClock();

--- a/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
@@ -1,0 +1,128 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertNumberBetween,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "./code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "./sim-lambda-handler.type.js";
+
+const instant = new Date("2026-01-01T00:00:00.000Z");
+
+/**
+ * Captured before any invocation substitutes the global Date, so a test can
+ * still ask what the host clock really says.
+ */
+const hostDate = Date;
+
+/**
+ * A simulation stopped at a known instant, with a function backed by a real
+ * in-process handler.
+ */
+async function makeSimulation(
+  handlerFunction: SimLambdaHandler,
+): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "stamper",
+      Role: "arn:aws:iam::111111111111:role/StamperRole",
+      Code: { ZipFile: makeLambdaZipFileInput(handlerFunction) },
+    }),
+  );
+
+  return simAws;
+}
+
+async function invokeStamper(simAws: SimAws): Promise<unknown> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: "stamper" }));
+
+  assertNonNullable(output.Payload);
+
+  return JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+}
+
+describe("sim Lambda in-process handler clock", () => {
+  it("gives the handler the simulation's time", async () => {
+    // Given a simulation stopped at a known instant, with a handler that
+    // asks JavaScript for the time rather than asking the simulator.
+    const simAws = await makeSimulation(() => new Date().toISOString());
+
+    // When it is invoked.
+    const stamped = await invokeStamper(simAws);
+
+    // Then it stamped the simulation's time, not the host's.
+    assertIdentical(stamped, "2026-01-01T00:00:00.000Z");
+  });
+
+  it("keeps the simulation's time across an await in the handler", async () => {
+    // Given a handler reading the time on both sides of an await.
+    const simAws = await makeSimulation(async () => {
+      const before = Date.now();
+      await Promise.resolve();
+      return { before, after: Date.now() };
+    });
+
+    // When it is invoked.
+    const stamped = (await invokeStamper(simAws)) as Record<string, number>;
+
+    // Then the invocation's clock followed it across the await.
+    assertIdentical(stamped["before"], instant.getTime());
+    assertIdentical(stamped["after"], instant.getTime());
+  });
+
+  it("moves with the simulation's clock between invocations", async () => {
+    // Given a handler that has already stamped the time once.
+    const simAws = await makeSimulation(() => new Date().toISOString());
+    const before = await invokeStamper(simAws);
+
+    // When the simulation's clock is advanced.
+    await simAws.clock().advanceBy({ hours: 1, minutes: 30 });
+
+    // Then the next invocation stamps the advanced time.
+    const after = await invokeStamper(simAws);
+    assertIdentical(before, "2026-01-01T00:00:00.000Z");
+    assertIdentical(after, "2026-01-01T01:30:00.000Z");
+  });
+
+  it("keeps each simulation's time to itself", async () => {
+    // Given two simulations with clocks stopped at different instants.
+    const first = await makeSimulation(() => new Date().toISOString());
+    const second = new SimAws({
+      clock: new SimFixedClock(new Date("2030-06-01T12:00:00.000Z")),
+    });
+    await second.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: "arn:aws:iam::111111111111:role/StamperRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => new Date().toISOString()),
+        },
+      }),
+    );
+
+    // When a function in each is invoked.
+    // Then each handler saw the time of the simulation it belongs to.
+    assertIdentical(await invokeStamper(first), "2026-01-01T00:00:00.000Z");
+    assertIdentical(await invokeStamper(second), "2030-06-01T12:00:00.000Z");
+  });
+
+  it("leaves the host clock alone outside an invocation", async () => {
+    // Given a simulation whose handler has run, installing the substitute.
+    const simAws = await makeSimulation(() => new Date().toISOString());
+    await invokeStamper(simAws);
+
+    // When the test itself reads the time afterwards.
+    const outsideInvocation = Date.now();
+
+    // Then it is the host's own time, untouched by the simulation.
+    const drift = Math.abs(outsideInvocation - new hostDate().getTime());
+    assertNumberBetween(drift, 0, 1000);
+  });
+});

--- a/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
@@ -19,13 +19,24 @@ const instant = new Date("2026-01-01T00:00:00.000Z");
 const hostDate = Date;
 
 /**
+ * Resolve after a real pause, so an invocation can be suspended part way
+ * through while another one runs.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
  * A simulation stopped at a known instant, with a function backed by a real
  * in-process handler.
  */
 async function makeSimulation(
   handlerFunction: SimLambdaHandler,
+  stoppedAt: Date = instant,
 ): Promise<SimAws> {
-  const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+  const simAws = new SimAws({ clock: new SimFixedClock(stoppedAt) });
 
   await simAws.lambda().createFunction(
     new CreateFunctionCommand({
@@ -91,26 +102,30 @@ describe("sim Lambda in-process handler clock", () => {
     assertIdentical(after, "2026-01-01T01:30:00.000Z");
   });
 
-  it("keeps each simulation's time to itself", async () => {
-    // Given two simulations with clocks stopped at different instants.
-    const first = await makeSimulation(() => new Date().toISOString());
-    const second = new SimAws({
-      clock: new SimFixedClock(new Date("2030-06-01T12:00:00.000Z")),
+  it("keeps each simulation's time to itself while they interleave", async () => {
+    // Given two simulations with clocks stopped at different instants, each
+    // with a handler that reads the time on the far side of an await.
+    const laterInstant = new Date("2030-06-01T12:00:00.000Z");
+    const first = await makeSimulation(async () => {
+      await tick(5);
+      return new Date().toISOString();
     });
-    await second.lambda().createFunction(
-      new CreateFunctionCommand({
-        FunctionName: "stamper",
-        Role: "arn:aws:iam::111111111111:role/StamperRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(() => new Date().toISOString()),
-        },
-      }),
-    );
+    const second = await makeSimulation(async () => {
+      await tick(1);
+      return new Date().toISOString();
+    }, laterInstant);
 
-    // When a function in each is invoked.
-    // Then each handler saw the time of the simulation it belongs to.
-    assertIdentical(await invokeStamper(first), "2026-01-01T00:00:00.000Z");
-    assertIdentical(await invokeStamper(second), "2030-06-01T12:00:00.000Z");
+    // When both are invoked at once, so each is suspended at its await while
+    // the other runs.
+    const [firstStamp, secondStamp] = await Promise.all([
+      invokeStamper(first),
+      invokeStamper(second),
+    ]);
+
+    // Then neither picked up the other's time: each read the clock of the
+    // simulation its function belongs to.
+    assertIdentical(firstStamp, "2026-01-01T00:00:00.000Z");
+    assertIdentical(secondStamp, "2030-06-01T12:00:00.000Z");
   });
 
   it("leaves the host clock alone outside an invocation", async () => {

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -11,6 +11,7 @@ import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
+import { simLambdaProcessClock } from "./invoke/sim-lambda-process-clock.js";
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import {
   defaultLambdaHandler,
@@ -226,12 +227,30 @@ export class SimLambdaFunction {
       async () =>
         await this.environment.runWith(
           async () =>
-            await this.runner.run(
-              this.code.handlerFunction(),
-              event,
-              contextBuilder,
+            await this.runWithSimulatedTime(
+              async () =>
+                await this.runner.run(
+                  this.code.handlerFunction(),
+                  event,
+                  contextBuilder,
+                ),
             ),
         ),
     );
+  }
+
+  /**
+   * Run an invocation with this simulation's time as the current time.
+   *
+   * Only code running in the host scope needs this. Zip code reads the Date
+   * its own vm sandbox was given, so a function backed by one leaves the
+   * global Date alone entirely.
+   */
+  private async runWithSimulatedTime<T>(run: () => Promise<T>): Promise<T> {
+    if (!this.code.runsInHostScope) {
+      return await run();
+    }
+
+    return await simLambdaProcessClock.run(this.clock, run);
   }
 }

--- a/src/util/clock/sim-clock-date.iso.test.ts
+++ b/src/util/clock/sim-clock-date.iso.test.ts
@@ -1,0 +1,99 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimClockDate } from "./sim-clock-date.js";
+import { SimFixedClock } from "./sim-clock.js";
+import { SimControllableClock } from "./sim-controllable-clock.js";
+
+const instant = new Date("2026-01-01T00:00:00.000Z");
+
+/**
+ * A Date bound to a clock stopped at a known instant.
+ */
+function fixedClockDate(): DateConstructor {
+  return makeSimClockDate(new SimFixedClock(instant));
+}
+
+describe("sim clock Date", () => {
+  it("reports the clock's time from now()", () => {
+    // Given a Date bound to a clock stopped at a known instant.
+    const simDate = fixedClockDate();
+
+    // When the current time is read.
+    // Then it is the clock's time rather than the host's.
+    assertIdentical(simDate.now(), instant.getTime());
+  });
+
+  it("builds the clock's time with no constructor arguments", () => {
+    // Given a Date bound to a clock stopped at a known instant.
+    const simDate = fixedClockDate();
+
+    // When a date is built without saying which instant it wants.
+    const built = new simDate();
+
+    // Then it is the clock's instant.
+    assertIdentical(built.toISOString(), "2026-01-01T00:00:00.000Z");
+  });
+
+  it("leaves a date built from an explicit instant alone", () => {
+    // Given a Date bound to a clock stopped at a known instant.
+    const simDate = fixedClockDate();
+
+    // When a date states the instant it wants.
+    const stated = new simDate("2020-03-12T19:03:58.000Z");
+    const fromParts = new simDate(Date.UTC(2020, 2, 12));
+
+    // Then the clock has nothing to do with it.
+    assertIdentical(stated.toISOString(), "2020-03-12T19:03:58.000Z");
+    assertIdentical(fromParts.toISOString(), "2020-03-12T00:00:00.000Z");
+  });
+
+  it("keeps dates recognisable as dates", () => {
+    // Given a Date bound to a clock.
+    const simDate = fixedClockDate();
+
+    // When dates from either constructor are checked against either.
+    // Then both are dates: the substitute shares one Date identity with the
+    // host, so nothing stops recognising a date it is handed.
+    assertInstanceOf(new simDate(), Date);
+    assertInstanceOf(new Date(), simDate);
+    assertIdentical(simDate.prototype, Date.prototype);
+  });
+
+  it("keeps the Date statics that do not ask for the time", () => {
+    // Given a Date bound to a clock.
+    const simDate = fixedClockDate();
+
+    // When the statics that state their own instant are used.
+    // Then they behave exactly as the host's do.
+    assertIdentical(
+      simDate.parse("2020-03-12T19:03:58.000Z"),
+      Date.parse("2020-03-12T19:03:58.000Z"),
+    );
+    assertIdentical(simDate.UTC(2020, 2, 12), Date.UTC(2020, 2, 12));
+  });
+
+  it("reports the clock's time when called without new", () => {
+    // Given a Date bound to a clock stopped at a known instant.
+    const simDate = fixedClockDate();
+
+    // When Date is called as a function, which reports a string.
+    // Then it is the clock's instant.
+    assertIdentical(simDate(), new Date(instant).toString());
+  });
+
+  it("follows the clock as it moves", () => {
+    // Given a Date bound to a controllable clock.
+    const clock = new SimControllableClock();
+    clock.setTo(instant);
+    const simDate = fixedClockDate();
+    const movingDate = makeSimClockDate(clock);
+
+    // When the clock is advanced after the Date was built.
+    clock.advanceBy({ hours: 1 });
+
+    // Then the substitute reads the clock again rather than a captured time.
+    assertIdentical(movingDate.now(), instant.getTime() + 60 * 60 * 1000);
+    // And a Date bound to a stopped clock still reports its own instant.
+    assertIdentical(simDate.now(), instant.getTime());
+  });
+});

--- a/src/util/clock/sim-clock-date.ts
+++ b/src/util/clock/sim-clock-date.ts
@@ -1,0 +1,49 @@
+import type { SimClock } from "./sim-clock.js";
+
+/**
+ * Build a Date constructor reporting a simulation's time.
+ *
+ * Controlling a simulation's clock is only half of what a test wants if the
+ * code under test asks JavaScript for the time instead of asking the
+ * simulator. This is the substitute to give that code: `Date.now()` and
+ * `new Date()` read the simulation's clock, and everything else about Date
+ * behaves as it always did.
+ *
+ * A Proxy rather than a subclass, because a subclass would introduce a second
+ * Date identity: `instanceof` and `Date.prototype` have to keep pointing at
+ * the same objects, or dates built anywhere else stop being recognised as
+ * dates by code holding this constructor.
+ *
+ * The clock is read per call, so freezing and advancing take effect on the
+ * next read rather than at the moment this is built.
+ */
+export function makeSimClockDate(clock: SimClock): DateConstructor {
+  // Captured before anything replaces the global, so a clock implemented in
+  // terms of `new Date()` cannot end up calling back into this substitute.
+  const hostDate = Date;
+  const nowMs = (): number => clock.now().getTime();
+
+  return new Proxy(hostDate, {
+    // Called without `new`, Date reports the current time as a string and
+    // ignores whatever arguments it was given.
+    apply: (): string => new hostDate(nowMs()).toString(),
+
+    construct: (target, constructorArguments: unknown[], newTarget): object => {
+      // Only the no-argument form asks for the current time. Every other form
+      // states the instant it wants, so it is left alone.
+      if (constructorArguments.length === 0) {
+        return Reflect.construct(target, [nowMs()], newTarget) as Date;
+      }
+
+      return Reflect.construct(target, constructorArguments, newTarget) as Date;
+    },
+
+    get: (target, property, receiver): unknown => {
+      if (property === "now") {
+        return nowMs;
+      }
+
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}


### PR DESCRIPTION
Date.now() and new Date() in function code now report the simulation's time. Zip code is handed a clock-bound Date by its vm sandbox; a real in-process handler gets one through an AsyncLocalStorage-backed global, installed only when such a handler actually runs.

Resolves https://github.com/KensioSoftware/yulin/issues/194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lambda functions now observe simulated time through `Date.now()` and `new Date()`.
  - Advancing the simulation clock changes timestamps returned by subsequent invocations.
  - Simulated time remains consistent across asynchronous handler operations and isolated between simulations.

- **Documentation**
  - Added guidance, examples, and limitations for simulated Lambda time behavior, including timers and module-level time reads.

- **Tests**
  - Added coverage for sandboxed and in-process Lambda clock behavior, date compatibility, concurrency, and clock advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->