### PR TITLE
feat: create simulated KMS keys from AWS::KMS::Key and AWS::KMS::Alias

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -20,6 +20,7 @@ Sim CloudFormation currently supports:
 - Deploying parsed template objects with `deployTemplate(...)`
 - Deploying synthesized JSON template files with `deployTemplateFile(...)`
 - Template `Parameters` with supplied values and defaults
+- Template `Outputs`, resolved after resource creation and read from `stack.outputs`
 - Common intrinsic functions:
   - `Ref`
   - `Fn::GetAtt`
@@ -987,6 +988,7 @@ Current supported resource areas include:
 Common template features currently supported include:
 
 - `Parameters`
+- `Outputs`, including `Description` and `Export`
 - `Ref`
 - `Fn::GetAtt`
 - `Fn::Join`
@@ -1000,7 +1002,7 @@ Notable limitations:
 - Only supported resource types create simulated service resources.
 - Unsupported resource properties may be ignored or rejected depending on the resource simulator.
 - Stack updates and deletes are not currently documented as supported operations.
-- Outputs, mappings, conditions, and many advanced CloudFormation features are not currently
+- Mappings, conditions, and many advanced CloudFormation features are not currently
   documented as supported operations.
 
 For best results, keep test templates focused on the resources and behaviours your application

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -33,6 +33,7 @@ Sim CloudFormation currently supports:
   - `AWS::CloudFront::Distribution`
   - `AWS::Lambda::Function`
   - `AWS::SecretsManager::Secret`
+  - `AWS::KMS::Key` and `AWS::KMS::Alias`
   - CloudFront Functions used by CDK-generated templates
   - selected CDK custom resources such as CDK S3 BucketDeployment
 
@@ -979,6 +980,7 @@ Current supported resource areas include:
 - `AWS::CloudFront::Distribution`
 - `AWS::Lambda::Function`
 - `AWS::SecretsManager::Secret`
+- `AWS::KMS::Key` and `AWS::KMS::Alias`
 - selected CloudFront Function resources emitted by CDK
 - selected CDK custom resources, including CDK S3 BucketDeployment
 

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -19,6 +19,7 @@ Sim KMS currently supports:
 - Key lifecycle with `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand` and `CancelKeyDeletionCommand`
 - Key policy evaluation by simulated IAM, including the rule that an identity policy cannot reach a key its policy does not admit
 - Key ARNs, key IDs, alias names and alias ARNs as interchangeable ways to name a key
+- Creating keys and aliases from `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 The simulator focuses on useful behaviour for isolated tests and local development rather than full KMS feature parity.
@@ -315,6 +316,66 @@ try {
 }
 ```
 
+## Deploying a key from CloudFormation
+
+Simulated CloudFormation creates a key from an `AWS::KMS::Key` resource and points an `AWS::KMS::Alias` at it, in the stack's account and region. The key comes out of the same `CreateKey` path an SDK caller uses, so it has real key material, and a `KeyPolicy` the template declares becomes the key policy. Omitting `KeyPolicy` gets the default root-delegation policy, exactly as `CreateKey` with no `Policy` does.
+
+`Ref` on the key gives its key ID rather than its ARN, as on real AWS, and `Fn::GetAtt` gives `Arn` or `KeyId`. `Ref` on the alias gives the alias name, such as `alias/app-key`, which is itself usable as a `KeyId`. That difference matters: a property wanting a key ID takes the `Ref`, and an IAM policy resource wanting the key needs `Fn::GetAtt … Arn`.
+
+```typescript sim-kms-cloudformation-key
+/**
+ * Deploying a KMS key and alias from a CloudFormation template, then
+ * encrypting through the alias the template created.
+ */
+
+import { DecryptCommand, EncryptCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      AppKey: {
+        Type: "AWS::KMS::Key",
+        Properties: { Description: "Application data key" },
+      },
+      AppKeyAlias: {
+        Type: "AWS::KMS::Alias",
+        Properties: {
+          AliasName: "alias/app-key",
+          TargetKeyId: { Ref: "AppKey" },
+        },
+      },
+    },
+    Outputs: {
+      KeyArn: { Value: { "Fn::GetAtt": ["AppKey", "Arn"] } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const kms = simAws.kms();
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: "alias/app-key",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+const decrypted = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+);
+
+console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
+console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
+```
+
+Properties asking for behaviour that is not simulated refuse the deployment rather than being ignored, so a template does not quietly deploy a key that would behave differently on AWS. `EnableKeyRotation`, `RotationPeriodInDays`, `MultiRegion` and `Tags` are all refused, and an asymmetric or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is refused by `CreateKey` in the same terms it refuses an SDK caller. `Enabled: false` is supported, and deploys a key that is disabled from the moment it exists.
+
 ## Inside a simulated Lambda handler
 
 Function code requiring `@aws-sdk/client-kms` is routed into the same simulated AWS environment, with the function's execution role as the caller. A handler that decrypts a value therefore has to be allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See [simulated Lambda](../lambda/) for how function code and execution roles work.
@@ -326,12 +387,14 @@ Current documented limitations:
 - Only symmetric encryption keys (`SYMMETRIC_DEFAULT`, `ENCRYPT_DECRYPT`) are simulated. Asymmetric keys, HMAC keys, `Sign`, `Verify` and `ReEncrypt` are not.
 - Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is refused.
 - Grants (`CreateGrant` and friends) are not simulated.
-- Automatic key rotation is not simulated.
-- Multi-Region keys are not simulated.
-- `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources are not supported yet.
+- Automatic key rotation is not simulated. An `AWS::KMS::Key` declaring `EnableKeyRotation` or `RotationPeriodInDays` is refused.
+- Multi-Region keys are not simulated. An `AWS::KMS::Key` declaring `MultiRegion: true` is refused.
+- `AWS::KMS::Key` accepts but ignores `PendingWindowInDays` and `BypassPolicyLockoutSafetyCheck`. Neither has anything to act on: simulated CloudFormation does not delete stacks, and simulated KMS applies no policy lockout safety check to bypass.
+- CloudFormation creates KMS resources but never changes or removes them: an `AWS::KMS::Alias` cannot be retargeted by a stack update, because `UpdateAlias` and `DeleteAlias` are not simulated.
+- `AWS::KMS::Grant` and `AWS::KMS::ReplicaKey` are not supported; a template declaring one is refused.
 - A key pending deletion stays in that state indefinitely. Advancing the simulated clock past the recovery window does not delete it, so the key ID stays taken.
 - Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
-- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated.
+- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An `AWS::KMS::Key` declaring `Tags` is refused rather than deploying with the tags dropped.
 - `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived, so a policy relying on them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
 - AWS managed keys created on demand get the same default key policy as a customer key, rather than the via-service-scoped policy real AWS gives them. Scheduling one for deletion is refused, as on real AWS, but disabling one is not, which real AWS does refuse.
 - Key material lives in process memory for the lifetime of the `SimAws` instance. That is fine for a simulator, but it is not a security boundary: anything sharing the process can reach it.

--- a/docs/services/kms/sim-kms-cloudformation-key.example.ts
+++ b/docs/services/kms/sim-kms-cloudformation-key.example.ts
@@ -1,0 +1,49 @@
+/**
+ * Deploying a KMS key and alias from a CloudFormation template, then
+ * encrypting through the alias the template created.
+ */
+
+import { DecryptCommand, EncryptCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      AppKey: {
+        Type: "AWS::KMS::Key",
+        Properties: { Description: "Application data key" },
+      },
+      AppKeyAlias: {
+        Type: "AWS::KMS::Alias",
+        Properties: {
+          AliasName: "alias/app-key",
+          TargetKeyId: { Ref: "AppKey" },
+        },
+      },
+    },
+    Outputs: {
+      KeyArn: { Value: { "Fn::GetAtt": ["AppKey", "Arn"] } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const kms = simAws.kms();
+
+const encrypted = await kms.encrypt(
+  new EncryptCommand({
+    KeyId: "alias/app-key",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+);
+
+const decrypted = await kms.decrypt(
+  new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+);
+
+console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
+console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."

--- a/src/service/cloudformation/resource/cfn/acm/sim-acm-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/acm/sim-acm-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimAcmCertificate } from "../../../../acm/certificate/sim-acm-certificate.js";
+import { SimAcmCertificateCfn } from "./sim-acm-certificate-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated ACM Resource.
+ */
+export function acmValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::CertificateManager::Certificate" &&
+    properties.simResource instanceof SimAcmCertificate
+  ) {
+    return new SimAcmCertificateCfn({ certificate: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -1,0 +1,33 @@
+import { SimCloudFrontDistribution } from "../../../../cloudfront/distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontDistributionCfn } from "./sim-cloudfront-distribution-cfn.js";
+import { SimCloudFrontFunction } from "../../../../cloudfront/cff/sim-cloudfront-function.js";
+import { SimCloudFrontFunctionCfn } from "./sim-cloudfront-function-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated CloudFront Resource.
+ */
+export function cloudFrontValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::CloudFront::Distribution" &&
+    properties.simResource instanceof SimCloudFrontDistribution
+  ) {
+    return new SimCloudFrontDistributionCfn({ distro: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::Function" &&
+    properties.simResource instanceof SimCloudFrontFunction
+  ) {
+    return new SimCloudFrontFunctionCfn({
+      cloudFrontFunction: properties.simResource,
+    });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/iam/sim-iam-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/iam/sim-iam-cfn-value-adapter.ts
@@ -1,0 +1,27 @@
+import type { SimIamManagedPolicy } from "../../../../iam/policy/sim-iam-policy.js";
+import type { SimIamRole } from "../../../../iam/role/sim-iam-role.js";
+import { SimIamManagedPolicyCfn } from "./sim-iam-managed-policy-cfn.js";
+import { SimIamRoleCfn } from "./sim-iam-role-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated IAM Resource.
+ */
+export function iamValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (properties.type === "AWS::IAM::ManagedPolicy") {
+    return new SimIamManagedPolicyCfn({
+      policy: properties.simResource as SimIamManagedPolicy,
+    });
+  }
+
+  if (properties.type === "AWS::IAM::Role") {
+    return new SimIamRoleCfn({ role: properties.simResource as SimIamRole });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/kms/sim-kms-alias-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/kms/sim-kms-alias-cfn.ts
@@ -1,0 +1,38 @@
+import type { SimKmsAlias } from "../../../../kms/key/sim-kms-alias.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimKmsAliasCfnProperties {
+  readonly alias: SimKmsAlias;
+}
+
+/**
+ * CloudFormation-facing values for a simulated KMS alias.
+ */
+export class SimKmsAliasCfn implements SimCfnResourceValueAdapter {
+  private readonly alias: SimKmsAlias;
+
+  constructor(properties: SimKmsAliasCfnProperties) {
+    this.alias = properties.alias;
+  }
+
+  /**
+   * AWS::KMS::Alias Ref returns the alias name, such as `alias/app-key`, which
+   * is directly usable as a KeyId.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.alias.aliasName;
+  }
+
+  /**
+   * AWS::KMS::Alias has no Fn::GetAtt attributes on real CloudFormation, so
+   * asking for one is refused rather than answered with the alias ARN a
+   * template might have been hoping for.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::KMS::Alias attribute ${attributeName}: ` +
+        `AWS::KMS::Alias has no Fn::GetAtt attributes`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/kms/sim-kms-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/kms/sim-kms-cfn-value-adapter.ts
@@ -1,0 +1,31 @@
+import { SimKmsAlias } from "../../../../kms/key/sim-kms-alias.js";
+import { SimKmsKey } from "../../../../kms/key/sim-kms-key.js";
+import { SimKmsAliasCfn } from "./sim-kms-alias-cfn.js";
+import { SimKmsKeyCfn } from "./sim-kms-key-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated KMS Resource.
+ */
+export function kmsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::KMS::Key" &&
+    properties.simResource instanceof SimKmsKey
+  ) {
+    return new SimKmsKeyCfn({ key: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::KMS::Alias" &&
+    properties.simResource instanceof SimKmsAlias
+  ) {
+    return new SimKmsAliasCfn({ alias: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/kms/sim-kms-key-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/kms/sim-kms-key-cfn.ts
@@ -1,0 +1,44 @@
+import type { SimKmsKey } from "../../../../kms/key/sim-kms-key.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimKmsKeyCfnProperties {
+  readonly key: SimKmsKey;
+}
+
+/**
+ * CloudFormation-facing values for a simulated KMS key.
+ */
+export class SimKmsKeyCfn implements SimCfnResourceValueAdapter {
+  private readonly key: SimKmsKey;
+
+  constructor(properties: SimKmsKeyCfnProperties) {
+    this.key = properties.key;
+  }
+
+  /**
+   * AWS::KMS::Key Ref returns the key ID, not the ARN. That is the difference
+   * that matters downstream: a `KmsKeyId` taking a Ref gets the bare UUID, and
+   * an IAM policy Resource wanting the key has to use Fn::GetAtt Arn.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.key.keyId;
+  }
+
+  /**
+   * AWS::KMS::Key attributes supported by the simulator.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.key.arn;
+      }
+      case "KeyId": {
+        return this.key.keyId;
+      }
+      default: {
+        throw new Error(`Unsupported AWS::KMS::Key attribute ${attributeName}`);
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
@@ -1,0 +1,31 @@
+import { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import { SimLambdaFunctionUrl } from "../../../../lambda/function/url/sim-lambda-function-url.js";
+import { SimLambdaFunctionCfn } from "./sim-lambda-function-cfn.js";
+import { SimLambdaFunctionUrlCfn } from "./sim-lambda-function-url-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Lambda Resource.
+ */
+export function lambdaValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Lambda::Function" &&
+    properties.simResource instanceof SimLambdaFunction
+  ) {
+    return new SimLambdaFunctionCfn({ lambdaFunction: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::Url" &&
+    properties.simResource instanceof SimLambdaFunctionUrl
+  ) {
+    return new SimLambdaFunctionUrlCfn({ functionUrl: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/route53/sim-route53-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/route53/sim-route53-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimRoute53HostedZone } from "../../../../route53/hosted-zone/sim-route53-hosted-zone.js";
+import { SimRoute53HostedZoneCfn } from "./sim-route53-hosted-zone-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Route 53 Resource.
+ */
+export function route53ValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Route53::HostedZone" &&
+    properties.simResource instanceof SimRoute53HostedZone
+  ) {
+    return new SimRoute53HostedZoneCfn({ hostedZone: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/s3/sim-s3-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/s3/sim-s3-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimS3Bucket } from "../../../../s3/bucket/sim-s3-bucket.js";
+import { SimS3BucketCfn } from "./sim-s3-bucket-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated S3 Resource.
+ */
+export function s3ValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::S3::Bucket" &&
+    properties.simResource instanceof SimS3Bucket
+  ) {
+    return new SimS3BucketCfn({ bucket: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/secretsmanager/sim-secrets-manager-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/secretsmanager/sim-secrets-manager-cfn-value-adapter.ts
@@ -1,0 +1,23 @@
+import { SimSecretsManagerSecret } from "../../../../secretsmanager/secret/sim-secrets-manager-secret.js";
+import { SimSecretsManagerSecretCfn } from "./sim-secrets-manager-secret-cfn.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Secrets Manager
+ * Resource.
+ */
+export function secretsManagerValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::SecretsManager::Secret" &&
+    properties.simResource instanceof SimSecretsManagerSecret
+  ) {
+    return new SimSecretsManagerSecretCfn({ secret: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -1,25 +1,13 @@
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
-import { SimS3Bucket } from "../../../s3/bucket/sim-s3-bucket.js";
-import { SimS3BucketCfn } from "./s3/sim-s3-bucket-cfn.js";
+import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
+import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
+import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
+import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
+import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
+import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
+import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
+import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
 import { SimCfnDefaultResourceValueAdapter } from "./sim-cfn-default-resource-value-adapter.js";
-import { SimCloudFrontDistribution } from "../../../cloudfront/distribution/sim-cloudfront-distribution.js";
-import { SimCloudFrontDistributionCfn } from "./cloudfront/sim-cloudfront-distribution-cfn.js";
-import { SimCloudFrontFunction } from "../../../cloudfront/cff/sim-cloudfront-function.js";
-import { SimCloudFrontFunctionCfn } from "./cloudfront/sim-cloudfront-function-cfn.js";
-import { SimRoute53HostedZone } from "../../../route53/hosted-zone/sim-route53-hosted-zone.js";
-import { SimRoute53HostedZoneCfn } from "./route53/sim-route53-hosted-zone-cfn.js";
-import { SimAcmCertificateCfn } from "./acm/sim-acm-certificate-cfn.js";
-import { SimAcmCertificate } from "../../../acm/certificate/sim-acm-certificate.js";
-import { SimIamManagedPolicyCfn } from "./iam/sim-iam-managed-policy-cfn.js";
-import type { SimIamManagedPolicy } from "../../../iam/policy/sim-iam-policy.js";
-import { SimIamRoleCfn } from "./iam/sim-iam-role-cfn.js";
-import type { SimIamRole } from "../../../iam/role/sim-iam-role.js";
-import { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
-import { SimLambdaFunctionCfn } from "./lambda/sim-lambda-function-cfn.js";
-import { SimLambdaFunctionUrl } from "../../../lambda/function/url/sim-lambda-function-url.js";
-import { SimLambdaFunctionUrlCfn } from "./lambda/sim-lambda-function-url-cfn.js";
-import { SimSecretsManagerSecret } from "../../../secretsmanager/secret/sim-secrets-manager-secret.js";
-import { SimSecretsManagerSecretCfn } from "./secretsmanager/sim-secrets-manager-secret-cfn.js";
 
 export interface SimCfnResourceValueAdapter {
   refValue(): SimCfnTemplateValue;
@@ -27,11 +15,17 @@ export interface SimCfnResourceValueAdapter {
   attributeValue(attributeName: string): SimCfnTemplateValue;
 }
 
-interface SimCfnResourceValueAdapterProperties {
+export interface SimCfnResourceValueAdapterProperties {
   readonly logicalId: string;
   readonly type: string | undefined;
   readonly simResource: object | undefined;
 }
+
+/**
+ * The adapter for a Resource type one service owns, or nothing when the
+ * Resource belongs to another service.
+ */
+export type SimCfnServiceValueAdapter = SimCfnResourceValueAdapter | undefined;
 
 /**
  * Build the CloudFormation-facing value adapter for a created simulated
@@ -39,95 +33,26 @@ interface SimCfnResourceValueAdapterProperties {
  *
  * The underlying simulated AWS service object stays service-focused; this
  * adapter owns CloudFormation-specific Ref and Fn::GetAtt behavior.
+ *
+ * Each service matches its own Resource types, beside that service's adapters,
+ * so this registry stays a list of services. A Resource no service claims
+ * falls through to the default adapter, which answers a Ref with the logical
+ * ID.
  */
 export function simCfnResourceValueAdapter(
   properties: SimCfnResourceValueAdapterProperties,
 ): SimCfnResourceValueAdapter {
-  if (
-    properties.type === "AWS::CertificateManager::Certificate" &&
-    properties.simResource instanceof SimAcmCertificate
-  ) {
-    return new SimAcmCertificateCfn({
-      certificate: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::S3::Bucket" &&
-    properties.simResource instanceof SimS3Bucket
-  ) {
-    return new SimS3BucketCfn({
-      bucket: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::CloudFront::Distribution" &&
-    properties.simResource instanceof SimCloudFrontDistribution
-  ) {
-    return new SimCloudFrontDistributionCfn({
-      distro: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::CloudFront::Function" &&
-    properties.simResource instanceof SimCloudFrontFunction
-  ) {
-    return new SimCloudFrontFunctionCfn({
-      cloudFrontFunction: properties.simResource,
-    });
-  }
-
-  if (properties.type === "AWS::IAM::ManagedPolicy") {
-    return new SimIamManagedPolicyCfn({
-      policy: properties.simResource as SimIamManagedPolicy,
-    });
-  }
-
-  if (properties.type === "AWS::IAM::Role") {
-    return new SimIamRoleCfn({
-      role: properties.simResource as SimIamRole,
-    });
-  }
-
-  if (
-    properties.type === "AWS::Lambda::Function" &&
-    properties.simResource instanceof SimLambdaFunction
-  ) {
-    return new SimLambdaFunctionCfn({
-      lambdaFunction: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::Lambda::Url" &&
-    properties.simResource instanceof SimLambdaFunctionUrl
-  ) {
-    return new SimLambdaFunctionUrlCfn({
-      functionUrl: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::SecretsManager::Secret" &&
-    properties.simResource instanceof SimSecretsManagerSecret
-  ) {
-    return new SimSecretsManagerSecretCfn({
-      secret: properties.simResource,
-    });
-  }
-
-  if (
-    properties.type === "AWS::Route53::HostedZone" &&
-    properties.simResource instanceof SimRoute53HostedZone
-  ) {
-    return new SimRoute53HostedZoneCfn({
-      hostedZone: properties.simResource,
-    });
-  }
-
-  return new SimCfnDefaultResourceValueAdapter({
-    logicalId: properties.logicalId,
-  });
+  return (
+    acmValueAdapter(properties) ??
+    cloudFrontValueAdapter(properties) ??
+    iamValueAdapter(properties) ??
+    kmsValueAdapter(properties) ??
+    lambdaValueAdapter(properties) ??
+    route53ValueAdapter(properties) ??
+    s3ValueAdapter(properties) ??
+    secretsManagerValueAdapter(properties) ??
+    new SimCfnDefaultResourceValueAdapter({
+      logicalId: properties.logicalId,
+    })
+  );
 }

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -54,6 +54,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "IAM": {
       return scopedAws.iam().cfnResourceFactory();
     }
+    case "KMS": {
+      return scopedAws.kms().cfnResourceFactory();
+    }
     case "Lambda": {
       return scopedAws.lambda().cfnResourceFactory();
     }

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -68,6 +68,25 @@ As elsewhere, implementation code under `src/` does not import real AWS SDK pack
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
 command instances.
 
+## CloudFormation
+
+`cfn/` creates keys and aliases from `AWS::KMS::Key` and `AWS::KMS::Alias`. Both creators go
+through the ordinary `CreateKey` and `CreateAlias` commands rather than building the stored objects
+directly, so a template gets the same key material, the same policy handling and the same key-type
+and alias-name refusals an SDK caller gets. `Enabled: false` is the one thing the commands cannot
+express, since neither the real nor the simulated `CreateKey` takes it; the key is disabled after
+creation, as real CloudFormation does.
+
+`SimCfnKmsUnsimulatedKeyProperties` is the counterweight to that reuse. Passing a property through
+to `CreateKey` only fails closed for the properties `CreateKey` knows about, and `AWS::KMS::Key` has
+several the API does not take at all: rotation, multi-Region and tags. Each of those changes what
+the key is, so the Resource is refused before the key exists rather than deploying a key that
+behaves differently here than on AWS.
+
+`Ref` and `Fn::GetAtt` behaviour lives with the other CloudFormation value adapters, in
+`cloudformation/resource/cfn/kms/`. A key's `Ref` is its key ID rather than its ARN, and an alias
+has no `Fn::GetAtt` attributes at all, which is refused rather than answered with the alias ARN.
+
 ## Key policies and IAM
 
 KMS is the first service here whose resource policy is mandatory, and that needed a small addition

--- a/src/service/kms/cfn/alias/sim-cfn-kms-alias-creator.ts
+++ b/src/service/kms/cfn/alias/sim-cfn-kms-alias-creator.ts
@@ -1,0 +1,55 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimKmsAlias } from "../../key/sim-kms-alias.js";
+import type { SimKms } from "../../sim-kms.js";
+import { SimCfnKmsAliasProperties } from "./sim-cfn-kms-alias-properties.js";
+
+interface SimCfnKmsAliasCreatorProperties {
+  readonly kms: SimKms;
+}
+
+/**
+ * Creates simulated KMS aliases from AWS::KMS::Alias Resources.
+ *
+ * The alias goes through the ordinary CreateAlias command, so a template gets
+ * the same name validation an SDK caller would: the `alias/` prefix is
+ * required, the `alias/aws/` prefix is reserved, and a name already in use is
+ * refused.
+ */
+export class SimCfnKmsAliasCreator {
+  private readonly kms: SimKms;
+
+  constructor(properties: SimCfnKmsAliasCreatorProperties) {
+    this.kms = properties.kms;
+  }
+
+  /**
+   * Create an alias from an AWS::KMS::Alias Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimKmsAlias> {
+    const aliasProperties = new SimCfnKmsAliasProperties({
+      resource,
+      properties,
+    });
+    const aliasName = aliasProperties.aliasName();
+
+    await this.kms.createAlias({
+      input: {
+        AliasName: aliasName,
+        TargetKeyId: aliasProperties.targetKeyId(),
+      },
+    });
+
+    const alias = this.kms.findAlias(aliasName);
+    assertDefined(
+      alias,
+      `sim KMS alias ${aliasName} after CloudFormation creation`,
+    );
+
+    return alias;
+  }
+}

--- a/src/service/kms/cfn/alias/sim-cfn-kms-alias-properties.ts
+++ b/src/service/kms/cfn/alias/sim-cfn-kms-alias-properties.ts
@@ -1,0 +1,53 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnKmsPropertyParser } from "../sim-cfn-kms-property-parser.js";
+
+interface SimCfnKmsAliasPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::KMS::Alias CloudFormation properties into the shape the alias
+ * creator needs.
+ *
+ * Both properties are required, as they are on real CloudFormation: an alias
+ * with no name names nothing, and an alias with no target points at nothing.
+ */
+export class SimCfnKmsAliasProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnKmsPropertyParser({
+    resourceType: "AWS::KMS::Alias",
+  });
+
+  constructor(properties: SimCfnKmsAliasPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The alias name, including its `alias/` prefix.
+   */
+  aliasName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["AliasName"],
+      "AliasName",
+    );
+  }
+
+  /**
+   * The key the alias points at, in any of the forms KMS accepts as a KeyId.
+   *
+   * A template usually gets here through `!Ref` on its AWS::KMS::Key, which
+   * resolves to that key's key ID.
+   */
+  targetKeyId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["TargetKeyId"],
+      "TargetKeyId",
+    );
+  }
+}

--- a/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
@@ -1,0 +1,75 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimKmsKey } from "../../key/sim-kms-key.js";
+import type { SimKms } from "../../sim-kms.js";
+import { SimCfnKmsKeyProperties } from "./sim-cfn-kms-key-properties.js";
+
+interface SimCfnKmsKeyCreatorProperties {
+  readonly kms: SimKms;
+}
+
+/**
+ * Creates simulated KMS keys from AWS::KMS::Key Resources.
+ *
+ * The key is created through the ordinary CreateKey command rather than
+ * constructed directly, so a key a template deployed is the same thing an SDK
+ * caller would have got: real key material, the same key policy handling, and
+ * the same refusal of key types this simulation does not model.
+ */
+export class SimCfnKmsKeyCreator {
+  private readonly kms: SimKms;
+
+  constructor(properties: SimCfnKmsKeyCreatorProperties) {
+    this.kms = properties.kms;
+  }
+
+  /**
+   * Create a key from an AWS::KMS::Key Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimKmsKey> {
+    const keyProperties = new SimCfnKmsKeyProperties({ resource, properties });
+
+    const created = await this.kms.createKey({
+      input: {
+        Description: keyProperties.description(),
+        Policy: keyProperties.policy(),
+        KeySpec: keyProperties.keySpec(),
+        KeyUsage: keyProperties.keyUsage(),
+        Origin: keyProperties.origin(),
+      },
+    });
+
+    const keyId = created.KeyMetadata?.KeyId;
+    assertDefined(
+      keyId,
+      `sim KMS key ID after CloudFormation creation for ${resource.logicalId}`,
+    );
+
+    const key = this.kms.findKey(keyId);
+    assertDefined(key, `sim KMS key ${keyId} after CloudFormation creation`);
+
+    this.applyEnabled(key, keyProperties.enabled());
+
+    return key;
+  }
+
+  /**
+   * Apply `Enabled: false`, which asks for a key that is disabled the moment
+   * it exists.
+   *
+   * CreateKey has no input for that, as the real API has none either: real
+   * CloudFormation makes the key and then disables it. The key model is
+   * disabled directly rather than through DisableKey, because CloudFormation
+   * is acting as the key's creator here and has no caller identity of its own
+   * to authorize.
+   */
+  private applyEnabled(key: SimKmsKey, enabled: boolean): void {
+    if (!enabled) {
+      key.disable();
+    }
+  }
+}

--- a/src/service/kms/cfn/key/sim-cfn-kms-key-properties.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-key-properties.ts
@@ -1,0 +1,106 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnKmsPropertyParser } from "../sim-cfn-kms-property-parser.js";
+import { SimCfnKmsUnsimulatedKeyProperties } from "./sim-cfn-kms-unsimulated-key-properties.js";
+
+interface SimCfnKmsKeyPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::KMS::Key CloudFormation properties into the shape the key creator
+ * needs.
+ *
+ * Keeping the property-shape rules here leaves the creator to do nothing but
+ * call CreateKey, and puts the refusals for unmodelled key behaviour in one
+ * place beside the properties they belong to.
+ *
+ * Those refusals run on construction rather than when a property is read, so
+ * a Resource asking for something unmodelled cannot get as far as creating a
+ * key that would then be wrong.
+ */
+export class SimCfnKmsKeyProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnKmsPropertyParser({
+    resourceType: "AWS::KMS::Key",
+  });
+
+  constructor(properties: SimCfnKmsKeyPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    new SimCfnKmsUnsimulatedKeyProperties({
+      propertyParser: this.propertyParser,
+    }).require(this.resource, this.properties);
+  }
+
+  /**
+   * The key Description.
+   */
+  description(): string | undefined {
+    return this.string(this.properties["Description"], "Description");
+  }
+
+  /**
+   * The key policy, as the JSON document string CreateKey takes.
+   *
+   * Omitting it gets the default root-delegation policy KMS applies, which is
+   * the same thing CreateKey does with no Policy.
+   */
+  policy(): string | undefined {
+    return this.propertyParser.optionalPolicyJson(
+      this.resource,
+      this.properties["KeyPolicy"],
+      "KeyPolicy",
+    );
+  }
+
+  /**
+   * The requested key spec, passed through so CreateKey refuses the specs this
+   * simulation does not create.
+   */
+  keySpec(): string | undefined {
+    return this.string(this.properties["KeySpec"], "KeySpec");
+  }
+
+  /**
+   * The requested key usage, passed through to CreateKey in the same way.
+   */
+  keyUsage(): string | undefined {
+    return this.string(this.properties["KeyUsage"], "KeyUsage");
+  }
+
+  /**
+   * The requested key material origin, passed through to CreateKey in the same
+   * way.
+   */
+  origin(): string | undefined {
+    return this.string(this.properties["Origin"], "Origin");
+  }
+
+  /**
+   * Whether the deployed key is enabled. A key is enabled unless the template
+   * says otherwise, as on real CloudFormation.
+   */
+  enabled(): boolean {
+    return (
+      this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["Enabled"],
+        "Enabled",
+      ) ?? true
+    );
+  }
+
+  private string(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(this.resource, value, name);
+  }
+}

--- a/src/service/kms/cfn/key/sim-cfn-kms-unsimulated-key-properties.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-unsimulated-key-properties.ts
@@ -1,0 +1,123 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnKmsPropertyParser } from "../sim-cfn-kms-property-parser.js";
+
+interface SimCfnKmsUnsimulatedKeyPropertiesProperties {
+  readonly propertyParser: SimCfnKmsPropertyParser;
+}
+
+/**
+ * Refuses AWS::KMS::Key properties that ask for behaviour simulated KMS does
+ * not model.
+ *
+ * Each of these changes what the key is, not merely how it is described, so
+ * quietly ignoring one would leave a template deploying a key that behaves
+ * differently here than it would on AWS: rotation that never happens, a
+ * multi-Region key whose replica cannot exist, or tags no policy can match.
+ * Refusing at deploy time makes that visible where it was declared.
+ */
+export class SimCfnKmsUnsimulatedKeyProperties {
+  private readonly propertyParser: SimCfnKmsPropertyParser;
+
+  constructor(properties: SimCfnKmsUnsimulatedKeyPropertiesProperties) {
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * Refuse the Resource if it asks for something unmodelled.
+   *
+   * KeySpec, KeyUsage and Origin are not checked here: they go through to
+   * CreateKey, which already refuses the types this simulation does not
+   * create.
+   */
+  require(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    this.requireNoRotation(resource, properties);
+    this.requireSingleRegion(resource, properties);
+    this.requireNoTags(resource, properties);
+  }
+
+  /**
+   * Automatic key rotation is not simulated.
+   *
+   * `EnableKeyRotation: false` is the AWS default and says nothing, so it is
+   * accepted.
+   */
+  private requireNoRotation(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    const enabled = this.propertyParser.optionalBoolean(
+      resource,
+      properties["EnableKeyRotation"],
+      "EnableKeyRotation",
+    );
+
+    if (enabled === true) {
+      throw this.propertyParser.propertyError(
+        resource,
+        "EnableKeyRotation is not simulated: simulated KMS keys keep the " +
+          "same key material for their lifetime, so a rotated ciphertext " +
+          "would not be modelled",
+      );
+    }
+
+    if (properties["RotationPeriodInDays"] !== undefined) {
+      throw this.propertyParser.propertyError(
+        resource,
+        "RotationPeriodInDays is not simulated: simulated KMS does not " +
+          "rotate key material",
+      );
+    }
+  }
+
+  /**
+   * Multi-Region keys are not simulated. A simulated key belongs to one
+   * account and region, and a ciphertext produced under it cannot be decrypted
+   * elsewhere.
+   */
+  private requireSingleRegion(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    const multiRegion = this.propertyParser.optionalBoolean(
+      resource,
+      properties["MultiRegion"],
+      "MultiRegion",
+    );
+
+    if (multiRegion === true) {
+      throw this.propertyParser.propertyError(
+        resource,
+        "MultiRegion is not simulated: a simulated key belongs to one " +
+          "account and region, and its ciphertext cannot be decrypted in " +
+          "another",
+      );
+    }
+  }
+
+  /**
+   * Tags are not simulated on KMS keys, so a template declaring them is
+   * refused rather than deploying a key whose tags nothing can read and no
+   * `aws:ResourceTag` condition can match.
+   */
+  private requireNoTags(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    const tags: SimCfnTemplateValue | undefined = properties["Tags"];
+
+    if (tags !== undefined) {
+      throw this.propertyParser.propertyError(
+        resource,
+        "Tags are not simulated on KMS keys: ListResourceTags and the " +
+          "aws:ResourceTag condition key would not see them",
+      );
+    }
+  }
+}

--- a/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
@@ -1,0 +1,144 @@
+import { GetKeyPolicyCommand } from "@aws-sdk/client-kms";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimKmsKey } from "../key/sim-kms-key.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("KMS CloudFormation Key property shapes", () => {
+  it("reads the string forms CloudFormation carries values in", async () => {
+    // Given a template whose Enabled is CloudFormation's string form of a
+    // boolean, and whose KeyPolicy is inlined JSON rather than an object.
+    const simAws = simAwsInEuWest2();
+    const policyJson = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "Inlined",
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::111111111111:root" },
+          Action: "kms:*",
+          Resource: "*",
+        },
+      ],
+    });
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: {
+            Type: "AWS::KMS::Key",
+            Properties: { Enabled: "false", KeyPolicy: policyJson },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then both are read as the values they stand for.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const stored = await simAws
+      .kms()
+      .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
+
+    assertIdentical(stored.Policy, policyJson);
+    assertFalse(key.isEnabled);
+  });
+
+  it("resolves the intrinsics CDK nests inside a KeyPolicy", async () => {
+    // Given the KeyPolicy shape CDK synthesises for a new kms.Key, whose
+    // account root principal is an Fn::Join over pseudo parameters rather than
+    // a literal ARN.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: {
+            Type: "AWS::KMS::Key",
+            UpdateReplacePolicy: "Retain",
+            DeletionPolicy: "Retain",
+            Properties: {
+              KeyPolicy: {
+                Statement: [
+                  {
+                    Action: "kms:*",
+                    Effect: "Allow",
+                    Principal: {
+                      AWS: {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            { Ref: "AWS::Partition" },
+                            ":iam::",
+                            { Ref: "AWS::AccountId" },
+                            ":root",
+                          ],
+                        ],
+                      },
+                    },
+                    Resource: "*",
+                  },
+                ],
+                Version: "2012-10-17",
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the policy the key holds names the resolved account root, so the
+    // key delegates to the account's IAM as the CDK construct intends.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const stored = await simAws
+      .kms()
+      .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
+
+    assertIdentical(
+      stored.Policy,
+      JSON.stringify({
+        Statement: [
+          {
+            Action: "kms:*",
+            Effect: "Allow",
+            Principal: { AWS: "arn:aws:iam::111111111111:root" },
+            Resource: "*",
+          },
+        ],
+        Version: "2012-10-17",
+      }),
+    );
+  });
+});
+
+/**
+ * Narrow the simulated resource a CloudFormation Resource is backed by to the
+ * key it should be.
+ */
+function keyOf(simResource: object | undefined): SimKmsKey {
+  const key = simResource as SimKmsKey | undefined;
+  assertNonNullable(key);
+
+  return key;
+}

--- a/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key-properties.iso.test.ts
@@ -1,14 +1,10 @@
 import { GetKeyPolicyCommand } from "@aws-sdk/client-kms";
-import {
-  assertFalse,
-  assertIdentical,
-  assertNonNullable,
-} from "@kensio/smartass";
+import { assertFalse, assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimKmsKey } from "../key/sim-kms-key.js";
+import { simKmsCfnKey } from "../../../../test/kms/cfn-key-resource.js";
 
 const accountIdOneOnes = "111111111111" as SimAwsAccountId;
 
@@ -52,7 +48,7 @@ describe("KMS CloudFormation Key property shapes", () => {
     await stack.waitForDeployComplete();
 
     // Then both are read as the values they stand for.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const stored = await simAws
       .kms()
       .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
@@ -110,7 +106,7 @@ describe("KMS CloudFormation Key property shapes", () => {
 
     // Then the policy the key holds names the resolved account root, so the
     // key delegates to the account's IAM as the CDK construct intends.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const stored = await simAws
       .kms()
       .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
@@ -131,14 +127,3 @@ describe("KMS CloudFormation Key property shapes", () => {
     );
   });
 });
-
-/**
- * Narrow the simulated resource a CloudFormation Resource is backed by to the
- * key it should be.
- */
-function keyOf(simResource: object | undefined): SimKmsKey {
-  const key = simResource as SimKmsKey | undefined;
-  assertNonNullable(key);
-
-  return key;
-}

--- a/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
@@ -1,0 +1,317 @@
+import {
+  DecryptCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+  GetKeyPolicyCommand,
+  ListAliasesCommand,
+  ListKeysCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimKmsKey } from "../key/sim-kms-key.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+const appKeyTemplate = {
+  Resources: {
+    AppKey: {
+      Type: "AWS::KMS::Key",
+      Properties: { Description: "Application data key" },
+    },
+    AppKeyAlias: {
+      Type: "AWS::KMS::Alias",
+      Properties: {
+        AliasName: "alias/app-key",
+        TargetKeyId: { Ref: "AppKey" },
+      },
+    },
+  },
+};
+
+describe("KMS CloudFormation Key and Alias deployment", () => {
+  it("creates a key an alias resolves, and encrypts with it", async () => {
+    // Given a template declaring a key and an alias pointing at it.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "app-stack", template: appKeyTemplate });
+    await stack.waitForDeployComplete();
+
+    // Then the alias resolves to the deployed key.
+    const kms = simAws.kms();
+    const described = await kms.describeKey(
+      new DescribeKeyCommand({ KeyId: "alias/app-key" }),
+    );
+
+    assertNonNullable(described.KeyMetadata);
+    assertIdentical(described.KeyMetadata.Description, "Application data key");
+    assertTrue(described.KeyMetadata.Enabled);
+    assertIdentical(described.KeyMetadata.KeyState, "Enabled");
+
+    // And the key encrypts and decrypts through its alias, as a deployed
+    // application would use it.
+    const encrypted = await kms.encrypt(
+      new EncryptCommand({
+        KeyId: "alias/app-key",
+        Plaintext: new TextEncoder().encode("hunter2"),
+      }),
+    );
+    assertNonNullable(encrypted.CiphertextBlob);
+
+    const decrypted = await kms.decrypt(
+      new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+    );
+    assertNonNullable(decrypted.Plaintext);
+    assertIdentical(new TextDecoder().decode(decrypted.Plaintext), "hunter2");
+  });
+
+  it("lists the deployed key and alias", async () => {
+    // Given a deployed key and alias.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "app-stack", template: appKeyTemplate });
+    await stack.waitForDeployComplete();
+
+    // When the account's keys and aliases are listed.
+    const kms = simAws.kms();
+    const keys = await kms.listKeys(new ListKeysCommand({}));
+    const aliases = await kms.listAliases(new ListAliasesCommand({}));
+
+    // Then both the template declared are there.
+    assertArrayLength(keys.Keys ?? [], 1);
+    assertArrayLength(aliases.Aliases ?? [], 1);
+
+    const alias = aliases.Aliases?.at(0);
+    assertNonNullable(alias);
+    assertIdentical(alias.AliasName, "alias/app-key");
+    assertIdentical(alias.TargetKeyId, keys.Keys?.at(0)?.KeyId);
+    assertIdentical(
+      alias.AliasArn,
+      "arn:aws:kms:eu-west-2:111111111111:alias/app-key",
+    );
+  });
+
+  it("resolves Ref to the key ID and Fn::GetAtt to the ARN and key ID", async () => {
+    // Given a template referencing its key every way CloudFormation allows.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        ...appKeyTemplate,
+        Outputs: {
+          KeyRef: { Value: { Ref: "AppKey" } },
+          KeyArn: { Value: { "Fn::GetAtt": ["AppKey", "Arn"] } },
+          KeyId: { Value: { "Fn::GetAtt": ["AppKey", "KeyId"] } },
+          AliasRef: { Value: { Ref: "AppKeyAlias" } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then Ref gives the bare key ID, not the ARN, as on real AWS.
+    const keyRef = stack.outputs.get("KeyRef")?.value;
+    const keyArn = stack.outputs.get("KeyArn")?.value;
+
+    assertTypeString(keyRef);
+    assertTypeString(keyArn);
+    assertIdentical(stack.outputs.get("KeyId")?.value, keyRef);
+    assertIdentical(keyArn, `arn:aws:kms:eu-west-2:111111111111:key/${keyRef}`);
+
+    // And Ref on the alias gives the alias name, which is itself a KeyId.
+    assertIdentical(stack.outputs.get("AliasRef")?.value, "alias/app-key");
+
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: keyRef }));
+    assertIdentical(described.KeyMetadata?.Arn, keyArn);
+  });
+
+  it("applies the KeyPolicy the template declares", async () => {
+    // Given a template declaring a key policy as an object, as a template
+    // writes one.
+    const simAws = simAwsInEuWest2();
+    const keyPolicy = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "DelegateToAccountIam",
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::111111111111:root" },
+          Action: "kms:*",
+          Resource: "*",
+        },
+      ],
+    };
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: {
+            Type: "AWS::KMS::Key",
+            Properties: { KeyPolicy: keyPolicy },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the deployed key holds that policy verbatim rather than the default
+    // one, so GetKeyPolicy returns exactly what the template declared.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const stored = await simAws
+      .kms()
+      .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
+
+    assertIdentical(stored.Policy, JSON.stringify(keyPolicy));
+    assertIdentical(stored.PolicyName, "default");
+  });
+
+  it("deploys a KeyPolicy that locks the key down", async () => {
+    // Given a template whose key policy names only one role, which is the
+    // case worth being able to test: no IAM policy widens it.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: {
+            Type: "AWS::KMS::Key",
+            Properties: {
+              KeyPolicy: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Principal: { AWS: "arn:aws:iam::111111111111:role/app" },
+                    Action: "kms:*",
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When another principal in the account tries to use the key.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().describeKey(new DescribeKeyCommand({ KeyId: key.keyId })),
+    );
+
+    // Then it is denied, because the template's policy never delegated to the
+    // account's IAM.
+    assertStringIncludes(error.message, "kms:DescribeKey");
+  });
+
+  it("gets the default root-delegation policy with no KeyPolicy", async () => {
+    // Given a template declaring a key with no policy at all.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "app-stack", template: appKeyTemplate });
+    await stack.waitForDeployComplete();
+
+    // Then the key gets the default policy CreateKey applies, which delegates
+    // to the account's IAM rather than granting anything outright.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const stored = await simAws
+      .kms()
+      .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
+
+    assertTypeString(stored.Policy);
+    assertStringIncludes(stored.Policy, "Enable IAM User Permissions");
+    assertStringIncludes(stored.Policy, "arn:aws:iam::111111111111:root");
+  });
+
+  it("creates a disabled key for Enabled false", async () => {
+    // Given a template asking for a key that is disabled from the start.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: { Type: "AWS::KMS::Key", Properties: { Enabled: false } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the key exists and is disabled, so using it fails as it would on
+    // real AWS.
+    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: key.keyId }));
+
+    assertNonNullable(described.KeyMetadata);
+    assertFalse(described.KeyMetadata.Enabled);
+    assertIdentical(described.KeyMetadata.KeyState, "Disabled");
+  });
+
+  it("creates the key in the stack's account and region", async () => {
+    // Given a simulated AWS whose default scope is not the stack's.
+    const simAws = new SimAws();
+
+    // When a template is deployed into another account and region.
+    const stack = await simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .cloudFormation()
+      .deployTemplate({ stackName: "app-stack", template: appKeyTemplate });
+    await stack.waitForDeployComplete();
+
+    // Then the key and its alias exist there, and nowhere else.
+    const scoped = simAws.account(accountIdOneOnes).region("us-east-1").kms();
+    const key = scoped.findKey("alias/app-key");
+
+    assertNonNullable(key);
+    assertStringStartsWith(key.arn, "arn:aws:kms:us-east-1:111111111111:key/");
+    assertUndefined(simAws.kms().findAlias("alias/app-key"));
+  });
+});
+
+/**
+ * Narrow the simulated resource a CloudFormation Resource is backed by to the
+ * key it should be.
+ */
+function keyOf(simResource: object | undefined): SimKmsKey {
+  const key = simResource as SimKmsKey | undefined;
+  assertNonNullable(key);
+
+  return key;
+}

--- a/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-key.iso.test.ts
@@ -22,7 +22,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimKmsKey } from "../key/sim-kms-key.js";
+import { simKmsCfnKey } from "../../../../test/kms/cfn-key-resource.js";
 
 const accountIdOneOnes = "111111111111" as SimAwsAccountId;
 
@@ -185,7 +185,7 @@ describe("KMS CloudFormation Key and Alias deployment", () => {
 
     // Then the deployed key holds that policy verbatim rather than the default
     // one, so GetKeyPolicy returns exactly what the template declared.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const stored = await simAws
       .kms()
       .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
@@ -224,7 +224,7 @@ describe("KMS CloudFormation Key and Alias deployment", () => {
     await stack.waitForDeployComplete();
 
     // When another principal in the account tries to use the key.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const error = await assertThrowsErrorAsync(async () =>
       simAws.kms().describeKey(new DescribeKeyCommand({ KeyId: key.keyId })),
     );
@@ -246,7 +246,7 @@ describe("KMS CloudFormation Key and Alias deployment", () => {
 
     // Then the key gets the default policy CreateKey applies, which delegates
     // to the account's IAM rather than granting anything outright.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const stored = await simAws
       .kms()
       .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: key.keyId }));
@@ -273,7 +273,7 @@ describe("KMS CloudFormation Key and Alias deployment", () => {
 
     // Then the key exists and is disabled, so using it fails as it would on
     // real AWS.
-    const key = keyOf(stack.getResource("AppKey")?.simResource);
+    const key = simKmsCfnKey(stack.getResource("AppKey")?.simResource);
     const described = await simAws
       .kms()
       .describeKey(new DescribeKeyCommand({ KeyId: key.keyId }));
@@ -304,14 +304,3 @@ describe("KMS CloudFormation Key and Alias deployment", () => {
     assertUndefined(simAws.kms().findAlias("alias/app-key"));
   });
 });
-
-/**
- * Narrow the simulated resource a CloudFormation Resource is backed by to the
- * key it should be.
- */
-function keyOf(simResource: object | undefined): SimKmsKey {
-  const key = simResource as SimKmsKey | undefined;
-  assertNonNullable(key);
-
-  return key;
-}

--- a/src/service/kms/cfn/sim-cfn-kms-property-parser.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-property-parser.ts
@@ -1,0 +1,150 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface SimCfnKmsPropertyParserProperties {
+  readonly resourceType: string;
+}
+
+/**
+ * Validates individual AWS::KMS::* CloudFormation property values, failing
+ * with a diagnostic naming the Resource type, the property and the logical ID.
+ *
+ * The Resource type is carried here because KMS creates two of them, and a
+ * message naming the wrong one would send a reader to the wrong template
+ * entry.
+ */
+export class SimCfnKmsPropertyParser {
+  private readonly resourceType: string;
+
+  constructor(properties: SimCfnKmsPropertyParserProperties) {
+    this.resourceType = properties.resourceType;
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and "false"
+   * in places, so both forms are accepted, as CloudFormation itself accepts
+   * them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Parse a policy document property, which CloudFormation carries as an
+   * object but which the KMS API takes as a JSON string.
+   *
+   * A string is passed through so a template that inlined the JSON itself
+   * still works, which is what CDK's `PolicyDocument.toJSON` output and a
+   * hand-written `!Sub` both end up producing.
+   */
+  optionalPolicyJson(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "string") {
+      return value;
+    }
+
+    return JSON.stringify(this.record(resource, value, label));
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+
+  /**
+   * Build the diagnostic error for a Resource this simulator refuses.
+   */
+  propertyError(resource: SimCfnResource, reason: string): Error {
+    return new Error(
+      `Invalid ${this.resourceType} Resource ${resource.logicalId}: ${reason}`,
+    );
+  }
+
+  /**
+   * Narrow a template value to an object, refusing anything else.
+   */
+  private record(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue,
+    label: string,
+  ): SimCfnTemplateValueRecord {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "an object");
+    }
+
+    return value;
+  }
+}

--- a/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
@@ -1,0 +1,53 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimKms } from "../sim-kms.js";
+import { SimCfnKmsAliasCreator } from "./alias/sim-cfn-kms-alias-creator.js";
+import { SimCfnKmsKeyCreator } from "./key/sim-cfn-kms-key-creator.js";
+
+interface SimKmsCfnResourceFactoryProperties {
+  readonly kms: SimKms;
+}
+
+/**
+ * CloudFormation Resource factory for simulated KMS resources.
+ */
+export class SimKmsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly keyCreator: SimCfnKmsKeyCreator;
+  private readonly aliasCreator: SimCfnKmsAliasCreator;
+
+  constructor(properties: SimKmsCfnResourceFactoryProperties) {
+    this.keyCreator = new SimCfnKmsKeyCreator({ kms: properties.kms });
+    this.aliasCreator = new SimCfnKmsAliasCreator({ kms: properties.kms });
+  }
+
+  /**
+   * Create a simulated KMS resource from a CloudFormation Resource.
+   *
+   * Grants and replica keys are not simulated, so their Resource types are
+   * reported as unsupported rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "Key": {
+        return await this.keyCreator.create(resource, properties);
+      }
+      case "Alias": {
+        return await this.aliasCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim KMS CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-validation.iso.test.ts
@@ -1,0 +1,280 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimKmsKey } from "../key/sim-kms-key.js";
+import { SimKmsCfnResourceFactory } from "./sim-cfn-kms-resource-factory.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function kmsResource(
+  resourceType: string,
+  properties: SimCfnTemplateValueRecord,
+): SimCfnResource {
+  return new SimCfnResource({
+    accountRegionScope: {
+      accountId: accountIdOneOnes,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadKey",
+    template: { Type: resourceType, Properties: properties },
+  });
+}
+
+/**
+ * Create a KMS Resource straight through the Resource factory, returning
+ * whatever it rejects with. Keeps the property rules under test without a
+ * whole stack.
+ */
+async function createKmsResource(
+  resourceTypeName: string,
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+  const factory = new SimKmsCfnResourceFactory({ kms: simAws.kms() });
+
+  try {
+    await factory.create(
+      resourceTypeName,
+      kmsResource(`AWS::KMS::${resourceTypeName}`, properties),
+      { simAws, resources: new Map() },
+    );
+  } catch (error) {
+    assertInstanceOf(error, Error);
+
+    return error;
+  }
+
+  throw new Error(`Expected ${resourceTypeName} creation to reject`);
+}
+
+describe("KMS CloudFormation Resource validation", () => {
+  it("refuses EnableKeyRotation", async () => {
+    // Given a template asking for automatic key rotation, which simulated KMS
+    // does not model.
+    // When the Resource is created, then it is refused rather than deploying a
+    // key whose material never actually rotates.
+    const error = await createKmsResource("Key", { EnableKeyRotation: true });
+
+    assertStringIncludes(error.message, "AWS::KMS::Key Resource BadKey");
+    assertStringIncludes(error.message, "EnableKeyRotation is not simulated");
+  });
+
+  it("accepts EnableKeyRotation false, which is the AWS default", async () => {
+    // Given a template turning rotation explicitly off, as CDK synthesises.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const factory = new SimKmsCfnResourceFactory({ kms: simAws.kms() });
+
+    // When the Resource is created.
+    const created = await factory.create(
+      "Key",
+      kmsResource("AWS::KMS::Key", { EnableKeyRotation: false }),
+      { simAws, resources: new Map() },
+    );
+
+    // Then it deploys, because it asked for nothing that is not simulated.
+    assertInstanceOf(created, SimKmsKey);
+  });
+
+  it("refuses RotationPeriodInDays", async () => {
+    // Given a template setting a rotation period.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", {
+      RotationPeriodInDays: 180,
+    });
+
+    assertStringIncludes(
+      error.message,
+      "RotationPeriodInDays is not simulated",
+    );
+  });
+
+  it("refuses MultiRegion", async () => {
+    // Given a template asking for a multi-Region key, whose whole point is a
+    // replica in another region that simulated KMS cannot produce.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", { MultiRegion: true });
+
+    assertStringIncludes(error.message, "MultiRegion is not simulated");
+  });
+
+  it("refuses Tags", async () => {
+    // Given a template tagging the key, which simulated KMS neither stores nor
+    // matches in a policy condition.
+    // When the Resource is created, then it is refused rather than dropping
+    // the tags silently.
+    const error = await createKmsResource("Key", {
+      Tags: [{ Key: "component", Value: "database" }],
+    });
+
+    assertStringIncludes(error.message, "Tags are not simulated on KMS keys");
+  });
+
+  it("refuses an asymmetric KeySpec", async () => {
+    // Given a template asking for an asymmetric key.
+    // When the Resource is created, then CreateKey refuses it in the same
+    // terms it refuses an SDK caller.
+    const error = await createKmsResource("Key", {
+      KeySpec: "RSA_2048",
+      KeyUsage: "ENCRYPT_DECRYPT",
+    });
+
+    assertStringIncludes(error.message, "KeySpec 'RSA_2048' is not simulated");
+  });
+
+  it("refuses an HMAC KeyUsage", async () => {
+    // Given a template asking for an HMAC key.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", {
+      KeyUsage: "GENERATE_VERIFY_MAC",
+    });
+
+    assertStringIncludes(
+      error.message,
+      "KeyUsage 'GENERATE_VERIFY_MAC' is not simulated",
+    );
+  });
+
+  it("refuses imported key material", async () => {
+    // Given a template asking for a key whose material comes from outside KMS.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", { Origin: "EXTERNAL" });
+
+    assertStringIncludes(error.message, "Origin 'EXTERNAL' is not simulated");
+  });
+
+  it("refuses a KeyPolicy that is not a policy document", async () => {
+    // Given a template whose KeyPolicy is a list rather than a document.
+    // When the Resource is created, then it is refused where the mistake was
+    // made rather than at some later authorization.
+    const error = await createKmsResource("Key", { KeyPolicy: ["allow"] });
+
+    assertStringIncludes(error.message, "KeyPolicy must be an object");
+  });
+
+  it("refuses a non-string Description", async () => {
+    // Given a template whose Description is a number.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", { Description: 42 });
+
+    assertStringIncludes(error.message, "Description must be a string");
+  });
+
+  it("refuses a non-boolean Enabled", async () => {
+    // Given a template whose Enabled is neither a boolean nor CloudFormation's
+    // string form of one.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Key", { Enabled: "maybe" });
+
+    assertStringIncludes(error.message, "Enabled must be a boolean");
+  });
+
+  it("refuses an Alias with no AliasName", async () => {
+    // Given a template declaring an alias that names nothing.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Alias", {
+      TargetKeyId: "some-key",
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::KMS::Alias BadKey: AliasName must be a string",
+    );
+  });
+
+  it("refuses an Alias with no TargetKeyId", async () => {
+    // Given a template declaring an alias that points at nothing.
+    // When the Resource is created, then it is refused.
+    const error = await createKmsResource("Alias", {
+      AliasName: "alias/app-key",
+    });
+
+    assertStringIncludes(error.message, "TargetKeyId must be a string");
+  });
+
+  it("refuses an Alias name KMS itself would refuse", async () => {
+    // Given a template declaring an alias in the prefix reserved for AWS
+    // managed keys.
+    // When the Resource is created, then CreateAlias refuses it, as it would
+    // an SDK caller.
+    const error = await createKmsResource("Alias", {
+      AliasName: "alias/aws/app-key",
+      TargetKeyId: "some-key",
+    });
+
+    assertStringIncludes(error.message, "is reserved for AWS managed keys");
+  });
+
+  it("refuses a KMS Resource type it does not create", async () => {
+    // Given a template declaring a KMS grant, which is not simulated.
+    // When the Resource is created, then it is reported as unsupported rather
+    // than treated as deployed.
+    const error = await createKmsResource("Grant", {});
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported sim KMS CloudFormation Resource Grant",
+    );
+  });
+
+  it("refuses Fn::GetAtt on an Alias, which has no attributes", async () => {
+    // Given a deployed alias.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppKey: { Type: "AWS::KMS::Key" },
+          AppKeyAlias: {
+            Type: "AWS::KMS::Alias",
+            Properties: {
+              AliasName: "alias/app-key",
+              TargetKeyId: { Ref: "AppKey" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When an attribute is asked for.
+    const error = assertThrowsError(() =>
+      stack.getResource("AppKeyAlias")?.attributeValue("Arn"),
+    );
+
+    // Then it is refused, because real AWS::KMS::Alias has no Fn::GetAtt
+    // attributes to answer with.
+    assertStringIncludes(
+      error.message,
+      "AWS::KMS::Alias has no Fn::GetAtt attributes",
+    );
+  });
+
+  it("refuses an unknown Key attribute", async () => {
+    // Given a deployed key.
+    const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: { Resources: { AppKey: { Type: "AWS::KMS::Key" } } },
+    });
+    await stack.waitForDeployComplete();
+
+    // When an attribute the simulator does not model is asked for.
+    const error = assertThrowsError(() =>
+      stack.getResource("AppKey")?.attributeValue("KeyRotationStatus"),
+    );
+
+    // Then it is refused rather than answered with something wrong.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::KMS::Key attribute KeyRotationStatus",
+    );
+  });
+});

--- a/src/service/kms/key/sim-kms-key-store.ts
+++ b/src/service/kms/key/sim-kms-key-store.ts
@@ -110,6 +110,17 @@ export class SimKmsKeyStore {
   }
 
   /**
+   * Find a stored alias by its name.
+   *
+   * Unlike `find`, this does not materialise an AWS managed key for a reserved
+   * `alias/aws/` name: it reports the alias that exists, not the key one would
+   * reach.
+   */
+  findAlias(aliasName: string): SimKmsAlias | undefined {
+    return this.aliases.get(aliasName);
+  }
+
+  /**
    * The aliases pointing at one key, or all of them.
    */
   aliasesFor(keyId: SimKmsKeyId | undefined): readonly SimKmsAlias[] {

--- a/src/service/kms/sim-kms.ts
+++ b/src/service/kms/sim-kms.ts
@@ -19,6 +19,8 @@ import { SimKmsKeyCommands } from "./command/key/sim-kms-key-commands.js";
 import { SimKmsListKeys } from "./command/key/sim-kms-list-keys.js";
 import { SimKmsKeyLifecycleCommands } from "./command/key/sim-kms-key-lifecycle-commands.js";
 import { SimKmsKeyPolicyCommands } from "./command/key/sim-kms-key-policy-commands.js";
+import { SimKmsCfnResourceFactory } from "./cfn/sim-cfn-kms-resource-factory.js";
+import type { SimKmsAlias } from "./key/sim-kms-alias.js";
 import type { SimKmsKey } from "./key/sim-kms-key.js";
 import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
 import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
@@ -54,6 +56,7 @@ export class SimKms {
   private readonly generateDataKeyCommand: SimKmsGenerateDataKey;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimKmsSdkCommandRouter(this);
+  private readonly cfnFactory = new SimKmsCfnResourceFactory({ kms: this });
 
   constructor(properties: SimKmsProperties = {}) {
     const {
@@ -108,6 +111,16 @@ export class SimKms {
    */
   findKey(keyId: string): SimKmsKey | undefined {
     return this.keys.find(keyId);
+  }
+
+  /**
+   * Find an alias by name.
+   *
+   * This is the simulator's own accessor, alongside `findKey`, for tests and
+   * for CloudFormation Resource creation to get at the alias it just made.
+   */
+  findAlias(aliasName: string): SimKmsAlias | undefined {
+    return this.keys.findAlias(aliasName);
   }
 
   /**
@@ -262,6 +275,14 @@ export class SimKms {
   ): Promise<simKmsCommands.SimGenerateDataKeyCommandOutput> {
     await this.background.sequence();
     return this.generateDataKeyCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory, which creates
+   * simulated keys and aliases from AWS::KMS::* Resources.
+   */
+  cfnResourceFactory(): SimKmsCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**

--- a/test/kms/cfn-key-resource.ts
+++ b/test/kms/cfn-key-resource.ts
@@ -1,0 +1,24 @@
+/**
+ * Narrows the simulated resource a CloudFormation Resource is backed by to the
+ * simulated KMS key it should be.
+ *
+ * Several KMS CloudFormation test files read the deployed key back off the
+ * Resource, and each was carrying the same cast-and-assert. This lives under
+ * `test/` for the same reasons as `test/iam/`: eslint rejects a test file that
+ * exports helpers alongside its own `describe` calls, and `test/**` is
+ * type-checked with everything else, excluded from the published build, not
+ * collected as a suite, and not counted in coverage.
+ */
+
+import { assertInstanceOf } from "@kensio/smartass";
+
+import { SimKmsKey } from "../../src/service/kms/key/sim-kms-key.js";
+
+/**
+ * The simulated KMS key backing a deployed CloudFormation Resource.
+ */
+export function simKmsCfnKey(simResource: object | undefined): SimKmsKey {
+  assertInstanceOf(simResource, SimKmsKey);
+
+  return simResource;
+}


### PR DESCRIPTION
Simulated CloudFormation creates a key from AWS::KMS::Key and points an AWS::KMS::Alias at it, through the ordinary CreateKey and CreateAlias commands. Ref on a key gives its key ID, Fn::GetAtt gives Arn and KeyId, and Ref on an alias gives the alias name.

Properties that ask for behaviour the simulator does not model refuse the deployment rather than being dropped: EnableKeyRotation, RotationPeriodInDays, MultiRegion, Tags, and asymmetric or HMAC key types.

Resolves https://github.com/KensioSoftware/yulin/issues/210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for KMS keys and aliases.
  * KMS keys can be created, configured, enabled or disabled, and referenced by ID or ARN.
  * KMS aliases can target deployed keys and be used for encryption and decryption.
  * Added CloudFormation integration for additional simulated services, including ACM, CloudFront, IAM, Lambda, Route 53, S3, and Secrets Manager.

* **Documentation**
  * Expanded CloudFormation and KMS documentation with usage examples, supported behavior, intrinsic references, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->