### PR TITLE
feat: sim S3 Bucket policies from AWS::S3::BucketPolicy

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="CodeRabbit">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="CodeRabbit" />
+              <option name="relativePathToSchema" value="https://coderabbit.ai/integrations/schema.v2.json" />
+              <option name="applicationDefined" value="true" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value=".coderabbit.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -15,6 +15,9 @@ Sim S3 currently supports:
 - Getting Objects with `GetObjectCommand`
 - Listing Objects with `ListObjectsCommand`
 - Configuring static website hosting with `PutBucketWebsiteCommand`
+- Bucket policies with `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and
+  `DeleteBucketPolicyCommand`, evaluated by sim IAM alongside identity policies
+- Creating Buckets and Bucket policies from `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
 - Serving static website requests on localhost with `serveSimAws`
 - Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
@@ -217,6 +220,123 @@ for (const object of objectContentItems) {
 ```
 
 Object listings are sorted by key.
+
+## Bucket policies
+
+A Bucket policy is a resource policy stored on the Bucket. Sim IAM evaluates it alongside the
+caller's identity policies whenever an Object command is authorized, so a policy can grant access to
+a principal that holds no identity policy at all, including an anonymous caller.
+
+Apply one with `PutBucketPolicyCommand`, read it back with `GetBucketPolicyCommand`, and remove it
+with `DeleteBucketPolicyCommand`. Each is authorized in its own right, against `s3:PutBucketPolicy`,
+`s3:GetBucketPolicy` and `s3:DeleteBucketPolicy`.
+
+In a CloudFormation template, a Bucket policy is a separate `AWS::S3::BucketPolicy` resource rather
+than a property of `AWS::S3::Bucket`. This is what CDK synthesizes for `bucket.grantRead(...)`,
+`grantPut(...)` and `addToResourcePolicy(...)`, so a template reaches it whether or not the app
+mentions a Bucket policy itself. Sim CloudFormation attaches it through the same `PutBucketPolicy`
+path an SDK call takes, so the document is validated and enforced identically either way.
+
+```typescript sim-s3-bucket-policy
+/**
+ * Granting access to a simulated S3 Bucket with a Bucket policy.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  GetBucketPolicyCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simIam = simAws.iam();
+const simS3 = simAws.s3();
+
+// The principal the Bucket policy will name. It gets no identity policy, so
+// the Bucket policy is the whole of its access.
+const roleOut = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports" },
+      },
+      ReportsBucketPolicy: {
+        Type: "AWS::S3::BucketPolicy",
+        Properties: {
+          Bucket: { Ref: "ReportsBucket" },
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { AWS: roleOut.Role.Arn },
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports/*",
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reports",
+    Key: "q3/report.txt",
+    Body: "quarterly numbers",
+  }),
+);
+
+// The deployed policy authorizes the read.
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "reports", Key: "q3/report.txt" }),
+  { caller: { kind: "arn", arn: roleOut.Role.Arn } },
+);
+
+console.log(objectOut.Metadata);
+
+// The same document comes back out as a JSON string.
+const policyOut = await simS3.getBucketPolicy(
+  new GetBucketPolicyCommand({ Bucket: "reports" }),
+);
+
+console.log(policyOut.Policy);
+```
+
+`GetBucketPolicyCommand` throws `NoSuchBucketPolicy` when the Bucket exists but has no policy, which
+is how real S3 distinguishes that from a Bucket that does not exist. `DeleteBucketPolicyCommand`
+succeeds either way, matching S3's idempotent behaviour.
+
+### Limitations
+
+Sim S3 does not model S3 Block Public Access. Real S3 enables all four settings by default on new
+Buckets, and `BlockPublicPolicy` causes `PutBucketPolicy` to reject a policy that allows public
+access. The simulator accepts such a policy, so a Bucket policy granting `Principal: "*"` can work
+here and be refused by real S3 unless the Bucket sets `PublicAccessBlockConfiguration` accordingly.
+
+Bucket ACLs and Object ownership settings are not modelled and are not planned. Object Ownership
+defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping
+them disabled in favour of policies.
 
 ## Static website hosting
 

--- a/docs/services/s3/sim-s3-bucket-policy.example.ts
+++ b/docs/services/s3/sim-s3-bucket-policy.example.ts
@@ -1,0 +1,83 @@
+/**
+ * Granting access to a simulated S3 Bucket with a Bucket policy.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  GetBucketPolicyCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simIam = simAws.iam();
+const simS3 = simAws.s3();
+
+// The principal the Bucket policy will name. It gets no identity policy, so
+// the Bucket policy is the whole of its access.
+const roleOut = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports" },
+      },
+      ReportsBucketPolicy: {
+        Type: "AWS::S3::BucketPolicy",
+        Properties: {
+          Bucket: { Ref: "ReportsBucket" },
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { AWS: roleOut.Role.Arn },
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports/*",
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reports",
+    Key: "q3/report.txt",
+    Body: "quarterly numbers",
+  }),
+);
+
+// The deployed policy authorizes the read.
+const objectOut = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "reports", Key: "q3/report.txt" }),
+  { caller: { kind: "arn", arn: roleOut.Role.Arn } },
+);
+
+console.log(objectOut.Metadata);
+
+// The same document comes back out as a JSON string.
+const policyOut = await simS3.getBucketPolicy(
+  new GetBucketPolicyCommand({ Bucket: "reports" }),
+);
+
+console.log(policyOut.Policy);

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -68,9 +68,18 @@ Supported command areas currently include:
 - `create-Bucket/`
 - `list-buckets/`
 - `put-bucket-website/`
+- `put-bucket-policy/`
+- `get-bucket-policy/`
+- `delete-bucket-policy/`
 - `put-object/`
 - `get-object/`
 - `list-objects/`
+
+`SimS3CommandHandlers` in `command/` owns the wiring: every handler is built from the same Bucket
+map, IAM and background scheduler, so that construction lives in one place rather than being
+repeated once per command on the service facade. `requireSimS3Bucket` is the shared Bucket lookup
+that raises `SimS3NoSuchBucket`, which is what real S3 answers before considering anything else
+about a Bucket-scoped request.
 
 It's important that implementation code under `src/` does not depend on real AWS SDK package
 classes. Command types are local structural types with shapes compatible with the AWS SDK. Tests may
@@ -132,6 +141,13 @@ Its public methods are small:
 - `configureWebsite(website)`
 - `getWebsite()`
 - `getWebsiteUrl()`
+- `configurePolicy(policy)`
+- `getPolicy()`
+- `deletePolicy()`
+
+The Bucket resource policy is stored parsed rather than as a JSON string, because that is the shape
+sim IAM evaluates. `GetBucketPolicy` serializes it back on the way out, so the string a caller reads
+is a normalized form of what was applied rather than the original text.
 
 By keeping storage behind `SimS3BucketStorage`, the Bucket model stays independent of whether
 objects live in memory or on the local filesystem.
@@ -349,9 +365,20 @@ S3 CloudFormation support lives under `cfn/`.
 
 `SimS3CloudFormationResourceFactory` currently supports:
 
-- `AWS::S3::Bucket`
+- `AWS::S3::Bucket`, through `SimCfnS3BucketCreator`
+- `AWS::S3::BucketPolicy`, through `SimCfnS3BucketPolicyCreator`
 
-Resource creation flow:
+The factory itself only dispatches on the resource type name; each creator owns one resource type,
+as the Lambda factory does.
+
+Bucket policy creation reads the `Bucket` and `PolicyDocument` properties from the resolved
+properties, then calls the normal `putBucketPolicy` command path, so a policy declared in a template
+is validated and enforced exactly as one applied through the SDK. The simulated Bucket is returned
+as the Resource's simulated object, because a Bucket policy has no existence of its own in S3.
+A `Bucket` naming a Bucket that does not exist fails the Stack with `SimS3NoSuchBucket` rather than
+being skipped.
+
+Bucket resource creation flow:
 
 1. determine the Bucket name
 
@@ -380,6 +407,7 @@ Handlers throw AWS-like errors for supported failure cases, including:
 
 - no such Bucket
 - no such key
+- no such Bucket policy
 - Bucket already exists
 - Bucket already owned by you
 

--- a/src/service/s3/bucket/sim-s3-bucket-arn.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-arn.ts
@@ -1,0 +1,11 @@
+import type { SimS3BucketName } from "./sim-s3-bucket.js";
+
+/**
+ * The ARN of a simulated S3 Bucket.
+ *
+ * S3 Bucket ARNs name no Account and no Region, because Bucket names are
+ * globally unique in S3. Object ARNs are this with `/<key>` appended.
+ */
+export function simS3BucketArn(bucketName: SimS3BucketName | string): string {
+  return `arn:aws:s3:::${bucketName}`;
+}

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -105,6 +105,16 @@ export class SimS3Bucket {
   }
 
   /**
+   * Remove the Bucket resource policy.
+   *
+   * Real S3 DeleteBucketPolicy is idempotent, so this reports nothing about
+   * whether there was a policy to remove.
+   */
+  deletePolicy(): void {
+    this.policy = undefined;
+  }
+
+  /**
    * Get the simulated AWS account Region scope for this Bucket.
    */
   getAccountRegionScope(): SimAwsAccountRegionScope {

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
@@ -1,0 +1,92 @@
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3 } from "../../sim-s3.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnS3BucketPolicyCreatorProperties {
+  readonly simS3: SimS3;
+}
+
+/**
+ * Creates simulated S3 Bucket policies from AWS::S3::BucketPolicy Resources.
+ *
+ * This is what CDK emits for every `grantRead`, `grantPut` and
+ * `addToResourcePolicy`, so a synthesized template reaches it whether or not
+ * the app mentions a Bucket policy itself. Creation goes through the normal
+ * PutBucketPolicy command path, so a policy declared in a template is validated
+ * and enforced exactly as one applied through the SDK.
+ */
+export class SimCfnS3BucketPolicyCreator {
+  private readonly simS3: SimS3;
+
+  constructor(properties: SimCfnS3BucketPolicyCreatorProperties) {
+    this.simS3 = properties.simS3;
+  }
+
+  /**
+   * Attach a policy to the Bucket named by the Resource.
+   *
+   * The simulated Bucket is returned as the Resource's simulated object,
+   * because a Bucket policy has no existence of its own in S3: it is state on
+   * the Bucket it is attached to.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimS3Bucket> {
+    const bucketName = this.bucketNameForResource(resource, properties);
+    const policyDocument = this.policyDocumentForResource(resource, properties);
+
+    await this.simS3.putBucketPolicy({
+      input: {
+        Bucket: bucketName,
+        Policy: jsonStringify(policyDocument),
+      },
+    });
+
+    const bucket = this.simS3.getSimBucketByName(bucketName);
+    assertDefined(
+      bucket,
+      `sim S3 Bucket ${bucketName} after CloudFormation Bucket policy creation`,
+    );
+
+    return bucket;
+  }
+
+  private bucketNameForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const bucketName = properties["Bucket"];
+
+    if (typeof bucketName !== "string") {
+      throw new TypeError(
+        `AWS::S3::BucketPolicy ${resource.logicalId} requires a Bucket name string, got ${typeof bucketName}`,
+      );
+    }
+
+    return bucketName;
+  }
+
+  private policyDocumentForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): object {
+    const policyDocument = properties["PolicyDocument"];
+
+    if (
+      policyDocument === undefined ||
+      policyDocument === null ||
+      typeof policyDocument !== "object" ||
+      Array.isArray(policyDocument)
+    ) {
+      throw new Error(
+        `AWS::S3::BucketPolicy ${resource.logicalId} requires a PolicyDocument object`,
+      );
+    }
+
+    return policyDocument;
+  }
+}

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
@@ -82,7 +82,7 @@ export class SimCfnS3BucketPolicyCreator {
       typeof policyDocument !== "object" ||
       Array.isArray(policyDocument)
     ) {
-      throw new Error(
+      throw new TypeError(
         `AWS::S3::BucketPolicy ${resource.logicalId} requires a PolicyDocument object`,
       );
     }

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
@@ -87,7 +87,12 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
               Bucket: { Ref: "ReportsBucket" },
               PolicyDocument: {
                 Version: "2012-10-17",
-                Statement: [publicReadStatement],
+                Statement: [
+                  {
+                    ...publicReadStatement,
+                    Resource: "arn:aws:s3:::reports/public/*",
+                  },
+                ],
               },
             },
           },
@@ -99,34 +104,32 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "reports",
-        Key: "q3.txt",
+        Key: "public/q3.txt",
         Body: "quarterly numbers",
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "private/q3.txt",
+        Body: "not for publication",
       }),
     );
 
     // When an anonymous caller reads an Object the policy covers.
     const output = await simS3.getObject(
-      new GetObjectCommand({ Bucket: "reports", Key: "q3.txt" }),
+      new GetObjectCommand({ Bucket: "reports", Key: "public/q3.txt" }),
       { caller: { kind: "anonymous" } },
     );
 
     // Then the deployed policy authorizes it, as an SDK-applied policy would.
     assertNonNullable(output.Body);
 
-    // And an Object outside the policy's Resource remains denied.
-    await simS3.putObject(
-      new PutObjectCommand({
-        Bucket: "reports",
-        Key: "q3.txt",
-        Body: "quarterly numbers",
-      }),
-    );
+    // And the same caller is denied an Object outside the policy's Resource.
     const error = await assertThrowsErrorAsync(async () =>
       simS3.getObject(
-        new GetObjectCommand({ Bucket: "reports", Key: "q3.txt" }),
-        {
-          caller: { kind: "arn", arn: "arn:aws:iam::222222222222:role/Other" },
-        },
+        new GetObjectCommand({ Bucket: "reports", Key: "private/q3.txt" }),
+        { caller: { kind: "anonymous" } },
       ),
     );
     assertInstanceOf(error, SimIamAccessDenied);

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
@@ -1,0 +1,290 @@
+import {
+  GetBucketPolicyCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimIamMalformedPolicyDocument } from "../../../iam/error/sim-iam.error.js";
+import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+
+describe("S3 CloudFormation BucketPolicy Resource", () => {
+  const publicReadStatement = {
+    Effect: "Allow",
+    Principal: "*",
+    Action: "s3:GetObject",
+    Resource: "arn:aws:s3:::reports/*",
+  };
+
+  it("attaches a Bucket policy declared alongside its Bucket", async () => {
+    // Given a template declaring a Bucket and a policy referencing it by Ref.
+    const template = {
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports" },
+        },
+        ReportsBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "ReportsBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [publicReadStatement],
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reports-stack",
+      template,
+    });
+
+    // Then the policy is on the Bucket and the Resource was not skipped.
+    const output = await simAws
+      .s3()
+      .getBucketPolicy(new GetBucketPolicyCommand({ Bucket: "reports" }));
+
+    assertObjectEquals(JSON.parse(output.Policy), {
+      Version: "2012-10-17",
+      Statement: [publicReadStatement],
+    });
+
+    const resource = stack.resources.get("ReportsBucketPolicy");
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("enforces a deployed Bucket policy through the Object authorizers", async () => {
+    // Given a deployed Bucket policy granting anonymous reads under one prefix.
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "enforced-stack",
+      template: {
+        Resources: {
+          ReportsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "reports" },
+          },
+          ReportsBucketPolicy: {
+            Type: "AWS::S3::BucketPolicy",
+            Properties: {
+              Bucket: { Ref: "ReportsBucket" },
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [publicReadStatement],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const simS3 = simAws.s3();
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "q3.txt",
+        Body: "quarterly numbers",
+      }),
+    );
+
+    // When an anonymous caller reads an Object the policy covers.
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "reports", Key: "q3.txt" }),
+      { caller: { kind: "anonymous" } },
+    );
+
+    // Then the deployed policy authorizes it, as an SDK-applied policy would.
+    assertNonNullable(output.Body);
+
+    // And an Object outside the policy's Resource remains denied.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "q3.txt",
+        Body: "quarterly numbers",
+      }),
+    );
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "reports", Key: "q3.txt" }),
+        {
+          caller: { kind: "arn", arn: "arn:aws:iam::222222222222:role/Other" },
+        },
+      ),
+    );
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("accepts a Bucket named by a literal string rather than a Ref", async () => {
+    // Given a template naming the Bucket as a plain string, so the engine has
+    // no dependency edge to order the two Resources by.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "literal-stack",
+      template: {
+        Resources: {
+          ReportsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "reports" },
+          },
+          ReportsBucketPolicy: {
+            Type: "AWS::S3::BucketPolicy",
+            Properties: {
+              Bucket: "reports",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [publicReadStatement],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the policy still reaches the Bucket.
+    const resource = stack.resources.get("ReportsBucketPolicy");
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+
+    const output = await simAws
+      .s3()
+      .getBucketPolicy(new GetBucketPolicyCommand({ Bucket: "reports" }));
+    assertObjectEquals(JSON.parse(output.Policy), {
+      Version: "2012-10-17",
+      Statement: [publicReadStatement],
+    });
+  });
+
+  it("fails the Stack when the named Bucket does not exist", async () => {
+    // Given a Bucket policy naming a Bucket no Resource creates.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "orphan-policy-stack",
+        template: {
+          Resources: {
+            OrphanBucketPolicy: {
+              Type: "AWS::S3::BucketPolicy",
+              Properties: {
+                Bucket: "never-created",
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [publicReadStatement],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the Stack fails with a diagnostic naming the logical ID and Bucket.
+    assertInstanceOf(error, SimS3NoSuchBucket);
+    assertStringIncludes(error.message, "OrphanBucketPolicy");
+    assertStringIncludes(error.message, "never-created");
+  });
+
+  it("fails the Stack when the policy document is malformed", async () => {
+    // Given a Bucket policy whose statement effect is not an IAM effect.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "malformed-policy-stack",
+        template: {
+          Resources: {
+            ReportsBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "reports" },
+            },
+            ReportsBucketPolicy: {
+              Type: "AWS::S3::BucketPolicy",
+              Properties: {
+                Bucket: { Ref: "ReportsBucket" },
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [{ ...publicReadStatement, Effect: "Permit" }],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the normal PutBucketPolicy validation rejects it.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+  });
+
+  it("rejects a Resource without a usable Bucket name or PolicyDocument", async () => {
+    // Given a Bucket policy Resource missing its Bucket property.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const bucketError = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "no-bucket-stack",
+        template: {
+          Resources: {
+            NamelessBucketPolicy: {
+              Type: "AWS::S3::BucketPolicy",
+              Properties: {
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [publicReadStatement],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the Resource is rejected by name rather than silently skipped.
+    assertStringIncludes(bucketError.message, "NamelessBucketPolicy");
+    assertStringIncludes(bucketError.message, "Bucket name string");
+
+    // When a Resource instead omits its PolicyDocument.
+    const documentError = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "no-document-stack",
+        template: {
+          Resources: {
+            ReportsBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "reports" },
+            },
+            EmptyBucketPolicy: {
+              Type: "AWS::S3::BucketPolicy",
+              Properties: { Bucket: { Ref: "ReportsBucket" } },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then that missing property is reported the same way.
+    assertStringIncludes(documentError.message, "EmptyBucketPolicy");
+    assertStringIncludes(documentError.message, "PolicyDocument object");
+  });
+});

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
@@ -1,0 +1,109 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimS3 } from "../../sim-s3.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3WebsiteConfiguration as SimS3WebsiteConfig } from "../../command/put-bucket-website/put-bucket-website.command.js";
+import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-name.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+interface SimCfnS3BucketCreatorProperties {
+  readonly simS3: SimS3;
+}
+
+/**
+ * Creates simulated S3 Buckets from AWS::S3::Bucket CloudFormation Resources.
+ */
+export class SimCfnS3BucketCreator {
+  private readonly simS3: SimS3;
+
+  constructor(properties: SimCfnS3BucketCreatorProperties) {
+    this.simS3 = properties.simS3;
+  }
+
+  /**
+   * Create a simulated Bucket, with its website configuration when declared.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimS3Bucket> {
+    const bucketName = this.bucketNameForResource(resource, properties);
+    validateS3BucketName(bucketName);
+
+    await this.simS3.createBucket({
+      input: {
+        Bucket: bucketName,
+      },
+    });
+
+    const bucket = this.simS3.getSimBucketByName(bucketName);
+    assertDefined(
+      bucket,
+      `sim S3 Bucket ${bucketName} after CloudFormation creation`,
+    );
+
+    const websiteConfig = this.websiteConfigurationForResource(properties);
+
+    if (websiteConfig !== undefined) {
+      await this.simS3.putBucketWebsite({
+        input: {
+          Bucket: bucketName,
+          WebsiteConfiguration: websiteConfig,
+        },
+      });
+    }
+
+    return bucket;
+  }
+
+  private bucketNameForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): string {
+    const bucketName = properties["BucketName"];
+
+    if (typeof bucketName === "string") {
+      return bucketName;
+    }
+
+    return resource.logicalId.toLowerCase();
+  }
+
+  private websiteConfigurationForResource(
+    properties: SimCfnTemplateValueRecord,
+  ): SimS3WebsiteConfig | undefined {
+    const websiteConfig = properties["WebsiteConfiguration"];
+
+    if (
+      websiteConfig === undefined ||
+      websiteConfig === null ||
+      typeof websiteConfig !== "object" ||
+      Array.isArray(websiteConfig)
+    ) {
+      return undefined;
+    }
+
+    if (
+      "RoutingRules" in websiteConfig &&
+      !Array.isArray(websiteConfig["RoutingRules"])
+    ) {
+      return undefined;
+    }
+
+    return {
+      ...websiteConfig,
+      IndexDocument:
+        typeof websiteConfig["IndexDocument"] === "string"
+          ? {
+              Suffix: websiteConfig["IndexDocument"],
+            }
+          : websiteConfig["IndexDocument"],
+      ErrorDocument:
+        typeof websiteConfig["ErrorDocument"] === "string"
+          ? {
+              Key: websiteConfig["ErrorDocument"],
+            }
+          : websiteConfig["ErrorDocument"],
+    } as SimS3WebsiteConfig;
+  }
+}

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -4,16 +4,20 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimS3 } from "../sim-s3.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
-import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
-import type { SimS3WebsiteConfiguration as SimS3WebsiteConfig } from "../command/put-bucket-website/put-bucket-website.command.js";
-import { validateS3BucketName } from "../bucket/validate/validate-s3-bucket-name.js";
-import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimCfnS3BucketCreator } from "./bucket/sim-cfn-s3-bucket-creator.js";
+import { SimCfnS3BucketPolicyCreator } from "./bucket-policy/sim-cfn-s3-bucket-policy-creator.js";
 
 /**
  * CloudFormation Resource factory for simulated S3 resources.
  */
 export class SimS3CloudFormationResourceFactory implements SimCfnServiceResourceFactory {
-  constructor(private readonly simS3: SimS3) {}
+  private readonly bucketCreator: SimCfnS3BucketCreator;
+  private readonly bucketPolicyCreator: SimCfnS3BucketPolicyCreator;
+
+  constructor(simS3: SimS3) {
+    this.bucketCreator = new SimCfnS3BucketCreator({ simS3 });
+    this.bucketPolicyCreator = new SimCfnS3BucketPolicyCreator({ simS3 });
+  }
 
   /**
    * Create a simulated S3 resource from a CloudFormation Resource.
@@ -25,7 +29,16 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
   ): Promise<object | undefined> {
     switch (resourceTypeName) {
       case "Bucket": {
-        return await this.createBucket(resource, context);
+        return await this.bucketCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "BucketPolicy": {
+        return await this.bucketPolicyCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
       }
       default: {
         throw new Error(
@@ -33,95 +46,5 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
         );
       }
     }
-  }
-
-  private async createBucket(
-    resource: SimCfnResource,
-    context: SimCloudFormationResourceCreateContext,
-  ): Promise<SimS3Bucket> {
-    const bucketName = this.bucketNameForResource(resource, context);
-    validateS3BucketName(bucketName);
-
-    await this.simS3.createBucket({
-      input: {
-        Bucket: bucketName,
-      },
-    });
-
-    const bucket = this.simS3.getSimBucketByName(bucketName);
-    assertDefined(
-      bucket,
-      `sim S3 Bucket ${bucketName} after CloudFormation creation`,
-    );
-
-    const websiteConfig = this.websiteConfigurationForResource(
-      resource,
-      context,
-    );
-
-    if (websiteConfig !== undefined) {
-      await this.simS3.putBucketWebsite({
-        input: {
-          Bucket: bucketName,
-          WebsiteConfiguration: websiteConfig,
-        },
-      });
-    }
-
-    return bucket;
-  }
-
-  private bucketNameForResource(
-    resource: SimCfnResource,
-    context: SimCloudFormationResourceCreateContext,
-  ): string {
-    const properties = context.resolvedProperties ?? resource.properties;
-    const bucketName = properties["BucketName"];
-
-    if (typeof bucketName === "string") {
-      return bucketName;
-    }
-
-    return resource.logicalId.toLowerCase();
-  }
-
-  private websiteConfigurationForResource(
-    resource: SimCfnResource,
-    context: SimCloudFormationResourceCreateContext,
-  ): SimS3WebsiteConfig | undefined {
-    const properties = context.resolvedProperties ?? resource.properties;
-    const websiteConfig = properties["WebsiteConfiguration"];
-
-    if (
-      websiteConfig === undefined ||
-      websiteConfig === null ||
-      typeof websiteConfig !== "object" ||
-      Array.isArray(websiteConfig)
-    ) {
-      return undefined;
-    }
-
-    if (
-      "RoutingRules" in websiteConfig &&
-      !Array.isArray(websiteConfig["RoutingRules"])
-    ) {
-      return undefined;
-    }
-
-    return {
-      ...websiteConfig,
-      IndexDocument:
-        typeof websiteConfig["IndexDocument"] === "string"
-          ? {
-              Suffix: websiteConfig["IndexDocument"],
-            }
-          : websiteConfig["IndexDocument"],
-      ErrorDocument:
-        typeof websiteConfig["ErrorDocument"] === "string"
-          ? {
-              Key: websiteConfig["ErrorDocument"],
-            }
-          : websiteConfig["ErrorDocument"],
-    } as SimS3WebsiteConfig;
   }
 }

--- a/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
+++ b/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
@@ -1,0 +1,27 @@
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+
+/**
+ * The resource policies sim IAM should evaluate for a request against a Bucket.
+ *
+ * A Bucket policy can grant Bucket-level administration actions in real S3, so
+ * the policy administration commands consult it the same way the Object
+ * commands do. A Bucket without a policy contributes nothing.
+ */
+export function simS3BucketResourcePolicies(
+  bucket: SimS3Bucket,
+): readonly SimIamResourcePolicyInput[] {
+  const policy = bucket.getPolicy();
+
+  if (policy === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      document: policy,
+      policyName: "BucketPolicy",
+      resourceArn: `arn:aws:s3:::${bucket.bucketName}`,
+    },
+  ];
+}

--- a/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
+++ b/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
@@ -1,4 +1,5 @@
 import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 
 /**
@@ -21,7 +22,7 @@ export function simS3BucketResourcePolicies(
     {
       document: policy,
       policyName: "BucketPolicy",
-      resourceArn: `arn:aws:s3:::${bucket.bucketName}`,
+      resourceArn: simS3BucketArn(bucket.bucketName),
     },
   ];
 }

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
 
@@ -27,7 +28,7 @@ export class DeleteBucketPolicyAuthorizer {
    * Ensure the caller may remove the Bucket policy.
    */
   authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
-    const resource = `arn:aws:s3:::${bucket.bucketName}`;
+    const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action: DeleteBucketPolicyAuthorizer.action,
       resource,

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
@@ -1,0 +1,46 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface DeleteBucketPolicyAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 DeleteBucketPolicy request.
+ *
+ * Real S3 governs removing a Bucket policy with s3:DeleteBucketPolicy, which is
+ * a distinct action from the s3:PutBucketPolicy that replaces one.
+ */
+export class DeleteBucketPolicyAuthorizer {
+  private static readonly action = "s3:DeleteBucketPolicy";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteBucketPolicyAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may remove the Bucket policy.
+   */
+  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:s3:::${bucket.bucketName}`;
+    const decision = this.iam.authorize({
+      action: DeleteBucketPolicyAuthorizer.action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteBucketPolicyAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.command.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.command.ts
@@ -1,0 +1,22 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteBucketPolicy command.
+ */
+export interface SimDeleteBucketPolicyCommand {
+  readonly input: SimDeleteBucketPolicyCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketPolicy input.
+ */
+export interface SimDeleteBucketPolicyCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketPolicy output.
+ */
+export interface SimDeleteBucketPolicyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.handler.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import { DeleteBucketPolicyAuthorizer } from "./delete-bucket-policy-authorizer.js";
+import type {
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput,
+} from "./delete-bucket-policy.command.js";
+
+interface DeleteBucketPolicyCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteBucketPolicyCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 DeleteBucketPolicyCommand handler.
+ */
+export class DeleteBucketPolicyCommandHandler implements CommandHandler<
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: DeleteBucketPolicyAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteBucketPolicyCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new DeleteBucketPolicyAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and remove a Bucket's resource policy.
+   *
+   * Real S3 answers the same way whether or not there was a policy to remove,
+   * so a Bucket without one is not an error here.
+   */
+  async handle(
+    command: SimDeleteBucketPolicyCommand,
+    options?: DeleteBucketPolicyCommandHandlerOptions,
+  ): Promise<SimDeleteBucketPolicyCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "DeleteBucketPolicyCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucket, options?.caller);
+
+    bucket.deletePolicy();
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.iso.test.ts
@@ -1,0 +1,225 @@
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteBucketPolicyCommand,
+  GetBucketPolicyCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimS3NoSuchBucket,
+  SimS3NoSuchBucketPolicy,
+} from "../../error/sim-s3.error.js";
+
+describe("S3 DeleteBucketPolicyCommand", () => {
+  const simAws = new SimAws();
+
+  it("removes the Bucket policy so it no longer grants access", async () => {
+    // Given a Bucket whose policy grants an anonymous caller Object reads.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "revocable-policy-bucket" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "revocable-policy-bucket",
+        Key: "public/notice.txt",
+        Body: "published",
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "revocable-policy-bucket",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::revocable-policy-bucket/public/*",
+          },
+        }),
+      }),
+    );
+
+    // When the policy is deleted.
+    await simS3.deleteBucketPolicy(
+      new DeleteBucketPolicyCommand({ Bucket: "revocable-policy-bucket" }),
+    );
+
+    // Then the Bucket reports no policy, and the grant it carried is gone.
+    const readError = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(
+        new GetBucketPolicyCommand({ Bucket: "revocable-policy-bucket" }),
+      ),
+    );
+    assertInstanceOf(readError, SimS3NoSuchBucketPolicy);
+
+    const accessError = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({
+          Bucket: "revocable-policy-bucket",
+          Key: "public/notice.txt",
+        }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+    assertInstanceOf(accessError, SimIamAccessDenied);
+  });
+
+  it("succeeds on a Bucket that has no policy to remove", async () => {
+    // Given an existing Bucket with no resource policy.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "idempotent-delete-bucket" }),
+    );
+
+    // When the Bucket policy is deleted anyway.
+    const output = await simS3.deleteBucketPolicy(
+      new DeleteBucketPolicyCommand({ Bucket: "idempotent-delete-bucket" }),
+    );
+
+    // Then S3 answers as it does for a Bucket that had one, as real S3 does.
+    assertInstanceOf(output.$metadata, Object);
+  });
+
+  it("rejects a non-existent Bucket before removing its policy", async () => {
+    // Given the top-level simulated S3 service without the requested Bucket.
+    const simS3 = simAws.s3();
+
+    // When DeleteBucketPolicy targets the missing Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketPolicy(
+        new DeleteBucketPolicyCommand({ Bucket: "absent-bucket" }),
+      ),
+    );
+
+    // Then S3 returns its missing-Bucket error.
+    assertInstanceOf(error, SimS3NoSuchBucket);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("rejects a missing required Bucket input", async () => {
+    // Given the top-level simulated S3 service.
+    const simS3 = simAws.s3();
+
+    // When DeleteBucketPolicy is called without its required Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketPolicy(
+        // @ts-expect-error -- testing invalid input
+        new DeleteBucketPolicyCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing Bucket input.
+    assertStringIncludes(
+      error.message,
+      "DeleteBucketPolicyCommand.input.Bucket",
+    );
+  });
+
+  it("denies a caller without DeleteBucketPolicy permission", async () => {
+    // Given a Bucket and a Role with no S3 policy-administration grant.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "protected-delete-bucket" }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "UnprivilegedPolicyRemover",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the unprivileged Role removes the Bucket policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketPolicy(
+        new DeleteBucketPolicyCommand({ Bucket: "protected-delete-bucket" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then IAM denies the distinct removal action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:DeleteBucketPolicy");
+    assertIdentical(error.resource, "arn:aws:s3:::protected-delete-bucket");
+  });
+
+  it("allows removal granted by the Bucket policy itself", async () => {
+    // Given a Bucket policy that grants a Role the removal action.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "self-revoking-bucket" }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PolicyRemover",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "self-revoking-bucket",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: roleCreation.Role.Arn },
+            Action: "s3:DeleteBucketPolicy",
+            Resource: "arn:aws:s3:::self-revoking-bucket",
+          },
+        }),
+      }),
+    );
+
+    // When the Role named by that policy removes it.
+    await simS3.deleteBucketPolicy(
+      new DeleteBucketPolicyCommand({ Bucket: "self-revoking-bucket" }),
+      { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+    );
+
+    // Then the policy is gone, so the same call is now denied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketPolicy(
+        new DeleteBucketPolicyCommand({ Bucket: "self-revoking-bucket" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
 
@@ -24,7 +25,7 @@ export class GetBucketPolicyAuthorizer {
    * Ensure the caller may read the Bucket policy.
    */
   authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
-    const resource = `arn:aws:s3:::${bucket.bucketName}`;
+    const resource = simS3BucketArn(bucket.bucketName);
     const decision = this.iam.authorize({
       action: GetBucketPolicyAuthorizer.action,
       resource,

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
@@ -1,0 +1,43 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface GetBucketPolicyAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 GetBucketPolicy request.
+ */
+export class GetBucketPolicyAuthorizer {
+  private static readonly action = "s3:GetBucketPolicy";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: GetBucketPolicyAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may read the Bucket policy.
+   */
+  authorize(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:s3:::${bucket.bucketName}`;
+    const decision = this.iam.authorize({
+      action: GetBucketPolicyAuthorizer.action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: GetBucketPolicyAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy.command.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 GetBucketPolicy command.
+ */
+export interface SimGetBucketPolicyCommand {
+  readonly input: SimGetBucketPolicyCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketPolicy input.
+ */
+export interface SimGetBucketPolicyCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketPolicy output.
+ *
+ * Real S3 answers with the policy document as a JSON string, so the simulator
+ * serializes its stored document rather than returning the parsed shape.
+ */
+export interface SimGetBucketPolicyCommandOutput {
+  readonly Policy: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy.handler.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy.handler.ts
@@ -1,0 +1,84 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchBucketPolicy } from "../../error/sim-s3.error.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import { GetBucketPolicyAuthorizer } from "./get-bucket-policy-authorizer.js";
+import type {
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput,
+} from "./get-bucket-policy.command.js";
+
+interface GetBucketPolicyCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface GetBucketPolicyCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 GetBucketPolicyCommand handler.
+ */
+export class GetBucketPolicyCommandHandler implements CommandHandler<
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: GetBucketPolicyAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetBucketPolicyCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new GetBucketPolicyAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and return a Bucket's resource policy.
+   */
+  async handle(
+    command: SimGetBucketPolicyCommand,
+    options?: GetBucketPolicyCommandHandlerOptions,
+  ): Promise<SimGetBucketPolicyCommandOutput> {
+    assertDefined(command.input.Bucket, "GetBucketPolicyCommand.input.Bucket");
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucket, options?.caller);
+
+    const policy = bucket.getPolicy();
+    if (policy === undefined) {
+      throw new SimS3NoSuchBucketPolicy(
+        `No Bucket policy on S3 Bucket ${bucketName}`,
+      );
+    }
+
+    return {
+      Policy: jsonStringify(policy),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy.iso.test.ts
@@ -1,0 +1,221 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetBucketPolicyCommand,
+  PutBucketPolicyCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimS3NoSuchBucket,
+  SimS3NoSuchBucketPolicy,
+} from "../../error/sim-s3.error.js";
+
+describe("S3 GetBucketPolicyCommand", () => {
+  const simAws = new SimAws();
+
+  const readReportsPolicy = {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: {
+        AWS: "arn:aws:iam::222222222222:role/ReportReader",
+      },
+      Action: "s3:GetObject",
+      Resource: "arn:aws:s3:::readable-policy-bucket/*",
+    },
+  };
+
+  it("returns the configured Bucket policy as a JSON document string", async () => {
+    // Given a Bucket with a resource policy applied through PutBucketPolicy.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "readable-policy-bucket" }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "readable-policy-bucket",
+        Policy: JSON.stringify(readReportsPolicy),
+      }),
+    );
+
+    // When the policy is read back.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "readable-policy-bucket" }),
+    );
+
+    // Then S3 answers with the document serialized as a JSON string.
+    assertTypeString(output.Policy);
+    assertObjectEquals(JSON.parse(output.Policy), readReportsPolicy);
+  });
+
+  it("reports no Bucket policy on a Bucket that has none", async () => {
+    // Given an existing Bucket with no resource policy.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "policy-free-bucket" }),
+    );
+
+    // When the Bucket policy is requested.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(
+        new GetBucketPolicyCommand({ Bucket: "policy-free-bucket" }),
+      ),
+    );
+
+    // Then S3 distinguishes this from a missing Bucket.
+    assertInstanceOf(error, SimS3NoSuchBucketPolicy);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+    assertStringIncludes(error.message, "policy-free-bucket");
+  });
+
+  it("rejects a non-existent Bucket before reading its policy", async () => {
+    // Given the top-level simulated S3 service without the requested Bucket.
+    const simS3 = simAws.s3();
+
+    // When GetBucketPolicy targets the missing Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(
+        new GetBucketPolicyCommand({ Bucket: "never-created-bucket" }),
+      ),
+    );
+
+    // Then S3 returns its missing-Bucket error rather than a missing-policy one.
+    assertInstanceOf(error, SimS3NoSuchBucket);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("rejects a missing required Bucket input", async () => {
+    // Given the top-level simulated S3 service.
+    const simS3 = simAws.s3();
+
+    // When GetBucketPolicy is called without its required Bucket.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(
+        // @ts-expect-error -- testing invalid input
+        new GetBucketPolicyCommand({}),
+      ),
+    );
+
+    // Then request validation identifies the missing Bucket input.
+    assertStringIncludes(error.message, "GetBucketPolicyCommand.input.Bucket");
+  });
+
+  it("denies a caller without GetBucketPolicy permission", async () => {
+    // Given a Bucket and a Role with no S3 policy-read grant.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "guarded-policy-bucket" }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "guarded-policy-bucket",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::guarded-policy-bucket/*",
+          },
+        }),
+      }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "UnprivilegedPolicyReader",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the unprivileged Role reads the Bucket policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(
+        new GetBucketPolicyCommand({ Bucket: "guarded-policy-bucket" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then IAM denies the Bucket-level policy read action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:GetBucketPolicy");
+    assertIdentical(error.resource, "arn:aws:s3:::guarded-policy-bucket");
+  });
+
+  it("allows a Role granted GetBucketPolicy by its identity policy", async () => {
+    // Given a Role whose identity policy grants the Bucket policy read.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "auditable-policy-bucket" }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "auditable-policy-bucket",
+        Policy: JSON.stringify(readReportsPolicy),
+      }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PolicyAuditor",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "PolicyAuditor",
+        PolicyName: "ReadBucketPolicies",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetBucketPolicy",
+            Resource: "arn:aws:s3:::auditable-policy-bucket",
+          },
+        }),
+      }),
+    );
+
+    // When the granted Role reads the Bucket policy.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "auditable-policy-bucket" }),
+      { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+    );
+
+    // Then the stored document is returned.
+    assertObjectEquals(JSON.parse(output.Policy), readReportsPolicy);
+  });
+});

--- a/src/service/s3/command/require-sim-s3-bucket.ts
+++ b/src/service/s3/command/require-sim-s3-bucket.ts
@@ -1,0 +1,22 @@
+import type { SimS3Bucket, SimS3BucketName } from "../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchBucket } from "../error/sim-s3.error.js";
+
+/**
+ * Get a Bucket from the scope's Bucket state, or raise S3's missing-Bucket
+ * error.
+ *
+ * Every Bucket-scoped command starts this way, and real S3 answers NoSuchBucket
+ * before it considers anything else about the request.
+ */
+export function requireSimS3Bucket(
+  buckets: Map<SimS3BucketName, SimS3Bucket>,
+  bucketName: SimS3BucketName,
+): SimS3Bucket {
+  const bucket = buckets.get(bucketName);
+
+  if (bucket === undefined) {
+    throw new SimS3NoSuchBucket(`No S3 Bucket named ${bucketName}`);
+  }
+
+  return bucket;
+}

--- a/src/service/s3/command/sim-s3-command-handlers.ts
+++ b/src/service/s3/command/sim-s3-command-handlers.ts
@@ -1,0 +1,209 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimS3Bucket, SimS3BucketName } from "../bucket/sim-s3-bucket.js";
+import type { SimS3GlobalRegistry } from "../sim-s3-global-registry.js";
+import type { SimS3RequestOptions } from "../sim-s3.js";
+import { CreateBucketCommandHandler } from "./create-bucket/create-bucket.handler.js";
+import type {
+  SimCreateBucketCommand,
+  SimCreateBucketCommandOutput,
+} from "./create-bucket/create-bucket.command.js";
+import { DeleteBucketPolicyCommandHandler } from "./delete-bucket-policy/delete-bucket-policy.handler.js";
+import type {
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput,
+} from "./delete-bucket-policy/delete-bucket-policy.command.js";
+import { GetBucketPolicyCommandHandler } from "./get-bucket-policy/get-bucket-policy.handler.js";
+import type {
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput,
+} from "./get-bucket-policy/get-bucket-policy.command.js";
+import { GetObjectCommandHandler } from "./get-object/get-object.handler.js";
+import type {
+  SimGetObjectCommand,
+  SimGetObjectCommandOutput,
+} from "./get-object/get-object.command.js";
+import { ListBucketsCommandHandler } from "./list-buckets/list-buckets.handler.js";
+import type {
+  SimListBucketsCommand,
+  SimListBucketsCommandOutput,
+} from "./list-buckets/list-buckets.command.js";
+import { ListObjectsCommandHandler } from "./list-objects/list-objects.handler.js";
+import type {
+  SimListObjectsCommand,
+  SimListObjectsCommandOutput,
+} from "./list-objects/list-objects.command.js";
+import { PutBucketPolicyCommandHandler } from "./put-bucket-policy/put-bucket-policy.handler.js";
+import type {
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput,
+} from "./put-bucket-policy/put-bucket-policy.command.js";
+import { PutBucketWebsiteCommandHandler } from "./put-bucket-website/put-bucket-website.handler.js";
+import type {
+  SimPutBucketWebsiteCommand,
+  SimPutBucketWebsiteCommandOutput,
+} from "./put-bucket-website/put-bucket-website.command.js";
+import { PutObjectCommandHandler } from "./put-object/put-object.handler.js";
+import type {
+  SimPutObjectCommand,
+  SimPutObjectCommandOutput,
+} from "./put-object/put-object.command.js";
+
+interface SimS3CommandHandlersProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly s3GlobalRegistry: SimS3GlobalRegistry;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The command handlers of one simulated S3 account/Region scope.
+ *
+ * Every handler authorizes against the same IAM and mutates the same Bucket
+ * state, so the wiring lives here rather than being repeated once per command
+ * in the service facade. That keeps SimS3 what it should be: state plus
+ * delegation.
+ */
+export class SimS3CommandHandlers {
+  private readonly properties: SimS3CommandHandlersProperties;
+
+  constructor(properties: SimS3CommandHandlersProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Create a Bucket in this scope and register it globally.
+   */
+  async createBucket(
+    command: SimCreateBucketCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimCreateBucketCommandOutput> {
+    return await new CreateBucketCommandHandler({
+      accountRegionScope: this.properties.accountRegionScope,
+      buckets: this.properties.buckets,
+      s3GlobalRegistry: this.properties.s3GlobalRegistry,
+      iam: this.properties.iam,
+      background: this.properties.background,
+    }).handle(command, options);
+  }
+
+  /**
+   * Replace a Bucket's resource policy.
+   */
+  async putBucketPolicy(
+    command: SimPutBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutBucketPolicyCommandOutput> {
+    return await new PutBucketPolicyCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Read a Bucket's resource policy.
+   */
+  async getBucketPolicy(
+    command: SimGetBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetBucketPolicyCommandOutput> {
+    return await new GetBucketPolicyCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Remove a Bucket's resource policy.
+   */
+  async deleteBucketPolicy(
+    command: SimDeleteBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeleteBucketPolicyCommandOutput> {
+    return await new DeleteBucketPolicyCommandHandler(
+      this.bucketState(),
+    ).handle(command, options);
+  }
+
+  /**
+   * Configure static website hosting on a Bucket.
+   */
+  async putBucketWebsite(
+    command: SimPutBucketWebsiteCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutBucketWebsiteCommandOutput> {
+    return await new PutBucketWebsiteCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List the Buckets this scope owns.
+   */
+  async listBuckets(
+    command: SimListBucketsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimListBucketsCommandOutput> {
+    return await new ListBucketsCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Store an Object in a Bucket.
+   */
+  async putObject(
+    command: SimPutObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutObjectCommandOutput> {
+    return await new PutObjectCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Read an Object from a Bucket.
+   */
+  async getObject(
+    command: SimGetObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetObjectCommandOutput> {
+    return await new GetObjectCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * List the Objects in a Bucket.
+   */
+  async listObjects(
+    command: SimListObjectsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimListObjectsCommandOutput> {
+    return await new ListObjectsCommandHandler(this.bucketState()).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * The state and collaborators every Bucket-scoped handler is built with.
+   */
+  private bucketState(): {
+    readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+    readonly iam: SimIamInterServiceAuthZ;
+    readonly background: BackgroundScheduler;
+  } {
+    return {
+      buckets: this.properties.buckets,
+      iam: this.properties.iam,
+      background: this.properties.background,
+    };
+  }
+}

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -40,6 +40,20 @@ export class SimS3NoSuchKey extends SimS3Error {
 }
 
 /**
+ * Simulated S3 NoSuchBucketPolicy error.
+ *
+ * Real S3 distinguishes a Bucket that does not exist from a Bucket that exists
+ * without a policy, so GetBucketPolicy answers this rather than an empty policy.
+ */
+export class SimS3NoSuchBucketPolicy extends SimS3Error {
+  public override readonly name = "NoSuchBucketPolicy";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
  * Simulated S3 BucketAlreadyExists error.
  */
 export class SimS3BucketAlreadyExists extends SimS3Error {

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "vitest";
 import {
   CreateBucketCommand,
+  DeleteBucketPolicyCommand,
+  GetBucketPolicyCommand,
   ListObjectsCommand,
   PutBucketPolicyCommand,
   PutBucketWebsiteCommand,
@@ -11,6 +13,7 @@ import {
   assertArrayIncludes,
   assertArrayLength,
   assertIdentical,
+  assertObjectEquals,
   assertStringIncludes,
   assertTypeObject,
   assertUndefined,
@@ -88,13 +91,56 @@ describe("simulated S3 SDK Command routing", () => {
     assertTypeObject(output.$metadata);
   });
 
+  it("routes GetBucketPolicyCommand and DeleteBucketPolicyCommand through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const policy = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::bucket-policy-lifecycle/*",
+        },
+      ],
+    };
+
+    await client.send(
+      new CreateBucketCommand({ Bucket: "bucket-policy-lifecycle" }),
+    );
+    await client.send(
+      new PutBucketPolicyCommand({
+        Bucket: "bucket-policy-lifecycle",
+        Policy: JSON.stringify(policy),
+      }),
+    );
+
+    // The policy round-trips through the intercepted client.
+    const readPolicyOut = await client.send(
+      new GetBucketPolicyCommand({ Bucket: "bucket-policy-lifecycle" }),
+    );
+    assertDefined(readPolicyOut.Policy, "GetBucketPolicy output Policy");
+    assertObjectEquals(JSON.parse(readPolicyOut.Policy), policy);
+
+    // And removing it goes through the same interception path.
+    const deletionOut = await client.send(
+      new DeleteBucketPolicyCommand({ Bucket: "bucket-policy-lifecycle" }),
+    );
+    assertTypeObject(deletionOut.$metadata);
+  });
+
   it("lists its supported SDK Command names", () => {
     const router = new SimS3SdkCommandRouter({} as SimS3);
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 7);
+    assertArrayLength(supported, 9);
     assertArrayIncludes(supported, "GetObjectCommand");
+    assertArrayIncludes(supported, "GetBucketPolicyCommand");
+    assertArrayIncludes(supported, "DeleteBucketPolicyCommand");
     assertUndefined(router.route("HeadObjectCommand"));
   });
 

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -11,6 +11,8 @@ import type {
 } from "../command/get-object/get-object.command.js";
 import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.command.js";
 import type { SimListObjectsCommand } from "../command/list-objects/list-objects.command.js";
+import type { SimDeleteBucketPolicyCommand } from "../command/delete-bucket-policy/delete-bucket-policy.command.js";
+import type { SimGetBucketPolicyCommand } from "../command/get-bucket-policy/get-bucket-policy.command.js";
 import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.command.js";
 import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.command.js";
 import type { SimPutObjectCommand } from "../command/put-object/put-object.command.js";
@@ -29,6 +31,22 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.createBucket(
             command as SimCreateBucketCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteBucketPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deleteBucketPolicy(
+            command as SimDeleteBucketPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetBucketPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.getBucketPolicy(
+            command as SimGetBucketPolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -1,16 +1,11 @@
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
-import { CreateBucketCommandHandler } from "./command/create-bucket/create-bucket.handler.js";
-import { ListBucketsCommandHandler } from "./command/list-buckets/list-buckets.handler.js";
-import { PutObjectCommandHandler } from "./command/put-object/put-object.handler.js";
-import { GetObjectCommandHandler } from "./command/get-object/get-object.handler.js";
-import { ListObjectsCommandHandler } from "./command/list-objects/list-objects.handler.js";
+import { SimS3CommandHandlers } from "./command/sim-s3-command-handlers.js";
 import { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
 import {
   simS3BucketUrl,
   simS3ServiceUrl,
 } from "./bucket/sim-s3-endpoint-url.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { PutBucketWebsiteCommandHandler } from "./command/put-bucket-website/put-bucket-website.handler.js";
 import { assertDefined } from "../../util/type-guard/defined.js";
 import { FilesystemS3BucketStorage } from "./storage/filesystem/s3-filesystem-storage.js";
 import type {
@@ -53,7 +48,14 @@ import type {
   SimPutBucketPolicyCommand,
   SimPutBucketPolicyCommandOutput,
 } from "./command/put-bucket-policy/put-bucket-policy.command.js";
-import { PutBucketPolicyCommandHandler } from "./command/put-bucket-policy/put-bucket-policy.handler.js";
+import type {
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput,
+} from "./command/get-bucket-policy/get-bucket-policy.command.js";
+import type {
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput,
+} from "./command/delete-bucket-policy/delete-bucket-policy.command.js";
 import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 
@@ -78,8 +80,7 @@ export class SimS3 {
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly s3GlobalRegistry: SimS3GlobalRegistry;
-  private readonly iam: SimIamInterServiceAuthZ;
-  private readonly background: BackgroundScheduler;
+  private readonly commands: SimS3CommandHandlers;
   private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
   private readonly sdkRouter = new SimS3SdkCommandRouter(this);
 
@@ -93,8 +94,13 @@ export class SimS3 {
 
     this.accountRegionScope = accountRegionScope;
     this.s3GlobalRegistry = s3GlobalRegistry;
-    this.iam = iam;
-    this.background = background;
+    this.commands = new SimS3CommandHandlers({
+      accountRegionScope,
+      buckets: this.buckets,
+      s3GlobalRegistry,
+      iam,
+      background,
+    });
   }
 
   /**
@@ -104,14 +110,7 @@ export class SimS3 {
     command: SimCreateBucketCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimCreateBucketCommandOutput> {
-    const handler = new CreateBucketCommandHandler({
-      accountRegionScope: this.accountRegionScope,
-      buckets: this.buckets,
-      s3GlobalRegistry: this.s3GlobalRegistry,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.createBucket(command, options);
   }
 
   /**
@@ -121,12 +120,27 @@ export class SimS3 {
     command: SimPutBucketPolicyCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimPutBucketPolicyCommandOutput> {
-    const handler = new PutBucketPolicyCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.putBucketPolicy(command, options);
+  }
+
+  /**
+   * Handle a Get Bucket Policy Command from the SDK.
+   */
+  async getBucketPolicy(
+    command: SimGetBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetBucketPolicyCommandOutput> {
+    return await this.commands.getBucketPolicy(command, options);
+  }
+
+  /**
+   * Handle a Delete Bucket Policy Command from the SDK.
+   */
+  async deleteBucketPolicy(
+    command: SimDeleteBucketPolicyCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeleteBucketPolicyCommandOutput> {
+    return await this.commands.deleteBucketPolicy(command, options);
   }
 
   /**
@@ -136,12 +150,7 @@ export class SimS3 {
     command: SimPutBucketWebsiteCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimPutBucketWebsiteCommandOutput> {
-    const handler = new PutBucketWebsiteCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.putBucketWebsite(command, options);
   }
 
   /**
@@ -151,12 +160,7 @@ export class SimS3 {
     command: SimListBucketsCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimListBucketsCommandOutput> {
-    const handler = new ListBucketsCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.listBuckets(command, options);
   }
 
   /**
@@ -166,12 +170,7 @@ export class SimS3 {
     command: SimPutObjectCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimPutObjectCommandOutput> {
-    const handler = new PutObjectCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.putObject(command, options);
   }
 
   /**
@@ -181,12 +180,7 @@ export class SimS3 {
     command: SimGetObjectCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimGetObjectCommandOutput> {
-    const handler = new GetObjectCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.getObject(command, options);
   }
 
   /**
@@ -196,12 +190,7 @@ export class SimS3 {
     command: SimListObjectsCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimListObjectsCommandOutput> {
-    const handler = new ListObjectsCommandHandler({
-      buckets: this.buckets,
-      iam: this.iam,
-      background: this.background,
-    });
-    return await handler.handle(command, options);
+    return await this.commands.listObjects(command, options);
   }
 
   /**


### PR DESCRIPTION
Add AWS::S3::BucketPolicy to sim CloudFormation, which previously skipped the resource and left the Bucket with no policy, and add GetBucketPolicy and DeleteBucketPolicy so a policy can be read back and removed.

Extract SimS3CommandHandlers so SimS3 stays a thin facade.

Resolves https://github.com/KensioSoftware/yulin/issues/198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated S3 bucket policy support: create/attach, retrieve, and delete bucket policies.
  * Bucket policy changes now affect access decisions for object reads.
  * Extended CloudFormation simulation for `AWS::S3::Bucket` (including website configuration) and `AWS::S3::BucketPolicy`.
  * Added SDK command routing for getting and deleting bucket policies.
* **Documentation**
  * Expanded S3 simulator docs with bucket policy behavior, limits, and a new usage example.
* **Bug Fixes**
  * Improved request validation and error handling, including correct “no such bucket/policy” and malformed policy document failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->