### PR TITLE
feat: encrypt and decrypt with simulated KMS keys

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ into tests, local development scripts, or small experiments.
 - [CloudFormation](./services/cloudformation/ "Simulated CloudFormation usage docs")
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
+- [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")
 - [Route53](./services/route53/ "Simulated Route53 usage docs")
 - [S3](./services/s3/ "Simulated S3 usage docs")

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -231,6 +231,8 @@ Replacing a key policy with `PutKeyPolicyCommand` can lock an account out of its
 
 Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a key ID, a key ARN, an alias name such as `alias/app-key`, or an alias ARN.
 
+A key ARN or alias ARN naming another account or region resolves to nothing, rather than having its identifier read out and looked up locally, so a foreign ARN cannot reach a key that happens to share an identifier.
+
 Aliases beginning `alias/aws/` are reserved for AWS managed keys. `CreateAlias` refuses to create one, but referencing one brings the key into existence, the way an AWS managed key appears on real AWS when a service first needs it.
 
 ```typescript sim-kms-aliases
@@ -331,7 +333,7 @@ Current documented limitations:
 - Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
 - Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated.
 - `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived, so a policy relying on them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
-- AWS managed keys created on demand get the same default key policy as a customer key, rather than the via-service-scoped policy real AWS gives them.
+- AWS managed keys created on demand get the same default key policy as a customer key, rather than the via-service-scoped policy real AWS gives them. Scheduling one for deletion is refused, as on real AWS, but disabling one is not, which real AWS does refuse.
 - Key material lives in process memory for the lifetime of the `SimAws` instance. That is fine for a simulator, but it is not a security boundary: anything sharing the process can reach it.
 - No other simulated service encrypts anything with KMS yet. Sim S3, sim DynamoDB and sim Lambda environment variables do not use simulated keys, and do not check `kms:Decrypt`.
 - KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -1,0 +1,337 @@
+# Simulated KMS
+
+Yulin includes a simulated AWS Key Management Service (KMS) for tests and local development.
+
+Encryption here is real encryption. Each simulated key holds real AES-256 key material and the operations run through Node.js's own `crypto`, so a ciphertext genuinely cannot be read without its key, and a decryption with the wrong encryption context genuinely fails. That is fast enough to be unremarkable in a test suite, and it means a passing test says something about how the code will behave against real KMS.
+
+KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
+
+## Available functionality
+
+Sim KMS currently supports:
+
+- Creating symmetric encryption keys with `CreateKeyCommand`, with the default key policy or one of your own
+- Describing and listing keys with `DescribeKeyCommand` and `ListKeysCommand`
+- Reading and replacing a key policy with `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
+- Encrypting and decrypting with `EncryptCommand` and `DecryptCommand`, including encryption context
+- Envelope encryption with `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
+- Aliases with `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases such as `alias/aws/s3`
+- Key lifecycle with `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand` and `CancelKeyDeletionCommand`
+- Key policy evaluation by simulated IAM, including the rule that an identity policy cannot reach a key its policy does not admit
+- Key ARNs, key IDs, alias names and alias ARNs as interchangeable ways to name a key
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+
+The simulator focuses on useful behaviour for isolated tests and local development rather than full KMS feature parity.
+
+## Encrypting and decrypting
+
+Create a key and use it. `Decrypt` needs no `KeyId` for a symmetric key, because the ciphertext already names the key that produced it.
+
+```typescript sim-kms-encrypt-decrypt
+/**
+ * Encrypting and decrypting with a simulated KMS key.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({ Description: "Application key" }),
+);
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+const decrypted = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+);
+
+console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
+```
+
+The ciphertext blob is opaque: it is not the plaintext, and nothing outside the simulator should try to read it. It is also not portable to real AWS, or between two `SimAws` instances.
+
+## Encryption context
+
+An encryption context is non-secret key/value data bound to a ciphertext. Supplying a different one on decryption fails, which is what makes it useful for tying a ciphertext to the thing it belongs to.
+
+```typescript sim-kms-encryption-context
+/**
+ * Binding an encryption context to a simulated KMS ciphertext.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimKmsInvalidCiphertextException } from "@kensio/yulin/kms";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+    EncryptionContext: { tenant: "acme" },
+  }),
+);
+
+try {
+  await kms.decrypt(
+    new DecryptCommand({
+      CiphertextBlob: encrypted.CiphertextBlob,
+      EncryptionContext: { tenant: "other" },
+    }),
+  );
+} catch (error) {
+  // The wrong context fails the cipher's own authentication, exactly as it
+  // does on real KMS.
+  console.log(error instanceof SimKmsInvalidCiphertextException); // true
+}
+```
+
+The context is an unordered map, so the same pairs written in a different order still decrypt.
+
+## Envelope encryption
+
+`Encrypt` takes at most 4096 bytes, which is the limit that makes envelope encryption necessary. `GenerateDataKey` returns a data key twice: once in the clear, to encrypt your data with, and once encrypted under the KMS key, to store alongside it.
+
+```typescript sim-kms-generate-data-key
+/**
+ * Envelope encryption with a simulated KMS data key.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  GenerateDataKeyCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+
+const dataKey = await kms.generateDataKey(
+  new GenerateDataKeyCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    KeySpec: "AES_256",
+  }),
+);
+
+console.log(dataKey.Plaintext?.length); // 32
+
+// Store dataKey.CiphertextBlob with the data; discard the plaintext copy.
+const recovered = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: dataKey.CiphertextBlob }),
+);
+
+console.log(recovered.Plaintext?.length); // 32
+```
+
+## Key policies and IAM
+
+This is the part of KMS most worth testing, and the part most often got wrong on real AWS.
+
+Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` reaches nothing unless the key's own policy admits the caller. How it admits them decides what else is needed:
+
+- A statement naming the caller grants access outright, so a role with no permissions of its own can still use the key.
+- A statement naming the account root, which is what the default key policy contains, only delegates to that account's IAM. The caller still needs an identity policy allowing the action.
+
+```typescript sim-kms-key-policy
+/**
+ * A simulated KMS key policy deciding who can use the key.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand, EncryptCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimIamAccessDenied } from "@kensio/yulin/iam";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Encrypter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// A key policy naming the Role directly, with no delegation to the Account.
+const created = await simAws.kms().createKey(
+  new CreateKeyCommand({
+    Policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: role.Role.Arn },
+          Action: "kms:Encrypt",
+          Resource: "*",
+        },
+      ],
+    }),
+  }),
+);
+
+// The Role can encrypt, with no identity policy of its own.
+await simAws.kms().encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+// The Account root cannot, because this key policy does not admit it.
+try {
+  await simAws.kms().encrypt(
+    new EncryptCommand({
+      KeyId: created.KeyMetadata?.Arn,
+      Plaintext: Buffer.from("hunter2", "utf8"),
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof SimIamAccessDenied); // true
+}
+```
+
+Replacing a key policy with `PutKeyPolicyCommand` can lock an account out of its own key. That is real KMS behaviour, and it is worth being able to reproduce in a test rather than in a deployment.
+
+## Naming a key
+
+Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a key ID, a key ARN, an alias name such as `alias/app-key`, or an alias ARN.
+
+Aliases beginning `alias/aws/` are reserved for AWS managed keys. `CreateAlias` refuses to create one, but referencing one brings the key into existence, the way an AWS managed key appears on real AWS when a service first needs it.
+
+```typescript sim-kms-aliases
+/**
+ * Naming a simulated KMS key by alias.
+ */
+
+import {
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+await kms.createAlias(
+  new CreateAliasCommand({
+    AliasName: "alias/app-key",
+    TargetKeyId: created.KeyMetadata?.KeyId,
+  }),
+);
+
+// The alias reaches the same key as its ID or ARN would.
+await kms.encrypt(
+  new EncryptCommand({
+    KeyId: "alias/app-key",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+// An AWS managed key appears the first time its alias is referenced.
+const managed = await kms.describeKey(
+  new DescribeKeyCommand({ KeyId: "alias/aws/s3" }),
+);
+
+console.log(managed.KeyMetadata?.KeyManager); // "AWS"
+```
+
+## Key state and deletion
+
+A key can be disabled, which leaves it present but unusable, and re-enabled later. Deletion is never immediate: `ScheduleKeyDeletion` sets a recovery window of 7 to 30 days, defaulting to 30, during which the key refuses to be used but can still be recovered with `CancelKeyDeletion`. Cancelling leaves the key disabled rather than enabled, so re-enabling it is a separate deliberate step.
+
+A disabled key fails cryptographic operations with `DisabledException`; a key pending deletion fails with `KMSInvalidStateException`. The difference is worth keeping, because one says to enable the key and the other says the key is on its way out.
+
+## Scoping
+
+KMS keys belong to an account and a region, as they do on real AWS. A key created in one region cannot be found or used from another, and a ciphertext produced under it cannot be decrypted elsewhere.
+
+```typescript sim-kms-scoping
+/**
+ * Simulated KMS keys are scoped to an account and region.
+ */
+
+import { CreateKeyCommand, DescribeKeyCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimKmsNotFoundException } from "@kensio/yulin/kms";
+
+const simAws = new SimAws();
+
+const created = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .kms()
+  .createKey(new CreateKeyCommand({}));
+
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .kms()
+    .describeKey(new DescribeKeyCommand({ KeyId: created.KeyMetadata?.Arn }));
+} catch (error) {
+  console.log(error instanceof SimKmsNotFoundException); // true
+}
+```
+
+## Inside a simulated Lambda handler
+
+Function code requiring `@aws-sdk/client-kms` is routed into the same simulated AWS environment, with the function's execution role as the caller. A handler that decrypts a value therefore has to be allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See [simulated Lambda](../lambda/) for how function code and execution roles work.
+
+## Limitations
+
+Current documented limitations:
+
+- Only symmetric encryption keys (`SYMMETRIC_DEFAULT`, `ENCRYPT_DECRYPT`) are simulated. Asymmetric keys, HMAC keys, `Sign`, `Verify` and `ReEncrypt` are not.
+- Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is refused.
+- Grants (`CreateGrant` and friends) are not simulated.
+- Automatic key rotation is not simulated.
+- Multi-Region keys are not simulated.
+- `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources are not supported yet.
+- A key pending deletion stays in that state indefinitely. Advancing the simulated clock past the recovery window does not delete it, so the key ID stays taken.
+- Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
+- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated.
+- `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived, so a policy relying on them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
+- AWS managed keys created on demand get the same default key policy as a customer key, rather than the via-service-scoped policy real AWS gives them.
+- Key material lives in process memory for the lifetime of the `SimAws` instance. That is fine for a simulator, but it is not a security boundary: anything sharing the process can reach it.
+- No other simulated service encrypts anything with KMS yet. Sim S3, sim DynamoDB and sim Lambda environment variables do not use simulated keys, and do not check `kms:Decrypt`.
+- KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/kms/sim-kms-aliases.example.ts
+++ b/docs/services/kms/sim-kms-aliases.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Naming a simulated KMS key by alias.
+ */
+
+import {
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+await kms.createAlias(
+  new CreateAliasCommand({
+    AliasName: "alias/app-key",
+    TargetKeyId: created.KeyMetadata?.KeyId,
+  }),
+);
+
+// The alias reaches the same key as its ID or ARN would.
+await kms.encrypt(
+  new EncryptCommand({
+    KeyId: "alias/app-key",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+// An AWS managed key appears the first time its alias is referenced.
+const managed = await kms.describeKey(
+  new DescribeKeyCommand({ KeyId: "alias/aws/s3" }),
+);
+
+console.log(managed.KeyMetadata?.KeyManager); // "AWS"

--- a/docs/services/kms/sim-kms-encrypt-decrypt.example.ts
+++ b/docs/services/kms/sim-kms-encrypt-decrypt.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Encrypting and decrypting with a simulated KMS key.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(
+  new CreateKeyCommand({ Description: "Application key" }),
+);
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+const decrypted = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+);
+
+console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"

--- a/docs/services/kms/sim-kms-encryption-context.example.ts
+++ b/docs/services/kms/sim-kms-encryption-context.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Binding an encryption context to a simulated KMS ciphertext.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimKmsInvalidCiphertextException } from "@kensio/yulin/kms";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+    EncryptionContext: { tenant: "acme" },
+  }),
+);
+
+try {
+  await kms.decrypt(
+    new DecryptCommand({
+      CiphertextBlob: encrypted.CiphertextBlob,
+      EncryptionContext: { tenant: "other" },
+    }),
+  );
+} catch (error) {
+  // The wrong context fails the cipher's own authentication, exactly as it
+  // does on real KMS.
+  console.log(error instanceof SimKmsInvalidCiphertextException); // true
+}

--- a/docs/services/kms/sim-kms-generate-data-key.example.ts
+++ b/docs/services/kms/sim-kms-generate-data-key.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Envelope encryption with a simulated KMS data key.
+ */
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  GenerateDataKeyCommand,
+} from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const kms = simAws.kms();
+
+const created = await kms.createKey(new CreateKeyCommand({}));
+
+const dataKey = await kms.generateDataKey(
+  new GenerateDataKeyCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    KeySpec: "AES_256",
+  }),
+);
+
+console.log(dataKey.Plaintext?.length); // 32
+
+// Store dataKey.CiphertextBlob with the data; discard the plaintext copy.
+const recovered = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: dataKey.CiphertextBlob }),
+);
+
+console.log(recovered.Plaintext?.length); // 32

--- a/docs/services/kms/sim-kms-key-policy.example.ts
+++ b/docs/services/kms/sim-kms-key-policy.example.ts
@@ -1,0 +1,64 @@
+/**
+ * A simulated KMS key policy deciding who can use the key.
+ */
+
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand, EncryptCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimIamAccessDenied } from "@kensio/yulin/iam";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Encrypter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// A key policy naming the Role directly, with no delegation to the Account.
+const created = await simAws.kms().createKey(
+  new CreateKeyCommand({
+    Policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: role.Role.Arn },
+          Action: "kms:Encrypt",
+          Resource: "*",
+        },
+      ],
+    }),
+  }),
+);
+
+// The Role can encrypt, with no identity policy of its own.
+await simAws.kms().encrypt(
+  new EncryptCommand({
+    KeyId: created.KeyMetadata?.Arn,
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+// The Account root cannot, because this key policy does not admit it.
+try {
+  await simAws.kms().encrypt(
+    new EncryptCommand({
+      KeyId: created.KeyMetadata?.Arn,
+      Plaintext: Buffer.from("hunter2", "utf8"),
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof SimIamAccessDenied); // true
+}

--- a/docs/services/kms/sim-kms-scoping.example.ts
+++ b/docs/services/kms/sim-kms-scoping.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Simulated KMS keys are scoped to an account and region.
+ */
+
+import { CreateKeyCommand, DescribeKeyCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimKmsNotFoundException } from "@kensio/yulin/kms";
+
+const simAws = new SimAws();
+
+const created = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .kms()
+  .createKey(new CreateKeyCommand({}));
+
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .kms()
+    .describeKey(new DescribeKeyCommand({ KeyId: created.KeyMetadata?.Arn }));
+} catch (error) {
+  console.log(error instanceof SimKmsNotFoundException); // true
+}

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -15,6 +15,7 @@
       "@kensio/yulin/dynamodb": ["../src/service/dynamodb/index.ts"],
       "@kensio/yulin/eslint": ["../src/config/eslint/index.ts"],
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
+      "@kensio/yulin/kms": ["../src/service/kms/index.ts"],
       "@kensio/yulin/lambda": ["../src/service/lambda/index.ts"],
       "@kensio/yulin/route53": ["../src/service/route53/index.ts"],
       "@kensio/yulin/s3": ["../src/service/s3/index.ts"],

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
       "import": "./dist/service/iam/index.js",
       "types": "./dist/service/iam/index.d.ts"
     },
+    "./kms": {
+      "import": "./dist/service/kms/index.js",
+      "types": "./dist/service/kms/index.d.ts"
+    },
     "./lambda": {
       "import": "./dist/service/lambda/index.js",
       "types": "./dist/service/lambda/index.d.ts"
@@ -103,6 +107,7 @@
     "@aws-sdk/client-cloudfront": "^3.1095.0",
     "@aws-sdk/client-dynamodb": "^3.1095.0",
     "@aws-sdk/client-iam": "^3.1095.0",
+    "@aws-sdk/client-kms": "^3.1095.0",
     "@aws-sdk/client-lambda": "^3.1095.0",
     "@aws-sdk/client-route-53": "^3.1095.0",
     "@aws-sdk/client-s3": "^3.1095.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@aws-sdk/client-iam':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/client-kms':
+        specifier: ^3.1095.0
+        version: 3.1095.0
       '@aws-sdk/client-lambda':
         specifier: ^3.1095.0
         version: 3.1095.0
@@ -186,6 +189,10 @@ packages:
 
   '@aws-sdk/client-iam@3.1095.0':
     resolution: {integrity: sha512-82qFOpSBLu6zK6D/mklXrX74XcwIKTvGFOAiTL+e9k+QlD3TKlyax6tqau2Tpm8slYFtsO39c0gISQmmTFNYFA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-kms@3.1095.0':
+    resolution: {integrity: sha512-inNKi30hcvb/pQtS6Of4vDbWE4qWjTQx00G8H70ID565762qpBm9HZk6OVB13WCUvnORUnLqgPSad+ebrEVb5Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-lambda@3.1095.0':
@@ -1951,6 +1958,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-iam@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.72
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-kms@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/credential-provider-node': 3.972.72

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -38,6 +38,9 @@ export function resolveSimSdkCommandRouter(
     case "IAM": {
       return scoped.iam().sdkCommandRouter();
     }
+    case "KMS": {
+      return scoped.kms().sdkCommandRouter();
+    }
     case "Lambda": {
       return scoped.lambda().sdkCommandRouter();
     }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -22,6 +22,7 @@ import { SimIamAccessKeyRegistry } from "../../iam/registry/sim-iam-access-key-r
 import { SimIamGlobalCredentialResolver } from "../../iam/registry/sim-iam-global-credential-resolver.js";
 import { SimIamSigV4Verifier } from "../../iam/sigv4/sim-iam-sigv4-verifier.js";
 import { SimAwsRequestCallerResolver } from "../../iam/request/sim-aws-request-caller-resolver.js";
+import { SimKms } from "../../kms/index.js";
 import { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
@@ -211,6 +212,20 @@ export class SimAwsServiceFactory {
    */
   createIam(scope: SimAwsAccountRegionContainer): SimIam {
     return this.accountServices.createIam(scope);
+  }
+
+  /**
+   * Create simulated KMS for an Account Region scope.
+   *
+   * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
+   * ciphertext produced in one Region cannot be decrypted in another.
+   */
+  createKms(scope: SimAwsAccountRegionContainer): SimKms {
+    return new SimKms({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.createIam(scope),
+      background: this.background,
+    });
   }
 
   /**

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -9,6 +9,7 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 
@@ -91,6 +92,15 @@ export class SimAwsAccountRegionContainer {
   iam(): SimIam {
     return this.memo.getOrCreate("iam", () =>
       this.simAws.serviceFactory.createIam(this),
+    );
+  }
+
+  /**
+   * Get simulated KMS for this account and region.
+   */
+  kms(): SimKms {
+    return this.memo.getOrCreate("kms", () =>
+      this.simAws.serviceFactory.createKms(this),
     );
   }
 

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -10,6 +10,7 @@ import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimIam } from "../iam/index.js";
+import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
 import { makeSimAwsAccountRootPrincipal } from "./caller/sim-aws-account-root-principal.js";
@@ -90,6 +91,13 @@ export class SimAwsAccount {
    */
   iam(): SimIam {
     return this.region().iam();
+  }
+
+  /**
+   * Get simulated KMS for this Account's default Region.
+   */
+  kms(): SimKms {
+    return this.region().kms();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -7,6 +7,7 @@ import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
+import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 
@@ -148,6 +149,13 @@ export class SimAwsRegion {
    */
   dynamoDb(): SimDynamoDatabase {
     return this.account().dynamoDb();
+  }
+
+  /**
+   * Get simulated KMS for this Region's default Account.
+   */
+  kms(): SimKms {
+    return this.account().kms();
   }
 
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -15,8 +15,6 @@ import {
 import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scope.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
-import type { SimCloudFrontRegistry } from "../cloudfront/registry/sim-cloud-front-registry.js";
-import type { SimLambdaUrlRegistry } from "../lambda/registry/sim-lambda-url-registry.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimRoute53 } from "../route53/index.js";
@@ -25,6 +23,7 @@ import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
+import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
@@ -224,6 +223,13 @@ export class SimAws {
   }
 
   /**
+   * Get simulated KMS in the default Account Region scope.
+   */
+  kms(): SimKms {
+    return this.accountRegionScope().kms();
+  }
+
+  /**
    * Get simulated Lambda in the default Account Region scope.
    */
   lambda(): SimLambda {
@@ -249,29 +255,6 @@ export class SimAws {
    */
   sts(): SimSts {
     return this.accountRegionScope().sts();
-  }
-
-  /**
-   * Get the shared simulated CloudFront registry.
-   *
-   * This is intended for CloudFront service/controller wiring so request routing
-   * uses the same registry as CloudFront SDK command handling.
-   * @internal
-   */
-  cloudFrontRegistry(): SimCloudFrontRegistry {
-    return this.serviceFactory.cloudFrontRegistry;
-  }
-
-  /**
-   * Get the shared simulated Lambda Function URL registry.
-   *
-   * This is intended for Lambda controller wiring, so serving a Function URL
-   * request resolves the owning Account from the same registry the Function
-   * URL commands register ids in.
-   * @internal
-   */
-  lambdaUrlRegistry(): SimLambdaUrlRegistry {
-    return this.serviceFactory.lambdaUrlRegistry;
   }
 
   /**

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -35,7 +35,7 @@ export class SimCloudFrontControllerDependenciesFactory {
   ): SimCloudFrontControllerDependencies {
     const simAws = properties.simAws ?? new SimAws();
     const cloudFrontRegistry =
-      properties.cloudFrontRegistry ?? simAws.cloudFrontRegistry();
+      properties.cloudFrontRegistry ?? simAws.serviceFactory.cloudFrontRegistry;
 
     return {
       distroRouter:

--- a/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
+++ b/src/service/cloudfront/router/sim-cloud-front-distro-router.ts
@@ -41,7 +41,8 @@ export class SimCloudFrontDistroRouter {
   constructor(properties: SimCloudFrontDistroRouterProperties = {}) {
     this.simAws = properties.simAws ?? new SimAws();
     const cloudFrontRegistry =
-      properties.cloudFrontRegistry ?? this.simAws.cloudFrontRegistry();
+      properties.cloudFrontRegistry ??
+      this.simAws.serviceFactory.cloudFrontRegistry;
     const distributions = properties.distributions ?? new Map();
 
     // Both sub-routers share the same SimAws, Registry and Distributions

--- a/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
+++ b/src/service/cloudfront/router/sim-cloudfront-distro-router.iso.test.ts
@@ -155,7 +155,7 @@ describe("Sim CloudFront Distribution Router", () => {
 
       const router = new SimCloudFrontDistroRouter({
         simAws,
-        cloudFrontRegistry: simAws.cloudFrontRegistry(),
+        cloudFrontRegistry: simAws.serviceFactory.cloudFrontRegistry,
       });
 
       const request = new Request(
@@ -240,7 +240,7 @@ describe("Sim CloudFront Distribution Router", () => {
 
       const router = new SimCloudFrontDistroRouter({
         simAws,
-        cloudFrontRegistry: simAws.cloudFrontRegistry(),
+        cloudFrontRegistry: simAws.serviceFactory.cloudFrontRegistry,
       });
 
       const request = new Request("http://cdn.example.test/foo/bar.json");

--- a/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
@@ -1,6 +1,12 @@
 interface SimIamAllowSidesProperties {
   readonly identity: boolean;
   readonly resource: boolean;
+
+  /**
+   * Whether a resource-policy Allow named the caller rather than its Account.
+   * Defaults to the resource side, for callers with no reason to distinguish.
+   */
+  readonly resourceDirect?: boolean | undefined;
 }
 
 /**
@@ -14,10 +20,13 @@ interface SimIamAllowSidesProperties {
 export class SimIamAllowSides {
   private readonly identityAllowed: boolean;
   private readonly resourceAllowed: boolean;
+  private readonly resourceDirectAllowed: boolean;
 
   constructor(properties: SimIamAllowSidesProperties) {
     this.identityAllowed = properties.identity;
     this.resourceAllowed = properties.resource;
+    this.resourceDirectAllowed =
+      properties.resourceDirect ?? properties.resource;
   }
 
   /**
@@ -32,6 +41,22 @@ export class SimIamAllowSides {
    */
   get resource(): boolean {
     return this.resourceAllowed;
+  }
+
+  /**
+   * Whether a resource-based policy allowed the request by naming the caller,
+   * rather than by delegating to the caller's Account.
+   */
+  get resourceDirect(): boolean {
+    return this.resourceDirectAllowed;
+  }
+
+  /**
+   * Whether the resource's policy admitted the caller only by delegating to
+   * its Account, which grants nothing on its own.
+   */
+  get resourceDelegated(): boolean {
+    return this.resourceAllowed && !this.resourceDirectAllowed;
   }
 }
 
@@ -72,5 +97,61 @@ export class SimIamBothSidesAllowRequirement implements SimIamAllowRequirement {
    */
   isSatisfiedBy(allows: SimIamAllowSides): boolean {
     return allows.identity && allows.resource;
+  }
+}
+
+/**
+ * The rule for a resource whose policy is mandatory: it must admit the caller.
+ *
+ * Most AWS resources have no resource policy until someone writes one, and its
+ * absence simply leaves the decision to IAM. A KMS key is not like that: it
+ * always has a key policy, and an identity policy cannot reach the key unless
+ * that policy admits the caller. Services holding such a resource ask for this
+ * rule rather than IAM inferring it, because only the service knows its
+ * resource works that way.
+ *
+ * How the policy admits the caller decides what else is needed. A statement
+ * naming the caller grants access outright, which is why a KMS key policy can
+ * make a key usable by a Role with no permissions of its own. A statement
+ * naming the Account only delegates to that Account's IAM, so an identity
+ * policy still has to allow the action. That second case is the one the
+ * default key policy creates, and getting it wrong would make every key in the
+ * simulation usable by every principal in its Account.
+ */
+export class SimIamMandatoryResourcePolicyRequirement implements SimIamAllowRequirement {
+  /**
+   * Whether the resource's own policy admitted the caller, and whether
+   * anything further is needed for the way it did so.
+   */
+  isSatisfiedBy(allows: SimIamAllowSides): boolean {
+    if (allows.resourceDirect) {
+      return true;
+    }
+
+    return allows.resourceDelegated && allows.identity;
+  }
+}
+
+/**
+ * Every applicable rule at once.
+ *
+ * A request can be subject to more than one: a cross-Account call against a
+ * KMS key has to satisfy both the cross-Account rule and the key's own
+ * mandatory-policy rule, and the stricter answer is the right one.
+ */
+export class SimIamEveryAllowRequirement implements SimIamAllowRequirement {
+  private readonly requirements: readonly SimIamAllowRequirement[];
+
+  constructor(requirements: readonly SimIamAllowRequirement[]) {
+    this.requirements = requirements;
+  }
+
+  /**
+   * Whether every rule is satisfied.
+   */
+  isSatisfiedBy(allows: SimIamAllowSides): boolean {
+    return this.requirements.every((requirement) =>
+      requirement.isSatisfiedBy(allows),
+    );
   }
 }

--- a/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
@@ -1,6 +1,7 @@
 import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
 import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
 import { SimIamAllowSides } from "./sim-iam-allow-requirement.js";
+import type { SimIamPrincipalMatch } from "../match/sim-iam-principal-match.js";
 
 /**
  * The matching Allow statements found for one authorization, kept per side.
@@ -15,16 +16,26 @@ export class SimIamAllowStatements {
   private readonly identityStatements: SimIamPolicyDocumentStatement[] = [];
   private readonly resourceStatements: SimIamPolicyDocumentStatement[] = [];
   private readonly trustStatements: SimIamPolicyDocumentStatement[] = [];
+  private readonly delegatedStatements: SimIamPolicyDocumentStatement[] = [];
 
   /**
    * Record a matching Allow against the policy side it came from.
+   *
+   * A resource-policy Allow that matched by way of the caller's Account rather
+   * than the caller itself is kept apart as well, so a rule that cares about
+   * the difference can ask for it.
    */
   record(
     policy: SimIamAuthZPolicySource,
     statement: SimIamPolicyDocumentStatement,
+    principal: SimIamPrincipalMatch,
   ): void {
     if (policy.sourceType === "trust") {
       this.trustStatements.push(statement);
+    }
+
+    if (principal.isAccountDelegation) {
+      this.delegatedStatements.push(statement);
     }
 
     this.sideStatements(policy).push(statement);
@@ -62,9 +73,14 @@ export class SimIamAllowStatements {
    * Which sides produced a matching Allow.
    */
   get sides(): SimIamAllowSides {
+    const delegated = new Set(this.delegatedStatements);
+
     return new SimIamAllowSides({
       identity: this.identityStatements.length > 0,
       resource: this.resourceStatements.length > 0,
+      resourceDirect: this.resourceStatements.some(
+        (statement) => !delegated.has(statement),
+      ),
     });
   }
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-allow-requirement.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-allow-requirement.ts
@@ -1,0 +1,33 @@
+import {
+  type SimIamAllowRequirement,
+  SimIamEveryAllowRequirement,
+  SimIamMandatoryResourcePolicyRequirement,
+} from "../allow/sim-iam-allow-requirement.js";
+import type { SimIamCallerAccount } from "../caller-account/sim-iam-caller-account.js";
+
+/**
+ * Works out which allow rules apply to one authorization request.
+ *
+ * Two things decide it, and both have to hold. The caller's Account says whose
+ * Allow counts: either side within one Account, both sides across Accounts.
+ * The resource-owning service says whether its resource insists on allowing,
+ * which is true of a KMS key and of nothing else so far.
+ */
+export class SimIamAuthZAllowRequirement {
+  /**
+   * The rule a request is subject to.
+   */
+  resolve(
+    callerAccount: SimIamCallerAccount,
+    requiresResourcePolicyAllow: boolean | undefined,
+  ): SimIamAllowRequirement {
+    if (requiresResourcePolicyAllow !== true) {
+      return callerAccount.allowRequirement;
+    }
+
+    return new SimIamEveryAllowRequirement([
+      callerAccount.allowRequirement,
+      new SimIamMandatoryResourcePolicyRequirement(),
+    ]);
+  }
+}

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamCallerAccountResolver } from "../caller-account/sim-iam-caller-account-resolver.js";
+import { SimIamAuthZAllowRequirement } from "./sim-iam-auth-z-allow-requirement.js";
 import type { SimIamAccountResolver } from "../../registry/sim-iam-account-resolver.js";
 import type {
   SimIamConditionValue,
@@ -74,6 +75,16 @@ export interface SimIamAuthorizationInput {
    * service-level resource policy.
    */
   readonly resourcePolicies?: readonly SimIamResourcePolicyInput[] | undefined;
+
+  /**
+   * Whether the resource's own policy must allow the request.
+   *
+   * Off by default, which is the ordinary AWS rule: a resource with no policy
+   * leaves the decision to the caller's identity policies. A service sets it
+   * for a resource whose policy is mandatory and is the root of trust for
+   * reaching it, which in AWS means a KMS key policy.
+   */
+  readonly requiresResourcePolicyAllow?: boolean | undefined;
 }
 
 interface SimIamAuthZContextBuilderProperties {
@@ -124,6 +135,7 @@ export class SimIamAuthZContextBuilder {
   private readonly callerContextBuilder: SimIamAuthZCallerContextBuilder;
   private readonly identityPolicyCoordinator: SimIamAuthZIdentityPolicyCoordinator;
   private readonly callerAccountResolver: SimIamCallerAccountResolver;
+  private readonly allowRequirement = new SimIamAuthZAllowRequirement();
 
   constructor(properties: SimIamAuthZContextBuilderProperties) {
     this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
@@ -156,7 +168,10 @@ export class SimIamAuthZContextBuilder {
         ...callerAccount.identityPolicies,
       ],
       resourcePolicies: this.resourcePolicySources(input),
-      allowRequirement: callerAccount.allowRequirement,
+      allowRequirement: this.allowRequirement.resolve(
+        callerAccount,
+        input.requiresResourcePolicyAllow,
+      ),
       action: input.action,
       resource: input.resource,
       conditionContext: this.conditionContext(input, callerContext.caller),

--- a/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
@@ -5,6 +5,7 @@ import type {
   SimIamAuthZPolicySource,
 } from "../context/sim-iam-auth-z-context.js";
 import { simIamWildcardMatch } from "../sim-iam-wildcard.js";
+import { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
 
 /**
  * Matches the principal portion of an IAM policy statement.
@@ -36,11 +37,11 @@ export class SimIamPolicyPrincipalMatcher {
   matches(
     policy: SimIamAuthZPolicySource,
     statement: SimIamParsedPolicyStatement,
-  ): boolean {
+  ): SimIamPrincipalMatch {
     if (policy.sourceType !== "resource" && policy.sourceType !== "trust") {
-      return (
+      return SimIamPrincipalMatch.direct().when(
         statement.principal === undefined &&
-        statement.notPrincipal === undefined
+          statement.notPrincipal === undefined,
       );
     }
 
@@ -49,10 +50,14 @@ export class SimIamPolicyPrincipalMatcher {
     }
 
     if (statement.notPrincipal !== undefined) {
-      return !this.valueMatches(statement.notPrincipal);
+      // Excluding the caller says nothing about the Account delegating, so a
+      // NotPrincipal that leaves the caller in is a direct grant.
+      return SimIamPrincipalMatch.direct().when(
+        !this.valueMatches(statement.notPrincipal).matched,
+      );
     }
 
-    return false;
+    return SimIamPrincipalMatch.none();
   }
 
   /**
@@ -62,31 +67,47 @@ export class SimIamPolicyPrincipalMatcher {
    * to their principal category so AWS values match caller ARNs and account
    * delegation, while Service values match service principals.
    */
-  private valueMatches(principal: SimIamPolicyDocumentPrincipal): boolean {
+  private valueMatches(
+    principal: SimIamPolicyDocumentPrincipal,
+  ): SimIamPrincipalMatch {
     if (typeof principal === "string") {
       return this.awsPatternMatches(principal);
     }
 
     if (Array.isArray(principal)) {
-      return principal.some((value: string): boolean =>
+      return this.firstMatch(principal, (value: string) =>
         this.awsPatternMatches(value),
       );
     }
 
-    return Object.entries(principal).some(([principalType, values]) => {
+    return this.firstMatch(Object.entries(principal), ([type, values]) => {
       const patterns = typeof values === "string" ? [values] : values;
 
-      if (principalType === "AWS") {
-        return patterns.some((pattern) => this.awsPatternMatches(pattern));
+      if (type === "AWS") {
+        return this.firstMatch(patterns, (pattern) =>
+          this.awsPatternMatches(pattern),
+        );
       }
 
       /* v8 ignore if -- service principals not yet fully supported */
-      if (principalType === "Service") {
-        return patterns.some((pattern) => this.servicePatternMatches(pattern));
+      if (type === "Service") {
+        return this.firstMatch(patterns, (pattern) =>
+          this.servicePatternMatches(pattern),
+        );
       }
 
-      return false;
+      return SimIamPrincipalMatch.none();
     });
+  }
+
+  /**
+   * The winning match among alternatives, since Principal lists are an OR.
+   */
+  private firstMatch<T>(
+    values: readonly T[],
+    match: (value: T) => SimIamPrincipalMatch,
+  ): SimIamPrincipalMatch {
+    return SimIamPrincipalMatch.first(values.map((value) => match(value)));
   }
 
   /**
@@ -96,40 +117,44 @@ export class SimIamPolicyPrincipalMatcher {
    * forms require an ARN-based caller. Account delegation forms compare against
    * the account ID derived by the caller resolver.
    */
-  private awsPatternMatches(pattern: string): boolean {
+  private awsPatternMatches(pattern: string): SimIamPrincipalMatch {
     if (pattern === "*") {
-      return true;
+      return SimIamPrincipalMatch.direct();
     }
 
     const caller = this.context.caller;
     if (caller.arn === undefined) {
-      return false;
+      return SimIamPrincipalMatch.none();
     }
 
     const delegatedAccountId = this.delegatedAccountId(pattern);
 
     if (delegatedAccountId !== undefined) {
-      return caller.accountId === delegatedAccountId;
+      return SimIamPrincipalMatch.accountDelegation().when(
+        caller.accountId === delegatedAccountId,
+      );
     }
 
-    return simIamWildcardMatch(pattern, caller.arn, {
-      caseSensitive: true,
-    });
+    return SimIamPrincipalMatch.direct().when(
+      simIamWildcardMatch(pattern, caller.arn, {
+        caseSensitive: true,
+      }),
+    );
   }
 
   /**
    * Compare a service principal pattern with the resolved caller.
    */
-  private servicePatternMatches(pattern: string): boolean {
+  private servicePatternMatches(pattern: string): SimIamPrincipalMatch {
     /* v8 ignore next -- service principals not yet fully supported */
     const service = this.context.caller.service;
 
     /* v8 ignore next -- service principals not yet fully supported */
-    return (
+    return SimIamPrincipalMatch.direct().when(
       service !== undefined &&
-      simIamWildcardMatch(pattern, service, {
-        caseSensitive: true,
-      })
+        simIamWildcardMatch(pattern, service, {
+          caseSensitive: true,
+        }),
     );
   }
 

--- a/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.iso.test.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.iso.test.ts
@@ -26,7 +26,7 @@ describe("SimIamPolicyStatementMatcher", () => {
     });
 
     // When the statement is matched against the caller.
-    const isMatches = matcher.matches(policy, statement);
+    const isMatches = matcher.matches(policy, statement).matched;
 
     // Then the array Principal is accepted because at least one entry matches.
     assertTrue(isMatches);
@@ -45,7 +45,7 @@ describe("SimIamPolicyStatementMatcher", () => {
     });
 
     // When the statement is matched against the caller.
-    const isMatches = matcher.matches(policy, statement);
+    const isMatches = matcher.matches(policy, statement).matched;
 
     // Then the unsupported principal type is ignored and the statement does not match.
     assertFalse(isMatches);
@@ -67,7 +67,7 @@ describe("SimIamPolicyStatementMatcher", () => {
     });
 
     // When the statement is matched against the caller.
-    const isMatches = matcher.matches(policy, statement);
+    const isMatches = matcher.matches(policy, statement).matched;
 
     // Then the AWS Principal array is accepted because at least one entry matches.
     assertTrue(isMatches);
@@ -85,7 +85,7 @@ describe("SimIamPolicyStatementMatcher", () => {
     });
 
     // When the request has no caller ARN.
-    const isMatches = matcher.matches(policy, statement);
+    const isMatches = matcher.matches(policy, statement).matched;
 
     // Then the concrete Principal cannot match.
     assertFalse(isMatches);
@@ -103,7 +103,7 @@ describe("SimIamPolicyStatementMatcher", () => {
     });
 
     // When the statement is matched against the caller.
-    const isMatches = matcher.matches(policy, statement);
+    const isMatches = matcher.matches(policy, statement).matched;
 
     // Then the resource policy is rejected because resource policies must name or exclude a principal.
     assertFalse(isMatches);

--- a/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
@@ -6,6 +6,7 @@ import type { SimIamParsedPolicyStatement } from "../../policy/parse/sim-iam-doc
 import { simIamWildcardMatch } from "../sim-iam-wildcard.js";
 import { SimIamPolicyConditionMatcher } from "./condition/sim-iam-policy-condition-matcher.js";
 import { SimIamPolicyPrincipalMatcher } from "./sim-iam-policy-principal-matcher.js";
+import type { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
 
 /**
  * Matches one parsed IAM policy statement against one authorization request.
@@ -46,12 +47,14 @@ export class SimIamPolicyStatementMatcher {
   matches(
     policy: SimIamAuthZPolicySource,
     statement: SimIamParsedPolicyStatement,
-  ): boolean {
-    return (
-      this.principalMatcher.matches(policy, statement) &&
-      this.actionMatches(statement) &&
-      this.resourceMatches(policy, statement) &&
-      this.conditionMatcher.matches(statement.condition)
+  ): SimIamPrincipalMatch {
+    const principal = this.principalMatcher.matches(policy, statement);
+
+    return principal.when(
+      principal.matched &&
+        this.actionMatches(statement) &&
+        this.resourceMatches(policy, statement) &&
+        this.conditionMatcher.matches(statement.condition),
     );
   }
 

--- a/src/service/iam/authorize/match/sim-iam-principal-match.iso.test.ts
+++ b/src/service/iam/authorize/match/sim-iam-principal-match.iso.test.ts
@@ -1,0 +1,50 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
+
+describe("SimIamPrincipalMatch.first", () => {
+  it("prefers a direct match over a delegated one", () => {
+    // Given a Principal list matching both by Account delegation and by naming
+    // the caller, which is what a key policy holding both statements produces.
+    const matches = [
+      SimIamPrincipalMatch.accountDelegation(),
+      SimIamPrincipalMatch.direct(),
+    ];
+
+    // When the winning match is chosen.
+    const first = SimIamPrincipalMatch.first(matches);
+
+    // Then the direct grant wins: a statement naming the caller grants to the
+    // caller whatever else the policy says.
+    assertTrue(first.matched);
+    assertFalse(first.isAccountDelegation);
+  });
+
+  it("keeps a delegated match when nothing names the caller", () => {
+    // Given only an Account delegation, as the default KMS key policy gives.
+    const matches = [
+      SimIamPrincipalMatch.none(),
+      SimIamPrincipalMatch.accountDelegation(),
+    ];
+
+    // When the winning match is chosen.
+    const first = SimIamPrincipalMatch.first(matches);
+
+    // Then it is still a match, and still marked as delegation, so a rule that
+    // cares can require an identity policy as well.
+    assertTrue(first.matched);
+    assertTrue(first.isAccountDelegation);
+  });
+
+  it("reports no match when nothing applies", () => {
+    // Given nothing matching.
+    const matches = [SimIamPrincipalMatch.none(), SimIamPrincipalMatch.none()];
+
+    // When the winning match is chosen.
+    const first = SimIamPrincipalMatch.first(matches);
+
+    // Then there is none.
+    assertFalse(first.matched);
+    assertFalse(first.isAccountDelegation);
+  });
+});

--- a/src/service/iam/authorize/match/sim-iam-principal-match.ts
+++ b/src/service/iam/authorize/match/sim-iam-principal-match.ts
@@ -1,0 +1,63 @@
+/**
+ * How a resource-policy statement came to apply to the caller.
+ *
+ * AWS treats these two differently. A statement naming the caller's own ARN is
+ * a grant to that principal. A statement naming the Account, as a bare account
+ * ID or a root ARN, delegates the decision to that Account's IAM rather than
+ * granting anything by itself. Most of this simulator does not yet act on the
+ * difference; a KMS key policy does, because it is the whole reason the
+ * default key policy does not make a key usable by everyone in the Account.
+ */
+export class SimIamPrincipalMatch {
+  public readonly matched: boolean;
+  public readonly isAccountDelegation: boolean;
+
+  private constructor(matched: boolean, isAccountDelegation: boolean) {
+    this.matched = matched;
+    this.isAccountDelegation = isAccountDelegation;
+  }
+
+  /**
+   * The statement does not apply to this caller.
+   */
+  static none(): SimIamPrincipalMatch {
+    return new SimIamPrincipalMatch(false, false);
+  }
+
+  /**
+   * The statement names this caller, or applies without naming an Account.
+   */
+  static direct(): SimIamPrincipalMatch {
+    return new SimIamPrincipalMatch(true, false);
+  }
+
+  /**
+   * The statement applies by way of the caller's Account.
+   */
+  static accountDelegation(): SimIamPrincipalMatch {
+    return new SimIamPrincipalMatch(true, true);
+  }
+
+  /**
+   * The first match among alternatives, since Principal lists are an OR.
+   *
+   * A direct match wins over a delegated one where both apply, because a
+   * statement naming the caller grants to the caller whatever else it says.
+   */
+  static first(matches: readonly SimIamPrincipalMatch[]): SimIamPrincipalMatch {
+    const matched = matches.filter((result) => result.matched);
+
+    return (
+      matched.find((result) => !result.isAccountDelegation) ??
+      matched[0] ??
+      this.none()
+    );
+  }
+
+  /**
+   * A match of the same kind, or none, according to a condition.
+   */
+  when(matched: boolean): SimIamPrincipalMatch {
+    return matched ? this : SimIamPrincipalMatch.none();
+  }
+}

--- a/src/service/iam/authorize/sim-iam-decision.ts
+++ b/src/service/iam/authorize/sim-iam-decision.ts
@@ -168,7 +168,9 @@ export class SimIamPolicyDecision {
     const parsedPolicy = this.policyDocumentParser.parse(policy.document);
 
     for (const statement of parsedPolicy.statements) {
-      if (!this.statementMatcher.matches(policy, statement)) {
+      const principal = this.statementMatcher.matches(policy, statement);
+
+      if (!principal.matched) {
         continue;
       }
 
@@ -177,7 +179,7 @@ export class SimIamPolicyDecision {
         continue;
       }
 
-      this.allows.record(policy, statement.source);
+      this.allows.record(policy, statement.source, principal);
     }
   }
 }

--- a/src/service/iam/index.ts
+++ b/src/service/iam/index.ts
@@ -1,4 +1,5 @@
 export { SimIam } from "./sim-iam.js";
+export { SimIamAccessDenied, SimIamError } from "./error/sim-iam.error.js";
 export type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";
 export type { SimIamCredentialIdentity } from "./credential/sim-aws-credentials.js";
 export {

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -1,0 +1,106 @@
+# Simulated KMS implementation
+
+This directory contains the simulated KMS service implementation.
+
+The guiding decision here is that the cryptography is real. A simulated key holds real AES-256 key
+material and every operation goes through Node.js's `crypto`, rather than a stand-in that records
+what it was asked to encrypt. That costs almost nothing in a test suite and it buys behaviour that
+would otherwise have to be hand-modelled: a ciphertext that cannot be read without its key, an
+authentication tag that fails on tampering, and an encryption context that has to match.
+
+## Entry points
+
+- `sim-kms.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public KMS simulator API for `@kensio/yulin/kms`.
+
+A `SimKms` instance owns a `SimKmsKeyStore` holding its keys and aliases. The simulator is scoped to
+an account and region, because real KMS keys are: a key ARN names its region, and a ciphertext
+produced in one region cannot be decrypted in another.
+
+## Key model
+
+Key state lives under `key/`.
+
+`SimKmsKey` is the stored resource: identifier, ARN, description, key manager, its policy, its key
+material and its lifecycle. `SimKmsKeyLifecycle` holds the state and the rules about which
+transitions are legal, so no command handler has to remember that a key pending deletion cannot be
+enabled, or which of the two failures an unusable key produces.
+
+`SimKmsKeyMaterial` holds the AES-256 bytes and performs the cipher operations. Nothing exposes the
+bytes, mirroring the fact that real key material never leaves KMS. That is a modelling choice, not a
+security boundary: this all runs in one process.
+
+`SimKmsCiphertextBlob` encodes the opaque blob KMS hands back. Real blobs are opaque to the caller
+but not to KMS, which is why `Decrypt` needs no `KeyId` for a symmetric key. The layout keeps that
+property by carrying the key ARN alongside the initialisation vector, authentication tag and
+ciphertext, behind a marker and a version byte so that arbitrary bytes are rejected rather than
+misread.
+
+`SimKmsEncryptionContextAad` serialises an encryption context into AES-GCM additional authenticated
+data. This is the neatest correspondence in the service: the encryption context is non-secret, is
+not stored in the ciphertext, and must match on decryption, which is precisely what AAD does. The
+serialisation sorts by key, because the context is an unordered map on real KMS.
+
+`SimKmsKeyStore` owns `KeyId` resolution. Every operation takes its target as a key ID, key ARN,
+alias name or alias ARN, so resolving those four forms belongs in one place. It also materialises an
+AWS managed key on first reference to a reserved `alias/aws/` name, which is how such a key comes
+into existence on real AWS.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
+rather than one class per command, so the `SimKms` facade stays a delegation:
+
+- `command/key/` — `CreateKey` and `DescribeKey`; `ListKeys`; the lifecycle commands; the key policy
+  commands
+- `command/crypto/` — `Encrypt` and `Decrypt`; `GenerateDataKey`
+- `command/alias/` — `CreateAlias`, `ListAliases`
+- `command/authorize/` — the shared IAM authorizer
+- `command/sim-kms-command.types.ts` — the command types gathered for the facade
+
+Input validation that is a rule in its own right lives beside the commands that apply it, rather
+than inside them: `SimKmsKeyType` for the key types this simulation models, `SimKmsPendingWindow`
+for the deletion recovery window, `SimKmsDataKeySpec` for data key lengths, `SimKmsPolicyDocument`
+for the JSON policy both `CreateKey` and `PutKeyPolicy` take, and `SimKmsCiphertextKey` for finding
+the key behind a ciphertext.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances.
+
+## Key policies and IAM
+
+KMS is the first service here whose resource policy is mandatory, and that needed a small addition
+to simulated IAM.
+
+Ordinarily a resource with no policy simply leaves the decision to the caller's identity policies.
+A KMS key is not like that: it always has a policy, and an identity policy cannot reach the key
+unless that policy admits the caller. `SimKmsAuthorizer` therefore passes the key policy as the
+resource side and sets `requiresResourcePolicyAllow`, which selects
+`SimIamMandatoryResourcePolicyRequirement` in the IAM authorization context.
+
+That rule also has to tell apart the two ways a policy can admit a caller, because AWS does:
+
+- a statement naming the caller grants access outright, which is why a key policy can make a key
+  usable by a role with no permissions of its own;
+- a statement naming the account root only delegates to that account's IAM, so an identity policy
+  still has to allow the action.
+
+`SimIamPrincipalMatch` carries that distinction out of the principal matcher, and
+`SimIamAuthZAllowRequirement` combines the resulting rule with the one the caller's account implies.
+Getting the second case wrong would be worse than not simulating key policies at all, since the
+default key policy is exactly a root delegation: every key in the simulation would be usable by
+every principal in its account.
+
+The distinction is currently applied only where this rule is asked for. Other services' resource
+policies still treat a root-principal match as an outright grant, which is looser than AWS. That is
+a pre-existing divergence in shared IAM rather than something this service introduced, and fixing it
+generally would change S3 bucket policy, Lambda function policy and role trust policy behaviour, so
+it wants its own change.
+
+Operations with no key to speak of, `CreateKey`, `ListKeys` and `ListAliases`, authorize against the
+region's keys with identity policies alone, because real KMS gives those actions no resource-level
+permissions.
+
+`Decrypt` is the one operation that authorizes against a key the caller never named: the key comes
+out of the ciphertext, so resolution has to happen before authorization can.

--- a/src/service/kms/command/alias/alias.command.ts
+++ b/src/service/kms/command/alias/alias.command.ts
@@ -1,0 +1,50 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim KMS CreateAlias command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/CreateAliasCommand/
+ */
+export interface SimCreateAliasCommand {
+  readonly input: SimCreateAliasCommandInput;
+}
+
+export interface SimCreateAliasCommandInput {
+  readonly AliasName?: string | undefined;
+  readonly TargetKeyId?: string | undefined;
+}
+
+export interface SimCreateAliasCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS ListAliases command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/ListAliasesCommand/
+ */
+export interface SimListAliasesCommand {
+  readonly input?: SimListAliasesCommandInput | undefined;
+}
+
+export interface SimListAliasesCommandInput {
+  /**
+   * Narrows the result to the aliases of one key. Real KMS returns every alias
+   * in the Region when this is omitted.
+   */
+  readonly KeyId?: string | undefined;
+
+  readonly Limit?: number | undefined;
+}
+
+export interface SimListAliasesCommandEntry {
+  readonly AliasName: string;
+  readonly AliasArn: string;
+  readonly TargetKeyId: string;
+}
+
+export interface SimListAliasesCommandOutput {
+  readonly Aliases?: readonly SimListAliasesCommandEntry[] | undefined;
+  readonly Truncated?: boolean | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kms/command/alias/sim-kms-alias-commands.ts
+++ b/src/service/kms/command/alias/sim-kms-alias-commands.ts
@@ -1,0 +1,83 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+import { SimKmsAliasName } from "../../key/sim-kms-alias.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput,
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput,
+} from "./alias.command.js";
+
+interface SimKmsAliasCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+interface SimKmsAliasCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The alias commands of one simulated KMS scope.
+ */
+export class SimKmsAliasCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly aliasName = new SimKmsAliasName();
+
+  constructor(properties: SimKmsAliasCommandsProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Point a new alias at a key.
+   *
+   * Real KMS checks kms:CreateAlias against both the alias and the target key.
+   * Only the key is checked here, because the key is what the alias gives
+   * access to and it is the half that carries a policy.
+   */
+  create(
+    command: SimCreateAliasCommand,
+    options?: SimKmsAliasCommandOptions,
+  ): SimCreateAliasCommandOutput {
+    const aliasName = command.input.AliasName;
+
+    if (aliasName === undefined) {
+      throw new SimKmsValidationException("AliasName is required");
+    }
+
+    this.aliasName.validateCustomerAlias(aliasName);
+
+    const key = this.keys.require(command.input.TargetKeyId);
+    this.authorizer.authorizeKey("kms:CreateAlias", key, options?.caller);
+    this.keys.addAlias(aliasName, key);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * List aliases, optionally narrowed to one key's.
+   */
+  list(
+    command: SimListAliasesCommand,
+    options?: SimKmsAliasCommandOptions,
+  ): SimListAliasesCommandOutput {
+    this.authorizer.authorizeAccount("kms:ListAliases", options?.caller);
+
+    const keyId = command.input?.KeyId;
+    const aliases = this.keys
+      .aliasesFor(
+        keyId === undefined ? undefined : this.keys.require(keyId).keyId,
+      )
+      .map((alias) => ({
+        AliasName: alias.aliasName,
+        AliasArn: alias.arn,
+        TargetKeyId: alias.targetKeyId,
+      }));
+
+    return { $metadata: {}, Aliases: aliases, Truncated: false };
+  }
+}

--- a/src/service/kms/command/alias/sim-kms-alias-commands.ts
+++ b/src/service/kms/command/alias/sim-kms-alias-commands.ts
@@ -78,6 +78,16 @@ export class SimKmsAliasCommands {
         TargetKeyId: alias.targetKeyId,
       }));
 
-    return { $metadata: {}, Aliases: aliases, Truncated: false };
+    const limit = command.input?.Limit;
+
+    if (limit === undefined || aliases.length <= limit) {
+      return { $metadata: {}, Aliases: aliases, Truncated: false };
+    }
+
+    return {
+      $metadata: {},
+      Aliases: aliases.slice(0, limit),
+      Truncated: true,
+    };
   }
 }

--- a/src/service/kms/command/authorize/sim-kms-authorizer.ts
+++ b/src/service/kms/command/authorize/sim-kms-authorizer.ts
@@ -1,0 +1,73 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimKmsKey } from "../../key/sim-kms-key.js";
+
+interface SimKmsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to KMS requests.
+ *
+ * KMS splits into two kinds of request, and they authorize differently:
+ *
+ * - operations on an existing key, where the key policy is mandatory and must
+ *   allow the request, so an identity policy alone never reaches the key;
+ * - operations with no key to speak of, such as CreateKey and ListKeys, which
+ *   real KMS gives no resource-level permissions and so are authorized against
+ *   `*` with identity policies alone.
+ */
+export class SimKmsAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimKmsAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a key.
+   *
+   * The key's policy is supplied as the resource side and is required to
+   * allow: this is the rule that makes a KMS key policy the root of trust for
+   * its key rather than one more input to the decision.
+   */
+  authorizeKey(action: string, key: SimKmsKey, caller?: SimAwsCaller): void {
+    const decision = this.iam.authorize({
+      action,
+      resource: key.arn,
+      caller,
+      resourcePolicies: [key.policy.asResourcePolicy()],
+      requiresResourcePolicyAllow: true,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource: key.arn,
+      });
+    }
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular key.
+   */
+  authorizeAccount(action: string, caller?: SimAwsCaller): void {
+    const resource = `arn:aws:kms:${this.accountRegionScope.regionName}:${this.accountRegionScope.accountId}:key/*`;
+
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/kms/command/authorize/sim-kms-key-policy-authz.iso.test.ts
+++ b/src/service/kms/command/authorize/sim-kms-key-policy-authz.iso.test.ts
@@ -1,0 +1,269 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+/**
+ * A Role with no permissions of its own, assumable by the Account.
+ */
+async function makeRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+): Promise<string> {
+  const created = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  return created.Role.Arn;
+}
+
+async function allowKmsAction(
+  simAws: SimAws,
+  roleName: string,
+  action: string,
+): Promise<void> {
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: `${action.replace(":", "-")}-policy`,
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: action, Resource: "*" },
+      }),
+    }),
+  );
+}
+
+describe("KMS key policy authorization", () => {
+  it("lets a Role use a key when the default key policy is in place", async () => {
+    // Given a key with the default policy, and a Role allowed kms:Encrypt.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const roleArn = await makeRole(simAws, accountId, "Encrypter");
+    await allowKmsAction(simAws, "Encrypter", "kms:Encrypt");
+
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When the Role encrypts under the key.
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: created.KeyMetadata.Arn,
+        Plaintext: plaintext,
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the default key policy delegates to IAM, and IAM allows it.
+    assertIdentical(encrypted.KeyId, created.KeyMetadata.Arn);
+  });
+
+  it("denies a Role that IAM does not allow, despite the default key policy", async () => {
+    // Given a key with the default policy and a Role with no KMS permissions.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const roleArn = await makeRole(simAws, accountId, "NoPermissions");
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When the Role tries to encrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+        }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then it is denied: delegating to IAM is not the same as granting.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Encrypt");
+  });
+
+  it("denies a Role IAM allows when the key policy does not permit it", async () => {
+    // Given a key whose policy names only one other Role, and a second Role
+    // that IAM does allow kms:Encrypt.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const permittedArn = await makeRole(simAws, accountId, "Permitted");
+    const outsiderArn = await makeRole(simAws, accountId, "Outsider");
+    await allowKmsAction(simAws, "Outsider", "kms:Encrypt");
+
+    const created = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: permittedArn },
+              Action: "kms:*",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+    assertNonNullable(created.KeyMetadata);
+
+    // When the Role IAM allows tries to use the key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+        }),
+        { caller: { kind: "arn", arn: outsiderArn } },
+      ),
+    );
+
+    // Then the key policy refuses it. This is the KMS rule worth testing: an
+    // identity policy cannot reach a key its policy does not admit.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("lets a key policy grant a Role access with no identity policy", async () => {
+    // Given a key whose policy names a Role directly, and that Role has no
+    // permissions of its own.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const roleArn = await makeRole(simAws, accountId, "NamedInKeyPolicy");
+
+    const created = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: roleArn },
+              Action: ["kms:Encrypt", "kms:Decrypt"],
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+    assertNonNullable(created.KeyMetadata);
+
+    // When the Role encrypts and decrypts.
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: created.KeyMetadata.Arn,
+        Plaintext: plaintext,
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+    const decrypted = await simAws
+      .kms()
+      .decrypt(
+        new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+        {
+          caller: { kind: "arn", arn: roleArn },
+        },
+      );
+
+    // Then the key policy alone is enough, as it is on real AWS.
+    const roundTripped = Buffer.from(decrypted.Plaintext ?? new Uint8Array());
+    assertIdentical(roundTripped.toString("utf8"), "hunter2");
+  });
+
+  it("authorizes Decrypt against the key the ciphertext names", async () => {
+    // Given two keys, and a Role the second key's policy admits but not the
+    // first's.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const roleArn = await makeRole(simAws, accountId, "SecondKeyOnly");
+    await allowKmsAction(simAws, "SecondKeyOnly", "kms:Decrypt");
+
+    const restricted = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+              Action: "kms:Encrypt",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+    assertNonNullable(restricted.KeyMetadata);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: restricted.KeyMetadata.Arn,
+        Plaintext: plaintext,
+      }),
+    );
+
+    // When the Role decrypts a ciphertext from the key that does not admit it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .decrypt(
+          new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+          { caller: { kind: "arn", arn: roleArn } },
+        ),
+    );
+
+    // Then the denial names that key, even though the caller never named it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.resource, restricted.KeyMetadata.Arn);
+  });
+
+  it("denies CreateKey to a Role IAM does not allow", async () => {
+    // Given a Role with no KMS permissions.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const roleArn = await makeRole(simAws, accountId, "NotAKeyCreator");
+
+    // When it tries to create a key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(new CreateKeyCommand({}), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then CreateKey is denied by identity policies alone, since there is no
+    // key yet to hold a policy.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:CreateKey");
+  });
+});

--- a/src/service/kms/command/crypto/crypto.command.ts
+++ b/src/service/kms/command/crypto/crypto.command.ts
@@ -1,0 +1,78 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimKmsEncryptionContext } from "../../key/sim-kms-encryption-context.js";
+
+/**
+ * Minimal structural sim KMS Encrypt command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/EncryptCommand/
+ */
+export interface SimEncryptCommand {
+  readonly input: SimEncryptCommandInput;
+}
+
+export interface SimEncryptCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly Plaintext?: Uint8Array | undefined;
+  readonly EncryptionContext?: SimKmsEncryptionContext | undefined;
+  readonly EncryptionAlgorithm?: string | undefined;
+}
+
+export interface SimEncryptCommandOutput {
+  readonly CiphertextBlob?: Uint8Array | undefined;
+  readonly KeyId?: string | undefined;
+  readonly EncryptionAlgorithm?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS Decrypt command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/DecryptCommand/
+ */
+export interface SimDecryptCommand {
+  readonly input: SimDecryptCommandInput;
+}
+
+export interface SimDecryptCommandInput {
+  readonly CiphertextBlob?: Uint8Array | undefined;
+
+  /**
+   * Optional for a symmetric key, because the ciphertext names the key that
+   * produced it. Supplying it asks KMS to check that expectation, and the
+   * request fails if the ciphertext came from a different key.
+   */
+  readonly KeyId?: string | undefined;
+
+  readonly EncryptionContext?: SimKmsEncryptionContext | undefined;
+  readonly EncryptionAlgorithm?: string | undefined;
+}
+
+export interface SimDecryptCommandOutput {
+  readonly Plaintext?: Uint8Array | undefined;
+  readonly KeyId?: string | undefined;
+  readonly EncryptionAlgorithm?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS GenerateDataKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/GenerateDataKeyCommand/
+ */
+export interface SimGenerateDataKeyCommand {
+  readonly input: SimGenerateDataKeyCommandInput;
+}
+
+export interface SimGenerateDataKeyCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly KeySpec?: string | undefined;
+  readonly NumberOfBytes?: number | undefined;
+  readonly EncryptionContext?: SimKmsEncryptionContext | undefined;
+}
+
+export interface SimGenerateDataKeyCommandOutput {
+  readonly CiphertextBlob?: Uint8Array | undefined;
+  readonly Plaintext?: Uint8Array | undefined;
+  readonly KeyId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kms/command/crypto/sim-kms-ciphertext-key.ts
+++ b/src/service/kms/command/crypto/sim-kms-ciphertext-key.ts
@@ -1,0 +1,73 @@
+import {
+  SimKmsIncorrectKeyException,
+  SimKmsInvalidCiphertextException,
+  SimKmsInvalidKeyUsageException,
+} from "../../error/sim-kms.error.js";
+import type { SimKmsKey } from "../../key/sim-kms-key.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+
+/**
+ * The only encryption algorithm a symmetric KMS key supports.
+ */
+export const simKmsSymmetricAlgorithm = "SYMMETRIC_DEFAULT";
+
+/**
+ * Resolves the key behind a ciphertext, and checks the caller's expectations.
+ *
+ * Decrypt is the one KMS operation whose target key comes from the ciphertext
+ * rather than the request, so working out which key that is, and what to say
+ * when it is not the one the caller expected, is its own small job.
+ */
+export class SimKmsCiphertextKey {
+  private readonly keys: SimKmsKeyStore;
+
+  constructor(keys: SimKmsKeyStore) {
+    this.keys = keys;
+  }
+
+  /**
+   * Find the key a ciphertext was produced under.
+   *
+   * A blob naming a key this scope does not have is an unreadable ciphertext
+   * rather than a missing key, because the caller never named the key and so
+   * cannot be told which one is missing.
+   */
+  behind(keyArn: string): SimKmsKey {
+    const key = this.keys.find(keyArn);
+
+    if (key === undefined) {
+      throw new SimKmsInvalidCiphertextException();
+    }
+
+    return key;
+  }
+
+  /**
+   * Check a supplied KeyId against the key the ciphertext actually names.
+   */
+  requireExpected(keyId: string | undefined, key: SimKmsKey): void {
+    if (keyId === undefined) {
+      return;
+    }
+
+    if (this.keys.find(keyId)?.keyId !== key.keyId) {
+      throw new SimKmsIncorrectKeyException(
+        `The ciphertext was not encrypted under the key '${keyId}'`,
+      );
+    }
+  }
+
+  /**
+   * Refuse an encryption algorithm this simulation does not model.
+   *
+   * Only symmetric keys are simulated, so an asymmetric algorithm is refused
+   * rather than quietly treated as the symmetric one.
+   */
+  requireSymmetricAlgorithm(algorithm: string | undefined): void {
+    if (algorithm !== undefined && algorithm !== simKmsSymmetricAlgorithm) {
+      throw new SimKmsInvalidKeyUsageException(
+        `Encryption algorithm '${algorithm}' is not supported: simulated KMS keys are symmetric, which supports only ${simKmsSymmetricAlgorithm}`,
+      );
+    }
+  }
+}

--- a/src/service/kms/command/crypto/sim-kms-ciphertext-key.ts
+++ b/src/service/kms/command/crypto/sim-kms-ciphertext-key.ts
@@ -44,13 +44,16 @@ export class SimKmsCiphertextKey {
 
   /**
    * Check a supplied KeyId against the key the ciphertext actually names.
+   *
+   * A KeyId naming no key at all is a missing key rather than the wrong one,
+   * so it is resolved the same way every other operation resolves its target.
    */
   requireExpected(keyId: string | undefined, key: SimKmsKey): void {
     if (keyId === undefined) {
       return;
     }
 
-    if (this.keys.find(keyId)?.keyId !== key.keyId) {
+    if (this.keys.require(keyId).keyId !== key.keyId) {
       throw new SimKmsIncorrectKeyException(
         `The ciphertext was not encrypted under the key '${keyId}'`,
       );

--- a/src/service/kms/command/crypto/sim-kms-crypto-commands.ts
+++ b/src/service/kms/command/crypto/sim-kms-crypto-commands.ts
@@ -1,0 +1,121 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+import { SimKmsCiphertextBlob } from "../../key/sim-kms-ciphertext-blob.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import {
+  SimKmsCiphertextKey,
+  simKmsSymmetricAlgorithm,
+} from "./sim-kms-ciphertext-key.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimDecryptCommand,
+  SimDecryptCommandOutput,
+  SimEncryptCommand,
+  SimEncryptCommandOutput,
+} from "./crypto.command.js";
+
+/**
+ * The largest plaintext Encrypt accepts for a symmetric key.
+ *
+ * This limit is the whole reason envelope encryption exists, so enforcing it
+ * is what makes a test that outgrows Encrypt fail here rather than in
+ * production.
+ */
+const maxPlaintextBytes = 4096;
+
+interface SimKmsCryptoCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+interface SimKmsCryptoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The Encrypt and Decrypt commands of one simulated KMS scope.
+ *
+ * They share the key store, the authorizer and the ciphertext blob format, so
+ * they are grouped rather than wired separately on the facade.
+ */
+export class SimKmsCryptoCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly blob = new SimKmsCiphertextBlob();
+  private readonly ciphertextKey: SimKmsCiphertextKey;
+
+  constructor(properties: SimKmsCryptoCommandsProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+    this.ciphertextKey = new SimKmsCiphertextKey(properties.keys);
+  }
+
+  /**
+   * Encrypt plaintext under a key.
+   */
+  encrypt(
+    command: SimEncryptCommand,
+    options?: SimKmsCryptoCommandOptions,
+  ): SimEncryptCommandOutput {
+    const plaintext = command.input.Plaintext;
+
+    this.ciphertextKey.requireSymmetricAlgorithm(
+      command.input.EncryptionAlgorithm,
+    );
+
+    if (plaintext === undefined || plaintext.length === 0) {
+      throw new SimKmsValidationException("Plaintext is required");
+    }
+
+    if (plaintext.length > maxPlaintextBytes) {
+      throw new SimKmsValidationException(
+        `Plaintext of ${String(plaintext.length)} bytes exceeds the ${String(maxPlaintextBytes)} byte limit for a symmetric key; encrypt a data key from GenerateDataKey instead`,
+      );
+    }
+
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:Encrypt", key, options?.caller);
+
+    return {
+      $metadata: {},
+      CiphertextBlob: key.encrypt(plaintext, command.input.EncryptionContext),
+      KeyId: key.arn,
+      EncryptionAlgorithm: simKmsSymmetricAlgorithm,
+    };
+  }
+
+  /**
+   * Decrypt a ciphertext produced by this simulation.
+   *
+   * The key comes from the ciphertext rather than the request, which is why
+   * KeyId is optional for a symmetric key. Authorization therefore happens
+   * against the key the blob names, once it is known.
+   */
+  decrypt(
+    command: SimDecryptCommand,
+    options?: SimKmsCryptoCommandOptions,
+  ): SimDecryptCommandOutput {
+    const ciphertextBlob = command.input.CiphertextBlob;
+
+    this.ciphertextKey.requireSymmetricAlgorithm(
+      command.input.EncryptionAlgorithm,
+    );
+
+    if (ciphertextBlob === undefined) {
+      throw new SimKmsValidationException("CiphertextBlob is required");
+    }
+
+    const parts = this.blob.decode(ciphertextBlob);
+    const key = this.ciphertextKey.behind(parts.keyArn);
+
+    this.authorizer.authorizeKey("kms:Decrypt", key, options?.caller);
+    this.ciphertextKey.requireExpected(command.input.KeyId, key);
+
+    return {
+      $metadata: {},
+      Plaintext: key.decrypt(parts, command.input.EncryptionContext),
+      KeyId: key.arn,
+      EncryptionAlgorithm: simKmsSymmetricAlgorithm,
+    };
+  }
+}

--- a/src/service/kms/command/crypto/sim-kms-crypto.iso.test.ts
+++ b/src/service/kms/command/crypto/sim-kms-crypto.iso.test.ts
@@ -17,6 +17,7 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import {
   SimKmsIncorrectKeyException,
   SimKmsInvalidCiphertextException,
+  SimKmsNotFoundException,
   SimKmsValidationException,
 } from "../../error/sim-kms.error.js";
 
@@ -181,6 +182,31 @@ describe("KMS Encrypt and Decrypt", () => {
 
     // Then KMS reports the caller's expectation was wrong.
     assertInstanceOf(error, SimKmsIncorrectKeyException);
+  });
+
+  it("reports an unknown KeyId on Decrypt as missing, not incorrect", async () => {
+    // Given a ciphertext from a real key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext("hunter2") }),
+      );
+
+    // When Decrypt names a key that does not exist at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: encrypted.CiphertextBlob,
+          KeyId: "no-such-key",
+        }),
+      ),
+    );
+
+    // Then it is missing, rather than being reported as the wrong key.
+    assertInstanceOf(error, SimKmsNotFoundException);
   });
 
   it("rejects bytes that are not one of its ciphertexts", async () => {

--- a/src/service/kms/command/crypto/sim-kms-crypto.iso.test.ts
+++ b/src/service/kms/command/crypto/sim-kms-crypto.iso.test.ts
@@ -1,0 +1,306 @@
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertNonNullable,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimKmsIncorrectKeyException,
+  SimKmsInvalidCiphertextException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+
+const plaintext = (value: string): Uint8Array =>
+  Uint8Array.from(Buffer.from(value, "utf8"));
+
+const text = (value: Uint8Array | undefined): string =>
+  Buffer.from(value ?? new Uint8Array()).toString("utf8");
+
+async function keyArnFor(simAws: SimAws): Promise<string> {
+  const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+  assertNonNullable(created.KeyMetadata);
+  return created.KeyMetadata.Arn;
+}
+
+describe("KMS Encrypt and Decrypt", () => {
+  it("round-trips plaintext through a key", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When plaintext is encrypted and the ciphertext decrypted again.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext("hunter2") }),
+      );
+    const decrypted = await simAws
+      .kms()
+      .decrypt(
+        new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+      );
+
+    // Then the original plaintext comes back, from the key the blob names.
+    assertIdentical(text(decrypted.Plaintext), "hunter2");
+    assertIdentical(decrypted.KeyId, keyArn);
+    assertIdentical(decrypted.EncryptionAlgorithm, "SYMMETRIC_DEFAULT");
+  });
+
+  it("produces a ciphertext that is not the plaintext", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When a recognisable plaintext is encrypted.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext("hunter2") }),
+      );
+
+    // Then the blob does not contain it: this is real AES-256-GCM, not a
+    // simulator pretending to encrypt.
+    assertNonNullable(encrypted.CiphertextBlob);
+    assertTrue(
+      !Buffer.from(encrypted.CiphertextBlob).includes(
+        Buffer.from("hunter2", "utf8"),
+      ),
+    );
+  });
+
+  it("fails to decrypt when the encryption context differs", async () => {
+    // Given a ciphertext encrypted with an encryption context.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: keyArn,
+        Plaintext: plaintext("hunter2"),
+        EncryptionContext: { tenant: "acme" },
+      }),
+    );
+
+    // When decryption supplies a different context.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: encrypted.CiphertextBlob,
+          EncryptionContext: { tenant: "other" },
+        }),
+      ),
+    );
+
+    // Then the ciphertext will not open, as on real KMS.
+    assertInstanceOf(error, SimKmsInvalidCiphertextException);
+  });
+
+  it("fails to decrypt when the encryption context is omitted", async () => {
+    // Given a ciphertext encrypted with an encryption context.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: keyArn,
+        Plaintext: plaintext("hunter2"),
+        EncryptionContext: { tenant: "acme" },
+      }),
+    );
+
+    // When decryption supplies no context at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .decrypt(
+          new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+        ),
+    );
+
+    // Then it fails: the context is part of what the ciphertext is bound to.
+    assertInstanceOf(error, SimKmsInvalidCiphertextException);
+  });
+
+  it("decrypts when the same context is given in a different order", async () => {
+    // Given a ciphertext encrypted with a two-entry encryption context.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: keyArn,
+        Plaintext: plaintext("hunter2"),
+        EncryptionContext: { tenant: "acme", purpose: "db" },
+      }),
+    );
+
+    // When decryption supplies the same pairs written the other way round.
+    const decrypted = await simAws.kms().decrypt(
+      new DecryptCommand({
+        CiphertextBlob: encrypted.CiphertextBlob,
+        EncryptionContext: { purpose: "db", tenant: "acme" },
+      }),
+    );
+
+    // Then it succeeds, because the context is an unordered map.
+    assertIdentical(text(decrypted.Plaintext), "hunter2");
+  });
+
+  it("cannot decrypt a ciphertext from a different key", async () => {
+    // Given two keys, and a ciphertext produced under the first.
+    const simAws = new SimAws();
+    const firstKeyArn = await keyArnFor(simAws);
+    const secondKeyArn = await keyArnFor(simAws);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: firstKeyArn,
+        Plaintext: plaintext("hunter2"),
+      }),
+    );
+
+    // When the second key is named on decryption.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: encrypted.CiphertextBlob,
+          KeyId: secondKeyArn,
+        }),
+      ),
+    );
+
+    // Then KMS reports the caller's expectation was wrong.
+    assertInstanceOf(error, SimKmsIncorrectKeyException);
+  });
+
+  it("rejects bytes that are not one of its ciphertexts", async () => {
+    // Given a simulated KMS with a key.
+    const simAws = new SimAws();
+    await keyArnFor(simAws);
+
+    // When arbitrary bytes are handed to Decrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: Uint8Array.from([1, 2, 3, 4]),
+        }),
+      ),
+    );
+
+    // Then they are an invalid ciphertext rather than a missing key.
+    assertInstanceOf(error, SimKmsInvalidCiphertextException);
+  });
+
+  it("refuses plaintext beyond the symmetric key limit", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When more than 4096 bytes are offered to Encrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: keyArn,
+          Plaintext: new Uint8Array(4097),
+        }),
+      ),
+    );
+
+    // Then it is refused, which is the limit envelope encryption exists for.
+    assertInstanceOf(error, SimKmsValidationException);
+    assertStringIncludes(error.message, "GenerateDataKey");
+  });
+});
+
+describe("KMS GenerateDataKey", () => {
+  it("returns a data key in the clear and encrypted under the key", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When a data key is generated.
+    const generated = await simAws
+      .kms()
+      .generateDataKey(
+        new GenerateDataKeyCommand({ KeyId: keyArn, KeySpec: "AES_256" }),
+      );
+
+    // Then both copies come back, and the encrypted one decrypts to the other.
+    assertNonNullable(generated.Plaintext);
+    assertIdentical(generated.Plaintext.byteLength, 32);
+
+    const decrypted = await simAws
+      .kms()
+      .decrypt(
+        new DecryptCommand({ CiphertextBlob: generated.CiphertextBlob }),
+      );
+
+    const recovered = Buffer.from(decrypted.Plaintext ?? new Uint8Array());
+    assertIdentical(
+      recovered.toString("hex"),
+      Buffer.from(generated.Plaintext).toString("hex"),
+    );
+  });
+
+  it("generates the requested number of bytes", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When a byte count is asked for instead of a key spec.
+    const generated = await simAws
+      .kms()
+      .generateDataKey(
+        new GenerateDataKeyCommand({ KeyId: keyArn, NumberOfBytes: 64 }),
+      );
+
+    // Then that many bytes come back.
+    assertIdentical(generated.Plaintext?.byteLength, 64);
+  });
+
+  it("refuses both KeySpec and NumberOfBytes together", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When both are supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().generateDataKey(
+        new GenerateDataKeyCommand({
+          KeyId: keyArn,
+          KeySpec: "AES_256",
+          NumberOfBytes: 32,
+        }),
+      ),
+    );
+
+    // Then KMS refuses, as it does on real AWS.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses neither KeySpec nor NumberOfBytes", async () => {
+    // Given a simulated KMS key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When neither is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .generateDataKey(new GenerateDataKeyCommand({ KeyId: keyArn })),
+    );
+
+    // Then KMS refuses rather than picking a length.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});

--- a/src/service/kms/command/crypto/sim-kms-data-key-spec.ts
+++ b/src/service/kms/command/crypto/sim-kms-data-key-spec.ts
@@ -1,0 +1,73 @@
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+
+/**
+ * The data key lengths the named KeySpec values stand for.
+ */
+const specLengths = new Map<string, number>([
+  ["AES_256", 32],
+  ["AES_128", 16],
+]);
+
+const minBytes = 1;
+const maxBytes = 1024;
+
+/**
+ * Works out how many bytes of data key GenerateDataKey should produce.
+ *
+ * Real KMS insists on exactly one of KeySpec and NumberOfBytes, and refuses
+ * the request otherwise rather than picking a default. Following that keeps a
+ * request that AWS would reject from quietly succeeding here.
+ */
+export class SimKmsDataKeySpec {
+  /**
+   * The data key length a request asks for.
+   */
+  lengthFor(
+    keySpec: string | undefined,
+    numberOfBytes: number | undefined,
+  ): number {
+    if (keySpec !== undefined && numberOfBytes !== undefined) {
+      throw new SimKmsValidationException(
+        "Specify either KeySpec or NumberOfBytes, but not both",
+      );
+    }
+
+    if (keySpec !== undefined) {
+      return this.specLength(keySpec);
+    }
+
+    if (numberOfBytes !== undefined) {
+      return this.byteCount(numberOfBytes);
+    }
+
+    throw new SimKmsValidationException(
+      "Specify either KeySpec or NumberOfBytes",
+    );
+  }
+
+  private specLength(keySpec: string): number {
+    const length = specLengths.get(keySpec);
+
+    if (length === undefined) {
+      throw new SimKmsValidationException(
+        `Unsupported KeySpec '${keySpec}': simulated KMS supports ${specLengths.keys().toArray().join(" and ")}`,
+      );
+    }
+
+    return length;
+  }
+
+  private byteCount(numberOfBytes: number): number {
+    if (
+      !Number.isSafeInteger(numberOfBytes) ||
+      numberOfBytes < minBytes ||
+      numberOfBytes > maxBytes
+    ) {
+      throw new SimKmsValidationException(
+        `NumberOfBytes must be a whole number between ${String(minBytes)} and ${String(maxBytes)}`,
+      );
+    }
+
+    return numberOfBytes;
+  }
+}

--- a/src/service/kms/command/crypto/sim-kms-generate-data-key.ts
+++ b/src/service/kms/command/crypto/sim-kms-generate-data-key.ts
@@ -1,0 +1,62 @@
+import { randomBytes } from "node:crypto";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimGenerateDataKeyCommand,
+  SimGenerateDataKeyCommandOutput,
+} from "./crypto.command.js";
+import { SimKmsDataKeySpec } from "./sim-kms-data-key-spec.js";
+
+interface SimKmsGenerateDataKeyProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+interface SimKmsGenerateDataKeyOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The GenerateDataKey command of one simulated KMS scope.
+ *
+ * This is the envelope encryption primitive, and the answer to Encrypt's
+ * 4096 byte limit: the plaintext copy of the data key encrypts the data and is
+ * then discarded, while the encrypted copy is stored alongside it so the data
+ * key can be recovered through Decrypt later.
+ */
+export class SimKmsGenerateDataKey {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly dataKeySpec = new SimKmsDataKeySpec();
+
+  constructor(properties: SimKmsGenerateDataKeyProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Generate a data key, returned both in the clear and encrypted.
+   */
+  handle(
+    command: SimGenerateDataKeyCommand,
+    options?: SimKmsGenerateDataKeyOptions,
+  ): SimGenerateDataKeyCommandOutput {
+    const length = this.dataKeySpec.lengthFor(
+      command.input.KeySpec,
+      command.input.NumberOfBytes,
+    );
+    const key = this.keys.require(command.input.KeyId);
+
+    this.authorizer.authorizeKey("kms:GenerateDataKey", key, options?.caller);
+
+    const dataKey = Uint8Array.from(randomBytes(length));
+
+    return {
+      $metadata: {},
+      Plaintext: dataKey,
+      CiphertextBlob: key.encrypt(dataKey, command.input.EncryptionContext),
+      KeyId: key.arn,
+    };
+  }
+}

--- a/src/service/kms/command/key/key.command.ts
+++ b/src/service/kms/command/key/key.command.ts
@@ -1,0 +1,188 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import type { SimKmsKeyMetadata } from "../../key/sim-kms-key-metadata.js";
+import type { SimKmsKeyState } from "../../key/sim-kms-key.js";
+
+/**
+ * Minimal structural sim KMS CreateKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/CreateKeyCommand/
+ */
+export interface SimCreateKeyCommand {
+  readonly input: SimCreateKeyCommandInput;
+}
+
+export interface SimCreateKeyCommandInput {
+  readonly Description?: string | undefined;
+
+  /**
+   * The key policy, as a JSON document string, exactly as the real API takes
+   * it. Omitting it gets the default policy KMS applies, which delegates to
+   * the Account's IAM.
+   */
+  readonly Policy?: string | undefined;
+
+  readonly KeyUsage?: string | undefined;
+  readonly KeySpec?: string | undefined;
+  readonly Origin?: string | undefined;
+}
+
+export interface SimCreateKeyCommandOutput {
+  readonly KeyMetadata?: SimKmsKeyMetadata | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS DescribeKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/DescribeKeyCommand/
+ */
+export interface SimDescribeKeyCommand {
+  readonly input: SimDescribeKeyCommandInput;
+}
+
+export interface SimDescribeKeyCommandInput {
+  readonly KeyId?: string | undefined;
+}
+
+export interface SimDescribeKeyCommandOutput {
+  readonly KeyMetadata?: SimKmsKeyMetadata | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS ListKeys command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/ListKeysCommand/
+ */
+export interface SimListKeysCommand {
+  readonly input?: SimListKeysCommandInput | undefined;
+}
+
+export interface SimListKeysCommandInput {
+  readonly Limit?: number | undefined;
+}
+
+export interface SimListKeysCommandEntry {
+  readonly KeyId: string;
+  readonly KeyArn: string;
+}
+
+export interface SimListKeysCommandOutput {
+  readonly Keys?: readonly SimListKeysCommandEntry[] | undefined;
+  readonly Truncated?: boolean | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS GetKeyPolicy command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/GetKeyPolicyCommand/
+ */
+export interface SimGetKeyPolicyCommand {
+  readonly input: SimGetKeyPolicyCommandInput;
+}
+
+export interface SimGetKeyPolicyCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly PolicyName?: string | undefined;
+}
+
+export interface SimGetKeyPolicyCommandOutput {
+  readonly Policy?: string | undefined;
+  readonly PolicyName?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS PutKeyPolicy command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/PutKeyPolicyCommand/
+ */
+export interface SimPutKeyPolicyCommand {
+  readonly input: SimPutKeyPolicyCommandInput;
+}
+
+export interface SimPutKeyPolicyCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly Policy?: string | SimIamPolicyDocument | undefined;
+  readonly PolicyName?: string | undefined;
+}
+
+export interface SimPutKeyPolicyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS EnableKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/EnableKeyCommand/
+ */
+export interface SimEnableKeyCommand {
+  readonly input: SimEnableKeyCommandInput;
+}
+
+export interface SimEnableKeyCommandInput {
+  readonly KeyId?: string | undefined;
+}
+
+export interface SimEnableKeyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS DisableKey command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/DisableKeyCommand/
+ */
+export interface SimDisableKeyCommand {
+  readonly input: SimDisableKeyCommandInput;
+}
+
+export interface SimDisableKeyCommandInput {
+  readonly KeyId?: string | undefined;
+}
+
+export interface SimDisableKeyCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS ScheduleKeyDeletion command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/ScheduleKeyDeletionCommand/
+ */
+export interface SimScheduleKeyDeletionCommand {
+  readonly input: SimScheduleKeyDeletionCommandInput;
+}
+
+export interface SimScheduleKeyDeletionCommandInput {
+  readonly KeyId?: string | undefined;
+  readonly PendingWindowInDays?: number | undefined;
+}
+
+export interface SimScheduleKeyDeletionCommandOutput {
+  readonly KeyId?: string | undefined;
+  readonly DeletionDate?: Date | undefined;
+  readonly KeyState?: SimKmsKeyState | undefined;
+  readonly PendingWindowInDays?: number | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim KMS CancelKeyDeletion command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/kms/command/CancelKeyDeletionCommand/
+ */
+export interface SimCancelKeyDeletionCommand {
+  readonly input: SimCancelKeyDeletionCommandInput;
+}
+
+export interface SimCancelKeyDeletionCommandInput {
+  readonly KeyId?: string | undefined;
+}
+
+export interface SimCancelKeyDeletionCommandOutput {
+  readonly KeyId?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/kms/command/key/sim-kms-key-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-commands.ts
@@ -1,0 +1,84 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsKeyFactory } from "../../key/sim-kms-key-factory.js";
+import { SimKmsPolicyDocument } from "../../key/sim-kms-policy-document.js";
+import { SimKmsKeyType } from "./sim-kms-key-type.js";
+import type { SimKmsKeyMetadataView } from "../../key/sim-kms-key-metadata.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimCreateKeyCommand,
+  SimCreateKeyCommandOutput,
+  SimDescribeKeyCommand,
+  SimDescribeKeyCommandOutput,
+} from "./key.command.js";
+
+interface SimKmsKeyCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly keyFactory: SimKmsKeyFactory;
+  readonly authorizer: SimKmsAuthorizer;
+  readonly metadata: SimKmsKeyMetadataView;
+}
+
+interface SimKmsKeyCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The key creation and description commands of one simulated KMS scope.
+ */
+export class SimKmsKeyCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly keyFactory: SimKmsKeyFactory;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly metadata: SimKmsKeyMetadataView;
+  private readonly keyType = new SimKmsKeyType();
+  private readonly policyDocument = new SimKmsPolicyDocument();
+
+  constructor(properties: SimKmsKeyCommandsProperties) {
+    this.keys = properties.keys;
+    this.keyFactory = properties.keyFactory;
+    this.authorizer = properties.authorizer;
+    this.metadata = properties.metadata;
+  }
+
+  /**
+   * Create a key with fresh key material.
+   *
+   * There is no key to hold a policy yet, so this authorizes against the
+   * Region's keys rather than a key policy. Real KMS gives kms:CreateKey no
+   * resource-level permissions for the same reason.
+   */
+  create(
+    command: SimCreateKeyCommand,
+    options?: SimKmsKeyCommandOptions,
+  ): SimCreateKeyCommandOutput {
+    this.keyType.require(
+      command.input.KeyUsage,
+      command.input.KeySpec,
+      command.input.Origin,
+    );
+    this.authorizer.authorizeAccount("kms:CreateKey", options?.caller);
+
+    const key = this.keyFactory.make({
+      description: command.input.Description,
+      policy: this.policyDocument.parseOptional(command.input.Policy),
+    });
+
+    this.keys.add(key);
+
+    return { $metadata: {}, KeyMetadata: this.metadata.describe(key) };
+  }
+
+  /**
+   * Describe a key.
+   */
+  describe(
+    command: SimDescribeKeyCommand,
+    options?: SimKmsKeyCommandOptions,
+  ): SimDescribeKeyCommandOutput {
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:DescribeKey", key, options?.caller);
+
+    return { $metadata: {}, KeyMetadata: this.metadata.describe(key) };
+  }
+}

--- a/src/service/kms/command/key/sim-kms-key-lifecycle-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-lifecycle-commands.ts
@@ -1,0 +1,117 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import { SimKmsPendingWindow } from "./sim-kms-pending-window.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimCancelKeyDeletionCommand,
+  SimCancelKeyDeletionCommandOutput,
+  SimDisableKeyCommand,
+  SimDisableKeyCommandOutput,
+  SimEnableKeyCommand,
+  SimEnableKeyCommandOutput,
+  SimScheduleKeyDeletionCommand,
+  SimScheduleKeyDeletionCommandOutput,
+} from "./key.command.js";
+
+interface SimKmsKeyLifecycleCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+  readonly clock: SimClock;
+}
+
+interface SimKmsKeyLifecycleCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that move a simulated KMS key between lifecycle states.
+ *
+ * The state transitions themselves belong to SimKmsKey, which refuses the ones
+ * its current state does not allow. These commands resolve the key, authorize
+ * the caller and report the result.
+ */
+export class SimKmsKeyLifecycleCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimKmsKeyLifecycleCommandsProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Enable a key.
+   */
+  enable(
+    command: SimEnableKeyCommand,
+    options?: SimKmsKeyLifecycleCommandOptions,
+  ): SimEnableKeyCommandOutput {
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:EnableKey", key, options?.caller);
+    key.enable();
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Disable a key, leaving it present but unusable.
+   */
+  disable(
+    command: SimDisableKeyCommand,
+    options?: SimKmsKeyLifecycleCommandOptions,
+  ): SimDisableKeyCommandOutput {
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:DisableKey", key, options?.caller);
+    key.disable();
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Schedule a key for deletion after a recovery window.
+   *
+   * The key stays in the store while it is pending deletion, because that is
+   * what recoverable means: the key is still there, refusing to be used, until
+   * the window runs out.
+   */
+  scheduleDeletion(
+    command: SimScheduleKeyDeletionCommand,
+    options?: SimKmsKeyLifecycleCommandOptions,
+  ): SimScheduleKeyDeletionCommandOutput {
+    const window = new SimKmsPendingWindow(command.input.PendingWindowInDays);
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey(
+      "kms:ScheduleKeyDeletion",
+      key,
+      options?.caller,
+    );
+
+    const deletionDate = window.deletionDateFrom(this.clock.now());
+    key.scheduleDeletion(deletionDate);
+
+    return {
+      $metadata: {},
+      KeyId: key.arn,
+      DeletionDate: deletionDate,
+      KeyState: key.keyState,
+      PendingWindowInDays: window.days,
+    };
+  }
+
+  /**
+   * Cancel a scheduled deletion, leaving the key disabled.
+   */
+  cancelDeletion(
+    command: SimCancelKeyDeletionCommand,
+    options?: SimKmsKeyLifecycleCommandOptions,
+  ): SimCancelKeyDeletionCommandOutput {
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:CancelKeyDeletion", key, options?.caller);
+    key.cancelDeletion();
+
+    return { $metadata: {}, KeyId: key.arn };
+  }
+}

--- a/src/service/kms/command/key/sim-kms-key-lifecycle.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-lifecycle.iso.test.ts
@@ -1,0 +1,251 @@
+import {
+  CancelKeyDeletionCommand,
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  DisableKeyCommand,
+  EnableKeyCommand,
+  EncryptCommand,
+  ScheduleKeyDeletionCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertFalse,
+  assertIdentical,
+  assertUndefined,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import {
+  SimKmsDisabledException,
+  SimKmsInvalidStateException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+async function keyArnFor(simAws: SimAws): Promise<string> {
+  const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+  assertNonNullable(created.KeyMetadata);
+  return created.KeyMetadata.Arn;
+}
+
+describe("KMS key state", () => {
+  it("refuses to encrypt with a disabled key", async () => {
+    // Given a key that has been disabled.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws.kms().disableKey(new DisableKeyCommand({ KeyId: keyArn }));
+
+    // When something tries to encrypt with it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext })),
+    );
+
+    // Then KMS reports the key as disabled rather than missing.
+    assertInstanceOf(error, SimKmsDisabledException);
+  });
+
+  it("reports a disabled key as present but not enabled", async () => {
+    // Given a key that has been disabled.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws.kms().disableKey(new DisableKeyCommand({ KeyId: keyArn }));
+
+    // When it is described.
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: keyArn }));
+
+    // Then it is still there, in the Disabled state.
+    assertIdentical(described.KeyMetadata?.KeyState, "Disabled");
+    assertFalse(described.KeyMetadata.Enabled);
+  });
+
+  it("encrypts again once a disabled key is re-enabled", async () => {
+    // Given a key that was disabled and enabled again.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws.kms().disableKey(new DisableKeyCommand({ KeyId: keyArn }));
+    await simAws.kms().enableKey(new EnableKeyCommand({ KeyId: keyArn }));
+
+    // When something encrypts with it.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext }));
+
+    // Then it works again.
+    assertIdentical(encrypted.KeyId, keyArn);
+  });
+});
+
+describe("KMS ScheduleKeyDeletion", () => {
+  it("schedules deletion a recovery window away rather than deleting", async () => {
+    // Given a key and a simulation whose clock is fixed.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-01-01T00:00:00.000Z")),
+    });
+    const keyArn = await keyArnFor(simAws);
+
+    // When deletion is scheduled with a seven day window.
+    const scheduled = await simAws.kms().scheduleKeyDeletion(
+      new ScheduleKeyDeletionCommand({
+        KeyId: keyArn,
+        PendingWindowInDays: 7,
+      }),
+    );
+
+    // Then the key is pending deletion, due seven days out, and still present.
+    assertIdentical(scheduled.KeyState, "PendingDeletion");
+    assertIdentical(
+      scheduled.DeletionDate?.toISOString(),
+      "2026-01-08T00:00:00.000Z",
+    );
+    assertIdentical(scheduled.PendingWindowInDays, 7);
+
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: keyArn }));
+    assertIdentical(described.KeyMetadata?.KeyState, "PendingDeletion");
+  });
+
+  it("defaults the recovery window to thirty days", async () => {
+    // Given a key in a simulation with a fixed clock.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-01-01T00:00:00.000Z")),
+    });
+    const keyArn = await keyArnFor(simAws);
+
+    // When deletion is scheduled with no window given.
+    const scheduled = await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // Then KMS applies its thirty day default.
+    assertIdentical(scheduled.PendingWindowInDays, 30);
+    assertIdentical(
+      scheduled.DeletionDate?.toISOString(),
+      "2026-01-31T00:00:00.000Z",
+    );
+  });
+
+  it("refuses a recovery window outside the allowed range", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When a window shorter than KMS allows is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().scheduleKeyDeletion(
+        new ScheduleKeyDeletionCommand({
+          KeyId: keyArn,
+          PendingWindowInDays: 1,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses to use a key pending deletion", async () => {
+    // Given a key scheduled for deletion.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // When something tries to encrypt with it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(new EncryptCommand({ KeyId: keyArn, Plaintext: plaintext })),
+    );
+
+    // Then the invalid state is reported, which is a different failure from a
+    // key merely being disabled.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+
+  it("refuses to enable a key pending deletion", async () => {
+    // Given a key scheduled for deletion.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // When something tries to enable it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().enableKey(new EnableKeyCommand({ KeyId: keyArn })),
+    );
+
+    // Then it is refused: deletion has to be cancelled first.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+
+  it("refuses to disable a key pending deletion", async () => {
+    // Given a key scheduled for deletion.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // When something tries to disable it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().disableKey(new DisableKeyCommand({ KeyId: keyArn })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+});
+
+describe("KMS CancelKeyDeletion", () => {
+  it("returns a key pending deletion to the disabled state", async () => {
+    // Given a key scheduled for deletion.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // When the deletion is cancelled.
+    const cancelled = await simAws
+      .kms()
+      .cancelKeyDeletion(new CancelKeyDeletionCommand({ KeyId: keyArn }));
+
+    // Then the key is disabled rather than enabled: real KMS makes re-enabling
+    // it a separate deliberate step.
+    assertIdentical(cancelled.KeyId, keyArn);
+
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: keyArn }));
+    assertNonNullable(described.KeyMetadata);
+    assertIdentical(described.KeyMetadata.KeyState, "Disabled");
+    assertUndefined(described.KeyMetadata.DeletionDate);
+  });
+
+  it("refuses to cancel deletion of a key that is not pending", async () => {
+    // Given an ordinary enabled key.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+
+    // When cancelling deletion is attempted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .cancelKeyDeletion(new CancelKeyDeletionCommand({ KeyId: keyArn })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+});

--- a/src/service/kms/command/key/sim-kms-key-lifecycle.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-lifecycle.iso.test.ts
@@ -62,7 +62,8 @@ describe("KMS key state", () => {
       .describeKey(new DescribeKeyCommand({ KeyId: keyArn }));
 
     // Then it is still there, in the Disabled state.
-    assertIdentical(described.KeyMetadata?.KeyState, "Disabled");
+    assertNonNullable(described.KeyMetadata);
+    assertIdentical(described.KeyMetadata.KeyState, "Disabled");
     assertFalse(described.KeyMetadata.Enabled);
   });
 
@@ -203,6 +204,30 @@ describe("KMS ScheduleKeyDeletion", () => {
     );
 
     // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+});
+
+describe("KMS ScheduleKeyDeletion on a key already pending", () => {
+  it("refuses to reschedule a deletion already pending", async () => {
+    // Given a key already scheduled for deletion.
+    const simAws = new SimAws();
+    const keyArn = await keyArnFor(simAws);
+    await simAws
+      .kms()
+      .scheduleKeyDeletion(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+
+    // When deletion is scheduled again.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().scheduleKeyDeletion(
+        new ScheduleKeyDeletionCommand({
+          KeyId: keyArn,
+          PendingWindowInDays: 7,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than quietly moving the deletion date.
     assertInstanceOf(error, SimKmsInvalidStateException);
   });
 });

--- a/src/service/kms/command/key/sim-kms-key-policy-commands.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-policy-commands.iso.test.ts
@@ -167,6 +167,32 @@ describe("KMS PutKeyPolicy", () => {
     assertInstanceOf(error, SimKmsValidationException);
   });
 
+  it("refuses JSON that is not a policy document", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When the policy is valid JSON but not an object.
+    const errors = await Promise.all(
+      ["null", "[]", '"a policy"'].map(async (policy) =>
+        assertThrowsErrorAsync(async () =>
+          simAws.kms().putKeyPolicy(
+            new PutKeyPolicyCommand({
+              KeyId: created.KeyMetadata?.Arn,
+              Policy: policy,
+            }),
+          ),
+        ),
+      ),
+    );
+
+    // Then each is refused here, rather than failing obscurely later when
+    // something tries to evaluate it.
+    for (const error of errors) {
+      assertInstanceOf(error, SimKmsValidationException);
+    }
+  });
+
   it("refuses a missing policy", async () => {
     // Given a key.
     const simAws = new SimAws();

--- a/src/service/kms/command/key/sim-kms-key-policy-commands.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-policy-commands.iso.test.ts
@@ -1,0 +1,219 @@
+import {
+  CreateKeyCommand,
+  EncryptCommand,
+  GetKeyPolicyCommand,
+  PutKeyPolicyCommand,
+} from "@aws-sdk/client-kms";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertUndefined,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS GetKeyPolicy", () => {
+  it("returns the default policy a key is created with", async () => {
+    // Given a key created with no policy of its own.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When its policy is read back.
+    const policy = await simAws
+      .kms()
+      .getKeyPolicy(
+        new GetKeyPolicyCommand({ KeyId: created.KeyMetadata?.Arn }),
+      );
+
+    // Then it is the default policy, delegating to the Account's IAM.
+    assertIdentical(policy.PolicyName, "default");
+    assertStringIncludes(policy.Policy ?? "", `arn:aws:iam::${accountId}:root`);
+  });
+
+  it("refuses a policy name other than default", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When some other policy name is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().getKeyPolicy(
+        new GetKeyPolicyCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          PolicyName: "other",
+        }),
+      ),
+    );
+
+    // Then it is refused: a KMS key has exactly one policy.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});
+
+describe("KMS PutKeyPolicy", () => {
+  it("can lock the Account out of its own key", async () => {
+    // Given a key with the default policy, usable by the Account root.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    const otherRole = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "SomeoneElse",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When the policy is replaced with one naming only another principal.
+    await simAws.kms().putKeyPolicy(
+      new PutKeyPolicyCommand({
+        KeyId: created.KeyMetadata.Arn,
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: otherRole.Role.Arn },
+              Action: "kms:*",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+
+    // Then the Account root can no longer use the key. This is real KMS
+    // behaviour, and the reason the console warns before saving such a policy.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("accepts a policy document object as well as a JSON string", async () => {
+    // Given a key.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When a policy is supplied as an object, which is the convenient thing to
+    // write from a test.
+    await simAws.kms().putKeyPolicy({
+      input: {
+        KeyId: created.KeyMetadata?.Arn,
+        Policy: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+              Action: "kms:*",
+              Resource: "*",
+            },
+          ],
+        },
+      },
+    });
+
+    // Then it is stored and read back as JSON.
+    const policy = await simAws
+      .kms()
+      .getKeyPolicy(
+        new GetKeyPolicyCommand({ KeyId: created.KeyMetadata?.Arn }),
+      );
+    assertStringIncludes(policy.Policy ?? "", "kms:*");
+  });
+
+  it("refuses a policy that is not valid JSON", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When the policy is not a policy document.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().putKeyPolicy(
+        new PutKeyPolicyCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Policy: "not json",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a missing policy", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When no policy is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().putKeyPolicy({ input: { KeyId: created.KeyMetadata?.Arn } }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a policy name other than default", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When some other policy name is named.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().putKeyPolicy(
+        new PutKeyPolicyCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          PolicyName: "other",
+          Policy: "{}",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});
+
+describe("SimKms.findKey", () => {
+  it("finds a key without going through a Command", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When a test reaches for it directly.
+    const key = simAws.kms().findKey(created.KeyMetadata.KeyId);
+
+    // Then the stored key comes back, with no authorization involved.
+    assertIdentical(key?.arn, created.KeyMetadata.Arn);
+    assertUndefined(simAws.kms().findKey("no-such-key"));
+  });
+});

--- a/src/service/kms/command/key/sim-kms-key-policy-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-policy-commands.ts
@@ -1,0 +1,94 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+import { simKmsKeyPolicyName } from "../../key/sim-kms-key-policy.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import { SimKmsPolicyDocument } from "../../key/sim-kms-policy-document.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimGetKeyPolicyCommand,
+  SimGetKeyPolicyCommandOutput,
+  SimPutKeyPolicyCommand,
+  SimPutKeyPolicyCommandOutput,
+} from "./key.command.js";
+
+interface SimKmsKeyPolicyCommandsProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+interface SimKmsKeyPolicyCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that read and replace a simulated KMS key policy.
+ *
+ * Replacing a key policy can lock the key out of its own Account, exactly as
+ * on real AWS: a policy with no statement for the Account root leaves the key
+ * reachable only by the principals it names, and no IAM policy will get it
+ * back. That is deliberate, and it is the behaviour worth being able to test.
+ */
+export class SimKmsKeyPolicyCommands {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+  private readonly policyDocument = new SimKmsPolicyDocument();
+
+  constructor(properties: SimKmsKeyPolicyCommandsProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Get a key's policy, as the JSON document string the real API returns.
+   */
+  get(
+    command: SimGetKeyPolicyCommand,
+    options?: SimKmsKeyPolicyCommandOptions,
+  ): SimGetKeyPolicyCommandOutput {
+    this.requireDefaultPolicyName(command.input.PolicyName);
+
+    const key = this.keys.require(command.input.KeyId);
+    this.authorizer.authorizeKey("kms:GetKeyPolicy", key, options?.caller);
+
+    return {
+      $metadata: {},
+      PolicyName: simKmsKeyPolicyName,
+      Policy: JSON.stringify(key.policy.document()),
+    };
+  }
+
+  /**
+   * Replace a key's policy.
+   */
+  put(
+    command: SimPutKeyPolicyCommand,
+    options?: SimKmsKeyPolicyCommandOptions,
+  ): SimPutKeyPolicyCommandOutput {
+    this.requireDefaultPolicyName(command.input.PolicyName);
+
+    const policy = command.input.Policy;
+
+    if (policy === undefined) {
+      throw new SimKmsValidationException("Policy is required");
+    }
+
+    const document = this.policyDocument.parse(policy);
+    const key = this.keys.require(command.input.KeyId);
+
+    this.authorizer.authorizeKey("kms:PutKeyPolicy", key, options?.caller);
+    key.policy.replaceWith(document);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * A KMS key has exactly one policy, and it is always called "default".
+   */
+  private requireDefaultPolicyName(policyName: string | undefined): void {
+    if (policyName !== undefined && policyName !== simKmsKeyPolicyName) {
+      throw new SimKmsValidationException(
+        `PolicyName must be '${simKmsKeyPolicyName}': a KMS key has exactly one policy`,
+      );
+    }
+  }
+}

--- a/src/service/kms/command/key/sim-kms-key-type.ts
+++ b/src/service/kms/command/key/sim-kms-key-type.ts
@@ -1,0 +1,47 @@
+import {
+  SimKmsInvalidKeyUsageException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+
+/**
+ * The only key type this simulation models.
+ */
+const symmetricKeySpec = "SYMMETRIC_DEFAULT";
+const encryptDecryptUsage = "ENCRYPT_DECRYPT";
+const kmsOrigin = "AWS_KMS";
+
+/**
+ * Checks a requested key type against what this simulation models.
+ *
+ * Asymmetric keys, HMAC keys and imported material all behave differently
+ * enough that pretending a symmetric key is one of them would make a passing
+ * test meaningless, so an unmodelled type is refused rather than substituted.
+ */
+export class SimKmsKeyType {
+  /**
+   * Refuse a key type this simulation does not model.
+   */
+  require(
+    keyUsage: string | undefined,
+    keySpec: string | undefined,
+    origin: string | undefined,
+  ): void {
+    if (keyUsage !== undefined && keyUsage !== encryptDecryptUsage) {
+      throw new SimKmsInvalidKeyUsageException(
+        `KeyUsage '${keyUsage}' is not simulated: simulated KMS creates ${encryptDecryptUsage} keys`,
+      );
+    }
+
+    if (keySpec !== undefined && keySpec !== symmetricKeySpec) {
+      throw new SimKmsInvalidKeyUsageException(
+        `KeySpec '${keySpec}' is not simulated: simulated KMS creates ${symmetricKeySpec} keys`,
+      );
+    }
+
+    if (origin !== undefined && origin !== kmsOrigin) {
+      throw new SimKmsValidationException(
+        `Origin '${origin}' is not simulated: simulated KMS generates its own key material`,
+      );
+    }
+  }
+}

--- a/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
@@ -1,0 +1,225 @@
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+} from "@aws-sdk/client-kms";
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimKmsInvalidKeyUsageException,
+  SimKmsValidationException,
+} from "../../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS CreateKey validation", () => {
+  it("refuses an asymmetric key spec", async () => {
+    // Given a simulation that models only symmetric keys.
+    const simAws = new SimAws();
+
+    // When an asymmetric key is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(new CreateKeyCommand({ KeySpec: "RSA_2048" })),
+    );
+
+    // Then it is refused rather than quietly made symmetric, so a test cannot
+    // pass against a key type this simulation does not model.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses a key usage other than encrypt and decrypt", async () => {
+    // Given a simulation that models only encryption keys.
+    const simAws = new SimAws();
+
+    // When a signing key is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(new CreateKeyCommand({ KeyUsage: "SIGN_VERIFY" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses imported key material", async () => {
+    // Given a simulation that generates its own key material.
+    const simAws = new SimAws();
+
+    // When an external origin is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(new CreateKeyCommand({ Origin: "EXTERNAL" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a key policy that is not valid JSON", async () => {
+    // Given a simulation.
+    const simAws = new SimAws();
+
+    // When the policy is not a policy document.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createKey(new CreateKeyCommand({ Policy: "not json" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("accepts an explicit symmetric key spec and usage", async () => {
+    // Given a simulation.
+    const simAws = new SimAws();
+
+    // When the defaults are stated explicitly, as CDK and CloudFormation do.
+    const created = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        KeySpec: "SYMMETRIC_DEFAULT",
+        KeyUsage: "ENCRYPT_DECRYPT",
+        Origin: "AWS_KMS",
+        Description: "Application key",
+      }),
+    );
+
+    // Then the key is created with the description it was given.
+    assertInstanceOf(created.KeyMetadata?.CreationDate, Date);
+  });
+});
+
+describe("KMS cryptographic operation validation", () => {
+  it("refuses an encryption algorithm a symmetric key does not support", async () => {
+    // Given a symmetric key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an asymmetric algorithm is named on Encrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+          EncryptionAlgorithm: "RSAES_OAEP_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses an unsupported encryption algorithm on Decrypt", async () => {
+    // Given a simulation.
+    const simAws = new SimAws();
+
+    // When an asymmetric algorithm is named on Decrypt.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: Uint8Array.from([1, 2, 3]),
+          EncryptionAlgorithm: "RSAES_OAEP_SHA_256",
+        }),
+      ),
+    );
+
+    // Then it is refused before the ciphertext is even read.
+    assertInstanceOf(error, SimKmsInvalidKeyUsageException);
+  });
+
+  it("refuses Encrypt with no plaintext", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When no plaintext is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt({ input: { KeyId: created.KeyMetadata?.Arn } }),
+    );
+
+    // Then the request is invalid.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses Decrypt with no ciphertext", async () => {
+    // Given a simulation.
+    const simAws = new SimAws();
+
+    // When no ciphertext is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(new DecryptCommand({})),
+    );
+
+    // Then the request is invalid.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an unsupported data key spec", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an unknown key spec is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().generateDataKey({
+        input: { KeyId: created.KeyMetadata?.Arn, KeySpec: "AES_512" },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a data key byte count outside the allowed range", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When more bytes than KMS will produce are asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().generateDataKey(
+        new GenerateDataKeyCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          NumberOfBytes: 2048,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("generates a 128 bit data key", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When the smaller AES key spec is asked for.
+    const generated = await simAws.kms().generateDataKey(
+      new GenerateDataKeyCommand({
+        KeyId: created.KeyMetadata?.Arn,
+        KeySpec: "AES_128",
+      }),
+    );
+
+    // Then sixteen bytes come back.
+    assertInstanceOf(generated.Plaintext, Uint8Array);
+  });
+});
+
+describe("KMS CreateAlias validation", () => {
+  it("refuses a missing alias name", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When no alias name is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .createAlias({ input: { TargetKeyId: created.KeyMetadata?.KeyId } }),
+    );
+
+    // Then the request is invalid.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});

--- a/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
+++ b/src/service/kms/command/key/sim-kms-key-validation.iso.test.ts
@@ -4,7 +4,12 @@ import {
   EncryptCommand,
   GenerateDataKeyCommand,
 } from "@aws-sdk/client-kms";
-import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import {
@@ -83,7 +88,9 @@ describe("KMS CreateKey validation", () => {
     );
 
     // Then the key is created with the description it was given.
-    assertInstanceOf(created.KeyMetadata?.CreationDate, Date);
+    assertNonNullable(created.KeyMetadata);
+    assertIdentical(created.KeyMetadata.Description, "Application key");
+    assertInstanceOf(created.KeyMetadata.CreationDate, Date);
   });
 });
 
@@ -203,6 +210,7 @@ describe("KMS cryptographic operation validation", () => {
 
     // Then sixteen bytes come back.
     assertInstanceOf(generated.Plaintext, Uint8Array);
+    assertIdentical(generated.Plaintext.byteLength, 16);
   });
 });
 

--- a/src/service/kms/command/key/sim-kms-list-keys.ts
+++ b/src/service/kms/command/key/sim-kms-list-keys.ts
@@ -1,0 +1,55 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
+import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
+import type {
+  SimListKeysCommand,
+  SimListKeysCommandOutput,
+} from "./key.command.js";
+
+interface SimKmsListKeysProperties {
+  readonly keys: SimKmsKeyStore;
+  readonly authorizer: SimKmsAuthorizer;
+}
+
+interface SimKmsListKeysOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The ListKeys command of one simulated KMS scope.
+ *
+ * Real KMS gives kms:ListKeys no resource-level permissions, so the listing is
+ * authorized once rather than per key. It therefore reports keys the caller
+ * may not be allowed to use, which is what real KMS does too.
+ */
+export class SimKmsListKeys {
+  private readonly keys: SimKmsKeyStore;
+  private readonly authorizer: SimKmsAuthorizer;
+
+  constructor(properties: SimKmsListKeysProperties) {
+    this.keys = properties.keys;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * List the keys in this scope, up to any requested limit.
+   */
+  handle(
+    command: SimListKeysCommand,
+    options?: SimKmsListKeysOptions,
+  ): SimListKeysCommandOutput {
+    this.authorizer.authorizeAccount("kms:ListKeys", options?.caller);
+
+    const limit = command.input?.Limit;
+    const entries = this.keys.keys
+      .values()
+      .map((key) => ({ KeyId: key.keyId, KeyArn: key.arn }))
+      .toArray();
+
+    if (limit === undefined || entries.length <= limit) {
+      return { $metadata: {}, Keys: entries, Truncated: false };
+    }
+
+    return { $metadata: {}, Keys: entries.slice(0, limit), Truncated: true };
+  }
+}

--- a/src/service/kms/command/key/sim-kms-pending-window.ts
+++ b/src/service/kms/command/key/sim-kms-pending-window.ts
@@ -1,0 +1,46 @@
+import { SimKmsValidationException } from "../../error/sim-kms.error.js";
+
+/**
+ * The deletion recovery window real KMS allows, and the one it defaults to.
+ */
+const minDays = 7;
+const maxDays = 30;
+const defaultDays = 30;
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+/**
+ * The recovery window between scheduling a KMS key's deletion and it happening.
+ *
+ * Real KMS will not take less than seven days or more than thirty, because the
+ * window is the only protection against destroying every ciphertext ever
+ * produced under the key.
+ */
+export class SimKmsPendingWindow {
+  public readonly days: number;
+
+  constructor(days: number | undefined) {
+    this.days = SimKmsPendingWindow.validated(days);
+  }
+
+  private static validated(days: number | undefined): number {
+    if (days === undefined) {
+      return defaultDays;
+    }
+
+    if (!Number.isSafeInteger(days) || days < minDays || days > maxDays) {
+      throw new SimKmsValidationException(
+        `PendingWindowInDays must be a whole number between ${String(minDays)} and ${String(maxDays)}`,
+      );
+    }
+
+    return days;
+  }
+
+  /**
+   * When a deletion scheduled now would fall due.
+   */
+  deletionDateFrom(now: Date): Date {
+    return new Date(now.getTime() + this.days * millisecondsPerDay);
+  }
+}

--- a/src/service/kms/command/sim-kms-command.types.ts
+++ b/src/service/kms/command/sim-kms-command.types.ts
@@ -1,0 +1,42 @@
+/**
+ * The command types of every simulated KMS operation, in one place.
+ *
+ * The SimKms facade handles all of them, so gathering the types here keeps it
+ * a delegation rather than a page of imports.
+ */
+export type {
+  SimCreateAliasCommand,
+  SimCreateAliasCommandOutput,
+  SimListAliasesCommand,
+  SimListAliasesCommandOutput,
+} from "./alias/alias.command.js";
+
+export type {
+  SimDecryptCommand,
+  SimDecryptCommandOutput,
+  SimEncryptCommand,
+  SimEncryptCommandOutput,
+  SimGenerateDataKeyCommand,
+  SimGenerateDataKeyCommandOutput,
+} from "./crypto/crypto.command.js";
+
+export type {
+  SimCancelKeyDeletionCommand,
+  SimCancelKeyDeletionCommandOutput,
+  SimCreateKeyCommand,
+  SimCreateKeyCommandOutput,
+  SimDescribeKeyCommand,
+  SimDescribeKeyCommandOutput,
+  SimDisableKeyCommand,
+  SimDisableKeyCommandOutput,
+  SimEnableKeyCommand,
+  SimEnableKeyCommandOutput,
+  SimGetKeyPolicyCommand,
+  SimGetKeyPolicyCommandOutput,
+  SimListKeysCommand,
+  SimListKeysCommandOutput,
+  SimPutKeyPolicyCommand,
+  SimPutKeyPolicyCommandOutput,
+  SimScheduleKeyDeletionCommand,
+  SimScheduleKeyDeletionCommandOutput,
+} from "./key/key.command.js";

--- a/src/service/kms/error/sim-kms.error.ts
+++ b/src/service/kms/error/sim-kms.error.ts
@@ -1,0 +1,124 @@
+/**
+ * Minimal metadata shape for simulated KMS errors.
+ */
+export interface SimKmsErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated KMS errors.
+ */
+export class SimKmsError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimKmsErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated KMS NotFoundException error.
+ *
+ * Real KMS reports a key, alias or key ARN it cannot find this way, whether
+ * the identifier is unknown or belongs to another Account or Region.
+ */
+export class SimKmsNotFoundException extends SimKmsError {
+  public override readonly name = "NotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS AlreadyExistsException error.
+ */
+export class SimKmsAlreadyExistsException extends SimKmsError {
+  public override readonly name = "AlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS DisabledException error.
+ *
+ * Real KMS distinguishes a disabled key from one pending deletion: a
+ * cryptographic operation on a disabled key fails this way, while a key
+ * pending deletion fails with KMSInvalidStateException.
+ */
+export class SimKmsDisabledException extends SimKmsError {
+  public override readonly name = "DisabledException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS KMSInvalidStateException error.
+ */
+export class SimKmsInvalidStateException extends SimKmsError {
+  public override readonly name = "KMSInvalidStateException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS InvalidCiphertextException error.
+ *
+ * This covers every reason a ciphertext will not open: it was not produced by
+ * this simulation, it was produced under a different key, or the encryption
+ * context does not match the one it was encrypted with. Real KMS is equally
+ * uninformative here on purpose, because saying more would leak something
+ * about the key or the plaintext.
+ */
+export class SimKmsInvalidCiphertextException extends SimKmsError {
+  public override readonly name = "InvalidCiphertextException";
+
+  constructor(message = "The ciphertext refers to a key that does not exist") {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS IncorrectKeyException error.
+ *
+ * Decrypt was given a KeyId, and the ciphertext was produced under a different
+ * key. Naming the key is optional for a symmetric ciphertext precisely because
+ * the blob already says which key made it, so a mismatch means the caller's
+ * expectation was wrong rather than the ciphertext being unreadable.
+ */
+export class SimKmsIncorrectKeyException extends SimKmsError {
+  public override readonly name = "IncorrectKeyException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS ValidationException error.
+ */
+export class SimKmsValidationException extends SimKmsError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated KMS InvalidKeyUsageException error.
+ */
+export class SimKmsInvalidKeyUsageException extends SimKmsError {
+  public override readonly name = "InvalidKeyUsageException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/kms/index.ts
+++ b/src/service/kms/index.ts
@@ -1,0 +1,22 @@
+export { SimKms, type SimKmsRequestOptions } from "./sim-kms.js";
+export {
+  SimKmsKey,
+  SimKmsKeyManager,
+  SimKmsKeyState,
+  type SimKmsKeyId,
+} from "./key/sim-kms-key.js";
+export { SimKmsAlias } from "./key/sim-kms-alias.js";
+export { SimKmsKeyPolicy } from "./key/sim-kms-key-policy.js";
+export type { SimKmsEncryptionContext } from "./key/sim-kms-encryption-context.js";
+export type { SimKmsKeyMetadata } from "./key/sim-kms-key-metadata.js";
+export {
+  SimKmsAlreadyExistsException,
+  SimKmsDisabledException,
+  SimKmsError,
+  SimKmsIncorrectKeyException,
+  SimKmsInvalidCiphertextException,
+  SimKmsInvalidKeyUsageException,
+  SimKmsInvalidStateException,
+  SimKmsNotFoundException,
+  SimKmsValidationException,
+} from "./error/sim-kms.error.js";

--- a/src/service/kms/key/sim-kms-alias.iso.test.ts
+++ b/src/service/kms/key/sim-kms-alias.iso.test.ts
@@ -1,0 +1,293 @@
+import {
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+  ListAliasesCommand,
+  ListKeysCommand,
+  ScheduleKeyDeletionCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimKmsAlreadyExistsException,
+  SimKmsInvalidStateException,
+  SimKmsValidationException,
+} from "../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS aliases", () => {
+  it("refuses an alias name already in use", async () => {
+    // Given an alias pointing at a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: created.KeyMetadata.KeyId,
+      }),
+    );
+
+    // When the same name is created again.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/app-key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then KMS refuses it.
+    assertInstanceOf(error, SimKmsAlreadyExistsException);
+  });
+
+  it("refuses an alias name without the alias prefix", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an alias is asked for without the required prefix.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "app-key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an alias reserved for AWS managed keys", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When a reserved alias is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/aws/s3",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused, as real KMS refuses the aws/ namespace.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses a bare alias prefix with no name after it", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When the prefix alone is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused: an alias has to name something.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an alias name beyond the KMS length limit", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When a name longer than 256 characters is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: `alias/${"a".repeat(256)}`,
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an alias name with characters KMS does not allow", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an alias containing a space is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/app key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("lists the aliases of one key", async () => {
+    // Given two keys, one of which has two aliases.
+    const simAws = new SimAws();
+    const first = await simAws.kms().createKey(new CreateKeyCommand({}));
+    const second = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(first.KeyMetadata);
+    assertNonNullable(second.KeyMetadata);
+
+    await Promise.all(
+      ["alias/one", "alias/two"].map(async (aliasName) =>
+        simAws.kms().createAlias(
+          new CreateAliasCommand({
+            AliasName: aliasName,
+            TargetKeyId: first.KeyMetadata?.KeyId,
+          }),
+        ),
+      ),
+    );
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/other",
+        TargetKeyId: second.KeyMetadata.KeyId,
+      }),
+    );
+
+    // When one key's aliases are listed.
+    const listed = await simAws
+      .kms()
+      .listAliases(new ListAliasesCommand({ KeyId: first.KeyMetadata.KeyId }));
+
+    // Then only its own come back.
+    assertArrayLength(listed.Aliases ?? [], 2);
+  });
+
+  it("truncates the alias listing at a requested limit", async () => {
+    // Given a key with two aliases.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    await Promise.all(
+      ["alias/one", "alias/two"].map(async (aliasName) =>
+        simAws.kms().createAlias(
+          new CreateAliasCommand({
+            AliasName: aliasName,
+            TargetKeyId: created.KeyMetadata?.KeyId,
+          }),
+        ),
+      ),
+    );
+
+    // When one alias is asked for.
+    const listed = await simAws
+      .kms()
+      .listAliases(new ListAliasesCommand({ Limit: 1 }));
+
+    // Then one comes back, marked truncated, as ListKeys does.
+    assertArrayLength(listed.Aliases ?? [], 1);
+    assertTrue(listed.Truncated ?? false);
+  });
+
+  it("lists every alias when no key is named", async () => {
+    // Given a key with one alias.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: created.KeyMetadata?.KeyId,
+      }),
+    );
+
+    // When aliases are listed with no key.
+    const listed = await simAws.kms().listAliases(new ListAliasesCommand({}));
+
+    // Then the alias is reported with its ARN and target.
+    assertArrayLength(listed.Aliases ?? [], 1);
+    assertIdentical(listed.Aliases?.[0]?.AliasName, "alias/app-key");
+  });
+});
+
+describe("KMS AWS managed keys", () => {
+  it("creates an AWS managed key on first reference to its alias", async () => {
+    // Given a simulation where nothing has created a key.
+    const simAws = new SimAws();
+
+    // When a reserved AWS alias is used to encrypt.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: "alias/aws/s3", Plaintext: plaintext }),
+      );
+
+    // Then the key exists, as an AWS managed one, the way it appears on real
+    // AWS when a service first needs it.
+    assertNonNullable(encrypted.KeyId);
+
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+    assertNonNullable(described.KeyMetadata);
+    assertIdentical(described.KeyMetadata.KeyManager, "AWS");
+    assertIdentical(described.KeyMetadata.Arn, encrypted.KeyId);
+  });
+
+  it("reuses the same AWS managed key on later references", async () => {
+    // Given an AWS managed key materialised by a first reference.
+    const simAws = new SimAws();
+    const first = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // When the alias is used again.
+    const second = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // Then it is the same key, not a new one each time.
+    assertIdentical(second.KeyMetadata?.Arn, first.KeyMetadata?.Arn);
+
+    const keys = await simAws.kms().listKeys(new ListKeysCommand({}));
+    assertArrayLength(keys.Keys ?? [], 1);
+  });
+
+  it("refuses to schedule deletion of an AWS managed key", async () => {
+    // Given an AWS managed key materialised by referencing its alias.
+    const simAws = new SimAws();
+    await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // When deletion is scheduled for it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .scheduleKeyDeletion(
+          new ScheduleKeyDeletionCommand({ KeyId: "alias/aws/s3" }),
+        ),
+    );
+
+    // Then it is refused: the owning service created it and only that service
+    // can remove it.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+});

--- a/src/service/kms/key/sim-kms-alias.iso.test.ts
+++ b/src/service/kms/key/sim-kms-alias.iso.test.ts
@@ -211,19 +211,30 @@ describe("KMS aliases", () => {
     // Given a key with one alias.
     const simAws = new SimAws();
     const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
     await simAws.kms().createAlias(
       new CreateAliasCommand({
         AliasName: "alias/app-key",
-        TargetKeyId: created.KeyMetadata?.KeyId,
+        TargetKeyId: created.KeyMetadata.KeyId,
       }),
     );
 
     // When aliases are listed with no key.
     const listed = await simAws.kms().listAliases(new ListAliasesCommand({}));
 
-    // Then the alias is reported with its ARN and target.
+    // Then the alias is reported with its ARN and target. The alias ARN names
+    // the Account and Region, the same as a key ARN does.
     assertArrayLength(listed.Aliases ?? [], 1);
-    assertIdentical(listed.Aliases?.[0]?.AliasName, "alias/app-key");
+
+    const alias = listed.Aliases?.[0];
+    assertNonNullable(alias);
+    assertIdentical(alias.AliasName, "alias/app-key");
+    assertIdentical(
+      alias.AliasArn,
+      `arn:aws:kms:${simAws.defaultRegionName}:${simAws.defaultAccountId}:alias/app-key`,
+    );
+    assertIdentical(alias.TargetKeyId, created.KeyMetadata.KeyId);
   });
 });
 

--- a/src/service/kms/key/sim-kms-alias.ts
+++ b/src/service/kms/key/sim-kms-alias.ts
@@ -48,11 +48,24 @@ export class SimKmsAlias {
  */
 export class SimKmsAliasName {
   private static readonly allowed = /^[\w/-]+$/u;
+  private static readonly maxLength = 256;
 
   /**
    * Validate an alias name a customer asked to create.
    */
   validateCustomerAlias(aliasName: string): void {
+    if (aliasName.length > SimKmsAliasName.maxLength) {
+      throw new SimKmsValidationException(
+        `Alias '${aliasName}' is longer than the ${String(SimKmsAliasName.maxLength)} character limit`,
+      );
+    }
+
+    if (aliasName === simKmsAliasPrefix) {
+      throw new SimKmsValidationException(
+        `Alias must name something after '${simKmsAliasPrefix}'`,
+      );
+    }
+
     if (!aliasName.startsWith(simKmsAliasPrefix)) {
       throw new SimKmsValidationException(
         `Alias must start with '${simKmsAliasPrefix}': ${aliasName}`,

--- a/src/service/kms/key/sim-kms-alias.ts
+++ b/src/service/kms/key/sim-kms-alias.ts
@@ -1,0 +1,74 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimKmsValidationException } from "../error/sim-kms.error.js";
+import type { SimKmsKeyId } from "./sim-kms-key.js";
+
+/**
+ * The prefix every KMS alias name carries.
+ */
+export const simKmsAliasPrefix = "alias/";
+
+/**
+ * The prefix reserved for aliases of AWS managed keys, such as
+ * `alias/aws/s3`. Real KMS refuses to let a customer create one.
+ */
+export const simKmsAwsAliasPrefix = "alias/aws/";
+
+interface SimKmsAliasProperties {
+  readonly aliasName: string;
+  readonly targetKeyId: SimKmsKeyId;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * An alias pointing at one simulated KMS key.
+ *
+ * An alias is a mutable name for a key rather than part of the key, so it is
+ * stored separately: retargeting an alias must not disturb the key, and
+ * deleting an alias must leave the key alone.
+ */
+export class SimKmsAlias {
+  public readonly aliasName: string;
+  public readonly arn: string;
+  public readonly targetKeyId: SimKmsKeyId;
+
+  constructor(properties: SimKmsAliasProperties) {
+    const { accountRegionScope } = properties;
+
+    this.aliasName = properties.aliasName;
+    this.arn = `arn:aws:kms:${accountRegionScope.regionName}:${accountRegionScope.accountId}:${properties.aliasName}`;
+    this.targetKeyId = properties.targetKeyId;
+  }
+}
+
+/**
+ * Checks alias names against the rules real KMS applies.
+ *
+ * Failing an invalid name here rather than storing it keeps a test from
+ * passing on an alias that CreateAlias would reject on real AWS.
+ */
+export class SimKmsAliasName {
+  private static readonly allowed = /^[\w/-]+$/u;
+
+  /**
+   * Validate an alias name a customer asked to create.
+   */
+  validateCustomerAlias(aliasName: string): void {
+    if (!aliasName.startsWith(simKmsAliasPrefix)) {
+      throw new SimKmsValidationException(
+        `Alias must start with '${simKmsAliasPrefix}': ${aliasName}`,
+      );
+    }
+
+    if (aliasName.startsWith(simKmsAwsAliasPrefix)) {
+      throw new SimKmsValidationException(
+        `Alias '${aliasName}' is reserved for AWS managed keys`,
+      );
+    }
+
+    if (!SimKmsAliasName.allowed.test(aliasName)) {
+      throw new SimKmsValidationException(
+        `Alias '${aliasName}' contains characters KMS does not allow`,
+      );
+    }
+  }
+}

--- a/src/service/kms/key/sim-kms-ciphertext-blob.iso.test.ts
+++ b/src/service/kms/key/sim-kms-ciphertext-blob.iso.test.ts
@@ -1,0 +1,121 @@
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import {
+  SimKmsInvalidCiphertextException,
+  SimKmsNotFoundException,
+} from "../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS ciphertext blobs", () => {
+  it("rejects a blob truncated part way through its header", async () => {
+    // Given a real ciphertext.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: created.KeyMetadata?.Arn,
+        Plaintext: plaintext,
+      }),
+    );
+    assertNonNullable(encrypted.CiphertextBlob);
+
+    // When it is cut short, leaving the marker intact but nothing after it.
+    const truncated = encrypted.CiphertextBlob.slice(0, 12);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(new DecryptCommand({ CiphertextBlob: truncated })),
+    );
+
+    // Then it is an invalid ciphertext rather than a crash reading past the end.
+    assertInstanceOf(error, SimKmsInvalidCiphertextException);
+  });
+
+  it("rejects a blob naming a key this scope does not have", async () => {
+    // Given a ciphertext produced in one Region.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const created = await simAws
+      .region("eu-west-2")
+      .kms()
+      .createKey(new CreateKeyCommand({}));
+    const encrypted = await simAws
+      .region("eu-west-2")
+      .kms()
+      .encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+        }),
+      );
+
+    // When another Region is asked to decrypt it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("us-east-1")
+        .kms()
+        .decrypt(
+          new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+        ),
+    );
+
+    // Then it is an invalid ciphertext, not a missing key: the caller never
+    // named a key, so there is none to report missing.
+    assertInstanceOf(error, SimKmsInvalidCiphertextException);
+  });
+});
+
+describe("KMS Account scope", () => {
+  it("reaches KMS through an Account scope", async () => {
+    // Given a simulation with a second Account.
+    const otherAccountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+
+    // When that Account's KMS creates a key.
+    const created = await simAws
+      .account(otherAccountId)
+      .kms()
+      .createKey(new CreateKeyCommand({}));
+
+    // Then the key belongs to that Account, and the default one cannot see it.
+    assertIdentical(created.KeyMetadata?.AWSAccountId, otherAccountId);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .describeKey(
+          new DescribeKeyCommand({ KeyId: created.KeyMetadata?.Arn }),
+        ),
+    );
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("does not invent a key for an unknown non-AWS alias", async () => {
+    // Given a simulation with no aliases.
+    const simAws = new SimAws();
+
+    // When an ordinary alias nothing created is named.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .describeKey(new DescribeKeyCommand({ KeyId: "alias/not-created" })),
+    );
+
+    // Then it is missing: only the reserved aws/ namespace appears on demand.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+});

--- a/src/service/kms/key/sim-kms-ciphertext-blob.ts
+++ b/src/service/kms/key/sim-kms-ciphertext-blob.ts
@@ -1,0 +1,111 @@
+import { SimKmsInvalidCiphertextException } from "../error/sim-kms.error.js";
+
+/**
+ * Marks a byte string as one of this simulation's ciphertext blobs, so that
+ * arbitrary bytes handed to Decrypt are rejected rather than misread as a
+ * short blob.
+ */
+const magic = Buffer.from("YULINKMS", "ascii");
+
+/**
+ * Blob layout version, so a future change to the layout can be told apart
+ * from a blob this simulation cannot read at all.
+ */
+const version = 1;
+
+const ivLength = 12;
+const authTagLength = 16;
+
+interface SimKmsCiphertextBlobPartsProperties {
+  readonly keyArn: string;
+  readonly iv: Uint8Array;
+  readonly authTag: Uint8Array;
+  readonly ciphertext: Uint8Array;
+}
+
+/**
+ * The parts of one ciphertext blob.
+ */
+export class SimKmsCiphertextBlobParts {
+  public readonly keyArn: string;
+  public readonly iv: Uint8Array;
+  public readonly authTag: Uint8Array;
+  public readonly ciphertext: Uint8Array;
+
+  constructor(properties: SimKmsCiphertextBlobPartsProperties) {
+    this.keyArn = properties.keyArn;
+    this.iv = properties.iv;
+    this.authTag = properties.authTag;
+    this.ciphertext = properties.ciphertext;
+  }
+}
+
+/**
+ * Encodes and decodes the opaque ciphertext blob KMS hands back.
+ *
+ * Real KMS blobs are opaque to the caller but not to KMS: a blob names the key
+ * that produced it, which is why Decrypt needs no KeyId for a symmetric key.
+ * This layout keeps that property, carrying the key ARN alongside the AES-GCM
+ * initialisation vector and authentication tag.
+ *
+ * Opaque means callers must not read it. It is not encrypted, and it is not
+ * portable to real AWS or between simulations.
+ */
+export class SimKmsCiphertextBlob {
+  /**
+   * Encode the parts of an encryption into one blob.
+   */
+  encode(parts: SimKmsCiphertextBlobParts): Uint8Array {
+    const keyArn = Buffer.from(parts.keyArn, "utf8");
+    const header = Buffer.alloc(2);
+    header.writeUInt8(version, 0);
+    header.writeUInt8(keyArn.length, 1);
+
+    return Uint8Array.from(
+      Buffer.concat([
+        magic,
+        header,
+        keyArn,
+        parts.iv,
+        parts.authTag,
+        parts.ciphertext,
+      ]),
+    );
+  }
+
+  /**
+   * Read the parts back out of a blob.
+   *
+   * Anything that is not a blob this simulation produced is an invalid
+   * ciphertext, which is the same answer real KMS gives for bytes it cannot
+   * make sense of.
+   */
+  decode(blob: Uint8Array): SimKmsCiphertextBlobParts {
+    const buffer = Buffer.from(blob);
+    const keyArnStart = magic.length + 2;
+
+    if (
+      buffer.length < keyArnStart ||
+      !buffer.subarray(0, magic.length).equals(magic) ||
+      buffer.readUInt8(magic.length) !== version
+    ) {
+      throw new SimKmsInvalidCiphertextException();
+    }
+
+    const keyArnLength = buffer.readUInt8(magic.length + 1);
+    const ivStart = keyArnStart + keyArnLength;
+    const authTagStart = ivStart + ivLength;
+    const ciphertextStart = authTagStart + authTagLength;
+
+    if (buffer.length < ciphertextStart) {
+      throw new SimKmsInvalidCiphertextException();
+    }
+
+    return new SimKmsCiphertextBlobParts({
+      keyArn: buffer.subarray(keyArnStart, ivStart).toString("utf8"),
+      iv: Uint8Array.from(buffer.subarray(ivStart, authTagStart)),
+      authTag: Uint8Array.from(buffer.subarray(authTagStart, ciphertextStart)),
+      ciphertext: Uint8Array.from(buffer.subarray(ciphertextStart)),
+    });
+  }
+}

--- a/src/service/kms/key/sim-kms-encryption-context.ts
+++ b/src/service/kms/key/sim-kms-encryption-context.ts
@@ -1,0 +1,49 @@
+/**
+ * An AWS KMS encryption context: non-secret key/value pairs bound to a
+ * ciphertext.
+ */
+export type SimKmsEncryptionContext = Readonly<Record<string, string>>;
+
+/**
+ * Serialises an encryption context into the additional authenticated data of
+ * an AES-GCM operation.
+ *
+ * The encryption context is exactly what AAD is for: it is not secret, it is
+ * not stored in the ciphertext, and supplying a different one on decryption
+ * has to fail. Binding it as AAD gets that behaviour from the cipher itself
+ * rather than from a comparison the simulator would have to remember to make.
+ *
+ * Real KMS treats the context as an unordered map, so the serialisation sorts
+ * by key. Two contexts with the same pairs written in a different order have
+ * to produce the same AAD, or a decryption that AWS would allow would fail
+ * here.
+ */
+export class SimKmsEncryptionContextAad {
+  /**
+   * Serialise an encryption context to the bytes bound into the ciphertext.
+   */
+  serialise(context: SimKmsEncryptionContext | undefined): Uint8Array {
+    return Buffer.from(this.canonical(context), "utf8");
+  }
+
+  /**
+   * The canonical string form of an encryption context.
+   *
+   * Pairs are sorted by key and both halves are escaped, so that no pair of
+   * distinct contexts can serialise to the same string by placing a separator
+   * inside a key or a value.
+   */
+  private canonical(context: SimKmsEncryptionContext | undefined): string {
+    if (context === undefined) {
+      return "";
+    }
+
+    return Object.entries(context)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, value]) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      )
+      .join("&");
+  }
+}

--- a/src/service/kms/key/sim-kms-key-factory.ts
+++ b/src/service/kms/key/sim-kms-key-factory.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import { SimKmsCiphertextBlob } from "./sim-kms-ciphertext-blob.js";
+import { SimKmsKey, type SimKmsKeyManager } from "./sim-kms-key.js";
+import { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import { SimKmsKeyPolicy } from "./sim-kms-key-policy.js";
+
+interface SimKmsKeyFactoryProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+interface SimKmsMakeKeyProperties {
+  readonly description?: string | undefined;
+  readonly policy?: SimIamPolicyDocument | undefined;
+  readonly keyManager?: SimKmsKeyManager | undefined;
+}
+
+/**
+ * Builds simulated KMS keys, including their key material.
+ *
+ * Key creation has to assemble an identifier, an ARN, real AES key material
+ * and a policy that all agree with each other, so it happens in one place
+ * rather than at each call site that needs a key.
+ */
+export class SimKmsKeyFactory {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: SimClock;
+  private readonly blob = new SimKmsCiphertextBlob();
+
+  constructor(properties: SimKmsKeyFactoryProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Make a new key with fresh key material.
+   *
+   * Real key IDs are UUIDs, and code in the wild parses them that way, so
+   * these are real UUIDs rather than a shorter simulator-only identifier.
+   */
+  make(properties: SimKmsMakeKeyProperties = {}): SimKmsKey {
+    const keyId = randomUUID();
+    const arn = `arn:aws:kms:${this.accountRegionScope.regionName}:${this.accountRegionScope.accountId}:key/${keyId}`;
+
+    return new SimKmsKey({
+      keyId,
+      accountRegionScope: this.accountRegionScope,
+      material: new SimKmsKeyMaterial({ keyArn: arn, blob: this.blob }),
+      policy: this.keyPolicy(arn, properties.policy),
+      creationDate: this.clock.now(),
+      description: properties.description,
+      keyManager: properties.keyManager,
+    });
+  }
+
+  private keyPolicy(
+    keyArn: string,
+    document: SimIamPolicyDocument | undefined,
+  ): SimKmsKeyPolicy {
+    if (document === undefined) {
+      return SimKmsKeyPolicy.default(keyArn, this.accountRegionScope.accountId);
+    }
+
+    return new SimKmsKeyPolicy(keyArn, document);
+  }
+}

--- a/src/service/kms/key/sim-kms-key-identifier.ts
+++ b/src/service/kms/key/sim-kms-key-identifier.ts
@@ -1,0 +1,104 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simKmsAliasPrefix } from "./sim-kms-alias.js";
+
+/**
+ * What a KeyId names: an alias, a key, or nothing this scope can resolve.
+ */
+export class SimKmsKeyIdentifier {
+  public readonly aliasName: string | undefined;
+  public readonly keyId: string | undefined;
+
+  private constructor(
+    aliasName: string | undefined,
+    keyId: string | undefined,
+  ) {
+    this.aliasName = aliasName;
+    this.keyId = keyId;
+  }
+
+  /**
+   * An identifier naming nothing resolvable here.
+   */
+  static none(): SimKmsKeyIdentifier {
+    return new SimKmsKeyIdentifier(undefined, undefined);
+  }
+
+  /**
+   * An identifier naming an alias.
+   */
+  static alias(aliasName: string): SimKmsKeyIdentifier {
+    return new SimKmsKeyIdentifier(aliasName, undefined);
+  }
+
+  /**
+   * An identifier naming a key.
+   */
+  static key(keyId: string): SimKmsKeyIdentifier {
+    return new SimKmsKeyIdentifier(undefined, keyId);
+  }
+}
+
+/**
+ * Reads the four forms of KeyId real KMS accepts, within one scope.
+ *
+ * A key ARN and an alias ARN both name an Account and a Region, and KMS keys
+ * are scoped to both. An ARN belonging to somewhere else therefore resolves to
+ * nothing here rather than having its identifier pulled out and looked up
+ * locally, which would let a foreign ARN reach a key that happens to share an
+ * identifier.
+ */
+export class SimKmsKeyIdentifierParser {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(accountRegionScope: SimAwsAccountRegionScope) {
+    this.accountRegionScope = accountRegionScope;
+  }
+
+  /**
+   * Read what a KeyId names.
+   */
+  parse(keyId: string): SimKmsKeyIdentifier {
+    if (keyId.startsWith("arn:")) {
+      return this.parseArn(keyId);
+    }
+
+    if (keyId.startsWith(simKmsAliasPrefix)) {
+      return SimKmsKeyIdentifier.alias(keyId);
+    }
+
+    return SimKmsKeyIdentifier.key(keyId);
+  }
+
+  /**
+   * Read a key or alias ARN, refusing one belonging to another scope.
+   */
+  private parseArn(arn: string): SimKmsKeyIdentifier {
+    const [, partition, service, regionName, accountId, ...rest] =
+      arn.split(":");
+
+    if (
+      partition !== "aws" ||
+      service !== "kms" ||
+      regionName !== this.accountRegionScope.regionName ||
+      accountId !== this.accountRegionScope.accountId
+    ) {
+      return SimKmsKeyIdentifier.none();
+    }
+
+    return this.parseArnResource(rest.join(":"));
+  }
+
+  private parseArnResource(resource: string): SimKmsKeyIdentifier {
+    if (resource.startsWith(simKmsAliasPrefix)) {
+      return SimKmsKeyIdentifier.alias(resource);
+    }
+
+    const keyId = /^key\/(.+)$/u.exec(resource)?.[1];
+
+    if (keyId === undefined) {
+      return SimKmsKeyIdentifier.none();
+    }
+
+    return SimKmsKeyIdentifier.key(keyId);
+  }
+}

--- a/src/service/kms/key/sim-kms-key-lifecycle.ts
+++ b/src/service/kms/key/sim-kms-key-lifecycle.ts
@@ -1,0 +1,130 @@
+import {
+  SimKmsDisabledException,
+  SimKmsInvalidStateException,
+} from "../error/sim-kms.error.js";
+
+/**
+ * The lifecycle states a simulated KMS key can be in.
+ *
+ * Real KMS has more of them, covering imported material, external key stores
+ * and multi-Region replication. These are the three a key reaches through the
+ * operations this simulation supports.
+ */
+export const SimKmsKeyState = {
+  Enabled: "Enabled",
+  Disabled: "Disabled",
+  PendingDeletion: "PendingDeletion",
+} as const;
+
+export type SimKmsKeyState =
+  (typeof SimKmsKeyState)[keyof typeof SimKmsKeyState];
+
+/**
+ * The lifecycle state of one simulated KMS key, and the moves it allows.
+ *
+ * Kept apart from the key itself so that the key is about what it holds and
+ * what it can do with it, while the rules about which transitions are legal
+ * and which failure each illegal one produces live in one place.
+ */
+export class SimKmsKeyLifecycle {
+  private readonly keyArn: string;
+  private currentState: SimKmsKeyState = SimKmsKeyState.Enabled;
+  private scheduledDeletionDate: Date | undefined;
+
+  constructor(keyArn: string) {
+    this.keyArn = keyArn;
+  }
+
+  /**
+   * The current lifecycle state.
+   */
+  get state(): SimKmsKeyState {
+    return this.currentState;
+  }
+
+  /**
+   * Whether the key is enabled, as DescribeKey reports it.
+   */
+  get isEnabled(): boolean {
+    return this.currentState === SimKmsKeyState.Enabled;
+  }
+
+  /**
+   * When the key is due to be deleted, if deletion is scheduled.
+   */
+  get deletionDate(): Date | undefined {
+    return this.scheduledDeletionDate;
+  }
+
+  /**
+   * Enable the key, if it is not pending deletion.
+   */
+  enable(): void {
+    this.refuseWhilePendingDeletion("enable");
+    this.currentState = SimKmsKeyState.Enabled;
+  }
+
+  /**
+   * Disable the key, if it is not pending deletion.
+   */
+  disable(): void {
+    this.refuseWhilePendingDeletion("disable");
+    this.currentState = SimKmsKeyState.Disabled;
+  }
+
+  /**
+   * Schedule the key for deletion after a recovery window.
+   *
+   * Real KMS does not delete a key on request. It waits out the window, during
+   * which the key is unusable but recoverable, because deleting key material
+   * destroys every ciphertext ever produced under it.
+   */
+  scheduleDeletion(deletionDate: Date): void {
+    this.currentState = SimKmsKeyState.PendingDeletion;
+    this.scheduledDeletionDate = deletionDate;
+  }
+
+  /**
+   * Cancel a scheduled deletion, leaving the key disabled.
+   *
+   * Real KMS does not restore the key to enabled: cancelling returns it to
+   * Disabled, and enabling it again is a separate deliberate step.
+   */
+  cancelDeletion(): void {
+    if (this.currentState !== SimKmsKeyState.PendingDeletion) {
+      throw new SimKmsInvalidStateException(
+        `Key ${this.keyArn} is not pending deletion`,
+      );
+    }
+
+    this.currentState = SimKmsKeyState.Disabled;
+    this.scheduledDeletionDate = undefined;
+  }
+
+  /**
+   * Refuse a cryptographic operation the current state does not allow.
+   *
+   * The two unusable states fail differently on real KMS, and the difference
+   * is worth keeping: DisabledException says to enable the key, while
+   * KMSInvalidStateException says the key is on its way out.
+   */
+  requireUsable(): void {
+    if (this.currentState === SimKmsKeyState.PendingDeletion) {
+      throw new SimKmsInvalidStateException(
+        `Key ${this.keyArn} is pending deletion and cannot be used`,
+      );
+    }
+
+    if (this.currentState === SimKmsKeyState.Disabled) {
+      throw new SimKmsDisabledException(`Key ${this.keyArn} is disabled`);
+    }
+  }
+
+  private refuseWhilePendingDeletion(action: string): void {
+    if (this.currentState === SimKmsKeyState.PendingDeletion) {
+      throw new SimKmsInvalidStateException(
+        `Key ${this.keyArn} is pending deletion and cannot be ${action}d`,
+      );
+    }
+  }
+}

--- a/src/service/kms/key/sim-kms-key-lifecycle.ts
+++ b/src/service/kms/key/sim-kms-key-lifecycle.ts
@@ -80,6 +80,7 @@ export class SimKmsKeyLifecycle {
    * destroys every ciphertext ever produced under it.
    */
   scheduleDeletion(deletionDate: Date): void {
+    this.refuseWhilePendingDeletion("schedule");
     this.currentState = SimKmsKeyState.PendingDeletion;
     this.scheduledDeletionDate = deletionDate;
   }
@@ -123,7 +124,7 @@ export class SimKmsKeyLifecycle {
   private refuseWhilePendingDeletion(action: string): void {
     if (this.currentState === SimKmsKeyState.PendingDeletion) {
       throw new SimKmsInvalidStateException(
-        `Key ${this.keyArn} is pending deletion and cannot be ${action}d`,
+        `Key ${this.keyArn} is already pending deletion and cannot be ${action}d`,
       );
     }
   }

--- a/src/service/kms/key/sim-kms-key-material.ts
+++ b/src/service/kms/key/sim-kms-key-material.ts
@@ -1,0 +1,106 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { SimKmsInvalidCiphertextException } from "../error/sim-kms.error.js";
+import {
+  SimKmsCiphertextBlobParts,
+  type SimKmsCiphertextBlob,
+} from "./sim-kms-ciphertext-blob.js";
+import {
+  SimKmsEncryptionContextAad,
+  type SimKmsEncryptionContext,
+} from "./sim-kms-encryption-context.js";
+
+/**
+ * The cipher backing a simulated symmetric KMS key.
+ *
+ * Real KMS symmetric keys are AES-256-GCM, so this uses the same thing rather
+ * than a stand-in. Encryption in this simulation is real encryption: a
+ * ciphertext genuinely cannot be read without the key, and the authentication
+ * tag genuinely fails on a tampered blob or a mismatched encryption context.
+ */
+const algorithm = "aes-256-gcm";
+
+const keyLength = 32;
+const ivLength = 12;
+
+interface SimKmsKeyMaterialProperties {
+  readonly keyArn: string;
+  readonly blob: SimKmsCiphertextBlob;
+  readonly bytes?: Uint8Array | undefined;
+}
+
+/**
+ * The key material of one simulated KMS key, and the operations that use it.
+ *
+ * The bytes are generated here and never leave: nothing exposes them, exactly
+ * as real key material never leaves KMS. That is a modelling choice rather
+ * than a security boundary, since this all runs in one process and anything
+ * sharing that process can reach the object.
+ */
+export class SimKmsKeyMaterial {
+  private readonly keyArn: string;
+  private readonly blob: SimKmsCiphertextBlob;
+  private readonly bytes: Uint8Array;
+  private readonly aad = new SimKmsEncryptionContextAad();
+
+  constructor(properties: SimKmsKeyMaterialProperties) {
+    this.keyArn = properties.keyArn;
+    this.blob = properties.blob;
+    this.bytes = properties.bytes ?? randomBytes(keyLength);
+  }
+
+  /**
+   * Encrypt plaintext under this key, binding the encryption context.
+   */
+  encrypt(
+    plaintext: Uint8Array,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    const iv = randomBytes(ivLength);
+    const cipher = createCipheriv(algorithm, this.bytes, iv);
+    cipher.setAAD(this.aad.serialise(encryptionContext));
+
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext),
+      cipher.final(),
+    ]);
+
+    const authTag = cipher.getAuthTag();
+
+    return this.blob.encode(
+      new SimKmsCiphertextBlobParts({
+        keyArn: this.keyArn,
+        iv: Uint8Array.from(iv),
+        authTag: Uint8Array.from(authTag),
+        ciphertext: Uint8Array.from(ciphertext),
+      }),
+    );
+  }
+
+  /**
+   * Decrypt a ciphertext produced under this key.
+   *
+   * A wrong encryption context fails the GCM authentication tag rather than an
+   * explicit comparison, so the failure comes from the cipher for the same
+   * reason it does on real KMS.
+   */
+  decrypt(
+    parts: SimKmsCiphertextBlobParts,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    const decipher = createDecipheriv(algorithm, this.bytes, parts.iv);
+    decipher.setAAD(this.aad.serialise(encryptionContext));
+    decipher.setAuthTag(parts.authTag);
+
+    try {
+      return Uint8Array.from(
+        Buffer.concat([decipher.update(parts.ciphertext), decipher.final()]),
+      );
+    } catch {
+      throw new SimKmsInvalidCiphertextException(
+        "The ciphertext could not be decrypted: it was produced under a " +
+          "different key, with a different encryption context, or has been " +
+          "altered",
+      );
+    }
+  }
+}

--- a/src/service/kms/key/sim-kms-key-metadata.ts
+++ b/src/service/kms/key/sim-kms-key-metadata.ts
@@ -51,12 +51,12 @@ export class SimKmsKeyMetadataView {
       AWSAccountId: this.accountId,
       KeyId: key.keyId,
       Arn: key.arn,
-      CreationDate: key.creationDate,
+      CreationDate: new Date(key.creationDate),
       Enabled: key.isEnabled,
       Description: key.description,
       KeyUsage: "ENCRYPT_DECRYPT",
       KeyState: key.keyState,
-      DeletionDate: key.deletionDate,
+      DeletionDate: this.copied(key.deletionDate),
       Origin: "AWS_KMS",
       KeyManager: key.keyManager,
       KeySpec: "SYMMETRIC_DEFAULT",
@@ -64,5 +64,16 @@ export class SimKmsKeyMetadataView {
       EncryptionAlgorithms: ["SYMMETRIC_DEFAULT"],
       MultiRegion: false,
     };
+  }
+
+  /**
+   * Copy a date, so the response never hands out the key's own instance.
+   */
+  private copied(date: Date | undefined): Date | undefined {
+    if (date === undefined) {
+      return undefined;
+    }
+
+    return new Date(date);
   }
 }

--- a/src/service/kms/key/sim-kms-key-metadata.ts
+++ b/src/service/kms/key/sim-kms-key-metadata.ts
@@ -1,0 +1,68 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type {
+  SimKmsKey,
+  SimKmsKeyManager,
+  SimKmsKeyState,
+} from "./sim-kms-key.js";
+
+/**
+ * The KeyMetadata structure CreateKey and DescribeKey return.
+ *
+ * Only symmetric encryption keys are simulated, so the fields describing key
+ * type are constants rather than stored state. They are reported anyway
+ * because application code reads them to decide what a key can do.
+ */
+export interface SimKmsKeyMetadata {
+  readonly AWSAccountId: SimAwsAccountId;
+  readonly KeyId: string;
+  readonly Arn: string;
+  readonly CreationDate: Date;
+  readonly Enabled: boolean;
+  readonly Description: string;
+  readonly KeyUsage: "ENCRYPT_DECRYPT";
+  readonly KeyState: SimKmsKeyState;
+  readonly DeletionDate?: Date | undefined;
+  readonly Origin: "AWS_KMS";
+  readonly KeyManager: SimKmsKeyManager;
+  readonly KeySpec: "SYMMETRIC_DEFAULT";
+  readonly CustomerMasterKeySpec: "SYMMETRIC_DEFAULT";
+  readonly EncryptionAlgorithms: readonly ["SYMMETRIC_DEFAULT"];
+  readonly MultiRegion: false;
+}
+
+/**
+ * Builds the AWS-shaped view of a stored key.
+ *
+ * Kept apart from SimKmsKey so the stored key stays a model of what a key is
+ * and does, rather than also owning the shape two commands happen to return.
+ */
+export class SimKmsKeyMetadataView {
+  private readonly accountId: SimAwsAccountId;
+
+  constructor(accountId: SimAwsAccountId) {
+    this.accountId = accountId;
+  }
+
+  /**
+   * Describe a key the way KMS reports it.
+   */
+  describe(key: SimKmsKey): SimKmsKeyMetadata {
+    return {
+      AWSAccountId: this.accountId,
+      KeyId: key.keyId,
+      Arn: key.arn,
+      CreationDate: key.creationDate,
+      Enabled: key.isEnabled,
+      Description: key.description,
+      KeyUsage: "ENCRYPT_DECRYPT",
+      KeyState: key.keyState,
+      DeletionDate: key.deletionDate,
+      Origin: "AWS_KMS",
+      KeyManager: key.keyManager,
+      KeySpec: "SYMMETRIC_DEFAULT",
+      CustomerMasterKeySpec: "SYMMETRIC_DEFAULT",
+      EncryptionAlgorithms: ["SYMMETRIC_DEFAULT"],
+      MultiRegion: false,
+    };
+  }
+}

--- a/src/service/kms/key/sim-kms-key-policy.ts
+++ b/src/service/kms/key/sim-kms-key-policy.ts
@@ -1,0 +1,78 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamResourcePolicyInput } from "../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+
+/**
+ * The name real KMS reports a key's policy under. A KMS key has exactly one
+ * policy and it is always called this.
+ */
+export const simKmsKeyPolicyName = "default";
+
+/**
+ * The key policy of one simulated KMS key.
+ *
+ * Every KMS key has a policy and it cannot be removed, which is what makes it
+ * the root of trust for the key: an IAM policy granting kms:Decrypt achieves
+ * nothing unless the key policy allows the access too. That is unlike other
+ * AWS resource policies, where the resource having no policy at all simply
+ * leaves the decision to IAM.
+ */
+export class SimKmsKeyPolicy {
+  private readonly keyArn: string;
+  private policyDocument: SimIamPolicyDocument;
+
+  constructor(keyArn: string, document: SimIamPolicyDocument) {
+    this.keyArn = keyArn;
+    this.policyDocument = document;
+  }
+
+  /**
+   * Build the default policy CreateKey applies when given no policy.
+   *
+   * This is the policy the AWS console and CLI create: it allows the Account
+   * root every KMS action, which is how a key ends up usable by whichever of
+   * the Account's principals IAM allows. A key created with a policy that
+   * omits this statement can only be used by the principals it names, and no
+   * IAM policy will widen that.
+   */
+  static default(keyArn: string, accountId: SimAwsAccountId): SimKmsKeyPolicy {
+    return new SimKmsKeyPolicy(keyArn, {
+      Version: "2012-10-17",
+      Id: "key-default-1",
+      Statement: [
+        {
+          Sid: "Enable IAM User Permissions",
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "kms:*",
+          Resource: "*",
+        },
+      ],
+    });
+  }
+
+  /**
+   * The stored policy document.
+   */
+  document(): SimIamPolicyDocument {
+    return this.policyDocument;
+  }
+
+  /**
+   * Replace the stored policy document.
+   */
+  replaceWith(document: SimIamPolicyDocument): void {
+    this.policyDocument = document;
+  }
+
+  /**
+   * This policy as the resource-policy side of an IAM authorization.
+   */
+  asResourcePolicy(): SimIamResourcePolicyInput {
+    return {
+      document: this.policyDocument,
+      policyName: simKmsKeyPolicyName,
+      resourceArn: this.keyArn,
+    };
+  }
+}

--- a/src/service/kms/key/sim-kms-key-resolution.iso.test.ts
+++ b/src/service/kms/key/sim-kms-key-resolution.iso.test.ts
@@ -1,0 +1,349 @@
+import {
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+  ListAliasesCommand,
+  ListKeysCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertFalse,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import {
+  SimKmsAlreadyExistsException,
+  SimKmsNotFoundException,
+  SimKmsValidationException,
+} from "../error/sim-kms.error.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS KeyId resolution", () => {
+  it("resolves a key by ID, ARN, alias name and alias ARN", async () => {
+    // Given a key with an alias.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+    const keyId = created.KeyMetadata.KeyId;
+    const keyArn = created.KeyMetadata.Arn;
+
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: keyId,
+      }),
+    );
+
+    const aliasArn = `arn:aws:kms:${simAws.defaultRegionName}:${accountId}:alias/app-key`;
+
+    // When the key is named each of the four ways KMS accepts.
+    const forms = [keyId, keyArn, "alias/app-key", aliasArn];
+
+    // Then every one of them reaches the same key.
+    const described = await Promise.all(
+      forms.map(async (form) =>
+        simAws.kms().describeKey(new DescribeKeyCommand({ KeyId: form })),
+      ),
+    );
+
+    for (const output of described) {
+      assertIdentical(output.KeyMetadata?.Arn, keyArn);
+    }
+  });
+
+  it("builds a key ARN from its Account and Region", async () => {
+    // Given a simulation with a known Account and Region.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When a key is created.
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // Then its ARN names both, as a real key ARN does.
+    assertStringStartsWith(
+      created.KeyMetadata?.Arn ?? "",
+      `arn:aws:kms:${simAws.defaultRegionName}:${accountId}:key/`,
+    );
+  });
+
+  it("does not resolve a key belonging to another Region", async () => {
+    // Given a key in one Region.
+    const simAws = new SimAws();
+    const created = await simAws
+      .region("eu-west-2")
+      .kms()
+      .createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When another Region's KMS is asked for it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("us-east-1")
+        .kms()
+        .describeKey(
+          new DescribeKeyCommand({ KeyId: created.KeyMetadata?.Arn }),
+        ),
+    );
+
+    // Then it is not found: KMS keys are Region-scoped.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("refuses an unknown key", async () => {
+    // Given a simulation with no keys.
+    const simAws = new SimAws();
+
+    // When an unknown key is named.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .describeKey(new DescribeKeyCommand({ KeyId: "no-such-key" })),
+    );
+
+    // Then KMS reports it missing.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("refuses a request with no KeyId", async () => {
+    // Given a simulation with no keys.
+    const simAws = new SimAws();
+
+    // When no KeyId is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().describeKey({ input: {} }),
+    );
+
+    // Then the request is invalid rather than the key missing.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+});
+
+describe("KMS aliases", () => {
+  it("refuses an alias name already in use", async () => {
+    // Given an alias pointing at a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: created.KeyMetadata.KeyId,
+      }),
+    );
+
+    // When the same name is created again.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/app-key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then KMS refuses it.
+    assertInstanceOf(error, SimKmsAlreadyExistsException);
+  });
+
+  it("refuses an alias name without the alias prefix", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an alias is asked for without the required prefix.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "app-key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an alias reserved for AWS managed keys", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When a reserved alias is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/aws/s3",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused, as real KMS refuses the aws/ namespace.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("refuses an alias name with characters KMS does not allow", async () => {
+    // Given a key.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an alias containing a space is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().createAlias(
+        new CreateAliasCommand({
+          AliasName: "alias/app key",
+          TargetKeyId: created.KeyMetadata?.KeyId,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimKmsValidationException);
+  });
+
+  it("lists the aliases of one key", async () => {
+    // Given two keys, one of which has two aliases.
+    const simAws = new SimAws();
+    const first = await simAws.kms().createKey(new CreateKeyCommand({}));
+    const second = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(first.KeyMetadata);
+    assertNonNullable(second.KeyMetadata);
+
+    await Promise.all(
+      ["alias/one", "alias/two"].map(async (aliasName) =>
+        simAws.kms().createAlias(
+          new CreateAliasCommand({
+            AliasName: aliasName,
+            TargetKeyId: first.KeyMetadata?.KeyId,
+          }),
+        ),
+      ),
+    );
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/other",
+        TargetKeyId: second.KeyMetadata.KeyId,
+      }),
+    );
+
+    // When one key's aliases are listed.
+    const listed = await simAws
+      .kms()
+      .listAliases(new ListAliasesCommand({ KeyId: first.KeyMetadata.KeyId }));
+
+    // Then only its own come back.
+    assertArrayLength(listed.Aliases ?? [], 2);
+  });
+
+  it("lists every alias when no key is named", async () => {
+    // Given a key with one alias.
+    const simAws = new SimAws();
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: created.KeyMetadata?.KeyId,
+      }),
+    );
+
+    // When aliases are listed with no key.
+    const listed = await simAws.kms().listAliases(new ListAliasesCommand({}));
+
+    // Then the alias is reported with its ARN and target.
+    assertArrayLength(listed.Aliases ?? [], 1);
+    assertIdentical(listed.Aliases?.[0]?.AliasName, "alias/app-key");
+  });
+});
+
+describe("KMS AWS managed keys", () => {
+  it("creates an AWS managed key on first reference to its alias", async () => {
+    // Given a simulation where nothing has created a key.
+    const simAws = new SimAws();
+
+    // When a reserved AWS alias is used to encrypt.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: "alias/aws/s3", Plaintext: plaintext }),
+      );
+
+    // Then the key exists, as an AWS managed one, the way it appears on real
+    // AWS when a service first needs it.
+    assertNonNullable(encrypted.KeyId);
+
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+    assertIdentical(described.KeyMetadata?.KeyManager, "AWS");
+    assertIdentical(described.KeyMetadata.Arn, encrypted.KeyId);
+  });
+
+  it("reuses the same AWS managed key on later references", async () => {
+    // Given an AWS managed key materialised by a first reference.
+    const simAws = new SimAws();
+    const first = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // When the alias is used again.
+    const second = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // Then it is the same key, not a new one each time.
+    assertIdentical(second.KeyMetadata?.Arn, first.KeyMetadata?.Arn);
+
+    const keys = await simAws.kms().listKeys(new ListKeysCommand({}));
+    assertArrayLength(keys.Keys ?? [], 1);
+  });
+});
+
+describe("KMS ListKeys", () => {
+  it("truncates the listing at a requested limit", async () => {
+    // Given three keys.
+    const simAws = new SimAws();
+    await Promise.all(
+      [1, 2, 3].map(async () =>
+        simAws.kms().createKey(new CreateKeyCommand({})),
+      ),
+    );
+
+    // When two are asked for.
+    const listed = await simAws
+      .kms()
+      .listKeys(new ListKeysCommand({ Limit: 2 }));
+
+    // Then two come back, marked truncated.
+    assertArrayLength(listed.Keys ?? [], 2);
+    assertTrue(listed.Truncated ?? false);
+  });
+
+  it("reports the whole listing as untruncated", async () => {
+    // Given two keys.
+    const simAws = new SimAws();
+    await simAws.kms().createKey(new CreateKeyCommand({}));
+    await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When they are listed with room to spare.
+    const listed = await simAws
+      .kms()
+      .listKeys(new ListKeysCommand({ Limit: 5 }));
+
+    // Then nothing is truncated.
+    assertArrayLength(listed.Keys ?? [], 2);
+    assertFalse(listed.Truncated ?? true);
+  });
+});

--- a/src/service/kms/key/sim-kms-key-resolution.iso.test.ts
+++ b/src/service/kms/key/sim-kms-key-resolution.iso.test.ts
@@ -2,8 +2,6 @@ import {
   CreateAliasCommand,
   CreateKeyCommand,
   DescribeKeyCommand,
-  EncryptCommand,
-  ListAliasesCommand,
   ListKeysCommand,
 } from "@aws-sdk/client-kms";
 import {
@@ -20,12 +18,9 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
 import {
-  SimKmsAlreadyExistsException,
   SimKmsNotFoundException,
   SimKmsValidationException,
 } from "../error/sim-kms.error.js";
-
-const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
 
 describe("KMS KeyId resolution", () => {
   it("resolves a key by ID, ARN, alias name and alias ARN", async () => {
@@ -129,188 +124,6 @@ describe("KMS KeyId resolution", () => {
   });
 });
 
-describe("KMS aliases", () => {
-  it("refuses an alias name already in use", async () => {
-    // Given an alias pointing at a key.
-    const simAws = new SimAws();
-    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
-    assertNonNullable(created.KeyMetadata);
-
-    await simAws.kms().createAlias(
-      new CreateAliasCommand({
-        AliasName: "alias/app-key",
-        TargetKeyId: created.KeyMetadata.KeyId,
-      }),
-    );
-
-    // When the same name is created again.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.kms().createAlias(
-        new CreateAliasCommand({
-          AliasName: "alias/app-key",
-          TargetKeyId: created.KeyMetadata?.KeyId,
-        }),
-      ),
-    );
-
-    // Then KMS refuses it.
-    assertInstanceOf(error, SimKmsAlreadyExistsException);
-  });
-
-  it("refuses an alias name without the alias prefix", async () => {
-    // Given a key.
-    const simAws = new SimAws();
-    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
-
-    // When an alias is asked for without the required prefix.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.kms().createAlias(
-        new CreateAliasCommand({
-          AliasName: "app-key",
-          TargetKeyId: created.KeyMetadata?.KeyId,
-        }),
-      ),
-    );
-
-    // Then it is refused.
-    assertInstanceOf(error, SimKmsValidationException);
-  });
-
-  it("refuses an alias reserved for AWS managed keys", async () => {
-    // Given a key.
-    const simAws = new SimAws();
-    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
-
-    // When a reserved alias is asked for.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.kms().createAlias(
-        new CreateAliasCommand({
-          AliasName: "alias/aws/s3",
-          TargetKeyId: created.KeyMetadata?.KeyId,
-        }),
-      ),
-    );
-
-    // Then it is refused, as real KMS refuses the aws/ namespace.
-    assertInstanceOf(error, SimKmsValidationException);
-  });
-
-  it("refuses an alias name with characters KMS does not allow", async () => {
-    // Given a key.
-    const simAws = new SimAws();
-    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
-
-    // When an alias containing a space is asked for.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.kms().createAlias(
-        new CreateAliasCommand({
-          AliasName: "alias/app key",
-          TargetKeyId: created.KeyMetadata?.KeyId,
-        }),
-      ),
-    );
-
-    // Then it is refused.
-    assertInstanceOf(error, SimKmsValidationException);
-  });
-
-  it("lists the aliases of one key", async () => {
-    // Given two keys, one of which has two aliases.
-    const simAws = new SimAws();
-    const first = await simAws.kms().createKey(new CreateKeyCommand({}));
-    const second = await simAws.kms().createKey(new CreateKeyCommand({}));
-    assertNonNullable(first.KeyMetadata);
-    assertNonNullable(second.KeyMetadata);
-
-    await Promise.all(
-      ["alias/one", "alias/two"].map(async (aliasName) =>
-        simAws.kms().createAlias(
-          new CreateAliasCommand({
-            AliasName: aliasName,
-            TargetKeyId: first.KeyMetadata?.KeyId,
-          }),
-        ),
-      ),
-    );
-    await simAws.kms().createAlias(
-      new CreateAliasCommand({
-        AliasName: "alias/other",
-        TargetKeyId: second.KeyMetadata.KeyId,
-      }),
-    );
-
-    // When one key's aliases are listed.
-    const listed = await simAws
-      .kms()
-      .listAliases(new ListAliasesCommand({ KeyId: first.KeyMetadata.KeyId }));
-
-    // Then only its own come back.
-    assertArrayLength(listed.Aliases ?? [], 2);
-  });
-
-  it("lists every alias when no key is named", async () => {
-    // Given a key with one alias.
-    const simAws = new SimAws();
-    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
-    await simAws.kms().createAlias(
-      new CreateAliasCommand({
-        AliasName: "alias/app-key",
-        TargetKeyId: created.KeyMetadata?.KeyId,
-      }),
-    );
-
-    // When aliases are listed with no key.
-    const listed = await simAws.kms().listAliases(new ListAliasesCommand({}));
-
-    // Then the alias is reported with its ARN and target.
-    assertArrayLength(listed.Aliases ?? [], 1);
-    assertIdentical(listed.Aliases?.[0]?.AliasName, "alias/app-key");
-  });
-});
-
-describe("KMS AWS managed keys", () => {
-  it("creates an AWS managed key on first reference to its alias", async () => {
-    // Given a simulation where nothing has created a key.
-    const simAws = new SimAws();
-
-    // When a reserved AWS alias is used to encrypt.
-    const encrypted = await simAws
-      .kms()
-      .encrypt(
-        new EncryptCommand({ KeyId: "alias/aws/s3", Plaintext: plaintext }),
-      );
-
-    // Then the key exists, as an AWS managed one, the way it appears on real
-    // AWS when a service first needs it.
-    assertNonNullable(encrypted.KeyId);
-
-    const described = await simAws
-      .kms()
-      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
-    assertIdentical(described.KeyMetadata?.KeyManager, "AWS");
-    assertIdentical(described.KeyMetadata.Arn, encrypted.KeyId);
-  });
-
-  it("reuses the same AWS managed key on later references", async () => {
-    // Given an AWS managed key materialised by a first reference.
-    const simAws = new SimAws();
-    const first = await simAws
-      .kms()
-      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
-
-    // When the alias is used again.
-    const second = await simAws
-      .kms()
-      .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
-
-    // Then it is the same key, not a new one each time.
-    assertIdentical(second.KeyMetadata?.Arn, first.KeyMetadata?.Arn);
-
-    const keys = await simAws.kms().listKeys(new ListKeysCommand({}));
-    assertArrayLength(keys.Keys ?? [], 1);
-  });
-});
-
 describe("KMS ListKeys", () => {
   it("truncates the listing at a requested limit", async () => {
     // Given three keys.
@@ -345,5 +158,86 @@ describe("KMS ListKeys", () => {
     // Then nothing is truncated.
     assertArrayLength(listed.Keys ?? [], 2);
     assertFalse(listed.Truncated ?? true);
+  });
+});
+
+describe("KMS ARN scoping", () => {
+  it("does not resolve a key ARN belonging to another Account", async () => {
+    // Given a key, and the same key ID written into another Account's ARN.
+    const accountId = makeSimAwsAccountId();
+    const otherAccountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    const foreignArn = `arn:aws:kms:${simAws.defaultRegionName}:${otherAccountId}:key/${created.KeyMetadata.KeyId}`;
+
+    // When the foreign ARN is used.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().describeKey(new DescribeKeyCommand({ KeyId: foreignArn })),
+    );
+
+    // Then it resolves to nothing, rather than having its key ID pulled out
+    // and looked up in this Account.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("does not resolve a key ARN belonging to another Region", async () => {
+    // Given a key, and the same key ID written into another Region's ARN.
+    const simAws = new SimAws();
+    const created = await simAws
+      .region("eu-west-2")
+      .kms()
+      .createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    const foreignArn = `arn:aws:kms:us-east-1:${simAws.defaultAccountId}:key/${created.KeyMetadata.KeyId}`;
+
+    // When the foreign ARN is used against the Region that owns the key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .kms()
+        .describeKey(new DescribeKeyCommand({ KeyId: foreignArn })),
+    );
+
+    // Then it is not found.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("does not resolve an ARN for another service", async () => {
+    // Given a simulation with a key.
+    const simAws = new SimAws({ defaultAccountId: makeSimAwsAccountId() });
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    // When an ARN naming a different service is used.
+    const otherServiceArn = `arn:aws:s3:${simAws.defaultRegionName}:${simAws.defaultAccountId}:key/${created.KeyMetadata.KeyId}`;
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .describeKey(new DescribeKeyCommand({ KeyId: otherServiceArn })),
+    );
+
+    // Then it is not found.
+    assertInstanceOf(error, SimKmsNotFoundException);
+  });
+
+  it("does not resolve an in-scope ARN naming neither a key nor an alias", async () => {
+    // Given a simulation with a key.
+    const simAws = new SimAws({ defaultAccountId: makeSimAwsAccountId() });
+    await simAws.kms().createKey(new CreateKeyCommand({}));
+
+    // When an ARN for this scope names some other kind of KMS resource.
+    const grantArn = `arn:aws:kms:${simAws.defaultRegionName}:${simAws.defaultAccountId}:grant/abc`;
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().describeKey(new DescribeKeyCommand({ KeyId: grantArn })),
+    );
+
+    // Then it is not found, rather than being read as a key identifier.
+    assertInstanceOf(error, SimKmsNotFoundException);
   });
 });

--- a/src/service/kms/key/sim-kms-key-store.ts
+++ b/src/service/kms/key/sim-kms-key-store.ts
@@ -1,0 +1,172 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimKmsAlreadyExistsException,
+  SimKmsNotFoundException,
+  SimKmsValidationException,
+} from "../error/sim-kms.error.js";
+import {
+  SimKmsAlias,
+  simKmsAliasPrefix,
+  simKmsAwsAliasPrefix,
+} from "./sim-kms-alias.js";
+import {
+  SimKmsKeyManager,
+  type SimKmsKey,
+  type SimKmsKeyId,
+} from "./sim-kms-key.js";
+import type { SimKmsKeyFactory } from "./sim-kms-key-factory.js";
+
+interface SimKmsKeyStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly keyFactory: SimKmsKeyFactory;
+}
+
+/**
+ * The keys and aliases of one simulated KMS scope, and how a KeyId resolves.
+ *
+ * Every KMS operation takes its target as a `KeyId` that may be a key ID, a
+ * key ARN, an alias name or an alias ARN, so resolution belongs in one place
+ * rather than in each command handler.
+ */
+export class SimKmsKeyStore {
+  public readonly keys = new Map<SimKmsKeyId, SimKmsKey>();
+  public readonly aliases = new Map<string, SimKmsAlias>();
+
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly keyFactory: SimKmsKeyFactory;
+
+  constructor(properties: SimKmsKeyStoreProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.keyFactory = properties.keyFactory;
+  }
+
+  /**
+   * Store a newly created key.
+   */
+  add(key: SimKmsKey): void {
+    this.keys.set(key.keyId, key);
+  }
+
+  /**
+   * Resolve a KeyId to the key it names, or refuse.
+   */
+  require(keyId: string | undefined): SimKmsKey {
+    if (keyId === undefined || keyId === "") {
+      throw new SimKmsValidationException("KeyId is required");
+    }
+
+    const key = this.find(keyId);
+
+    if (key === undefined) {
+      throw new SimKmsNotFoundException(
+        `Key '${keyId}' does not exist in Account ${this.accountRegionScope.accountId} Region ${this.accountRegionScope.regionName}`,
+      );
+    }
+
+    return key;
+  }
+
+  /**
+   * Resolve a KeyId in any of the forms real KMS accepts.
+   *
+   * An alias of an AWS managed key resolves to a key created on demand, since
+   * that is how such a key comes into existence on real AWS: the service that
+   * needs it asks for it, and it appears without anyone creating it.
+   */
+  find(keyId: string): SimKmsKey | undefined {
+    const aliasName = this.aliasNameIn(keyId);
+
+    if (aliasName !== undefined) {
+      return this.findByAlias(aliasName);
+    }
+
+    return this.keys.get(this.keyIdIn(keyId));
+  }
+
+  /**
+   * Point an alias at a key, refusing a name already in use.
+   */
+  addAlias(aliasName: string, targetKey: SimKmsKey): SimKmsAlias {
+    if (this.aliases.has(aliasName)) {
+      throw new SimKmsAlreadyExistsException(
+        `Alias '${aliasName}' already exists`,
+      );
+    }
+
+    const alias = new SimKmsAlias({
+      aliasName,
+      targetKeyId: targetKey.keyId,
+      accountRegionScope: this.accountRegionScope,
+    });
+
+    this.aliases.set(aliasName, alias);
+
+    return alias;
+  }
+
+  /**
+   * The aliases pointing at one key, or all of them.
+   */
+  aliasesFor(keyId: SimKmsKeyId | undefined): readonly SimKmsAlias[] {
+    const all = this.aliases.values().toArray();
+
+    if (keyId === undefined) {
+      return all;
+    }
+
+    return all.filter((alias) => alias.targetKeyId === keyId);
+  }
+
+  /**
+   * Find the key an alias points at, creating an AWS managed key if the alias
+   * is a reserved one that has not been used yet.
+   */
+  private findByAlias(aliasName: string): SimKmsKey | undefined {
+    const alias = this.aliases.get(aliasName);
+
+    if (alias !== undefined) {
+      return this.keys.get(alias.targetKeyId);
+    }
+
+    if (!aliasName.startsWith(simKmsAwsAliasPrefix)) {
+      return undefined;
+    }
+
+    return this.makeAwsManagedKey(aliasName);
+  }
+
+  /**
+   * Create an AWS managed key on first reference to its reserved alias.
+   */
+  private makeAwsManagedKey(aliasName: string): SimKmsKey {
+    const key = this.keyFactory.make({
+      description: `Default key that protects my ${aliasName.slice(simKmsAwsAliasPrefix.length)} resources when no other key is defined`,
+      keyManager: SimKmsKeyManager.Aws,
+    });
+
+    this.add(key);
+    this.addAlias(aliasName, key);
+
+    return key;
+  }
+
+  /**
+   * The alias name in a KeyId, whether given bare or as an alias ARN.
+   */
+  private aliasNameIn(keyId: string): string | undefined {
+    if (keyId.startsWith(simKmsAliasPrefix)) {
+      return keyId;
+    }
+
+    const arnAlias = /:(alias\/.+)$/u.exec(keyId);
+
+    return arnAlias?.[1];
+  }
+
+  /**
+   * The key ID in a KeyId, whether given bare or as a key ARN.
+   */
+  private keyIdIn(keyId: string): SimKmsKeyId {
+    return /:key\/(.+)$/u.exec(keyId)?.[1] ?? keyId;
+  }
+}

--- a/src/service/kms/key/sim-kms-key-store.ts
+++ b/src/service/kms/key/sim-kms-key-store.ts
@@ -4,11 +4,8 @@ import {
   SimKmsNotFoundException,
   SimKmsValidationException,
 } from "../error/sim-kms.error.js";
-import {
-  SimKmsAlias,
-  simKmsAliasPrefix,
-  simKmsAwsAliasPrefix,
-} from "./sim-kms-alias.js";
+import { SimKmsAlias, simKmsAwsAliasPrefix } from "./sim-kms-alias.js";
+import { SimKmsKeyIdentifierParser } from "./sim-kms-key-identifier.js";
 import {
   SimKmsKeyManager,
   type SimKmsKey,
@@ -34,10 +31,14 @@ export class SimKmsKeyStore {
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly keyFactory: SimKmsKeyFactory;
+  private readonly identifiers: SimKmsKeyIdentifierParser;
 
   constructor(properties: SimKmsKeyStoreProperties) {
     this.accountRegionScope = properties.accountRegionScope;
     this.keyFactory = properties.keyFactory;
+    this.identifiers = new SimKmsKeyIdentifierParser(
+      properties.accountRegionScope,
+    );
   }
 
   /**
@@ -74,13 +75,17 @@ export class SimKmsKeyStore {
    * needs it asks for it, and it appears without anyone creating it.
    */
   find(keyId: string): SimKmsKey | undefined {
-    const aliasName = this.aliasNameIn(keyId);
+    const identifier = this.identifiers.parse(keyId);
 
-    if (aliasName !== undefined) {
-      return this.findByAlias(aliasName);
+    if (identifier.aliasName !== undefined) {
+      return this.findByAlias(identifier.aliasName);
     }
 
-    return this.keys.get(this.keyIdIn(keyId));
+    if (identifier.keyId === undefined) {
+      return undefined;
+    }
+
+    return this.keys.get(identifier.keyId);
   }
 
   /**
@@ -148,25 +153,5 @@ export class SimKmsKeyStore {
     this.addAlias(aliasName, key);
 
     return key;
-  }
-
-  /**
-   * The alias name in a KeyId, whether given bare or as an alias ARN.
-   */
-  private aliasNameIn(keyId: string): string | undefined {
-    if (keyId.startsWith(simKmsAliasPrefix)) {
-      return keyId;
-    }
-
-    const arnAlias = /:(alias\/.+)$/u.exec(keyId);
-
-    return arnAlias?.[1];
-  }
-
-  /**
-   * The key ID in a KeyId, whether given bare or as a key ARN.
-   */
-  private keyIdIn(keyId: string): SimKmsKeyId {
-    return /:key\/(.+)$/u.exec(keyId)?.[1] ?? keyId;
   }
 }

--- a/src/service/kms/key/sim-kms-key.ts
+++ b/src/service/kms/key/sim-kms-key.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimKmsInvalidStateException } from "../error/sim-kms.error.js";
 import type { SimKmsCiphertextBlobParts } from "./sim-kms-ciphertext-blob.js";
 import type { SimKmsEncryptionContext } from "./sim-kms-encryption-context.js";
 import {
@@ -102,8 +103,21 @@ export class SimKmsKey {
 
   /**
    * Schedule the key for deletion after a recovery window.
+   *
+   * An AWS managed key is refused. The service that owns it created it and
+   * only that service can remove it, so letting a test delete one would let
+   * the test pass on something real AWS would not allow. The failure is
+   * reported as an invalid state, which is one of the errors real
+   * ScheduleKeyDeletion returns, rather than claiming to know exactly which
+   * error AWS picks for this case.
    */
   scheduleDeletion(deletionDate: Date): void {
+    if (this.keyManager === SimKmsKeyManager.Aws) {
+      throw new SimKmsInvalidStateException(
+        `Key ${this.arn} is an AWS managed key and cannot be scheduled for deletion`,
+      );
+    }
+
     this.lifecycle.scheduleDeletion(deletionDate);
   }
 

--- a/src/service/kms/key/sim-kms-key.ts
+++ b/src/service/kms/key/sim-kms-key.ts
@@ -1,0 +1,138 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimKmsCiphertextBlobParts } from "./sim-kms-ciphertext-blob.js";
+import type { SimKmsEncryptionContext } from "./sim-kms-encryption-context.js";
+import {
+  SimKmsKeyLifecycle,
+  type SimKmsKeyState,
+} from "./sim-kms-key-lifecycle.js";
+import type { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
+import type { SimKmsKeyPolicy } from "./sim-kms-key-policy.js";
+
+export { SimKmsKeyState } from "./sim-kms-key-lifecycle.js";
+
+/**
+ * Who created and controls a key. AWS managed keys are created by a service
+ * on first use rather than by the customer, and cannot be deleted.
+ */
+export const SimKmsKeyManager = {
+  Aws: "AWS",
+  Customer: "CUSTOMER",
+} as const;
+
+export type SimKmsKeyManager =
+  (typeof SimKmsKeyManager)[keyof typeof SimKmsKeyManager];
+
+export type SimKmsKeyId = string;
+
+interface SimKmsKeyProperties {
+  readonly keyId: SimKmsKeyId;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly material: SimKmsKeyMaterial;
+  readonly policy: SimKmsKeyPolicy;
+  readonly creationDate: Date;
+  readonly description?: string | undefined;
+  readonly keyManager?: SimKmsKeyManager | undefined;
+}
+
+/**
+ * A stored simulated KMS key.
+ *
+ * The key owns its material, its policy and its lifecycle, because all three
+ * live exactly as long as the key does and every cryptographic operation needs
+ * to consult all three.
+ */
+export class SimKmsKey {
+  public readonly keyId: SimKmsKeyId;
+  public readonly arn: string;
+  public readonly creationDate: Date;
+  public readonly keyManager: SimKmsKeyManager;
+  public readonly policy: SimKmsKeyPolicy;
+  public readonly description: string;
+
+  private readonly material: SimKmsKeyMaterial;
+  private readonly lifecycle: SimKmsKeyLifecycle;
+
+  constructor(properties: SimKmsKeyProperties) {
+    const { accountRegionScope } = properties;
+
+    this.keyId = properties.keyId;
+    this.arn = `arn:aws:kms:${accountRegionScope.regionName}:${accountRegionScope.accountId}:key/${properties.keyId}`;
+    this.material = properties.material;
+    this.policy = properties.policy;
+    this.creationDate = properties.creationDate;
+    this.description = properties.description ?? "";
+    this.keyManager = properties.keyManager ?? SimKmsKeyManager.Customer;
+    this.lifecycle = new SimKmsKeyLifecycle(this.arn);
+  }
+
+  /**
+   * The key's current lifecycle state.
+   */
+  get keyState(): SimKmsKeyState {
+    return this.lifecycle.state;
+  }
+
+  /**
+   * Whether the key is enabled, as DescribeKey reports it.
+   */
+  get isEnabled(): boolean {
+    return this.lifecycle.isEnabled;
+  }
+
+  /**
+   * When the key is due to be deleted, if deletion is scheduled.
+   */
+  get deletionDate(): Date | undefined {
+    return this.lifecycle.deletionDate;
+  }
+
+  /**
+   * Enable the key.
+   */
+  enable(): void {
+    this.lifecycle.enable();
+  }
+
+  /**
+   * Disable the key, leaving it present but unusable.
+   */
+  disable(): void {
+    this.lifecycle.disable();
+  }
+
+  /**
+   * Schedule the key for deletion after a recovery window.
+   */
+  scheduleDeletion(deletionDate: Date): void {
+    this.lifecycle.scheduleDeletion(deletionDate);
+  }
+
+  /**
+   * Cancel a scheduled deletion, leaving the key disabled.
+   */
+  cancelDeletion(): void {
+    this.lifecycle.cancelDeletion();
+  }
+
+  /**
+   * Encrypt plaintext under this key.
+   */
+  encrypt(
+    plaintext: Uint8Array,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    this.lifecycle.requireUsable();
+    return this.material.encrypt(plaintext, encryptionContext);
+  }
+
+  /**
+   * Decrypt a ciphertext produced under this key.
+   */
+  decrypt(
+    parts: SimKmsCiphertextBlobParts,
+    encryptionContext?: SimKmsEncryptionContext,
+  ): Uint8Array {
+    this.lifecycle.requireUsable();
+    return this.material.decrypt(parts, encryptionContext);
+  }
+}

--- a/src/service/kms/key/sim-kms-policy-document.ts
+++ b/src/service/kms/key/sim-kms-policy-document.ts
@@ -1,0 +1,42 @@
+import { SimKmsValidationException } from "../error/sim-kms.error.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+
+/**
+ * Reads a key policy from the JSON string the real KMS API takes.
+ *
+ * CreateKey and PutKeyPolicy both take the policy this way, so parsing it, and
+ * refusing it in the same terms when it is not a policy document, belongs in
+ * one place.
+ */
+export class SimKmsPolicyDocument {
+  /**
+   * Parse a policy, or refuse if it is not valid JSON.
+   *
+   * A document object is accepted too, because writing one inline is the
+   * obvious thing to do from a test and stringifying it adds nothing.
+   */
+  parse(policy: string | SimIamPolicyDocument): SimIamPolicyDocument {
+    if (typeof policy !== "string") {
+      return policy;
+    }
+
+    try {
+      return JSON.parse(policy) as SimIamPolicyDocument;
+    } catch {
+      throw new SimKmsValidationException(
+        "Policy is not a valid JSON policy document",
+      );
+    }
+  }
+
+  /**
+   * Parse an optional policy, leaving it undefined when none was given.
+   */
+  parseOptional(policy: string | undefined): SimIamPolicyDocument | undefined {
+    if (policy === undefined) {
+      return undefined;
+    }
+
+    return this.parse(policy);
+  }
+}

--- a/src/service/kms/key/sim-kms-policy-document.ts
+++ b/src/service/kms/key/sim-kms-policy-document.ts
@@ -20,13 +20,7 @@ export class SimKmsPolicyDocument {
       return policy;
     }
 
-    try {
-      return JSON.parse(policy) as SimIamPolicyDocument;
-    } catch {
-      throw new SimKmsValidationException(
-        "Policy is not a valid JSON policy document",
-      );
-    }
+    return this.requireDocument(this.parsed(policy));
   }
 
   /**
@@ -38,5 +32,35 @@ export class SimKmsPolicyDocument {
     }
 
     return this.parse(policy);
+  }
+
+  /**
+   * A policy has to be a JSON object. `null`, an array and a bare scalar are
+   * all valid JSON and none of them is a policy document, so refusing them
+   * here reports the problem where it was made rather than at the point some
+   * later authorization tries to evaluate them.
+   */
+  private requireDocument(parsed: unknown): SimIamPolicyDocument {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new SimKmsValidationException(
+        "Policy is not a valid JSON policy document",
+      );
+    }
+
+    return parsed;
+  }
+
+  private parsed(policy: string): unknown {
+    try {
+      return JSON.parse(policy);
+    } catch {
+      throw new SimKmsValidationException(
+        "Policy is not a valid JSON policy document",
+      );
+    }
   }
 }

--- a/src/service/kms/sdk/sim-kms-sdk-command-router.iso.test.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-command-router.iso.test.ts
@@ -1,0 +1,134 @@
+import {
+  CancelKeyDeletionCommand,
+  CreateAliasCommand,
+  CreateKeyCommand,
+  DecryptCommand,
+  DescribeKeyCommand,
+  DisableKeyCommand,
+  EnableKeyCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+  GetKeyPolicyCommand,
+  KMSClient,
+  ListAliasesCommand,
+  ListKeysCommand,
+  PutKeyPolicyCommand,
+  ScheduleKeyDeletionCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("SimKmsSdkCommandRouter", () => {
+  it("names every Command simulated KMS handles", () => {
+    // Given a scoped simulated KMS.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.kms().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateKeyCommand",
+      "DescribeKeyCommand",
+      "ListKeysCommand",
+      "GetKeyPolicyCommand",
+      "PutKeyPolicyCommand",
+      "EnableKeyCommand",
+      "DisableKeyCommand",
+      "ScheduleKeyDeletionCommand",
+      "CancelKeyDeletionCommand",
+      "CreateAliasCommand",
+      "ListAliasesCommand",
+      "EncryptCommand",
+      "DecryptCommand",
+      "GenerateDataKeyCommand",
+    ]);
+  });
+
+  it("has no route for a Command simulated KMS does not handle", () => {
+    // Given a scoped simulated KMS.
+    const simAws = new SimAws();
+
+    // When an unsupported Command name is looked up.
+    const route = simAws.kms().sdkCommandRouter().route("CreateGrantCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+
+  it("routes every supported Command through an intercepted client", async () => {
+    // Given an intercepted KMS SDK client.
+    const accountId = makeSimAwsAccountId();
+    const simSdk = new SimSdk({
+      simAws: new SimAws({ defaultAccountId: accountId }),
+    });
+    simSdk.intercept(KMSClient);
+
+    const kms = new KMSClient({ region: "us-east-1" });
+
+    // When each supported Command is sent through the SDK.
+    const created = await kms.send(
+      new CreateKeyCommand({ Description: "Router key" }),
+    );
+    assertNonNullable(created.KeyMetadata);
+    const keyArn = created.KeyMetadata.Arn;
+
+    await kms.send(
+      new CreateAliasCommand({
+        AliasName: "alias/router",
+        TargetKeyId: keyArn,
+      }),
+    );
+
+    const encrypted = await kms.send(
+      new EncryptCommand({ KeyId: "alias/router", Plaintext: plaintext }),
+    );
+    const decrypted = await kms.send(
+      new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+    );
+    const dataKey = await kms.send(
+      new GenerateDataKeyCommand({ KeyId: keyArn, KeySpec: "AES_256" }),
+    );
+
+    const described = await kms.send(new DescribeKeyCommand({ KeyId: keyArn }));
+    const keys = await kms.send(new ListKeysCommand({}));
+    const aliases = await kms.send(new ListAliasesCommand({}));
+    const policy = await kms.send(new GetKeyPolicyCommand({ KeyId: keyArn }));
+
+    await kms.send(
+      new PutKeyPolicyCommand({
+        KeyId: keyArn,
+        Policy: policy.Policy,
+      }),
+    );
+
+    await kms.send(new DisableKeyCommand({ KeyId: keyArn }));
+    await kms.send(new EnableKeyCommand({ KeyId: keyArn }));
+    await kms.send(new ScheduleKeyDeletionCommand({ KeyId: keyArn }));
+    const cancelled = await kms.send(
+      new CancelKeyDeletionCommand({ KeyId: keyArn }),
+    );
+
+    // Then each reached simulated KMS and came back with an AWS-shaped result.
+    const roundTripped = Buffer.from(decrypted.Plaintext ?? new Uint8Array());
+    assertIdentical(roundTripped.toString("utf8"), "hunter2");
+    assertIdentical(dataKey.Plaintext?.byteLength, 32);
+    assertIdentical(described.KeyMetadata?.Description, "Router key");
+    assertArrayLength(keys.Keys ?? [], 1);
+    assertArrayLength(aliases.Aliases ?? [], 1);
+    assertIdentical(cancelled.KeyId, keyArn);
+
+    simSdk.restoreAll();
+  });
+});

--- a/src/service/kms/sdk/sim-kms-sdk-command-router.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-command-router.ts
@@ -1,0 +1,164 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimCreateAliasCommand,
+  SimListAliasesCommand,
+} from "../command/alias/alias.command.js";
+import type {
+  SimDecryptCommand,
+  SimEncryptCommand,
+  SimGenerateDataKeyCommand,
+} from "../command/crypto/crypto.command.js";
+import type {
+  SimCancelKeyDeletionCommand,
+  SimCreateKeyCommand,
+  SimDescribeKeyCommand,
+  SimDisableKeyCommand,
+  SimEnableKeyCommand,
+  SimGetKeyPolicyCommand,
+  SimListKeysCommand,
+  SimPutKeyPolicyCommand,
+  SimScheduleKeyDeletionCommand,
+} from "../command/key/key.command.js";
+import type { SimKms } from "../sim-kms.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated KMS instance.
+ */
+export class SimKmsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simKms: SimKms) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.createKey(
+            command as SimCreateKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.describeKey(
+            command as SimDescribeKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListKeysCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.listKeys(
+            command as SimListKeysCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetKeyPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.getKeyPolicy(
+            command as SimGetKeyPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutKeyPolicyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.putKeyPolicy(
+            command as SimPutKeyPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "EnableKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.enableKey(
+            command as SimEnableKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DisableKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.disableKey(
+            command as SimDisableKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ScheduleKeyDeletionCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.scheduleKeyDeletion(
+            command as SimScheduleKeyDeletionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CancelKeyDeletionCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.cancelKeyDeletion(
+            command as SimCancelKeyDeletionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateAliasCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.createAlias(
+            command as SimCreateAliasCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListAliasesCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.listAliases(
+            command as SimListAliasesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "EncryptCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.encrypt(
+            command as SimEncryptCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DecryptCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.decrypt(
+            command as SimDecryptCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GenerateDataKeyCommand",
+        async (command, context): Promise<unknown> =>
+          await simKms.generateDataKey(
+            command as SimGenerateDataKeyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated KMS can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated KMS supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/kms/sdk/sim-kms-sdk-routing.iso.test.ts
+++ b/src/service/kms/sdk/sim-kms-sdk-routing.iso.test.ts
@@ -1,0 +1,131 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  EncryptCommand,
+  KMSClient,
+} from "@aws-sdk/client-kms";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { SimSdk } from "../../../sdk/index.js";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { makeLambdaCodeZip } from "../../lambda/function/code/make-lambda-code-zip.js";
+
+const emptyBytes = new Uint8Array();
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+describe("KMS SDK interception", () => {
+  it("routes an intercepted KMSClient to simulated KMS", async () => {
+    // Given an intercepted KMS SDK client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(KMSClient);
+
+    const kmsClient = new KMSClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a key and uses it.
+    const created = await kmsClient.send(new CreateKeyCommand({}));
+    const encrypted = await kmsClient.send(
+      new EncryptCommand({
+        KeyId: created.KeyMetadata?.KeyId,
+        Plaintext: plaintext,
+      }),
+    );
+    const decrypted = await kmsClient.send(
+      new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+    );
+
+    // Then the round trip works with nothing touching the network.
+    const roundTripped = Buffer.from(decrypted.Plaintext ?? emptyBytes);
+    assertIdentical(roundTripped.toString("utf8"), "hunter2");
+
+    simSdk.restoreAll();
+  });
+
+  it("decrypts inside a Lambda handler as the execution Role", async () => {
+    // Given a key whose policy admits only one Role, and a function running as
+    // that Role, whose code fetches and decrypts a value with the SDK.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "DecrypterRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "DecrypterRole",
+        PolicyName: "DecryptPolicy",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "kms:Decrypt", Resource: "*" },
+        }),
+      }),
+    );
+
+    const created = await simAws.kms().createKey(new CreateKeyCommand({}));
+    assertNonNullable(created.KeyMetadata);
+
+    const encrypted = await simAws.kms().encrypt(
+      new EncryptCommand({
+        KeyId: created.KeyMetadata.Arn,
+        Plaintext: plaintext,
+      }),
+    );
+    assertNonNullable(encrypted.CiphertextBlob);
+
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "decrypter",
+        Role: role.Role.Arn,
+        Handler: "index.handler",
+        Code: {
+          ZipFile: makeLambdaCodeZip({
+            "index.js":
+              'const { KMSClient, DecryptCommand } = require("@aws-sdk/client-kms");\n' +
+              "exports.handler = async (event) => {\n" +
+              "  const client = new KMSClient({});\n" +
+              "  const out = await client.send(new DecryptCommand({\n" +
+              "    CiphertextBlob: Buffer.from(event.blob, 'base64'),\n" +
+              "  }));\n" +
+              "  return Buffer.from(out.Plaintext).toString('utf8');\n" +
+              "};\n",
+          }),
+        },
+      }),
+    );
+
+    await simAws.backgroundTasksComplete();
+
+    // When the function is invoked with the ciphertext.
+    const blobBase64 = Buffer.from(encrypted.CiphertextBlob).toString("base64");
+    const invoked = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "decrypter",
+        Payload: JSON.stringify({
+          blob: blobBase64,
+        }),
+      }),
+    );
+
+    // Then the handler's own SDK call reached simulated KMS as the execution
+    // Role, and the key policy plus that Role's identity policy allowed it.
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+    assertStringIncludes(payload.toString("utf8"), "hunter2");
+  });
+});

--- a/src/service/kms/sim-kms.ts
+++ b/src/service/kms/sim-kms.ts
@@ -1,0 +1,273 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import { SimKmsAliasCommands } from "./command/alias/sim-kms-alias-commands.js";
+import type * as simKmsCommands from "./command/sim-kms-command.types.js";
+import { SimKmsAuthorizer } from "./command/authorize/sim-kms-authorizer.js";
+import { SimKmsCryptoCommands } from "./command/crypto/sim-kms-crypto-commands.js";
+import { SimKmsGenerateDataKey } from "./command/crypto/sim-kms-generate-data-key.js";
+import { SimKmsKeyCommands } from "./command/key/sim-kms-key-commands.js";
+import { SimKmsListKeys } from "./command/key/sim-kms-list-keys.js";
+import { SimKmsKeyLifecycleCommands } from "./command/key/sim-kms-key-lifecycle-commands.js";
+import { SimKmsKeyPolicyCommands } from "./command/key/sim-kms-key-policy-commands.js";
+import type { SimKmsKey } from "./key/sim-kms-key.js";
+import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
+import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
+import { SimKmsKeyStore } from "./key/sim-kms-key-store.js";
+import { SimKmsSdkCommandRouter } from "./sdk/sim-kms-sdk-command-router.js";
+
+export interface SimKmsRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface SimKmsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated KMS. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * Encryption here is real encryption, not a stand-in: each key holds real
+ * AES-256 key material and the operations run through Node's crypto. A
+ * ciphertext genuinely cannot be read without its key, and a decryption with
+ * the wrong encryption context genuinely fails.
+ */
+export class SimKms {
+  private readonly keys: SimKmsKeyStore;
+  private readonly keyCommands: SimKmsKeyCommands;
+  private readonly listKeysCommand: SimKmsListKeys;
+  private readonly lifecycleCommands: SimKmsKeyLifecycleCommands;
+  private readonly policyCommands: SimKmsKeyPolicyCommands;
+  private readonly aliasCommands: SimKmsAliasCommands;
+  private readonly cryptoCommands: SimKmsCryptoCommands;
+  private readonly generateDataKeyCommand: SimKmsGenerateDataKey;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimKmsSdkCommandRouter(this);
+
+  constructor(properties: SimKmsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const keyFactory = new SimKmsKeyFactory({
+      accountRegionScope,
+      clock: background,
+    });
+    const authorizer = new SimKmsAuthorizer({ iam, accountRegionScope });
+
+    this.background = background;
+    this.keys = new SimKmsKeyStore({ accountRegionScope, keyFactory });
+    this.keyCommands = new SimKmsKeyCommands({
+      keys: this.keys,
+      keyFactory,
+      authorizer,
+      metadata: new SimKmsKeyMetadataView(accountRegionScope.accountId),
+    });
+    this.listKeysCommand = new SimKmsListKeys({ keys: this.keys, authorizer });
+    this.lifecycleCommands = new SimKmsKeyLifecycleCommands({
+      keys: this.keys,
+      authorizer,
+      clock: background,
+    });
+    this.policyCommands = new SimKmsKeyPolicyCommands({
+      keys: this.keys,
+      authorizer,
+    });
+    this.aliasCommands = new SimKmsAliasCommands({
+      keys: this.keys,
+      authorizer,
+    });
+    this.cryptoCommands = new SimKmsCryptoCommands({
+      keys: this.keys,
+      authorizer,
+    });
+    this.generateDataKeyCommand = new SimKmsGenerateDataKey({
+      keys: this.keys,
+      authorizer,
+    });
+  }
+
+  /**
+   * Find a key by key ID, key ARN, alias name or alias ARN.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting key
+   * state without going through a Command and its authorization.
+   */
+  findKey(keyId: string): SimKmsKey | undefined {
+    return this.keys.find(keyId);
+  }
+
+  /**
+   * Handle a CreateKey Command from the SDK.
+   */
+  async createKey(
+    command: simKmsCommands.SimCreateKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimCreateKeyCommandOutput> {
+    await this.background.sequence();
+    return this.keyCommands.create(command, options);
+  }
+
+  /**
+   * Handle a DescribeKey Command from the SDK.
+   */
+  async describeKey(
+    command: simKmsCommands.SimDescribeKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimDescribeKeyCommandOutput> {
+    await this.background.sequence();
+    return this.keyCommands.describe(command, options);
+  }
+
+  /**
+   * Handle a ListKeys Command from the SDK.
+   */
+  async listKeys(
+    command: simKmsCommands.SimListKeysCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimListKeysCommandOutput> {
+    await this.background.sequence();
+    return this.listKeysCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a GetKeyPolicy Command from the SDK.
+   */
+  async getKeyPolicy(
+    command: simKmsCommands.SimGetKeyPolicyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimGetKeyPolicyCommandOutput> {
+    await this.background.sequence();
+    return this.policyCommands.get(command, options);
+  }
+
+  /**
+   * Handle a PutKeyPolicy Command from the SDK.
+   */
+  async putKeyPolicy(
+    command: simKmsCommands.SimPutKeyPolicyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimPutKeyPolicyCommandOutput> {
+    await this.background.sequence();
+    return this.policyCommands.put(command, options);
+  }
+
+  /**
+   * Handle an EnableKey Command from the SDK.
+   */
+  async enableKey(
+    command: simKmsCommands.SimEnableKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimEnableKeyCommandOutput> {
+    await this.background.sequence();
+    return this.lifecycleCommands.enable(command, options);
+  }
+
+  /**
+   * Handle a DisableKey Command from the SDK.
+   */
+  async disableKey(
+    command: simKmsCommands.SimDisableKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimDisableKeyCommandOutput> {
+    await this.background.sequence();
+    return this.lifecycleCommands.disable(command, options);
+  }
+
+  /**
+   * Handle a ScheduleKeyDeletion Command from the SDK.
+   */
+  async scheduleKeyDeletion(
+    command: simKmsCommands.SimScheduleKeyDeletionCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimScheduleKeyDeletionCommandOutput> {
+    await this.background.sequence();
+    return this.lifecycleCommands.scheduleDeletion(command, options);
+  }
+
+  /**
+   * Handle a CancelKeyDeletion Command from the SDK.
+   */
+  async cancelKeyDeletion(
+    command: simKmsCommands.SimCancelKeyDeletionCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimCancelKeyDeletionCommandOutput> {
+    await this.background.sequence();
+    return this.lifecycleCommands.cancelDeletion(command, options);
+  }
+
+  /**
+   * Handle a CreateAlias Command from the SDK.
+   */
+  async createAlias(
+    command: simKmsCommands.SimCreateAliasCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimCreateAliasCommandOutput> {
+    await this.background.sequence();
+    return this.aliasCommands.create(command, options);
+  }
+
+  /**
+   * Handle a ListAliases Command from the SDK.
+   */
+  async listAliases(
+    command: simKmsCommands.SimListAliasesCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimListAliasesCommandOutput> {
+    await this.background.sequence();
+    return this.aliasCommands.list(command, options);
+  }
+
+  /**
+   * Handle an Encrypt Command from the SDK.
+   */
+  async encrypt(
+    command: simKmsCommands.SimEncryptCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimEncryptCommandOutput> {
+    await this.background.sequence();
+    return this.cryptoCommands.encrypt(command, options);
+  }
+
+  /**
+   * Handle a Decrypt Command from the SDK.
+   */
+  async decrypt(
+    command: simKmsCommands.SimDecryptCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimDecryptCommandOutput> {
+    await this.background.sequence();
+    return this.cryptoCommands.decrypt(command, options);
+  }
+
+  /**
+   * Handle a GenerateDataKey Command from the SDK.
+   */
+  async generateDataKey(
+    command: simKmsCommands.SimGenerateDataKeyCommand,
+    options?: SimKmsRequestOptions,
+  ): Promise<simKmsCommands.SimGenerateDataKeyCommandOutput> {
+    await this.background.sequence();
+    return this.generateDataKeyCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/lambda/serve/sim-lambda-url-router.ts
+++ b/src/service/lambda/serve/sim-lambda-url-router.ts
@@ -45,7 +45,7 @@ export class SimLambdaUrlRouter {
   constructor(properties: SimLambdaUrlRouterProperties = {}) {
     this.simAws = properties.simAws ?? new SimAws();
     this.urlRegistry =
-      properties.urlRegistry ?? this.simAws.lambdaUrlRegistry();
+      properties.urlRegistry ?? this.simAws.serviceFactory.lambdaUrlRegistry;
   }
 
   /**


### PR DESCRIPTION
Simulated KMS with real AES-256-GCM key material via Node crypto. The encryption context binds as GCM additional authenticated data, so a mismatched context fails the cipher as it does on real KMS.

Key policies are evaluated by sim IAM as mandatory resource policies, distinguishing a statement naming the caller from one delegating to the Account, so the default key policy still requires an identity policy allow.

Resolves https://github.com/KensioSoftware/yulin/issues/204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a simulated AWS KMS service with key management, aliases, encryption/decryption, envelope-style data keys, and key lifecycle handling (including encryption-context verification).
  * Exposed KMS through scoped simulator accessors and AWS SDK KMS command routing (including Lambda execution scenarios).
  * Added public package export for KMS and supporting docs/examples.
* **Authorization Improvements**
  * Enhanced IAM evaluation to distinguish direct resource-policy allowances from delegated/account-based authorization, controlled by a new request flag.
* **Documentation**
  * Expanded KMS service documentation and added runnable KMS examples.
* **Tests**
  * Added integration and validation test coverage for KMS crypto, aliases, lifecycle, authorization, scoping, and SDK routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->