### PR TITLE
docs: plain explanatory writing across all docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ npm i -D @kensio/yulin
 - [CloudFormation](./docs/services/cloudformation "Simulated CloudFormation docs")
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
 - [IAM](./docs/services/iam "Simulated IAM docs")
+- [KMS](./docs/services/kms "Simulated KMS docs")
+- [Lambda](./docs/services/lambda "Simulated Lambda docs")
 - [Route53](./docs/services/route53 "Simulated Route53 docs")
 - [S3](./docs/services/s3 "Simulated S3 docs")
+- [Secrets Manager](./docs/services/secretsmanager "Simulated Secrets Manager docs")
 - [STS](./docs/services/sts "Simulated STS docs")
 
 ## Feature specific docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,7 @@
 # Simulated AWS usage documentation
 
-This directory contains area-specific documentation for Yulin.
-
-Each section includes explanations of the simulated behaviour and example code that can be copied
-into tests, local development scripts, or small experiments.
+This directory contains area-specific documentation for Yulin. Each page explains the simulated
+behaviour and includes example code that can be copied into tests or local development scripts.
 
 ## Service documentation
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,12 +1,11 @@
 # Simulated AWS SDK
 
 Yulin can intercept AWS SDK clients and route their Commands to simulated AWS services. The code
-under test uses the AWS SDK exactly as it would in production, and never needs to know that it's
-dealing with a simulator behind the scenes.
+under test uses the AWS SDK as it would in production, and needs no knowledge of the simulator.
 
-This is the recommended way to use Yulin for testing implementation code that already uses the AWS
-SDK. Direct interaction with `SimAws` remains useful for seeding and inspecting simulated state
-from within tests.
+This is the recommended way to test implementation code that already uses the AWS SDK. Direct
+interaction with `SimAws` remains useful for seeding and inspecting simulated state from within
+tests.
 
 ## How it works
 
@@ -83,9 +82,8 @@ The resolved caller is passed through to the simulated service, so simulated
 caller without permission for a Command is denied, like real AWS. When no caller can be
 identified, Commands run as the simulation's default Account root.
 
-`runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent
-during the run are attributed to that caller — with no changes to the client or the code under
-test:
+`runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent during
+the run are attributed to that caller, with no changes to the client or the code under test:
 
 ```typescript sim-sdk-run-as
 /**
@@ -163,7 +161,7 @@ Restoring puts back the client's real SDK `send`:
 - `interception.restore()` restores one interception; `simSdk.intercept(...)` returns the handle.
 - `simSdk.restoreAll()` restores everything intercepted through that `SimSdk`.
 - `SimSdk` and interception handles are disposable, so `using simSdk = new SimSdk();` restores
-  automatically at the end of the scope — convenient in tests.
+  automatically at the end of the scope, which is convenient in tests.
 
 ## Choosing Commands to intercept
 
@@ -174,13 +172,13 @@ throw a diagnostic error.
 
 ## Supported services and Commands
 
-All simulated services support SDK interception: ACM, CloudFormation, CloudFront, DynamoDB, IAM,
-Route53, S3, and STS. Each service's own docs under [docs/services](../services/) list the
-Commands it simulates.
+All simulated services support SDK interception: ACM, CloudFormation, CloudFront, DynamoDB, IAM, KMS,
+Lambda, Route53, S3, Secrets Manager and STS. Each service's own docs under
+[docs/services](../services/) list the Commands it simulates.
 
 Sending a Command the simulated service doesn't support throws an error naming the Command and
-listing the supported ones, so gaps show up clearly in test output rather than as silent
-misbehaviour. Clients for AWS services Yulin doesn't simulate at all are rejected the same way.
+listing the supported ones, so gaps show up in test output rather than as silent misbehaviour.
+Clients for AWS services Yulin doesn't simulate at all are rejected the same way.
 
 ## Limitations
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -176,9 +176,12 @@ All simulated services support SDK interception: ACM, CloudFormation, CloudFront
 Lambda, Route53, S3, Secrets Manager and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
-Sending a Command the simulated service doesn't support throws an error naming the Command and
-listing the supported ones, so gaps show up in test output rather than as silent misbehaviour.
-Clients for AWS services Yulin doesn't simulate at all are rejected the same way.
+Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:
+
+- A Command the simulated service doesn't support throws `SimSdkUnsupportedCommandError`, naming the
+  Command and listing the Commands that service does support.
+- A client for an AWS service Yulin doesn't simulate at all throws `SimSdkUnknownServiceError`,
+  naming the service. There is no Command list to report, since no simulated service was resolved.
 
 ## Limitations
 

--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -2,32 +2,25 @@
 
 Yulin includes a simulated AWS Certificate Manager (ACM) service for tests and local development.
 
-Sim ACM can be used through `SimAws` to request certificates, inspect certificate details, list
-certificates, and create certificates from sim CloudFormation templates.
-
 ## Available functionality
 
 Sim ACM currently supports:
 
-- Requesting certificates with `RequestCertificateCommand`
-- Describing certificates with `DescribeCertificateCommand`
-- Listing certificates with `ListCertificatesCommand`
+- `RequestCertificateCommand`, `DescribeCertificateCommand` and `ListCertificatesCommand`
 - DNS validation against records in sim Route53
 - CloudFormation-published validation records from `DomainValidationOptions[].HostedZoneId`
-- EMAIL validation method shapes (but validation always succeeds regardless)
+- EMAIL validation method shapes, though validation always succeeds regardless
 - Subject alternative names
 - Certificate tags, up to the ACM limit of 50 tags
-- Deterministic simulated certificate ARNs scoped to account and region
+- Deterministic certificate ARNs scoped to account and region
 - Deterministic DNS validation CNAME records
 - Background certificate issuance from `PENDING_VALIDATION` to `ISSUED`
 - Per-domain validation status for multi-domain certificates
-- CloudFormation resource:
-  - `AWS::CertificateManager::Certificate`
-- CloudFormation `Ref` and `Fn::GetAtt` values for ACM certificates
+- The `AWS::CertificateManager::Certificate` CloudFormation resource, with `Ref` and `Fn::GetAtt`
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-ACM feature parity. Unsupported ACM options may be ignored or may throw errors depending on whether
-the simulator needs them to model the requested behavior.
+The simulator focuses on useful behaviour for tests and local development rather than full ACM
+feature parity. Unsupported ACM options may be ignored or may throw errors depending on whether the
+simulator needs them to model the requested behaviour.
 
 ## Basic certificate request
 
@@ -246,9 +239,8 @@ hosted zone covers the certificate domain, the certificate waits for its validat
 covering hosted zone there is nothing to validate against, so the certificate is issued as soon as
 background tasks drain.
 
-That keeps certificates realistic when you are simulating Route53, without getting in the way when
-your DNS lives outside the simulation. Templates commonly reference hosted zones managed by another
-team or another tool, and those certificates keep working here.
+Templates commonly reference hosted zones managed by another team or another tool. Those
+certificates keep working here, because the simulation holds no zone for their domain.
 
 ```typescript sim-acm-dns-validation
 /**
@@ -335,9 +327,8 @@ public DNS. A certificate in one account can be validated by a hosted zone in an
 
 ### Skipping the validation record
 
-If you want a realistic hosted zone but not the certificate ceremony, `completeDnsValidation()`
-publishes the validation records for a pending certificate. The certificate is issued by the time it
-resolves.
+`completeDnsValidation()` publishes the validation records for a pending certificate, for a test that
+wants a hosted zone without the validation steps. The certificate is issued by the time it resolves.
 
 ```typescript sim-acm-complete-dns-validation
 /**

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1,10 +1,9 @@
 # Simulated CloudFormation
 
-Yulin includes a simulated CloudFormation service for isolated tests, local development, and CI.
+Yulin includes a simulated CloudFormation service for tests and local development.
 
-Sim CloudFormation creates supported simulated AWS resources from CloudFormation templates. It can
-be used with hand-written templates, AWS SDK-style `CreateStackCommand` calls, or synthesized CDK
-template files.
+Sim CloudFormation creates simulated AWS resources from CloudFormation templates. It can be used with
+hand-written templates, AWS SDK-style `CreateStackCommand` calls, or synthesized CDK template files.
 
 The simulator focuses on useful behaviour for tests and local development rather than full
 CloudFormation feature parity. Unsupported resources may be skipped or may fail depending on how
@@ -14,29 +13,17 @@ safely the simulator can model the requested behaviour.
 
 Sim CloudFormation currently supports:
 
-- Creating stacks with `CreateStackCommand`
-- Describing stacks with `DescribeStacksCommand`
+- `CreateStackCommand` and `DescribeStacksCommand`
 - Waiting for simulated stack deployment completion
-- Deploying parsed template objects with `deployTemplate(...)`
-- Deploying synthesized JSON template files with `deployTemplateFile(...)`
+- `deployTemplate(...)` for parsed template objects
+- `deployTemplateFile(...)` for synthesized JSON template files
 - Template `Parameters` with supplied values and defaults
 - Template `Outputs`, resolved after resource creation and read from `stack.outputs`
-- Common intrinsic functions:
-  - `Ref`
-  - `Fn::GetAtt`
-  - `Fn::Join`
-  - `Fn::Sub`
+- The `Ref`, `Fn::GetAtt`, `Fn::Join` and `Fn::Sub` intrinsic functions
 - Explicit resource dependencies with `DependsOn`
 - Implicit dependencies from resource `Ref` expressions
-- Supported simulated resources, including:
-  - `AWS::CloudFormation::WaitConditionHandle`
-  - `AWS::S3::Bucket`
-  - `AWS::CloudFront::Distribution`
-  - `AWS::Lambda::Function`
-  - `AWS::SecretsManager::Secret`
-  - `AWS::KMS::Key` and `AWS::KMS::Alias`
-  - CloudFront Functions used by CDK-generated templates
-  - selected CDK custom resources such as CDK S3 BucketDeployment
+- The resource types listed under [Supported resources](#supported-resources-and-limitations) below,
+  including selected CDK custom resources such as CDK S3 BucketDeployment
 
 ## Basic usage
 
@@ -672,17 +659,16 @@ try {
 }
 ```
 
-The `bindings` array matches a template resource logical ID to a local handler function. This is
-especially useful when CDK has embedded or transformed CloudFront Function source in synthesized
-output, but your test wants to provide an executable local function directly.
+The `bindings` array matches a template resource logical ID to a local handler function. Use it when
+CDK has embedded or transformed CloudFront Function source in synthesized output, but your test wants
+to provide an executable local function directly.
 
 ## Lambda function bindings
 
-`AWS::Lambda::Function` resources support the same bindings, and this is the most convenient way
-to deploy Lambdas through sim CloudFormation: the deployed function is backed by your real
-in-process handler, so tests can close over test state and step through the handler in a debugger,
-while the stack still wires roles, grants, and references exactly as the template declares. A
-bound function may omit template `Code` and `Handler` entirely.
+`AWS::Lambda::Function` resources support the same bindings. The deployed function is backed by your
+real in-process handler, so tests can close over test state and step through the handler in a
+debugger, while the stack still wires roles, grants and references as the template declares. A bound
+function may omit template `Code` and `Handler` entirely.
 
 ```typescript sim-cloudformation-lambda-binding
 /**
@@ -972,41 +958,27 @@ try {
 
 ## Supported resources and limitations
 
-Sim CloudFormation supports a focused subset of CloudFormation.
+Sim CloudFormation supports a subset of CloudFormation. The resource types it creates are:
 
-Current supported resource areas include:
-
+- `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
-- `AWS::S3::Bucket`
-- `AWS::CloudFront::Distribution`
-- `AWS::Lambda::Function`
-- `AWS::SecretsManager::Secret`
+- `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`
+- `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
-- selected CloudFront Function resources emitted by CDK
+- `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`
+- `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet`
+- `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
+- `AWS::SecretsManager::Secret`
 - selected CDK custom resources, including CDK S3 BucketDeployment
 
-Common template features currently supported include:
+Each service's own docs describe what its resource types support. Notable limitations:
 
-- `Parameters`
-- `Outputs`, including `Description` and `Export`
-- `Ref`
-- `Fn::GetAtt`
-- `Fn::Join`
-- `Fn::Sub`
-- `DependsOn`
-
-Notable limitations:
-
-- `TemplateBody` must be JSON when using `CreateStackCommand`; YAML parsing is not currently
-  provided by the CloudFormation service.
+- `TemplateBody` must be JSON when using `CreateStackCommand`. YAML parsing is not currently provided
+  by the CloudFormation service.
 - Only supported resource types create simulated service resources.
 - Unsupported resource properties may be ignored or rejected depending on the resource simulator.
-- Stack updates and deletes are not currently documented as supported operations.
-- Mappings, conditions, and many advanced CloudFormation features are not currently
-  documented as supported operations.
-
-For best results, keep test templates focused on the resources and behaviours your application
-actually needs.
+- Stack updates and deletes are not supported.
+- Mappings, conditions, and many advanced CloudFormation features are not supported.
 
 ## Standalone SimCloudFormation
 

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -3,18 +3,17 @@
 Yulin includes a simulated CloudFront service for tests and local development.
 
 Sim CloudFront can be used directly through `SimAws`, and it can also be served on localhost
-alongside other simulated AWS services. This is most useful when you want application code to make
-HTTP requests through a CloudFront-like layer without talking to real AWS.
+alongside other simulated AWS services, so application code can make HTTP requests through a
+CloudFront-like layer without talking to real AWS.
 
-Alternatively, you can also instantiate `SimCloudFront` directly on its own, in which case it has
-its own isolated state that is not connected to a wider simulated AWS environment.
+`SimCloudFront` can also be instantiated on its own, in which case it has its own isolated state that
+is not connected to a wider simulated AWS environment.
 
 ## Available functionality
 
 Sim CloudFront currently supports:
 
-- Creating Distributions with `CreateDistributionCommand`
-- Getting Distributions with `GetDistributionCommand`
+- `CreateDistributionCommand` and `GetDistributionCommand`
 - S3 Origins backed by sim S3 Buckets
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
 - Default cache Behavior and path-based cache Behaviors
@@ -22,9 +21,9 @@ Sim CloudFront currently supports:
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
 - Serving simulated CloudFront traffic on localhost with `serveSimAws`
 
-The simulator focuses on useful behavior for isolated tests and local dev rather than full
-CloudFront feature parity. Unsupported CloudFront options may be ignored or may throw errors
-depending on whether the simulator needs them to model the requested behaviour safely.
+The simulator focuses on useful behaviour for tests and local development rather than full CloudFront
+feature parity. Unsupported CloudFront options may be ignored or may throw errors depending on
+whether the simulator needs them to model the requested behaviour safely.
 
 ## Basic Distribution setup
 
@@ -159,19 +158,17 @@ local Yulin server while preserving the simulated CloudFront hostname.
 
 ## Viewer certificates
 
-A Distribution with alternate domain names needs an ACM certificate, and CloudFront is fussy about
-which one it will take. Sim CloudFront applies the same rules, so a Distribution that real
-CloudFront would reject at deploy time is rejected here first, with
-`InvalidViewerCertificate`:
+A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only
+certain ones. Sim CloudFront applies the same rules, so a Distribution that real CloudFront would
+reject at deploy time is rejected here first, with `InvalidViewerCertificate`:
 
 - the certificate must be in `us-east-1`, wherever the rest of your infrastructure lives;
 - the certificate must exist and be `ISSUED`;
-- every alternate domain name must be covered by the certificate's domain name or one of its
-  subject alternative names, with a wildcard covering exactly one label.
+- every alternate domain name must be covered by the certificate's domain name or one of its subject
+  alternative names, with a wildcard covering exactly one label.
 
-The `us-east-1` rule is the one worth knowing about. It catches people out because nothing else in a
-stack cares, so a Distribution in `eu-west-2` with a certificate alongside it looks perfectly
-reasonable until CloudFront refuses it.
+The `us-east-1` rule is easy to miss, because nothing else in a stack cares about it. A Distribution
+in `eu-west-2` with a certificate alongside it looks fine until CloudFront refuses it.
 
 ```typescript sim-cloudfront-viewer-certificate
 /**

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -1,39 +1,35 @@
 # Simulated IAM
 
-Yulin includes a simulated IAM service for isolated tests, local development, and CI.
+Yulin includes a simulated IAM service for tests and local development.
 
-Sim IAM can be used directly through `SimAws` or instantiated on its own as `SimIam` with isolated
-state. It stores simulated Roles, Users, and Policies, and evaluates allow/deny authorization
-decisions for them. Other simulated services use sim IAM to authorize their own actions, simulated
-STS uses it to issue temporary Role sessions, and sim CloudFormation can create IAM resources from
-templates.
+Sim IAM stores simulated Roles, Users and Policies, and evaluates allow/deny authorization decisions
+for them. Other simulated services use it to authorize their own actions, simulated STS uses it to
+issue temporary Role sessions, and sim CloudFormation can create IAM resources from templates. It can
+also be instantiated on its own as `SimIam` with isolated state.
 
 ## Available functionality
 
 Sim IAM currently supports:
 
-- Creating Roles with `CreateRoleCommand`, including trust-policy validation
-- Getting and listing Roles with `GetRoleCommand` and `ListRolesCommand`, with pagination
-- Inline Role policies with `PutRolePolicyCommand`
-- Managed Policies with `CreatePolicyCommand`, `GetPolicyCommand`, and `ListPoliciesCommand`
-- Attaching managed Policies to Roles with `AttachRolePolicyCommand`
-- Users with `CreateUserCommand` and inline User policies with `PutUserPolicyCommand`
-- User access keys with `CreateAccessKeyCommand`, registered for credential authentication
+- `CreateRoleCommand`, including trust-policy validation
+- `GetRoleCommand` and `ListRolesCommand`, with pagination
+- `PutRolePolicyCommand`, for inline Role policies
+- `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
+- `AttachRolePolicyCommand`
+- `CreateUserCommand` and `PutUserPolicyCommand`
+- `CreateAccessKeyCommand`, registering access keys for credential authentication
 - Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
   service-supplied resource policies, and policy conditions with explicit-deny precedence
 - IAM authorization at simulated service boundaries, such as Route53 actions
-- Resolving the caller of an HTTP request into simulated AWS, from an `x-sim-aws-caller` header or
-  a verified SigV4 signature, defaulting to anonymous
+- Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
+  signature, defaulting to anonymous
 - Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
   policies
-- CloudFormation resources:
-  - `AWS::IAM::Role`
-  - `AWS::IAM::ManagedPolicy`
-  - `AWS::IAM::Policy` (inline policies put onto referenced Roles)
+- The `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` CloudFormation resources
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-IAM feature parity. Unsupported IAM options may be ignored or may throw errors depending on whether
-the simulator needs them to model the requested behaviour.
+The simulator focuses on useful behaviour for tests and local development rather than full IAM
+feature parity. Unsupported IAM options may be ignored or may throw errors depending on whether the
+simulator needs them to model the requested behaviour.
 
 ## Basic usage
 
@@ -104,7 +100,7 @@ a request was allowed or denied. The decision models the common IAM evaluation r
 - A matching explicit `Deny` statement in any evaluated policy wins
 - Otherwise, within one Account, a matching `Allow` in an identity policy or resource policy allows
   the request
-- Across Accounts, a matching `Allow` is needed from each side — see
+- Across Accounts, a matching `Allow` is needed from each side. See
   [Cross-Account requests](#cross-account-requests)
 - Otherwise the request is implicitly denied
 
@@ -464,18 +460,18 @@ expired sessions are rejected.
 
 ## Callers of HTTP requests
 
-An in-process SDK call can be told who its caller is. A request arriving over HTTP — through
-`serveSimAws`, or through `SimAwsHttp.fetch(...)` in the same process — carries no such thing, so
-sim IAM works the caller out from the request itself, in a fixed order:
+An in-process SDK call can be told who its caller is. A request arriving over HTTP, through
+`serveSimAws` or through `SimAwsHttp.fetch(...)` in the same process, carries no such thing. Sim IAM
+works the caller out from the request itself, in a fixed order:
 
 1. An `x-sim-aws-caller` header naming the principal directly.
 2. An `Authorization: AWS4-HMAC-SHA256` header, verified as a SigV4 signature.
 3. Neither, giving **anonymous**.
 
-The last step matters. Sim IAM treats an omitted in-process caller as the Account root with
-unrestricted access, which is a convenience inside a test. Over HTTP the same default would make
-every unauthenticated request an administrator, so a served request that says nothing about who
-sent it is anonymous instead, and never the Account root.
+Sim IAM treats an omitted in-process caller as the Account root with unrestricted access, which is a
+convenience inside a test. Over HTTP the same default would make every unauthenticated request an
+administrator, so a served request that says nothing about who sent it is anonymous instead, and
+never the Account root.
 
 ### Naming the caller directly
 
@@ -495,8 +491,8 @@ The value is one of three forms:
 | `service:<name>` | An AWS service principal, such as `service:s3.amazonaws.com` |
 | `anonymous`      | Explicitly anonymous                                         |
 
-The header is always enabled and not configurable, it takes precedence over a valid signature, and
-it does not check that the ARN exists — naming a principal is not claiming it was created, exactly
+The header is always enabled and not configurable, and it takes precedence over a valid signature. It
+does not check that the ARN exists, since naming a principal is not claiming it was created, exactly
 as `runAs` behaves. It is stripped before the request reaches the simulated service, so a Lambda
 handler echoing `event.headers` never sees simulator control metadata.
 
@@ -555,10 +551,10 @@ identity `resolveCredentials` returns in process. For an assumed-role session th
 request is attributed to the session while its permissions come from the Role behind it, so a
 policy on the Role applies to a request the session signed.
 
-Sign the URL you actually call. Serving rewrites AWS endpoint hostnames to local ones — a Function
-URL is served at `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>` — and the `host` header is
-part of what a signature covers, so a signature made against the real AWS hostname will not verify
-against the local one.
+Sign the URL you actually call. Serving rewrites AWS endpoint hostnames to local ones, so a Function
+URL is served at `<url-id>.lambda-url.<region>.sim-aws.localhost:<port>`. The `host` header is part of
+what a signature covers, so a signature made against the real AWS hostname will not verify against
+the local one.
 
 A signature whose credential scope names a different service or Region than the endpoint it reached
 is refused before anything else is checked, and says so. The scope feeds the signing key, so without
@@ -584,7 +580,7 @@ request was accepted:
 
 | Header                   | On an accepted request                                                                   | On a refused request                                |
 | ------------------------ | ---------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `x-sim-aws-caller`       | The principal the request was attributed to, in the same form the request header accepts | Absent — there is no principal to report            |
+| `x-sim-aws-caller`       | The principal the request was attributed to, in the same form the request header accepts | Absent, as there is no principal to report          |
 | `x-sim-aws-auth`         | How that was decided: `caller-header`, `sigv4`, or `none`                                | `rejected`                                          |
 | `x-sim-aws-error`        | Absent                                                                                   | The AWS error code, such as `SignatureDoesNotMatch` |
 | `x-sim-aws-error-detail` | Absent                                                                                   | What the simulator can say about why                |
@@ -662,9 +658,9 @@ that never mention IAM keep working.
 
 Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy`, and
 `AWS::IAM::Policy`. An `AWS::IAM::Policy` puts its document onto each Role named in `Roles` as an
-inline policy — the pattern CDK grants such as `bucket.grantRead(fn)` synthesize as a
-"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals, so naming
-them fails creation rather than silently dropping the grant.
+inline policy. That is the shape CDK grants such as `bucket.grantRead(fn)` synthesize as a
+"DefaultPolicy" resource. IAM Users and Groups are not simulated as policy principals, so naming them
+fails creation rather than silently dropping the grant.
 
 ```typescript sim-iam-cloudformation
 /**
@@ -802,8 +798,8 @@ Accounts, as it is on AWS:
 Either one on its own is denied. A resource policy naming another Account's principal delegates to
 that Account rather than granting on its behalf, and an Account cannot grant its own principals
 access to somebody else's resource. An explicit `Deny` on either side denies. Callers with no
-identity side — a service principal, or an anonymous request — are unaffected, and are still allowed
-by a resource policy alone.
+identity side, such as a service principal or an anonymous request, are unaffected, and are still
+allowed by a resource policy alone.
 
 ```typescript sim-iam-cross-account
 /**
@@ -888,7 +884,7 @@ nothing, which is also what a principal ARN that was never given any permissions
 
 A standalone `SimIam` has no simulation around it and so no other Account to ask: a principal whose
 ARN belongs to another Account is always denied, however permissive the resource policy. Anonymous
-and service-principal callers are not affected — they have no Account either way, so a resource
+and service-principal callers are not affected, since they have no Account either way, so a resource
 policy still allows them. The Account ID is available as `simIam.accountId`, which is what a test
 naming its own principals should build their ARNs from.
 
@@ -924,9 +920,9 @@ console.log(roleCreation.Role.Arn);
 ```
 
 A standalone `SimIam` instance has its own isolated state, scoped to a generated Account ID, and is
-not connected to a wider `SimAws` environment. Note that other services instantiated standalone,
-such as `new SimRoute53()`, fall back to allow-all authorization — connect services through a
-shared `SimAws` instance when a test should exercise real IAM enforcement.
+not connected to a wider `SimAws` environment. Other services instantiated standalone, such as
+`new SimRoute53()`, fall back to allow-all authorization. Connect services through a shared `SimAws`
+instance when a test should exercise real IAM enforcement.
 
 ## Limitations
 

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -2,7 +2,9 @@
 
 Yulin includes a simulated AWS Key Management Service (KMS) for tests and local development.
 
-Encryption here is real encryption. Each simulated key holds real AES-256 key material and the operations run through Node.js's own `crypto`, so a ciphertext genuinely cannot be read without its key, and a decryption with the wrong encryption context genuinely fails. That is fast enough to be unremarkable in a test suite, and it means a passing test says something about how the code will behave against real KMS.
+Encryption is real. Each simulated key holds AES-256 key material and the operations run through
+Node.js's own `crypto`, so a ciphertext cannot be read without its key, and a decryption with the
+wrong encryption context fails.
 
 KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
 
@@ -10,19 +12,20 @@ KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
 
 Sim KMS currently supports:
 
-- Creating symmetric encryption keys with `CreateKeyCommand`, with the default key policy or one of your own
-- Describing and listing keys with `DescribeKeyCommand` and `ListKeysCommand`
-- Reading and replacing a key policy with `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
-- Encrypting and decrypting with `EncryptCommand` and `DecryptCommand`, including encryption context
-- Envelope encryption with `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
-- Aliases with `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases such as `alias/aws/s3`
-- Key lifecycle with `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand` and `CancelKeyDeletionCommand`
-- Key policy evaluation by simulated IAM, including the rule that an identity policy cannot reach a key its policy does not admit
+- `CreateKeyCommand`, for symmetric encryption keys
+- `DescribeKeyCommand` and `ListKeysCommand`
+- `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
+- `EncryptCommand` and `DecryptCommand`, including encryption context
+- `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
+- `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases
+- `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand`, `CancelKeyDeletionCommand`
+- Key policy evaluation by simulated IAM
 - Key ARNs, key IDs, alias names and alias ARNs as interchangeable ways to name a key
-- Creating keys and aliases from `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources
+- The `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
-The simulator focuses on useful behaviour for isolated tests and local development rather than full KMS feature parity.
+The simulator focuses on useful behaviour for tests and local development rather than full KMS
+feature parity.
 
 ## Encrypting and decrypting
 
@@ -62,11 +65,13 @@ const decrypted = await kms.decrypt(
 console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter2"
 ```
 
-The ciphertext blob is opaque: it is not the plaintext, and nothing outside the simulator should try to read it. It is also not portable to real AWS, or between two `SimAws` instances.
+The ciphertext blob is opaque. Nothing outside the simulator should try to read it. It is not
+portable to real AWS, or between two `SimAws` instances.
 
 ## Encryption context
 
-An encryption context is non-secret key/value data bound to a ciphertext. Supplying a different one on decryption fails, which is what makes it useful for tying a ciphertext to the thing it belongs to.
+An encryption context is non-secret key/value data bound to a ciphertext. Supplying a different one
+on decryption fails, which ties a ciphertext to the thing it belongs to.
 
 ```typescript sim-kms-encryption-context
 /**
@@ -113,7 +118,9 @@ The context is an unordered map, so the same pairs written in a different order 
 
 ## Envelope encryption
 
-`Encrypt` takes at most 4096 bytes, which is the limit that makes envelope encryption necessary. `GenerateDataKey` returns a data key twice: once in the clear, to encrypt your data with, and once encrypted under the KMS key, to store alongside it.
+`Encrypt` takes at most 4096 bytes, which is the limit that makes envelope encryption necessary.
+`GenerateDataKey` returns a data key twice: once in the clear, to encrypt your data with, and once
+encrypted under the KMS key, to store alongside it.
 
 ```typescript sim-kms-generate-data-key
 /**
@@ -152,12 +159,14 @@ console.log(recovered.Plaintext?.length); // 32
 
 ## Key policies and IAM
 
-This is the part of KMS most worth testing, and the part most often got wrong on real AWS.
+Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` reaches
+nothing unless the key's own policy admits the caller. How it admits them decides what else is
+needed:
 
-Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` reaches nothing unless the key's own policy admits the caller. How it admits them decides what else is needed:
-
-- A statement naming the caller grants access outright, so a role with no permissions of its own can still use the key.
-- A statement naming the account root, which is what the default key policy contains, only delegates to that account's IAM. The caller still needs an identity policy allowing the action.
+- A statement naming the caller grants access outright, so a role with no permissions of its own can
+  still use the key.
+- A statement naming the account root, which is what the default key policy contains, only delegates
+  to that account's IAM. The caller still needs an identity policy allowing the action.
 
 ```typescript sim-kms-key-policy
 /**
@@ -226,15 +235,21 @@ try {
 }
 ```
 
-Replacing a key policy with `PutKeyPolicyCommand` can lock an account out of its own key. That is real KMS behaviour, and it is worth being able to reproduce in a test rather than in a deployment.
+Replacing a key policy with `PutKeyPolicyCommand` can lock an account out of its own key, as it can
+on real KMS.
 
 ## Naming a key
 
-Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a key ID, a key ARN, an alias name such as `alias/app-key`, or an alias ARN.
+Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a
+key ID, a key ARN, an alias name such as `alias/app-key`, or an alias ARN.
 
-A key ARN or alias ARN naming another account or region resolves to nothing, rather than having its identifier read out and looked up locally, so a foreign ARN cannot reach a key that happens to share an identifier.
+A key ARN or alias ARN naming another account or region resolves to nothing, rather than having its
+identifier read out and looked up locally. A foreign ARN cannot reach a key that happens to share an
+identifier.
 
-Aliases beginning `alias/aws/` are reserved for AWS managed keys. `CreateAlias` refuses to create one, but referencing one brings the key into existence, the way an AWS managed key appears on real AWS when a service first needs it.
+Aliases beginning `alias/aws/` are reserved for AWS managed keys. `CreateAlias` refuses to create
+one, but referencing one brings the key into existence, the way an AWS managed key appears on real
+AWS when a service first needs it.
 
 ```typescript sim-kms-aliases
 /**
@@ -279,13 +294,22 @@ console.log(managed.KeyMetadata?.KeyManager); // "AWS"
 
 ## Key state and deletion
 
-A key can be disabled, which leaves it present but unusable, and re-enabled later. Deletion is never immediate: `ScheduleKeyDeletion` sets a recovery window of 7 to 30 days, defaulting to 30, during which the key refuses to be used but can still be recovered with `CancelKeyDeletion`. Cancelling leaves the key disabled rather than enabled, so re-enabling it is a separate deliberate step.
+A key can be disabled, which leaves it present but unusable, and re-enabled later.
 
-A disabled key fails cryptographic operations with `DisabledException`; a key pending deletion fails with `KMSInvalidStateException`. The difference is worth keeping, because one says to enable the key and the other says the key is on its way out.
+Deletion is never immediate. `ScheduleKeyDeletion` sets a recovery window of 7 to 30 days, defaulting
+to 30. During that window the key refuses to be used but can still be recovered with
+`CancelKeyDeletion`. Cancelling leaves the key disabled rather than enabled, so re-enabling it is a
+separate step.
+
+A disabled key fails cryptographic operations with `DisabledException`. A key pending deletion fails
+with `KMSInvalidStateException`. The two are distinct: one means the key can be enabled again, the
+other means it is on its way out.
 
 ## Scoping
 
-KMS keys belong to an account and a region, as they do on real AWS. A key created in one region cannot be found or used from another, and a ciphertext produced under it cannot be decrypted elsewhere.
+KMS keys belong to an account and a region, as they do on real AWS. A key created in one region
+cannot be found or used from another, and a ciphertext produced under it cannot be decrypted
+elsewhere.
 
 ```typescript sim-kms-scoping
 /**
@@ -318,9 +342,16 @@ try {
 
 ## Deploying a key from CloudFormation
 
-Simulated CloudFormation creates a key from an `AWS::KMS::Key` resource and points an `AWS::KMS::Alias` at it, in the stack's account and region. The key comes out of the same `CreateKey` path an SDK caller uses, so it has real key material, and a `KeyPolicy` the template declares becomes the key policy. Omitting `KeyPolicy` gets the default root-delegation policy, exactly as `CreateKey` with no `Policy` does.
+Simulated CloudFormation creates a key from an `AWS::KMS::Key` resource and points an
+`AWS::KMS::Alias` at it, in the stack's account and region. The key comes out of the same `CreateKey`
+path an SDK caller uses, so it has real key material. A `KeyPolicy` the template declares becomes the
+key policy. Omitting `KeyPolicy` gets the default root-delegation policy, as `CreateKey` with no
+`Policy` does.
 
-`Ref` on the key gives its key ID rather than its ARN, as on real AWS, and `Fn::GetAtt` gives `Arn` or `KeyId`. `Ref` on the alias gives the alias name, such as `alias/app-key`, which is itself usable as a `KeyId`. That difference matters: a property wanting a key ID takes the `Ref`, and an IAM policy resource wanting the key needs `Fn::GetAtt … Arn`.
+`Ref` on the key gives its key ID rather than its ARN, as on real AWS, and `Fn::GetAtt` gives `Arn`
+or `KeyId`. `Ref` on the alias gives the alias name, such as `alias/app-key`, which is itself usable
+as a `KeyId`. So a property wanting a key ID takes the `Ref`, while an IAM policy resource wanting
+the key needs `Fn::GetAtt … Arn`.
 
 ```typescript sim-kms-cloudformation-key
 /**
@@ -374,29 +405,52 @@ console.log(Buffer.from(decrypted.Plaintext ?? []).toString("utf8")); // "hunter
 console.log(stack.outputs.get("KeyArn")?.value); // "arn:aws:kms:...:key/..."
 ```
 
-Properties asking for behaviour that is not simulated refuse the deployment rather than being ignored, so a template does not quietly deploy a key that would behave differently on AWS. `EnableKeyRotation`, `RotationPeriodInDays`, `MultiRegion` and `Tags` are all refused, and an asymmetric or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is refused by `CreateKey` in the same terms it refuses an SDK caller. `Enabled: false` is supported, and deploys a key that is disabled from the moment it exists.
+Properties asking for behaviour that is not simulated refuse the deployment rather than being
+ignored, so a template does not quietly deploy a key that would behave differently on AWS.
+`EnableKeyRotation`, `RotationPeriodInDays`, `MultiRegion` and `Tags` are all refused. An asymmetric
+or HMAC `KeySpec` or `KeyUsage`, or an `Origin` other than `AWS_KMS`, is refused by `CreateKey` in
+the same terms it refuses an SDK caller. `Enabled: false` is supported, and deploys a key that is
+disabled from the moment it exists.
 
 ## Inside a simulated Lambda handler
 
-Function code requiring `@aws-sdk/client-kms` is routed into the same simulated AWS environment, with the function's execution role as the caller. A handler that decrypts a value therefore has to be allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See [simulated Lambda](../lambda/) for how function code and execution roles work.
+Function code requiring `@aws-sdk/client-kms` is routed into the same simulated AWS environment, with
+the function's execution role as the caller. A handler that decrypts a value therefore has to be
+allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See
+[simulated Lambda](../lambda/) for how function code and execution roles work.
 
 ## Limitations
 
 Current documented limitations:
 
-- Only symmetric encryption keys (`SYMMETRIC_DEFAULT`, `ENCRYPT_DECRYPT`) are simulated. Asymmetric keys, HMAC keys, `Sign`, `Verify` and `ReEncrypt` are not.
-- Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is refused.
+- Only symmetric encryption keys (`SYMMETRIC_DEFAULT`, `ENCRYPT_DECRYPT`) are simulated. Asymmetric
+  keys, HMAC keys, `Sign`, `Verify` and `ReEncrypt` are not.
+- Imported key material and custom key stores are not simulated; `Origin` other than `AWS_KMS` is
+  refused.
 - Grants (`CreateGrant` and friends) are not simulated.
-- Automatic key rotation is not simulated. An `AWS::KMS::Key` declaring `EnableKeyRotation` or `RotationPeriodInDays` is refused.
+- Automatic key rotation is not simulated. An `AWS::KMS::Key` declaring `EnableKeyRotation` or
+  `RotationPeriodInDays` is refused.
 - Multi-Region keys are not simulated. An `AWS::KMS::Key` declaring `MultiRegion: true` is refused.
-- `AWS::KMS::Key` accepts but ignores `PendingWindowInDays` and `BypassPolicyLockoutSafetyCheck`. Neither has anything to act on: simulated CloudFormation does not delete stacks, and simulated KMS applies no policy lockout safety check to bypass.
-- CloudFormation creates KMS resources but never changes or removes them: an `AWS::KMS::Alias` cannot be retargeted by a stack update, because `UpdateAlias` and `DeleteAlias` are not simulated.
-- `AWS::KMS::Grant` and `AWS::KMS::ReplicaKey` are not supported; a template declaring one is refused.
-- A key pending deletion stays in that state indefinitely. Advancing the simulated clock past the recovery window does not delete it, so the key ID stays taken.
+- `AWS::KMS::Key` accepts but ignores `PendingWindowInDays` and `BypassPolicyLockoutSafetyCheck`.
+  Neither has anything to act on: simulated CloudFormation does not delete stacks, and simulated KMS
+  applies no policy lockout safety check to bypass.
+- CloudFormation creates KMS resources but never changes or removes them. An `AWS::KMS::Alias` cannot
+  be retargeted by a stack update, because `UpdateAlias` and `DeleteAlias` are not simulated.
+- `AWS::KMS::Grant` and `AWS::KMS::ReplicaKey` are not supported; a template declaring one is
+  refused.
+- A key pending deletion stays in that state indefinitely. Advancing the simulated clock past the
+  recovery window does not delete it, so the key ID stays taken.
 - Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
-- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An `AWS::KMS::Key` declaring `Tags` is refused rather than deploying with the tags dropped.
-- `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived, so a policy relying on them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
-- AWS managed keys created on demand get the same default key policy as a customer key, rather than the via-service-scoped policy real AWS gives them. Scheduling one for deletion is refused, as on real AWS, but disabling one is not, which real AWS does refuse.
-- Key material lives in process memory for the lifetime of the `SimAws` instance. That is fine for a simulator, but it is not a security boundary: anything sharing the process can reach it.
-- No other simulated service encrypts anything with KMS yet. Sim S3, sim DynamoDB and sim Lambda environment variables do not use simulated keys, and do not check `kms:Decrypt`.
+- Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An
+  `AWS::KMS::Key` declaring `Tags` is refused rather than deploying with the tags dropped.
+- `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived,
+  so a policy relying on them will not match. Ordinary condition operators on values sim IAM does
+  supply work as usual.
+- AWS managed keys created on demand get the same default key policy as a customer key, rather than
+  the via-service-scoped policy real AWS gives them. Scheduling one for deletion is refused, as on
+  real AWS, but disabling one is not, which real AWS does refuse.
+- Key material lives in process memory for the lifetime of the `SimAws` instance. That is not a
+  security boundary: anything sharing the process can reach it.
+- No other simulated service encrypts anything with KMS yet. Sim S3, sim DynamoDB and sim Lambda
+  environment variables do not use simulated keys, and do not check `kms:Decrypt`.
 - KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1,13 +1,10 @@
 # Simulated Lambda
 
-Yulin includes a simulated AWS Lambda service for tests and local development. Functions are
-created and invoked entirely in-process and in-memory. There is no need for containers or real AWS
-infrastructure.
+Yulin includes a simulated AWS Lambda service for tests and local development. Functions are created
+and invoked in-process and in memory, with no containers and no real AWS infrastructure.
 
-Sim Lambda can be used through `SimAws` to create functions, inspect their configuration, invoke
-them, and create functions from sim CloudFormation templates. Handlers run with their execution
-role as the simulated caller, so AWS calls made inside a handler are authorized by simulated IAM,
-similar to real Lambda.
+Handlers run with their execution role as the simulated caller, so AWS calls made inside a handler
+are authorized by simulated IAM, as on real Lambda.
 
 Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath.
 
@@ -15,43 +12,34 @@ Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath.
 
 Sim Lambda currently supports:
 
-- Creating functions with `CreateFunctionCommand`
-- Fetching function configuration with `GetFunctionCommand`
-- Invoking functions with `InvokeCommand`, including the `RequestResponse`, `Event`, and `DryRun`
-  invocation types
-- Function URLs, created with `CreateFunctionUrlConfigCommand` and served over real HTTP on
-  localhost with `serveSimAws`, so application code can call a simulated function the way it calls
-  a deployed one
+- `CreateFunctionCommand` and `GetFunctionCommand`
+- `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
+- Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
+  with `serveSimAws`
 - `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
-  resolved from the request and reporting it to the handler as
-  `requestContext.authorizer.iam`
-- Function resource-based policies with `AddPermissionCommand`, `RemovePermissionCommand` and
-  `GetPolicyCommand`, evaluated alongside identity policies, including cross-account invocation,
-  which also needs the caller's own Account to allow the action
+  resolved from the request
+- `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
+  policies evaluated alongside identity policies
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
   - a zip object stored in sim S3 via `Code.S3Bucket`/`S3Key`
-- A Node.js `vm` runtime for zip-packaged code: warm module state across invocations, relative
-  requires between archived files, Node.js built-in modules, and AWS-like runtime environment
-  variables
-- Per-function environment variables with `Environment.Variables`, isolated from the host process
-  and from other functions
-- Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated
-  AWS environment
-- Execution roles: handlers run as their execution `Role`, evaluated against simulated IAM
+- A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations
+- Per-function environment variables with `Environment.Variables`
+- Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
+  environment
+- Execution roles, evaluated against simulated IAM
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
   `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
-- AWS-like validation and errors, such as `ResourceConflictException` for duplicate function names
-  and `Could not unzip uploaded file` for invalid zip bytes
-- CloudFormation resources `AWS::Lambda::Function`, `AWS::Lambda::Url` and
-  `AWS::Lambda::Permission`, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
+- AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
+- The `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission` CloudFormation
+  resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
 
 Real `LambdaClient` instances can also be routed into sim Lambda with
 [SDK interception](../../sdk/ "Simulated AWS SDK interception docs").
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-Lambda feature parity.
+The simulator focuses on useful behaviour for tests and local development rather than full Lambda
+feature parity.
 
 ## Creating and invoking a function
 
@@ -113,10 +101,10 @@ Creating a function requires an execution `Role` ARN, as on real AWS. A new func
 `Pending` state and becomes `Active` in the background; wait with
 `simAws.backgroundTasksComplete()` when a test asserts on the `Active` state.
 
-Handlers use the same signature as real Node.js Lambda handlers — `(event, context, callback)` —
-and all the real completion styles work: returning a promise, returning a plain value, calling the
-callback, or the legacy context `done`/`fail`/`succeed` methods. Typed handlers written against
-the `aws-lambda` typings package can be passed in unchanged.
+Handlers use the same signature as real Node.js Lambda handlers, `(event, context, callback)`. All
+the real completion styles work: returning a promise, returning a plain value, calling the callback,
+or the legacy context `done`/`fail`/`succeed` methods. Typed handlers written against the
+`aws-lambda` typings package can be passed in unchanged.
 
 A handler that throws is reported AWS-style: the invocation output has `FunctionError:
 "Unhandled"` and the payload is an error document with `errorType`, `errorMessage`, and `trace`,
@@ -190,9 +178,9 @@ The vm runtime models the real Node.js runtime closely:
   modules, and use dependencies bundled under the archive's `node_modules/`.
 - The sandbox provides an AWS-like `process.env` with the standard runtime variables
   (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, ...).
-- Import and handler problems surface as invocation errors with the real runtime error types —
-  `Runtime.ImportModuleError`, `Runtime.HandlerNotFound`, `Runtime.UserCodeSyntaxError`,
-  `Runtime.MalformedHandlerName` — rather than failing creation.
+- Import and handler problems surface as invocation errors rather than failing creation, with the
+  real runtime error types (`Runtime.ImportModuleError`, `Runtime.HandlerNotFound`,
+  `Runtime.UserCodeSyntaxError`, `Runtime.MalformedHandlerName`).
 
 Code is CommonJS, as zipped `.js` files are on the real `nodejs` runtimes; ES module source
 (`export` syntax) is not supported yet and fails with a clear hint. `Code.ZipFile` bytes that are
@@ -447,11 +435,10 @@ A Function URL is an HTTP endpoint for one function. Creating one with
 https://<url-id>.lambda-url.<region>.on.aws/
 ```
 
-Serving that URL with `serveSimAws` is the point of the feature: application code, a frontend dev
-server, or curl can make real HTTP requests to a simulated Lambda function, alongside the other
-simulated services on the same local server. Pass the Function URL through `srv.localUrl(...)`,
-which keeps the endpoint's hostname but sends the request to the local server, in the same way it
-adapts simulated S3 website and CloudFront URLs.
+Serve that URL with `serveSimAws` and application code, a frontend dev server, or curl can make real
+HTTP requests to the function, alongside the other simulated services on the same local server. Pass
+the Function URL through `srv.localUrl(...)`, which keeps the endpoint's hostname but sends the
+request to the local server, in the same way it adapts simulated S3 website and CloudFront URLs.
 
 ```typescript sim-lambda-function-url
 /**
@@ -568,9 +555,9 @@ action from `lambda:InvokeFunction`, which the Invoke API uses: real AWS separat
 policy can grant the HTTP endpoint without granting the SDK operation, and a policy naming only one
 of them does not grant the other here either.
 
-The caller comes from the request itself — a SigV4 signature, or an `x-sim-aws-caller` header
-naming a principal directly. A request that offers neither is anonymous, owns no policies, and is
-refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how
+The caller comes from the request itself, through either a SigV4 signature or an `x-sim-aws-caller`
+header naming a principal directly. A request that offers neither is anonymous, owns no policies, and
+is refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how
 that resolution works and how to sign a served request.
 
 An `AWS_IAM` invocation carries its caller into the event as
@@ -680,9 +667,8 @@ AWS decides a cross-Account request. See
 [Cross-Account requests](../iam/README.md#cross-account-requests).
 
 `AddPermissionCommand` grants a statement, `RemovePermissionCommand` revokes it by `StatementId`,
-and `GetPolicyCommand` returns the assembled document. `AddPermission` is a shorthand for writing a
-statement — Lambda expands the parts into one — so the statement it returns is the clearest account
-of what a grant actually means:
+and `GetPolicyCommand` returns the assembled document. `AddPermission` is a shorthand: Lambda expands
+its parts into one statement, so reading that statement back shows what the grant means:
 
 ```typescript sim-lambda-add-permission
 /**
@@ -826,18 +812,18 @@ The same applies to zip-packaged code in the vm runtime and to functions deploye
 [executable binding](#executable-bindings).
 
 Variable names are validated as on real AWS. A name must match the Lambda name pattern
-`[a-zA-Z]([a-zA-Z0-9_])+` — starting with a letter, at least two characters, and otherwise letters,
-digits and underscores — or it is rejected with `ValidationException`. The names Lambda reserves
-for the runtime (`AWS_REGION`, `AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be
-declared, and are rejected with `InvalidParameterValueException`. As on AWS, the pattern is checked
-first, so a reserved name that also breaks it, such as `_HANDLER`, is reported as the constraint
-violation.
+`[a-zA-Z]([a-zA-Z0-9_])+`, meaning it starts with a letter, is at least two characters, and otherwise
+holds letters, digits and underscores. A name that does not match is rejected with
+`ValidationException`. The names Lambda reserves for the runtime (`AWS_REGION`,
+`AWS_LAMBDA_FUNCTION_NAME`, `LAMBDA_TASK_ROOT` and so on) cannot be declared, and are rejected with
+`InvalidParameterValueException`. As on AWS, the pattern is checked first, so a reserved name that
+also breaks it, such as `_HANDLER`, is reported as the constraint violation.
 
 ### Read environment variables inside the handler
 
-There is one thing to know about functions backed by a real in-process handler function. Because
-that handler is an ordinary function in your test process rather than code loaded into a sandbox,
-it only gets the function's own `process.env` while it is actually running.
+A function backed by a real in-process handler behaves differently here. That handler is an ordinary
+function in your test process rather than code loaded into a sandbox, so it only gets the function's
+own `process.env` while it is actually running.
 
 That means a variable read at module scope is read too early:
 
@@ -852,13 +838,13 @@ export const handler = async () => {
 };
 ```
 
-Moving the read inside the handler is the fix, and is worth doing anyway for testability. Zip
-code in the vm runtime is unaffected, because it is imported at cold start, during an invocation.
+Moving the read inside the handler fixes it. Zip code in the vm runtime is unaffected, because it is
+imported at cold start, during an invocation.
 
-In practice this often does not come up: test suites commonly export the same variables they
-configure their functions with, and then a module-scope read gets the right value regardless. Sim
-Lambda warns on the console when that is not the case, in the two situations where the difference
-actually changes what your code sees:
+This often does not come up, because test suites commonly export the same variables they configure
+their functions with, and then a module-scope read gets the right value anyway. Sim Lambda warns on
+the console when that is not the case, in the two situations where the difference changes what your
+code sees:
 
 - a declared variable whose name the host process also sets, with a different value
 - two simulated functions declaring the same variable name with different values
@@ -970,7 +956,7 @@ Supported function properties:
 - `FunctionName` (defaults to the logical ID)
 - `Role` (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`; both resolve to the
   role's ARN)
-- `Code` — inline `ZipFile` source string, or `S3Bucket`/`S3Key` fetched from same-scope sim S3
+- `Code` (inline `ZipFile` source string, or `S3Bucket`/`S3Key` fetched from same-scope sim S3)
 - `Handler`
 - `Runtime`
 - `Description`
@@ -1092,8 +1078,8 @@ failing the deployment.
 
 ## Executable bindings
 
-Deploy-time `bindings` let a template function be backed by a real in-process handler instead of
-its template code — the CloudFormation counterpart of `makeLambdaZipFileInput(...)`. The bound
+Deploy-time `bindings` let a template function be backed by a real in-process handler instead of its
+template code. They are the CloudFormation counterpart of `makeLambdaZipFileInput(...)`. The bound
 handler runs with the same execution-role attribution as template code, can close over test state,
 and can be stepped through in a debugger.
 
@@ -1158,7 +1144,8 @@ deploy with the unmatched target named for diagnosis.
 Current documented limitations:
 
 - Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, and the Function URL config
-  commands are supported — no `UpdateFunctionCode`, `DeleteFunction`, or function listing yet.
+  commands are supported. There is no `UpdateFunctionCode`, `DeleteFunction`, or function listing
+  yet.
 - A cross-account grant is only half of what admits a call: the caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account the simulation knows nothing about is denied.
@@ -1179,7 +1166,7 @@ Current documented limitations:
 - Function versions, aliases, and qualifiers are not simulated (`Version` is always `$LATEST`).
 - The vm runtime supports CommonJS function code only; ES module source (`.mjs` / `export`
   syntax) is not supported yet.
-- Container image functions (`Code.ImageUri`) are not supported — the simulator stays Docker-free.
+- Container image functions (`Code.ImageUri`) are not supported. The simulator stays Docker-free.
 - Lambda Layers are not simulated.
 - Environment variables declared with `Environment.Variables` reach a real in-process handler
   function only while it runs, so a variable read at module scope sees the host process value

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1143,7 +1143,8 @@ deploy with the unmatched target named for diagnosis.
 
 Current documented limitations:
 
-- Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, and the Function URL config
+- Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, the permission commands
+  (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`) and the Function URL config
   commands are supported. There is no `UpdateFunctionCode`, `DeleteFunction`, or function listing
   yet.
 - A cross-account grant is only half of what admits a call: the caller's own Account has to allow

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -11,26 +11,21 @@ services, such as simulated CloudFront distributions or simulated S3 bucket webs
 
 Sim Route53 currently supports:
 
-- Creating Hosted Zones with `CreateHostedZoneCommand`
-- Getting Hosted Zones with `GetHostedZoneCommand`
-- Listing Hosted Zones by name with `ListHostedZonesByNameCommand`
-- Changing record sets with `ChangeResourceRecordSetsCommand`
-- Listing record sets in a Hosted Zone with `ListResourceRecordSetsCommand`
-- `CREATE`, `UPSERT`, and `DELETE` record changes
-- Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS`, and `SOA`
+- `CreateHostedZoneCommand`, `GetHostedZoneCommand` and `ListHostedZonesByNameCommand`
+- `ChangeResourceRecordSetsCommand` and `ListResourceRecordSetsCommand`
+- `CREATE`, `UPSERT` and `DELETE` record changes
+- Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`
 - Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
 - Alias records, with `AliasTarget.DNSName` stored as the record value
 - Local hostname resolution through `*.sim-aws.localhost`
 - A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
-- Real DNS answers over UDP, so records can be queried with `dig` or any DNS client
-- CloudFormation resources:
-  - `AWS::Route53::HostedZone`
-  - `AWS::Route53::RecordSet`
+- DNS answers over UDP, so records can be queried with `dig` or any DNS client
+- The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources
 - CDK-created Route53 Hosted Zones and records in synthesized templates
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-Route53 feature parity. Unsupported Route53 options may be ignored or may throw errors depending on
-whether the simulator needs them to model the requested behavior.
+The simulator focuses on useful behaviour for tests and local development rather than full Route53
+feature parity. Unsupported Route53 options may be ignored or may throw errors depending on whether
+the simulator needs them to model the requested behaviour.
 
 ## Basic Hosted Zone usage
 
@@ -396,8 +391,8 @@ back as `StartRecordName` and `StartRecordType`. Marker names are normalised, so
 and `WWW.EXAMPLE.TEST.` select the same starting point.
 
 Alias records are returned with an `AliasTarget` rather than `ResourceRecords`. The simulator stores
-an alias target as a record value plus an alias flag, so `AliasTarget.DNSName` is returned but
-`AliasTarget.HostedZoneId` is not — it is not part of the stored record.
+an alias target as a record value plus an alias flag, so `AliasTarget.DNSName` is returned.
+`AliasTarget.HostedZoneId` is not part of the stored record and is not returned.
 
 ## Inspecting hosted zones in a browser
 
@@ -584,9 +579,9 @@ number is already held on UDP by something else, DNS binds an ephemeral port ins
 `srv.dnsPort` rather than assuming it matches `srv.port`.
 
 Nothing binds port 53, which would need root. To resolve simulated names system-wide without naming a
-port, point your resolver at the simulator yourself — on macOS, a file such as `/etc/resolver/test`
-containing `nameserver 127.0.0.1` and `port <dnsPort>` makes the whole `.test` TLD resolve through it.
-That is a change to your machine, so Yulin does not make it for you.
+port, point your resolver at the simulator yourself. On macOS, a file such as `/etc/resolver/test`
+containing `nameserver 127.0.0.1` and `port <dnsPort>` makes the whole `.test` TLD resolve through
+it. That is a change to your machine, so Yulin does not make it for you.
 
 ### What is answered
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1,6 +1,6 @@
 # Simulated S3
 
-Yulin includes a simulated S3 service for isolated tests, local development, and CI.
+Yulin includes a simulated S3 service for tests and local development.
 
 Sim S3 can be used directly through `SimAws` or instantiated on its own as `SimS3` with isolated
 state. Yulin can serve a simulated S3 service on localhost.
@@ -9,17 +9,14 @@ state. Yulin can serve a simulated S3 service on localhost.
 
 Sim S3 currently supports:
 
-- Creating Buckets with `CreateBucketCommand`
-- Listing Buckets with `ListBucketsCommand`
-- Putting Objects with `PutObjectCommand`
-- Getting Objects with `GetObjectCommand`
-- Listing Objects with `ListObjectsCommand`
-- Configuring static website hosting with `PutBucketWebsiteCommand`
-- Bucket policies with `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and
-  `DeleteBucketPolicyCommand`, evaluated by sim IAM alongside identity policies
-- Creating Buckets and Bucket policies from `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
-- Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the
-  Bucket opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
+- `CreateBucketCommand` and `ListBucketsCommand`
+- `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
+- `PutBucketWebsiteCommand`, for static website hosting
+- `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
+  sim IAM alongside identity policies
+- The `AWS::S3::Bucket` and `AWS::S3::BucketPolicy` CloudFormation resources
+- Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the Bucket
+  opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
 - Serving static website requests on localhost with `serveSimAws`
 - Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
@@ -29,9 +26,9 @@ Sim S3 currently supports:
 - In-memory Object storage by default
 - Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-S3 feature parity. Unsupported S3 options may be ignored or may throw errors depending on whether
-the simulator needs them to model the requested behaviour.
+The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
+parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
+needs them to model the requested behaviour.
 
 ## Basic usage
 
@@ -399,8 +396,7 @@ Configure Bucket website hosting with `PutBucketWebsiteCommand`.
 
 Website hosting settles which Object answers a request, not who may read it. A browser asking for a
 page is anonymous, and anonymous holds nothing unless a Bucket policy grants it, so a site with no
-Bucket policy answers `403` to every ordinary visitor. That is what real S3 does, and it is the
-mistake this most often catches: a site that works because nothing was checking. See
+Bucket policy answers `403` to every ordinary visitor, as it does on real S3. See
 [Block Public Access](#block-public-access) for the two commands a public site needs; the localhost
 serving example below shows them in place. The examples in this section configure hosting without
 serving it, so they leave that out.
@@ -698,10 +694,10 @@ const response = await fetch(url); // 403
 
 ### Uploads and checksums
 
-Presigned `PutObjectCommand` URLs work in the same way, and bring one trap worth knowing about. The
-AWS SDK computes a checksum when it presigns, which is before there is a body to hash, and hoists it
-into the signed URL. Uploading anything else through that URL then fails against real S3, and fails
-here too, with `XAmzContentChecksumMismatch`. Build the client with
+Presigned `PutObjectCommand` URLs work in the same way, with one thing to watch. The AWS SDK computes
+a checksum when it presigns, which is before there is a body to hash, and hoists it into the signed
+URL. Uploading anything else through that URL then fails against real S3, and fails here too, with
+`XAmzContentChecksumMismatch`. Build the client with
 `requestChecksumCalculation: "WHEN_REQUIRED"` to presign upload URLs that accept a body:
 
 ```typescript

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -1,8 +1,7 @@
 # Simulated Secrets Manager
 
-Yulin includes a simulated AWS Secrets Manager for tests and local development.
-
-The point of simulating it is the part mocking an SDK client cannot tell you: whether the secret exists, whether the caller's execution role is allowed to read it, and whether the code reached the right account and region. A handler that fetches a database password on cold start can be exercised end to end, and a policy that would fail on real AWS fails here too.
+Yulin includes a simulated AWS Secrets Manager for tests and local development. Secrets are stored
+in memory, versioned by staging label, and every operation is authorized by simulated IAM.
 
 Secrets Manager-specific types are imported from the `@kensio/yulin/secretsmanager` subpath.
 
@@ -10,20 +9,20 @@ Secrets Manager-specific types are imported from the `@kensio/yulin/secretsmanag
 
 Sim Secrets Manager currently supports:
 
-- Creating secrets with `CreateSecretCommand`, holding either a string or binary
-- Reading values with `GetSecretValueCommand`, by staging label or by version id
-- Writing new versions with `PutSecretValueCommand` and `UpdateSecretCommand`
-- Describing and listing with `DescribeSecretCommand` and `ListSecretsCommand`
-- Deleting with `DeleteSecretCommand`, with a real recovery window, and taking it back with `RestoreSecretCommand`
-- `AWSCURRENT` and `AWSPREVIOUS` staging labels, and custom labels of your own
+- `CreateSecretCommand`, holding either a string or binary
+- `GetSecretValueCommand`, by staging label or by version id
+- `PutSecretValueCommand` and `UpdateSecretCommand`, each writing a new version
+- `DescribeSecretCommand` and `ListSecretsCommand`
+- `DeleteSecretCommand`, with a recovery window, and `RestoreSecretCommand`
+- `AWSCURRENT` and `AWSPREVIOUS` staging labels, and custom labels
 - Secret ARNs carrying the six random characters real Secrets Manager appends
 - Friendly names, full ARNs and partial ARNs as interchangeable ways to name a secret
 - Authorization of every operation by simulated IAM, against the real IAM action
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
-- Creating secrets from `AWS::SecretsManager::Secret` CloudFormation resources, including
-  `GenerateSecretString` generated passwords
+- The `AWS::SecretsManager::Secret` CloudFormation resource, including `GenerateSecretString`
 
-The simulator focuses on useful behaviour for isolated tests and local development rather than full Secrets Manager feature parity.
+The simulator focuses on useful behaviour for tests and local development rather than full Secrets
+Manager feature parity.
 
 ## Creating and reading a secret
 
@@ -60,11 +59,15 @@ const credentials = JSON.parse(read.SecretString ?? "{}") as {
 console.log(credentials.password); // "hunter2"
 ```
 
-`SecretString` and `SecretBinary` are mutually exclusive on write, and exactly one of them comes back on read.
+`SecretString` and `SecretBinary` are mutually exclusive on write, and exactly one of them comes back
+on read.
 
 ## Secret ARNs and IAM policies
 
-Real Secrets Manager appends a hyphen and six random characters to the secret name in its ARN, so a secret named `db-creds` gets an ARN ending `:secret:db-creds-AbCdEf`. This is the detail that most often breaks a policy on real AWS, and it is reproduced here: a policy naming the bare ARN matches nothing, and a policy has to end in `-??????` or a wildcard.
+Real Secrets Manager appends a hyphen and six random characters to the secret name in its ARN, so a
+secret named `db-creds` gets an ARN ending `:secret:db-creds-AbCdEf`. Sim Secrets Manager does the
+same. A policy naming the bare ARN therefore matches nothing, and a policy has to end in `-??????` or
+a wildcard.
 
 ```typescript sim-secrets-manager-iam-policy
 /**
@@ -128,17 +131,22 @@ const read = await simAws
 console.log(read.SecretString); // "hunter2"
 ```
 
-`ListSecrets` is the exception: real Secrets Manager gives it no resource-level permissions, so a policy allowing it has to use a resource of `*`. A policy naming individual secret ARNs grants nothing, here as there.
+`ListSecrets` is the exception: real Secrets Manager gives it no resource-level permissions, so a
+policy allowing it has to use a resource of `*`. A policy naming individual secret ARNs grants
+nothing, here as there.
 
 ## Naming a secret
 
-Every operation takes its target as a `SecretId`, and any of the three forms real Secrets Manager accepts will do: the friendly name, the full ARN including the suffix, or the partial ARN without it.
+Every operation takes its target as a `SecretId`, and any of the three forms real Secrets Manager
+accepts will do: the friendly name, the full ARN including the suffix, or the partial ARN without it.
 
-An ARN naming another account or region resolves to nothing, rather than having its name read out and looked up locally, so a foreign ARN cannot reach a secret that happens to share a name.
+An ARN naming another account or region resolves to nothing, rather than having its name read out and
+looked up locally. A foreign ARN cannot reach a secret that happens to share a name.
 
 ## Versions and staging labels
 
-Every write creates a version rather than replacing one. `AWSCURRENT` names the version a plain read returns, and writing a new current version demotes the previous one to `AWSPREVIOUS`.
+Every write creates a version rather than replacing one. `AWSCURRENT` names the version a plain read
+returns, and writing a new current version demotes the previous one to `AWSPREVIOUS`.
 
 ```typescript sim-secrets-manager-staging-labels
 /**
@@ -178,15 +186,21 @@ console.log(current.SecretString); // "new-key"
 console.log(previous.SecretString); // "old-key"
 ```
 
-A `ClientRequestToken` becomes the version id, as it does on real AWS. Repeating a write with the same token and the same value is ignored, which is what makes a retry safe; the same token with a different value is refused, because a version's value never changes once written.
+A `ClientRequestToken` becomes the version id, as it does on real AWS. Repeating a write with the
+same token and the same value is ignored, which makes a retry safe. The same token with a different
+value is refused, because a version's value never changes once written.
 
-`DescribeSecret` reports `VersionIdsToStages`, which lists only the versions still carrying a staging label. A version that has lost every label is on its way out of existence, so it is left out.
+`DescribeSecret` reports `VersionIdsToStages`, which lists only the versions still carrying a staging
+label. A version that has lost every label is on its way out of existence, so it is left out.
 
 ## Deletion and the recovery window
 
-`DeleteSecret` does not delete. It schedules deletion after a recovery window of 7 to 30 days, defaulting to 30, and during that window the secret is still there: it can be described and restored, it refuses to be read or written, and — the part that catches people out — it still holds its name.
+`DeleteSecret` does not delete. It schedules deletion after a recovery window of 7 to 30 days,
+defaulting to 30. During that window the secret is still there: it can be described and restored, it
+refuses to be read or written, and it still holds its name.
 
-That last one is the failure a redeployed stack actually hits, so it is worth being able to reproduce. Advancing the simulated clock past the window frees the name.
+Holding the name is what a redeployed stack hits. Advancing the simulated clock past the window frees
+it.
 
 ```typescript sim-secrets-manager-deletion
 /**
@@ -231,13 +245,16 @@ const recreated = await secretsManager.createSecret(
 console.log(recreated.Name); // "db-creds"
 ```
 
-`ForceDeleteWithoutRecovery` deletes at once and frees the name straight away. Asking for it alongside `RecoveryWindowInDays` is a contradiction, and is refused.
+`ForceDeleteWithoutRecovery` deletes at once and frees the name straight away. Asking for it
+alongside `RecoveryWindowInDays` is a contradiction, and is refused.
 
 See [simulated time](../../time/ "Simulated time docs") for what else the clock can do.
 
 ## Scoping
 
-Secrets belong to an account and a region, as they do on real AWS. A secret name is unique within one account and region and nowhere wider, so the same name can be used in two regions for two different secrets.
+Secrets belong to an account and a region, as they do on real AWS. A secret name is unique within one
+account and region and nowhere wider, so the same name can be used in two regions for two different
+secrets.
 
 ```typescript sim-secrets-manager-scoping
 /**
@@ -275,9 +292,14 @@ try {
 
 ## Deploying a secret from CloudFormation
 
-Simulated CloudFormation creates a secret from an `AWS::SecretsManager::Secret` resource, in the stack's account and region. A template either supplies the value with `SecretString` or asks Secrets Manager to generate one with `GenerateSecretString`, as on real AWS; declaring both is refused, as CloudFormation refuses it.
+Simulated CloudFormation creates a secret from an `AWS::SecretsManager::Secret` resource, in the
+stack's account and region. A template either supplies the value with `SecretString` or asks Secrets
+Manager to generate one with `GenerateSecretString`, as on real AWS. Declaring both is refused, as
+CloudFormation refuses it.
 
-`Ref` on the resource gives the full secret ARN, random suffix and all, and `Fn::GetAtt … Id` gives the same. That is what makes a `Ref` usable directly as a `SecretId`, whether it goes into a Lambda's environment or into an IAM policy resource.
+`Ref` on the resource gives the full secret ARN, random suffix and all, and `Fn::GetAtt … Id` gives
+the same. A `Ref` is therefore usable directly as a `SecretId`, whether it goes into a Lambda's
+environment or into an IAM policy resource.
 
 ```typescript sim-secrets-manager-cloudformation-secret
 /**
@@ -335,36 +357,82 @@ console.log(credentials.username); // "app"
 console.log(credentials.password?.length); // 24
 ```
 
-Generated passwords are genuinely random, so a test reads the value back out of the simulation the way a deployed application does rather than predicting it. `SecretStringTemplate` and `GenerateStringKey` go together: the generated password is added to the template's JSON object under that key. Without them, the whole secret value is the generated password, which is what an empty `GenerateSecretString: {}` — the property CDK synthesises for a `secretsmanager.Secret` with no options — produces.
+Generated passwords are random, so a test reads the value back out of the simulation the way a
+deployed application does rather than predicting it.
 
-The other generation options behave as they do on real AWS: `PasswordLength` (32 by default), `ExcludeCharacters`, `ExcludeUppercase`, `ExcludeLowercase`, `ExcludeNumbers`, `ExcludePunctuation`, `IncludeSpace`, and `RequireEachIncludedType`, which is on unless turned off so a generated password carries one of every character type it was not told to exclude.
+`SecretStringTemplate` and `GenerateStringKey` go together: the generated password is added to the
+template's JSON object under that key. Without them, the whole secret value is the generated
+password. That is what an empty `GenerateSecretString: {}` produces, which is the property CDK
+synthesises for a `secretsmanager.Secret` with no options.
 
-A secret with no `Name` is named after its logical ID. Real CloudFormation names it after the stack and appends its own random characters, so a template relying on the exact generated name would be relying on something it cannot predict anyway.
+The other generation options behave as they do on real AWS: `PasswordLength` (32 by default),
+`ExcludeCharacters`, `ExcludeUppercase`, `ExcludeLowercase`, `ExcludeNumbers`, `ExcludePunctuation`,
+`IncludeSpace`, and `RequireEachIncludedType`. The last is on unless turned off, so a generated
+password carries one of every character type it was not told to exclude.
+
+A secret with no `Name` is named after its logical ID. Real CloudFormation names it after the stack
+and appends its own random characters, so a template cannot rely on the exact generated name either
+way.
 
 ## Inside a simulated Lambda handler
 
-Function code requiring `@aws-sdk/client-secrets-manager` is routed into the same simulated AWS environment, with the function's execution role as the caller. A handler fetching a secret therefore has to be allowed to, by that role's policy, the same as on real AWS. See [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles work.
+Function code requiring `@aws-sdk/client-secrets-manager` is routed into the same simulated AWS
+environment, with the function's execution role as the caller. A handler fetching a secret therefore
+has to be allowed to, by that role's policy, the same as on real AWS. See
+[simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles
+work.
 
-The same applies to `SimSdk` interception: intercepting `SecretsManagerClient` routes ordinary SDK code into the simulation with nothing touching the network. See [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
+The same applies to `SimSdk` interception: intercepting `SecretsManagerClient` routes ordinary SDK
+code into the simulation with nothing touching the network. See
+[AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
 ## Limitations
 
 Current documented limitations:
 
-- Secret values are not encrypted. `KmsKeyId` is accepted and reported by `DescribeSecret`, but nothing is encrypted with it and no `kms:Decrypt` check happens. That is looser than real AWS, where a caller also needs permission on the key. Simulated KMS is not wired into this service yet.
-- A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's resource part when a partial ARN is resolved. Note that this rules out ordinary-looking names such as `app-secret` and `prod-config`, since `secret` and `config` are six characters; name them `app-credentials` or `prod-settings` instead.
-- `RotateSecret`, `CancelRotateSecret` and the rotation Lambda protocol are not simulated. `DescribeSecret` always reports `RotationEnabled` as `false`.
-- `AWS::SecretsManager::Secret` supports `Name`, `Description`, `KmsKeyId`, `SecretString`, `GenerateSecretString` and `Tags`. `ReplicaRegions` is ignored, and the other resource types — `SecretTargetAttachment`, `RotationSchedule` and `ResourcePolicy` — are reported as unsupported and skipped rather than deployed.
-- A template declaring neither `SecretString` nor `GenerateSecretString` is refused, which is stricter than real CloudFormation: it creates an empty secret in that case, and a secret with no version is not simulated. A secret that nothing can read is more likely a mistake in the template than something to deploy quietly.
-- `ExcludeCharacters` that removes every character of an included type is refused rather than generating a password missing a type it was told to include.
-- `{{resolve:secretsmanager:...}}` dynamic references are not supported. That is a CloudFormation engine feature rather than a Secrets Manager one; pass the ARN from `Ref` instead.
-- Resource policies (`PutResourcePolicy`, `GetResourcePolicy`, `DeleteResourcePolicy`, `ValidateResourcePolicy`) are not simulated, so cross-account access to a secret cannot be granted.
-- Replica regions are not simulated. `AddReplicaRegions`, `ReplicateSecretToRegions` and `RemoveRegionsFromReplication` do nothing, and `ReplicationStatus` is not reported.
-- `BatchGetSecretValue` is not supported, and neither is the Parameters and Secrets Lambda Extension HTTP endpoint.
-- `ListSecrets` refuses `Filters`, `SortOrder` and `SortBy` rather than ignoring them, since quietly returning an unfiltered or differently ordered list would be worse. Secrets are listed in creation order, with `MaxResults` and `NextToken` paging over them. A `NextToken` this simulation did not issue, including one whose offset is past the end of the list, is refused rather than answered with an empty page.
-- Tags are stored and reported by `DescribeSecret` and `ListSecrets`, but `TagResource` and `UntagResource` are not supported, and the `secretsmanager:ResourceTag` and `aws:ResourceTag` condition keys are not derived.
-- Other Secrets Manager condition keys, such as `secretsmanager:SecretId` and `secretsmanager:VersionStage`, are not derived either, so a policy relying on them will not match. Ordinary condition operators on values sim IAM does supply work as usual.
-- A version that loses every staging label is kept indefinitely and stays readable by version id, rather than being removed as real Secrets Manager removes it after about a day. It is left out of `VersionIdsToStages` either way.
-- `LastAccessedDate`, `LastRotatedDate`, `NextRotationDate`, `OwningService` and `PrimaryRegion` are not reported.
-- Secret values live in process memory for the lifetime of the `SimAws` instance. That is fine for a simulator, but it is not a security boundary: anything sharing the process can reach them.
+- Secret values are not encrypted. `KmsKeyId` is accepted and reported by `DescribeSecret`, but
+  nothing is encrypted with it and no `kms:Decrypt` check happens. That is looser than real AWS,
+  where a caller also needs permission on the key. Simulated KMS is not wired into this service yet.
+- A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than
+  AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's
+  resource part when a partial ARN is resolved. This rules out ordinary-looking names such as
+  `app-secret` and `prod-config`, since `secret` and `config` are six characters. Name them
+  `app-credentials` or `prod-settings` instead.
+- `RotateSecret`, `CancelRotateSecret` and the rotation Lambda protocol are not simulated.
+  `DescribeSecret` always reports `RotationEnabled` as `false`.
+- `AWS::SecretsManager::Secret` supports `Name`, `Description`, `KmsKeyId`, `SecretString`,
+  `GenerateSecretString` and `Tags`. `ReplicaRegions` is ignored. The other resource types
+  (`SecretTargetAttachment`, `RotationSchedule` and `ResourcePolicy`) are reported as unsupported and
+  skipped rather than deployed.
+- A template declaring neither `SecretString` nor `GenerateSecretString` is refused, which is
+  stricter than real CloudFormation. Real CloudFormation creates an empty secret in that case, and a
+  secret with no version is not simulated.
+- `ExcludeCharacters` that removes every character of an included type is refused rather than
+  generating a password missing a type it was told to include.
+- `{{resolve:secretsmanager:...}}` dynamic references are not supported. That is a CloudFormation
+  engine feature rather than a Secrets Manager one; pass the ARN from `Ref` instead.
+- Resource policies (`PutResourcePolicy`, `GetResourcePolicy`, `DeleteResourcePolicy`,
+  `ValidateResourcePolicy`) are not simulated, so cross-account access to a secret cannot be granted.
+- Replica regions are not simulated. `AddReplicaRegions`, `ReplicateSecretToRegions` and
+  `RemoveRegionsFromReplication` do nothing, and `ReplicationStatus` is not reported.
+- `BatchGetSecretValue` is not supported, and neither is the Parameters and Secrets Lambda Extension
+  HTTP endpoint.
+- `ListSecrets` refuses `Filters`, `SortOrder` and `SortBy` rather than ignoring them, since quietly
+  returning an unfiltered or differently ordered list would be worse. Secrets are listed in creation
+  order, with `MaxResults` and `NextToken` paging over them. A `NextToken` this simulation did not
+  issue, including one whose offset is past the end of the list, is refused rather than answered with
+  an empty page.
+- Tags are stored and reported by `DescribeSecret` and `ListSecrets`, but `TagResource` and
+  `UntagResource` are not supported, and the `secretsmanager:ResourceTag` and `aws:ResourceTag`
+  condition keys are not derived.
+- Other Secrets Manager condition keys, such as `secretsmanager:SecretId` and
+  `secretsmanager:VersionStage`, are not derived either, so a policy relying on them will not match.
+  Ordinary condition operators on values sim IAM does supply work as usual.
+- A version that loses every staging label is kept indefinitely and stays readable by version id,
+  rather than being removed as real Secrets Manager removes it after about a day. It is left out of
+  `VersionIdsToStages` either way.
+- `LastAccessedDate`, `LastRotatedDate`, `NextRotationDate`, `OwningService` and `PrimaryRegion` are
+  not reported.
+- Secret values live in process memory for the lifetime of the `SimAws` instance. That is not a
+  security boundary: anything sharing the process can reach them.
 - Secrets Manager is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sts/README.md
+++ b/docs/services/sts/README.md
@@ -1,18 +1,17 @@
 # Simulated STS
 
-Yulin includes a simulated STS (Security Token Service) for isolated tests, local development, and
-CI.
+Yulin includes a simulated STS (Security Token Service) for tests and local development.
 
-Sim STS is used through `SimAws` as `simAws.sts()`, scoped to the Account making the assume
-request. Its job is to simulate assuming IAM Roles: it evaluates the request against
-[simulated IAM](../iam/) policies and issues temporary session credentials that the rest of the
-simulated environment authenticates like real AWS credentials.
+Sim STS is used through `SimAws` as `simAws.sts()`, scoped to the Account making the assume request.
+It simulates assuming IAM Roles: it evaluates the request against [simulated IAM](../iam/) policies
+and issues temporary session credentials that the rest of the simulated environment authenticates
+like real AWS credentials.
 
 ## Available functionality
 
 Sim STS currently supports:
 
-- Assuming Roles with `AssumeRoleCommand`
+- `AssumeRoleCommand`
 - Trust-policy evaluation against the target Role's assume-role policy document
 - Identity-policy evaluation of the source caller, requiring `sts:AssumeRole` permission on the
   target Role
@@ -22,9 +21,9 @@ Sim STS currently supports:
 - Temporary credentials registered with the target Account's sim IAM, including session-token and
   expiry validation
 
-The simulator focuses on useful behavior for isolated tests and local development rather than full
-STS feature parity. Unsupported STS options may be ignored or may throw errors depending on whether
-the simulator needs them to model the requested behaviour.
+The simulator focuses on useful behaviour for tests and local development rather than full STS
+feature parity. Unsupported STS options may be ignored or may throw errors depending on whether the
+simulator needs them to model the requested behaviour.
 
 ## Basic usage
 
@@ -74,10 +73,10 @@ The output matches the AWS shape: `AssumedRoleUser.Arn` is the session ARN, such
 temporary `AccessKeyId`, `SecretAccessKey`, `SessionToken`, and `Expiration`.
 
 The issued credentials are registered with the target Account's sim IAM, so they can authenticate
-later simulated requests — for example as the `caller` of an IAM authorization attempt, where
-identity policies come from the underlying Role. See
-[the sim IAM docs](../iam/#sts-assumerole-sessions) for a full example. Credentials missing their
-session token, or used after `Expiration`, are rejected with an AWS-like invalid-credentials error.
+later simulated requests, for example as the `caller` of an IAM authorization attempt, where identity
+policies come from the underlying Role. See [the sim IAM docs](../iam/#sts-assumerole-sessions) for a
+full example. Credentials missing their session token, or used after `Expiration`, are rejected with
+an AWS-like invalid-credentials error.
 
 `DurationSeconds` controls the session lifetime and defaults to 3600 seconds (one hour); it must be
 a positive integer.
@@ -163,10 +162,10 @@ const assumeRoleOutput = await account.sts().assumeRole(
 console.log(assumeRoleOutput.AssumedRoleUser?.Arn);
 ```
 
-If either side denies the request — the trust policy does not cover the caller, the caller has no
-identity policy allowing `sts:AssumeRole`, or an explicit `Deny` matches — STS throws an AWS-like
-access-denied error with a `403` status code, naming the `sts:AssumeRole` action and the target
-Role ARN, and no session is created.
+STS throws an AWS-like access-denied error if either side denies the request, which happens when the
+trust policy does not cover the caller, the caller has no identity policy allowing `sts:AssumeRole`,
+or an explicit `Deny` matches. The error has a `403` status code and names the `sts:AssumeRole`
+action and the target Role ARN. No session is created.
 
 Cross-Account assumption works the same way: create the source and target Roles in different
 simulated Accounts of the same `SimAws` instance, and call `assumeRole` on the source Account's
@@ -226,8 +225,8 @@ request is denied.
 
 Sim STS models Role assumption rather than the full STS API. Notable gaps:
 
-- `AssumeRoleCommand` is the only supported command — there is no `GetCallerIdentity`, federation,
-  or web-identity support
+- `AssumeRoleCommand` is the only supported command. There is no `GetCallerIdentity`, federation, or
+  web-identity support
 - Session policies (`Policy` / `PolicyArns`), tags, and `SourceIdentity` requests are not evaluated
 - Condition support in trust policies is limited to the operators supported by
   [sim IAM](../iam/#policy-conditions)

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -1,13 +1,12 @@
 # Simulated time
 
 Every timestamp a simulated AWS service produces comes from that simulation's own clock, and that
-clock can be moved. Time can be frozen, set to an instant, or advanced by a duration, so behaviour
-that only becomes interesting once time passes — a temporary session expiring, for one — can be
-tested without waiting for it.
+clock can be moved. Time can be frozen, set to an instant, or advanced by a duration. Behaviour that
+depends on time passing, such as a temporary session expiring, can be tested without waiting for it.
 
-Nothing here replaces the clock for the whole process. Time belongs to a `SimAws` instance, so
-moving it never disturbs another simulation running in the same test file, or the real clock, or
-any other code in the process.
+Nothing here replaces the clock for the whole process. Time belongs to a `SimAws` instance, so moving
+it never disturbs another simulation running in the same test file, the real clock, or any other code
+in the process.
 
 ## Available functionality
 
@@ -28,7 +27,7 @@ By default a new `SimAws` runs in step with the real system clock.
 
 ## Starting at a known instant
 
-Pass a clock to start somewhere specific. `SimFixedClock` is the usual choice — it reports one
+Pass a clock to start somewhere specific. `SimFixedClock` is the usual choice, since it reports one
 instant and does not move on its own:
 
 ```typescript sim-clock-freeze-and-advance
@@ -66,27 +65,26 @@ for a simulation whose time should pass by itself.
 
 ## Frozen and running
 
-There are two modes, and they answer different questions:
+There are two modes:
 
-- **Frozen** — simulated time only moves when something moves it. A frozen clock reports the same
-  instant however long the host takes, so a slow test cannot drift past the state it set up. This
-  is what a deterministic assertion wants.
-- **Running** — simulated time tracks the clock underneath, offset from it. On the default real
-  clock that means time passes by itself, which is what "jump forward an hour and carry on" wants.
+- **Frozen**: simulated time only moves when something moves it. A frozen clock reports the same
+  instant however long the host takes, so a slow test cannot drift past the state it set up. This is
+  what a deterministic assertion wants.
+- **Running**: simulated time tracks the clock underneath, offset from it. On the default real clock
+  that means time passes by itself, which is what "jump forward an hour and carry on" wants.
 
-Moving time deliberately freezes it: `setTo(...)` and `advanceBy(...)` both leave the clock
-stopped where they put it. Having asked for a specific instant, a test should get to assert on that
-instant rather than on that instant plus however long the assertion took. `resume()` is the way
-back to running, and it carries on from where the clock stopped rather than snapping back to the
-clock underneath.
+Moving time deliberately freezes it. `setTo(...)` and `advanceBy(...)` both leave the clock stopped
+where they put it, so a test that asked for a specific instant asserts on that instant rather than on
+that instant plus however long the assertion took. `resume()` is the way back to running, and it
+carries on from where the clock stopped rather than snapping back to the clock underneath.
 
 `simAws.clock().isFrozen` reports which mode the clock is in.
 
 ## Advancing time
 
 `advanceBy(...)` takes a duration written as any combination of `days`, `hours`, `minutes`,
-`seconds` and `milliseconds`, which add together. Durations are never negative — time passing only
-runs forwards, and `setTo(...)` is the explicit way to move a clock back.
+`seconds` and `milliseconds`, which add together. Durations are never negative, since time passing
+only runs forwards. `setTo(...)` is the explicit way to move a clock back.
 
 Advancing does two things: it moves the clock, and it runs whatever the passage of time should have
 caused. Work scheduled for an instant inside the interval is dispatched in due order, each task
@@ -202,8 +200,8 @@ const second = await lambda.invoke(
 console.log(Buffer.from(second.Payload!).toString()); // {"at":"2026-07-26T11:00:00.000Z"}
 ```
 
-How that is arranged depends on where the function code runs, which is worth knowing because one
-of the two touches a process global:
+How that is arranged depends on where the function code runs. One of the two touches a process
+global:
 
 - **Zip code** runs in a vm sandbox owning its own globals, so it is handed a `Date` bound to the
   simulation's clock. Nothing outside the sandbox is affected.


### PR DESCRIPTION
Remove marketing phrasing, long sentences and preamble from every docs page.

Trim each Available functionality list to one short line per item, and correct the stale SDK interception, CloudFormation resource and README service lists against the current source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the main README to include additional AWS service documentation links for **KMS**, **Lambda**, and **Secrets Manager**.
  * Improved SDK and simulator documentation guidance, including supported services/commands, error behavior, scope behavior, and test-focused wording.
  * Refreshed and clarified documentation across service READMEs, including **ACM, CloudFormation, CloudFront, IAM, KMS, Lambda, Route53, S3, Secrets Manager, STS**, and **simulated time**, with expanded supported lists, reworded semantics, and clearer limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->