### PR TITLE
feat: read configuration from a simulated SSM Parameter Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm i -D @kensio/yulin
 - [Route53](./docs/services/route53 "Simulated Route53 docs")
 - [S3](./docs/services/s3 "Simulated S3 docs")
 - [Secrets Manager](./docs/services/secretsmanager "Simulated Secrets Manager docs")
+- [SSM Parameter Store](./docs/services/ssm "Simulated SSM Parameter Store docs")
 - [STS](./docs/services/sts "Simulated STS docs")
 
 ## Feature specific docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [Route53](./services/route53/ "Simulated Route53 usage docs")
 - [S3](./services/s3/ "Simulated S3 usage docs")
 - [Secrets Manager](./services/secretsmanager/ "Simulated Secrets Manager usage docs")
+- [SSM Parameter Store](./services/ssm/ "Simulated SSM Parameter Store usage docs")
 - [STS](./services/sts/ "Simulated STS usage docs")
 
 ## Feature documentation

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -276,7 +276,7 @@ request.
 
 ## String lists
 
-A `StringList` value is one comma separated string, on read as well as on write. It is not returned
+A `StringList` value is one comma-separated string, on read as well as on write. It is not returned
 as an array.
 
 ```typescript sim-ssm-string-list

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -1,0 +1,504 @@
+# Simulated SSM Parameter Store
+
+Yulin includes a simulated AWS Systems Manager Parameter Store for tests and local development.
+Parameters are stored in memory, versioned on every write, and every operation is authorized by
+simulated IAM.
+
+Only Parameter Store is simulated. Nothing else in Systems Manager is.
+
+SSM-specific types are imported from the `@kensio/yulin/ssm` subpath.
+
+## Available functionality
+
+Sim SSM currently supports:
+
+- `PutParameterCommand`, creating a parameter or overwriting one
+- `GetParameterCommand`, by name, by `name:version` or by `name:label`
+- `GetParametersCommand`, reporting names it could not resolve in `InvalidParameters`
+- `GetParametersByPathCommand`, with and without `Recursive`
+- `DeleteParameterCommand` and `DeleteParametersCommand`
+- `DescribeParametersCommand`
+- `String` and `StringList` parameter types
+- Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
+- Authorization of every operation by simulated IAM, against the real IAM action and ARN
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+
+The simulator focuses on useful behaviour for tests and local development rather than full Parameter
+Store feature parity.
+
+## Writing and reading a parameter
+
+`PutParameter` needs a `Type` when the parameter is new. `GetParameter` returns the current version.
+
+```typescript sim-ssm-put-and-get
+/**
+ * Writing a simulated parameter and reading it back.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-host" }),
+);
+
+console.log(read.Parameter?.Value); // "db.internal"
+console.log(read.Parameter?.Version); // 1
+```
+
+A parameter written without a leading slash and one read with it are the same parameter, because
+both name the same ARN.
+
+## Parameter ARNs and IAM policies
+
+A parameter ARN drops the leading slash from the name. `/myapp/prod/db-host` becomes
+`arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/prod/db-host`, with one slash after `parameter`
+rather than two. A policy written with the doubled slash matches nothing.
+
+```typescript sim-ssm-iam-policy
+/**
+ * A simulated IAM policy allowing a Role to read one parameter.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbHost",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        // One slash after `parameter`, not two, whatever the name looks like.
+        Resource: `arn:aws:ssm:${regionName}:${accountId}:parameter/myapp/prod/db-host`,
+      },
+    }),
+  }),
+);
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }), {
+    caller: { kind: "arn", arn: role.Role.Arn },
+  });
+
+console.log(read.Parameter?.Value); // "db.internal"
+```
+
+`DescribeParameters` is the exception. Real Parameter Store gives that action no resource-level
+permissions, so it authorizes against `*` here, and a policy naming individual parameter ARNs grants
+nothing.
+
+`GetParametersByPath` authorizes against the path rather than against each parameter it returns.
+Access to a path is access to everything under it, so a recursive listing of `/myapp` returns
+`/myapp/prod/db-host` even where a policy explicitly denies that parameter.
+
+## Versions
+
+Every write makes a new version. `PutParameter` refuses a name that is already taken unless the
+request sets `Overwrite`, and an earlier version stays readable by number.
+
+```typescript sim-ssm-parameter-versions
+/**
+ * Overwriting a simulated parameter and reading an earlier version.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const overwritten = await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Value: "db2.internal",
+    Overwrite: true,
+  }),
+);
+
+console.log(overwritten.Version); // 2
+
+const first = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-host:1" }),
+);
+
+console.log(first.Parameter?.Value); // "db.internal"
+console.log(first.Parameter?.Selector); // ":1"
+```
+
+A parameter's type cannot change. Overwriting a `String` parameter as a `StringList` fails with
+`HierarchyTypeMismatchException`, as it does on real AWS. Delete the parameter and create a new one
+instead.
+
+## Reading a hierarchy
+
+`GetParametersByPath` reads a whole level of the hierarchy. Without `Recursive` it returns only the
+level immediately below the path.
+
+```typescript sim-ssm-parameters-by-path
+/**
+ * Reading a hierarchy of simulated parameters as application configuration.
+ */
+
+import {
+  GetParametersByPathCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-port",
+    Type: "String",
+    Value: "5432",
+  }),
+);
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/test/db-host",
+    Type: "String",
+    Value: "db.test.internal",
+  }),
+);
+
+const listed = await ssm.getParametersByPath(
+  new GetParametersByPathCommand({ Path: "/myapp/prod" }),
+);
+
+console.log(listed.Parameters?.map((parameter) => parameter.Name));
+// [ "/myapp/prod/db-host", "/myapp/prod/db-port" ]
+```
+
+A page holds ten parameters, as it does on real AWS. Follow `NextToken` to read the rest.
+
+## Reading several parameters at once
+
+`GetParameters` takes up to ten names. A name that resolves to nothing comes back in
+`InvalidParameters` rather than failing the request, which is what makes a typo easy to miss.
+
+```typescript sim-ssm-get-parameters-batch
+/**
+ * Reading several simulated parameters, including one name with a typo.
+ */
+
+import { GetParametersCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await ssm.getParameters(
+  new GetParametersCommand({
+    Names: ["/myapp/prod/db-host", "/myapp/prod/db-hostt"],
+  }),
+);
+
+console.log(read.Parameters?.map((parameter) => parameter.Name));
+// [ "/myapp/prod/db-host" ]
+console.log(read.InvalidParameters); // [ "/myapp/prod/db-hostt" ]
+```
+
+`GetParameters` still authorizes each name, so one name the caller may not read fails the whole
+request.
+
+## String lists
+
+A `StringList` value is one comma separated string, on read as well as on write. It is not returned
+as an array.
+
+```typescript sim-ssm-string-list
+/**
+ * Reading a simulated StringList parameter.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/allowed-origins",
+    Type: "StringList",
+    Value: "https://one.example,https://two.example",
+  }),
+);
+
+const read = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/allowed-origins" }),
+);
+
+const origins = read.Parameter?.Value?.split(",") ?? [];
+
+console.log(origins.length); // 2
+```
+
+## Parameter names
+
+Name validation matches real Parameter Store, because a name it accepts and AWS refuses is a
+deployment failure a passing test would have hidden. A name:
+
+- may contain letters, digits, `_`, `.`, `-` and `/`
+- must start with `/` if it contains a hierarchy at all
+- may not have more than fifteen hierarchy levels
+- may not start with `aws` or `ssm` in any case, which Parameter Store reserves
+- may not contain spaces between characters, though surrounding spaces are stripped
+- may not make an ARN longer than 1011 characters, counting the ARN prefix for the account and region
+
+A `String` or `StringList` value holds at most 4KB, which is the standard tier limit. This is the one
+people hit, usually by putting a whole JSON configuration blob in one parameter.
+
+## Reading configuration in a Lambda handler
+
+Function code that reads its configuration on cold start needs no special treatment. Any
+`@aws-sdk/client-ssm` client the handler creates is intercepted and dispatched with the function's
+execution role as the caller, so the role's policy decides whether the read succeeds.
+
+```typescript sim-ssm-lambda-handler-config
+/**
+ * A simulated Lambda handler reading its configuration from Parameter Store.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReaderRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReaderRole",
+    PolicyName: "ReadConfig",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: `arn:aws:ssm:${regionName}:${accountId}:parameter/myapp/prod/*`,
+      },
+    }),
+  }),
+);
+
+const handlerCode = [
+  'const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");',
+  "exports.handler = async () => {",
+  "  const client = new SSMClient({});",
+  '  const command = new GetParameterCommand({ Name: "/myapp/prod/db-host" });',
+  "  const out = await client.send(command);",
+  "  return out.Parameter.Value;",
+  "};",
+].join("\n");
+
+const zipFile = makeLambdaCodeZip({ "index.js": handlerCode });
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "config-reader",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: { ZipFile: zipFile },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+console.log(Buffer.from(invoked.Payload ?? []).toString("utf8")); // "db.internal"
+```
+
+## Account and region scoping
+
+A parameter belongs to one account and region, as it does on real AWS. The same name in another
+scope is another parameter.
+
+```typescript sim-ssm-scoping
+/**
+ * The same simulated parameter name in two Account and Region scopes.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .ssm()
+  .putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/db-host",
+      Type: "String",
+      Value: "eu.db.internal",
+    }),
+  );
+
+await simAws
+  .account("222222222222")
+  .region("us-east-1")
+  .ssm()
+  .putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/db-host",
+      Type: "String",
+      Value: "us.db.internal",
+    }),
+  );
+
+const read = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/db-host" }));
+
+console.log(read.Parameter?.ARN);
+// "arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/db-host"
+```
+
+## Limitations
+
+Current documented limitations:
+
+- `SecureString` is refused rather than stored. Nothing here would encrypt it, so a passing test
+  would say nothing about the KMS key, the `kms:Decrypt` permission or `WithDecryption`.
+  `WithDecryption` is accepted and ignored on reads, as real Parameter Store ignores it for `String`
+  and `StringList`.
+- Parameter labels are not simulated. `LabelParameterVersion` is not implemented, so nothing can
+  create a label, and a `name:label` selector is refused with an error saying so.
+- `GetParameterHistory` is not simulated, though earlier versions stay readable by number.
+- The advanced tier is not simulated. `Tier: Advanced` and `Tier: Intelligent-Tiering` are refused,
+  and every parameter reports `Tier: Standard` with the 4KB standard tier value limit.
+- Parameter policies (expiration and notification) are not simulated. `Policies` is refused, and
+  `DescribeParameters` always reports an empty `Policies` list.
+- Tags are not simulated. `Tags` on `PutParameter` is refused, and `AddTagsToResource`,
+  `RemoveTagsFromResource` and `ListTagsForResource` are not supported.
+- `AllowedPattern` is refused rather than ignored, because a value it was meant to reject would
+  otherwise be stored without complaint.
+- `KeyId` is refused, since it only applies to `SecureString` parameters.
+- `DataType` other than `text` is refused. Real Parameter Store validates an `aws:ec2:image` value
+  against EC2, which this simulation cannot do.
+- Filters are refused rather than ignored. `GetParametersByPath` refuses `ParameterFilters`, and
+  `DescribeParameters` refuses `Filters` and `ParameterFilters`. Parameters are listed in name order.
+- `DescribeParameters` refuses `Shared`. Parameters cannot be shared between simulated accounts, and
+  there is no resource policy support, so cross-account access to a parameter cannot be granted.
+- Every version is kept. Real Parameter Store keeps the hundred most recent versions and deletes the
+  oldest as new ones are made, which can fail with `ParameterMaxVersionLimitExceeded`.
+- There is no per-account parameter count limit, so `ParameterLimitExceeded` never happens.
+- Deletion is immediate. Real Parameter Store asks for thirty seconds before a deleted name is reused;
+  here the name is free straight away.
+- `AWS::SSM::Parameter` is not supported as a CloudFormation resource, and `{{resolve:ssm:...}}`
+  template references are not resolved.
+- Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
+  `ssm` prefixes are refused, as they are on real AWS.
+- The Parameters and Secrets Lambda extension HTTP endpoint is not simulated. Handler code has to use
+  the SDK.
+- Nothing else in Systems Manager is simulated: Run Command, Session Manager, Patch Manager, State
+  Manager, Automation, inventory and maintenance windows are all absent.
+- SSM is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/ssm/sim-ssm-get-parameters-batch.example.ts
+++ b/docs/services/ssm/sim-ssm-get-parameters-batch.example.ts
@@ -1,0 +1,28 @@
+/**
+ * Reading several simulated parameters, including one name with a typo.
+ */
+
+import { GetParametersCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await ssm.getParameters(
+  new GetParametersCommand({
+    Names: ["/myapp/prod/db-host", "/myapp/prod/db-hostt"],
+  }),
+);
+
+console.log(read.Parameters?.map((parameter) => parameter.Name));
+// [ "/myapp/prod/db-host" ]
+console.log(read.InvalidParameters); // [ "/myapp/prod/db-hostt" ]

--- a/docs/services/ssm/sim-ssm-iam-policy.example.ts
+++ b/docs/services/ssm/sim-ssm-iam-policy.example.ts
@@ -1,0 +1,58 @@
+/**
+ * A simulated IAM policy allowing a Role to read one parameter.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbHost",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        // One slash after `parameter`, not two, whatever the name looks like.
+        Resource: `arn:aws:ssm:${regionName}:${accountId}:parameter/myapp/prod/db-host`,
+      },
+    }),
+  }),
+);
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }), {
+    caller: { kind: "arn", arn: role.Role.Arn },
+  });
+
+console.log(read.Parameter?.Value); // "db.internal"

--- a/docs/services/ssm/sim-ssm-lambda-handler-config.example.ts
+++ b/docs/services/ssm/sim-ssm-lambda-handler-config.example.ts
@@ -1,0 +1,80 @@
+/**
+ * A simulated Lambda handler reading its configuration from Parameter Store.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReaderRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReaderRole",
+    PolicyName: "ReadConfig",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: `arn:aws:ssm:${regionName}:${accountId}:parameter/myapp/prod/*`,
+      },
+    }),
+  }),
+);
+
+const handlerCode = [
+  'const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");',
+  "exports.handler = async () => {",
+  "  const client = new SSMClient({});",
+  '  const command = new GetParameterCommand({ Name: "/myapp/prod/db-host" });',
+  "  const out = await client.send(command);",
+  "  return out.Parameter.Value;",
+  "};",
+].join("\n");
+
+const zipFile = makeLambdaCodeZip({ "index.js": handlerCode });
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "config-reader",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: { ZipFile: zipFile },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+console.log(Buffer.from(invoked.Payload ?? []).toString("utf8")); // "db.internal"

--- a/docs/services/ssm/sim-ssm-parameter-versions.example.ts
+++ b/docs/services/ssm/sim-ssm-parameter-versions.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Overwriting a simulated parameter and reading an earlier version.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const overwritten = await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Value: "db2.internal",
+    Overwrite: true,
+  }),
+);
+
+console.log(overwritten.Version); // 2
+
+const first = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-host:1" }),
+);
+
+console.log(first.Parameter?.Value); // "db.internal"
+console.log(first.Parameter?.Selector); // ":1"

--- a/docs/services/ssm/sim-ssm-parameters-by-path.example.ts
+++ b/docs/services/ssm/sim-ssm-parameters-by-path.example.ts
@@ -1,0 +1,42 @@
+/**
+ * Reading a hierarchy of simulated parameters as application configuration.
+ */
+
+import {
+  GetParametersByPathCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-port",
+    Type: "String",
+    Value: "5432",
+  }),
+);
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/test/db-host",
+    Type: "String",
+    Value: "db.test.internal",
+  }),
+);
+
+const listed = await ssm.getParametersByPath(
+  new GetParametersByPathCommand({ Path: "/myapp/prod" }),
+);
+
+console.log(listed.Parameters?.map((parameter) => parameter.Name));
+// [ "/myapp/prod/db-host", "/myapp/prod/db-port" ]

--- a/docs/services/ssm/sim-ssm-put-and-get.example.ts
+++ b/docs/services/ssm/sim-ssm-put-and-get.example.ts
@@ -1,0 +1,25 @@
+/**
+ * Writing a simulated parameter and reading it back.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-host",
+    Type: "String",
+    Value: "db.internal",
+  }),
+);
+
+const read = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-host" }),
+);
+
+console.log(read.Parameter?.Value); // "db.internal"
+console.log(read.Parameter?.Version); // 1

--- a/docs/services/ssm/sim-ssm-scoping.example.ts
+++ b/docs/services/ssm/sim-ssm-scoping.example.ts
@@ -1,0 +1,42 @@
+/**
+ * The same simulated parameter name in two Account and Region scopes.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .ssm()
+  .putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/db-host",
+      Type: "String",
+      Value: "eu.db.internal",
+    }),
+  );
+
+await simAws
+  .account("222222222222")
+  .region("us-east-1")
+  .ssm()
+  .putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/db-host",
+      Type: "String",
+      Value: "us.db.internal",
+    }),
+  );
+
+const read = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: "/myapp/db-host" }));
+
+console.log(read.Parameter?.ARN);
+// "arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/db-host"

--- a/docs/services/ssm/sim-ssm-string-list.example.ts
+++ b/docs/services/ssm/sim-ssm-string-list.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Reading a simulated StringList parameter.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/allowed-origins",
+    Type: "StringList",
+    Value: "https://one.example,https://two.example",
+  }),
+);
+
+const read = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/allowed-origins" }),
+);
+
+const origins = read.Parameter?.Value?.split(",") ?? [];
+
+console.log(origins.length); // 2

--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
       "import": "./dist/service/secretsmanager/index.js",
       "types": "./dist/service/secretsmanager/index.d.ts"
     },
+    "./ssm": {
+      "import": "./dist/service/ssm/index.js",
+      "types": "./dist/service/ssm/index.d.ts"
+    },
     "./serve": {
       "import": "./dist/serve/index.js",
       "types": "./dist/serve/index.d.ts"
@@ -116,6 +120,7 @@
     "@aws-sdk/client-route-53": "^3.1095.0",
     "@aws-sdk/client-s3": "^3.1095.0",
     "@aws-sdk/client-secrets-manager": "^3.1095.0",
+    "@aws-sdk/client-ssm": "^3.1095.0",
     "@aws-sdk/client-sts": "^3.1095.0",
     "@aws-sdk/s3-request-presigner": "^3.1095.0",
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/client-ssm':
+        specifier: ^3.1095.0
+        version: 3.1095.0
       '@aws-sdk/client-sts':
         specifier: ^3.1095.0
         version: 3.1095.0
@@ -212,6 +215,10 @@ packages:
 
   '@aws-sdk/client-secrets-manager@3.1095.0':
     resolution: {integrity: sha512-CiBryu8nC+8PVx72ybrxIPLOMoGLW0hGMWMvgqBWm8ZYOeE+w+c7HcLsuLhEiPzKMON8Xng0lPKCIm1ANWsv+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-ssm@3.1095.0':
+    resolution: {integrity: sha512-0A88Y+mFdsHGHInTC0xLiKkrIrVz7uzDImOv50zIFb189oo4oTStOd9Ht1gw4Il5nXnLd2qokfVxePnZwaIoFg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sts@3.1095.0':
@@ -2024,6 +2031,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-secrets-manager@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.72
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-ssm@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/credential-provider-node': 3.972.72

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -53,6 +53,9 @@ export function resolveSimSdkCommandRouter(
     case "Secrets Manager": {
       return scoped.secretsManager().sdkCommandRouter();
     }
+    case "SSM": {
+      return scoped.ssm().sdkCommandRouter();
+    }
     case "STS": {
       return scoped.sts().sdkCommandRouter();
     }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -26,6 +26,7 @@ import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-regis
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
+import { SimSsm } from "../../ssm/index.js";
 import { SimSts } from "../../sts/sim-sts.js";
 
 interface SimAwsServiceFactoryProperties {
@@ -261,6 +262,20 @@ export class SimAwsServiceFactory {
    */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return new SimSecretsManager({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /**
+   * Create simulated SSM for an Account Region scope.
+   *
+   * Parameters are Region-scoped on real AWS: a parameter name is unique
+   * within one Account and Region, and its ARN names the Region.
+   */
+  createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
+    return new SimSsm({
       accountRegionScope: scope.accountRegionScope,
       iam: this.createIam(scope),
       background: this.background,

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -12,6 +12,7 @@ import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 
 export type SimAccountRegionScopeKey = `${SimAwsAccountId}:${AwsRegionName}`;
@@ -138,6 +139,15 @@ export class SimAwsAccountRegionContainer {
   secretsManager(): SimSecretsManager {
     return this.memo.getOrCreate("secretsManager", () =>
       this.simAws.serviceFactory.createSecretsManager(this),
+    );
+  }
+
+  /**
+   * Get simulated SSM for this account and region.
+   */
+  ssm(): SimSsm {
+    return this.memo.getOrCreate("ssm", () =>
+      this.simAws.serviceFactory.createSsm(this),
     );
   }
 

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -26,6 +26,7 @@ import type { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
 import { simAwsRunAsContext } from "./caller/sim-aws-run-as-context.js";
@@ -256,6 +257,13 @@ export class SimAws {
    */
   secretsManager(): SimSecretsManager {
     return this.accountRegionScope().secretsManager();
+  }
+
+  /**
+   * Get simulated SSM in the default Account Region scope.
+   */
+  ssm(): SimSsm {
+    return this.accountRegionScope().ssm();
   }
 
   /**

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -1,0 +1,111 @@
+# Simulated SSM Parameter Store implementation
+
+This directory contains the simulated SSM Parameter Store implementation. Nothing else in Systems
+Manager is simulated: no Run Command, Session Manager, Patch Manager, State Manager, Automation,
+inventory or maintenance windows.
+
+The guiding decision here is that the parameter ARN drops the leading slash from the name. A
+parameter called `/myapp/prod/db-host` has the ARN
+`arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/prod/db-host`, with one slash after `parameter`
+rather than two. Getting that wrong is the most common way an SSM IAM policy fails, and it fails at
+deployment rather than at review. Building the ARN in one place means a policy that works against
+this simulation is one that would work on real AWS, and a policy naming the doubled-slash form fails
+here instead.
+
+## Entry points
+
+- `sim-ssm.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public SSM simulator API for `@kensio/yulin/ssm`.
+
+A `SimSsm` instance owns a `SimSsmParameterStore` holding its parameters. The simulator is scoped to
+an account and region because real parameters are: a parameter ARN names its region, and a parameter
+name is unique within one account and region rather than globally.
+
+## Parameter model
+
+Parameter state lives under `parameter/`.
+
+`SimSsmParameter` is the stored resource: its name, its type, its ARN and its versions. The type
+belongs to the parameter rather than to a version because real Parameter Store refuses to change it.
+Overwriting a `String` parameter as a `StringList` fails with `HierarchyTypeMismatchException`, and
+the only way through is to delete the parameter and create a new one.
+
+`SimSsmParameterName` validates a name. This is the part worth getting right, because every rule in
+it is a deploy-time failure someone has hit: a hierarchical name without its leading slash, a name
+under the reserved `aws` or `ssm` prefix, a hierarchy sixteen levels deep, an inner space. The
+length limit needs the account and region, because real Parameter Store counts the ARN prefix
+towards the 1011 characters a name may use, so the same name is legal in one region and too long in
+another.
+
+`SimSsmParameterName.resourceFor` is the normalization the whole service keys on: the name with any
+leading slash dropped. A parameter written as `db-host` and read as `/db-host` is one parameter,
+because both name the same ARN, and no IAM policy could tell them apart.
+
+`SimSsmParameterArn` builds the ARN from that resource form. `ssmParameterArnPrefix` is exported
+beside it because the name validator and the authorizer both need the prefix without needing a
+parameter.
+
+`SimSsmParameterValue` holds one version's value and enforces the standard tier's 4KB limit, in
+UTF-8 bytes. A `StringList` is one comma separated string here, as it is on real AWS, rather than an
+array: handler code that splits it on commas is exercising the shape AWS would give it.
+
+`SimSsmParameterSelector` parses the `name:version` and `name:label` forms a request may write. A
+parameter name cannot contain a colon, so the first one separates the two parts, and a selector of
+only digits is a version while anything else is a label.
+
+`SimSsmParameterPath` is the level of the hierarchy `GetParametersByPath` names. It owns both the
+containment rule and the path's own ARN, because the path is what that operation authorizes against.
+
+`SimSsmParameterWriter` is the single path by which a parameter is created or updated. Keeping
+creation and overwrite in one collaborator is what stops the two drifting apart on the rules that
+only exist where they meet: a name already in use, and a type that cannot change.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
+rather than one class per command, so the `SimSsm` facade stays a delegation:
+
+- `command/parameter/` — the commands, their structural input/output types, the shared output views
+  and the shared paging
+- `command/authorize/` — the shared IAM authorizer
+
+`SimSsmUnsimulatedPutOptions` gathers every PutParameter option this simulation refuses, in one
+readable place, rather than scattering the refusals through the write path.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances.
+
+## Authorization
+
+`SimSsmAuthorizer` splits requests three ways, as real Parameter Store does:
+
+- operations on a parameter authorize the real IAM action against that parameter's ARN, whether or
+  not the parameter exists, because real IAM evaluates a request before the service handles it;
+- `GetParametersByPath` authorizes against the path's own ARN, and access to a path is access to
+  everything under it, so a parameter that an explicit deny names is still returned by a recursive
+  listing of its parent;
+- `DescribeParameters` authorizes against `*`, because real Parameter Store gives that action no
+  resource-level permissions, so a policy naming individual parameter ARNs grants nothing.
+
+`GetParameters` and `DeleteParameters` authorize each name in the batch, so one name the caller may
+not reach fails the whole request rather than being quietly left out of the results.
+
+There is no resource policy support, so cross-account access to a parameter cannot be granted.
+
+## Divergences worth knowing
+
+- `SecureString` is refused. Nothing here would encrypt it, so accepting it would let a test pass
+  while saying nothing about the KMS key, the `kms:Decrypt` permission or `WithDecryption`.
+- Parameter labels are refused rather than looked up. `LabelParameterVersion` is not implemented, so
+  nothing could create one, and a label selector says that instead of reporting the parameter as
+  missing.
+- The advanced tier, parameter policies, tags, `AllowedPattern`, `KeyId` and non-text data types are
+  refused rather than ignored.
+- `GetParametersByPath` and `DescribeParameters` refuse filters rather than ignoring them.
+- Every version is kept. Real Parameter Store keeps the hundred most recent and deletes the oldest
+  as new ones are made.
+- There is no `AWS::SSM::Parameter` CloudFormation resource and no `{{resolve:ssm:...}}` support
+  yet, so this service has no `cfn/` directory.
+
+The full list is in [docs/services/ssm](../../../docs/services/ssm/).

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -46,7 +46,7 @@ beside it because the name validator and the authorizer both need the prefix wit
 parameter.
 
 `SimSsmParameterValue` holds one version's value and enforces the standard tier's 4KB limit, in
-UTF-8 bytes. A `StringList` is one comma separated string here, as it is on real AWS, rather than an
+UTF-8 bytes. A `StringList` is one comma-separated string here, as it is on real AWS, rather than an
 array: handler code that splits it on commas is exercising the shape AWS would give it.
 
 `SimSsmParameterSelector` parses the `name:version` and `name:label` forms a request may write. A

--- a/src/service/ssm/command/authorize/sim-ssm-authorizer.ts
+++ b/src/service/ssm/command/authorize/sim-ssm-authorizer.ts
@@ -1,0 +1,98 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { ssmParameterArnPrefix } from "../../parameter/sim-ssm-parameter-arn.js";
+
+/**
+ * The resource an operation with no particular parameter authorizes against.
+ *
+ * Real Parameter Store gives DescribeParameters no resource-level
+ * permissions, so a policy allowing it has to use a resource of `*`.
+ * Authorizing against `*` here is what makes a policy naming individual
+ * parameter ARNs fail the same way it would on real AWS.
+ */
+const anyResource = "*";
+
+interface SimSsmAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to SSM Parameter Store requests.
+ *
+ * Every operation on a parameter authorizes against that parameter's ARN,
+ * which drops the leading slash from the name. A policy written against
+ * `parameter//myapp/prod/db-host` therefore reaches nothing here, exactly as
+ * it reaches nothing on real AWS.
+ */
+export class SimSsmAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSsmAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a parameter, named by the
+   * resource part of its ARN.
+   *
+   * The parameter need not exist. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the parameter is there, and PutParameter authorizes against the ARN
+   * the parameter is about to have.
+   */
+  authorizeParameterResource(
+    action: string,
+    resource: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      ssmParameterArnPrefix(this.accountRegionScope) + resource,
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action on a full ARN, as a hierarchy
+   * path is named.
+   */
+  authorizeArn(
+    action: string,
+    arn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, arn, caller);
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular
+   * parameter.
+   */
+  authorizeAny(action: string, caller?: SimAwsCaller): SimAwsResolvedCaller {
+    return this.authorizeResource(action, anyResource, caller);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/ssm/command/authorize/sim-ssm-iam.iso.test.ts
+++ b/src/service/ssm/command/authorize/sim-ssm-iam.iso.test.ts
@@ -1,0 +1,320 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  DeleteParameterCommand,
+  DescribeParametersCommand,
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  GetParametersCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+interface SimAwsWithRole {
+  readonly simAws: SimAws;
+  readonly caller: SimAwsCaller;
+}
+
+async function simAwsWithRole(
+  policyStatement: object,
+): Promise<SimAwsWithRole> {
+  const simAws = new SimAws({ defaultAccountId: accountIdOneOnes });
+  const accountId = simAws.defaultAccountId;
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ParameterReader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "ParameterReader",
+      PolicyName: "ParameterPolicy",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: policyStatement,
+      }),
+    }),
+  );
+
+  return { simAws, caller: { kind: "arn", arn: role.Role.Arn } };
+}
+
+async function seedDbHost(simAws: SimAws): Promise<void> {
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+    }),
+  );
+}
+
+describe("SSM IAM authorization", () => {
+  it("allows a read the caller's policy permits", async () => {
+    // Given a Role allowed to read one parameter by its real ARN.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParameter",
+      Resource: `arn:aws:ssm:${new SimAws().defaultRegionName}:${accountIdOneOnes}:parameter/myapp/prod/db-host`,
+    });
+    await seedDbHost(simAws);
+
+    // When it reads that parameter.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }), {
+        caller,
+      });
+
+    // Then the read succeeds.
+    assertIdentical(read.Parameter?.Value, "db.internal");
+  });
+
+  it("denies a policy that keeps the name's leading slash in the ARN", async () => {
+    // Given a Role whose policy names the parameter the way it is easy to
+    // write it: ARN prefix plus the name, slash and all.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParameter",
+      Resource: `arn:aws:ssm:${new SimAws().defaultRegionName}:${accountIdOneOnes}:parameter//myapp/prod/db-host`,
+    });
+    await seedDbHost(simAws);
+
+    // When it reads the parameter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(
+          new GetParameterCommand({ Name: "/myapp/prod/db-host" }),
+          { caller },
+        ),
+    );
+
+    // Then it is denied here rather than in a deployment, because the real ARN
+    // has one slash after `parameter`, not two.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a write the caller's policy does not permit", async () => {
+    // Given a Role allowed only to read.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParameter",
+      Resource: "*",
+    });
+
+    // When it writes a parameter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/db-host",
+          Type: "String",
+          Value: "db.internal",
+        }),
+        { caller },
+      ),
+    );
+
+    // Then it is denied, against the ARN the parameter would have had.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a delete the caller's policy does not permit", async () => {
+    // Given a Role allowed only to read.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParameter",
+      Resource: "*",
+    });
+    await seedDbHost(simAws);
+
+    // When it deletes the parameter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .deleteParameter(
+          new DeleteParameterCommand({ Name: "/myapp/prod/db-host" }),
+          { caller },
+        ),
+    );
+
+    // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a batch read where one name is not permitted", async () => {
+    // Given a Role allowed to read one parameter of two.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParameters",
+      Resource: `arn:aws:ssm:${new SimAws().defaultRegionName}:${accountIdOneOnes}:parameter/myapp/prod/db-host`,
+    });
+    await seedDbHost(simAws);
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-port",
+        Type: "String",
+        Value: "5432",
+      }),
+    );
+
+    // When it reads both in one batch.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameters(
+        new GetParametersCommand({
+          Names: ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+        }),
+        { caller },
+      ),
+    );
+
+    // Then the whole batch is denied, as it is on real AWS: one unpermitted
+    // name fails the request rather than being left out of the results.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a read of a parameter that is not there", async () => {
+    // Given a Role with no parameter permissions at all.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    });
+
+    // When it reads a parameter that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(new GetParameterCommand({ Name: "/myapp/missing" }), {
+          caller,
+        }),
+    );
+
+    // Then it is denied rather than told the parameter is missing, because
+    // real IAM evaluates the request before the service sees it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("authorizes a path listing against the path itself", async () => {
+    // Given a Role allowed on a path but explicitly denied one parameter
+    // under it.
+    const regionName = new SimAws().defaultRegionName;
+    const parameterArn = `arn:aws:ssm:${regionName}:${accountIdOneOnes}:parameter/myapp/prod/db-host`;
+    const { simAws, caller } = await simAwsWithRole([
+      {
+        Effect: "Allow",
+        Action: "ssm:GetParametersByPath",
+        Resource: `arn:aws:ssm:${regionName}:${accountIdOneOnes}:parameter/myapp`,
+      },
+      {
+        Effect: "Deny",
+        Action: "ssm:GetParametersByPath",
+        Resource: parameterArn,
+      },
+    ]);
+    await seedDbHost(simAws);
+
+    // When it lists the path recursively.
+    const listed = await simAws.ssm().getParametersByPath(
+      new GetParametersByPathCommand({
+        Path: "/myapp",
+        Recursive: true,
+      }),
+      { caller },
+    );
+
+    // Then the denied parameter still comes back, because access to a path is
+    // access to everything under it on real Parameter Store.
+    assertArrayEquals(
+      listed.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host"],
+    );
+  });
+
+  it("denies a path listing the caller's policy does not reach", async () => {
+    // Given a Role allowed on a different path.
+    const regionName = new SimAws().defaultRegionName;
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:GetParametersByPath",
+      Resource: `arn:aws:ssm:${regionName}:${accountIdOneOnes}:parameter/other`,
+    });
+    await seedDbHost(simAws);
+
+    // When it lists a path the policy does not name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParametersByPath(
+          new GetParametersByPathCommand({ Path: "/myapp", Recursive: true }),
+          { caller },
+        ),
+    );
+
+    // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies DescribeParameters to a policy naming parameter ARNs", async () => {
+    // Given a Role allowed to describe, but only against parameter ARNs.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:DescribeParameters",
+      Resource: `arn:aws:ssm:${new SimAws().defaultRegionName}:${accountIdOneOnes}:parameter/myapp/*`,
+    });
+    await seedDbHost(simAws);
+
+    // When it describes the parameters.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .describeParameters(new DescribeParametersCommand({}), { caller }),
+    );
+
+    // Then it is denied, because real Parameter Store gives this action no
+    // resource-level permissions and it has to be allowed on `*`.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows DescribeParameters to a policy allowing it on everything", async () => {
+    // Given a Role allowed to describe on `*`.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "ssm:DescribeParameters",
+      Resource: "*",
+    });
+    await seedDbHost(simAws);
+
+    // When it describes the parameters.
+    const described = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}), { caller });
+
+    // Then the listing succeeds.
+    assertArrayEquals(
+      described.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host"],
+    );
+  });
+});

--- a/src/service/ssm/command/parameter/parameter.command.ts
+++ b/src/service/ssm/command/parameter/parameter.command.ts
@@ -1,0 +1,109 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * A parameter as sim SSM reports it in a value-carrying response.
+ *
+ * https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_Parameter.html
+ */
+export interface SimSsmParameterOutput {
+  readonly ARN?: string | undefined;
+  readonly DataType?: string | undefined;
+  readonly LastModifiedDate?: Date | undefined;
+  readonly Name?: string | undefined;
+  readonly Selector?: string | undefined;
+  readonly Type?: string | undefined;
+  readonly Value?: string | undefined;
+  readonly Version?: number | undefined;
+}
+
+/**
+ * A parameter as sim SSM reports it in a metadata-only response, which
+ * carries no value.
+ *
+ * https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ParameterMetadata.html
+ */
+export interface SimSsmParameterMetadata {
+  readonly ARN?: string | undefined;
+  readonly DataType?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly LastModifiedDate?: Date | undefined;
+  readonly LastModifiedUser?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Policies?: readonly unknown[] | undefined;
+  readonly Tier?: string | undefined;
+  readonly Type?: string | undefined;
+  readonly Version?: number | undefined;
+}
+
+/**
+ * A tag on a parameter, which sim SSM refuses rather than stores.
+ */
+export interface SimSsmTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SSM PutParameter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/PutParameterCommand/
+ */
+export interface SimPutParameterCommand {
+  readonly input: SimPutParameterCommandInput;
+}
+
+export interface SimPutParameterCommandInput {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+  readonly Type?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly Overwrite?: boolean | undefined;
+  readonly DataType?: string | undefined;
+  readonly Tier?: string | undefined;
+  readonly AllowedPattern?: string | undefined;
+  readonly KeyId?: string | undefined;
+  readonly Policies?: string | undefined;
+  readonly Tags?: readonly SimSsmTag[] | undefined;
+}
+
+export interface SimPutParameterCommandOutput {
+  readonly Version?: number | undefined;
+  readonly Tier?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SSM DeleteParameter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/DeleteParameterCommand/
+ */
+export interface SimDeleteParameterCommand {
+  readonly input: SimDeleteParameterCommandInput;
+}
+
+export interface SimDeleteParameterCommandInput {
+  readonly Name?: string | undefined;
+}
+
+export interface SimDeleteParameterCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SSM DeleteParameters command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/DeleteParametersCommand/
+ */
+export interface SimDeleteParametersCommand {
+  readonly input: SimDeleteParametersCommandInput;
+}
+
+export interface SimDeleteParametersCommandInput {
+  readonly Names?: readonly string[] | undefined;
+}
+
+export interface SimDeleteParametersCommandOutput {
+  readonly DeletedParameters?: readonly string[] | undefined;
+  readonly InvalidParameters?: readonly string[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ssm/command/parameter/query.command.ts
+++ b/src/service/ssm/command/parameter/query.command.ts
@@ -1,0 +1,100 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimSsmParameterMetadata,
+  SimSsmParameterOutput,
+} from "./parameter.command.js";
+
+/**
+ * A filter on a parameter query, which sim SSM refuses rather than applies.
+ */
+export interface SimSsmParameterFilter {
+  readonly Key?: string | undefined;
+  readonly Option?: string | undefined;
+  readonly Values?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim SSM GetParameter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/GetParameterCommand/
+ */
+export interface SimGetParameterCommand {
+  readonly input: SimGetParameterCommandInput;
+}
+
+export interface SimGetParameterCommandInput {
+  readonly Name?: string | undefined;
+  readonly WithDecryption?: boolean | undefined;
+}
+
+export interface SimGetParameterCommandOutput {
+  readonly Parameter?: SimSsmParameterOutput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SSM GetParameters command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/GetParametersCommand/
+ */
+export interface SimGetParametersCommand {
+  readonly input: SimGetParametersCommandInput;
+}
+
+export interface SimGetParametersCommandInput {
+  readonly Names?: readonly string[] | undefined;
+  readonly WithDecryption?: boolean | undefined;
+}
+
+export interface SimGetParametersCommandOutput {
+  readonly Parameters?: readonly SimSsmParameterOutput[] | undefined;
+  readonly InvalidParameters?: readonly string[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SSM GetParametersByPath command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/GetParametersByPathCommand/
+ */
+export interface SimGetParametersByPathCommand {
+  readonly input: SimGetParametersByPathCommandInput;
+}
+
+export interface SimGetParametersByPathCommandInput {
+  readonly Path?: string | undefined;
+  readonly Recursive?: boolean | undefined;
+  readonly ParameterFilters?: readonly SimSsmParameterFilter[] | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+  readonly WithDecryption?: boolean | undefined;
+}
+
+export interface SimGetParametersByPathCommandOutput {
+  readonly Parameters?: readonly SimSsmParameterOutput[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SSM DescribeParameters command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/command/DescribeParametersCommand/
+ */
+export interface SimDescribeParametersCommand {
+  readonly input?: SimDescribeParametersCommandInput | undefined;
+}
+
+export interface SimDescribeParametersCommandInput {
+  readonly Filters?: readonly SimSsmParameterFilter[] | undefined;
+  readonly ParameterFilters?: readonly SimSsmParameterFilter[] | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+  readonly Shared?: boolean | undefined;
+}
+
+export interface SimDescribeParametersCommandOutput {
+  readonly Parameters?: readonly SimSsmParameterMetadata[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/ssm/command/parameter/sim-ssm-delete-parameter-commands.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-delete-parameter-commands.iso.test.ts
@@ -1,0 +1,166 @@
+import {
+  DeleteParameterCommand,
+  DeleteParametersCommand,
+  GetParameterCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSsmParameterNotFound,
+  SimSsmValidationException,
+} from "../../error/sim-ssm.error.js";
+
+async function put(simAws: SimAws, name: string): Promise<void> {
+  await simAws
+    .ssm()
+    .putParameter(
+      new PutParameterCommand({ Name: name, Type: "String", Value: "x" }),
+    );
+}
+
+describe("SSM DeleteParameter", () => {
+  it("removes a parameter and its versions", async () => {
+    // Given a parameter with two versions.
+    const simAws = new SimAws();
+    await put(simAws, "/myapp/db-host");
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Value: "y",
+        Overwrite: true,
+      }),
+    );
+
+    // When it is deleted.
+    await simAws
+      .ssm()
+      .deleteParameter(new DeleteParameterCommand({ Name: "/myapp/db-host" }));
+
+    // Then nothing of it is left, including its earlier version.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(new GetParameterCommand({ Name: "/myapp/db-host:1" })),
+    );
+
+    assertInstanceOf(error, SimSsmParameterNotFound);
+  });
+
+  it("frees the name for a new parameter", async () => {
+    // Given a deleted String parameter.
+    const simAws = new SimAws();
+    await put(simAws, "/myapp/db-host");
+    await simAws
+      .ssm()
+      .deleteParameter(new DeleteParameterCommand({ Name: "/myapp/db-host" }));
+
+    // When the name is used again, this time for a different type.
+    const put2 = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "StringList",
+        Value: "a,b",
+      }),
+    );
+
+    // Then it is a new parameter starting at version 1, which is the way to
+    // change a parameter's type on real AWS.
+    assertIdentical(put2.Version, 1);
+  });
+
+  it("refuses a name no parameter answers to", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a missing parameter is deleted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .deleteParameter(new DeleteParameterCommand({ Name: "/myapp/gone" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmParameterNotFound);
+  });
+
+  it("requires a name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a request names nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().deleteParameter(new DeleteParameterCommand({ Name: "" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+});
+
+describe("SSM DeleteParameters", () => {
+  it("separates the names it deleted from the names it did not", async () => {
+    // Given two stored parameters.
+    const simAws = new SimAws();
+    await put(simAws, "/myapp/db-host");
+    await put(simAws, "/myapp/db-port");
+
+    // When a batch deletes both and two names that are not there.
+    const deleted = await simAws.ssm().deleteParameters(
+      new DeleteParametersCommand({
+        Names: [
+          "/myapp/db-port",
+          "/myapp/vanished",
+          "/myapp/db-host",
+          "/myapp/gone",
+        ],
+      }),
+    );
+
+    // Then the missing names are reported rather than failing the request.
+    assertArrayEquals(deleted.DeletedParameters, [
+      "/myapp/db-host",
+      "/myapp/db-port",
+    ]);
+    assertArrayEquals(deleted.InvalidParameters, [
+      "/myapp/gone",
+      "/myapp/vanished",
+    ]);
+  });
+
+  it("requires at least one name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a batch names nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().deleteParameters(new DeleteParametersCommand({ Names: [] })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("refuses more names than one request may carry", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a batch names eleven parameters.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().deleteParameters(
+        new DeleteParametersCommand({
+          Names: Array.from({ length: 11 }, (_, index) => `p${String(index)}`),
+        }),
+      ),
+    );
+
+    // Then it is refused at the ten Parameter Store allows.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-delete-parameter-commands.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-delete-parameter-commands.ts
@@ -1,0 +1,113 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import { SimSsmParameterName } from "../../parameter/sim-ssm-parameter-name.js";
+import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type {
+  SimDeleteParameterCommand,
+  SimDeleteParameterCommandOutput,
+  SimDeleteParametersCommand,
+  SimDeleteParametersCommandOutput,
+} from "./parameter.command.js";
+import { requireParameterNames } from "./sim-ssm-parameter-names.js";
+
+interface SimSsmDeleteParameterCommandsProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly authorizer: SimSsmAuthorizer;
+}
+
+interface SimSsmDeleteParameterCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that delete parameters.
+ *
+ * A parameter is gone as soon as it is deleted: Parameter Store has no
+ * recovery window, so its whole version history goes with it and the name is
+ * free again.
+ */
+export class SimSsmDeleteParameterCommands {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly authorizer: SimSsmAuthorizer;
+
+  constructor(properties: SimSsmDeleteParameterCommandsProperties) {
+    this.parameters = properties.parameters;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Delete one parameter, refusing if it is not there.
+   */
+  delete(
+    command: SimDeleteParameterCommand,
+    options?: SimSsmDeleteParameterCommandsOptions,
+  ): SimDeleteParameterCommandOutput {
+    const requested = command.input.Name;
+
+    if (requested === undefined || requested.trim() === "") {
+      throw new SimSsmValidationException(
+        "DeleteParameter requires a parameter Name",
+      );
+    }
+
+    this.authorize("ssm:DeleteParameter", requested, options?.caller);
+    this.parameters.remove(this.parameters.require(requested));
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Delete several parameters at once.
+   *
+   * A name no parameter answers to comes back in `InvalidParameters` rather
+   * than failing the request, so the parameters that were found are still
+   * deleted.
+   */
+  deleteMany(
+    command: SimDeleteParametersCommand,
+    options?: SimSsmDeleteParameterCommandsOptions,
+  ): SimDeleteParametersCommandOutput {
+    const names = requireParameterNames(
+      command.input.Names,
+      "DeleteParameters",
+    );
+    const deleted: string[] = [];
+    const invalid: string[] = [];
+
+    for (const name of names) {
+      this.authorize("ssm:DeleteParameters", name, options?.caller);
+
+      const parameter = this.parameters.find(name);
+
+      if (parameter === undefined) {
+        invalid.push(name);
+      } else {
+        this.parameters.remove(parameter);
+        deleted.push(name);
+      }
+    }
+
+    return {
+      $metadata: {},
+      DeletedParameters: deleted.toSorted((one, other) =>
+        one.localeCompare(other),
+      ),
+      InvalidParameters: invalid.toSorted((one, other) =>
+        one.localeCompare(other),
+      ),
+    };
+  }
+
+  private authorize(
+    action: string,
+    requested: string,
+    caller: SimAwsCaller | undefined,
+  ): void {
+    this.authorizer.authorizeParameterResource(
+      action,
+      SimSsmParameterName.resourceFor(requested),
+      caller,
+    );
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-describe-parameters.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-describe-parameters.iso.test.ts
@@ -1,0 +1,221 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  DescribeParametersCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+
+describe("SSM DescribeParameters", () => {
+  it("lists parameter metadata without values, in name order", async () => {
+    // Given two stored parameters.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-port",
+        Type: "String",
+        Value: "5432",
+      }),
+    );
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "db.internal",
+        Description: "The database host",
+      }),
+    );
+
+    // When the parameters are described.
+    const described = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}));
+
+    // Then the metadata comes back in name order, with no values in it.
+    assertNonNullable(described.Parameters);
+    assertArrayEquals(
+      described.Parameters.map((parameter) => parameter.Name),
+      ["/myapp/db-host", "/myapp/db-port"],
+    );
+
+    const first = described.Parameters.at(0);
+
+    assertNonNullable(first);
+    assertIdentical(first.Description, "The database host");
+    assertIdentical(first.Type, "String");
+    assertIdentical(first.Tier, "Standard");
+    assertIdentical(first.Version, 1);
+    assertArrayEquals(first.Policies, []);
+    assertUndefined(
+      (first as { Value?: string }).Value,
+      "DescribeParameters reports no value",
+    );
+  });
+
+  it("records the caller that last wrote each parameter", async () => {
+    // Given a Role that writes a parameter.
+    const simAws = new SimAws();
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Deployer",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Deployer",
+        PolicyName: "WriteParameters",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "ssm:PutParameter",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+      { caller: { kind: "arn", arn: role.Role.Arn } },
+    );
+
+    // When the parameters are described.
+    const described = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}));
+
+    // Then the writer is reported, as real Parameter Store reports it.
+    assertIdentical(
+      described.Parameters?.at(0)?.LastModifiedUser,
+      role.Role.Arn,
+    );
+  });
+
+  it("pages at fifty parameters", async () => {
+    // Given fifty-one parameters.
+    const simAws = new SimAws();
+
+    await Promise.all(
+      Array.from({ length: 51 }, async (_, index) =>
+        simAws.ssm().putParameter(
+          new PutParameterCommand({
+            Name: `/myapp/p${String(index).padStart(2, "0")}`,
+            Type: "String",
+            Value: "x",
+          }),
+        ),
+      ),
+    );
+
+    // When they are described without a MaxResults.
+    const first = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}));
+
+    // Then fifty come back with a token for the rest.
+    assertArrayLength(first.Parameters ?? [], 50);
+
+    const second = await simAws
+      .ssm()
+      .describeParameters(
+        new DescribeParametersCommand({ NextToken: first.NextToken }),
+      );
+
+    assertArrayLength(second.Parameters ?? [], 1);
+    assertUndefined(second.NextToken);
+  });
+
+  it("refuses more results per page than Parameter Store returns", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks for more than fifty at a time.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .describeParameters(new DescribeParametersCommand({ MaxResults: 51 })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "between 1 and 50");
+  });
+
+  it("refuses filters", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks to be filtered.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().describeParameters(
+        new DescribeParametersCommand({
+          ParameterFilters: [{ Key: "Type", Values: ["String"] }],
+        }),
+      ),
+    );
+
+    // Then it is refused rather than listing more than real Parameter Store
+    // would.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Filters");
+  });
+
+  it("refuses a request for shared parameters", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks for parameters shared from another Account.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .describeParameters(new DescribeParametersCommand({ Shared: true })),
+    );
+
+    // Then it is refused, because sharing is not simulated.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Shared");
+  });
+
+  it("describes nothing when a request carries no input at all", async () => {
+    // Given a simulated AWS with one parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "x",
+      }),
+    );
+
+    // When a Command is handled that carries no input object.
+    const described = await simAws.ssm().describeParameters({});
+
+    // Then the listing still works, as an SDK caller passing {} would expect.
+    assertArrayLength(described.Parameters ?? [], 1);
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-describe-parameters.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-describe-parameters.ts
@@ -1,0 +1,97 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type {
+  SimDescribeParametersCommand,
+  SimDescribeParametersCommandInput,
+  SimDescribeParametersCommandOutput,
+} from "./query.command.js";
+import { SimSsmParameterPage } from "./sim-ssm-parameter-page.js";
+import { SimSsmParameterView } from "./sim-ssm-parameter-view.js";
+
+/**
+ * The page size real Parameter Store uses for a describe listing.
+ */
+const maxResults = 50;
+
+interface SimSsmDescribeParametersProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly authorizer: SimSsmAuthorizer;
+}
+
+interface SimSsmDescribeParametersOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The DescribeParameters command.
+ *
+ * Real Parameter Store gives this action no resource-level permissions, so it
+ * authorizes against `*` rather than against each parameter, and it does not
+ * filter the listing by what the caller may read. A policy naming individual
+ * parameter ARNs therefore grants nothing here, which is what it grants on
+ * real AWS.
+ *
+ * Values are never reported: this is the metadata listing, and reading a
+ * value takes GetParameter and its own permission.
+ */
+export class SimSsmDescribeParameters {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly authorizer: SimSsmAuthorizer;
+  private readonly view = new SimSsmParameterView();
+
+  constructor(properties: SimSsmDescribeParametersProperties) {
+    this.parameters = properties.parameters;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * List the parameters in this scope, without their values.
+   */
+  handle(
+    command: SimDescribeParametersCommand,
+    options?: SimSsmDescribeParametersOptions,
+  ): SimDescribeParametersCommandOutput {
+    const input = command.input ?? {};
+
+    this.refuseUnsimulatedInput(input);
+    this.authorizer.authorizeAny("ssm:DescribeParameters", options?.caller);
+
+    const page = new SimSsmParameterPage(this.parameters.allByName, input, {
+      operation: "DescribeParameters",
+      maxResults,
+    });
+
+    return {
+      $metadata: {},
+      Parameters: page.items.map((parameter) => this.view.metadata(parameter)),
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Refuse the request inputs this simulation does not model.
+   *
+   * Ignoring a filter would list more parameters than real Parameter Store
+   * lists, which is the kind of divergence that makes a passing test mean
+   * nothing.
+   */
+  private refuseUnsimulatedInput(
+    input: SimDescribeParametersCommandInput,
+  ): void {
+    if (input.Filters !== undefined || input.ParameterFilters !== undefined) {
+      throw new SimSsmValidationException(
+        "DescribeParameters Filters and ParameterFilters are not simulated: " +
+          "parameters are listed in name order",
+      );
+    }
+
+    if (input.Shared !== undefined) {
+      throw new SimSsmValidationException(
+        "DescribeParameters Shared is not simulated: parameters cannot be " +
+          "shared between simulated Accounts",
+      );
+    }
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.iso.test.ts
@@ -1,0 +1,281 @@
+import {
+  GetParameterCommand,
+  GetParametersCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSsmParameterNotFound,
+  SimSsmParameterVersionNotFound,
+  SimSsmValidationException,
+} from "../../error/sim-ssm.error.js";
+
+async function simAwsWithDbHost(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      Description: "The production database host",
+    }),
+  );
+
+  return simAws;
+}
+
+describe("SSM GetParameter", () => {
+  it("reads the current value of a parameter", async () => {
+    // Given a stored parameter.
+    const simAws = await simAwsWithDbHost();
+
+    // When it is read.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }));
+
+    // Then the value comes back with the details Parameter Store reports.
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "db.internal");
+    assertIdentical(read.Parameter.Type, "String");
+    assertIdentical(read.Parameter.Version, 1);
+    assertIdentical(read.Parameter.DataType, "text");
+    assertUndefined(read.Parameter.Selector);
+  });
+
+  it("returns a StringList as one comma separated string", async () => {
+    // Given a StringList parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/hosts",
+        Type: "StringList",
+        Value: "one.internal,two.internal",
+      }),
+    );
+
+    // When it is read.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/hosts" }));
+
+    // Then it is a string to split, not an array, as it is on real AWS.
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "one.internal,two.internal");
+    assertIdentical(read.Parameter.Type, "StringList");
+  });
+
+  it("reads an earlier version by its number", async () => {
+    // Given a parameter that has been overwritten.
+    const simAws = await simAwsWithDbHost();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Value: "db2.internal",
+        Overwrite: true,
+      }),
+    );
+
+    // When the first version is asked for by name and version.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host:1" }));
+
+    // Then the older value comes back, with the selector reported.
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "db.internal");
+    assertIdentical(read.Parameter.Version, 1);
+    assertIdentical(read.Parameter.Selector, ":1");
+    assertIdentical(read.Parameter.Name, "/myapp/prod/db-host");
+  });
+
+  it("refuses a version the parameter does not have", async () => {
+    // Given a parameter with one version.
+    const simAws = await simAwsWithDbHost();
+
+    // When a later version is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(
+          new GetParameterCommand({ Name: "/myapp/prod/db-host:9" }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmParameterVersionNotFound);
+  });
+
+  it("says why a label selector cannot be resolved", async () => {
+    // Given a stored parameter.
+    const simAws = await simAwsWithDbHost();
+
+    // When it is asked for by label.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(
+          new GetParameterCommand({ Name: "/myapp/prod/db-host:release" }),
+        ),
+    );
+
+    // Then it says labels are not simulated, rather than reporting the
+    // parameter as missing.
+    assertInstanceOf(error, SimSsmParameterNotFound);
+    assertStringIncludes(error.message, "labels are not simulated");
+  });
+
+  it("refuses a name ending in a colon", async () => {
+    // Given a stored parameter.
+    const simAws = await simAwsWithDbHost();
+
+    // When a selector is started but not written.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(
+          new GetParameterCommand({ Name: "/myapp/prod/db-host:" }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("refuses a name no parameter answers to", async () => {
+    // Given a simulated AWS with one parameter.
+    const simAws = await simAwsWithDbHost();
+
+    // When a name with a typo is read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParameter(
+          new GetParameterCommand({ Name: "/myapp/prod/db-hostt" }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmParameterNotFound);
+  });
+
+  it("requires a name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a request names nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameter(new GetParameterCommand({ Name: " " })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("ignores WithDecryption for an unencrypted parameter", async () => {
+    // Given a String parameter.
+    const simAws = await simAwsWithDbHost();
+
+    // When it is read asking for decryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-host",
+        WithDecryption: true,
+      }),
+    );
+
+    // Then the flag makes no difference, as it makes none on real AWS.
+    assertIdentical(read.Parameter?.Value, "db.internal");
+  });
+});
+
+describe("SSM GetParameters", () => {
+  it("separates the names it found from the names it did not", async () => {
+    // Given two stored parameters.
+    const simAws = await simAwsWithDbHost();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-port",
+        Type: "String",
+        Value: "5432",
+      }),
+    );
+
+    // When a batch asks for both and for a name with a typo.
+    const read = await simAws.ssm().getParameters(
+      new GetParametersCommand({
+        Names: [
+          "/myapp/prod/db-port",
+          "/myapp/prod/db-hostt",
+          "/myapp/prod/db-host",
+        ],
+      }),
+    );
+
+    // Then the typo comes back as invalid rather than failing the request,
+    // which is what makes it easy to miss on real AWS.
+    assertArrayEquals(
+      read.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+    );
+    assertArrayEquals(read.InvalidParameters, ["/myapp/prod/db-hostt"]);
+  });
+
+  it("reports a version selector that resolves to nothing as invalid", async () => {
+    // Given a parameter with one version.
+    const simAws = await simAwsWithDbHost();
+
+    // When a batch asks for a version it does not have.
+    const read = await simAws.ssm().getParameters(
+      new GetParametersCommand({
+        Names: ["/myapp/prod/db-host:9"],
+      }),
+    );
+
+    // Then the selector comes back as invalid rather than throwing.
+    assertArrayEquals(read.Parameters, []);
+    assertArrayEquals(read.InvalidParameters, ["/myapp/prod/db-host:9"]);
+  });
+
+  it("requires at least one name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a batch asks for nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameters(new GetParametersCommand({ Names: [] })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("refuses more names than one request may carry", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a batch asks for eleven parameters.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameters(
+        new GetParametersCommand({
+          Names: Array.from({ length: 11 }, (_, index) => `p${String(index)}`),
+        }),
+      ),
+    );
+
+    // Then it is refused at the ten Parameter Store allows.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "at most 10");
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.iso.test.ts
@@ -54,7 +54,7 @@ describe("SSM GetParameter", () => {
     assertUndefined(read.Parameter.Selector);
   });
 
-  it("returns a StringList as one comma separated string", async () => {
+  it("returns a StringList as one comma-separated string", async () => {
     // Given a StringList parameter.
     const simAws = new SimAws();
     await simAws.ssm().putParameter(

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.ts
@@ -1,0 +1,104 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type {
+  SimGetParameterCommand,
+  SimGetParameterCommandOutput,
+  SimGetParametersCommand,
+  SimGetParametersCommandOutput,
+} from "./query.command.js";
+import { requireParameterNames } from "./sim-ssm-parameter-names.js";
+import {
+  type SimSsmFoundParameter,
+  SimSsmParameterReader,
+} from "./sim-ssm-parameter-reader.js";
+
+interface SimSsmGetParameterCommandsProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly authorizer: SimSsmAuthorizer;
+}
+
+interface SimSsmGetParameterCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that read parameter values.
+ *
+ * `WithDecryption` is accepted and ignored, as real Parameter Store ignores it
+ * for `String` and `StringList` parameters. Nothing else here is encrypted,
+ * because `SecureString` is not simulated.
+ */
+export class SimSsmGetParameterCommands {
+  private readonly reader: SimSsmParameterReader;
+
+  constructor(properties: SimSsmGetParameterCommandsProperties) {
+    this.reader = new SimSsmParameterReader(properties);
+  }
+
+  /**
+   * Read one parameter, refusing if it is not there.
+   */
+  get(
+    command: SimGetParameterCommand,
+    options?: SimSsmGetParameterCommandsOptions,
+  ): SimGetParameterCommandOutput {
+    const requested = command.input.Name;
+
+    if (requested === undefined || requested.trim() === "") {
+      throw new SimSsmValidationException(
+        "GetParameter requires a parameter Name",
+      );
+    }
+
+    const found = this.reader.read(
+      "ssm:GetParameter",
+      requested,
+      options?.caller,
+    );
+
+    return { $metadata: {}, Parameter: found.output };
+  }
+
+  /**
+   * Read several parameters at once.
+   *
+   * A name no parameter answers to comes back in `InvalidParameters` rather
+   * than failing the request. That is what makes a typo silently return
+   * nothing on real AWS, so a test that asserts on `Parameters` alone passes
+   * while the application reads no configuration at all.
+   */
+  getMany(
+    command: SimGetParametersCommand,
+    options?: SimSsmGetParameterCommandsOptions,
+  ): SimGetParametersCommandOutput {
+    const names = requireParameterNames(command.input.Names, "GetParameters");
+    const found: SimSsmFoundParameter[] = [];
+    const invalid: string[] = [];
+
+    for (const name of names) {
+      const parameter = this.reader.readOrInvalid(
+        "ssm:GetParameters",
+        name,
+        options?.caller,
+      );
+
+      if (parameter === undefined) {
+        invalid.push(name);
+      } else {
+        found.push(parameter);
+      }
+    }
+
+    return {
+      $metadata: {},
+      // Real Parameter Store lists these in alphabetical order rather than in
+      // the order the request asked for them.
+      Parameters: found
+        .toSorted((one, other) => one.name.localeCompare(other.name))
+        .map((entry) => entry.output),
+      InvalidParameters: invalid,
+    };
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.iso.test.ts
@@ -208,6 +208,25 @@ describe("SSM GetParametersByPath", () => {
     assertInstanceOf(error, SimSsmValidationException);
   });
 
+  it("refuses a zero token, which no listing ever issues", async () => {
+    // Given a hierarchy.
+    const simAws = await simAwsWithHierarchy();
+
+    // When a listing continues from a token pointing at the first parameter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParametersByPath(
+        new GetParametersByPathCommand({
+          Path: "/myapp",
+          NextToken: "0",
+        }),
+      ),
+    );
+
+    // Then it is refused. The first page is the one reached with no token at
+    // all, so this is a token the simulation could not have issued.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
   it("requires a path", async () => {
     // Given a simulated AWS.
     const simAws = new SimAws();

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.iso.test.ts
@@ -1,0 +1,261 @@
+import {
+  GetParametersByPathCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+
+async function simAwsWithHierarchy(): Promise<SimAws> {
+  const simAws = new SimAws();
+  const names = [
+    "/myapp/prod/db-host",
+    "/myapp/prod/db-port",
+    "/myapp/prod/cache/host",
+    "/myapp/test/db-host",
+    "/other/thing",
+  ];
+
+  await Promise.all(
+    names.map(async (name) =>
+      simAws
+        .ssm()
+        .putParameter(
+          new PutParameterCommand({ Name: name, Type: "String", Value: name }),
+        ),
+    ),
+  );
+
+  return simAws;
+}
+
+async function namesUnder(
+  simAws: SimAws,
+  path: string,
+  recursive?: boolean,
+): Promise<readonly (string | undefined)[]> {
+  const listed = await simAws.ssm().getParametersByPath(
+    new GetParametersByPathCommand({
+      Path: path,
+      ...(recursive !== undefined && { Recursive: recursive }),
+    }),
+  );
+
+  return listed.Parameters?.map((parameter) => parameter.Name) ?? [];
+}
+
+describe("SSM GetParametersByPath", () => {
+  it("lists only the level immediately below the path by default", async () => {
+    // Given a hierarchy with parameters at two depths under /myapp/prod.
+    const simAws = await simAwsWithHierarchy();
+
+    // When the path is listed without Recursive.
+    const names = await namesUnder(simAws, "/myapp/prod");
+
+    // Then the deeper parameter is left out, in name order.
+    assertArrayEquals(names, ["/myapp/prod/db-host", "/myapp/prod/db-port"]);
+  });
+
+  it("lists everything below the path when recursive", async () => {
+    // Given the same hierarchy.
+    const simAws = await simAwsWithHierarchy();
+
+    // When the path is listed recursively.
+    const names = await namesUnder(simAws, "/myapp/prod", true);
+
+    // Then the deeper parameter is included too.
+    assertArrayEquals(names, [
+      "/myapp/prod/cache/host",
+      "/myapp/prod/db-host",
+      "/myapp/prod/db-port",
+    ]);
+  });
+
+  it("accepts a path written with a trailing slash", async () => {
+    // Given the same hierarchy.
+    const simAws = await simAwsWithHierarchy();
+
+    // When the path is written the way the AWS API reference example writes
+    // it, with a trailing slash.
+    const names = await namesUnder(simAws, "/myapp/prod/");
+
+    // Then it names the same level.
+    assertArrayEquals(names, ["/myapp/prod/db-host", "/myapp/prod/db-port"]);
+  });
+
+  it("lists the root level from the root path", async () => {
+    // Given a parameter with no hierarchy and one with a hierarchy.
+    const simAws = await simAwsWithHierarchy();
+    await simAws
+      .ssm()
+      .putParameter(
+        new PutParameterCommand({ Name: "flat", Type: "String", Value: "x" }),
+      );
+
+    // When the root path is listed without Recursive.
+    const names = await namesUnder(simAws, "/");
+
+    // Then only the parameter at the root comes back.
+    assertArrayEquals(names, ["flat"]);
+  });
+
+  it("reports the current value of each parameter it lists", async () => {
+    // Given a parameter under a path that has been overwritten.
+    const simAws = await simAwsWithHierarchy();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Value: "db2.internal",
+        Overwrite: true,
+      }),
+    );
+
+    // When the path is listed.
+    const listed = await simAws
+      .ssm()
+      .getParametersByPath(
+        new GetParametersByPathCommand({ Path: "/myapp/prod" }),
+      );
+
+    // Then the listing carries the current value and version.
+    const first = listed.Parameters?.at(0);
+
+    assertNonNullable(first);
+    assertIdentical(first.Value, "db2.internal");
+    assertIdentical(first.Version, 2);
+  });
+
+  it("pages at ten parameters, as real Parameter Store does", async () => {
+    // Given twelve parameters under one path.
+    const simAws = new SimAws();
+
+    await Promise.all(
+      Array.from({ length: 12 }, async (_, index) =>
+        simAws.ssm().putParameter(
+          new PutParameterCommand({
+            Name: `/myapp/p${String(index).padStart(2, "0")}`,
+            Type: "String",
+            Value: "x",
+          }),
+        ),
+      ),
+    );
+
+    // When the path is listed without a MaxResults.
+    const firstPage = await simAws
+      .ssm()
+      .getParametersByPath(new GetParametersByPathCommand({ Path: "/myapp" }));
+
+    // Then only ten come back, with a token for the rest. Code that ignores
+    // the token silently reads two thirds of a configuration hierarchy.
+    assertArrayLength(firstPage.Parameters ?? [], 10);
+
+    const second = await simAws.ssm().getParametersByPath(
+      new GetParametersByPathCommand({
+        Path: "/myapp",
+        NextToken: firstPage.NextToken,
+      }),
+    );
+
+    assertArrayLength(second.Parameters ?? [], 2);
+    assertUndefined(second.NextToken);
+  });
+
+  it("refuses more results per page than Parameter Store returns", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks for more than ten at a time.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParametersByPath(
+        new GetParametersByPathCommand({
+          Path: "/myapp",
+          MaxResults: 11,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "between 1 and 10");
+  });
+
+  it("refuses a token it did not issue", async () => {
+    // Given a hierarchy.
+    const simAws = await simAwsWithHierarchy();
+
+    // When a listing continues from an invented token.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParametersByPath(
+        new GetParametersByPathCommand({
+          Path: "/myapp",
+          NextToken: "not-a-token",
+        }),
+      ),
+    );
+
+    // Then it is refused rather than starting again from the beginning.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("requires a path", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing names no path.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParametersByPath(new GetParametersByPathCommand({ Path: "" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("refuses a path without its leading slash", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing names a path that is not fully qualified.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .getParametersByPath(new GetParametersByPathCommand({ Path: "myapp" })),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "forward slash");
+  });
+
+  it("refuses parameter filters", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks to be filtered.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParametersByPath(
+        new GetParametersByPathCommand({
+          Path: "/myapp",
+          ParameterFilters: [{ Key: "Type", Values: ["String"] }],
+        }),
+      ),
+    );
+
+    // Then it is refused rather than returning more than real Parameter Store
+    // would.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "ParameterFilters");
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.ts
@@ -1,0 +1,91 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import { SimSsmParameterPath } from "../../parameter/sim-ssm-parameter-path.js";
+import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type {
+  SimGetParametersByPathCommand,
+  SimGetParametersByPathCommandOutput,
+} from "./query.command.js";
+import { SimSsmParameterPage } from "./sim-ssm-parameter-page.js";
+import { SimSsmParameterView } from "./sim-ssm-parameter-view.js";
+
+/**
+ * The page size real Parameter Store uses for a path listing.
+ */
+const maxResults = 10;
+
+interface SimSsmGetParametersByPathProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly authorizer: SimSsmAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+interface SimSsmGetParametersByPathOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The GetParametersByPath command.
+ *
+ * This authorizes against the path rather than against each parameter it
+ * returns, as real Parameter Store does. Access to a path is access to
+ * everything under it: a caller allowed `/myapp` can read `/myapp/prod/db-host`
+ * recursively even where a policy explicitly denies that parameter.
+ */
+export class SimSsmGetParametersByPath {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly authorizer: SimSsmAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly view = new SimSsmParameterView();
+
+  constructor(properties: SimSsmGetParametersByPathProperties) {
+    this.parameters = properties.parameters;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * List the parameters under one level of the hierarchy.
+   */
+  handle(
+    command: SimGetParametersByPathCommand,
+    options?: SimSsmGetParametersByPathOptions,
+  ): SimGetParametersByPathCommandOutput {
+    const { input } = command;
+
+    if (input.ParameterFilters !== undefined) {
+      throw new SimSsmValidationException(
+        "GetParametersByPath ParameterFilters are not simulated: applying " +
+          "none of them would return more parameters than real Parameter " +
+          "Store returns",
+      );
+    }
+
+    const path = new SimSsmParameterPath({
+      path: input.Path,
+      accountRegionScope: this.accountRegionScope,
+    });
+
+    this.authorizer.authorizeArn(
+      "ssm:GetParametersByPath",
+      path.arn,
+      options?.caller,
+    );
+
+    const page = new SimSsmParameterPage(
+      this.parameters.under(path, input.Recursive === true),
+      input,
+      { operation: "GetParametersByPath", maxResults },
+    );
+
+    return {
+      $metadata: {},
+      Parameters: page.items.map((parameter) =>
+        this.view.value(parameter, parameter.currentVersion),
+      ),
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-names.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-names.ts
@@ -1,0 +1,32 @@
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+
+/**
+ * The most names GetParameters and DeleteParameters accept in one request.
+ *
+ * This is a real limit and a commonly hit one: code that reads a growing list
+ * of parameters in one batch works until the eleventh is added.
+ */
+const maxNames = 10;
+
+/**
+ * Read the parameter names a batch request carries, or refuse.
+ */
+export function requireParameterNames(
+  names: readonly string[] | undefined,
+  operation: string,
+): readonly string[] {
+  if (names === undefined || names.length === 0) {
+    throw new SimSsmValidationException(
+      `${operation} requires at least one parameter name in Names`,
+    );
+  }
+
+  if (names.length > maxNames) {
+    throw new SimSsmValidationException(
+      `${operation} accepts at most ${String(maxNames)} names in one ` +
+        `request, and was given ${String(names.length)}`,
+    );
+  }
+
+  return names;
+}

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-page.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-page.ts
@@ -63,9 +63,10 @@ export class SimSsmParameterPage<TItem> {
   /**
    * Read a continuation token as its offset into the listed parameters.
    *
-   * Tokens are the canonical non-negative integer representation these
-   * commands emit, so anything else is refused rather than silently starting
-   * again from the beginning.
+   * Tokens are the canonical positive integer representation these commands
+   * emit, so anything else is refused rather than silently starting again from
+   * the beginning. That includes `0`, which is never issued because the first
+   * page is the one reached without a token at all.
    */
   private static startIndex(
     nextToken: string | undefined,
@@ -79,7 +80,7 @@ export class SimSsmParameterPage<TItem> {
 
     if (
       !Number.isSafeInteger(startIndex) ||
-      startIndex < 0 ||
+      startIndex < 1 ||
       startIndex >= listedCount ||
       String(startIndex) !== nextToken
     ) {

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-page.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-page.ts
@@ -1,0 +1,93 @@
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+
+/**
+ * The paging fields a parameter listing request carries.
+ */
+export interface SimSsmParameterPageInput {
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+interface SimSsmParameterPageLimits {
+  readonly operation: string;
+  readonly maxResults: number;
+}
+
+/**
+ * One page of listed parameters, and the token that reaches the next one.
+ *
+ * The page sizes are small and worth keeping: GetParametersByPath returns ten
+ * parameters at a time on real AWS, so code that reads a hierarchy without
+ * following NextToken silently stops at the tenth parameter.
+ */
+export class SimSsmParameterPage<TItem> {
+  public readonly items: readonly TItem[];
+  public readonly nextToken: string | undefined;
+
+  constructor(
+    listed: readonly TItem[],
+    input: SimSsmParameterPageInput,
+    limits: SimSsmParameterPageLimits,
+  ) {
+    const maxResults = SimSsmParameterPage.maxResults(input.MaxResults, limits);
+    const startIndex = SimSsmParameterPage.startIndex(
+      input.NextToken,
+      listed.length,
+    );
+    const nextIndex = startIndex + maxResults;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = nextIndex >= listed.length ? undefined : String(nextIndex);
+  }
+
+  private static maxResults(
+    requested: number | undefined,
+    limits: SimSsmParameterPageLimits,
+  ): number {
+    const maxResults = requested ?? limits.maxResults;
+
+    if (
+      !Number.isSafeInteger(maxResults) ||
+      maxResults < 1 ||
+      maxResults > limits.maxResults
+    ) {
+      throw new SimSsmValidationException(
+        `${limits.operation} MaxResults must be a whole number between 1 ` +
+          `and ${String(limits.maxResults)}`,
+      );
+    }
+
+    return maxResults;
+  }
+
+  /**
+   * Read a continuation token as its offset into the listed parameters.
+   *
+   * Tokens are the canonical non-negative integer representation these
+   * commands emit, so anything else is refused rather than silently starting
+   * again from the beginning.
+   */
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(nextToken);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex < 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimSsmValidationException(
+        "NextToken is not a token this simulation issued",
+      );
+    }
+
+    return startIndex;
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-reader.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-reader.ts
@@ -1,0 +1,103 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimSsmParameterNotFound,
+  SimSsmParameterVersionNotFound,
+} from "../../error/sim-ssm.error.js";
+import { SimSsmParameterName } from "../../parameter/sim-ssm-parameter-name.js";
+import { SimSsmParameterSelector } from "../../parameter/sim-ssm-parameter-selector.js";
+import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type { SimSsmParameterOutput } from "./parameter.command.js";
+import { SimSsmParameterView } from "./sim-ssm-parameter-view.js";
+
+/**
+ * A parameter a read resolved, with the stored name it is ordered by.
+ *
+ * The name is carried separately rather than read back off the output because
+ * a batch read has to sort by it, and the reported shape leaves every field
+ * optional.
+ */
+export interface SimSsmFoundParameter {
+  readonly name: string;
+  readonly output: SimSsmParameterOutput;
+}
+
+interface SimSsmParameterReaderProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly authorizer: SimSsmAuthorizer;
+}
+
+/**
+ * Resolves one requested parameter name to the value a read reports.
+ *
+ * GetParameter and GetParameters differ only in what they do when a name
+ * resolves to nothing, so everything before that point belongs here.
+ */
+export class SimSsmParameterReader {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly authorizer: SimSsmAuthorizer;
+  private readonly view = new SimSsmParameterView();
+
+  constructor(properties: SimSsmParameterReaderProperties) {
+    this.parameters = properties.parameters;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Read one requested name, authorizing it before resolving it.
+   *
+   * Authorization comes first because real IAM evaluates a request before the
+   * service sees it: a caller with no permission is refused whether or not the
+   * parameter exists, rather than being told it is missing.
+   */
+  read(
+    action: string,
+    requested: string,
+    caller: SimAwsCaller | undefined,
+  ): SimSsmFoundParameter {
+    const selector = new SimSsmParameterSelector(requested);
+
+    this.authorizer.authorizeParameterResource(
+      action,
+      SimSsmParameterName.resourceFor(selector.name),
+      caller,
+    );
+
+    const parameter = this.parameters.require(selector.name);
+
+    return {
+      name: parameter.name.value,
+      output: this.view.value(
+        parameter,
+        selector.versionOf(parameter),
+        selector.selector,
+      ),
+    };
+  }
+
+  /**
+   * Read one name of a batch, reporting a name that resolves to nothing as
+   * invalid rather than failing the whole request.
+   *
+   * A refused authorization still throws, because one name the caller may not
+   * read fails the whole batch on real AWS.
+   */
+  readOrInvalid(
+    action: string,
+    requested: string,
+    caller: SimAwsCaller | undefined,
+  ): SimSsmFoundParameter | undefined {
+    try {
+      return this.read(action, requested, caller);
+    } catch (error: unknown) {
+      if (
+        error instanceof SimSsmParameterNotFound ||
+        error instanceof SimSsmParameterVersionNotFound
+      ) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-view.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-view.ts
@@ -1,0 +1,68 @@
+import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
+import type { SimSsmParameterVersion } from "../../parameter/sim-ssm-parameter-version.js";
+import type {
+  SimSsmParameterMetadata,
+  SimSsmParameterOutput,
+} from "./parameter.command.js";
+
+/**
+ * The tier every simulated parameter is in.
+ *
+ * The advanced tier is not simulated, so nothing here can be in it.
+ */
+export const standardTier = "Standard";
+
+/**
+ * Converts a stored parameter into the shapes Parameter Store reports it in.
+ *
+ * There are two, and the difference is the point: the value-carrying shape
+ * that GetParameter returns, and the metadata-only shape that
+ * DescribeParameters returns. Building both here keeps them agreeing about
+ * everything they share.
+ */
+export class SimSsmParameterView {
+  /**
+   * The parameter shape that carries a value.
+   *
+   * `Selector` is only reported when the request asked for a version or a
+   * label, as real Parameter Store only reports it then.
+   */
+  value(
+    parameter: SimSsmParameter,
+    version: SimSsmParameterVersion,
+    selector?: string,
+  ): SimSsmParameterOutput {
+    return {
+      ARN: parameter.arn.value,
+      Name: parameter.name.value,
+      Type: parameter.type.value,
+      Value: version.value.value,
+      Version: version.version,
+      DataType: version.dataType,
+      LastModifiedDate: version.lastModifiedDate,
+      Selector: selector,
+    };
+  }
+
+  /**
+   * The parameter shape that carries no value.
+   *
+   * `Policies` is always empty because parameter policies are not simulated.
+   */
+  metadata(parameter: SimSsmParameter): SimSsmParameterMetadata {
+    const version = parameter.currentVersion;
+
+    return {
+      ARN: parameter.arn.value,
+      Name: parameter.name.value,
+      Type: parameter.type.value,
+      Version: version.version,
+      DataType: version.dataType,
+      Description: version.description,
+      LastModifiedDate: version.lastModifiedDate,
+      LastModifiedUser: version.lastModifiedUser,
+      Policies: [],
+      Tier: standardTier,
+    };
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-put-parameter.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-put-parameter.iso.test.ts
@@ -1,0 +1,267 @@
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSsmHierarchyTypeMismatchException,
+  SimSsmParameterAlreadyExists,
+  SimSsmUnsupportedParameterType,
+  SimSsmValidationException,
+} from "../../error/sim-ssm.error.js";
+
+describe("SSM PutParameter", () => {
+  it("starts a new parameter at version 1 in the standard tier", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a parameter is created.
+    const put = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+    );
+
+    // Then it is the first version of a standard tier parameter.
+    assertIdentical(put.Version, 1);
+    assertIdentical(put.Tier, "Standard");
+  });
+
+  it("increments the version on an overwrite", async () => {
+    // Given an existing parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Type: "String",
+        Value: "a",
+      }),
+    );
+
+    // When it is overwritten twice.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Value: "b",
+        Overwrite: true,
+      }),
+    );
+    const third = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Value: "c",
+        Overwrite: true,
+      }),
+    );
+
+    // Then each write makes a new version, and the latest value is current.
+    assertIdentical(third.Version, 3);
+
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "db-host" }));
+
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "c");
+    assertIdentical(read.Parameter.Version, 3);
+  });
+
+  it("refuses an existing name when the request does not ask to overwrite", async () => {
+    // Given an existing parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Type: "String",
+        Value: "a",
+      }),
+    );
+
+    // When another write uses the same name without Overwrite.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "db-host",
+          Type: "String",
+          Value: "b",
+        }),
+      ),
+    );
+
+    // Then it is refused rather than replacing the value.
+    assertInstanceOf(error, SimSsmParameterAlreadyExists);
+    assertStringIncludes(error.message, "Overwrite");
+  });
+
+  it("requires a Type when the parameter is new", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a parameter is created without a Type.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ssm()
+        .putParameter(new PutParameterCommand({ Name: "db-host", Value: "a" })),
+    );
+
+    // Then it is refused, as Parameter Store requires one to create.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Type is required");
+  });
+
+  it("refuses changing the type of an existing parameter", async () => {
+    // Given a String parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Type: "String",
+        Value: "a",
+      }),
+    );
+
+    // When an overwrite names a different type.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "db-host",
+          Type: "StringList",
+          Value: "a,b",
+          Overwrite: true,
+        }),
+      ),
+    );
+
+    // Then it is refused, because Parameter Store cannot convert a parameter.
+    assertInstanceOf(error, SimSsmHierarchyTypeMismatchException);
+    assertStringIncludes(error.message, "create a new, unique parameter");
+  });
+
+  it("allows an overwrite that repeats the existing type", async () => {
+    // Given a StringList parameter.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "hosts",
+        Type: "StringList",
+        Value: "a,b",
+      }),
+    );
+
+    // When an overwrite names the same type again.
+    const put = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "hosts",
+        Type: "StringList",
+        Value: "a,b,c",
+        Overwrite: true,
+      }),
+    );
+
+    // Then it is accepted.
+    assertIdentical(put.Version, 2);
+  });
+
+  it("refuses a SecureString parameter", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a parameter asks to be encrypted.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "db-password",
+          Type: "SecureString",
+          Value: "hunter2",
+        }),
+      ),
+    );
+
+    // Then it is refused rather than stored in the clear, because nothing here
+    // would encrypt it.
+    assertInstanceOf(error, SimSsmUnsupportedParameterType);
+    assertStringIncludes(error.message, "not simulated");
+  });
+
+  it("refuses a type Parameter Store does not have", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When an unknown type is asked for. The SDK's own union would refuse
+    // this, so the request is written structurally rather than as a Command.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter({
+        input: { Name: "db-host", Type: "Number", Value: "1" },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmUnsupportedParameterType);
+  });
+
+  it("refuses a value larger than the standard tier holds", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a whole configuration blob is put in one parameter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/config",
+          Type: "String",
+          Value: "x".repeat(4097),
+        }),
+      ),
+    );
+
+    // Then it is refused at the 4KB limit real Parameter Store enforces.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "4096 bytes");
+  });
+
+  it("refuses an empty value", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a parameter is written with no value.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "db-host",
+          Type: "String",
+          Value: "",
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("leaves no parameter behind when the value is refused", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a create is refused for its value rather than its name.
+    await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/config",
+          Type: "String",
+          Value: "x".repeat(4097),
+        }),
+      ),
+    );
+
+    // Then no half-made parameter is left in the store.
+    assertUndefined(simAws.ssm().findParameter("/myapp/config"));
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-put-parameter.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-put-parameter.ts
@@ -1,0 +1,80 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimSsmParameterName } from "../../parameter/sim-ssm-parameter-name.js";
+import type { SimSsmParameterWriter } from "../../parameter/sim-ssm-parameter-writer.js";
+import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type {
+  SimPutParameterCommand,
+  SimPutParameterCommandOutput,
+} from "./parameter.command.js";
+import { standardTier } from "./sim-ssm-parameter-view.js";
+import { SimSsmUnsimulatedPutOptions } from "./sim-ssm-unsimulated-put-options.js";
+
+interface SimSsmPutParameterProperties {
+  readonly writer: SimSsmParameterWriter;
+  readonly authorizer: SimSsmAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+interface SimSsmPutParameterOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The PutParameter command.
+ *
+ * The name is validated before anything else happens, because the name is
+ * what the request authorizes against: a policy allowing the caller to write
+ * `/myapp/prod/*` has to be evaluated against the ARN the parameter is about
+ * to have, whether or not it exists yet.
+ */
+export class SimSsmPutParameter {
+  private readonly writer: SimSsmParameterWriter;
+  private readonly authorizer: SimSsmAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly unsimulatedOptions = new SimSsmUnsimulatedPutOptions();
+
+  constructor(properties: SimSsmPutParameterProperties) {
+    this.writer = properties.writer;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Create or update a parameter.
+   */
+  handle(
+    command: SimPutParameterCommand,
+    options?: SimSsmPutParameterOptions,
+  ): SimPutParameterCommandOutput {
+    const { input } = command;
+
+    this.unsimulatedOptions.refuseIn(input);
+
+    const name = new SimSsmParameterName({
+      name: input.Name,
+      accountRegionScope: this.accountRegionScope,
+    });
+    const caller = this.authorizer.authorizeParameterResource(
+      "ssm:PutParameter",
+      name.resource,
+      options?.caller,
+    );
+
+    const version = this.writer.write({
+      name,
+      value: input.Value,
+      type: input.Type,
+      overwrite: input.Overwrite,
+      description: input.Description,
+      dataType: input.DataType,
+      lastModifiedUser: caller.arn,
+    });
+
+    return {
+      $metadata: {},
+      Version: version.version,
+      Tier: standardTier,
+    };
+  }
+}

--- a/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.iso.test.ts
@@ -1,0 +1,123 @@
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import type { SimPutParameterCommandInput } from "./parameter.command.js";
+
+async function refusedOption(
+  input: Partial<SimPutParameterCommandInput>,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () =>
+    simAws.ssm().putParameter({
+      input: {
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "db.internal",
+        ...input,
+      },
+    }),
+  );
+}
+
+describe("SSM PutParameter options that are not simulated", () => {
+  it("accepts the standard tier", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a request names the tier this simulation models.
+    const put = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "db.internal",
+        Tier: "Standard",
+      }),
+    );
+
+    // Then it is accepted.
+    assertStringIncludes(String(put.Version), "1");
+  });
+
+  it("refuses the advanced tier", async () => {
+    // When a request asks for a tier this simulation does not model.
+    const error = await refusedOption({ Tier: "Advanced" });
+
+    // Then it is refused rather than quietly downgraded.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Advanced");
+  });
+
+  it("accepts the text data type", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a request names the only data type this simulation models.
+    const put = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/db-host",
+        Type: "String",
+        Value: "db.internal",
+        DataType: "text",
+      }),
+    );
+
+    // Then it is accepted.
+    assertStringIncludes(String(put.Version), "1");
+  });
+
+  it("refuses a data type validated against another service", async () => {
+    // When a request asks for an AMI id to be validated.
+    const error = await refusedOption({ DataType: "aws:ec2:image" });
+
+    // Then it is refused, because nothing here could do the validation.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "aws:ec2:image");
+  });
+
+  it("refuses an AllowedPattern", async () => {
+    // When a request asks for its value to be pattern checked.
+    const error = await refusedOption({ AllowedPattern: String.raw`^\d+$` });
+
+    // Then it is refused, rather than storing a value the pattern would have
+    // rejected on real AWS.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "AllowedPattern");
+  });
+
+  it("refuses parameter policies", async () => {
+    // When a request attaches a policy.
+    const error = await refusedOption({ Policies: "[]" });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Policies");
+  });
+
+  it("refuses tags", async () => {
+    // When a request tags the parameter.
+    const error = await refusedOption({
+      Tags: [{ Key: "Environment", Value: "prod" }],
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "Tags");
+  });
+
+  it("refuses a KMS key id", async () => {
+    // When a request names a key to encrypt with.
+    const error = await refusedOption({ KeyId: "alias/aws/ssm" });
+
+    // Then it is refused, because only SecureString parameters are encrypted
+    // and those are not simulated either.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "KeyId");
+  });
+});

--- a/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.ts
@@ -1,0 +1,65 @@
+import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import { ssmTextDataType } from "../../parameter/sim-ssm-parameter-version.js";
+import type { SimPutParameterCommandInput } from "./parameter.command.js";
+import { standardTier } from "./sim-ssm-parameter-view.js";
+
+/**
+ * Refuses the PutParameter options this simulation does not model.
+ *
+ * Every one of these changes what the parameter does on real AWS, so ignoring
+ * any of them would let a request succeed here and behave differently in a
+ * deployment. An AllowedPattern that is quietly dropped is the clearest case:
+ * the value it was meant to reject would be stored without complaint.
+ */
+export class SimSsmUnsimulatedPutOptions {
+  /**
+   * Refuse a request carrying an option this simulation cannot honour.
+   */
+  refuseIn(input: SimPutParameterCommandInput): void {
+    this.refuseTier(input.Tier);
+    this.refuseDataType(input.DataType);
+    this.refuse("AllowedPattern", input.AllowedPattern, "value validation");
+    this.refuse("Policies", input.Policies, "parameter policies");
+    this.refuse("Tags", input.Tags, "parameter tags");
+    this.refuse(
+      "KeyId",
+      input.KeyId,
+      "encryption, which only applies to SecureString parameters",
+    );
+  }
+
+  private refuseTier(tier: string | undefined): void {
+    if (tier === undefined || tier === standardTier) {
+      return;
+    }
+
+    throw new SimSsmValidationException(
+      `Parameter Tier '${tier}' is not simulated: only the ${standardTier} ` +
+        `tier is, so a parameter here holds at most 4KB and carries no ` +
+        `policies`,
+    );
+  }
+
+  private refuseDataType(dataType: string | undefined): void {
+    if (dataType === undefined || dataType === ssmTextDataType) {
+      return;
+    }
+
+    throw new SimSsmValidationException(
+      `Parameter DataType '${dataType}' is not simulated: real Parameter ` +
+        `Store validates such a value against another service, which this ` +
+        `simulation cannot do. Only '${ssmTextDataType}' is supported.`,
+    );
+  }
+
+  private refuse(option: string, value: unknown, feature: string): void {
+    if (value === undefined) {
+      return;
+    }
+
+    throw new SimSsmValidationException(
+      `PutParameter ${option} is not simulated: ${feature} would be ignored ` +
+        `here and applied on real AWS`,
+    );
+  }
+}

--- a/src/service/ssm/command/sim-ssm-command.types.ts
+++ b/src/service/ssm/command/sim-ssm-command.types.ts
@@ -1,0 +1,32 @@
+/**
+ * The sim SSM Command types, gathered for the service facade.
+ */
+export type {
+  SimDeleteParameterCommand,
+  SimDeleteParameterCommandInput,
+  SimDeleteParameterCommandOutput,
+  SimDeleteParametersCommand,
+  SimDeleteParametersCommandInput,
+  SimDeleteParametersCommandOutput,
+  SimPutParameterCommand,
+  SimPutParameterCommandInput,
+  SimPutParameterCommandOutput,
+  SimSsmParameterMetadata,
+  SimSsmParameterOutput,
+  SimSsmTag,
+} from "./parameter/parameter.command.js";
+export type {
+  SimDescribeParametersCommand,
+  SimDescribeParametersCommandInput,
+  SimDescribeParametersCommandOutput,
+  SimGetParameterCommand,
+  SimGetParameterCommandInput,
+  SimGetParameterCommandOutput,
+  SimGetParametersByPathCommand,
+  SimGetParametersByPathCommandInput,
+  SimGetParametersByPathCommandOutput,
+  SimGetParametersCommand,
+  SimGetParametersCommandInput,
+  SimGetParametersCommandOutput,
+  SimSsmParameterFilter,
+} from "./parameter/query.command.js";

--- a/src/service/ssm/error/sim-ssm.error.ts
+++ b/src/service/ssm/error/sim-ssm.error.ts
@@ -1,0 +1,124 @@
+/**
+ * Minimal metadata shape for simulated SSM errors.
+ */
+export interface SimSsmErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated SSM errors.
+ */
+export class SimSsmError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimSsmErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated SSM ParameterNotFound error.
+ *
+ * Real Parameter Store reports an unknown parameter name and an unknown label
+ * this way.
+ */
+export class SimSsmParameterNotFound extends SimSsmError {
+  public override readonly name = "ParameterNotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM ParameterVersionNotFound error.
+ *
+ * This is what a numbered version selector produces when the parameter exists
+ * but that version of it does not.
+ */
+export class SimSsmParameterVersionNotFound extends SimSsmError {
+  public override readonly name = "ParameterVersionNotFound";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM ParameterAlreadyExists error.
+ *
+ * PutParameter produces this when the name is taken and the request did not
+ * ask to overwrite.
+ */
+export class SimSsmParameterAlreadyExists extends SimSsmError {
+  public override readonly name = "ParameterAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM ParameterPatternMismatchException error.
+ *
+ * This is the failure a malformed parameter name produces: disallowed
+ * characters, a hierarchy without its leading slash, or a reserved prefix.
+ */
+export class SimSsmParameterPatternMismatchException extends SimSsmError {
+  public override readonly name = "ParameterPatternMismatchException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM HierarchyLevelLimitExceededException error.
+ */
+export class SimSsmHierarchyLevelLimitExceededException extends SimSsmError {
+  public override readonly name = "HierarchyLevelLimitExceededException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM HierarchyTypeMismatchException error.
+ *
+ * Parameter Store refuses to change the type of an existing parameter, so an
+ * overwrite naming a different type fails rather than converting it.
+ */
+export class SimSsmHierarchyTypeMismatchException extends SimSsmError {
+  public override readonly name = "HierarchyTypeMismatchException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM UnsupportedParameterType error.
+ */
+export class SimSsmUnsupportedParameterType extends SimSsmError {
+  public override readonly name = "UnsupportedParameterType";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SSM ValidationException error.
+ *
+ * Real Parameter Store reports a missing or malformed request input this way,
+ * and it is also what this simulation refuses an unsimulated input with.
+ */
+export class SimSsmValidationException extends SimSsmError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/ssm/index.ts
+++ b/src/service/ssm/index.ts
@@ -1,0 +1,25 @@
+export { SimSsm, type SimSsmRequestOptions } from "./sim-ssm.js";
+export { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
+export { SimSsmParameterArn } from "./parameter/sim-ssm-parameter-arn.js";
+export { SimSsmParameterName } from "./parameter/sim-ssm-parameter-name.js";
+export { SimSsmParameterPath } from "./parameter/sim-ssm-parameter-path.js";
+export {
+  SimSsmParameterType,
+  type SimSsmParameterTypeName,
+} from "./parameter/sim-ssm-parameter-type.js";
+export { SimSsmParameterValue } from "./parameter/sim-ssm-parameter-value.js";
+export {
+  SimSsmParameterVersion,
+  ssmTextDataType,
+} from "./parameter/sim-ssm-parameter-version.js";
+export {
+  SimSsmError,
+  SimSsmHierarchyLevelLimitExceededException,
+  SimSsmHierarchyTypeMismatchException,
+  SimSsmParameterAlreadyExists,
+  SimSsmParameterNotFound,
+  SimSsmParameterPatternMismatchException,
+  SimSsmParameterVersionNotFound,
+  SimSsmUnsupportedParameterType,
+  SimSsmValidationException,
+} from "./error/sim-ssm.error.js";

--- a/src/service/ssm/parameter/sim-ssm-parameter-arn.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-arn.ts
@@ -1,0 +1,46 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The part of a parameter ARN that comes before the parameter's own name.
+ *
+ * It ends in a slash, and the name follows it with its own leading slash
+ * dropped, so `/myapp/prod/db-host` becomes `...:parameter/myapp/prod/db-host`
+ * rather than `...:parameter//myapp/prod/db-host`.
+ */
+export function ssmParameterArnPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:aws:ssm:${regionName}:${accountId}:parameter/`;
+}
+
+interface SimSsmParameterArnProperties {
+  readonly resource: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The ARN of one simulated parameter.
+ *
+ * The single detail worth getting right here is the leading slash. A
+ * hierarchical parameter name starts with one and its ARN does not repeat it,
+ * so an IAM policy written as `...:parameter//myapp/prod/db-host` matches
+ * nothing. Building the ARN in one place is what makes a policy that works
+ * here one that would work on real AWS.
+ */
+export class SimSsmParameterArn {
+  /**
+   * The parameter name with its leading slash dropped, which is the part of
+   * the ARN after `parameter/`.
+   */
+  public readonly resource: string;
+
+  public readonly value: string;
+
+  constructor(properties: SimSsmParameterArnProperties) {
+    this.resource = properties.resource;
+    this.value =
+      ssmParameterArnPrefix(properties.accountRegionScope) + this.resource;
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-name.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-name.iso.test.ts
@@ -1,0 +1,221 @@
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimSsmHierarchyLevelLimitExceededException,
+  SimSsmParameterPatternMismatchException,
+  SimSsmValidationException,
+} from "../error/sim-ssm.error.js";
+
+async function refusedName(name: string): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () =>
+    simAws
+      .ssm()
+      .putParameter(
+        new PutParameterCommand({ Name: name, Type: "String", Value: "x" }),
+      ),
+  );
+}
+
+describe("SSM parameter names", () => {
+  it("drops the leading slash from the name in the parameter ARN", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+    const { defaultAccountId, defaultRegionName } = simAws;
+
+    // When a hierarchical parameter is created.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+    );
+
+    // Then its ARN carries the name once, without a doubled slash.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }));
+
+    assertNonNullable(read.Parameter);
+    assertIdentical(
+      read.Parameter.ARN,
+      `arn:aws:ssm:${defaultRegionName}:${defaultAccountId}:parameter/myapp/prod/db-host`,
+    );
+    assertIdentical(read.Parameter.Name, "/myapp/prod/db-host");
+  });
+
+  it("gives a flat name an ARN without a hierarchy", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+    const { defaultAccountId, defaultRegionName } = simAws;
+
+    // When a parameter is created with no hierarchy in its name.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Type: "String",
+        Value: "x",
+      }),
+    );
+
+    // Then its ARN names it directly.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "db-host" }));
+
+    assertIdentical(
+      read.Parameter?.ARN,
+      `arn:aws:ssm:${defaultRegionName}:${defaultAccountId}:parameter/db-host`,
+    );
+  });
+
+  it("reaches the same parameter with or without a leading slash", async () => {
+    // Given a parameter created without a leading slash.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "db-host",
+        Type: "String",
+        Value: "x",
+      }),
+    );
+
+    // When it is read with one.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/db-host" }));
+
+    // Then it is the same parameter, because both forms name the same ARN.
+    assertIdentical(read.Parameter?.Value, "x");
+  });
+
+  it("trims spaces around a name and keeps the trimmed form", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a name is written with surrounding spaces, as real Parameter Store
+    // strips them.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "  /myapp/db-host  ",
+        Type: "String",
+        Value: "x",
+      }),
+    );
+
+    // Then the parameter is stored under the trimmed name.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/db-host" }));
+
+    assertIdentical(read.Parameter?.Name, "/myapp/db-host");
+  });
+
+  it("refuses a hierarchical name without its leading slash", async () => {
+    // When a name has a hierarchy but is not fully qualified.
+    const error = await refusedName("myapp/prod/db-host");
+
+    // Then it is refused, as real Parameter Store refuses it.
+    assertInstanceOf(error, SimSsmParameterPatternMismatchException);
+    assertStringIncludes(error.message, "/myapp/prod/db-host");
+  });
+
+  it("refuses a name with characters Parameter Store does not allow", async () => {
+    // When a name contains a character outside the allowed set.
+    const error = await refusedName("/myapp/db$host");
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmParameterPatternMismatchException);
+  });
+
+  it("refuses a name with spaces between characters", async () => {
+    // When a name has an inner space, which trimming cannot fix.
+    const error = await refusedName("/myapp/db host");
+
+    // Then it is refused as a validation failure.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "spaces");
+  });
+
+  it("refuses an empty name", async () => {
+    // When no usable name is given.
+    const error = await refusedName(" ".repeat(3));
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmValidationException);
+  });
+
+  it("refuses an empty hierarchy level", async () => {
+    // When a name has two slashes in a row.
+    const error = await refusedName("/myapp//db-host");
+
+    // Then it is refused rather than treated as one level.
+    assertInstanceOf(error, SimSsmParameterPatternMismatchException);
+    assertStringIncludes(error.message, "empty hierarchy level");
+  });
+
+  it("refuses a hierarchy deeper than fifteen levels", async () => {
+    // When a name has sixteen levels.
+    const error = await refusedName(
+      `/${Array.from({ length: 16 }, (_, index) => `level${String(index)}`).join("/")}`,
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmHierarchyLevelLimitExceededException);
+    assertStringIncludes(error.message, "16 hierarchy levels");
+  });
+
+  it("allows a hierarchy of exactly fifteen levels", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+    const name = `/${Array.from({ length: 15 }, (_, index) => `level${String(index)}`).join("/")}`;
+
+    // When a name uses the whole depth Parameter Store allows.
+    const put = await simAws
+      .ssm()
+      .putParameter(
+        new PutParameterCommand({ Name: name, Type: "String", Value: "x" }),
+      );
+
+    // Then it is accepted.
+    assertIdentical(put.Version, 1);
+  });
+
+  it("refuses a name under the reserved aws prefix", async () => {
+    // When a name starts with the prefix Parameter Store reserves.
+    const error = await refusedName("/aws/reference/my-thing");
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSsmParameterPatternMismatchException);
+    assertStringIncludes(error.message, "reserves");
+  });
+
+  it("refuses a name under the reserved ssm prefix whatever its case", async () => {
+    // When a name starts with the other reserved prefix, differently cased.
+    const error = await refusedName("/SSM/my-thing");
+
+    // Then it is refused, because the check is case-insensitive on real AWS.
+    assertInstanceOf(error, SimSsmParameterPatternMismatchException);
+    assertStringIncludes(error.message, "ssm");
+  });
+
+  it("refuses a name too long for the parameter ARN", async () => {
+    // When a name would make an ARN longer than Parameter Store allows.
+    const error = await refusedName(`/${"a".repeat(1100)}`);
+
+    // Then it is refused, counting the ARN prefix as real Parameter Store
+    // counts it.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "1011");
+  });
+});

--- a/src/service/ssm/parameter/sim-ssm-parameter-name.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-name.ts
@@ -1,0 +1,172 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSsmHierarchyLevelLimitExceededException,
+  SimSsmParameterPatternMismatchException,
+  SimSsmValidationException,
+} from "../error/sim-ssm.error.js";
+import { ssmParameterArnPrefix } from "./sim-ssm-parameter-arn.js";
+
+const allowedCharacters = /^[\w./-]+$/;
+const maxHierarchyLevels = 15;
+const reservedPrefixes = ["aws", "ssm"];
+
+/**
+ * The longest a parameter name may be, counting the ARN that precedes it.
+ *
+ * Real Parameter Store reserves the rest of the 2048 character ARN for its own
+ * use, and counts the ARN prefix towards the 1011 characters left. That is why
+ * this limit needs the Account and Region: the same name is legal in one
+ * Region and too long in another.
+ */
+const maxArnLength = 1011;
+
+interface SimSsmParameterNameProperties {
+  readonly name: string | undefined;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The name of one simulated parameter, validated as real Parameter Store
+ * validates it.
+ *
+ * The rules are worth applying in one place because they are a common
+ * deploy-time failure rather than an obscure edge: a hierarchy missing its
+ * leading slash, a name under the reserved `/aws` prefix, or a hierarchy
+ * sixteen levels deep all fail at PutParameter on real AWS.
+ */
+export class SimSsmParameterName {
+  /**
+   * The name as Parameter Store stores and reports it, leading slash and all.
+   */
+  public readonly value: string;
+
+  /**
+   * The name with any leading slash dropped, which is how it appears in the
+   * parameter's ARN and how this simulation keys it.
+   */
+  public readonly resource: string;
+
+  constructor(properties: SimSsmParameterNameProperties) {
+    const name = SimSsmParameterName.trimmed(properties.name);
+
+    this.value = name;
+    this.resource = SimSsmParameterName.resourceFor(name);
+
+    this.requireAllowedCharacters(name);
+    this.requireWellFormedHierarchy(name);
+    this.requireUnreservedPrefix();
+    this.requireWithinArnLength(properties.accountRegionScope);
+  }
+
+  /**
+   * Normalize a name to the resource part of its ARN.
+   *
+   * A parameter put as `db-host` and one read as `/db-host` are the same
+   * parameter, because both name the same ARN. Keying on this form is what
+   * makes the two interchangeable.
+   */
+  static resourceFor(name: string): string {
+    return name.trim().replace(/^\//, "");
+  }
+
+  private static trimmed(name: string | undefined): string {
+    if (name === undefined || name.trim() === "") {
+      throw new SimSsmValidationException(
+        "A parameter name is required and cannot be empty",
+      );
+    }
+
+    // Real Parameter Store strips surrounding spaces and refuses inner ones.
+    const trimmed = name.trim();
+
+    if (trimmed.includes(" ")) {
+      throw new SimSsmValidationException(
+        `Parameter name '${trimmed}' contains spaces, which Parameter Store ` +
+          `does not allow between characters`,
+      );
+    }
+
+    return trimmed;
+  }
+
+  private requireAllowedCharacters(name: string): void {
+    if (allowedCharacters.test(name)) {
+      return;
+    }
+
+    throw new SimSsmParameterPatternMismatchException(
+      `Parameter name '${name}' contains characters Parameter Store does not ` +
+        `allow: only letters, digits, the characters _.- and the / hierarchy ` +
+        `separator are permitted`,
+    );
+  }
+
+  /**
+   * Refuse a hierarchy that Parameter Store would refuse.
+   *
+   * The leading slash is the one people actually get wrong: a name written as
+   * `myapp/prod/db-host` looks fine and is rejected on real AWS, because a
+   * name containing a hierarchy has to be fully qualified.
+   */
+  private requireWellFormedHierarchy(name: string): void {
+    if (!name.includes("/")) {
+      return;
+    }
+
+    if (!name.startsWith("/")) {
+      throw new SimSsmParameterPatternMismatchException(
+        `Parameter name '${name}' is hierarchical, so it must start with a ` +
+          `forward slash: '/${name}'`,
+      );
+    }
+
+    const levels = this.resource.split("/");
+
+    if (levels.includes("")) {
+      throw new SimSsmParameterPatternMismatchException(
+        `Parameter name '${name}' has an empty hierarchy level`,
+      );
+    }
+
+    if (levels.length > maxHierarchyLevels) {
+      throw new SimSsmHierarchyLevelLimitExceededException(
+        `Parameter name '${name}' has ${String(levels.length)} hierarchy ` +
+          `levels; a hierarchy can have a maximum of ` +
+          `${String(maxHierarchyLevels)} levels`,
+      );
+    }
+  }
+
+  private requireUnreservedPrefix(): void {
+    const lowerCased = this.resource.toLowerCase();
+    const reserved = reservedPrefixes.find((prefix) =>
+      lowerCased.startsWith(prefix),
+    );
+
+    if (reserved === undefined) {
+      return;
+    }
+
+    throw new SimSsmParameterPatternMismatchException(
+      `Parameter name '${this.value}' starts with '${reserved}', which ` +
+        `Parameter Store reserves for its own parameters`,
+    );
+  }
+
+  private requireWithinArnLength(
+    accountRegionScope: SimAwsAccountRegionScope,
+  ): void {
+    const arnLength =
+      ssmParameterArnPrefix(accountRegionScope).length + this.resource.length;
+
+    if (arnLength <= maxArnLength) {
+      return;
+    }
+
+    throw new SimSsmValidationException(
+      `Parameter name '${this.value}' makes an ARN of ${String(arnLength)} ` +
+        `characters; Parameter Store allows ${String(maxArnLength)} ` +
+        `including the ARN prefix for this Account and Region`,
+    );
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-path.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-path.ts
@@ -1,0 +1,80 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSsmValidationException } from "../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "./sim-ssm-parameter.js";
+import { ssmParameterArnPrefix } from "./sim-ssm-parameter-arn.js";
+
+interface SimSsmParameterPathProperties {
+  readonly path: string | undefined;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * A level of the parameter hierarchy, as GetParametersByPath names one.
+ *
+ * The path is also the resource GetParametersByPath authorizes against, which
+ * is the part worth modelling: real Parameter Store grants access to a whole
+ * subtree through its path, so a caller allowed `/myapp` can read `/myapp/prod`
+ * recursively even where an explicit deny names the parameter itself.
+ */
+export class SimSsmParameterPath {
+  /**
+   * The path as the request wrote it.
+   */
+  public readonly value: string;
+
+  /**
+   * The ARN of the path, which is what an IAM policy names.
+   */
+  public readonly arn: string;
+
+  private readonly prefix: string;
+
+  constructor(properties: SimSsmParameterPathProperties) {
+    this.value = SimSsmParameterPath.validated(properties.path);
+
+    // A trailing slash is optional in the request and never part of the ARN.
+    const resource = this.value.replace(/^\//, "").replace(/\/$/, "");
+
+    this.arn = ssmParameterArnPrefix(properties.accountRegionScope) + resource;
+    this.prefix = resource === "" ? "" : `${resource}/`;
+  }
+
+  private static validated(path: string | undefined): string {
+    if (path === undefined || path.trim() === "") {
+      throw new SimSsmValidationException(
+        "A Path is required for GetParametersByPath",
+      );
+    }
+
+    const trimmed = path.trim();
+
+    if (!trimmed.startsWith("/")) {
+      throw new SimSsmValidationException(
+        `Path '${trimmed}' does not start with a forward slash: a parameter ` +
+          `hierarchy starts at '/'`,
+      );
+    }
+
+    return trimmed;
+  }
+
+  /**
+   * Whether a parameter lies under this path.
+   *
+   * Without `recursive` only the level immediately below the path counts, so
+   * `/myapp/db-host` is under `/myapp` and `/myapp/prod/db-host` is not.
+   */
+  contains(parameter: SimSsmParameter, recursive: boolean): boolean {
+    const { resource } = parameter.arn;
+
+    if (!resource.startsWith(this.prefix)) {
+      return false;
+    }
+
+    if (recursive) {
+      return true;
+    }
+
+    return !resource.slice(this.prefix.length).includes("/");
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-selector.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-selector.ts
@@ -1,0 +1,83 @@
+import {
+  SimSsmParameterNotFound,
+  SimSsmValidationException,
+} from "../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "./sim-ssm-parameter.js";
+import type { SimSsmParameterVersion } from "./sim-ssm-parameter-version.js";
+
+const versionNumberPattern = /^\d+$/;
+
+/**
+ * A parameter name as a request writes it, with an optional version or label
+ * selector after a colon.
+ *
+ * A parameter name cannot contain a colon, so the first one separates the name
+ * from the selector. `name:3` names a version and `name:release` names a
+ * label, which is how real Parameter Store tells the two apart: a label may
+ * not start with a digit.
+ */
+export class SimSsmParameterSelector {
+  /**
+   * The parameter name, without the selector.
+   */
+  public readonly name: string;
+
+  /**
+   * The selector as Parameter Store reports it back, such as `:3`.
+   */
+  public readonly selector: string | undefined;
+
+  private readonly version: number | undefined;
+  private readonly label: string | undefined;
+
+  constructor(requestedName: string) {
+    const colonIndex = requestedName.indexOf(":");
+
+    if (colonIndex === -1) {
+      this.name = requestedName;
+      return;
+    }
+
+    const selected = requestedName.slice(colonIndex + 1);
+
+    if (selected === "") {
+      throw new SimSsmValidationException(
+        `Parameter name '${requestedName}' ends in a colon with no version ` +
+          `or label after it`,
+      );
+    }
+
+    this.name = requestedName.slice(0, colonIndex);
+    this.selector = `:${selected}`;
+
+    if (versionNumberPattern.test(selected)) {
+      this.version = Number(selected);
+    } else {
+      this.label = selected;
+    }
+  }
+
+  /**
+   * The version of a parameter this selector names.
+   *
+   * Parameter labels are refused rather than looked up. Nothing in this
+   * simulation can create one, because LabelParameterVersion is not
+   * implemented, so a label selector could only ever fail. Saying why beats
+   * reporting the parameter as missing.
+   */
+  versionOf(parameter: SimSsmParameter): SimSsmParameterVersion {
+    if (this.label !== undefined) {
+      throw new SimSsmParameterNotFound(
+        `Parameter '${this.name}' has no label '${this.label}': parameter ` +
+          `labels are not simulated, because LabelParameterVersion is not ` +
+          `implemented. Select a version number instead.`,
+      );
+    }
+
+    if (this.version === undefined) {
+      return parameter.currentVersion;
+    }
+
+    return parameter.versionNumbered(this.version);
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-store.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-store.ts
@@ -1,0 +1,89 @@
+import { SimSsmParameterNotFound } from "../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "./sim-ssm-parameter.js";
+import { SimSsmParameterName } from "./sim-ssm-parameter-name.js";
+import type { SimSsmParameterPath } from "./sim-ssm-parameter-path.js";
+
+/**
+ * The parameters of one simulated SSM scope, and how a requested name
+ * resolves to one of them.
+ *
+ * Parameters are keyed by the resource part of their ARN rather than by the
+ * name as written, so `/db-host` and `db-host` reach the same parameter. They
+ * have to: both name the same ARN, so no IAM policy could tell them apart.
+ */
+export class SimSsmParameterStore {
+  private readonly parameters = new Map<string, SimSsmParameter>();
+
+  /**
+   * Every parameter in this scope, in creation order.
+   */
+  get all(): readonly SimSsmParameter[] {
+    return this.parameters.values().toArray();
+  }
+
+  /**
+   * Store a newly created parameter.
+   */
+  add(parameter: SimSsmParameter): void {
+    this.parameters.set(parameter.arn.resource, parameter);
+  }
+
+  /**
+   * Forget a deleted parameter.
+   */
+  remove(parameter: SimSsmParameter): void {
+    this.parameters.delete(parameter.arn.resource);
+  }
+
+  /**
+   * Find a parameter by name, with or without its leading slash.
+   */
+  find(name: string): SimSsmParameter | undefined {
+    return this.parameters.get(SimSsmParameterName.resourceFor(name));
+  }
+
+  /**
+   * Resolve a parameter by name, or refuse.
+   */
+  require(name: string): SimSsmParameter {
+    const found = this.find(name);
+
+    if (found === undefined) {
+      throw new SimSsmParameterNotFound(
+        `Parameter '${name}' not found: verify the name and try again`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * The parameters under one level of the hierarchy, in name order.
+   *
+   * Real Parameter Store returns a path listing sorted by name rather than in
+   * creation order.
+   */
+  under(
+    path: SimSsmParameterPath,
+    recursive: boolean,
+  ): readonly SimSsmParameter[] {
+    return this.sortedByName(
+      this.all.filter((parameter) => path.contains(parameter, recursive)),
+    );
+  }
+
+  /**
+   * Every parameter in this scope, in name order.
+   */
+  get allByName(): readonly SimSsmParameter[] {
+    return this.sortedByName(this.all);
+  }
+
+  private sortedByName(
+    parameters: readonly SimSsmParameter[],
+  ): readonly SimSsmParameter[] {
+    return parameters.toSorted((one, other) =>
+      one.name.value.localeCompare(other.name.value),
+    );
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-type.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-type.ts
@@ -1,0 +1,63 @@
+import {
+  SimSsmUnsupportedParameterType,
+  SimSsmValidationException,
+} from "../error/sim-ssm.error.js";
+
+/**
+ * The parameter types this simulation stores.
+ */
+export type SimSsmParameterTypeName = "String" | "StringList";
+
+const simulatedTypes: ReadonlySet<string> = new Set(["String", "StringList"]);
+
+/**
+ * The type of one simulated parameter.
+ *
+ * `SecureString` is refused rather than stored. Nothing in this simulation
+ * would encrypt it, so accepting it would let a test pass while proving
+ * nothing about the KMS key, the `kms:Decrypt` permission or the
+ * `WithDecryption` flag a real deployment depends on.
+ */
+export class SimSsmParameterType {
+  public readonly value: SimSsmParameterTypeName;
+
+  constructor(type: string) {
+    this.value = SimSsmParameterType.validated(type);
+  }
+
+  /**
+   * Read the type a new parameter is created with.
+   *
+   * Parameter Store requires a type when a parameter is created and allows it
+   * to be left out when one is updated.
+   */
+  static forNewParameter(type: string | undefined): SimSsmParameterType {
+    if (type === undefined) {
+      throw new SimSsmValidationException(
+        "A parameter Type is required when creating a parameter",
+      );
+    }
+
+    return new SimSsmParameterType(type);
+  }
+
+  private static validated(type: string): SimSsmParameterTypeName {
+    if (type === "SecureString") {
+      throw new SimSsmUnsupportedParameterType(
+        "SecureString parameters are not simulated: nothing here would " +
+          "encrypt the value, so a passing test would say nothing about the " +
+          "KMS key or the kms:Decrypt permission the real parameter needs. " +
+          "Use String or StringList.",
+      );
+    }
+
+    if (!simulatedTypes.has(type)) {
+      throw new SimSsmUnsupportedParameterType(
+        `Parameter type '${type}' is not a Parameter Store type: use String ` +
+          `or StringList`,
+      );
+    }
+
+    return type as SimSsmParameterTypeName;
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-value.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-value.ts
@@ -1,0 +1,46 @@
+import { SimSsmValidationException } from "../error/sim-ssm.error.js";
+
+/**
+ * The content size a standard tier parameter may hold.
+ *
+ * This is the limit people actually hit, usually by putting a whole JSON
+ * configuration blob in one parameter. The advanced tier's 8KB is not
+ * simulated, so this is the only limit here.
+ */
+const maxValueBytes = 4096;
+
+/**
+ * The value held by one version of a simulated parameter.
+ *
+ * A `StringList` value is a single comma separated string here, as it is on
+ * real Parameter Store. It is stored and returned that way rather than split
+ * into an array, so handler code that splits it on commas is exercising the
+ * same shape it would get from AWS.
+ */
+export class SimSsmParameterValue {
+  public readonly value: string;
+
+  constructor(value: string | undefined) {
+    this.value = SimSsmParameterValue.validated(value);
+  }
+
+  private static validated(value: string | undefined): string {
+    if (value === undefined || value === "") {
+      throw new SimSsmValidationException(
+        "A parameter Value is required and cannot be empty",
+      );
+    }
+
+    const byteLength = Buffer.byteLength(value, "utf8");
+
+    if (byteLength > maxValueBytes) {
+      throw new SimSsmValidationException(
+        `Parameter value is ${String(byteLength)} bytes; a standard tier ` +
+          `parameter holds at most ${String(maxValueBytes)} bytes. The ` +
+          `advanced tier is not simulated.`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-value.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-value.ts
@@ -12,7 +12,7 @@ const maxValueBytes = 4096;
 /**
  * The value held by one version of a simulated parameter.
  *
- * A `StringList` value is a single comma separated string here, as it is on
+ * A `StringList` value is a single comma-separated string here, as it is on
  * real Parameter Store. It is stored and returned that way rather than split
  * into an array, so handler code that splits it on commas is exercising the
  * same shape it would get from AWS.

--- a/src/service/ssm/parameter/sim-ssm-parameter-version.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-version.ts
@@ -1,0 +1,50 @@
+import type { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
+
+/**
+ * The data type of a parameter's value.
+ *
+ * Only plain text is simulated. `aws:ec2:image` and `aws:ssm:integration` are
+ * validated against other services by real Parameter Store, which this
+ * simulation does not do.
+ */
+export const ssmTextDataType = "text";
+
+/**
+ * The details one write of a parameter carries, beyond its value.
+ */
+export interface SimSsmParameterVersionDetails {
+  readonly description?: string | undefined;
+  readonly dataType?: string | undefined;
+  readonly lastModifiedUser?: string | undefined;
+}
+
+interface SimSsmParameterVersionProperties extends SimSsmParameterVersionDetails {
+  readonly version: number;
+  readonly value: SimSsmParameterValue;
+  readonly lastModifiedDate: Date;
+}
+
+/**
+ * One version of a simulated parameter.
+ *
+ * Every write makes a new version rather than replacing the value, because
+ * that is what makes the `name:version` selector mean anything: a caller can
+ * still read what the parameter said two deployments ago.
+ */
+export class SimSsmParameterVersion {
+  public readonly version: number;
+  public readonly value: SimSsmParameterValue;
+  public readonly lastModifiedDate: Date;
+  public readonly lastModifiedUser: string | undefined;
+  public readonly description: string | undefined;
+  public readonly dataType: string;
+
+  constructor(properties: SimSsmParameterVersionProperties) {
+    this.version = properties.version;
+    this.value = properties.value;
+    this.lastModifiedDate = properties.lastModifiedDate;
+    this.lastModifiedUser = properties.lastModifiedUser;
+    this.description = properties.description;
+    this.dataType = properties.dataType ?? ssmTextDataType;
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
@@ -1,0 +1,128 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSsmHierarchyTypeMismatchException,
+  SimSsmParameterAlreadyExists,
+} from "../error/sim-ssm.error.js";
+import { SimSsmParameter } from "./sim-ssm-parameter.js";
+import type { SimSsmParameterName } from "./sim-ssm-parameter-name.js";
+import type { SimSsmParameterStore } from "./sim-ssm-parameter-store.js";
+import { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
+import { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
+import type {
+  SimSsmParameterVersion,
+  SimSsmParameterVersionDetails,
+} from "./sim-ssm-parameter-version.js";
+
+/**
+ * One write of a parameter, as PutParameter describes it.
+ */
+export interface SimSsmParameterWrite extends SimSsmParameterVersionDetails {
+  readonly name: SimSsmParameterName;
+  readonly value: string | undefined;
+  readonly type: string | undefined;
+  readonly overwrite: boolean | undefined;
+}
+
+interface SimSsmParameterWriterProperties {
+  readonly parameters: SimSsmParameterStore;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+/**
+ * The single path by which a simulated parameter is created or updated.
+ *
+ * Keeping creation and overwrite in one collaborator is what stops the two
+ * drifting apart on the rules that only show up when they meet: a name that is
+ * already taken, and a type that cannot change once the parameter exists.
+ */
+export class SimSsmParameterWriter {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimSsmParameterWriterProperties) {
+    this.parameters = properties.parameters;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Write a new version of a parameter, creating it if it is new.
+   *
+   * Everything is validated before anything is stored, so a request refused
+   * for its value leaves no half-made parameter behind.
+   */
+  write(request: SimSsmParameterWrite): SimSsmParameterVersion {
+    const value = new SimSsmParameterValue(request.value);
+    const parameter = this.parameterFor(request);
+
+    return parameter.addVersion(value, this.clock.now(), {
+      description: request.description,
+      dataType: request.dataType,
+      lastModifiedUser: request.lastModifiedUser,
+    });
+  }
+
+  private parameterFor(request: SimSsmParameterWrite): SimSsmParameter {
+    const existing = this.parameters.find(request.name.value);
+
+    if (existing === undefined) {
+      return this.created(request);
+    }
+
+    this.requireOverwriteAllowed(request, existing);
+
+    return existing;
+  }
+
+  private created(request: SimSsmParameterWrite): SimSsmParameter {
+    const parameter = new SimSsmParameter({
+      name: request.name,
+      type: SimSsmParameterType.forNewParameter(request.type),
+      accountRegionScope: this.accountRegionScope,
+    });
+
+    this.parameters.add(parameter);
+
+    return parameter;
+  }
+
+  /**
+   * Refuse an overwrite that real Parameter Store refuses.
+   *
+   * A request that leaves out Overwrite is a create, so a name already in use
+   * fails rather than quietly replacing what is there. A request naming a
+   * different type fails too: Parameter Store has no way to convert a stored
+   * parameter, so the caller has to delete it and make a new one.
+   */
+  private requireOverwriteAllowed(
+    request: SimSsmParameterWrite,
+    existing: SimSsmParameter,
+  ): void {
+    if (request.overwrite !== true) {
+      throw new SimSsmParameterAlreadyExists(
+        `The parameter '${existing.name.value}' already exists. To overwrite ` +
+          `this value, set the Overwrite option in the request to true.`,
+      );
+    }
+
+    if (request.type === undefined) {
+      return;
+    }
+
+    const requested = new SimSsmParameterType(request.type);
+
+    if (requested.value === existing.type.value) {
+      return;
+    }
+
+    throw new SimSsmHierarchyTypeMismatchException(
+      `Parameter '${existing.name.value}' is a ${existing.type.value} ` +
+        `parameter and cannot be changed to ${requested.value}. Parameter ` +
+        `Store does not support changing a parameter type: create a new, ` +
+        `unique parameter instead.`,
+    );
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter.ts
@@ -1,0 +1,86 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSsmParameterVersionNotFound } from "../error/sim-ssm.error.js";
+import { SimSsmParameterArn } from "./sim-ssm-parameter-arn.js";
+import type { SimSsmParameterName } from "./sim-ssm-parameter-name.js";
+import type { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
+import type { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
+import {
+  SimSsmParameterVersion,
+  type SimSsmParameterVersionDetails,
+} from "./sim-ssm-parameter-version.js";
+
+interface SimSsmParameterProperties {
+  readonly name: SimSsmParameterName;
+  readonly type: SimSsmParameterType;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * One simulated parameter and its versions.
+ *
+ * The type belongs to the parameter rather than to a version because real
+ * Parameter Store refuses to change it: a `String` parameter cannot be
+ * overwritten as a `StringList`, and the caller has to delete it and make a
+ * new one.
+ */
+export class SimSsmParameter {
+  public readonly name: SimSsmParameterName;
+  public readonly type: SimSsmParameterType;
+  public readonly arn: SimSsmParameterArn;
+
+  private readonly versions = new Map<number, SimSsmParameterVersion>();
+  private latest = 0;
+
+  constructor(properties: SimSsmParameterProperties) {
+    this.name = properties.name;
+    this.type = properties.type;
+    this.arn = new SimSsmParameterArn({
+      resource: properties.name.resource,
+      accountRegionScope: properties.accountRegionScope,
+    });
+  }
+
+  /**
+   * The version a request that names no version reads.
+   */
+  get currentVersion(): SimSsmParameterVersion {
+    return this.versionNumbered(this.latest);
+  }
+
+  /**
+   * Add a version holding a new value, and make it the current one.
+   */
+  addVersion(
+    value: SimSsmParameterValue,
+    lastModifiedDate: Date,
+    details: SimSsmParameterVersionDetails = {},
+  ): SimSsmParameterVersion {
+    this.latest += 1;
+
+    const version = new SimSsmParameterVersion({
+      ...details,
+      version: this.latest,
+      value,
+      lastModifiedDate,
+    });
+
+    this.versions.set(version.version, version);
+
+    return version;
+  }
+
+  /**
+   * Read one numbered version of this parameter, or refuse.
+   */
+  versionNumbered(version: number): SimSsmParameterVersion {
+    const found = this.versions.get(version);
+
+    if (found === undefined) {
+      throw new SimSsmParameterVersionNotFound(
+        `Parameter '${this.name.value}' has no version ${String(version)}`,
+      );
+    }
+
+    return found;
+  }
+}

--- a/src/service/ssm/sdk/sim-ssm-sdk-command-router.iso.test.ts
+++ b/src/service/ssm/sdk/sim-ssm-sdk-command-router.iso.test.ts
@@ -1,0 +1,35 @@
+import { assertArrayIncludesAll, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimSsmSdkCommandRouter", () => {
+  it("names every Command simulated SSM handles", () => {
+    // Given a scoped simulated SSM.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.ssm().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "PutParameterCommand",
+      "GetParameterCommand",
+      "GetParametersCommand",
+      "GetParametersByPathCommand",
+      "DeleteParameterCommand",
+      "DeleteParametersCommand",
+      "DescribeParametersCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated SSM.
+    const simAws = new SimAws();
+
+    // When a Systems Manager Command outside Parameter Store is looked up.
+    const route = simAws.ssm().sdkCommandRouter().route("SendCommandCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});

--- a/src/service/ssm/sdk/sim-ssm-sdk-command-router.ts
+++ b/src/service/ssm/sdk/sim-ssm-sdk-command-router.ts
@@ -1,0 +1,99 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimDeleteParameterCommand,
+  SimDeleteParametersCommand,
+  SimPutParameterCommand,
+} from "../command/parameter/parameter.command.js";
+import type {
+  SimDescribeParametersCommand,
+  SimGetParameterCommand,
+  SimGetParametersByPathCommand,
+  SimGetParametersCommand,
+} from "../command/parameter/query.command.js";
+import type { SimSsm } from "../sim-ssm.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated SSM.
+ */
+export class SimSsmSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simSsm: SimSsm) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "PutParameterCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.putParameter(
+            command as SimPutParameterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetParameterCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.getParameter(
+            command as SimGetParameterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetParametersCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.getParameters(
+            command as SimGetParametersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetParametersByPathCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.getParametersByPath(
+            command as SimGetParametersByPathCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteParameterCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.deleteParameter(
+            command as SimDeleteParameterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteParametersCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.deleteParameters(
+            command as SimDeleteParametersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeParametersCommand",
+        async (command, context): Promise<unknown> =>
+          await simSsm.describeParameters(
+            command as SimDescribeParametersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated SSM can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated SSM supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/ssm/sdk/sim-ssm-sdk-routing.iso.test.ts
+++ b/src/service/ssm/sdk/sim-ssm-sdk-routing.iso.test.ts
@@ -1,0 +1,220 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  DeleteParameterCommand,
+  DeleteParametersCommand,
+  DescribeParametersCommand,
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  GetParametersCommand,
+  PutParameterCommand,
+  SSMClient,
+} from "@aws-sdk/client-ssm";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+} from "../../aws/sim-aws-account.js";
+import { makeLambdaCodeZip } from "../../lambda/function/code/make-lambda-code-zip.js";
+
+const emptyBytes = new Uint8Array();
+
+const readParameterCode =
+  'const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");\n' +
+  "exports.handler = async () => {\n" +
+  "  const client = new SSMClient({});\n" +
+  "  const out = await client.send(new GetParameterCommand({\n" +
+  '    Name: "/myapp/prod/db-host",\n' +
+  "  }));\n" +
+  "  return out.Parameter.Value;\n" +
+  "};\n";
+
+async function simAwsWithParameterAndRole(
+  accountId: SimAwsAccountId,
+  policyStatement?: object,
+): Promise<SimAws> {
+  const simAws = new SimAws({ defaultAccountId: accountId });
+
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+    }),
+  );
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ParameterReaderRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ParameterReaderRole",
+        PolicyName: "ReadParameter",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "config-reader",
+      Role: role.Role.Arn,
+      Handler: "index.handler",
+      Code: { ZipFile: makeLambdaCodeZip({ "index.js": readParameterCode }) },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+describe("SSM SDK interception", () => {
+  it("routes an intercepted SSMClient to simulated Parameter Store", async () => {
+    // Given an intercepted SSM SDK client.
+    const simSdk = new SimSdk();
+    simSdk.intercept(SSMClient);
+
+    const client = new SSMClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code writes a parameter and reads it back.
+    await client.send(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+    );
+    const read = await client.send(
+      new GetParameterCommand({ Name: "/myapp/prod/db-host" }),
+    );
+
+    // Then it works with nothing touching the network, and the ARN names the
+    // Region the client was configured for.
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "db.internal");
+    assertStringIncludes(String(read.Parameter.ARN), "arn:aws:ssm:eu-west-2:");
+
+    simSdk.restoreAll();
+  });
+
+  it("routes every supported Command through the intercepted client", async () => {
+    // Given an intercepted SSM SDK client with two parameters.
+    const simSdk = new SimSdk();
+    simSdk.intercept(SSMClient);
+
+    const client = new SSMClient({ region: "eu-west-2" });
+    await client.send(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+    );
+    await client.send(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-port",
+        Type: "String",
+        Value: "5432",
+      }),
+    );
+
+    // When each of the remaining operations is used.
+    const many = await client.send(
+      new GetParametersCommand({
+        Names: ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+      }),
+    );
+    const byPath = await client.send(
+      new GetParametersByPathCommand({ Path: "/myapp/prod" }),
+    );
+    const described = await client.send(new DescribeParametersCommand({}));
+    await client.send(
+      new DeleteParameterCommand({ Name: "/myapp/prod/db-port" }),
+    );
+    const deleted = await client.send(
+      new DeleteParametersCommand({ Names: ["/myapp/prod/db-host"] }),
+    );
+
+    // Then each one reached simulated Parameter Store.
+    assertArrayEquals(
+      many.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+    );
+    assertArrayEquals(
+      byPath.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+    );
+    assertArrayEquals(
+      described.Parameters?.map((parameter) => parameter.Name),
+      ["/myapp/prod/db-host", "/myapp/prod/db-port"],
+    );
+    assertArrayEquals(deleted.DeletedParameters, ["/myapp/prod/db-host"]);
+
+    simSdk.restoreAll();
+  });
+
+  it("reads a parameter inside a Lambda handler as the execution Role", async () => {
+    // Given a function whose code reads its configuration on invocation,
+    // running as a Role allowed to read that parameter.
+    const accountId = makeSimAwsAccountId();
+    const simAws = await simAwsWithParameterAndRole(accountId, {
+      Effect: "Allow",
+      Action: "ssm:GetParameter",
+      // The leading slash of the name is not repeated in the ARN.
+      Resource: `arn:aws:ssm:us-east-1:${accountId}:parameter/myapp/prod/db-host`,
+    });
+
+    // When the function is invoked.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+    // Then the handler's own SDK call reached simulated Parameter Store as the
+    // execution Role, and that Role's policy allowed it.
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "db.internal");
+  });
+
+  it("denies a Lambda handler whose Role may not read the parameter", async () => {
+    // Given the same function, running as a Role with no SSM permissions.
+    const simAws = await simAwsWithParameterAndRole(makeSimAwsAccountId());
+
+    // When the function is invoked.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+    // Then the handler fails the way it would on real AWS, rather than reading
+    // the configuration anyway.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "not authorized");
+  });
+});

--- a/src/service/ssm/sdk/sim-ssm-sdk-routing.iso.test.ts
+++ b/src/service/ssm/sdk/sim-ssm-sdk-routing.iso.test.ts
@@ -95,7 +95,7 @@ async function simAwsWithParameterAndRole(
 describe("SSM SDK interception", () => {
   it("routes an intercepted SSMClient to simulated Parameter Store", async () => {
     // Given an intercepted SSM SDK client.
-    const simSdk = new SimSdk();
+    using simSdk = new SimSdk();
     simSdk.intercept(SSMClient);
 
     const client = new SSMClient({ region: "eu-west-2" });
@@ -117,13 +117,11 @@ describe("SSM SDK interception", () => {
     assertNonNullable(read.Parameter);
     assertIdentical(read.Parameter.Value, "db.internal");
     assertStringIncludes(String(read.Parameter.ARN), "arn:aws:ssm:eu-west-2:");
-
-    simSdk.restoreAll();
   });
 
   it("routes every supported Command through the intercepted client", async () => {
     // Given an intercepted SSM SDK client with two parameters.
-    const simSdk = new SimSdk();
+    using simSdk = new SimSdk();
     simSdk.intercept(SSMClient);
 
     const client = new SSMClient({ region: "eu-west-2" });
@@ -173,8 +171,6 @@ describe("SSM SDK interception", () => {
       ["/myapp/prod/db-host", "/myapp/prod/db-port"],
     );
     assertArrayEquals(deleted.DeletedParameters, ["/myapp/prod/db-host"]);
-
-    simSdk.restoreAll();
   });
 
   it("reads a parameter inside a Lambda handler as the execution Role", async () => {

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -1,0 +1,187 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimSsmAuthorizer } from "./command/authorize/sim-ssm-authorizer.js";
+import { SimSsmDeleteParameterCommands } from "./command/parameter/sim-ssm-delete-parameter-commands.js";
+import { SimSsmDescribeParameters } from "./command/parameter/sim-ssm-describe-parameters.js";
+import { SimSsmGetParameterCommands } from "./command/parameter/sim-ssm-get-parameter-commands.js";
+import { SimSsmGetParametersByPath } from "./command/parameter/sim-ssm-get-parameters-by-path.js";
+import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js";
+import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
+import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
+import { SimSsmParameterStore } from "./parameter/sim-ssm-parameter-store.js";
+import { SimSsmParameterWriter } from "./parameter/sim-ssm-parameter-writer.js";
+import { SimSsmSdkCommandRouter } from "./sdk/sim-ssm-sdk-command-router.js";
+
+export interface SimSsmRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface SimSsmProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated SSM Parameter Store. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * Parameters are scoped to an account and region, as they are on real AWS: a
+ * parameter name is unique within one of those scopes and its ARN names the
+ * region.
+ *
+ * Only Parameter Store is simulated. Nothing else in Systems Manager is.
+ */
+export class SimSsm {
+  private readonly parameters: SimSsmParameterStore;
+  private readonly putParameterCommand: SimSsmPutParameter;
+  private readonly readCommands: SimSsmGetParameterCommands;
+  private readonly pathCommand: SimSsmGetParametersByPath;
+  private readonly deletionCommands: SimSsmDeleteParameterCommands;
+  private readonly describeParametersCommand: SimSsmDescribeParameters;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimSsmSdkCommandRouter(this);
+
+  constructor(properties: SimSsmProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimSsmAuthorizer({ iam, accountRegionScope });
+
+    this.background = background;
+    this.parameters = new SimSsmParameterStore();
+    this.putParameterCommand = new SimSsmPutParameter({
+      writer: new SimSsmParameterWriter({
+        parameters: this.parameters,
+        accountRegionScope,
+        clock: background,
+      }),
+      authorizer,
+      accountRegionScope,
+    });
+    this.readCommands = new SimSsmGetParameterCommands({
+      parameters: this.parameters,
+      authorizer,
+    });
+    this.pathCommand = new SimSsmGetParametersByPath({
+      parameters: this.parameters,
+      authorizer,
+      accountRegionScope,
+    });
+    this.deletionCommands = new SimSsmDeleteParameterCommands({
+      parameters: this.parameters,
+      authorizer,
+    });
+    this.describeParametersCommand = new SimSsmDescribeParameters({
+      parameters: this.parameters,
+      authorizer,
+    });
+  }
+
+  /**
+   * Find a parameter by name, with or without its leading slash.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * parameter state without going through a Command and its authorization.
+   */
+  findParameter(name: string): SimSsmParameter | undefined {
+    return this.parameters.find(name);
+  }
+
+  /**
+   * Handle a PutParameter Command from the SDK.
+   */
+  async putParameter(
+    command: simSsmCommands.SimPutParameterCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimPutParameterCommandOutput> {
+    await this.background.sequence();
+    return this.putParameterCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a GetParameter Command from the SDK.
+   */
+  async getParameter(
+    command: simSsmCommands.SimGetParameterCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimGetParameterCommandOutput> {
+    await this.background.sequence();
+    return this.readCommands.get(command, options);
+  }
+
+  /**
+   * Handle a GetParameters Command from the SDK.
+   */
+  async getParameters(
+    command: simSsmCommands.SimGetParametersCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimGetParametersCommandOutput> {
+    await this.background.sequence();
+    return this.readCommands.getMany(command, options);
+  }
+
+  /**
+   * Handle a GetParametersByPath Command from the SDK.
+   */
+  async getParametersByPath(
+    command: simSsmCommands.SimGetParametersByPathCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimGetParametersByPathCommandOutput> {
+    await this.background.sequence();
+    return this.pathCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DeleteParameter Command from the SDK.
+   */
+  async deleteParameter(
+    command: simSsmCommands.SimDeleteParameterCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimDeleteParameterCommandOutput> {
+    await this.background.sequence();
+    return this.deletionCommands.delete(command, options);
+  }
+
+  /**
+   * Handle a DeleteParameters Command from the SDK.
+   */
+  async deleteParameters(
+    command: simSsmCommands.SimDeleteParametersCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimDeleteParametersCommandOutput> {
+    await this.background.sequence();
+    return this.deletionCommands.deleteMany(command, options);
+  }
+
+  /**
+   * Handle a DescribeParameters Command from the SDK.
+   */
+  async describeParameters(
+    command: simSsmCommands.SimDescribeParametersCommand,
+    options?: SimSsmRequestOptions,
+  ): Promise<simSsmCommands.SimDescribeParametersCommandOutput> {
+    await this.background.sequence();
+    return this.describeParametersCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}


### PR DESCRIPTION
Adds a SimSsm facade for Parameter Store, scoped by account and region, handling PutParameter, GetParameter, GetParameters, GetParametersByPath, DeleteParameter, DeleteParameters and DescribeParameters through simulated IAM. Parameter ARNs drop the name's leading slash, so a policy written against the wrong form fails here rather than in a deployment.

SecureString is refused, since nothing would encrypt it, and parameter labels are refused with an explanation rather than looked up, since LabelParameterVersion is not implemented.

Resolves https://github.com/KensioSoftware/yulin/issues/212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Systems Manager (SSM) Parameter Store support, including parameter CRUD, versioning, and describe/list-by-path operations.
  * Supports `String` and `StringList` parameters with account/region scoping and IAM-based authorization, including Lambda-role access.
  * Added SDK command routing and a public `./ssm` package export.

* **Documentation**
  * Added SSM service docs, including the new simulator behavior/limitations overview and multiple usage examples.
  * Updated service documentation indexes to include SSM. 

* **Tests**
  * Added extensive SSM simulator tests covering validation, paging, batching, and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->