### PR TITLE
feat: create simulated secrets from AWS::SecretsManager::Secret

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -32,6 +32,7 @@ Sim CloudFormation currently supports:
   - `AWS::S3::Bucket`
   - `AWS::CloudFront::Distribution`
   - `AWS::Lambda::Function`
+  - `AWS::SecretsManager::Secret`
   - CloudFront Functions used by CDK-generated templates
   - selected CDK custom resources such as CDK S3 BucketDeployment
 
@@ -977,6 +978,7 @@ Current supported resource areas include:
 - `AWS::S3::Bucket`
 - `AWS::CloudFront::Distribution`
 - `AWS::Lambda::Function`
+- `AWS::SecretsManager::Secret`
 - selected CloudFront Function resources emitted by CDK
 - selected CDK custom resources, including CDK S3 BucketDeployment
 

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -20,6 +20,8 @@ Sim Secrets Manager currently supports:
 - Friendly names, full ARNs and partial ARNs as interchangeable ways to name a secret
 - Authorization of every operation by simulated IAM, against the real IAM action
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+- Creating secrets from `AWS::SecretsManager::Secret` CloudFormation resources, including
+  `GenerateSecretString` generated passwords
 
 The simulator focuses on useful behaviour for isolated tests and local development rather than full Secrets Manager feature parity.
 
@@ -271,6 +273,74 @@ try {
 }
 ```
 
+## Deploying a secret from CloudFormation
+
+Simulated CloudFormation creates a secret from an `AWS::SecretsManager::Secret` resource, in the stack's account and region. A template either supplies the value with `SecretString` or asks Secrets Manager to generate one with `GenerateSecretString`, as on real AWS; declaring both is refused, as CloudFormation refuses it.
+
+`Ref` on the resource gives the full secret ARN, random suffix and all, and `Fn::GetAtt … Id` gives the same. That is what makes a `Ref` usable directly as a `SecretId`, whether it goes into a Lambda's environment or into an IAM policy resource.
+
+```typescript sim-secrets-manager-cloudformation-secret
+/**
+ * Deploying a secret from a CloudFormation template and reading back the
+ * password the deployment generated.
+ */
+
+import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "database-stack",
+  template: {
+    Resources: {
+      DbSecret: {
+        Type: "AWS::SecretsManager::Secret",
+        Properties: {
+          Name: "db-credentials",
+          Description: "Credentials for the application database",
+          GenerateSecretString: {
+            SecretStringTemplate: JSON.stringify({ username: "app" }),
+            GenerateStringKey: "password",
+            PasswordLength: 24,
+            ExcludePunctuation: true,
+          },
+        },
+      },
+    },
+    Outputs: {
+      DbSecretArn: {
+        Value: { Ref: "DbSecret" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the ARN including its suffix, so it works as a SecretId.
+const secretArn = stack.outputs.get("DbSecretArn")?.value as string;
+
+const read = await simAws
+  .secretsManager()
+  .getSecretValue(new GetSecretValueCommand({ SecretId: secretArn }));
+
+const credentials = JSON.parse(read.SecretString ?? "{}") as {
+  username?: string;
+  password?: string;
+};
+
+console.log(credentials.username); // "app"
+console.log(credentials.password?.length); // 24
+```
+
+Generated passwords are genuinely random, so a test reads the value back out of the simulation the way a deployed application does rather than predicting it. `SecretStringTemplate` and `GenerateStringKey` go together: the generated password is added to the template's JSON object under that key. Without them, the whole secret value is the generated password, which is what an empty `GenerateSecretString: {}` — the property CDK synthesises for a `secretsmanager.Secret` with no options — produces.
+
+The other generation options behave as they do on real AWS: `PasswordLength` (32 by default), `ExcludeCharacters`, `ExcludeUppercase`, `ExcludeLowercase`, `ExcludeNumbers`, `ExcludePunctuation`, `IncludeSpace`, and `RequireEachIncludedType`, which is on unless turned off so a generated password carries one of every character type it was not told to exclude.
+
+A secret with no `Name` is named after its logical ID. Real CloudFormation names it after the stack and appends its own random characters, so a template relying on the exact generated name would be relying on something it cannot predict anyway.
+
 ## Inside a simulated Lambda handler
 
 Function code requiring `@aws-sdk/client-secrets-manager` is routed into the same simulated AWS environment, with the function's execution role as the caller. A handler fetching a secret therefore has to be allowed to, by that role's policy, the same as on real AWS. See [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles work.
@@ -284,7 +354,10 @@ Current documented limitations:
 - Secret values are not encrypted. `KmsKeyId` is accepted and reported by `DescribeSecret`, but nothing is encrypted with it and no `kms:Decrypt` check happens. That is looser than real AWS, where a caller also needs permission on the key. Simulated KMS is not wired into this service yet.
 - A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's resource part when a partial ARN is resolved. Note that this rules out ordinary-looking names such as `app-secret` and `prod-config`, since `secret` and `config` are six characters; name them `app-credentials` or `prod-settings` instead.
 - `RotateSecret`, `CancelRotateSecret` and the rotation Lambda protocol are not simulated. `DescribeSecret` always reports `RotationEnabled` as `false`.
-- `AWS::SecretsManager::Secret` and the other CloudFormation resource types are not supported yet, and neither are `{{resolve:secretsmanager:...}}` dynamic references.
+- `AWS::SecretsManager::Secret` supports `Name`, `Description`, `KmsKeyId`, `SecretString`, `GenerateSecretString` and `Tags`. `ReplicaRegions` is ignored, and the other resource types — `SecretTargetAttachment`, `RotationSchedule` and `ResourcePolicy` — are reported as unsupported and skipped rather than deployed.
+- A template declaring neither `SecretString` nor `GenerateSecretString` is refused, which is stricter than real CloudFormation: it creates an empty secret in that case, and a secret with no version is not simulated. A secret that nothing can read is more likely a mistake in the template than something to deploy quietly.
+- `ExcludeCharacters` that removes every character of an included type is refused rather than generating a password missing a type it was told to include.
+- `{{resolve:secretsmanager:...}}` dynamic references are not supported. That is a CloudFormation engine feature rather than a Secrets Manager one; pass the ARN from `Ref` instead.
 - Resource policies (`PutResourcePolicy`, `GetResourcePolicy`, `DeleteResourcePolicy`, `ValidateResourcePolicy`) are not simulated, so cross-account access to a secret cannot be granted.
 - Replica regions are not simulated. `AddReplicaRegions`, `ReplicateSecretToRegions` and `RemoveRegionsFromReplication` do nothing, and `ReplicationStatus` is not reported.
 - `BatchGetSecretValue` is not supported, and neither is the Parameters and Secrets Lambda Extension HTTP endpoint.

--- a/docs/services/secretsmanager/sim-secrets-manager-cloudformation-secret.example.ts
+++ b/docs/services/secretsmanager/sim-secrets-manager-cloudformation-secret.example.ts
@@ -1,0 +1,53 @@
+/**
+ * Deploying a secret from a CloudFormation template and reading back the
+ * password the deployment generated.
+ */
+
+import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "database-stack",
+  template: {
+    Resources: {
+      DbSecret: {
+        Type: "AWS::SecretsManager::Secret",
+        Properties: {
+          Name: "db-credentials",
+          Description: "Credentials for the application database",
+          GenerateSecretString: {
+            SecretStringTemplate: JSON.stringify({ username: "app" }),
+            GenerateStringKey: "password",
+            PasswordLength: 24,
+            ExcludePunctuation: true,
+          },
+        },
+      },
+    },
+    Outputs: {
+      DbSecretArn: {
+        Value: { Ref: "DbSecret" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the ARN including its suffix, so it works as a SecretId.
+const secretArn = stack.outputs.get("DbSecretArn")?.value as string;
+
+const read = await simAws
+  .secretsManager()
+  .getSecretValue(new GetSecretValueCommand({ SecretId: secretArn }));
+
+const credentials = JSON.parse(read.SecretString ?? "{}") as {
+  username?: string;
+  password?: string;
+};
+
+console.log(credentials.username); // "app"
+console.log(credentials.password?.length); // 24

--- a/src/service/cloudformation/cdk/secretsmanager/sim-cdk-secret-lambda.loc.test.ts
+++ b/src/service/cloudformation/cdk/secretsmanager/sim-cdk-secret-lambda.loc.test.ts
@@ -1,0 +1,125 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringLength,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const emptyBytes = new Uint8Array();
+
+/**
+ * A handler reading the secret whose ARN CDK put in its environment.
+ */
+const readSecretHandlerSource = `
+const { SecretsManagerClient, GetSecretValueCommand } = require("@aws-sdk/client-secrets-manager");
+const client = new SecretsManagerClient({});
+exports.handler = async () => {
+  const output = await client.send(
+    new GetSecretValueCommand({ SecretId: process.env.SECRET_ARN }),
+  );
+  return JSON.parse(output.SecretString);
+};
+`;
+
+describe("Sim CDK Secrets Manager deployment local integration", () => {
+  it("deploys a CDK secret a granted Lambda reads", async () => {
+    // Given a CDK stack with a generated secret and a Lambda granted read
+    // access to it, handed the secret ARN through its environment.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const dbSecret = new secretsmanager.Secret(stack, "DbSecret", {
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: "app" }),
+    generateStringKey: "password",
+    passwordLength: 24,
+    excludePunctuation: true,
+  },
+});
+
+const readerFunction = new lambda.Function(stack, "ReaderFunction", {
+  functionName: "cdk-secret-reader",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(readSecretHandlerSource)}),
+  environment: {
+    SECRET_ARN: dbSecret.secretArn,
+  },
+});
+
+dbSecret.grantRead(readerFunction);
+
+new cdk.CfnOutput(stack, "DbSecretArn", {
+  value: dbSecret.secretArn,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into sim CloudFormation, with no
+    // hand-editing of the GenerateSecretString CDK emits.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the secret ARN CDK output carries the random suffix real Secrets
+    // Manager appends.
+    const secretArn = stack.outputs.get("DbSecretArn")?.value;
+    assertTypeString(secretArn);
+
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(new GetSecretValueCommand({ SecretId: secretArn }));
+    assertTypeString(read.SecretString);
+
+    // And the deployed function reads the generated password as its granted
+    // execution role.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "cdk-secret-reader" }));
+
+    assertUndefined(invoked.FunctionError);
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    const value = JSON.parse(payload) as {
+      username?: string;
+      password?: string;
+    };
+
+    assertIdentical(value.username, "app");
+    assertNonNullable(value.password);
+    assertStringLength(value.password, 24);
+    assertIdentical(read.SecretString, JSON.stringify(value));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/secretsmanager/sim-secrets-manager-secret-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/secretsmanager/sim-secrets-manager-secret-cfn.ts
@@ -1,0 +1,42 @@
+import type { SimSecretsManagerSecret } from "../../../../secretsmanager/secret/sim-secrets-manager-secret.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSecretsManagerSecretCfnProperties {
+  readonly secret: SimSecretsManagerSecret;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Secrets Manager secret.
+ */
+export class SimSecretsManagerSecretCfn implements SimCfnResourceValueAdapter {
+  private readonly secret: SimSecretsManagerSecret;
+
+  constructor(properties: SimSecretsManagerSecretCfnProperties) {
+    this.secret = properties.secret;
+  }
+
+  /**
+   * AWS::SecretsManager::Secret Ref returns the full secret ARN, random
+   * suffix and all, which is what makes a Ref usable as a SecretId.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.secret.arn.value;
+  }
+
+  /**
+   * AWS::SecretsManager::Secret attributes supported by the simulator.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Id": {
+        return this.secret.arn.value;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::SecretsManager::Secret attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -18,6 +18,8 @@ import { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.
 import { SimLambdaFunctionCfn } from "./lambda/sim-lambda-function-cfn.js";
 import { SimLambdaFunctionUrl } from "../../../lambda/function/url/sim-lambda-function-url.js";
 import { SimLambdaFunctionUrlCfn } from "./lambda/sim-lambda-function-url-cfn.js";
+import { SimSecretsManagerSecret } from "../../../secretsmanager/secret/sim-secrets-manager-secret.js";
+import { SimSecretsManagerSecretCfn } from "./secretsmanager/sim-secrets-manager-secret-cfn.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -104,6 +106,15 @@ export function simCfnResourceValueAdapter(
   ) {
     return new SimLambdaFunctionUrlCfn({
       functionUrl: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::SecretsManager::Secret" &&
+    properties.simResource instanceof SimSecretsManagerSecret
+  ) {
+    return new SimSecretsManagerSecretCfn({
+      secret: properties.simResource,
     });
   }
 

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -63,6 +63,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "S3": {
       return scopedAws.s3().cfnResourceFactory();
     }
+    case "SecretsManager": {
+      return scopedAws.secretsManager().cfnResourceFactory();
+    }
     default: {
       throw new Error(
         `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,

--- a/src/service/secretsmanager/README.md
+++ b/src/service/secretsmanager/README.md
@@ -89,6 +89,29 @@ There is no resource policy support yet, so unlike KMS this service passes no re
 the IAM decision. Cross-account access to a secret therefore cannot be granted, which is documented
 as a limitation rather than quietly allowed.
 
+## CloudFormation
+
+`cfn/` owns `AWS::SecretsManager::*`, resolved into the CloudFormation engine by
+`sim-cfn-service-resolver.ts`. Only `Secret` is created; the other resource types are reported as
+unsupported, which is what makes the engine skip them rather than fail the stack.
+
+`SimCfnSecretsManagerSecretCreator` goes through the ordinary `CreateSecret` command rather than
+building a secret directly, so a secret a template deployed is the same thing an SDK caller would
+have got, name validation and ARN suffix included. Property reading lives in
+`SimCfnSecretsManagerSecretProperties`, which owns the one rule worth stating in a single place: a
+template supplies a value or asks for one to be generated, never both and never neither.
+
+Password generation lives in `secret/generate/` rather than in `cfn/`, because it is Secrets Manager
+behaviour rather than CloudFormation behaviour — `GetRandomPassword` would use the same rules under
+the same option names. `SimSecretsManagerPasswordSpec` validates a request when it is described, so
+a contradiction such as four required character types in a three-character password is refused
+before anything is generated. The randomness is real rather than seedable: a test that wants the
+generated value reads it back out of the simulation, as a deployed application does.
+
+`Ref` and `Fn::GetAtt … Id` both give the full ARN, through `SimSecretsManagerSecretCfn`. That
+carries the random suffix, which is what makes a `Ref` into an IAM policy resource behave here the
+way it does on real AWS.
+
 ## Divergences worth knowing
 
 - `KmsKeyId` is stored and reported but nothing is encrypted with it, and no `kms:Decrypt` check
@@ -97,5 +120,10 @@ as a limitation rather than quietly allowed.
 - `ListSecrets` refuses `Filters` and `SortOrder` rather than ignoring them.
 - A version that has lost every staging label is kept rather than removed, so it stays readable by
   version id. It is left out of `VersionIdsToStages` either way.
+- An `AWS::SecretsManager::Secret` declaring neither `SecretString` nor `GenerateSecretString` is
+  refused. Real CloudFormation creates an empty secret; a secret with no version is not simulated,
+  and refusing is the fail-closed reading.
+- `ExcludeCharacters` that empties an included character type is refused rather than generating a
+  password quietly missing a type it was told to include.
 
 The full list is in [docs/services/secretsmanager](../../../docs/services/secretsmanager/).

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generate-secret-string-parser.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generate-secret-string-parser.ts
@@ -1,0 +1,124 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimSecretsManagerGeneratedSecretString } from "../../secret/generate/sim-secrets-manager-generated-secret-string.js";
+import { SimSecretsManagerPasswordSpec } from "../../secret/generate/sim-secrets-manager-password-spec.js";
+import { SimCfnSecretsManagerPropertyParser } from "../sim-cfn-secrets-manager-property-parser.js";
+
+/**
+ * Parses the AWS::SecretsManager::Secret GenerateSecretString property into a
+ * generated secret value.
+ *
+ * CDK synthesises this property for every `secretsmanager.Secret`, even an
+ * empty one, so a template that omits every option still has to generate the
+ * 32-character password real Secrets Manager would.
+ */
+export class SimCfnSecretsManagerGenerateSecretStringParser {
+  private readonly propertyParser = new SimCfnSecretsManagerPropertyParser();
+
+  /**
+   * Parse GenerateSecretString, if the Resource declares it.
+   */
+  parse(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+  ): SimSecretsManagerGeneratedSecretString | undefined {
+    const properties = this.propertyParser.optionalRecord(
+      resource,
+      value,
+      "GenerateSecretString",
+    );
+
+    if (properties === undefined) {
+      return undefined;
+    }
+
+    return new SimSecretsManagerGeneratedSecretString({
+      password: this.passwordSpec(resource, properties),
+      secretStringTemplate: this.string(
+        resource,
+        properties["SecretStringTemplate"],
+        "SecretStringTemplate",
+      ),
+      generateStringKey: this.string(
+        resource,
+        properties["GenerateStringKey"],
+        "GenerateStringKey",
+      ),
+    });
+  }
+
+  private passwordSpec(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimSecretsManagerPasswordSpec {
+    return new SimSecretsManagerPasswordSpec({
+      passwordLength: this.propertyParser.optionalNumber(
+        resource,
+        properties["PasswordLength"],
+        "GenerateSecretString.PasswordLength",
+      ),
+      excludeCharacters: this.string(
+        resource,
+        properties["ExcludeCharacters"],
+        "ExcludeCharacters",
+      ),
+      excludeUppercase: this.boolean(
+        resource,
+        properties["ExcludeUppercase"],
+        "ExcludeUppercase",
+      ),
+      excludeLowercase: this.boolean(
+        resource,
+        properties["ExcludeLowercase"],
+        "ExcludeLowercase",
+      ),
+      excludeNumbers: this.boolean(
+        resource,
+        properties["ExcludeNumbers"],
+        "ExcludeNumbers",
+      ),
+      excludePunctuation: this.boolean(
+        resource,
+        properties["ExcludePunctuation"],
+        "ExcludePunctuation",
+      ),
+      includeSpace: this.boolean(
+        resource,
+        properties["IncludeSpace"],
+        "IncludeSpace",
+      ),
+      requireEachIncludedType: this.boolean(
+        resource,
+        properties["RequireEachIncludedType"],
+        "RequireEachIncludedType",
+      ),
+    });
+  }
+
+  private string(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(
+      resource,
+      value,
+      `GenerateSecretString.${name}`,
+    );
+  }
+
+  private boolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): boolean | undefined {
+    return this.propertyParser.optionalBoolean(
+      resource,
+      value,
+      `GenerateSecretString.${name}`,
+    );
+  }
+}

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-creator.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-creator.ts
@@ -1,0 +1,61 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSecretsManagerSecret } from "../../secret/sim-secrets-manager-secret.js";
+import type { SimSecretsManager } from "../../sim-secrets-manager.js";
+import { SimCfnSecretsManagerSecretProperties } from "./sim-cfn-secrets-manager-secret-properties.js";
+
+interface SimCfnSecretsManagerSecretCreatorProperties {
+  readonly secretsManager: SimSecretsManager;
+}
+
+/**
+ * Creates simulated secrets from AWS::SecretsManager::Secret Resources.
+ *
+ * The secret is created through the ordinary CreateSecret command rather than
+ * constructed directly, so a secret a template deployed is the same thing an
+ * SDK caller would have got, name validation and ARN suffix included.
+ */
+export class SimCfnSecretsManagerSecretCreator {
+  private readonly secretsManager: SimSecretsManager;
+
+  constructor(properties: SimCfnSecretsManagerSecretCreatorProperties) {
+    this.secretsManager = properties.secretsManager;
+  }
+
+  /**
+   * Create a secret from an AWS::SecretsManager::Secret Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSecretsManagerSecret> {
+    const secretProperties = new SimCfnSecretsManagerSecretProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.secretsManager.createSecret({
+      input: {
+        Name: secretProperties.name(),
+        Description: secretProperties.description(),
+        KmsKeyId: secretProperties.kmsKeyId(),
+        SecretString: secretProperties.secretString(),
+        Tags: secretProperties.tags(),
+      },
+    });
+
+    assertDefined(
+      created.ARN,
+      `sim Secrets Manager secret ARN after CloudFormation creation for ${resource.logicalId}`,
+    );
+
+    const secret = this.secretsManager.findSecret(created.ARN);
+    assertDefined(
+      secret,
+      `sim Secrets Manager secret ${created.ARN} after CloudFormation creation`,
+    );
+
+    return secret;
+  }
+}

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-properties.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-properties.ts
@@ -1,0 +1,127 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSecretsManagerTag } from "../../secret/sim-secrets-manager-secret.js";
+import { SimCfnSecretsManagerPropertyParser } from "../sim-cfn-secrets-manager-property-parser.js";
+import { SimCfnSecretsManagerGenerateSecretStringParser } from "./sim-cfn-secrets-manager-generate-secret-string-parser.js";
+
+interface SimCfnSecretsManagerSecretPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SecretsManager::Secret CloudFormation properties into the shape
+ * the secret creator needs.
+ *
+ * Keeping the property-shape rules here leaves the creator to do nothing but
+ * call CreateSecret, and puts the one rule worth stating in a single place:
+ * a template supplies a value or asks for one to be generated, never both.
+ */
+export class SimCfnSecretsManagerSecretProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnSecretsManagerPropertyParser();
+  private readonly generateParser =
+    new SimCfnSecretsManagerGenerateSecretStringParser();
+
+  constructor(properties: SimCfnSecretsManagerSecretPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The secret name.
+   *
+   * An unnamed secret is named after its logical ID, as sim CloudFormation
+   * names other unnamed resources. Real CloudFormation prefixes the stack
+   * name and appends its own random characters, so a template relying on the
+   * exact generated name would be relying on something it cannot predict
+   * anyway.
+   */
+  name(): string {
+    return (
+      this.string(this.properties["Name"], "Name") ?? this.resource.logicalId
+    );
+  }
+
+  /**
+   * The secret Description.
+   */
+  description(): string | undefined {
+    return this.string(this.properties["Description"], "Description");
+  }
+
+  /**
+   * The KMS key the secret says it is encrypted under.
+   */
+  kmsKeyId(): string | undefined {
+    return this.string(this.properties["KmsKeyId"], "KmsKeyId");
+  }
+
+  /**
+   * The secret Tags.
+   */
+  tags(): readonly SimSecretsManagerTag[] | undefined {
+    return this.propertyParser.optionalTags(
+      this.resource,
+      this.properties["Tags"],
+      "Tags",
+    );
+  }
+
+  /**
+   * The value the secret's first version holds.
+   *
+   * Either the template supplies one or it asks for one to be generated.
+   */
+  secretString(): string {
+    const supplied = this.string(
+      this.properties["SecretString"],
+      "SecretString",
+    );
+    const generated = this.generateParser.parse(
+      this.resource,
+      this.properties["GenerateSecretString"],
+    );
+
+    if (supplied !== undefined && generated !== undefined) {
+      throw this.propertyError(
+        "SecretString and GenerateSecretString cannot both be declared: " +
+          "a secret either holds the value the template supplies or one " +
+          "Secrets Manager generates",
+      );
+    }
+
+    if (supplied !== undefined) {
+      return supplied;
+    }
+
+    if (generated !== undefined) {
+      return generated.generate();
+    }
+
+    throw this.propertyError(
+      "either SecretString or GenerateSecretString is required. Real " +
+        "CloudFormation creates an empty secret when both are omitted, " +
+        "which simulated Secrets Manager does not model, so it refuses the " +
+        "Resource rather than creating a secret that has no value to read",
+    );
+  }
+
+  private string(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(this.resource, value, name);
+  }
+
+  private propertyError(reason: string): Error {
+    return new Error(
+      `Invalid AWS::SecretsManager::Secret Resource ` +
+        `${this.resource.logicalId}: ${reason}`,
+    );
+  }
+}

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-property-parser.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-property-parser.ts
@@ -31,6 +31,23 @@ export class SimCfnSecretsManagerPropertyParser {
   }
 
   /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
    * Parse a property value that must be a number when present.
    *
    * CloudFormation carries template numbers as strings often enough that a
@@ -105,6 +122,10 @@ export class SimCfnSecretsManagerPropertyParser {
   /**
    * Parse the Tags property, which CloudFormation carries as a list of
    * Key/Value pairs.
+   *
+   * Both parts of a pair are required, as they are on real CloudFormation. A
+   * half-written tag is refused rather than stored with an absent key or
+   * value, which nothing downstream could match on.
    */
   optionalTags(
     resource: SimCfnResource,
@@ -124,8 +145,8 @@ export class SimCfnSecretsManagerPropertyParser {
       const tag = this.record(resource, entry, entryLabel);
 
       return {
-        Key: this.optionalString(resource, tag["Key"], `${entryLabel}.Key`),
-        Value: this.optionalString(
+        Key: this.requiredString(resource, tag["Key"], `${entryLabel}.Key`),
+        Value: this.requiredString(
           resource,
           tag["Value"],
           `${entryLabel}.Value`,

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-property-parser.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-property-parser.ts
@@ -1,0 +1,168 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSecretsManagerTag } from "../secret/sim-secrets-manager-secret.js";
+
+/**
+ * Validates individual AWS::SecretsManager::* CloudFormation property values,
+ * failing with a diagnostic naming the Resource type, the property and the
+ * logical ID.
+ */
+export class SimCfnSecretsManagerPropertyParser {
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that must be a number when present.
+   *
+   * CloudFormation carries template numbers as strings often enough that a
+   * numeric string is accepted here, as CloudFormation itself accepts one.
+   */
+  optionalNumber(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    throw this.invalidPropertyError(resource, label, "a number");
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and
+   * "false" in places, so both forms are accepted, as CloudFormation itself
+   * accepts them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Parse a property value that must be an object when present.
+   */
+  optionalRecord(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimCfnTemplateValueRecord | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.record(resource, value, label);
+  }
+
+  /**
+   * Parse the Tags property, which CloudFormation carries as a list of
+   * Key/Value pairs.
+   */
+  optionalTags(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): readonly SimSecretsManagerTag[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "a list");
+    }
+
+    return value.map((entry, index) => {
+      const entryLabel = `${label}.${String(index)}`;
+      const tag = this.record(resource, entry, entryLabel);
+
+      return {
+        Key: this.optionalString(resource, tag["Key"], `${entryLabel}.Key`),
+        Value: this.optionalString(
+          resource,
+          tag["Value"],
+          `${entryLabel}.Value`,
+        ),
+      };
+    });
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   *
+   * AWS::SecretsManager::Secret is the only Resource type this simulator
+   * creates, so it is named here rather than read from the Resource.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid AWS::SecretsManager::Secret ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+
+  /**
+   * Narrow a template value to an object, refusing anything else.
+   */
+  private record(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue,
+    label: string,
+  ): SimCfnTemplateValueRecord {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "an object");
+    }
+
+    return value;
+  }
+}

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
@@ -1,0 +1,52 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimSecretsManager } from "../sim-secrets-manager.js";
+import { SimCfnSecretsManagerSecretCreator } from "./secret/sim-cfn-secrets-manager-secret-creator.js";
+
+interface SimSecretsManagerCfnResourceFactoryProperties {
+  readonly secretsManager: SimSecretsManager;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Secrets Manager resources.
+ */
+export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly secretCreator: SimCfnSecretsManagerSecretCreator;
+
+  constructor(properties: SimSecretsManagerCfnResourceFactoryProperties) {
+    this.secretCreator = new SimCfnSecretsManagerSecretCreator({
+      secretsManager: properties.secretsManager,
+    });
+  }
+
+  /**
+   * Create a simulated Secrets Manager resource from a CloudFormation
+   * Resource.
+   *
+   * Rotation, resource policies and target attachments are not simulated, so
+   * their Resource types are reported as unsupported and skipped rather than
+   * quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Secret": {
+        return await this.secretCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Secrets Manager CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-lambda.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-lambda.iso.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertStringLength,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+
+const emptyBytes = new Uint8Array();
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * A handler that reads the secret whose ARN its environment carries, as an
+ * application fetching its database password on a cold start does.
+ */
+const readSecretHandlerSource = `
+const { SecretsManagerClient, GetSecretValueCommand } = require("@aws-sdk/client-secrets-manager");
+const client = new SecretsManagerClient({});
+exports.handler = async () => {
+  const output = await client.send(
+    new GetSecretValueCommand({ SecretId: process.env.SECRET_ARN }),
+  );
+  return JSON.parse(output.SecretString);
+};
+`;
+
+/**
+ * A secret ARN without the random suffix, written as CloudFormation would
+ * substitute it.
+ */
+const bareSecretArnSubstitution =
+  // eslint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+  "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:db-credentials";
+
+/**
+ * A stack holding a generated secret and a Lambda handed its ARN, with the
+ * function's execution Role allowed to read exactly that secret.
+ */
+const template: CfnTemplateBodyRecord = {
+  Resources: {
+    DbSecret: {
+      Type: "AWS::SecretsManager::Secret",
+      Properties: {
+        Name: "db-credentials",
+        GenerateSecretString: {
+          SecretStringTemplate: JSON.stringify({ username: "app" }),
+          GenerateStringKey: "password",
+          PasswordLength: 20,
+        },
+      },
+    },
+    ReaderRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "SecretReaderRole",
+        AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        Policies: [
+          {
+            PolicyName: "ReadDbSecret",
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Action: "secretsmanager:GetSecretValue",
+                  Resource: { Ref: "DbSecret" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    ReaderFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "secret-reader",
+        Role: { "Fn::GetAtt": ["ReaderRole", "Arn"] },
+        Handler: "index.handler",
+        Runtime: "nodejs20.x",
+        Code: { ZipFile: readSecretHandlerSource },
+        Environment: {
+          Variables: {
+            SECRET_ARN: { Ref: "DbSecret" },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("Secrets Manager CloudFormation Secret with Lambda", () => {
+  it("hands a Lambda the secret ARN to read the generated password", async () => {
+    // Given a stack with a generated secret, a Lambda holding its ARN in the
+    // environment, and an execution Role allowed to read it.
+    const simAws = new SimAws();
+
+    // When the stack is deployed and the function is invoked.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "db-stack", template });
+    await stack.waitForDeployComplete();
+
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "secret-reader" }));
+
+    // Then the handler read the generated value out of simulated Secrets
+    // Manager as its execution Role.
+    assertUndefined(invoked.FunctionError);
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    const value = JSON.parse(payload) as {
+      username?: string;
+      password?: string;
+    };
+
+    assertIdentical(value.username, "app");
+    assertTypeString(value.password);
+    assertStringLength(value.password, 20);
+
+    // And what the handler read is the value the deployment generated, which
+    // nothing in the test had to predict.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+      );
+    assertIdentical(read.SecretString, JSON.stringify(value));
+  });
+
+  it("denies a Lambda whose Role names the secret without its ARN suffix", async () => {
+    // Given the same stack, except that the Role's policy names the secret by
+    // a bare ARN, as a hand-written policy easily does.
+    const simAws = new SimAws();
+    const bareArnTemplate: CfnTemplateBodyRecord = {
+      Resources: {
+        ...template.Resources,
+        ReaderRole: {
+          Type: "AWS::IAM::Role",
+          Properties: {
+            RoleName: "SecretReaderRole",
+            AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            Policies: [
+              {
+                PolicyName: "ReadDbSecret",
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Effect: "Allow",
+                      Action: "secretsmanager:GetSecretValue",
+                      Resource: { "Fn::Sub": bareSecretArnSubstitution },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    // When the stack is deployed and the function is invoked.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "db-stack", template: bareArnTemplate });
+    await stack.waitForDeployComplete();
+
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "secret-reader" }));
+
+    // Then the read is denied, exactly as it would be on real AWS, where the
+    // secret's ARN carries six random characters the policy has to allow for.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    assertStringIncludes(payload, "not authorized");
+  });
+});

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-validation.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-validation.iso.test.ts
@@ -174,6 +174,30 @@ describe("Secrets Manager CloudFormation Secret validation", () => {
     );
   });
 
+  it("refuses a half-written tag", async () => {
+    // Given tag entries missing a part CloudFormation requires.
+    // When each Resource is created, then each is refused rather than storing
+    // a tag with nothing to match on.
+    const empty = await createSecretResource({
+      SecretString: "hunter2",
+      Tags: [{}],
+    });
+    assertIdentical(
+      empty.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: Tags.0.Key must be a string",
+    );
+
+    const noValue = await createSecretResource({
+      SecretString: "hunter2",
+      Tags: [{ Key: "component" }],
+    });
+    assertIdentical(
+      noValue.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: " +
+        "Tags.0.Value must be a string",
+    );
+  });
+
   it("reports Resource types it does not simulate as unsupported", async () => {
     // Given a Secrets Manager Resource type that is not simulated.
     // When the Resource is created, then it is reported as unsupported, which

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-validation.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret-validation.iso.test.ts
@@ -1,0 +1,306 @@
+import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringLength,
+  assertThrowsError,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimSecretsManagerCfnResourceFactory } from "./sim-cfn-secrets-manager-resource-factory.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function secretResource(
+  properties: SimCfnTemplateValueRecord,
+  logicalId = "BadSecret",
+): SimCfnResource {
+  return new SimCfnResource({
+    accountRegionScope: {
+      accountId: accountIdOneOnes,
+      regionName: "eu-west-2",
+    },
+    logicalId,
+    template: {
+      Type: "AWS::SecretsManager::Secret",
+      Properties: properties,
+    },
+  });
+}
+
+/**
+ * Create a secret straight through the Resource factory, returning whatever it
+ * rejects with. Keeps the property rules under test without a whole stack.
+ */
+async function createSecretResource(
+  properties: SimCfnTemplateValueRecord,
+  resourceTypeName = "Secret",
+): Promise<Error> {
+  const simAws = new SimAws();
+  const factory = new SimSecretsManagerCfnResourceFactory({
+    secretsManager: simAws.secretsManager(),
+  });
+
+  try {
+    await factory.create(resourceTypeName, secretResource(properties), {
+      simAws,
+      resources: new Map(),
+    });
+  } catch (error) {
+    assertInstanceOf(error, Error);
+
+    return error;
+  }
+
+  throw new Error("Expected Secret creation to reject");
+}
+
+describe("Secrets Manager CloudFormation Secret validation", () => {
+  it("refuses SecretString and GenerateSecretString together", async () => {
+    // Given a template both supplying a value and asking for a generated one,
+    // which real CloudFormation rejects.
+    // When the Resource is created, then it is refused.
+    const error = await createSecretResource({
+      Name: "db-credentials",
+      SecretString: "hunter2",
+      GenerateSecretString: {},
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::SecretsManager::Secret Resource BadSecret: " +
+        "SecretString and GenerateSecretString cannot both be declared: " +
+        "a secret either holds the value the template supplies or one " +
+        "Secrets Manager generates",
+    );
+  });
+
+  it("refuses a secret with no value at all", async () => {
+    // Given a template declaring neither a value nor a generated one. Real
+    // CloudFormation creates an empty secret, which is not simulated, so the
+    // Resource is refused rather than deployed with nothing to read.
+    // When the Resource is created, then it is refused.
+    const error = await createSecretResource({ Name: "db-credentials" });
+
+    assertStringIncludes(
+      error.message,
+      "either SecretString or GenerateSecretString is required",
+    );
+  });
+
+  it("refuses malformed property values", async () => {
+    // Given properties of the wrong shape.
+    // When each Resource is created, then each is refused by name.
+    const name = await createSecretResource({ Name: 42, SecretString: "x" });
+    assertInstanceOf(name, TypeError);
+    assertIdentical(
+      name.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: Name must be a string",
+    );
+
+    const generate = await createSecretResource({
+      GenerateSecretString: "please",
+    });
+    assertIdentical(
+      generate.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: " +
+        "GenerateSecretString must be an object",
+    );
+
+    const length = await createSecretResource({
+      GenerateSecretString: { PasswordLength: "very long" },
+    });
+    assertIdentical(
+      length.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: " +
+        "GenerateSecretString.PasswordLength must be a number",
+    );
+
+    const emptyLength = await createSecretResource({
+      GenerateSecretString: { PasswordLength: " " },
+    });
+    assertStringIncludes(
+      emptyLength.message,
+      "PasswordLength must be a number",
+    );
+
+    const require = await createSecretResource({
+      GenerateSecretString: { RequireEachIncludedType: "maybe" },
+    });
+    assertIdentical(
+      require.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: " +
+        "GenerateSecretString.RequireEachIncludedType must be a boolean",
+    );
+  });
+
+  it("refuses malformed Tags", async () => {
+    // Given Tags that are not a list of Key/Value objects.
+    // When each Resource is created, then each is refused.
+    const notAList = await createSecretResource({
+      SecretString: "hunter2",
+      Tags: { component: "database" },
+    });
+    assertIdentical(
+      notAList.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: Tags must be a list",
+    );
+
+    const notObjects = await createSecretResource({
+      SecretString: "hunter2",
+      Tags: ["component"],
+    });
+    assertIdentical(
+      notObjects.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: Tags.0 must be an object",
+    );
+
+    const badValue = await createSecretResource({
+      SecretString: "hunter2",
+      Tags: [{ Key: "component", Value: 7 }],
+    });
+    assertIdentical(
+      badValue.message,
+      "Invalid AWS::SecretsManager::Secret BadSecret: " +
+        "Tags.0.Value must be a string",
+    );
+  });
+
+  it("reports Resource types it does not simulate as unsupported", async () => {
+    // Given a Secrets Manager Resource type that is not simulated.
+    // When the Resource is created, then it is reported as unsupported, which
+    // is what makes sim CloudFormation skip it rather than fail the stack.
+    const error = await createSecretResource({}, "RotationSchedule");
+
+    assertIdentical(
+      error.message,
+      "Unsupported sim Secrets Manager CloudFormation Resource RotationSchedule",
+    );
+  });
+
+  it("skips an unsimulated Secrets Manager Resource in a deployed stack", async () => {
+    // Given a stack whose template carries a rotation schedule alongside a
+    // secret.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              SecretString: "hunter2",
+            },
+          },
+          DbSecretRotation: {
+            Type: "AWS::SecretsManager::RotationSchedule",
+            Properties: {
+              SecretId: { Ref: "DbSecret" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the secret deploys and the rotation schedule is skipped with a
+    // reason, rather than quietly counting as deployed.
+    const rotation = stack.getResource("DbSecretRotation");
+    assertNonNullable(rotation);
+    assertTrue(rotation.skipped);
+    assertStringIncludes(
+      rotation.skippedReason ?? "",
+      "Unsupported sim Secrets Manager CloudFormation Resource RotationSchedule",
+    );
+
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+      );
+    assertIdentical(read.SecretString, "hunter2");
+  });
+
+  it("refuses an attribute a secret does not have", async () => {
+    // Given a deployed secret.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              SecretString: "hunter2",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("DbSecret");
+    assertNonNullable(resource);
+
+    // When an attribute the simulator does not model is read, then it is
+    // refused rather than answered with something made up.
+    const error = assertThrowsError(() => resource.attributeValue("Arn"));
+
+    assertIdentical(
+      error.message,
+      "Unsupported AWS::SecretsManager::Secret attribute Arn",
+    );
+  });
+
+  it("accepts template values CloudFormation carries as strings", async () => {
+    // Given a template whose numeric and boolean options arrive as strings,
+    // as they do when they come from a Parameter.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Parameters: {
+          PasswordLength: { Type: "String", Default: "18" },
+        },
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              GenerateSecretString: {
+                PasswordLength: { Ref: "PasswordLength" },
+                ExcludePunctuation: "true",
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then they are read as the number and boolean they stand for.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+      );
+
+    assertTypeString(read.SecretString);
+    assertStringLength(read.SecretString, 18);
+    assertTrue(/^[\dA-Za-z]+$/.test(read.SecretString));
+  });
+});

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
@@ -1,0 +1,287 @@
+import {
+  DescribeSecretCommand,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringLength,
+  assertStringStartsWith,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimSecretsManagerSecret } from "../secret/sim-secrets-manager-secret.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("Secrets Manager CloudFormation Secret deployment", () => {
+  it("creates a secret holding the SecretString the template supplies", async () => {
+    // Given a template declaring a secret with a supplied value.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              Description: "Credentials for the application database",
+              KmsKeyId: "alias/aws/secretsmanager",
+              SecretString: JSON.stringify({
+                username: "app",
+                password: "hunter2",
+              }),
+              Tags: [{ Key: "component", Value: "database" }],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the deployed secret holds that value under its AWSCURRENT version.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+      );
+
+    assertIdentical(
+      read.SecretString,
+      JSON.stringify({ username: "app", password: "hunter2" }),
+    );
+    assertIdentical(read.VersionStages?.at(0), "AWSCURRENT");
+
+    // And the metadata the template declared is reported back.
+    const described = await simAws
+      .secretsManager()
+      .describeSecret(
+        new DescribeSecretCommand({ SecretId: "db-credentials" }),
+      );
+
+    assertIdentical(
+      described.Description,
+      "Credentials for the application database",
+    );
+    assertIdentical(described.KmsKeyId, "alias/aws/secretsmanager");
+    assertArrayLength(described.Tags ?? [], 1);
+    assertIdentical(described.Tags?.at(0)?.Key, "component");
+  });
+
+  it("resolves Ref and Fn::GetAtt Id to the full secret ARN", async () => {
+    // Given a template referencing its secret both ways.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              SecretString: "hunter2",
+            },
+          },
+        },
+        Outputs: {
+          SecretRef: { Value: { Ref: "DbSecret" } },
+          SecretId: { Value: { "Fn::GetAtt": ["DbSecret", "Id"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then both resolve to the ARN carrying the six random characters real
+    // Secrets Manager appends, so either can be used as a SecretId.
+    const secretRef = stack.outputs.get("SecretRef")?.value;
+    const secretId = stack.outputs.get("SecretId")?.value;
+
+    assertTypeString(secretRef);
+    assertTypeString(secretId);
+    assertIdentical(secretRef, secretId);
+    assertStringStartsWith(
+      secretRef,
+      "arn:aws:secretsmanager:eu-west-2:111111111111:secret:db-credentials-",
+    );
+
+    const suffix = secretRef.split("db-credentials-", 2).at(1);
+    assertNonNullable(suffix);
+    assertStringLength(suffix, 6);
+
+    // And the ARN the template resolved names the deployed secret.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(new GetSecretValueCommand({ SecretId: secretRef }));
+    assertIdentical(read.SecretString, "hunter2");
+  });
+
+  it("generates a value from GenerateSecretString", async () => {
+    // Given a template asking Secrets Manager to generate the password.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              GenerateSecretString: {
+                SecretStringTemplate: JSON.stringify({ username: "app" }),
+                GenerateStringKey: "password",
+                PasswordLength: 24,
+                ExcludePunctuation: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the deployed secret holds the template's username alongside a
+    // generated password honouring the options, which a test reads out of the
+    // simulation exactly as a deployed application would.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+      );
+
+    assertTypeString(read.SecretString);
+    const value = JSON.parse(read.SecretString) as {
+      username?: string;
+      password?: string;
+    };
+
+    assertIdentical(value.username, "app");
+    assertTypeString(value.password);
+    assertStringLength(value.password, 24);
+    assertTrue(/^[\dA-Za-z]+$/.test(value.password));
+  });
+
+  it("generates a whole-value password for an empty GenerateSecretString", async () => {
+    // Given the property CDK synthesises for a secret with no options, which
+    // is an empty object rather than an absent property.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          ApiSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              GenerateSecretString: {},
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the secret is named after its logical ID, as sim CloudFormation
+    // names other unnamed resources.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(new GetSecretValueCommand({ SecretId: "ApiSecret" }));
+
+    // And it holds the 32-character password real Secrets Manager defaults to.
+    assertTypeString(read.SecretString);
+    assertStringLength(read.SecretString, 32);
+  });
+
+  it("backs the CloudFormation Resource with the simulated secret", async () => {
+    // Given a deployed secret.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "db-stack",
+      template: {
+        Resources: {
+          DbSecret: {
+            Type: "AWS::SecretsManager::Secret",
+            Properties: {
+              Name: "db-credentials",
+              SecretString: "hunter2",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Resource is inspected.
+    const resource = stack.getResource("DbSecret");
+    assertNonNullable(resource);
+
+    // Then it is backed by the same simulated secret the service holds.
+    const secret = resource.simResource as SimSecretsManagerSecret | undefined;
+    assertNonNullable(secret);
+    assertIdentical(secret.name, "db-credentials");
+    assertIdentical(
+      simAws.secretsManager().findSecret("db-credentials")?.arn.value,
+      secret.arn.value,
+    );
+  });
+
+  it("creates the secret in the stack's account and region", async () => {
+    // Given a simulated AWS whose default scope is not the stack's.
+    const simAws = new SimAws();
+
+    // When a template is deployed into another account and region.
+    const stack = await simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "db-stack",
+        template: {
+          Resources: {
+            DbSecret: {
+              Type: "AWS::SecretsManager::Secret",
+              Properties: {
+                Name: "db-credentials",
+                SecretString: "hunter2",
+              },
+            },
+          },
+        },
+      });
+    await stack.waitForDeployComplete();
+
+    // Then the secret exists in that account and region, and nowhere else.
+    const scoped = simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .secretsManager();
+
+    const scopedSecret = scoped.findSecret("db-credentials");
+    assertNonNullable(scopedSecret);
+    assertStringStartsWith(
+      scopedSecret.arn.value,
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:",
+    );
+    assertUndefined(simAws.secretsManager().findSecret("db-credentials"));
+  });
+});

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-generated-secret-string.iso.test.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-generated-secret-string.iso.test.ts
@@ -1,0 +1,129 @@
+import {
+  assertIdentical,
+  assertStringLength,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSecretsManagerGeneratedSecretString } from "./sim-secrets-manager-generated-secret-string.js";
+import { SimSecretsManagerPasswordSpec } from "./sim-secrets-manager-password-spec.js";
+
+describe("Secrets Manager generated secret strings", () => {
+  it("puts the generated password into the template under its key", () => {
+    // Given a template naming a username and a key for the generated value.
+    const generated = new SimSecretsManagerGeneratedSecretString({
+      password: new SimSecretsManagerPasswordSpec({ passwordLength: 16 }),
+      secretStringTemplate: JSON.stringify({ username: "app" }),
+      generateStringKey: "password",
+    });
+
+    // When the secret value is generated.
+    const value: unknown = JSON.parse(generated.generate());
+
+    // Then the template's own fields survive alongside the generated one.
+    assertIdentical((value as { username?: string }).username, "app");
+    const password = (value as { password?: string }).password;
+    assertTypeString(password);
+    assertStringLength(password, 16);
+  });
+
+  it("makes the whole value the password when there is no template", () => {
+    // Given a generated secret with no template or key, as an empty
+    // GenerateSecretString gives.
+    const generated = new SimSecretsManagerGeneratedSecretString({
+      password: new SimSecretsManagerPasswordSpec({ passwordLength: 20 }),
+    });
+
+    // When the secret value is generated.
+    const value = generated.generate();
+
+    // Then the value is the password itself rather than a JSON object.
+    assertStringLength(value, 20);
+  });
+
+  it("overwrites a key the template already has", () => {
+    // Given a template that already carries the key being generated.
+    const generated = new SimSecretsManagerGeneratedSecretString({
+      password: new SimSecretsManagerPasswordSpec({ passwordLength: 12 }),
+      secretStringTemplate: JSON.stringify({ password: "placeholder" }),
+      generateStringKey: "password",
+    });
+
+    // When the secret value is generated.
+    const value: unknown = JSON.parse(generated.generate());
+
+    // Then the generated password replaces the placeholder.
+    const password = (value as { password?: string }).password;
+    assertTypeString(password);
+    assertStringLength(password, 12);
+  });
+
+  it("refuses a template without a key to put the password under", () => {
+    // Given a template but no GenerateStringKey.
+    // When the generated secret is described, then it is refused.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerGeneratedSecretString({
+        password: new SimSecretsManagerPasswordSpec(),
+        secretStringTemplate: JSON.stringify({ username: "app" }),
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "SecretStringTemplate and GenerateStringKey have to be supplied together",
+    );
+  });
+
+  it("refuses a key with no template to put it in", () => {
+    // Given a GenerateStringKey but no template.
+    // When the generated secret is described, then it is refused.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerGeneratedSecretString({
+        password: new SimSecretsManagerPasswordSpec(),
+        generateStringKey: "password",
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "SecretStringTemplate and GenerateStringKey have to be supplied together",
+    );
+  });
+
+  it("refuses a template that is not valid JSON", () => {
+    // Given a template that cannot be parsed.
+    const generated = new SimSecretsManagerGeneratedSecretString({
+      password: new SimSecretsManagerPasswordSpec(),
+      secretStringTemplate: "{username: app}",
+      generateStringKey: "password",
+    });
+
+    // When the secret value is generated, then it is refused.
+    const error = assertThrowsError(() => generated.generate());
+
+    assertStringIncludes(
+      error.message,
+      "SecretStringTemplate is not valid JSON",
+    );
+  });
+
+  it("refuses a template that is not a JSON object", () => {
+    // Given a template holding a JSON array rather than an object.
+    const generated = new SimSecretsManagerGeneratedSecretString({
+      password: new SimSecretsManagerPasswordSpec(),
+      secretStringTemplate: JSON.stringify(["app"]),
+      generateStringKey: "password",
+    });
+
+    // When the secret value is generated, then it is refused: there is
+    // nowhere for a keyed value to go.
+    const error = assertThrowsError(() => generated.generate());
+
+    assertStringIncludes(
+      error.message,
+      "SecretStringTemplate must be a JSON object",
+    );
+  });
+});

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-generated-secret-string.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-generated-secret-string.ts
@@ -1,0 +1,94 @@
+import { SimSecretsManagerInvalidParameterException } from "../../error/sim-secrets-manager.error.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimSecretsManagerPasswordGenerator } from "./sim-secrets-manager-password-generator.js";
+import type { SimSecretsManagerPasswordSpec } from "./sim-secrets-manager-password-spec.js";
+
+interface SimSecretsManagerGeneratedSecretStringProperties {
+  readonly password: SimSecretsManagerPasswordSpec;
+  readonly secretStringTemplate?: string | undefined;
+  readonly generateStringKey?: string | undefined;
+}
+
+/**
+ * A secret value Secrets Manager generates rather than one a caller supplies.
+ *
+ * With a template and a key, the generated password is added to the template's
+ * JSON object under that key, which is how a secret ends up holding a username
+ * a template chose alongside a password nobody has ever seen. With neither,
+ * the whole secret value is the generated password.
+ */
+export class SimSecretsManagerGeneratedSecretString {
+  private readonly password: SimSecretsManagerPasswordSpec;
+  private readonly secretStringTemplate: string | undefined;
+  private readonly generateStringKey: string | undefined;
+  private readonly generator = new SimSecretsManagerPasswordGenerator();
+
+  constructor(properties: SimSecretsManagerGeneratedSecretStringProperties) {
+    this.password = properties.password;
+    this.secretStringTemplate = properties.secretStringTemplate;
+    this.generateStringKey = properties.generateStringKey;
+
+    this.requireTemplateAndKeyTogether();
+  }
+
+  /**
+   * Generate the value the secret's first version will hold.
+   */
+  generate(): string {
+    const password = this.generator.generate(this.password);
+    const { secretStringTemplate: template, generateStringKey: key } = this;
+
+    if (template === undefined || key === undefined) {
+      return password;
+    }
+
+    return JSON.stringify({
+      ...this.templateObject(template),
+      [key]: password,
+    });
+  }
+
+  /**
+   * Refuse a template without a key, or a key without a template.
+   *
+   * Real Secrets Manager requires each one when the other is given: a template
+   * with nowhere to put the password would silently produce a secret with no
+   * generated value in it at all.
+   */
+  private requireTemplateAndKeyTogether(): void {
+    const hasTemplate = this.secretStringTemplate !== undefined;
+    const hasKey = this.generateStringKey !== undefined;
+
+    if (hasTemplate === hasKey) {
+      return;
+    }
+
+    throw new SimSecretsManagerInvalidParameterException(
+      "SecretStringTemplate and GenerateStringKey have to be supplied " +
+        "together: a template needs a key naming where the generated value " +
+        "goes, and a key needs a template to put it in",
+    );
+  }
+
+  private templateObject(template: string): Record<string, unknown> {
+    const parsed = this.parsedTemplate(template);
+
+    if (!isRecord(parsed)) {
+      throw new SimSecretsManagerInvalidParameterException(
+        `SecretStringTemplate must be a JSON object: ${template}`,
+      );
+    }
+
+    return parsed;
+  }
+
+  private parsedTemplate(template: string): unknown {
+    try {
+      return JSON.parse(template);
+    } catch {
+      throw new SimSecretsManagerInvalidParameterException(
+        `SecretStringTemplate is not valid JSON: ${template}`,
+      );
+    }
+  }
+}

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-character-set.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-character-set.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-secrets/no-secrets -- character alphabets, not secrets. */
+import { SimSecretsManagerInvalidParameterException } from "../../error/sim-secrets-manager.error.js";
+
+/**
+ * The character groups Secrets Manager draws a generated password from.
+ *
+ * These are the exact sets real Secrets Manager uses, including its
+ * punctuation set, so a password generated here passes the same password
+ * policies a real one would.
+ */
+export const secretsManagerPasswordCharacters = [
+  { name: "uppercase", characters: "ABCDEFGHIJKLMNOPQRSTUVWXYZ" },
+  { name: "lowercase", characters: "abcdefghijklmnopqrstuvwxyz" },
+  { name: "numbers", characters: "0123456789" },
+  { name: "punctuation", characters: "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" },
+  { name: "space", characters: " " },
+] as const;
+
+/**
+ * One named group of characters a generated password can draw on.
+ *
+ * A set knows how to narrow itself by excluded characters, which is what makes
+ * `ExcludeCharacters` apply to the required-type rule as well as to the pool:
+ * a type that has nothing left cannot be required.
+ */
+export class SimSecretsManagerPasswordCharacterSet {
+  public readonly name: string;
+  public readonly characters: string;
+
+  constructor(name: string, characters: string) {
+    this.name = name;
+    this.characters = characters;
+  }
+
+  /**
+   * Whether every character of this set has been excluded.
+   */
+  get isEmpty(): boolean {
+    return this.characters.length === 0;
+  }
+
+  /**
+   * The same set with every excluded character removed.
+   */
+  without(excluded: string): SimSecretsManagerPasswordCharacterSet {
+    let remaining = "";
+
+    for (const character of this.characters) {
+      if (!excluded.includes(character)) {
+        remaining += character;
+      }
+    }
+
+    return new SimSecretsManagerPasswordCharacterSet(this.name, remaining);
+  }
+
+  /**
+   * Refuse a set that has been excluded down to nothing.
+   *
+   * Real Secrets Manager is vague about an `ExcludeCharacters` that empties a
+   * character type it was also told to include. Refusing is the fail-closed
+   * reading: the request contradicts itself, and generating a password that
+   * quietly lacks a type it asked for would be worse than saying so.
+   */
+  requireNotEmpty(): void {
+    if (!this.isEmpty) {
+      return;
+    }
+
+    throw new SimSecretsManagerInvalidParameterException(
+      `ExcludeCharacters excludes every ${this.name} character, but ` +
+        `${this.name} characters are included in the generated password`,
+    );
+  }
+}

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-character-sets.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-character-sets.ts
@@ -1,0 +1,101 @@
+import { SimSecretsManagerInvalidParameterException } from "../../error/sim-secrets-manager.error.js";
+import {
+  secretsManagerPasswordCharacters,
+  SimSecretsManagerPasswordCharacterSet,
+} from "./sim-secrets-manager-password-character-set.js";
+
+/**
+ * The character-selection options a Secrets Manager password request carries.
+ *
+ * These are the `GetRandomPassword` options under their own names, which is
+ * also what `GenerateSecretString` gives a CloudFormation template.
+ */
+export interface SimSecretsManagerPasswordCharacterOptions {
+  readonly excludeUppercase?: boolean | undefined;
+  readonly excludeLowercase?: boolean | undefined;
+  readonly excludeNumbers?: boolean | undefined;
+  readonly excludePunctuation?: boolean | undefined;
+  readonly includeSpace?: boolean | undefined;
+  readonly excludeCharacters?: string | undefined;
+}
+
+/**
+ * The character sets one generated password is allowed to draw on.
+ *
+ * The `Exclude*` flags decide which types are included at all, and
+ * `ExcludeCharacters` then narrows each included type. Keeping the types apart
+ * rather than merging them into one alphabet is what lets
+ * `RequireEachIncludedType` mean anything.
+ */
+export class SimSecretsManagerPasswordCharacterSets {
+  public readonly included: readonly SimSecretsManagerPasswordCharacterSet[];
+
+  constructor(options: SimSecretsManagerPasswordCharacterOptions = {}) {
+    this.included = SimSecretsManagerPasswordCharacterSets.include(options);
+  }
+
+  private static include(
+    options: SimSecretsManagerPasswordCharacterOptions,
+  ): readonly SimSecretsManagerPasswordCharacterSet[] {
+    const excluded = options.excludeCharacters ?? "";
+    const candidates = secretsManagerPasswordCharacters
+      .filter((set) => {
+        return this.isIncluded(set.name, options);
+      })
+      .map((set) => {
+        return new SimSecretsManagerPasswordCharacterSet(
+          set.name,
+          set.characters,
+        ).without(excluded);
+      });
+
+    for (const set of candidates) {
+      set.requireNotEmpty();
+    }
+
+    if (candidates.length === 0) {
+      throw new SimSecretsManagerInvalidParameterException(
+        "A generated password needs at least one character type: every one " +
+          "of uppercase, lowercase, numbers and punctuation was excluded",
+      );
+    }
+
+    return candidates;
+  }
+
+  /**
+   * Whether a character type is included, by the flag that governs it.
+   *
+   * Every type but the space is included unless excluded; the space is the
+   * other way round, as it is on real AWS.
+   */
+  private static isIncluded(
+    name: (typeof secretsManagerPasswordCharacters)[number]["name"],
+    options: SimSecretsManagerPasswordCharacterOptions,
+  ): boolean {
+    switch (name) {
+      case "uppercase": {
+        return options.excludeUppercase !== true;
+      }
+      case "lowercase": {
+        return options.excludeLowercase !== true;
+      }
+      case "numbers": {
+        return options.excludeNumbers !== true;
+      }
+      case "punctuation": {
+        return options.excludePunctuation !== true;
+      }
+      case "space": {
+        return options.includeSpace === true;
+      }
+    }
+  }
+
+  /**
+   * Every character any included type allows, as one pool.
+   */
+  get alphabet(): string {
+    return this.included.map((set) => set.characters).join("");
+  }
+}

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-exclusions.iso.test.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-exclusions.iso.test.ts
@@ -1,0 +1,83 @@
+import {
+  assertFalse,
+  assertStringIncludes,
+  assertStringLength,
+  assertStringNotIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSecretsManagerPasswordGenerator } from "./sim-secrets-manager-password-generator.js";
+import {
+  SimSecretsManagerPasswordSpec,
+  type SimSecretsManagerPasswordOptions,
+} from "./sim-secrets-manager-password-spec.js";
+
+const generator = new SimSecretsManagerPasswordGenerator();
+
+/**
+ * Generation is random, so a property that has to hold for every generated
+ * password is checked over a run of them rather than once.
+ */
+function generateMany(
+  options: SimSecretsManagerPasswordOptions,
+): readonly string[] {
+  return Array.from({ length: 20 }, () => {
+    return generator.generate(new SimSecretsManagerPasswordSpec(options));
+  });
+}
+
+describe("Secrets Manager generated password exclusions", () => {
+  it("leaves out excluded character types", () => {
+    // Given every type excluded except lowercase letters.
+    // When passwords are generated.
+    const passwords = generateMany({
+      passwordLength: 12,
+      excludeUppercase: true,
+      excludeNumbers: true,
+      excludePunctuation: true,
+    });
+
+    // Then they are lowercase letters and nothing else.
+    for (const password of passwords) {
+      assertTrue(/^[a-z]+$/.test(password));
+      assertFalse(/[A-Z\d]/.test(password));
+    }
+  });
+
+  it("leaves out individually excluded characters", () => {
+    // Given a set of characters a password must not contain.
+    // When passwords are generated.
+    const passwords = generateMany({
+      passwordLength: 40,
+      excludeCharacters: "abcABC123",
+    });
+
+    // Then none of those characters appear.
+    for (const password of passwords) {
+      for (const excluded of "abcABC123") {
+        assertStringNotIncludes(password, excluded);
+      }
+    }
+  });
+
+  it("includes a space when asked to", () => {
+    // Given a request including the space character, with everything else
+    // excluded so the space has to appear.
+    // When a password is generated.
+    const passwords = generateMany({
+      passwordLength: 5,
+      includeSpace: true,
+      excludeUppercase: true,
+      excludeLowercase: true,
+      excludeNumbers: true,
+      excludePunctuation: true,
+    });
+
+    // Then it is made of spaces.
+    for (const password of passwords) {
+      assertStringIncludes(password, " ");
+      assertStringLength(password, 5);
+    }
+  });
+});

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-generator.iso.test.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-generator.iso.test.ts
@@ -1,0 +1,65 @@
+import { assertStringLength, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSecretsManagerPasswordGenerator } from "./sim-secrets-manager-password-generator.js";
+import {
+  SimSecretsManagerPasswordSpec,
+  type SimSecretsManagerPasswordOptions,
+} from "./sim-secrets-manager-password-spec.js";
+
+const generator = new SimSecretsManagerPasswordGenerator();
+
+function generate(options: SimSecretsManagerPasswordOptions = {}): string {
+  return generator.generate(new SimSecretsManagerPasswordSpec(options));
+}
+
+describe("Secrets Manager generated passwords", () => {
+  it("generates 32 characters when no length is asked for", () => {
+    // Given no options at all, as an empty GenerateSecretString gives.
+    // When a password is generated.
+    const password = generate();
+
+    // Then it is the 32 characters real Secrets Manager defaults to.
+    assertStringLength(password, 32);
+  });
+
+  it("generates the length asked for", () => {
+    // Given a requested password length.
+    // When a password is generated.
+    const password = generate({ passwordLength: 24 });
+
+    // Then it is exactly that long.
+    assertStringLength(password, 24);
+  });
+
+  it("includes one of every included character type by default", () => {
+    // Given the default character types. Generation is random, so the
+    // guarantee is checked over a run of passwords rather than one.
+    // When passwords are generated.
+    const passwords = Array.from({ length: 20 }, () => {
+      return generate({ passwordLength: 8 });
+    });
+
+    // Then every one of them carries all four types, as real Secrets Manager
+    // guarantees when RequireEachIncludedType is left alone.
+    for (const password of passwords) {
+      assertTrue(/[A-Z]/.test(password));
+      assertTrue(/[a-z]/.test(password));
+      assertTrue(/\d/.test(password));
+      assertTrue(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(password));
+    }
+  });
+
+  it("drops the one-of-each guarantee when RequireEachIncludedType is off", () => {
+    // Given a single-character password with all four types included, which
+    // could not hold one of each.
+    // When a password is generated without requiring each type.
+    const password = generate({
+      passwordLength: 1,
+      requireEachIncludedType: false,
+    });
+
+    // Then it is generated anyway, from the whole pool.
+    assertStringLength(password, 1);
+  });
+});

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-generator.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-generator.ts
@@ -1,0 +1,61 @@
+import { randomInt } from "node:crypto";
+import type { SimSecretsManagerPasswordSpec } from "./sim-secrets-manager-password-spec.js";
+
+/**
+ * Generates the random passwords Secrets Manager generates.
+ *
+ * The randomness is real rather than seedable: a test that wants the value
+ * reads it back out of the simulation, the same way a deployed application
+ * does, rather than predicting it. A predictable generator would make a test
+ * pass for a reason that says nothing about the deployed system.
+ */
+export class SimSecretsManagerPasswordGenerator {
+  /**
+   * Generate one password meeting a validated spec.
+   *
+   * Each required type contributes a character first and the rest is drawn
+   * from the whole pool, then the result is shuffled so the required
+   * characters do not always land at the front.
+   */
+  generate(spec: SimSecretsManagerPasswordSpec): string {
+    const characters = this.requiredCharacters(spec);
+    const alphabet = spec.characterSets.alphabet;
+
+    while (characters.length < spec.length) {
+      characters.push(this.pick(alphabet));
+    }
+
+    return this.shuffled(characters).join("");
+  }
+
+  private requiredCharacters(spec: SimSecretsManagerPasswordSpec): string[] {
+    if (!spec.requireEachIncludedType) {
+      return [];
+    }
+
+    return spec.characterSets.included.map((set) => this.pick(set.characters));
+  }
+
+  /**
+   * Pick one character uniformly, without the modulo bias a raw random byte
+   * would introduce.
+   */
+  private pick(characters: string): string {
+    return characters.charAt(randomInt(characters.length));
+  }
+
+  /**
+   * Take characters from the pool at random until it is empty, which is the
+   * Fisher-Yates shuffle written as a drawing rather than as index swaps.
+   */
+  private shuffled(characters: readonly string[]): string[] {
+    const pool = [...characters];
+    const shuffled: string[] = [];
+
+    while (pool.length > 0) {
+      shuffled.push(...pool.splice(randomInt(pool.length), 1));
+    }
+
+    return shuffled;
+  }
+}

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-spec.iso.test.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-spec.iso.test.ts
@@ -1,0 +1,82 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSecretsManagerPasswordSpec } from "./sim-secrets-manager-password-spec.js";
+
+describe("Secrets Manager password requests", () => {
+  it("refuses a password too short to hold one of each required type", () => {
+    // Given three characters and four required character types.
+    // When the request is described, then it is refused.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({ passwordLength: 3 });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "PasswordLength 3 is too short to include one of each of the 4 character types",
+    );
+  });
+
+  it("refuses a password length outside the range AWS accepts", () => {
+    // Given a zero-length password.
+    // When the request is described, then it is refused.
+    const tooShort = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({ passwordLength: 0 });
+    });
+    assertStringIncludes(
+      tooShort.message,
+      "PasswordLength 0 must be between 1 and 4096 characters",
+    );
+
+    // And a password longer than Secrets Manager generates is refused too.
+    const tooLong = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({ passwordLength: 4097 });
+    });
+    assertStringIncludes(tooLong.message, "must be between 1 and 4096");
+  });
+
+  it("refuses a fractional password length", () => {
+    // Given a length that is not a whole number.
+    // When the request is described, then it is refused.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({ passwordLength: 12.5 });
+    });
+
+    assertStringIncludes(error.message, "must be a whole number");
+  });
+
+  it("refuses a request excluding every character type", () => {
+    // Given every character type excluded.
+    // When the request is described, then it is refused rather than
+    // generating an empty password.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({
+        excludeUppercase: true,
+        excludeLowercase: true,
+        excludeNumbers: true,
+        excludePunctuation: true,
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "A generated password needs at least one character type",
+    );
+  });
+
+  it("refuses ExcludeCharacters that empties an included character type", () => {
+    // Given every digit excluded by character while numbers stay included.
+    // When the request is described, then the contradiction is refused rather
+    // than quietly generating a password with no digits in it.
+    const error = assertThrowsError(() => {
+      return new SimSecretsManagerPasswordSpec({
+        excludeCharacters: "0123456789",
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ExcludeCharacters excludes every numbers character",
+    );
+  });
+});

--- a/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-spec.ts
+++ b/src/service/secretsmanager/secret/generate/sim-secrets-manager-password-spec.ts
@@ -1,0 +1,93 @@
+import { SimSecretsManagerInvalidParameterException } from "../../error/sim-secrets-manager.error.js";
+import type { SimSecretsManagerPasswordCharacterOptions } from "./sim-secrets-manager-password-character-sets.js";
+import { SimSecretsManagerPasswordCharacterSets } from "./sim-secrets-manager-password-character-sets.js";
+
+/**
+ * The length real Secrets Manager generates when a request does not ask for
+ * one, and the range it accepts.
+ */
+const defaultPasswordLength = 32;
+const minimumPasswordLength = 1;
+const maximumPasswordLength = 4096;
+
+/**
+ * Everything a Secrets Manager password request can ask for.
+ */
+export interface SimSecretsManagerPasswordOptions extends SimSecretsManagerPasswordCharacterOptions {
+  readonly passwordLength?: number | undefined;
+  readonly requireEachIncludedType?: boolean | undefined;
+}
+
+/**
+ * A validated request for one generated password.
+ *
+ * Validation lives here rather than in the generator so a contradictory
+ * request — a length of zero, or four required character types in a
+ * three-character password — is refused when it is described rather than
+ * silently honoured in part when it is generated.
+ */
+export class SimSecretsManagerPasswordSpec {
+  public readonly length: number;
+  public readonly characterSets: SimSecretsManagerPasswordCharacterSets;
+
+  /**
+   * Whether every included character type has to appear at least once.
+   *
+   * Real Secrets Manager defaults this on, so a generated password contains
+   * one of everything it was not told to exclude.
+   */
+  public readonly requireEachIncludedType: boolean;
+
+  constructor(options: SimSecretsManagerPasswordOptions = {}) {
+    this.length = SimSecretsManagerPasswordSpec.validLength(
+      options.passwordLength,
+    );
+    this.characterSets = new SimSecretsManagerPasswordCharacterSets(options);
+    this.requireEachIncludedType = options.requireEachIncludedType !== false;
+
+    this.requireTypesFit();
+  }
+
+  private static validLength(length: number | undefined): number {
+    if (length === undefined) {
+      return defaultPasswordLength;
+    }
+
+    if (!Number.isSafeInteger(length)) {
+      throw new SimSecretsManagerInvalidParameterException(
+        `PasswordLength ${String(length)} must be a whole number`,
+      );
+    }
+
+    if (length < minimumPasswordLength || length > maximumPasswordLength) {
+      throw new SimSecretsManagerInvalidParameterException(
+        `PasswordLength ${String(length)} must be between ` +
+          `${String(minimumPasswordLength)} and ` +
+          `${String(maximumPasswordLength)} characters`,
+      );
+    }
+
+    return length;
+  }
+
+  /**
+   * Refuse a password too short to hold one of each required type.
+   */
+  private requireTypesFit(): void {
+    if (!this.requireEachIncludedType) {
+      return;
+    }
+
+    const typeCount = this.characterSets.included.length;
+
+    if (typeCount <= this.length) {
+      return;
+    }
+
+    throw new SimSecretsManagerInvalidParameterException(
+      `PasswordLength ${String(this.length)} is too short to include one of ` +
+        `each of the ${String(typeCount)} character types the request ` +
+        `requires. Exclude a character type or ask for a longer password.`,
+    );
+  }
+}

--- a/src/service/secretsmanager/sim-secrets-manager.ts
+++ b/src/service/secretsmanager/sim-secrets-manager.ts
@@ -10,6 +10,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimSecretsManagerCfnResourceFactory } from "./cfn/sim-cfn-secrets-manager-resource-factory.js";
 import { SimSecretsManagerAuthorizer } from "./command/authorize/sim-secrets-manager-authorizer.js";
 import { SimSecretsManagerLifecycleCommands } from "./command/secret/sim-secrets-manager-lifecycle-commands.js";
 import { SimSecretsManagerListSecrets } from "./command/secret/sim-secrets-manager-list-secrets.js";
@@ -50,6 +51,9 @@ export class SimSecretsManager {
   private readonly valueCommands: SimSecretsManagerValueCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSecretsManagerSdkCommandRouter(this);
+  private readonly cfnFactory = new SimSecretsManagerCfnResourceFactory({
+    secretsManager: this,
+  });
 
   constructor(properties: SimSecretsManagerProperties = {}) {
     const {
@@ -196,6 +200,14 @@ export class SimSecretsManager {
   ): Promise<simSecretsManagerCommands.SimRestoreSecretCommandOutput> {
     await this.background.sequence();
     return this.lifecycleCommands.restore(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory, which creates
+   * simulated secrets from AWS::SecretsManager::* Resources.
+   */
+  cfnResourceFactory(): SimSecretsManagerCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Deploying a template containing AWS::SecretsManager::Secret creates a simulated secret in the stack's account and region, with Ref and Fn::GetAtt Id giving the full ARN including its random suffix. GenerateSecretString generates a password honouring the template, key, length and exclusion options, so a CDK-synthesised secretsmanager.Secret deploys without hand-editing.

Resolves https://github.com/KensioSoftware/yulin/issues/206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for `AWS::SecretsManager::Secret`, including `Ref`/`Fn::GetAtt` resolving to the full secret ARN.
  * Added support for creating secrets via `GenerateSecretString` (including JSON templates and key-based insertion) with configurable password length and character options.
  * Introduced stricter fail-closed validation for invalid secret configurations and password character exclusions.
* **Documentation**
  * Expanded CloudFormation and Secrets Manager documentation, examples, and supported-property/limitation details.
* **Tests**
  * Added new end-to-end and ISO test coverage for secret deployment, Lambda read behavior, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->