### PR TITLE
feat: sim S3 static website serving authorized by sim IAM

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -756,6 +756,29 @@ try {
             WebsiteConfiguration: {
               IndexDocument: "index.html",
             },
+            // A website Bucket needs a public Bucket policy, which Block
+            // Public Access refuses until the Bucket opts out.
+            PublicAccessBlockConfiguration: {
+              BlockPublicAcls: true,
+              IgnorePublicAcls: true,
+            },
+          },
+        },
+        SiteBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "SiteBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: "*",
+                  Action: "s3:GetObject",
+                  Resource: "arn:aws:s3:::local-site-bucket/*",
+                },
+              ],
+            },
           },
         },
       },

--- a/docs/services/cloudformation/sim-cloudformation-serve-localhost.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-serve-localhost.example.ts
@@ -20,6 +20,29 @@ try {
             WebsiteConfiguration: {
               IndexDocument: "index.html",
             },
+            // A website Bucket needs a public Bucket policy, which Block
+            // Public Access refuses until the Bucket opts out.
+            PublicAccessBlockConfiguration: {
+              BlockPublicAcls: true,
+              IgnorePublicAcls: true,
+            },
+          },
+        },
+        SiteBucketPolicy: {
+          Type: "AWS::S3::BucketPolicy",
+          Properties: {
+            Bucket: { Ref: "SiteBucket" },
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Principal: "*",
+                  Action: "s3:GetObject",
+                  Resource: "arn:aws:s3:::local-site-bucket/*",
+                },
+              ],
+            },
           },
         },
       },

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -384,6 +384,11 @@ stricter than real S3. A `NotPrincipal` statement, a statement with no `Principa
 Account-level and organisation-level Block Public Access, access points, and `GetBucketPolicyStatus`
 are not simulated.
 
+The static website endpoint authorizes a request that names a principal as that principal, where a
+real S3 website endpoint supports only publicly readable content and authenticates nothing. The
+simulator is looser here, so a website reachable in a test as a named principal can be unreachable
+in the same way against real S3.
+
 Bucket ACLs and Object ownership settings are not modelled and are not planned. Object Ownership
 defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping
 them disabled in favour of policies.
@@ -392,11 +397,20 @@ them disabled in favour of policies.
 
 Configure Bucket website hosting with `PutBucketWebsiteCommand`.
 
-Website hosting settles which Object answers a request, not who may read it. The website endpoint
-serves only what the Bucket policy has made readable, as real S3 does, so a site with no Bucket
-policy answers `403` to every request. See [Block Public Access](#block-public-access) for the two
-commands a public site needs; the localhost serving example below shows them in place. The examples
-in this section configure hosting without serving it, so they leave that out.
+Website hosting settles which Object answers a request, not who may read it. A browser asking for a
+page is anonymous, and anonymous holds nothing unless a Bucket policy grants it, so a site with no
+Bucket policy answers `403` to every ordinary visitor. That is what real S3 does, and it is the
+mistake this most often catches: a site that works because nothing was checking. See
+[Block Public Access](#block-public-access) for the two commands a public site needs; the localhost
+serving example below shows them in place. The examples in this section configure hosting without
+serving it, so they leave that out.
+
+A request that does name a principal, through a signature or the `x-sim-aws-caller` header, is
+authorized as that principal, so an identity policy granting `s3:GetObject` reaches the website
+endpoint too. Real S3 has no such thing: its website endpoint supports only publicly readable
+content and never authenticates a request. This is a deliberate simulator affordance, in keeping
+with the other simulated services that serve HTTP, and it means a website test driven as a named
+principal proves less than one driven as a browser would be.
 
 ```typescript sim-s3-static-website-hosting
 /**

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -347,6 +347,11 @@ await simS3.putPublicAccessBlock(
 );
 ```
 
+The configuration you supply replaces the previous one wholesale, so a setting you leave out of it
+is off rather than kept. That matches CDK: `BlockPublicAccess.BLOCK_ACLS` names only the two ACL
+settings, and pairing it with `publicReadAccess: true` is the usual way to build a public website
+Bucket.
+
 `GetPublicAccessBlockCommand` reads the settings back and `DeletePublicAccessBlockCommand` removes
 them, which returns the Bucket to fully blocked rather than leaving it open. In a CloudFormation
 template the settings are the `PublicAccessBlockConfiguration` property of `AWS::S3::Bucket`, and a
@@ -386,6 +391,12 @@ them disabled in favour of policies.
 ## Static website hosting
 
 Configure Bucket website hosting with `PutBucketWebsiteCommand`.
+
+Website hosting settles which Object answers a request, not who may read it. The website endpoint
+serves only what the Bucket policy has made readable, as real S3 does, so a site with no Bucket
+policy answers `403` to every request. See [Block Public Access](#block-public-access) for the two
+commands a public site needs; the localhost serving example below shows them in place. The examples
+in this section configure hosting without serving it, so they leave that out.
 
 ```typescript sim-s3-static-website-hosting
 /**
@@ -461,8 +472,10 @@ to access the simulated services via your browser or commandline with curl.
 
 import {
   CreateBucketCommand,
+  PutBucketPolicyCommand,
   PutBucketWebsiteCommand,
   PutObjectCommand,
+  PutPublicAccessBlockCommand,
 } from "@aws-sdk/client-s3";
 import { SimAws } from "@kensio/yulin";
 import { serveSimAws } from "@kensio/yulin/serve";
@@ -496,6 +509,32 @@ try {
           Suffix: "index.html",
         },
       },
+    }),
+  );
+
+  // A website endpoint serves only what the Bucket policy makes readable, and
+  // a public policy needs the Block Public Access opt-out first.
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "foo-site",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "foo-site",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::foo-site/*",
+        },
+      }),
     }),
   );
 

--- a/docs/services/s3/sim-s3-serve-localhost.example.ts
+++ b/docs/services/s3/sim-s3-serve-localhost.example.ts
@@ -4,8 +4,10 @@
 
 import {
   CreateBucketCommand,
+  PutBucketPolicyCommand,
   PutBucketWebsiteCommand,
   PutObjectCommand,
+  PutPublicAccessBlockCommand,
 } from "@aws-sdk/client-s3";
 import { SimAws } from "@kensio/yulin";
 import { serveSimAws } from "@kensio/yulin/serve";
@@ -39,6 +41,32 @@ try {
           Suffix: "index.html",
         },
       },
+    }),
+  );
+
+  // A website endpoint serves only what the Bucket policy makes readable, and
+  // a public policy needs the Block Public Access opt-out first.
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "foo-site",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "foo-site",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::foo-site/*",
+        },
+      }),
     }),
   );
 

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -6,10 +6,12 @@ import { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-c
  * Which of a service's endpoints a hostname named.
  *
  * Only S3 has more than one, and the difference is not cosmetic: the website
- * endpoint serves public static sites and never authenticates, while the REST
- * endpoint is the API the SDK and presigned URLs talk to. The hostname is the
- * only thing that says which, so it is settled where hostnames are understood
- * rather than guessed at again downstream.
+ * endpoint serves a static site to whoever the Bucket policy has made it
+ * readable by, while the REST endpoint is the API the SDK and presigned URLs
+ * talk to. Both authorize, and a website visitor presenting nothing is simply
+ * anonymous. The hostname is the only thing that says which endpoint was
+ * addressed, so it is settled where hostnames are understood rather than
+ * guessed at again downstream.
  */
 export type SimAwsServiceEndpoint = "rest" | "website";
 

--- a/src/serve/dns/sim-aws-dns-server.loc.test.ts
+++ b/src/serve/dns/sim-aws-dns-server.loc.test.ts
@@ -21,6 +21,7 @@ import {
   assertTrue,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "../../service/s3/bucket/website/sim-s3-public-website.fixture.js";
 import { SimAws } from "../../service/aws/sim-aws.js";
 import {
   serveSimAws,
@@ -70,6 +71,7 @@ describe("Simulated AWS DNS server", () => {
         WebsiteConfiguration: { IndexDocument: { Suffix: "index.html" } },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "my-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "my-site",

--- a/src/serve/http/sim-aws-http.iso.test.ts
+++ b/src/serve/http/sim-aws-http.iso.test.ts
@@ -4,6 +4,7 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "../../service/s3/bucket/website/sim-s3-public-website.fixture.js";
 import {
   assertIdentical,
   assertStringIncludes,
@@ -116,6 +117,7 @@ describe("Simulated AWS HTTP", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "foo-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "foo-site",
@@ -154,6 +156,7 @@ describe("Simulated AWS HTTP", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "head-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "head-site",

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.loc.test.ts
@@ -44,6 +44,10 @@ const stack = new cdk.Stack(app, "TestStack", {
 const bucket = new s3.Bucket(stack, "SiteBucket", {
   bucketName: "foo-bucket",
   websiteIndexDocument: "index.html",
+  // A website Bucket must be publicly readable, which needs the Block Public
+  // Access opt-out. CDK synthesizes an AWS::S3::BucketPolicy for this.
+  publicReadAccess: true,
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ACLS,
 });
 new s3deploy.BucketDeployment(stack, "DeploySite", {
   sources: [s3deploy.Source.asset(${JSON.stringify(publicDirectory)})],

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -157,9 +157,18 @@ is a normalized form of what was applied rather than the original text.
 
 ## Block Public Access
 
-`bucket/public-access/` holds the Block Public Access model. Every Bucket has a
-`SimS3PublicAccessBlock` with all four settings enabled, matching real S3's default for new Buckets,
-and a setting left unspecified is taken as enabled rather than disabled.
+`bucket/public-access/` holds the Block Public Access model. There are two distinct states and
+`SimS3PublicAccessBlock` has a named constructor for each. `blockingAll()` is what a Bucket nobody
+has configured gets, matching real S3's default for new Buckets. `fromConfiguration(...)` is what a
+`PutPublicAccessBlock` call or a `PublicAccessBlockConfiguration` property produces, and it takes
+the configuration literally: a setting left out of it is off, because the configuration replaces the
+previous one wholesale rather than merging into it.
+
+That second rule is load-bearing. CDK's `BlockPublicAccess.BLOCK_ACLS` sets only `blockPublicAcls`
+and `ignorePublicAcls`, leaving `BlockPublicPolicy` out of the synthesized template entirely, and
+pairing it with `publicReadAccess` is the standard way to build a public website Bucket. Treating
+the omitted setting as enabled refuses that template, which real AWS deploys without complaint; the
+CDK BucketDeployment local test exercises exactly this.
 
 Only `BlockPublicPolicy` currently has an effect. `SimS3PublicPolicyGuard` applies it in the
 `PutBucketPolicy` handler, after authorization, because the setting refuses a policy the caller is

--- a/src/service/s3/bucket/public-access/sim-s3-public-access-block.ts
+++ b/src/service/s3/bucket/public-access/sim-s3-public-access-block.ts
@@ -12,46 +12,76 @@ export interface SimS3PublicAccessBlockConfiguration {
 }
 
 /**
+ * A Block Public Access configuration with every setting settled.
+ *
+ * The AWS-facing shape leaves all four optional, so this is what the simulator
+ * holds once the omissions have been resolved.
+ */
+export interface SimS3PublicAccessBlockSettings {
+  readonly BlockPublicAcls: boolean;
+  readonly IgnorePublicAcls: boolean;
+  readonly BlockPublicPolicy: boolean;
+  readonly RestrictPublicBuckets: boolean;
+}
+
+/**
  * The S3 Block Public Access settings of one simulated Bucket.
  *
- * Real S3 enables all four settings on every new Bucket, so that is what a
- * Bucket gets unless something turns one off.
+ * There are two distinct states here and they are not the same. A Bucket nobody
+ * has configured blocks everything, which is what real S3 does for every new
+ * Bucket. A Bucket someone has configured has exactly what they asked for: the
+ * configuration replaces the previous one wholesale, so a setting left out of
+ * it is off rather than inherited.
  *
- * A setting the caller leaves unspecified is taken as enabled. Real S3 replaces
- * the whole configuration on PutPublicAccessBlock, and its documentation does
- * not state what an omitted element means, so the simulator takes the
- * restrictive reading: being stricter than AWS surfaces as a puzzling test
- * failure, while being looser surfaces as a production incident.
+ * That second rule matters more than it looks. CDK's `BlockPublicAccess.
+ * BLOCK_ACLS` sets only `blockPublicAcls` and `ignorePublicAcls`, leaving
+ * `BlockPublicPolicy` out of the synthesized template, and pairing it with
+ * `publicReadAccess` is the standard way to build a public website Bucket.
+ * Treating the omitted setting as enabled would refuse that template, which
+ * real AWS deploys without complaint.
  */
 export class SimS3PublicAccessBlock {
-  private readonly blockPublicAcls: boolean;
-  private readonly ignorePublicAcls: boolean;
-  private readonly blockPublicPolicy: boolean;
-  private readonly restrictPublicBuckets: boolean;
+  private constructor(
+    private readonly settings: SimS3PublicAccessBlockSettings,
+  ) {}
 
-  constructor(configuration: SimS3PublicAccessBlockConfiguration = {}) {
-    this.blockPublicAcls = configuration.BlockPublicAcls ?? true;
-    this.ignorePublicAcls = configuration.IgnorePublicAcls ?? true;
-    this.blockPublicPolicy = configuration.BlockPublicPolicy ?? true;
-    this.restrictPublicBuckets = configuration.RestrictPublicBuckets ?? true;
+  /**
+   * The all-blocked state a Bucket has until something configures it.
+   */
+  static blockingAll(): SimS3PublicAccessBlock {
+    return new SimS3PublicAccessBlock({
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+      BlockPublicPolicy: true,
+      RestrictPublicBuckets: true,
+    });
+  }
+
+  /**
+   * A configuration exactly as supplied, with anything omitted turned off.
+   */
+  static fromConfiguration(
+    configuration: SimS3PublicAccessBlockConfiguration,
+  ): SimS3PublicAccessBlock {
+    return new SimS3PublicAccessBlock({
+      BlockPublicAcls: configuration.BlockPublicAcls ?? false,
+      IgnorePublicAcls: configuration.IgnorePublicAcls ?? false,
+      BlockPublicPolicy: configuration.BlockPublicPolicy ?? false,
+      RestrictPublicBuckets: configuration.RestrictPublicBuckets ?? false,
+    });
   }
 
   /**
    * Whether this Bucket refuses a Bucket policy that allows public access.
    */
   blocksPublicPolicy(): boolean {
-    return this.blockPublicPolicy;
+    return this.settings.BlockPublicPolicy;
   }
 
   /**
    * The configuration as an AWS-shaped record, for GetPublicAccessBlock.
    */
-  toConfiguration(): Required<SimS3PublicAccessBlockConfiguration> {
-    return {
-      BlockPublicAcls: this.blockPublicAcls,
-      IgnorePublicAcls: this.ignorePublicAcls,
-      BlockPublicPolicy: this.blockPublicPolicy,
-      RestrictPublicBuckets: this.restrictPublicBuckets,
-    };
+  toConfiguration(): SimS3PublicAccessBlockSettings {
+    return { ...this.settings };
   }
 }

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -40,7 +40,7 @@ export class SimS3Bucket {
       storage = new MemoryS3BucketStorage(),
       website = new SimS3BucketWebsite(),
       policy,
-      publicAccessBlock = new SimS3PublicAccessBlock(),
+      publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
     } = properties;
 
     validateS3BucketName(bucketName);
@@ -140,7 +140,7 @@ export class SimS3Bucket {
    * new Bucket starts in, rather than leaving it unprotected.
    */
   deletePublicAccessBlock(): void {
-    this.publicAccessBlock = new SimS3PublicAccessBlock();
+    this.publicAccessBlock = SimS3PublicAccessBlock.blockingAll();
   }
 
   /**

--- a/src/service/s3/bucket/website/redirect/s3-bucket-website-redirects.loc.test.ts
+++ b/src/service/s3/bucket/website/redirect/s3-bucket-website-redirects.loc.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { assertIdentical } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "../sim-s3-public-website.fixture.js";
 import { SimAwsLocalServer } from "../../../../../serve/index.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
 
@@ -45,6 +46,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "folder-index-redirect-site");
 
     const response = await fetch(
       `http://folder-index-redirect-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/docs`,
@@ -85,6 +87,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "missing-redirect-site");
 
     const response = await fetch(
       `http://missing-redirect-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/missing.html`,
@@ -132,6 +135,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "index-before-rule-site");
 
     const response = await fetch(
       `http://index-before-rule-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/docs/`,
@@ -160,6 +164,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "redirect-all-site");
 
     const response = await fetch(
       `http://redirect-all-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/docs/page.html`,

--- a/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
+++ b/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "./sim-s3-public-website.fixture.js";
 import { SimAwsLocalServer } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 
@@ -71,6 +72,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "root-index-site");
 
     const response = await fetch(
       `http://root-index-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/`,
@@ -108,6 +110,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "folder-index-site");
 
     const response = await fetch(
       `http://folder-index-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/docs/`,
@@ -144,6 +147,7 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "error-document-site");
 
     const response = await fetch(
       `http://error-document-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/missing.html`,

--- a/src/service/s3/bucket/website/sim-s3-public-website.fixture.ts
+++ b/src/service/s3/bucket/website/sim-s3-public-website.fixture.ts
@@ -1,0 +1,41 @@
+import type { SimS3 } from "../../sim-s3.js";
+
+/**
+ * Make a Bucket's Objects publicly readable, as a static website Bucket must
+ * be.
+ *
+ * Real S3 serves a website endpoint only what the Bucket policy has made
+ * readable, and blocks a public Bucket policy on a new Bucket, so a website
+ * needs both steps. This issues exactly the two commands a real deployment
+ * issues rather than reaching around them, so a test using it exercises the
+ * same path a user's own setup would.
+ */
+export async function grantPublicWebsiteRead(
+  simS3: SimS3,
+  bucketName: string,
+): Promise<void> {
+  await simS3.putPublicAccessBlock({
+    input: {
+      Bucket: bucketName,
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    },
+  });
+
+  await simS3.putBucketPolicy({
+    input: {
+      Bucket: bucketName,
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: `arn:aws:s3:::${bucketName}/*`,
+        },
+      }),
+    },
+  });
+}

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-public-access-block.iso.test.ts
@@ -40,8 +40,8 @@ describe("S3 CloudFormation PublicAccessBlockConfiguration", () => {
       },
     });
 
-    // Then the Bucket carries those settings, with the unspecified ones at
-    // their blocked default.
+    // Then the Bucket carries exactly those settings, with the ones the
+    // template left out turned off.
     const output = await simAws
       .s3()
       .getPublicAccessBlock(
@@ -49,8 +49,8 @@ describe("S3 CloudFormation PublicAccessBlockConfiguration", () => {
       );
 
     assertObjectEquals(output.PublicAccessBlockConfiguration, {
-      BlockPublicAcls: true,
-      IgnorePublicAcls: true,
+      BlockPublicAcls: false,
+      IgnorePublicAcls: false,
       BlockPublicPolicy: false,
       RestrictPublicBuckets: false,
     });

--- a/src/service/s3/command/get-public-access-block/get-public-access-block.command.ts
+++ b/src/service/s3/command/get-public-access-block/get-public-access-block.command.ts
@@ -1,5 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimS3PublicAccessBlockConfiguration } from "../../bucket/public-access/sim-s3-public-access-block.js";
+import type { SimS3PublicAccessBlockSettings } from "../../bucket/public-access/sim-s3-public-access-block.js";
 
 /**
  * Minimal structural sim S3 GetPublicAccessBlock command.
@@ -19,6 +19,6 @@ export interface SimGetPublicAccessBlockCommandInput {
  * Minimal structural sim S3 GetPublicAccessBlock output.
  */
 export interface SimGetPublicAccessBlockCommandOutput {
-  readonly PublicAccessBlockConfiguration: Required<SimS3PublicAccessBlockConfiguration>;
+  readonly PublicAccessBlockConfiguration: SimS3PublicAccessBlockSettings;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/put-public-access-block/public-access-block.iso.test.ts
+++ b/src/service/s3/command/put-public-access-block/public-access-block.iso.test.ts
@@ -43,28 +43,35 @@ describe("S3 Block Public Access commands", () => {
     assertObjectEquals(output.PublicAccessBlockConfiguration, allBlocked);
   });
 
-  it("replaces the whole configuration, defaulting omitted settings to blocked", async () => {
-    // Given a Bucket at the default settings.
+  it("replaces the whole configuration, turning omitted settings off", async () => {
+    // Given a Bucket at the all-blocked default.
     const simS3 = simAws.s3();
 
     await simS3.createBucket(new CreateBucketCommand({ Bucket: "partial" }));
 
-    // When only one setting is specified.
+    // When a configuration naming only the two ACL settings is applied, as
+    // CDK's BlockPublicAccess.BLOCK_ACLS preset synthesizes.
     await simS3.putPublicAccessBlock(
       new PutPublicAccessBlockCommand({
         Bucket: "partial",
-        PublicAccessBlockConfiguration: { BlockPublicPolicy: false },
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          IgnorePublicAcls: true,
+        },
       }),
     );
 
-    // Then the others take their blocked default rather than being left as-is.
+    // Then the settings it left out are off, because the configuration
+    // replaces the previous one rather than merging into it.
     const output = await simS3.getPublicAccessBlock(
       new GetPublicAccessBlockCommand({ Bucket: "partial" }),
     );
 
     assertObjectEquals(output.PublicAccessBlockConfiguration, {
-      ...allBlocked,
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
       BlockPublicPolicy: false,
+      RestrictPublicBuckets: false,
     });
   });
 

--- a/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
+++ b/src/service/s3/command/put-public-access-block/put-public-access-block.handler.ts
@@ -56,8 +56,8 @@ export class PutPublicAccessBlockCommandHandler implements CommandHandler<
    * Authorize and replace a Bucket's Block Public Access settings.
    *
    * The supplied configuration replaces the previous one wholesale, so a
-   * setting it leaves out returns to its enabled default rather than keeping
-   * whatever the Bucket had before.
+   * setting it leaves out is turned off rather than kept from whatever the
+   * Bucket had before.
    */
   async handle(
     command: SimPutPublicAccessBlockCommand,
@@ -80,7 +80,9 @@ export class PutPublicAccessBlockCommandHandler implements CommandHandler<
     this.authorizer.authorizeWrite(bucket, options?.caller);
 
     bucket.configurePublicAccessBlock(
-      new SimS3PublicAccessBlock(command.input.PublicAccessBlockConfiguration),
+      SimS3PublicAccessBlock.fromConfiguration(
+        command.input.PublicAccessBlockConfiguration,
+      ),
     );
 
     return {

--- a/src/service/s3/serve/sim-s3-controller.loc.test.ts
+++ b/src/service/s3/serve/sim-s3-controller.loc.test.ts
@@ -10,6 +10,7 @@ import {
   assertStringIncludes,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "../bucket/website/sim-s3-public-website.fixture.js";
 import { SimAwsLocalServer } from "../../../serve/index.js";
 import { SimAws } from "../../aws/sim-aws.js";
 
@@ -40,6 +41,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "foo-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "foo-site",
@@ -80,6 +82,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "head-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "head-site",
@@ -121,6 +124,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "encoded-path-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "encoded-path-site",
@@ -156,6 +160,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "folder-index-redirect-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "folder-index-redirect-site",
@@ -195,6 +200,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "folder-index-follow-site");
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "folder-index-follow-site",
@@ -252,6 +258,7 @@ describe("Simulated S3 local HTTP controller", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, "missing-object-site");
 
     const response = await fetch(
       `http://missing-object-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/missing.txt`,

--- a/src/service/s3/serve/sim-s3-controller.ts
+++ b/src/service/s3/serve/sim-s3-controller.ts
@@ -16,8 +16,9 @@ interface SimS3ServiceControllerProperties {
  *
  * S3 answers on two endpoints that behave differently, so a request is routed
  * by the hostname it arrived on before anything else: the website endpoint
- * serves a static site to anyone, and the REST endpoint serves the API to
- * whoever the request is authenticated as.
+ * serves a static site, and the REST endpoint serves the API. Both serve as
+ * whoever the request is authenticated as, so a website Bucket needs a Bucket
+ * policy making it readable before it serves anything.
  */
 export class SimS3ServiceController implements SimAwsServiceController {
   private readonly s3Router: SimS3RequestRouter;
@@ -27,7 +28,7 @@ export class SimS3ServiceController implements SimAwsServiceController {
   constructor(properties: SimS3ServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.s3Router = new SimS3RequestRouter({ simAws });
-    this.s3GetObjectController = new SimS3GetObjectController();
+    this.s3GetObjectController = new SimS3GetObjectController({ simAws });
     this.s3RestController = new SimS3RestController({ simAws });
   }
 
@@ -52,9 +53,8 @@ export class SimS3ServiceController implements SimAwsServiceController {
     }
 
     return await this.s3GetObjectController.handleRequest(
-      route.bucket,
-      route.objectKey,
-      request,
+      route,
+      serviceRequest,
     );
   }
 }

--- a/src/service/s3/serve/sim-s3-get-object-controller.ts
+++ b/src/service/s3/serve/sim-s3-get-object-controller.ts
@@ -16,8 +16,14 @@ interface SimS3GetObjectControllerProperties {
  *
  * Real S3 serves a website endpoint only what the Bucket policy makes readable,
  * answering 403 for an Object that is not publicly readable. Objects are
- * therefore read through the ordinary GetObject command as the requesting
- * principal, so a Bucket with no policy serves nothing.
+ * therefore read through the ordinary GetObject command, so a Bucket with no
+ * policy serves nothing to the browser that asks for a page.
+ *
+ * The reading is done as whoever the boundary resolved rather than always as
+ * anonymous, which is a deliberate divergence: a real website endpoint
+ * authenticates nothing, so an identity policy could never reach it there. It
+ * keeps the simulator's served services consistent with each other, at the cost
+ * of being looser than S3 for a request that names a principal.
  */
 export class SimS3GetObjectController {
   private readonly simAws: SimAws;

--- a/src/service/s3/serve/sim-s3-get-object-controller.ts
+++ b/src/service/s3/serve/sim-s3-get-object-controller.ts
@@ -1,30 +1,45 @@
+import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
-import type { SimS3Object } from "../object/s3-object.js";
+import type { SimS3WebsiteRoute } from "./sim-s3-route.js";
+import { SimS3WebsiteObjectLoader } from "./website/sim-s3-website-object-loader.js";
+import type { SimS3WebsiteObject } from "./website/sim-s3-website-object.js";
+import { SimS3WebsiteResponses } from "./website/sim-s3-website-responses.js";
+
+interface SimS3GetObjectControllerProperties {
+  readonly simAws: SimAws;
+}
 
 /**
- * Serves a simulated S3 Object over HTTP.
+ * Serves a simulated S3 Object over the static website endpoint.
+ *
+ * Real S3 serves a website endpoint only what the Bucket policy makes readable,
+ * answering 403 for an Object that is not publicly readable. Objects are
+ * therefore read through the ordinary GetObject command as the requesting
+ * principal, so a Bucket with no policy serves nothing.
  */
 export class SimS3GetObjectController {
+  private readonly simAws: SimAws;
+  private readonly responses = new SimS3WebsiteResponses();
+
+  constructor(properties: SimS3GetObjectControllerProperties) {
+    this.simAws = properties.simAws;
+  }
+
   /**
-   * Handle a GET request for an S3 Object via simulated S3.
+   * Handle a GET or HEAD request for an S3 Object via the website endpoint.
    */
   async handleRequest(
-    bucket: SimS3Bucket,
-    objectKey: string,
-    request: Request,
+    route: SimS3WebsiteRoute,
+    serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
+    const { bucket } = route;
     const website = bucket.getWebsite();
+    const { request } = serviceRequest;
 
     if (!website.websiteEnabled()) {
-      return new Response(
-        `Static website hosting is not enabled for bucket ${bucket.bucketName}\n`,
-        {
-          status: 403,
-          headers: {
-            "content-type": "text/plain; charset=utf-8",
-          },
-        },
-      );
+      return this.responses.websiteNotEnabled(bucket.bucketName);
     }
 
     if (website.redirectsAllRequests()) {
@@ -34,84 +49,116 @@ export class SimS3GetObjectController {
       );
     }
 
-    const response = await this.websiteResponse(bucket, objectKey, request);
+    const loader = SimS3WebsiteObjectLoader.forRoute(
+      this.simAws,
+      route,
+      serviceRequest,
+    );
 
-    return website.redirectForRequestResponse(request, response);
+    return website.redirectForRequestResponse(
+      request,
+      await this.websiteResponse(route, request, loader),
+    );
   }
 
   private async websiteResponse(
-    bucket: SimS3Bucket,
-    objectKey: string,
+    route: SimS3WebsiteRoute,
     request: Request,
+    loader: SimS3WebsiteObjectLoader,
   ): Promise<Response> {
-    const website = bucket.getWebsite();
-    const websiteObjectKey = website.objectKeyForRequest(objectKey);
-    const object = await bucket.getObject(websiteObjectKey);
+    const { bucket, objectKey } = route;
+    const websiteObjectKey = bucket.getWebsite().objectKeyForRequest(objectKey);
+    const object = await this.loadRequested(loader, websiteObjectKey);
 
-    if (object !== undefined) {
-      return this.foundObjectResponse(object, request);
+    if (object instanceof SimIamAccessDenied) {
+      return await this.deniedResponse(bucket, request, loader);
     }
 
+    if (object !== undefined) {
+      return this.responses.foundObject(object, request);
+    }
+
+    return await this.missingResponse(route, request, loader, websiteObjectKey);
+  }
+
+  /**
+   * Answer a request for an Object the Bucket does not hold, which is either a
+   * folder needing a trailing slash, the error document, or a plain 404.
+   */
+  private async missingResponse(
+    route: SimS3WebsiteRoute,
+    request: Request,
+    loader: SimS3WebsiteObjectLoader,
+    websiteObjectKey: string,
+  ): Promise<Response> {
+    const { bucket, objectKey } = route;
+    const website = bucket.getWebsite();
     const folderIndexDocumentKey =
       website.folderIndexDocumentKeyForRequest(objectKey);
 
-    if (folderIndexDocumentKey !== undefined) {
-      const folderIndexDocumentObject = await bucket.getObject(
-        folderIndexDocumentKey,
-      );
-
-      if (folderIndexDocumentObject !== undefined) {
-        return website.trailingSlashRedirect(request);
-      }
+    if (
+      folderIndexDocumentKey !== undefined &&
+      (await loader.loadIfPermitted(folderIndexDocumentKey)) !== undefined
+    ) {
+      return website.trailingSlashRedirect(request);
     }
 
-    const errorDocumentKey = website.errorDocumentKey();
+    const errorDocumentObject = await this.errorDocument(bucket, loader);
 
-    if (errorDocumentKey !== undefined) {
-      const errorDocumentObject = await bucket.getObject(errorDocumentKey);
-
-      if (errorDocumentObject !== undefined) {
-        return this.foundObjectResponse(errorDocumentObject, request, 404);
-      }
+    if (errorDocumentObject !== undefined) {
+      return this.responses.foundObject(errorDocumentObject, request, 404);
     }
 
-    return this.notFoundResponse(bucket, websiteObjectKey);
+    return this.responses.notFound(bucket.bucketName, websiteObjectKey);
   }
 
-  private foundObjectResponse(
-    object: SimS3Object,
+  /**
+   * Load the Object the visitor asked for, reporting a denial as a value so
+   * the caller can answer 403 rather than falling through to the 404 path.
+   */
+  private async loadRequested(
+    loader: SimS3WebsiteObjectLoader,
+    objectKey: string,
+  ): Promise<SimS3WebsiteObject | SimIamAccessDenied | undefined> {
+    try {
+      return await loader.load(objectKey);
+    } catch (error) {
+      if (error instanceof SimIamAccessDenied) {
+        return error;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Real S3 serves the custom error document for the whole 4XX class, so a
+   * denied request gets it too, provided the visitor may read it.
+   */
+  private async deniedResponse(
+    bucket: SimS3Bucket,
     request: Request,
-    status = 200,
-  ): Response {
-    const contentType = object.metadata.values["content-type"];
+    loader: SimS3WebsiteObjectLoader,
+  ): Promise<Response> {
+    const errorDocumentObject = await this.errorDocument(bucket, loader);
 
-    const headers = {
-      "content-length": String(object.body.length),
-      ...(contentType !== undefined && { "content-type": contentType }),
-    };
-
-    if (request.method === "HEAD") {
-      return new Response(undefined, {
-        status,
-        headers,
-      });
+    if (errorDocumentObject !== undefined) {
+      return this.responses.foundObject(errorDocumentObject, request, 403);
     }
 
-    return new Response(object.body, {
-      status,
-      headers,
-    });
+    return this.responses.accessDenied(bucket.bucketName);
   }
 
-  private notFoundResponse(bucket: SimS3Bucket, objectKey: string): Response {
-    return new Response(
-      `Object ${objectKey} not found in bucket ${bucket.bucketName}`,
-      {
-        status: 404,
-        headers: {
-          "content-type": "text/plain; charset=utf-8",
-        },
-      },
-    );
+  private async errorDocument(
+    bucket: SimS3Bucket,
+    loader: SimS3WebsiteObjectLoader,
+  ): Promise<SimS3WebsiteObject | undefined> {
+    const errorDocumentKey = bucket.getWebsite().errorDocumentKey();
+
+    if (errorDocumentKey === undefined) {
+      return undefined;
+    }
+
+    return await loader.loadIfPermitted(errorDocumentKey);
   }
 }

--- a/src/service/s3/serve/sim-s3-request-router.ts
+++ b/src/service/s3/serve/sim-s3-request-router.ts
@@ -89,6 +89,7 @@ export class SimS3RequestRouter {
     return {
       action: "website",
       bucket: found.bucket,
+      bucketScope: found.bucketScope,
       objectKey: segments.join("/"),
     };
   }

--- a/src/service/s3/serve/sim-s3-route.ts
+++ b/src/service/s3/serve/sim-s3-route.ts
@@ -2,11 +2,17 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
 
 /**
- * A request the static website endpoint should answer.
+ * A request the static website endpoint should answer, as the caller the
+ * authentication boundary resolved.
+ *
+ * The Bucket's scope is carried because serving goes through that scope's
+ * GetObject command, so the website endpoint authorizes exactly as the REST
+ * endpoint does.
  */
 export interface SimS3WebsiteRoute {
   readonly action: "website";
   readonly bucket: SimS3Bucket;
+  readonly bucketScope: SimAwsAccountRegionScope;
   readonly objectKey: string;
 }
 

--- a/src/service/s3/serve/sim-s3-website-authorization.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-website-authorization.iso.test.ts
@@ -1,0 +1,234 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  PutBucketWebsiteCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { grantPublicWebsiteRead } from "../bucket/website/sim-s3-public-website.fixture.js";
+import type { SimS3 } from "../sim-s3.js";
+
+/**
+ * Authorization on the static website endpoint.
+ *
+ * Real S3 serves a website endpoint only what the Bucket policy has made
+ * readable, answering 403 for an Object that is not publicly readable. Getting
+ * this wrong in the simulator is the expensive direction: a site that works in
+ * a test and 403s on deploy is the single most common S3 static website
+ * mistake, and one the simulator could not reproduce before.
+ */
+describe("Simulated S3 static website authorization", () => {
+  const siteUrl = (bucketName: string, path = "/index.html"): string =>
+    `http://${bucketName}.s3-website.eu-west-2.sim-aws.localhost${path}`;
+
+  const websiteSite = async (
+    simS3: SimS3,
+    bucketName: string,
+    errorDocumentKey?: string,
+  ): Promise<void> => {
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simS3.putBucketWebsite(
+      new PutBucketWebsiteCommand({
+        Bucket: bucketName,
+        WebsiteConfiguration: {
+          IndexDocument: { Suffix: "index.html" },
+          ...(errorDocumentKey !== undefined && {
+            ErrorDocument: { Key: errorDocumentKey },
+          }),
+        },
+      }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "index.html",
+        Body: "<h1>Hello</h1>",
+        ContentType: "text/html; charset=utf-8",
+      }),
+    );
+  };
+
+  it("refuses a website Bucket with no Bucket policy", async () => {
+    // Given a website Bucket whose Objects nothing has made readable.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "unreadable-site");
+
+    // When a browser asks for the index document.
+    const response = await simAwsHttp.fetch(siteUrl("unreadable-site"));
+
+    // Then the site answers 403, as real S3 does for an Object that is not
+    // publicly readable.
+    assertResponseStatus(response, 403);
+    assertStringIncludes(await response.text(), "Access denied");
+  });
+
+  it("serves the site once a Bucket policy makes it readable", async () => {
+    // Given the same Bucket with a policy granting anonymous reads.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "readable-site");
+    await grantPublicWebsiteRead(simS3, "readable-site");
+
+    // When a browser asks for the index document.
+    const response = await simAwsHttp.fetch(siteUrl("readable-site"));
+
+    // Then it is served.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Hello</h1>");
+  });
+
+  it("refuses a HEAD request the same way it refuses a GET", async () => {
+    // Given a website Bucket with no Bucket policy.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "head-unreadable-site");
+
+    // When a browser sends HEAD rather than GET.
+    const response = await simAwsHttp.fetch(siteUrl("head-unreadable-site"), {
+      method: "HEAD",
+    });
+
+    // Then the same authorization applies.
+    assertResponseStatus(response, 403);
+  });
+
+  it("serves the error document on a denied request when it is readable", async () => {
+    // Given a website Bucket whose policy makes only the error document
+    // readable, so the requested Object is denied but the error document is
+    // not.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "error-doc-site", "error.html");
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "error-doc-site",
+        Key: "error.html",
+        Body: "<h1>Nothing to see</h1>",
+        ContentType: "text/html; charset=utf-8",
+      }),
+    );
+    await simS3.putPublicAccessBlock({
+      input: {
+        Bucket: "error-doc-site",
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          IgnorePublicAcls: true,
+        },
+      },
+    });
+    await simS3.putBucketPolicy({
+      input: {
+        Bucket: "error-doc-site",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::error-doc-site/error.html",
+          },
+        }),
+      },
+    });
+
+    // When a browser asks for the index document.
+    const response = await simAwsHttp.fetch(siteUrl("error-doc-site"));
+
+    // Then the custom error document is served with the 403, because real S3
+    // returns it for the whole 4XX class rather than only for 404.
+    assertResponseStatus(response, 403);
+    assertIdentical(await response.text(), "<h1>Nothing to see</h1>");
+  });
+
+  it("falls back to a plain refusal when the error document is unreadable too", async () => {
+    // Given a website Bucket with an error document and no Bucket policy at
+    // all, so nothing in it is readable.
+    const simAws = new SimAws();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "closed-error-doc-site", "error.html");
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "closed-error-doc-site",
+        Key: "error.html",
+        Body: "<h1>Nothing to see</h1>",
+      }),
+    );
+
+    // When a browser asks for the index document.
+    const response = await simAwsHttp.fetch(siteUrl("closed-error-doc-site"));
+
+    // Then the refusal is answered plainly rather than by serving a document
+    // the visitor is equally not allowed to read.
+    assertResponseStatus(response, 403);
+    assertStringIncludes(await response.text(), "Access denied");
+  });
+
+  it("authorizes a named principal rather than treating every visitor as anonymous", async () => {
+    // Given a Bucket readable by one Role and not by the public.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const simIam = simAws.iam();
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await websiteSite(simS3, "private-site");
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "SiteReader",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "SiteReader",
+        PolicyName: "ReadSite",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::private-site/*",
+          },
+        }),
+      }),
+    );
+
+    // When the request names that Role, and when it names nobody.
+    const namedResponse = await simAwsHttp.fetch(siteUrl("private-site"), {
+      headers: { "x-sim-aws-caller": roleCreation.Role.Arn },
+    });
+    const anonymousResponse = await simAwsHttp.fetch(siteUrl("private-site"));
+
+    // Then the website endpoint serves the Role what its identity policy
+    // grants, and still refuses everyone else.
+    assertResponseStatus(namedResponse, 200);
+    assertIdentical(await namedResponse.text(), "<h1>Hello</h1>");
+    assertResponseStatus(anonymousResponse, 403);
+  });
+});

--- a/src/service/s3/serve/sim-s3-website-authorization.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-website-authorization.iso.test.ts
@@ -24,6 +24,10 @@ import type { SimS3 } from "../sim-s3.js";
  * this wrong in the simulator is the expensive direction: a site that works in
  * a test and 403s on deploy is the single most common S3 static website
  * mistake, and one the simulator could not reproduce before.
+ *
+ * The last case here covers a deliberate divergence rather than S3 behaviour:
+ * a real website endpoint authenticates nothing, so identity policies cannot
+ * reach it there.
  */
 describe("Simulated S3 static website authorization", () => {
   const siteUrl = (bucketName: string, path = "/index.html"): string =>
@@ -226,7 +230,8 @@ describe("Simulated S3 static website authorization", () => {
     const anonymousResponse = await simAwsHttp.fetch(siteUrl("private-site"));
 
     // Then the website endpoint serves the Role what its identity policy
-    // grants, and still refuses everyone else.
+    // grants, and still refuses everyone else. Real S3 would refuse both,
+    // because its website endpoint never authenticates a request.
     assertResponseStatus(namedResponse, 200);
     assertIdentical(await namedResponse.text(), "<h1>Hello</h1>");
     assertResponseStatus(anonymousResponse, 403);

--- a/src/service/s3/serve/website/sim-s3-website-object-loader.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object-loader.ts
@@ -1,0 +1,107 @@
+import type { SimAwsServiceRequest } from "../../../../serve/controller/sim-service-controller.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3WebsiteRoute } from "../sim-s3-route.js";
+import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
+import type { SimS3 } from "../../sim-s3.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+import { SimS3WebsiteObject } from "./sim-s3-website-object.js";
+
+interface SimS3WebsiteObjectLoaderProperties {
+  readonly simS3: SimS3;
+  readonly bucketName: SimS3BucketName;
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * Reads Objects for the static website endpoint as the requesting principal.
+ *
+ * Everything goes through the ordinary GetObject command, so a website request
+ * is authorized by the same IAM code path an in-process SDK call goes through.
+ * A browser presenting nothing is anonymous, and anonymous holds nothing unless
+ * the Bucket policy grants it, which is what makes a Bucket that is not
+ * publicly readable answer 403 here as it does in real S3.
+ */
+export class SimS3WebsiteObjectLoader {
+  private readonly simS3: SimS3;
+  private readonly bucketName: SimS3BucketName;
+  private readonly caller: SimAwsCaller;
+
+  constructor(properties: SimS3WebsiteObjectLoaderProperties) {
+    this.simS3 = properties.simS3;
+    this.bucketName = properties.bucketName;
+    this.caller = properties.caller;
+  }
+
+  /**
+   * A loader for one routed website request, reading from the scope that owns
+   * the Bucket as the principal the boundary resolved.
+   */
+  static forRoute(
+    simAws: SimAws,
+    route: SimS3WebsiteRoute,
+    serviceRequest: SimAwsServiceRequest,
+  ): SimS3WebsiteObjectLoader {
+    return new SimS3WebsiteObjectLoader({
+      simS3: simAws
+        .accountRegionScope(
+          route.bucketScope.accountId,
+          route.bucketScope.regionName,
+        )
+        .s3(),
+      bucketName: route.bucket.bucketName,
+      caller: serviceRequest.caller.toCaller(),
+    });
+  }
+
+  /**
+   * Load an Object, or nothing when the Bucket holds no such key.
+   *
+   * A denial is raised rather than reported as absence, because the two mean
+   * different things to a website visitor: one is 404, the other 403.
+   */
+  async load(objectKey: string): Promise<SimS3WebsiteObject | undefined> {
+    try {
+      const output = await this.simS3.getObject(
+        { input: { Bucket: this.bucketName, Key: objectKey } },
+        { caller: this.caller },
+      );
+
+      return new SimS3WebsiteObject(
+        await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
+        output.Metadata?.["content-type"],
+      );
+    } catch (error) {
+      if (error instanceof SimS3NoSuchKey) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Load an Object the site only needs if it is readable, treating a denial as
+   * absence.
+   *
+   * The folder index probe and the error document are looked up to decide what
+   * to serve rather than because the visitor asked for them, so a denial on
+   * either should fall through to the next option instead of becoming the
+   * answer.
+   */
+  async loadIfPermitted(
+    objectKey: string,
+  ): Promise<SimS3WebsiteObject | undefined> {
+    try {
+      return await this.load(objectKey);
+    } catch (error) {
+      if (error instanceof SimIamAccessDenied) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/service/s3/serve/website/sim-s3-website-object.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object.ts
@@ -1,0 +1,26 @@
+/**
+ * An Object the static website endpoint is about to serve.
+ *
+ * The website endpoint reads Objects through the ordinary GetObject command
+ * rather than out of Bucket storage, so what it gets back is a stream and a
+ * metadata record. This is that, collapsed into the two things an HTTP
+ * response needs.
+ */
+export class SimS3WebsiteObject {
+  constructor(
+    public readonly body: Buffer,
+    public readonly contentType: string | undefined,
+  ) {}
+
+  /**
+   * The headers describing this Object in a website response.
+   */
+  headers(): Record<string, string> {
+    return {
+      "content-length": String(this.body.length),
+      ...(this.contentType !== undefined && {
+        "content-type": this.contentType,
+      }),
+    };
+  }
+}

--- a/src/service/s3/serve/website/sim-s3-website-responses.ts
+++ b/src/service/s3/serve/website/sim-s3-website-responses.ts
@@ -1,0 +1,61 @@
+import type { SimS3WebsiteObject } from "./sim-s3-website-object.js";
+
+const plainTextHeaders = {
+  "content-type": "text/plain; charset=utf-8",
+} as const;
+
+/**
+ * The HTTP responses the simulated S3 static website endpoint answers with.
+ *
+ * Kept apart from the controller because deciding what to serve and building
+ * the response that serves it are separate jobs, and only the first one is
+ * interesting.
+ */
+export class SimS3WebsiteResponses {
+  /**
+   * Serve an Object, with no body when the request was a HEAD.
+   */
+  foundObject(
+    object: SimS3WebsiteObject,
+    request: Request,
+    status = 200,
+  ): Response {
+    const headers = object.headers();
+
+    if (request.method === "HEAD") {
+      return new Response(undefined, { status, headers });
+    }
+
+    return new Response(object.body, { status, headers });
+  }
+
+  /**
+   * Refuse a request for an Object the caller may not read.
+   */
+  accessDenied(bucketName: string): Response {
+    return new Response(`Access denied for bucket ${bucketName}\n`, {
+      status: 403,
+      headers: plainTextHeaders,
+    });
+  }
+
+  /**
+   * Refuse a request to a Bucket that is not serving a website at all.
+   */
+  websiteNotEnabled(bucketName: string): Response {
+    return new Response(
+      `Static website hosting is not enabled for bucket ${bucketName}\n`,
+      { status: 403, headers: plainTextHeaders },
+    );
+  }
+
+  /**
+   * Report an Object the Bucket does not hold.
+   */
+  notFound(bucketName: string, objectKey: string): Response {
+    return new Response(
+      `Object ${objectKey} not found in bucket ${bucketName}`,
+      { status: 404, headers: plainTextHeaders },
+    );
+  }
+}

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.loc.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.loc.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, it } from "vitest";
+import { grantPublicWebsiteRead } from "../../bucket/website/sim-s3-public-website.fixture.js";
 import { SimAwsLocalServer } from "../../../../serve/index.js";
 import { TemporaryDirectory as TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import {
@@ -53,6 +54,7 @@ describe("Serve sim S3 Bucket on localhost with filesystem storage", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, bucketName);
 
     const simBucket = simS3.getSimBucketByName(bucketName);
     assertNonNullable(simBucket);
@@ -107,6 +109,7 @@ describe("Serve sim S3 Bucket on localhost with filesystem storage", () => {
         },
       }),
     );
+    await grantPublicWebsiteRead(simS3, bucketName);
 
     const simBucket = simS3.getSimBucketByName(bucketName);
     assertNonNullable(simBucket);


### PR DESCRIPTION
The website endpoint read Objects straight from Bucket storage, serving anything in a website-enabled Bucket to anyone. It now reads through the GetObject command as the requesting principal, so a Bucket with no policy answers 403 as real S3 does, and a denied request gets the custom error document when it is readable.

Also corrects PublicAccessBlockConfiguration: an explicit configuration replaces the previous one wholesale and a setting left out of it is off. CDK's BLOCK_ACLS preset omits BlockPublicPolicy, so treating omissions as enabled refused the standard CDK public-website template.

Resolves https://github.com/KensioSoftware/yulin/issues/200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced simulated S3 static website behavior, including standardized GET/HEAD handling, redirects, and error-document flows.
  * Website routing now consistently applies bucket scope with the caller’s permissions and requires bucket-policy readability.
* **Bug Fixes**
  * Unreadable website content returns accurate 403s; missing objects return 404s.
  * Partial public-access-block configurations now treat omitted settings as disabled (replacing prior merge/default behavior).
* **Documentation**
  * Updated S3 and CloudFormation examples to show the needed public-access and bucket policy for localhost website hosting.
* **Tests**
  * Expanded website HTTP and DNS test coverage to grant the required public website read access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->