### PR TITLE
feat: sim S3 Block Public Access on by default

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -18,6 +18,8 @@ Sim S3 currently supports:
 - Bucket policies with `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and
   `DeleteBucketPolicyCommand`, evaluated by sim IAM alongside identity policies
 - Creating Buckets and Bucket policies from `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
+- Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the
+  Bucket opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
 - Serving static website requests on localhost with `serveSimAws`
 - Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
@@ -327,12 +329,55 @@ console.log(policyOut.Policy);
 is how real S3 distinguishes that from a Bucket that does not exist. `DeleteBucketPolicyCommand`
 succeeds either way, matching S3's idempotent behaviour.
 
+A Bucket policy granting `Principal: "*"` is refused by default. See
+[Block Public Access](#block-public-access) below.
+
+## Block Public Access
+
+Real S3 turns on all four Block Public Access settings for every new Bucket, and `BlockPublicPolicy`
+makes `PutBucketPolicy` reject a policy that allows public access. Sim S3 does the same, so a Bucket
+starts closed and a public Bucket policy is refused with `AccessDenied` until the Bucket opts out:
+
+```typescript
+await simS3.putPublicAccessBlock(
+  new PutPublicAccessBlockCommand({
+    Bucket: "site",
+    PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+  }),
+);
+```
+
+`GetPublicAccessBlockCommand` reads the settings back and `DeletePublicAccessBlockCommand` removes
+them, which returns the Bucket to fully blocked rather than leaving it open. In a CloudFormation
+template the settings are the `PublicAccessBlockConfiguration` property of `AWS::S3::Bucket`, and a
+Stack whose `AWS::S3::BucketPolicy` is public without that opt-out fails to deploy, exactly as the
+real deployment would.
+
+The settings govern what may be written rather than what is already stored, so turning
+`BlockPublicPolicy` back on afterwards leaves an existing public policy in place.
+
+### What counts as public
+
+A statement is public when it allows a wildcard `Principal` without pinning the caller down. A
+`Condition` fixing `aws:SourceAccount`, `aws:SourceArn`, `aws:PrincipalOrgID`, `aws:SourceVpc`,
+`aws:SourceVpce`, `aws:SourceOwner`, `aws:userid`, `s3:DataAccessPointArn` or
+`s3:DataAccessPointAccount` to a value with no wildcard in it makes the statement non-public, as it
+does in real S3. A `Service` principal is never a wildcard, and a `Deny` statement is never public.
+
 ### Limitations
 
-Sim S3 does not model S3 Block Public Access. Real S3 enables all four settings by default on new
-Buckets, and `BlockPublicPolicy` causes `PutBucketPolicy` to reject a policy that allows public
-access. The simulator accepts such a policy, so a Bucket policy granting `Principal: "*"` can work
-here and be refused by real S3 unless the Bucket sets `PublicAccessBlockConfiguration` accordingly.
+Only `BlockPublicPolicy` changes behaviour. The other three settings are stored and reported but do
+nothing: `BlockPublicAcls` and `IgnorePublicAcls` govern ACLs, which are not modelled, and
+`RestrictPublicBuckets` changes how an existing public policy is evaluated for cross-account callers
+rather than rejecting a write, which is not yet simulated.
+
+Anything the simulator cannot classify confidently counts as public and is refused, so it can be
+stricter than real S3. A `NotPrincipal` statement, a statement with no `Principal`, and a
+`Condition` on `aws:SourceIp` all count as public here. Real S3 accepts a sufficiently narrow
+`aws:SourceIp` CIDR range as non-public; the simulator does not judge range breadth.
+
+Account-level and organisation-level Block Public Access, access points, and `GetBucketPolicyStatus`
+are not simulated.
 
 Bucket ACLs and Object ownership settings are not modelled and are not planned. Object Ownership
 defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -71,6 +71,9 @@ Supported command areas currently include:
 - `put-bucket-policy/`
 - `get-bucket-policy/`
 - `delete-bucket-policy/`
+- `put-public-access-block/`
+- `get-public-access-block/`
+- `delete-public-access-block/`
 - `put-object/`
 - `get-object/`
 - `list-objects/`
@@ -144,10 +147,35 @@ Its public methods are small:
 - `configurePolicy(policy)`
 - `getPolicy()`
 - `deletePolicy()`
+- `configurePublicAccessBlock(publicAccessBlock)`
+- `getPublicAccessBlock()`
+- `deletePublicAccessBlock()`
 
 The Bucket resource policy is stored parsed rather than as a JSON string, because that is the shape
 sim IAM evaluates. `GetBucketPolicy` serializes it back on the way out, so the string a caller reads
 is a normalized form of what was applied rather than the original text.
+
+## Block Public Access
+
+`bucket/public-access/` holds the Block Public Access model. Every Bucket has a
+`SimS3PublicAccessBlock` with all four settings enabled, matching real S3's default for new Buckets,
+and a setting left unspecified is taken as enabled rather than disabled.
+
+Only `BlockPublicPolicy` currently has an effect. `SimS3PublicPolicyGuard` applies it in the
+`PutBucketPolicy` handler, after authorization, because the setting refuses a policy the caller is
+otherwise entitled to apply. It throws `SimS3AccessDenied`, which is S3 itself refusing the request
+rather than sim IAM denying it, so it is deliberately not `SimIamAccessDenied`.
+
+Deciding whether a document is public is split up so each piece stays small:
+
+- `SimS3PublicPolicy` walks the statements and decides the document
+- `simS3PrincipalIsWildcard` decides whether a statement's `Principal` names everyone
+- `simS3ConditionPinsPrincipal` decides whether a `Condition` ties a wildcard `Principal` to fixed
+  values, which is what makes an otherwise public statement non-public in real S3
+
+The determination fails closed throughout: a statement the simulator cannot classify counts as
+public, so the policy is refused rather than quietly stored. `aws:SourceIp` is deliberately excluded
+from the pinning condition keys because real S3 judges CIDR breadth and the simulator does not.
 
 By keeping storage behind `SimS3BucketStorage`, the Bucket model stays independent of whether
 objects live in memory or on the local filesystem.
@@ -408,6 +436,7 @@ Handlers throw AWS-like errors for supported failure cases, including:
 - no such Bucket
 - no such key
 - no such Bucket policy
+- access denied, for S3's own refusals such as Block Public Access
 - Bucket already exists
 - Bucket already owned by you
 

--- a/src/service/s3/bucket/public-access/sim-s3-pinning-condition.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-pinning-condition.ts
@@ -1,0 +1,95 @@
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../iam/policy/sim-iam-policy.js";
+
+/**
+ * Condition keys that tie a wildcard Principal down to specific callers.
+ *
+ * These are the keys real S3 accepts as making an otherwise public Bucket
+ * policy non-public. `aws:SourceIp` is deliberately absent: S3 judges a CIDR
+ * range's breadth, treating anything wider than /8 as still public, and the
+ * simulator does not model that. Leaving it out means such a policy is treated
+ * as public, which errs toward refusing rather than allowing.
+ */
+const pinningConditionKeys: ReadonlySet<string> = new Set([
+  "aws:principalorgid",
+  "aws:sourcearn",
+  "aws:sourcevpc",
+  "aws:sourcevpce",
+  "aws:sourceowner",
+  "aws:sourceaccount",
+  "aws:userid",
+  "s3:dataaccesspointarn",
+  "s3:dataaccesspointaccount",
+]);
+
+/**
+ * Condition operators that pin a key to a value.
+ *
+ * Negative and `IfExists` operators are absent because neither constrains who
+ * can call: an `IfExists` condition passes when the key is missing entirely.
+ */
+const pinningOperators: ReadonlySet<string> = new Set([
+  "stringequals",
+  "stringequalsignorecase",
+  "stringlike",
+  "arnequals",
+  "arnlike",
+]);
+
+/**
+ * Whether a statement Condition constrains a wildcard Principal to fixed
+ * values, which is what stops real S3 counting the statement as public.
+ */
+export function simS3ConditionPinsPrincipal(
+  condition: SimIamPolicyDocumentCondition | undefined,
+): boolean {
+  if (condition === undefined) {
+    return false;
+  }
+
+  for (const [operator, keyValues] of Object.entries(condition)) {
+    if (!pinningOperators.has(operator.toLowerCase())) {
+      continue;
+    }
+
+    if (pinsAnyKey(keyValues)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function pinsAnyKey(
+  keyValues: Readonly<Record<string, SimIamConditionValue>>,
+): boolean {
+  for (const [conditionKey, value] of Object.entries(keyValues)) {
+    if (
+      pinningConditionKeys.has(conditionKey.toLowerCase()) &&
+      isFixedValue(value)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * A value is fixed when it matches one caller rather than a set of them, so no
+ * wildcard characters and no unresolved IAM policy variable.
+ */
+function isFixedValue(value: SimIamConditionValue): boolean {
+  const values = Array.isArray(value) ? value : [value];
+
+  return values.every(
+    (candidate) =>
+      typeof candidate === "string" &&
+      candidate.length > 0 &&
+      !candidate.includes("*") &&
+      !candidate.includes("?") &&
+      !candidate.includes("${"),
+  );
+}

--- a/src/service/s3/bucket/public-access/sim-s3-public-access-block.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-access-block.ts
@@ -1,0 +1,57 @@
+/**
+ * Structural shape of an S3 PublicAccessBlockConfiguration.
+ *
+ * Matches the AWS SDK and CloudFormation property shape, so the same object can
+ * come from either.
+ */
+export interface SimS3PublicAccessBlockConfiguration {
+  readonly BlockPublicAcls?: boolean | undefined;
+  readonly IgnorePublicAcls?: boolean | undefined;
+  readonly BlockPublicPolicy?: boolean | undefined;
+  readonly RestrictPublicBuckets?: boolean | undefined;
+}
+
+/**
+ * The S3 Block Public Access settings of one simulated Bucket.
+ *
+ * Real S3 enables all four settings on every new Bucket, so that is what a
+ * Bucket gets unless something turns one off.
+ *
+ * A setting the caller leaves unspecified is taken as enabled. Real S3 replaces
+ * the whole configuration on PutPublicAccessBlock, and its documentation does
+ * not state what an omitted element means, so the simulator takes the
+ * restrictive reading: being stricter than AWS surfaces as a puzzling test
+ * failure, while being looser surfaces as a production incident.
+ */
+export class SimS3PublicAccessBlock {
+  private readonly blockPublicAcls: boolean;
+  private readonly ignorePublicAcls: boolean;
+  private readonly blockPublicPolicy: boolean;
+  private readonly restrictPublicBuckets: boolean;
+
+  constructor(configuration: SimS3PublicAccessBlockConfiguration = {}) {
+    this.blockPublicAcls = configuration.BlockPublicAcls ?? true;
+    this.ignorePublicAcls = configuration.IgnorePublicAcls ?? true;
+    this.blockPublicPolicy = configuration.BlockPublicPolicy ?? true;
+    this.restrictPublicBuckets = configuration.RestrictPublicBuckets ?? true;
+  }
+
+  /**
+   * Whether this Bucket refuses a Bucket policy that allows public access.
+   */
+  blocksPublicPolicy(): boolean {
+    return this.blockPublicPolicy;
+  }
+
+  /**
+   * The configuration as an AWS-shaped record, for GetPublicAccessBlock.
+   */
+  toConfiguration(): Required<SimS3PublicAccessBlockConfiguration> {
+    return {
+      BlockPublicAcls: this.blockPublicAcls,
+      IgnorePublicAcls: this.ignorePublicAcls,
+      BlockPublicPolicy: this.blockPublicPolicy,
+      RestrictPublicBuckets: this.restrictPublicBuckets,
+    };
+  }
+}

--- a/src/service/s3/bucket/public-access/sim-s3-public-policy-guard.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-policy-guard.ts
@@ -1,0 +1,35 @@
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import { SimS3AccessDenied } from "../../error/sim-s3.error.js";
+import type { SimS3Bucket } from "../sim-s3-bucket.js";
+import { SimS3PublicPolicy } from "./sim-s3-public-policy.js";
+
+/**
+ * Refuses a Bucket policy that the Bucket's Block Public Access settings do
+ * not allow.
+ *
+ * Real S3 applies this after deciding the caller may set a policy at all, so
+ * it refuses a policy the caller is otherwise entitled to apply. Enabling the
+ * setting later does not disturb a policy already stored: it governs what may
+ * be written, not what is already there.
+ */
+export class SimS3PublicPolicyGuard {
+  private readonly publicPolicy = new SimS3PublicPolicy();
+
+  /**
+   * Throw when the Bucket blocks public policies and this document is one.
+   */
+  guard(bucket: SimS3Bucket, document: SimIamPolicyDocument): void {
+    if (!bucket.getPublicAccessBlock().blocksPublicPolicy()) {
+      return;
+    }
+
+    if (!this.publicPolicy.isPublic(document)) {
+      return;
+    }
+
+    throw new SimS3AccessDenied(
+      `BlockPublicPolicy is enabled on S3 Bucket ${bucket.bucketName}, ` +
+        "so a Bucket policy allowing public access is refused",
+    );
+  }
+}

--- a/src/service/s3/bucket/public-access/sim-s3-public-policy.iso.test.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-policy.iso.test.ts
@@ -1,0 +1,162 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import { SimS3PublicPolicy } from "./sim-s3-public-policy.js";
+
+describe("S3 public Bucket policy detection", () => {
+  const publicPolicy = new SimS3PublicPolicy();
+
+  const documentGranting = (
+    statement: Record<string, unknown>,
+  ): SimIamPolicyDocument => ({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports/*",
+        ...statement,
+      },
+    ],
+  });
+
+  it("treats a wildcard Principal as public in each of its shapes", () => {
+    // Given the ways a policy can name everyone.
+    // When each is judged.
+    // Then all of them count as public.
+    assertTrue(publicPolicy.isPublic(documentGranting({ Principal: "*" })));
+    assertTrue(
+      publicPolicy.isPublic(documentGranting({ Principal: { AWS: "*" } })),
+    );
+    assertTrue(
+      publicPolicy.isPublic(documentGranting({ Principal: { AWS: ["*"] } })),
+    );
+    assertTrue(publicPolicy.isPublic(documentGranting({ Principal: ["*"] })));
+  });
+
+  it("treats a Principal naming fixed identities as non-public", () => {
+    // Given statements granting specific principals.
+    // When each is judged.
+    // Then none of them is public.
+    assertFalse(
+      publicPolicy.isPublic(
+        documentGranting({
+          Principal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
+        }),
+      ),
+    );
+
+    // A Service principal names something specific, so it is not a wildcard
+    // even though it grants outside the Account.
+    assertFalse(
+      publicPolicy.isPublic(
+        documentGranting({
+          Principal: { Service: "cloudfront.amazonaws.com" },
+        }),
+      ),
+    );
+  });
+
+  it("treats a wildcard Principal pinned by a Condition as non-public", () => {
+    // Given a wildcard Principal constrained to one Account.
+    const document = documentGranting({
+      Principal: "*",
+      Condition: { StringEquals: { "aws:SourceAccount": "222222222222" } },
+    });
+
+    // When it is judged.
+    // Then the fixed condition value makes it non-public, as in real S3.
+    assertFalse(publicPolicy.isPublic(document));
+  });
+
+  it("still counts a Condition value containing a wildcard as public", () => {
+    // Given a condition that matches a set of callers rather than one.
+    const document = documentGranting({
+      Principal: "*",
+      Condition: { StringLike: { "aws:SourceVpc": "vpc-*" } },
+    });
+
+    // When it is judged.
+    // Then it remains public, matching the example in S3's own documentation.
+    assertTrue(publicPolicy.isPublic(document));
+  });
+
+  it("ignores condition keys and operators that do not pin the caller", () => {
+    // Given conditions that constrain something other than who is calling.
+    const unrelatedKey = documentGranting({
+      Principal: "*",
+      Condition: { StringEquals: { "s3:prefix": "public/" } },
+    });
+
+    // An IfExists operator passes when the key is absent, so it pins nothing.
+    const ifExists = documentGranting({
+      Principal: "*",
+      Condition: {
+        StringEqualsIfExists: { "aws:SourceAccount": "222222222222" },
+      },
+    });
+
+    // aws:SourceIp is deliberately not modelled, so it does not rescue a
+    // policy from being public.
+    const sourceIp = documentGranting({
+      Principal: "*",
+      Condition: { IpAddress: { "aws:SourceIp": "203.0.113.0/24" } },
+    });
+
+    // When each is judged.
+    // Then none of them stops the statement being public.
+    assertTrue(publicPolicy.isPublic(unrelatedKey));
+    assertTrue(publicPolicy.isPublic(ifExists));
+    assertTrue(publicPolicy.isPublic(sourceIp));
+  });
+
+  it("ignores Deny statements when judging public access", () => {
+    // Given a document whose only wildcard statement denies rather than allows.
+    const document = documentGranting({
+      Effect: "Deny",
+      Principal: "*",
+    });
+
+    // When it is judged.
+    // Then it is not public: a Deny grants nobody anything.
+    assertFalse(publicPolicy.isPublic(document));
+  });
+
+  it("counts anything it cannot classify as public", () => {
+    // Given statements the simulator has no confident reading of.
+    const notPrincipal = documentGranting({
+      NotPrincipal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
+    });
+    const noPrincipal = documentGranting({});
+
+    // When each is judged.
+    // Then both count as public, so the policy is refused rather than allowed.
+    assertTrue(publicPolicy.isPublic(notPrincipal));
+    assertTrue(publicPolicy.isPublic(noPrincipal));
+  });
+
+  it("counts a document public when any one of its statements is", () => {
+    // Given a document mixing a fixed grant with a public one.
+    const document = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::reports/private/*",
+        },
+        {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::reports/public/*",
+        },
+      ],
+    } as SimIamPolicyDocument;
+
+    // When it is judged.
+    // Then the public statement decides the whole document.
+    assertTrue(publicPolicy.isPublic(document));
+  });
+});

--- a/src/service/s3/bucket/public-access/sim-s3-public-policy.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-policy.ts
@@ -1,0 +1,45 @@
+import { simIamPolicyDocumentStatements } from "../../../iam/policy/sim-iam-pol-document-statements.js";
+import type {
+  SimIamPolicyDocument,
+  SimIamPolicyDocumentStatement,
+} from "../../../iam/policy/sim-iam-policy.js";
+import { simS3ConditionPinsPrincipal } from "./sim-s3-pinning-condition.js";
+import { simS3PrincipalIsWildcard } from "./sim-s3-public-principal.js";
+
+/**
+ * Decides whether a Bucket policy allows public access, which is what S3 Block
+ * Public Access judges a PutBucketPolicy call against.
+ *
+ * Real S3 starts by assuming a policy is public and looks for a reason it is
+ * not: a statement qualifies as non-public only when it grants access to fixed
+ * values. The simulator follows the same direction, so anything it cannot
+ * classify stays public and gets refused.
+ */
+export class SimS3PublicPolicy {
+  /**
+   * Whether any statement in the document grants public access.
+   */
+  isPublic(document: SimIamPolicyDocument): boolean {
+    return simIamPolicyDocumentStatements(document).some((statement) =>
+      this.statementIsPublic(statement),
+    );
+  }
+
+  private statementIsPublic(statement: SimIamPolicyDocumentStatement): boolean {
+    if (statement.Effect !== "Allow") {
+      return false;
+    }
+
+    // NotPrincipal grants to everyone except the listed identities, which is
+    // public by any reading.
+    if (statement.NotPrincipal !== undefined) {
+      return true;
+    }
+
+    if (!simS3PrincipalIsWildcard(statement.Principal)) {
+      return false;
+    }
+
+    return !simS3ConditionPinsPrincipal(statement.Condition);
+  }
+}

--- a/src/service/s3/bucket/public-access/sim-s3-public-principal.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-principal.ts
@@ -1,0 +1,50 @@
+import type {
+  SimIamPolicyDocumentPrincipal,
+  SimIamPolicyDocumentPrincipalObject,
+} from "../../../iam/policy/sim-iam-policy.js";
+
+/**
+ * Whether a policy statement Principal names everyone rather than fixed
+ * identities.
+ *
+ * Only the `AWS` principal type can be a wildcard that opens a Bucket to the
+ * world. A `Service`, `Federated` or `CanonicalUser` principal names something
+ * specific, so a statement granting one of those is not public.
+ */
+export function simS3PrincipalIsWildcard(
+  principal: SimIamPolicyDocumentPrincipal | undefined,
+): boolean {
+  if (principal === undefined) {
+    // A Bucket policy statement must name a Principal. One that does not is
+    // not something the simulator can classify, so it counts as public.
+    return true;
+  }
+
+  if (typeof principal === "string") {
+    return principal === "*";
+  }
+
+  if (Array.isArray(principal)) {
+    return principal.includes("*");
+  }
+
+  return awsPrincipalIsWildcard(
+    principal as SimIamPolicyDocumentPrincipalObject,
+  );
+}
+
+function awsPrincipalIsWildcard(
+  principal: SimIamPolicyDocumentPrincipalObject,
+): boolean {
+  for (const [principalType, value] of Object.entries(principal)) {
+    if (principalType.toLowerCase() !== "aws") {
+      continue;
+    }
+
+    if (typeof value === "string" ? value === "*" : value.includes("*")) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -3,6 +3,7 @@ import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
+import { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
@@ -17,6 +18,7 @@ interface SimS3BucketProperties {
   readonly storage?: SimS3BucketStorage;
   readonly website?: SimS3BucketWebsite;
   readonly policy?: SimIamPolicyDocument | undefined;
+  readonly publicAccessBlock?: SimS3PublicAccessBlock;
 }
 
 /**
@@ -29,6 +31,7 @@ export class SimS3Bucket {
   private storage: SimS3BucketStorage;
   private website: SimS3BucketWebsite;
   private policy: SimIamPolicyDocument | undefined;
+  private publicAccessBlock: SimS3PublicAccessBlock;
 
   constructor(properties: SimS3BucketProperties) {
     const {
@@ -37,6 +40,7 @@ export class SimS3Bucket {
       storage = new MemoryS3BucketStorage(),
       website = new SimS3BucketWebsite(),
       policy,
+      publicAccessBlock = new SimS3PublicAccessBlock(),
     } = properties;
 
     validateS3BucketName(bucketName);
@@ -46,6 +50,7 @@ export class SimS3Bucket {
     this.storage = storage;
     this.website = website;
     this.policy = policy;
+    this.publicAccessBlock = publicAccessBlock;
   }
 
   /**
@@ -112,6 +117,30 @@ export class SimS3Bucket {
    */
   deletePolicy(): void {
     this.policy = undefined;
+  }
+
+  /**
+   * Replace this Bucket's Block Public Access settings.
+   */
+  configurePublicAccessBlock(publicAccessBlock: SimS3PublicAccessBlock): void {
+    this.publicAccessBlock = publicAccessBlock;
+  }
+
+  /**
+   * Get this Bucket's Block Public Access settings.
+   */
+  getPublicAccessBlock(): SimS3PublicAccessBlock {
+    return this.publicAccessBlock;
+  }
+
+  /**
+   * Remove this Bucket's Block Public Access settings.
+   *
+   * Removing the configuration returns the Bucket to the all-enabled state a
+   * new Bucket starts in, rather than leaving it unprotected.
+   */
+  deletePublicAccessBlock(): void {
+    this.publicAccessBlock = new SimS3PublicAccessBlock();
   }
 
   /**

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy.iso.test.ts
@@ -32,7 +32,10 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
       Resources: {
         ReportsBucket: {
           Type: "AWS::S3::Bucket",
-          Properties: { BucketName: "reports" },
+          Properties: {
+            BucketName: "reports",
+            PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+          },
         },
         ReportsBucketPolicy: {
           Type: "AWS::S3::BucketPolicy",
@@ -79,7 +82,12 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
         Resources: {
           ReportsBucket: {
             Type: "AWS::S3::Bucket",
-            Properties: { BucketName: "reports" },
+            Properties: {
+              BucketName: "reports",
+              // A public Bucket policy needs Block Public Access turned off,
+              // exactly as a real deployment does.
+              PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+            },
           },
           ReportsBucketPolicy: {
             Type: "AWS::S3::BucketPolicy",
@@ -145,7 +153,12 @@ describe("S3 CloudFormation BucketPolicy Resource", () => {
         Resources: {
           ReportsBucket: {
             Type: "AWS::S3::Bucket",
-            Properties: { BucketName: "reports" },
+            Properties: {
+              BucketName: "reports",
+              // A public Bucket policy needs Block Public Access turned off,
+              // exactly as a real deployment does.
+              PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+            },
           },
           ReportsBucketPolicy: {
             Type: "AWS::S3::BucketPolicy",

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimS3 } from "../../sim-s3.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3PublicAccessBlockConfiguration } from "../../bucket/public-access/sim-s3-public-access-block.js";
 import type { SimS3WebsiteConfiguration as SimS3WebsiteConfig } from "../../command/put-bucket-website/put-bucket-website.command.js";
 import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-name.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
@@ -53,7 +54,40 @@ export class SimCfnS3BucketCreator {
       });
     }
 
+    const publicAccessConfig =
+      this.publicAccessConfigurationForResource(properties);
+
+    if (publicAccessConfig !== undefined) {
+      await this.simS3.putPublicAccessBlock({
+        input: {
+          Bucket: bucketName,
+          PublicAccessBlockConfiguration: publicAccessConfig,
+        },
+      });
+    }
+
     return bucket;
+  }
+
+  /**
+   * Read PublicAccessBlockConfiguration, which a template uses to open a
+   * Bucket up from the all-blocked state a new Bucket starts in.
+   */
+  private publicAccessConfigurationForResource(
+    properties: SimCfnTemplateValueRecord,
+  ): SimS3PublicAccessBlockConfiguration | undefined {
+    const publicAccessConfig = properties["PublicAccessBlockConfiguration"];
+
+    if (
+      publicAccessConfig === undefined ||
+      publicAccessConfig === null ||
+      typeof publicAccessConfig !== "object" ||
+      Array.isArray(publicAccessConfig)
+    ) {
+      return undefined;
+    }
+
+    return publicAccessConfig;
   }
 
   private bucketNameForResource(

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
@@ -1,0 +1,162 @@
+import { GetPublicAccessBlockCommand } from "@aws-sdk/client-s3";
+import {
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3AccessDenied } from "../../error/sim-s3.error.js";
+
+describe("S3 CloudFormation PublicAccessBlockConfiguration", () => {
+  const publicReadStatement = {
+    Effect: "Allow",
+    Principal: "*",
+    Action: "s3:GetObject",
+    Resource: "arn:aws:s3:::site/*",
+  };
+
+  it("applies PublicAccessBlockConfiguration when the Bucket is created", async () => {
+    // Given a template opening one Block Public Access setting.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "configured-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "site",
+              PublicAccessBlockConfiguration: {
+                BlockPublicPolicy: false,
+                RestrictPublicBuckets: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the Bucket carries those settings, with the unspecified ones at
+    // their blocked default.
+    const output = await simAws
+      .s3()
+      .getPublicAccessBlock(
+        new GetPublicAccessBlockCommand({ Bucket: "site" }),
+      );
+
+    assertObjectEquals(output.PublicAccessBlockConfiguration, {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+      BlockPublicPolicy: false,
+      RestrictPublicBuckets: false,
+    });
+  });
+
+  it("blocks public access on a Bucket that declares no configuration", async () => {
+    // Given a template with a plain Bucket.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "default-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "site" },
+          },
+        },
+      },
+    });
+
+    // Then it starts fully blocked, as a new Bucket does in real S3.
+    const output = await simAws
+      .s3()
+      .getPublicAccessBlock(
+        new GetPublicAccessBlockCommand({ Bucket: "site" }),
+      );
+
+    assertObjectEquals(output.PublicAccessBlockConfiguration, {
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+      BlockPublicPolicy: true,
+      RestrictPublicBuckets: true,
+    });
+  });
+
+  it("fails the Stack when a public Bucket policy is blocked", async () => {
+    // Given a template attaching a public policy to a Bucket that has not
+    // opted out of blocking them.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "blocked-stack",
+        template: {
+          Resources: {
+            SiteBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "site" },
+            },
+            SiteBucketPolicy: {
+              Type: "AWS::S3::BucketPolicy",
+              Properties: {
+                Bucket: { Ref: "SiteBucket" },
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [publicReadStatement],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the Stack fails, naming the logical ID and the setting that
+    // refused the policy, rather than deploying a Bucket real S3 would not.
+    assertInstanceOf(error, SimS3AccessDenied);
+    assertStringIncludes(error.message, "SiteBucketPolicy");
+    assertStringIncludes(error.message, "BlockPublicPolicy");
+  });
+
+  it("deploys the same public policy when the Bucket opts out", async () => {
+    // Given the same template with the Bucket opting out of the block.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "opted-out-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "site",
+              PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+            },
+          },
+          SiteBucketPolicy: {
+            Type: "AWS::S3::BucketPolicy",
+            Properties: {
+              Bucket: { Ref: "SiteBucket" },
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [publicReadStatement],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the Stack deploys and the policy is attached.
+    const resource = stack.resources.get("SiteBucketPolicy");
+    assertStringIncludes(resource?.status ?? "", "CREATE_COMPLETE");
+  });
+});

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy.iso.test.ts
@@ -6,6 +6,7 @@ import {
   GetObjectCommand,
   PutBucketPolicyCommand,
   PutObjectCommand,
+  PutPublicAccessBlockCommand,
 } from "@aws-sdk/client-s3";
 import {
   assertIdentical,
@@ -37,6 +38,13 @@ describe("S3 DeleteBucketPolicyCommand", () => {
         Bucket: "revocable-policy-bucket",
         Key: "public/notice.txt",
         Body: "published",
+      }),
+    );
+    // A public grant needs Block Public Access turned off first.
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "revocable-policy-bucket",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
       }),
     );
     await simS3.putBucketPolicy(

--- a/src/service/s3/command/delete-public-access-block/delete-public-access-block.command.ts
+++ b/src/service/s3/command/delete-public-access-block/delete-public-access-block.command.ts
@@ -1,0 +1,22 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeletePublicAccessBlock command.
+ */
+export interface SimDeletePublicAccessBlockCommand {
+  readonly input: SimDeletePublicAccessBlockCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeletePublicAccessBlock input.
+ */
+export interface SimDeletePublicAccessBlockCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeletePublicAccessBlock output.
+ */
+export interface SimDeletePublicAccessBlockCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-public-access-block/delete-public-access-block.handler.ts
+++ b/src/service/s3/command/delete-public-access-block/delete-public-access-block.handler.ts
@@ -1,0 +1,80 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3PublicAccessBlockAuthorizer } from "../public-access-block/sim-s3-public-access-block-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimDeletePublicAccessBlockCommand,
+  SimDeletePublicAccessBlockCommandOutput,
+} from "./delete-public-access-block.command.js";
+
+interface DeletePublicAccessBlockCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeletePublicAccessBlockCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 DeletePublicAccessBlockCommand handler.
+ */
+export class DeletePublicAccessBlockCommandHandler implements CommandHandler<
+  SimDeletePublicAccessBlockCommand,
+  SimDeletePublicAccessBlockCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3PublicAccessBlockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeletePublicAccessBlockCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3PublicAccessBlockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and remove a Bucket's Block Public Access settings, returning
+   * the Bucket to the all-enabled state a new Bucket starts in.
+   */
+  async handle(
+    command: SimDeletePublicAccessBlockCommand,
+    options?: DeletePublicAccessBlockCommandHandlerOptions,
+  ): Promise<SimDeletePublicAccessBlockCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "DeletePublicAccessBlockCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options?.caller);
+
+    bucket.deletePublicAccessBlock();
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy.iso.test.ts
@@ -130,7 +130,9 @@ describe("S3 GetBucketPolicyCommand", () => {
           Version: "2012-10-17",
           Statement: {
             Effect: "Allow",
-            Principal: "*",
+            Principal: {
+              AWS: "arn:aws:iam::222222222222:role/ReportReader",
+            },
             Action: "s3:GetObject",
             Resource: "arn:aws:s3:::guarded-policy-bucket/*",
           },

--- a/src/service/s3/command/get-public-access-block/get-public-access-block.command.ts
+++ b/src/service/s3/command/get-public-access-block/get-public-access-block.command.ts
@@ -1,0 +1,24 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3PublicAccessBlockConfiguration } from "../../bucket/public-access/sim-s3-public-access-block.js";
+
+/**
+ * Minimal structural sim S3 GetPublicAccessBlock command.
+ */
+export interface SimGetPublicAccessBlockCommand {
+  readonly input: SimGetPublicAccessBlockCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetPublicAccessBlock input.
+ */
+export interface SimGetPublicAccessBlockCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetPublicAccessBlock output.
+ */
+export interface SimGetPublicAccessBlockCommandOutput {
+  readonly PublicAccessBlockConfiguration: Required<SimS3PublicAccessBlockConfiguration>;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-public-access-block/get-public-access-block.handler.ts
+++ b/src/service/s3/command/get-public-access-block/get-public-access-block.handler.ts
@@ -1,0 +1,83 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3PublicAccessBlockAuthorizer } from "../public-access-block/sim-s3-public-access-block-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimGetPublicAccessBlockCommand,
+  SimGetPublicAccessBlockCommandOutput,
+} from "./get-public-access-block.command.js";
+
+interface GetPublicAccessBlockCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface GetPublicAccessBlockCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 GetPublicAccessBlockCommand handler.
+ */
+export class GetPublicAccessBlockCommandHandler implements CommandHandler<
+  SimGetPublicAccessBlockCommand,
+  SimGetPublicAccessBlockCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3PublicAccessBlockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetPublicAccessBlockCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3PublicAccessBlockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and return a Bucket's Block Public Access settings.
+   *
+   * Every simulated Bucket has settings, so unlike the Bucket policy there is
+   * no missing-configuration case to report.
+   */
+  async handle(
+    command: SimGetPublicAccessBlockCommand,
+    options?: GetPublicAccessBlockCommandHandlerOptions,
+  ): Promise<SimGetPublicAccessBlockCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "GetPublicAccessBlockCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeRead(bucket, options?.caller);
+
+    return {
+      PublicAccessBlockConfiguration: bucket
+        .getPublicAccessBlock()
+        .toConfiguration(),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
+++ b/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
@@ -1,0 +1,69 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface SimS3PublicAccessBlockAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the S3 Block Public Access commands.
+ *
+ * Reading the configuration is governed by s3:GetBucketPublicAccessBlock.
+ * Both writing and removing it are governed by s3:PutBucketPublicAccessBlock:
+ * real S3 has no separate delete permission, so removing the configuration
+ * needs exactly what setting it needs.
+ */
+export class SimS3PublicAccessBlockAuthorizer {
+  private static readonly readAction = "s3:GetBucketPublicAccessBlock";
+  private static readonly writeAction = "s3:PutBucketPublicAccessBlock";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3PublicAccessBlockAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may read the Bucket's Block Public Access settings.
+   */
+  authorizeRead(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    this.authorize(SimS3PublicAccessBlockAuthorizer.readAction, bucket, caller);
+  }
+
+  /**
+   * Ensure the caller may replace or remove the Block Public Access settings.
+   */
+  authorizeWrite(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    this.authorize(
+      SimS3PublicAccessBlockAuthorizer.writeAction,
+      bucket,
+      caller,
+    );
+  }
+
+  private authorize(
+    action: string,
+    bucket: SimS3Bucket,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = simS3BucketArn(bucket.bucketName);
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy-public-access.iso.test.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy-public-access.iso.test.ts
@@ -1,0 +1,189 @@
+import {
+  CreateBucketCommand,
+  GetBucketPolicyCommand,
+  PutBucketPolicyCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3AccessDenied } from "../../error/sim-s3.error.js";
+
+describe("S3 PutBucketPolicy under Block Public Access", () => {
+  const simAws = new SimAws();
+
+  const publicPolicy = (bucketName: string): string =>
+    JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: "*",
+        Action: "s3:GetObject",
+        Resource: `arn:aws:s3:::${bucketName}/*`,
+      },
+    });
+
+  it("refuses a public Bucket policy on a Bucket at its defaults", async () => {
+    // Given a new Bucket, which blocks public policies as real S3 does.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "blocked" }));
+
+    // When a public Bucket policy is applied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketPolicy(
+        new PutBucketPolicyCommand({
+          Bucket: "blocked",
+          Policy: publicPolicy("blocked"),
+        }),
+      ),
+    );
+
+    // Then S3 refuses it, naming the setting responsible.
+    assertInstanceOf(error, SimS3AccessDenied);
+    assertIdentical(error.$metadata.httpStatusCode, 403);
+    assertStringIncludes(error.message, "BlockPublicPolicy");
+
+    // And nothing was stored.
+    const readError = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketPolicy(new GetBucketPolicyCommand({ Bucket: "blocked" })),
+    );
+    assertStringIncludes(readError.message, "No Bucket policy");
+  });
+
+  it("accepts a public Bucket policy once BlockPublicPolicy is turned off", async () => {
+    // Given a Bucket that has opted out of blocking public policies.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "opened" }));
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "opened",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      }),
+    );
+
+    // When the same public policy is applied.
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "opened",
+        Policy: publicPolicy("opened"),
+      }),
+    );
+
+    // Then it is stored.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "opened" }),
+    );
+    assertObjectEquals(
+      JSON.parse(output.Policy),
+      JSON.parse(publicPolicy("opened")),
+    );
+  });
+
+  it("accepts a non-public Bucket policy while blocking is on", async () => {
+    // Given a Bucket at its blocked defaults.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "fixed" }));
+
+    // When a policy granting a fixed principal is applied.
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "fixed",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::fixed/*",
+          },
+        }),
+      }),
+    );
+
+    // Then Block Public Access has nothing to say about it.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "fixed" }),
+    );
+    assertStringIncludes(output.Policy, "222222222222");
+  });
+
+  it("accepts a wildcard Principal pinned to a fixed Account", async () => {
+    // Given a Bucket at its blocked defaults.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "pinned" }));
+
+    // When a wildcard Principal is constrained by a fixed condition value.
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "pinned",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::pinned/*",
+            Condition: {
+              StringEquals: { "aws:SourceAccount": "222222222222" },
+            },
+          },
+        }),
+      }),
+    );
+
+    // Then the policy is not public, so it is stored.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "pinned" }),
+    );
+    assertStringIncludes(output.Policy, "aws:SourceAccount");
+  });
+
+  it("leaves an existing public policy in place when blocking is turned back on", async () => {
+    // Given a Bucket carrying a public policy applied while blocking was off.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "grandfathered" }),
+    );
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "grandfathered",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      }),
+    );
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "grandfathered",
+        Policy: publicPolicy("grandfathered"),
+      }),
+    );
+
+    // When blocking is turned back on.
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "grandfathered",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: true },
+      }),
+    );
+
+    // Then the stored policy is untouched: the setting governs new policies
+    // rather than removing existing ones, as AWS documents.
+    const output = await simS3.getBucketPolicy(
+      new GetBucketPolicyCommand({ Bucket: "grandfathered" }),
+    );
+    assertObjectEquals(
+      JSON.parse(output.Policy),
+      JSON.parse(publicPolicy("grandfathered")),
+    );
+  });
+});

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
@@ -13,7 +13,8 @@ import type {
   SimS3Bucket,
   SimS3BucketName,
 } from "../../bucket/sim-s3-bucket.js";
-import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+import { SimS3PublicPolicyGuard } from "../../bucket/public-access/sim-s3-public-policy-guard.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
 import { PutBucketPolicyAuthorizer } from "./put-bucket-policy-authorizer.js";
 import type {
   SimPutBucketPolicyCommand,
@@ -41,6 +42,7 @@ export class PutBucketPolicyCommandHandler implements CommandHandler<
   private readonly authorizer: PutBucketPolicyAuthorizer;
   private readonly background: BackgroundScheduler;
   private readonly policyValidator: SimIamPolicyDocumentValidator;
+  private readonly publicPolicyGuard = new SimS3PublicPolicyGuard();
 
   constructor(properties: PutBucketPolicyCommandHandlerProperties) {
     const {
@@ -67,16 +69,17 @@ export class PutBucketPolicyCommandHandler implements CommandHandler<
     this.policyValidator.validateRequired(command.input.Policy);
 
     const bucketName = command.input.Bucket as SimS3BucketName;
-    const bucket = this.buckets.get(bucketName);
-    if (bucket === undefined) {
-      throw new SimS3NoSuchBucket(`No S3 Bucket named ${bucketName}`);
-    }
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
 
     await this.background.sequence();
 
     this.authorizer.authorize(bucketName, options?.caller);
 
-    bucket.configurePolicy(jsonParse(command.input.Policy));
+    const document = jsonParse(command.input.Policy);
+
+    this.publicPolicyGuard.guard(bucket, document);
+
+    bucket.configurePolicy(document);
 
     return {
       $metadata: {},

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.iso.test.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.iso.test.ts
@@ -9,6 +9,7 @@ import {
   GetObjectCommand,
   PutBucketPolicyCommand,
   PutObjectCommand,
+  PutPublicAccessBlockCommand,
 } from "@aws-sdk/client-s3";
 import {
   assertBufferEqual,
@@ -139,6 +140,14 @@ describe("S3 PutBucketPolicyCommand", () => {
             },
           },
         }),
+      }),
+    );
+
+    // A public grant needs Block Public Access turned off first.
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "conditional-policy-bucket",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
       }),
     );
 

--- a/src/service/s3/command/put-public-access-block/public-access-block.iso.test.ts
+++ b/src/service/s3/command/put-public-access-block/public-access-block.iso.test.ts
@@ -1,0 +1,266 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeletePublicAccessBlockCommand,
+  GetPublicAccessBlockCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+
+describe("S3 Block Public Access commands", () => {
+  const simAws = new SimAws();
+
+  const allBlocked = {
+    BlockPublicAcls: true,
+    IgnorePublicAcls: true,
+    BlockPublicPolicy: true,
+    RestrictPublicBuckets: true,
+  };
+
+  it("blocks all public access on a newly created Bucket", async () => {
+    // Given a Bucket created with no Block Public Access configuration.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "fresh" }));
+
+    // When its settings are read.
+    const output = await simS3.getPublicAccessBlock(
+      new GetPublicAccessBlockCommand({ Bucket: "fresh" }),
+    );
+
+    // Then all four are enabled, as on every new Bucket in real S3.
+    assertObjectEquals(output.PublicAccessBlockConfiguration, allBlocked);
+  });
+
+  it("replaces the whole configuration, defaulting omitted settings to blocked", async () => {
+    // Given a Bucket at the default settings.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "partial" }));
+
+    // When only one setting is specified.
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "partial",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      }),
+    );
+
+    // Then the others take their blocked default rather than being left as-is.
+    const output = await simS3.getPublicAccessBlock(
+      new GetPublicAccessBlockCommand({ Bucket: "partial" }),
+    );
+
+    assertObjectEquals(output.PublicAccessBlockConfiguration, {
+      ...allBlocked,
+      BlockPublicPolicy: false,
+    });
+  });
+
+  it("returns the Bucket to fully blocked when the configuration is deleted", async () => {
+    // Given a Bucket with every setting turned off.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "reopened" }));
+    await simS3.putPublicAccessBlock(
+      new PutPublicAccessBlockCommand({
+        Bucket: "reopened",
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: false,
+          IgnorePublicAcls: false,
+          BlockPublicPolicy: false,
+          RestrictPublicBuckets: false,
+        },
+      }),
+    );
+
+    // When the configuration is deleted.
+    await simS3.deletePublicAccessBlock(
+      new DeletePublicAccessBlockCommand({ Bucket: "reopened" }),
+    );
+
+    // Then the Bucket is blocked again rather than left unprotected.
+    const output = await simS3.getPublicAccessBlock(
+      new GetPublicAccessBlockCommand({ Bucket: "reopened" }),
+    );
+
+    assertObjectEquals(output.PublicAccessBlockConfiguration, allBlocked);
+  });
+
+  it("rejects a non-existent Bucket", async () => {
+    // Given the top-level simulated S3 service without the requested Bucket.
+    const simS3 = simAws.s3();
+
+    // When each command targets the missing Bucket.
+    const readError = await assertThrowsErrorAsync(async () =>
+      simS3.getPublicAccessBlock(
+        new GetPublicAccessBlockCommand({ Bucket: "absent" }),
+      ),
+    );
+    const writeError = await assertThrowsErrorAsync(async () =>
+      simS3.putPublicAccessBlock(
+        new PutPublicAccessBlockCommand({
+          Bucket: "absent",
+          PublicAccessBlockConfiguration: {},
+        }),
+      ),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      simS3.deletePublicAccessBlock(
+        new DeletePublicAccessBlockCommand({ Bucket: "absent" }),
+      ),
+    );
+
+    // Then S3 returns its missing-Bucket error each time.
+    assertInstanceOf(readError, SimS3NoSuchBucket);
+    assertInstanceOf(writeError, SimS3NoSuchBucket);
+    assertInstanceOf(removalError, SimS3NoSuchBucket);
+  });
+
+  it("rejects missing required request inputs", async () => {
+    // Given the top-level simulated S3 service.
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "inputs" }));
+
+    // When the commands are called without their required inputs.
+    const bucketError = await assertThrowsErrorAsync(async () =>
+      simS3.getPublicAccessBlock(
+        // @ts-expect-error -- testing invalid input
+        new GetPublicAccessBlockCommand({}),
+      ),
+    );
+    const configError = await assertThrowsErrorAsync(async () =>
+      simS3.putPublicAccessBlock(
+        // @ts-expect-error -- testing invalid input
+        new PutPublicAccessBlockCommand({ Bucket: "inputs" }),
+      ),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      simS3.deletePublicAccessBlock(
+        // @ts-expect-error -- testing invalid input
+        new DeletePublicAccessBlockCommand({}),
+      ),
+    );
+
+    // Then request validation names the missing input.
+    assertStringIncludes(
+      bucketError.message,
+      "GetPublicAccessBlockCommand.input.Bucket",
+    );
+    assertStringIncludes(
+      configError.message,
+      "PutPublicAccessBlockCommand.input.PublicAccessBlockConfiguration",
+    );
+    assertStringIncludes(
+      removalError.message,
+      "DeletePublicAccessBlockCommand.input.Bucket",
+    );
+  });
+
+  it("denies a caller without the Block Public Access permissions", async () => {
+    // Given a Role granted only the read side of the configuration.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "guarded" }));
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PublicAccessAuditor",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "PublicAccessAuditor",
+        PolicyName: "ReadPublicAccessBlock",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetBucketPublicAccessBlock",
+            Resource: "arn:aws:s3:::guarded",
+          },
+        }),
+      }),
+    );
+    const caller = { kind: "arn", arn: roleCreation.Role.Arn } as const;
+
+    // When the Role reads, then tries to change the configuration.
+    const readOutput = await simS3.getPublicAccessBlock(
+      new GetPublicAccessBlockCommand({ Bucket: "guarded" }),
+      { caller },
+    );
+    const writeError = await assertThrowsErrorAsync(async () =>
+      simS3.putPublicAccessBlock(
+        new PutPublicAccessBlockCommand({
+          Bucket: "guarded",
+          PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+        }),
+        { caller },
+      ),
+    );
+
+    // Then the read succeeds and the write is denied on the distinct action.
+    assertObjectEquals(readOutput.PublicAccessBlockConfiguration, allBlocked);
+    assertInstanceOf(writeError, SimIamAccessDenied);
+    assertIdentical(writeError.action, "s3:PutBucketPublicAccessBlock");
+  });
+
+  it("governs deletion with the same permission as replacement", async () => {
+    // Given a Role granted only the read permission.
+    const accountId = makeSimAwsAccountId();
+    const scopedSimAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = scopedSimAws.iam();
+    const simS3 = scopedSimAws.s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "undeletable" }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PublicAccessRemover",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When it tries to delete the configuration.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deletePublicAccessBlock(
+        new DeletePublicAccessBlockCommand({ Bucket: "undeletable" }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then S3 asks for the put permission, having no separate delete one.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:PutBucketPublicAccessBlock");
+  });
+});

--- a/src/service/s3/command/put-public-access-block/put-public-access-block.command.ts
+++ b/src/service/s3/command/put-public-access-block/put-public-access-block.command.ts
@@ -1,0 +1,25 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3PublicAccessBlockConfiguration } from "../../bucket/public-access/sim-s3-public-access-block.js";
+
+/**
+ * Minimal structural sim S3 PutPublicAccessBlock command.
+ */
+export interface SimPutPublicAccessBlockCommand {
+  readonly input: SimPutPublicAccessBlockCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutPublicAccessBlock input.
+ */
+export interface SimPutPublicAccessBlockCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly PublicAccessBlockConfiguration?:
+    SimS3PublicAccessBlockConfiguration | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutPublicAccessBlock output.
+ */
+export interface SimPutPublicAccessBlockCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
+++ b/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
@@ -1,0 +1,90 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3PublicAccessBlock } from "../../bucket/public-access/sim-s3-public-access-block.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3PublicAccessBlockAuthorizer } from "../public-access-block/sim-s3-public-access-block-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimPutPublicAccessBlockCommand,
+  SimPutPublicAccessBlockCommandOutput,
+} from "./put-public-access-block.command.js";
+
+interface PutPublicAccessBlockCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface PutPublicAccessBlockCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 PutPublicAccessBlockCommand handler.
+ */
+export class PutPublicAccessBlockCommandHandler implements CommandHandler<
+  SimPutPublicAccessBlockCommand,
+  SimPutPublicAccessBlockCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3PublicAccessBlockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutPublicAccessBlockCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3PublicAccessBlockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and replace a Bucket's Block Public Access settings.
+   *
+   * The supplied configuration replaces the previous one wholesale, so a
+   * setting it leaves out returns to its enabled default rather than keeping
+   * whatever the Bucket had before.
+   */
+  async handle(
+    command: SimPutPublicAccessBlockCommand,
+    options?: PutPublicAccessBlockCommandHandlerOptions,
+  ): Promise<SimPutPublicAccessBlockCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "PutPublicAccessBlockCommand.input.Bucket",
+    );
+    assertDefined(
+      command.input.PublicAccessBlockConfiguration,
+      "PutPublicAccessBlockCommand.input.PublicAccessBlockConfiguration",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options?.caller);
+
+    bucket.configurePublicAccessBlock(
+      new SimS3PublicAccessBlock(command.input.PublicAccessBlockConfiguration),
+    );
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/sim-s3-command-handlers.ts
+++ b/src/service/s3/command/sim-s3-command-handlers.ts
@@ -45,6 +45,21 @@ import type {
   SimPutBucketWebsiteCommandOutput,
 } from "./put-bucket-website/put-bucket-website.command.js";
 import { PutObjectCommandHandler } from "./put-object/put-object.handler.js";
+import { PutPublicAccessBlockCommandHandler } from "./put-public-access-block/put-public-access-block.handler.js";
+import type {
+  SimPutPublicAccessBlockCommand,
+  SimPutPublicAccessBlockCommandOutput,
+} from "./put-public-access-block/put-public-access-block.command.js";
+import { GetPublicAccessBlockCommandHandler } from "./get-public-access-block/get-public-access-block.handler.js";
+import type {
+  SimGetPublicAccessBlockCommand,
+  SimGetPublicAccessBlockCommandOutput,
+} from "./get-public-access-block/get-public-access-block.command.js";
+import { DeletePublicAccessBlockCommandHandler } from "./delete-public-access-block/delete-public-access-block.handler.js";
+import type {
+  SimDeletePublicAccessBlockCommand,
+  SimDeletePublicAccessBlockCommandOutput,
+} from "./delete-public-access-block/delete-public-access-block.command.js";
 import type {
   SimPutObjectCommand,
   SimPutObjectCommandOutput,
@@ -123,6 +138,42 @@ export class SimS3CommandHandlers {
     options?: SimS3RequestOptions,
   ): Promise<SimDeleteBucketPolicyCommandOutput> {
     return await new DeleteBucketPolicyCommandHandler(
+      this.bucketState(),
+    ).handle(command, options);
+  }
+
+  /**
+   * Replace a Bucket's Block Public Access settings.
+   */
+  async putPublicAccessBlock(
+    command: SimPutPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutPublicAccessBlockCommandOutput> {
+    return await new PutPublicAccessBlockCommandHandler(
+      this.bucketState(),
+    ).handle(command, options);
+  }
+
+  /**
+   * Read a Bucket's Block Public Access settings.
+   */
+  async getPublicAccessBlock(
+    command: SimGetPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetPublicAccessBlockCommandOutput> {
+    return await new GetPublicAccessBlockCommandHandler(
+      this.bucketState(),
+    ).handle(command, options);
+  }
+
+  /**
+   * Remove a Bucket's Block Public Access settings.
+   */
+  async deletePublicAccessBlock(
+    command: SimDeletePublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeletePublicAccessBlockCommandOutput> {
+    return await new DeletePublicAccessBlockCommandHandler(
       this.bucketState(),
     ).handle(command, options);
   }

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -1,0 +1,55 @@
+/**
+ * The structural command and output types of every simulated S3 operation.
+ *
+ * Collected here so the service facade and its command handlers can name them
+ * in one import each, rather than repeating a per-command import list.
+ */
+
+export type {
+  SimCreateBucketCommand,
+  SimCreateBucketCommandOutput,
+} from "./create-bucket/create-bucket.command.js";
+export type {
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput,
+} from "./delete-bucket-policy/delete-bucket-policy.command.js";
+export type {
+  SimDeletePublicAccessBlockCommand,
+  SimDeletePublicAccessBlockCommandOutput,
+} from "./delete-public-access-block/delete-public-access-block.command.js";
+export type {
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput,
+} from "./get-bucket-policy/get-bucket-policy.command.js";
+export type {
+  SimGetObjectCommand,
+  SimGetObjectCommandOutput,
+} from "./get-object/get-object.command.js";
+export type {
+  SimGetPublicAccessBlockCommand,
+  SimGetPublicAccessBlockCommandOutput,
+} from "./get-public-access-block/get-public-access-block.command.js";
+export type {
+  SimListBucketsCommand,
+  SimListBucketsCommandOutput,
+} from "./list-buckets/list-buckets.command.js";
+export type {
+  SimListObjectsCommand,
+  SimListObjectsCommandOutput,
+} from "./list-objects/list-objects.command.js";
+export type {
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput,
+} from "./put-bucket-policy/put-bucket-policy.command.js";
+export type {
+  SimPutBucketWebsiteCommand,
+  SimPutBucketWebsiteCommandOutput,
+} from "./put-bucket-website/put-bucket-website.command.js";
+export type {
+  SimPutObjectCommand,
+  SimPutObjectCommandOutput,
+} from "./put-object/put-object.command.js";
+export type {
+  SimPutPublicAccessBlockCommand,
+  SimPutPublicAccessBlockCommandOutput,
+} from "./put-public-access-block/put-public-access-block.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -54,6 +54,20 @@ export class SimS3NoSuchBucketPolicy extends SimS3Error {
 }
 
 /**
+ * Simulated S3 AccessDenied error.
+ *
+ * This is S3 itself refusing a request, as Block Public Access does, rather
+ * than sim IAM denying it after evaluating policies.
+ */
+export class SimS3AccessDenied extends SimS3Error {
+  public override readonly name = "AccessDenied";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 403 });
+  }
+}
+
+/**
  * Simulated S3 BucketAlreadyExists error.
  */
 export class SimS3BucketAlreadyExists extends SimS3Error {

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -2,19 +2,24 @@ import { describe, it } from "vitest";
 import {
   CreateBucketCommand,
   DeleteBucketPolicyCommand,
+  DeletePublicAccessBlockCommand,
   GetBucketPolicyCommand,
+  GetPublicAccessBlockCommand,
   ListObjectsCommand,
   PutBucketPolicyCommand,
   PutBucketWebsiteCommand,
   PutObjectCommand,
+  PutPublicAccessBlockCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
 import {
   assertArrayIncludes,
   assertArrayLength,
+  assertFalse,
   assertIdentical,
   assertObjectEquals,
   assertStringIncludes,
+  assertTrue,
   assertTypeObject,
   assertUndefined,
 } from "@kensio/smartass";
@@ -79,7 +84,7 @@ describe("simulated S3 SDK Command routing", () => {
           Statement: [
             {
               Effect: "Allow",
-              Principal: "*",
+              Principal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
               Action: "s3:GetObject",
               Resource: "arn:aws:s3:::bucket-policy/*",
             },
@@ -101,7 +106,7 @@ describe("simulated S3 SDK Command routing", () => {
       Statement: [
         {
           Effect: "Allow",
-          Principal: "*",
+          Principal: { AWS: "arn:aws:iam::222222222222:role/Reader" },
           Action: "s3:GetObject",
           Resource: "arn:aws:s3:::bucket-policy-lifecycle/*",
         },
@@ -132,15 +137,45 @@ describe("simulated S3 SDK Command routing", () => {
     assertTypeObject(deletionOut.$metadata);
   });
 
+  it("routes the Block Public Access Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-bpa" }));
+
+    await client.send(
+      new PutPublicAccessBlockCommand({
+        Bucket: "bucket-bpa",
+        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+      }),
+    );
+
+    const readOut = await client.send(
+      new GetPublicAccessBlockCommand({ Bucket: "bucket-bpa" }),
+    );
+    assertFalse(readOut.PublicAccessBlockConfiguration?.BlockPublicPolicy);
+
+    // Removing the configuration restores the blocked default.
+    await client.send(
+      new DeletePublicAccessBlockCommand({ Bucket: "bucket-bpa" }),
+    );
+    const restoredOut = await client.send(
+      new GetPublicAccessBlockCommand({ Bucket: "bucket-bpa" }),
+    );
+    assertTrue(restoredOut.PublicAccessBlockConfiguration?.BlockPublicPolicy);
+  });
+
   it("lists its supported SDK Command names", () => {
     const router = new SimS3SdkCommandRouter({} as SimS3);
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 9);
+    assertArrayLength(supported, 12);
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "GetBucketPolicyCommand");
     assertArrayIncludes(supported, "DeleteBucketPolicyCommand");
+    assertArrayIncludes(supported, "PutPublicAccessBlockCommand");
     assertUndefined(router.route("HeadObjectCommand"));
   });
 

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -16,6 +16,9 @@ import type { SimGetBucketPolicyCommand } from "../command/get-bucket-policy/get
 import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.command.js";
 import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.command.js";
 import type { SimPutObjectCommand } from "../command/put-object/put-object.command.js";
+import type { SimPutPublicAccessBlockCommand } from "../command/put-public-access-block/put-public-access-block.command.js";
+import type { SimGetPublicAccessBlockCommand } from "../command/get-public-access-block/get-public-access-block.command.js";
+import type { SimDeletePublicAccessBlockCommand } from "../command/delete-public-access-block/delete-public-access-block.command.js";
 import type { SimS3 } from "../sim-s3.js";
 
 /**
@@ -88,6 +91,30 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.putBucketWebsite(
             command as SimPutBucketWebsiteCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutPublicAccessBlockCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.putPublicAccessBlock(
+            command as SimPutPublicAccessBlockCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetPublicAccessBlockCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.getPublicAccessBlock(
+            command as SimGetPublicAccessBlockCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeletePublicAccessBlockCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deletePublicAccessBlock(
+            command as SimDeletePublicAccessBlockCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -1,37 +1,39 @@
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3CommandHandlers } from "./command/sim-s3-command-handlers.js";
+import type {
+  SimCreateBucketCommand,
+  SimCreateBucketCommandOutput,
+  SimDeleteBucketPolicyCommand,
+  SimDeleteBucketPolicyCommandOutput,
+  SimDeletePublicAccessBlockCommand,
+  SimDeletePublicAccessBlockCommandOutput,
+  SimGetBucketPolicyCommand,
+  SimGetBucketPolicyCommandOutput,
+  SimGetObjectCommand,
+  SimGetObjectCommandOutput,
+  SimGetPublicAccessBlockCommand,
+  SimGetPublicAccessBlockCommandOutput,
+  SimListBucketsCommand,
+  SimListBucketsCommandOutput,
+  SimListObjectsCommand,
+  SimListObjectsCommandOutput,
+  SimPutBucketPolicyCommand,
+  SimPutBucketPolicyCommandOutput,
+  SimPutBucketWebsiteCommand,
+  SimPutBucketWebsiteCommandOutput,
+  SimPutObjectCommand,
+  SimPutObjectCommandOutput,
+  SimPutPublicAccessBlockCommand,
+  SimPutPublicAccessBlockCommandOutput,
+} from "./command/sim-s3-command.types.js";
 import { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { assertDefined } from "../../util/type-guard/defined.js";
+import { FilesystemS3BucketStorage } from "./storage/filesystem/s3-filesystem-storage.js";
 import {
   simS3BucketUrl,
   simS3ServiceUrl,
 } from "./bucket/sim-s3-endpoint-url.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { assertDefined } from "../../util/type-guard/defined.js";
-import { FilesystemS3BucketStorage } from "./storage/filesystem/s3-filesystem-storage.js";
-import type {
-  SimPutObjectCommand,
-  SimPutObjectCommandOutput,
-} from "./command/put-object/put-object.command.js";
-import type {
-  SimPutBucketWebsiteCommand,
-  SimPutBucketWebsiteCommandOutput,
-} from "./command/put-bucket-website/put-bucket-website.command.js";
-import type {
-  SimListObjectsCommand,
-  SimListObjectsCommandOutput,
-} from "./command/list-objects/list-objects.command.js";
-import type {
-  SimListBucketsCommand,
-  SimListBucketsCommandOutput,
-} from "./command/list-buckets/list-buckets.command.js";
-import type {
-  SimGetObjectCommand,
-  SimGetObjectCommandOutput,
-} from "./command/get-object/get-object.command.js";
-import type {
-  SimCreateBucketCommand,
-  SimCreateBucketCommandOutput,
-} from "./command/create-bucket/create-bucket.command.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -44,18 +46,6 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import type {
-  SimPutBucketPolicyCommand,
-  SimPutBucketPolicyCommandOutput,
-} from "./command/put-bucket-policy/put-bucket-policy.command.js";
-import type {
-  SimGetBucketPolicyCommand,
-  SimGetBucketPolicyCommandOutput,
-} from "./command/get-bucket-policy/get-bucket-policy.command.js";
-import type {
-  SimDeleteBucketPolicyCommand,
-  SimDeleteBucketPolicyCommandOutput,
-} from "./command/delete-bucket-policy/delete-bucket-policy.command.js";
 import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 
@@ -141,6 +131,36 @@ export class SimS3 {
     options?: SimS3RequestOptions,
   ): Promise<SimDeleteBucketPolicyCommandOutput> {
     return await this.commands.deleteBucketPolicy(command, options);
+  }
+
+  /**
+   * Handle a Put Public Access Block Command from the SDK.
+   */
+  async putPublicAccessBlock(
+    command: SimPutPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutPublicAccessBlockCommandOutput> {
+    return await this.commands.putPublicAccessBlock(command, options);
+  }
+
+  /**
+   * Handle a Get Public Access Block Command from the SDK.
+   */
+  async getPublicAccessBlock(
+    command: SimGetPublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetPublicAccessBlockCommandOutput> {
+    return await this.commands.getPublicAccessBlock(command, options);
+  }
+
+  /**
+   * Handle a Delete Public Access Block Command from the SDK.
+   */
+  async deletePublicAccessBlock(
+    command: SimDeletePublicAccessBlockCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeletePublicAccessBlockCommandOutput> {
+    return await this.commands.deletePublicAccessBlock(command, options);
   }
 
   /**


### PR DESCRIPTION
New Buckets block all public access, as in real S3, so PutBucketPolicy refuses a policy allowing public access unless the Bucket opts out. Adds PutPublicAccessBlock, GetPublicAccessBlock and DeletePublicAccessBlock, and the PublicAccessBlockConfiguration property of AWS::S3::Bucket.

Only BlockPublicPolicy has an effect; the other three settings are stored and reported. Existing tests attaching public Bucket policies now declare the opt-out a real deployment needs.

Resolves https://github.com/KensioSoftware/yulin/issues/199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated S3 Block Public Access support for buckets.
  * New commands allow configuring, retrieving, and deleting public access settings.
  * New buckets block public bucket policies by default.
  * CloudFormation bucket creation now supports public access block configuration.
  * Public policies can be enabled only after opting out of `BlockPublicPolicy`.

* **Bug Fixes**
  * Public bucket policies now return an S3-style access-denied error when blocked.

* **Documentation**
  * Expanded S3 documentation with default behavior, policy evaluation rules, and simulator limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->