### PR TITLE
feat: create simulated SSM parameters from AWS::SSM::Parameter

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -969,6 +969,7 @@ Sim CloudFormation supports a subset of CloudFormation. The resource types it cr
 - `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet`
 - `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
 - `AWS::SecretsManager::Secret`
+- `AWS::SSM::Parameter`
 - selected CDK custom resources, including CDK S3 BucketDeployment
 
 Each service's own docs describe what its resource types support. Notable limitations:

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -19,6 +19,7 @@ Sim SSM currently supports:
 - `DeleteParameterCommand` and `DeleteParametersCommand`
 - `DescribeParametersCommand`
 - `String` and `StringList` parameter types
+- The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
 - Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
@@ -323,6 +324,76 @@ deployment failure a passing test would have hidden. A name:
 A `String` or `StringList` value holds at most 4KB, which is the standard tier limit. This is the one
 people hit, usually by putting a whole JSON configuration blob in one parameter.
 
+## Deploying a parameter from CloudFormation
+
+Simulated CloudFormation creates a parameter from an `AWS::SSM::Parameter` resource, in the stack's
+account and region. The parameter is written through `PutParameter`, so a template-created parameter
+is the same thing an SDK caller would get: the same name validation, the same ARN, version 1.
+
+`Ref` on the resource gives the parameter name rather than its ARN, as it does on real AWS, so it can
+be handed straight to `GetParameter`. `Fn::GetAtt … Type` and `Fn::GetAtt … Value` give those
+properties.
+
+```typescript sim-ssm-cloudformation-parameter
+/**
+ * Deploying a parameter from a CloudFormation template and reading it back.
+ */
+
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "config-stack",
+  template: {
+    Resources: {
+      DbHost: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/prod/db-host",
+          Type: "String",
+          Value: "db.internal",
+          Description: "Where the application database lives",
+        },
+      },
+    },
+    Outputs: {
+      DbHostParameter: {
+        Value: { Ref: "DbHost" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the parameter name, so it works as a GetParameter Name.
+const parameterName = stack.outputs.get("DbHostParameter")?.value as string;
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: parameterName }));
+
+console.log(read.Parameter?.Value); // "db.internal"
+console.log(read.Parameter?.Version); // 1
+```
+
+A parameter with no `Name` is named after its logical ID. Real CloudFormation generates a name from
+the stack name and its own random characters, so a template cannot rely on the exact generated name
+either way.
+
+An IAM policy granting access to a template-created parameter needs the ARN rather than the `Ref`.
+Build it with `Fn::Sub`, remembering that the ARN drops the name's leading slash:
+
+```yaml
+Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/myapp/prod/db-host"
+```
+
+CDK does this for you. `ssm.StringParameter` with `grantRead(fn)` synthesises a template that deploys
+here without hand-editing.
+
 ## Reading configuration in a Lambda handler
 
 Function code that reads its configuration on cold start needs no special treatment. Any
@@ -493,8 +564,19 @@ Current documented limitations:
 - There is no per-account parameter count limit, so `ParameterLimitExceeded` never happens.
 - Deletion is immediate. Real Parameter Store asks for thirty seconds before a deleted name is reused;
   here the name is free straight away.
-- `AWS::SSM::Parameter` is not supported as a CloudFormation resource, and `{{resolve:ssm:...}}`
-  template references are not resolved.
+- `AWS::SSM::Parameter` supports `Name`, `Type`, `Value`, `Description` and `Tier`. `AllowedPattern`,
+  `DataType`, `Policies` and `Tags` reach `PutParameter`, which refuses them for the reasons above.
+  `Type: SecureString` is refused, as real CloudFormation refuses it for this resource type: the
+  plaintext value would sit in the template.
+- The other `AWS::SSM::*` resource types (`Document`, `Association`, `MaintenanceWindow`,
+  `PatchBaseline`, `ResourceDataSync` and the rest) are reported as unsupported and skipped rather
+  than deployed.
+- Every deployment of an `AWS::SSM::Parameter` is a create, so a name another stack already used is
+  refused. Sim CloudFormation has no stack updates, so the in-place overwrite real CloudFormation
+  does when a template changes `Value` cannot happen yet.
+- `{{resolve:ssm:...}}` dynamic references and the `AWS::SSM::Parameter::Value<String>` template
+  parameter type are not supported. Those are CloudFormation engine features rather than Parameter
+  Store ones; pass the name from `Ref` instead.
 - Public parameters under `/aws/service/...` do not exist, and names under the reserved `aws` and
   `ssm` prefixes are refused, as they are on real AWS.
 - The Parameters and Secrets Lambda extension HTTP endpoint is not simulated. Handler code has to use

--- a/docs/services/ssm/sim-ssm-cloudformation-parameter.example.ts
+++ b/docs/services/ssm/sim-ssm-cloudformation-parameter.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Deploying a parameter from a CloudFormation template and reading it back.
+ */
+
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "config-stack",
+  template: {
+    Resources: {
+      DbHost: {
+        Type: "AWS::SSM::Parameter",
+        Properties: {
+          Name: "/myapp/prod/db-host",
+          Type: "String",
+          Value: "db.internal",
+          Description: "Where the application database lives",
+        },
+      },
+    },
+    Outputs: {
+      DbHostParameter: {
+        Value: { Ref: "DbHost" },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the parameter name, so it works as a GetParameter Name.
+const parameterName = stack.outputs.get("DbHostParameter")?.value as string;
+
+const read = await simAws
+  .ssm()
+  .getParameter(new GetParameterCommand({ Name: parameterName }));
+
+console.log(read.Parameter?.Value); // "db.internal"
+console.log(read.Parameter?.Version); // 1

--- a/src/service/cloudformation/cdk/ssm/sim-cdk-ssm-parameter.loc.test.ts
+++ b/src/service/cloudformation/cdk/ssm/sim-cdk-ssm-parameter.loc.test.ts
@@ -1,0 +1,115 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const emptyBytes = new Uint8Array();
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+/**
+ * A handler reading the parameter whose name CDK put in its environment.
+ */
+const readParameterHandlerSource = `
+const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
+const client = new SSMClient({});
+exports.handler = async () => {
+  const output = await client.send(
+    new GetParameterCommand({ Name: process.env.DB_HOST_PARAMETER }),
+  );
+  return { host: output.Parameter.Value };
+};
+`;
+
+describe("Sim CDK SSM Parameter deployment local integration", () => {
+  it("deploys a CDK string parameter a granted Lambda reads", async () => {
+    // Given a CDK stack with a string parameter and a Lambda granted read
+    // access to it, handed the parameter name through its environment.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as ssm from "aws-cdk-lib/aws-ssm";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const dbHost = new ssm.StringParameter(stack, "DbHost", {
+  parameterName: "/myapp/prod/db-host",
+  stringValue: "db.internal",
+  description: "Where the application database lives",
+});
+
+const readerFunction = new lambda.Function(stack, "ReaderFunction", {
+  functionName: "cdk-config-reader",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(readParameterHandlerSource)}),
+  environment: {
+    DB_HOST_PARAMETER: dbHost.parameterName,
+  },
+});
+
+dbHost.grantRead(readerFunction);
+
+new cdk.CfnOutput(stack, "DbHostName", {
+  value: dbHost.parameterName,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the AWS::SSM::Parameter
+    // Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the parameter name CDK output carries is the deployed parameter.
+    const parameterName = stack.outputs.get("DbHostName")?.value;
+    assertTypeString(parameterName);
+
+    const read = await scoped
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: parameterName }));
+    assertIdentical(read.Parameter?.Value, "db.internal");
+
+    // And the deployed function reads that value as its granted execution
+    // role, against the parameter ARN the CDK grant produced.
+    const invoked = await scoped
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "cdk-config-reader" }));
+
+    assertUndefined(invoked.FunctionError);
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    assertIdentical(payload, JSON.stringify({ host: "db.internal" }));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -7,6 +7,7 @@ import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
 import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
+import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
 import { SimCfnDefaultResourceValueAdapter } from "./sim-cfn-default-resource-value-adapter.js";
 
 export interface SimCfnResourceValueAdapter {
@@ -51,6 +52,7 @@ export function simCfnResourceValueAdapter(
     route53ValueAdapter(properties) ??
     s3ValueAdapter(properties) ??
     secretsManagerValueAdapter(properties) ??
+    ssmValueAdapter(properties) ??
     new SimCfnDefaultResourceValueAdapter({
       logicalId: properties.logicalId,
     })

--- a/src/service/cloudformation/resource/cfn/ssm/sim-ssm-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/ssm/sim-ssm-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimSsmParameter } from "../../../../ssm/parameter/sim-ssm-parameter.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimSsmParameterCfn } from "./sim-ssm-parameter-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated SSM Resource.
+ */
+export function ssmValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::SSM::Parameter" &&
+    properties.simResource instanceof SimSsmParameter
+  ) {
+    return new SimSsmParameterCfn({ parameter: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/ssm/sim-ssm-parameter-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/ssm/sim-ssm-parameter-cfn.ts
@@ -1,0 +1,48 @@
+import type { SimSsmParameter } from "../../../../ssm/parameter/sim-ssm-parameter.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSsmParameterCfnProperties {
+  readonly parameter: SimSsmParameter;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SSM parameter.
+ */
+export class SimSsmParameterCfn implements SimCfnResourceValueAdapter {
+  private readonly parameter: SimSsmParameter;
+
+  constructor(properties: SimSsmParameterCfnProperties) {
+    this.parameter = properties.parameter;
+  }
+
+  /**
+   * AWS::SSM::Parameter Ref returns the parameter name rather than its ARN,
+   * which is what makes a Ref usable as a GetParameter Name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.parameter.name.value;
+  }
+
+  /**
+   * AWS::SSM::Parameter attributes.
+   *
+   * `Value` reads the current version, so a Resource depending on it sees
+   * what the parameter holds after the stack deployed it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Type": {
+        return this.parameter.type.value;
+      }
+      case "Value": {
+        return this.parameter.currentVersion.value.value;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::SSM::Parameter attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -69,6 +69,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "SecretsManager": {
       return scopedAws.secretsManager().cfnResourceFactory();
     }
+    case "SSM": {
+      return scopedAws.ssm().cfnResourceFactory();
+    }
     default: {
       throw new Error(
         `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -72,6 +72,25 @@ rather than one class per command, so the `SimSsm` facade stays a delegation:
 `SimSsmUnsimulatedPutOptions` gathers every PutParameter option this simulation refuses, in one
 readable place, rather than scattering the refusals through the write path.
 
+## CloudFormation
+
+`cfn/` creates parameters from `AWS::SSM::Parameter` Resources. `SimCfnSsmParameterProperties` reads
+the template properties and `SimCfnSsmParameterCreator` hands them to PutParameter, so a
+template-created parameter is the same thing an SDK caller would get and the options this simulation
+refuses are refused in one place.
+
+The one rule that lives in the CloudFormation layer is the type. Real CloudFormation refuses
+`SecureString` for this Resource type whatever Parameter Store itself supports, because the plaintext
+value would sit in the template, so the refusal belongs to the Resource rather than to the
+simulation.
+
+`Ref` and `Fn::GetAtt` behaviour is in `SimSsmParameterCfn`, beside the other services' adapters
+under `cloudformation/resource/cfn/`. `Ref` gives the parameter name rather than its ARN, as
+`AWS::SSM::Parameter` does on real AWS.
+
+Parameter Store is all this service simulates, so the other `AWS::SSM::*` Resource types are reported
+as unsupported and the engine skips them.
+
 As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
 command instances.
@@ -105,7 +124,9 @@ There is no resource policy support, so cross-account access to a parameter cann
 - `GetParametersByPath` and `DescribeParameters` refuse filters rather than ignoring them.
 - Every version is kept. Real Parameter Store keeps the hundred most recent and deletes the oldest
   as new ones are made.
-- There is no `AWS::SSM::Parameter` CloudFormation resource and no `{{resolve:ssm:...}}` support
-  yet, so this service has no `cfn/` directory.
+- Every deployment of an `AWS::SSM::Parameter` is a create, because sim CloudFormation has no stack
+  updates. A name another stack already used is refused rather than overwritten.
+- There is no `{{resolve:ssm:...}}` support and no `AWS::SSM::Parameter::Value<String>` template
+  parameter type. Both are CloudFormation engine features rather than Parameter Store ones.
 
 The full list is in [docs/services/ssm](../../../docs/services/ssm/).

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
@@ -1,0 +1,67 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
+import type { SimSsm } from "../../sim-ssm.js";
+import { SimCfnSsmParameterProperties } from "./sim-cfn-ssm-parameter-properties.js";
+
+interface SimCfnSsmParameterCreatorProperties {
+  readonly ssm: SimSsm;
+}
+
+/**
+ * Creates simulated parameters from AWS::SSM::Parameter Resources.
+ *
+ * The parameter is written through the ordinary PutParameter command rather
+ * than constructed directly, so a parameter a template deployed is the same
+ * thing an SDK caller would have got: the same name validation, the same ARN,
+ * the same refusals for the options this simulation does not model.
+ *
+ * The write is a create rather than an overwrite. Sim CloudFormation has no
+ * UpdateStack, so every deployment is a create, and a name already in use
+ * fails here as a second stack claiming the same parameter name fails on real
+ * CloudFormation.
+ */
+export class SimCfnSsmParameterCreator {
+  private readonly ssm: SimSsm;
+
+  constructor(properties: SimCfnSsmParameterCreatorProperties) {
+    this.ssm = properties.ssm;
+  }
+
+  /**
+   * Create a parameter from an AWS::SSM::Parameter Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSsmParameter> {
+    const parameterProperties = new SimCfnSsmParameterProperties({
+      resource,
+      properties,
+    });
+    const name = parameterProperties.name();
+
+    await this.ssm.putParameter({
+      input: {
+        Name: name,
+        Type: parameterProperties.type(),
+        Value: parameterProperties.value(),
+        Description: parameterProperties.description(),
+        Tier: parameterProperties.tier(),
+        AllowedPattern: parameterProperties.allowedPattern(),
+        DataType: parameterProperties.dataType(),
+        Policies: parameterProperties.policies(),
+        Tags: parameterProperties.tags(),
+      },
+    });
+
+    const parameter = this.ssm.findParameter(name);
+    assertDefined(
+      parameter,
+      `sim SSM parameter ${name} after CloudFormation creation`,
+    );
+
+    return parameter;
+  }
+}

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
@@ -1,0 +1,171 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSsmTag } from "../../command/parameter/parameter.command.js";
+
+interface SimCfnSsmParameterPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SSM::Parameter CloudFormation properties into the shape
+ * PutParameter takes.
+ *
+ * Everything this reads is handed to PutParameter rather than applied here,
+ * so the options Parameter Store refuses are refused in one place. The one
+ * rule that belongs here is the type: real CloudFormation refuses
+ * `SecureString` for this Resource type whatever Parameter Store itself
+ * supports, so the refusal is a property of the Resource rather than of the
+ * simulation.
+ */
+export class SimCfnSsmParameterProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: SimCfnSsmParameterPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The parameter name.
+   *
+   * An unnamed parameter is named after its logical ID, as sim CloudFormation
+   * names other unnamed resources. Real CloudFormation generates a name from
+   * the stack name and its own random characters, which a template could not
+   * predict anyway.
+   */
+  name(): string {
+    return (
+      this.string(this.properties["Name"], "Name") ?? this.resource.logicalId
+    );
+  }
+
+  /**
+   * The parameter type.
+   *
+   * Required, as it is on real CloudFormation, and never `SecureString`.
+   */
+  type(): string {
+    const type = this.string(this.properties["Type"], "Type");
+
+    if (type === undefined) {
+      throw this.propertyError("Type is required");
+    }
+
+    if (type === "SecureString") {
+      throw this.propertyError(
+        "Type SecureString is not supported. Real CloudFormation refuses to " +
+          "create a SecureString parameter from a template, because the " +
+          "plaintext value would sit in the template, so a stack has to " +
+          "reference a parameter created another way",
+      );
+    }
+
+    return type;
+  }
+
+  /**
+   * The value the parameter's first version holds.
+   */
+  value(): string {
+    const value = this.string(this.properties["Value"], "Value");
+
+    if (value === undefined) {
+      throw this.propertyError("Value is required");
+    }
+
+    return value;
+  }
+
+  /**
+   * The parameter Description.
+   */
+  description(): string | undefined {
+    return this.string(this.properties["Description"], "Description");
+  }
+
+  /**
+   * The parameter Tier.
+   *
+   * Handed to PutParameter, which refuses any tier but Standard.
+   */
+  tier(): string | undefined {
+    return this.string(this.properties["Tier"], "Tier");
+  }
+
+  /**
+   * The parameter AllowedPattern, which PutParameter refuses.
+   */
+  allowedPattern(): string | undefined {
+    return this.string(this.properties["AllowedPattern"], "AllowedPattern");
+  }
+
+  /**
+   * The parameter DataType, which PutParameter refuses beyond plain text.
+   */
+  dataType(): string | undefined {
+    return this.string(this.properties["DataType"], "DataType");
+  }
+
+  /**
+   * The parameter Policies, which PutParameter refuses.
+   */
+  policies(): string | undefined {
+    return this.string(this.properties["Policies"], "Policies");
+  }
+
+  /**
+   * The parameter Tags, which PutParameter refuses.
+   *
+   * CloudFormation carries these as a map of names to values for this
+   * Resource type, rather than the list of Key/Value pairs most Resource
+   * types use, so they are turned into the list shape PutParameter takes.
+   */
+  tags(): readonly SimSsmTag[] | undefined {
+    const tags = this.properties["Tags"];
+
+    if (tags === undefined) {
+      return undefined;
+    }
+
+    if (typeof tags !== "object" || tags === null || Array.isArray(tags)) {
+      throw this.propertyError("Tags must be an object");
+    }
+
+    return Object.entries(tags).map(([key, value]) => {
+      return { Key: key, Value: this.stringValue(value, `Tags.${key}`) };
+    });
+  }
+
+  private string(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.stringValue(value, name);
+  }
+
+  private stringValue(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string {
+    if (typeof value !== "string") {
+      throw this.propertyError(`${name} must be a string`);
+    }
+
+    return value;
+  }
+
+  private propertyError(reason: string): Error {
+    return new Error(
+      `Invalid AWS::SSM::Parameter Resource ${this.resource.logicalId}: ${reason}`,
+    );
+  }
+}

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter-lambda.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter-lambda.iso.test.ts
@@ -1,0 +1,170 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+ * variable names are UPPER_SNAKE_CASE by AWS convention, not code
+ * identifier names. */
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const emptyBytes = new Uint8Array();
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * A handler reading the parameter whose name its environment carries, as an
+ * application fetching its configuration on a cold start does.
+ */
+const readParameterHandlerSource = `
+const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
+const client = new SSMClient({});
+exports.handler = async () => {
+  const output = await client.send(
+    new GetParameterCommand({ Name: process.env.DB_HOST_PARAMETER }),
+  );
+  return { host: output.Parameter.Value };
+};
+`;
+
+/**
+ * The parameter's ARN, written as CloudFormation would substitute it. The
+ * leading slash of the name is dropped, so there is one slash after
+ * `parameter` rather than two.
+ */
+const parameterArnSubstitution =
+  // eslint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+  "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/myapp/prod/db-host";
+
+function readerRole(
+  parameterArn: SimCfnTemplateValue,
+): CfnTemplateBodyRecord["Resources"] {
+  return {
+    ReaderRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "ConfigReaderRole",
+        AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        Policies: [
+          {
+            PolicyName: "ReadDbHost",
+            PolicyDocument: {
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Effect: "Allow",
+                  Action: "ssm:GetParameter",
+                  Resource: parameterArn,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * A stack holding a parameter and a Lambda handed its name, with the
+ * function's execution Role allowed to read exactly that parameter.
+ */
+const template: CfnTemplateBodyRecord = {
+  Resources: {
+    DbHost: {
+      Type: "AWS::SSM::Parameter",
+      Properties: {
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      },
+    },
+    ...readerRole({ "Fn::Sub": parameterArnSubstitution }),
+    ReaderFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "config-reader",
+        Role: { "Fn::GetAtt": ["ReaderRole", "Arn"] },
+        Handler: "index.handler",
+        Runtime: "nodejs20.x",
+        Code: { ZipFile: readParameterHandlerSource },
+        Environment: {
+          Variables: { DB_HOST_PARAMETER: { Ref: "DbHost" } },
+        },
+      },
+    },
+  },
+};
+
+describe("SSM CloudFormation Parameter with Lambda", () => {
+  it("hands a Lambda the parameter name to read its value", async () => {
+    // Given a stack with a parameter, a Lambda holding its name in the
+    // environment, and an execution Role allowed to read it.
+    const simAws = new SimAws();
+
+    // When the stack is deployed and the function is invoked.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "config-stack", template });
+    await stack.waitForDeployComplete();
+
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+    // Then the handler read the deployed value out of simulated Parameter
+    // Store as its execution Role, which is what a Ref to a parameter is for.
+    assertUndefined(invoked.FunctionError);
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    assertIdentical(payload, JSON.stringify({ host: "db.internal" }));
+  });
+
+  it("denies a Lambda whose Role names the parameter with a doubled slash", async () => {
+    // Given the same stack, except that the Role's policy keeps the name's
+    // leading slash after `parameter`, as a hand-written policy easily does.
+    const simAws = new SimAws();
+    const doubledSlashTemplate: CfnTemplateBodyRecord = {
+      Resources: {
+        ...template.Resources,
+        ...readerRole({
+          "Fn::Sub":
+            // eslint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+            "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter//myapp/prod/db-host",
+        }),
+      },
+    };
+
+    // When the stack is deployed and the function is invoked.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: doubledSlashTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "config-reader" }));
+
+    // Then the read is denied, exactly as it would be on real AWS, where a
+    // parameter ARN has one slash after `parameter`.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    assertStringIncludes(payload, "not authorized");
+  });
+});

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter-validation.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter-validation.iso.test.ts
@@ -1,0 +1,279 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimSsmCfnResourceFactory } from "./sim-cfn-ssm-resource-factory.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function parameterResource(
+  properties: SimCfnTemplateValueRecord,
+  logicalId = "BadParameter",
+): SimCfnResource {
+  return new SimCfnResource({
+    accountRegionScope: {
+      accountId: accountIdOneOnes,
+      regionName: "eu-west-2",
+    },
+    logicalId,
+    template: { Type: "AWS::SSM::Parameter", Properties: properties },
+  });
+}
+
+/**
+ * Run work that is expected to reject, returning whatever it rejected with.
+ */
+async function rejection(work: () => Promise<unknown>): Promise<Error> {
+  try {
+    await work();
+  } catch (error) {
+    assertInstanceOf(error, Error);
+
+    return error;
+  }
+
+  throw new Error("Expected Parameter creation to reject");
+}
+
+/**
+ * Create a parameter straight through the Resource factory, returning
+ * whatever it rejects with. Keeps the property rules under test without a
+ * whole stack.
+ */
+async function createParameterResource(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const factory = new SimSsmCfnResourceFactory({ ssm: simAws.ssm() });
+
+  return await rejection(async () => {
+    return await factory.create("Parameter", parameterResource(properties), {
+      simAws,
+      resources: new Map(),
+    });
+  });
+}
+
+describe("SSM CloudFormation Parameter validation", () => {
+  it("refuses a SecureString parameter", async () => {
+    // Given a template asking for a SecureString, which real CloudFormation
+    // refuses for this Resource type.
+    // When the Resource is created, then it is refused.
+    const error = await createParameterResource({
+      Name: "/myapp/prod/db-password",
+      Type: "SecureString",
+      Value: "hunter2",
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Type SecureString " +
+        "is not supported.",
+    );
+  });
+
+  it("refuses a parameter with no Type or no Value", async () => {
+    // Given templates leaving out a property CloudFormation requires.
+    // When each Resource is created, then each is refused by name.
+    const noType = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Value: "db.internal",
+    });
+    assertIdentical(
+      noType.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Type is required",
+    );
+
+    const noValue = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+    });
+    assertIdentical(
+      noValue.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Value is required",
+    );
+  });
+
+  it("refuses malformed property values", async () => {
+    // Given properties of the wrong shape.
+    // When each Resource is created, then each is refused by name.
+    const name = await createParameterResource({
+      Name: 42,
+      Type: "String",
+      Value: "db.internal",
+    });
+    assertIdentical(
+      name.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Name must be a " +
+        "string",
+    );
+
+    const tags = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      Tags: ["component"],
+    });
+    assertIdentical(
+      tags.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Tags must be an " +
+        "object",
+    );
+
+    const tagValue = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      Tags: { component: 42 },
+    });
+    assertIdentical(
+      tagValue.message,
+      "Invalid AWS::SSM::Parameter Resource BadParameter: Tags.component " +
+        "must be a string",
+    );
+  });
+
+  it("passes the options Parameter Store refuses through to PutParameter", async () => {
+    // Given templates declaring properties this simulation does not model.
+    // When each Resource is created, then PutParameter refuses it, so the
+    // refusal reads the same whether a template or an SDK caller asked.
+    const tier = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      Tier: "Advanced",
+    });
+    assertStringIncludes(
+      tier.message,
+      "Parameter Tier 'Advanced' is not simulated",
+    );
+
+    const allowedPattern = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      AllowedPattern: "^[a-z.]+$",
+    });
+    assertStringIncludes(
+      allowedPattern.message,
+      "PutParameter AllowedPattern is not simulated",
+    );
+
+    const parameterTags = await createParameterResource({
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+      Tags: { component: "database" },
+    });
+    assertStringIncludes(
+      parameterTags.message,
+      "PutParameter Tags is not simulated",
+    );
+  });
+
+  it("refuses a name another stack already used", async () => {
+    // Given a parameter a stack already deployed. Sim CloudFormation has no
+    // UpdateStack, so every deployment is a create, and real CloudFormation
+    // fails a create naming a parameter that exists.
+    const simAws = new SimAws();
+    const factory = new SimSsmCfnResourceFactory({ ssm: simAws.ssm() });
+    const properties = {
+      Name: "/myapp/prod/db-host",
+      Type: "String",
+      Value: "db.internal",
+    };
+    await factory.create("Parameter", parameterResource(properties), {
+      simAws,
+      resources: new Map(),
+    });
+
+    // When a second stack claims the same name, then it is refused.
+    const error = await rejection(async () => {
+      return await factory.create("Parameter", parameterResource(properties), {
+        simAws,
+        resources: new Map(),
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "The parameter '/myapp/prod/db-host' already exists",
+    );
+  });
+
+  it("refuses an attribute AWS::SSM::Parameter does not have", async () => {
+    // Given a deployed parameter.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          DbHost: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/prod/db-host",
+              Type: "String",
+              Value: "db.internal",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("DbHost");
+    assertNonNullable(resource);
+
+    // When an attribute the Resource type does not have is read, then it is
+    // refused rather than resolving to nothing.
+    const error = assertThrowsError(() => {
+      resource.attributeValue("Arn");
+    });
+    assertIdentical(
+      error.message,
+      "Unsupported AWS::SSM::Parameter attribute Arn",
+    );
+  });
+
+  it("records the rest of Systems Manager as skipped", async () => {
+    // Given a template declaring a Systems Manager Resource type that is not
+    // Parameter Store, which is all this simulation models.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ops-stack",
+      template: {
+        Resources: {
+          RunbookDocument: {
+            Type: "AWS::SSM::Document",
+            Properties: { Content: { schemaVersion: "2.2" } },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stack completes with that Resource skipped rather than failing
+    // the deployment.
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertTrue(skipped.skipped);
+    assertIdentical(
+      skipped.skippedReason,
+      "Unsupported sim SSM CloudFormation Resource Document",
+    );
+  });
+});

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
@@ -1,0 +1,210 @@
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("SSM CloudFormation Parameter deployment", () => {
+  it("creates a parameter at version 1 from the template properties", async () => {
+    // Given a template declaring a parameter.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          DbHost: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/prod/db-host",
+              Type: "String",
+              Value: "db.internal",
+              Description: "Where the application database lives",
+              Tier: "Standard",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the parameter reads back as an SDK caller would read it, at the
+    // first version, because the deployment created it.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/myapp/prod/db-host" }));
+
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "db.internal");
+    assertIdentical(read.Parameter.Type, "String");
+    assertIdentical(read.Parameter.Version, 1);
+    assertIdentical(
+      read.Parameter.ARN,
+      "arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/prod/db-host",
+    );
+
+    // And the Description the template declared is reported back.
+    const described = await simAws.ssm().describeParameters({ input: {} });
+    assertIdentical(
+      described.Parameters?.at(0)?.Description,
+      "Where the application database lives",
+    );
+  });
+
+  it("resolves Ref to the parameter name and Fn::GetAtt to its Type and Value", async () => {
+    // Given a template referencing its parameter every way it can.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          DbHost: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/prod/db-host",
+              Type: "String",
+              Value: "db.internal",
+            },
+          },
+        },
+        Outputs: {
+          ParameterRef: { Value: { Ref: "DbHost" } },
+          ParameterType: { Value: { "Fn::GetAtt": ["DbHost", "Type"] } },
+          ParameterValue: { Value: { "Fn::GetAtt": ["DbHost", "Value"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then Ref is the name, as AWS::SSM::Parameter Ref is, so it can be
+    // handed straight to GetParameter.
+    assertIdentical(
+      stack.outputs.get("ParameterRef")?.value,
+      "/myapp/prod/db-host",
+    );
+    assertIdentical(stack.outputs.get("ParameterType")?.value, "String");
+    assertIdentical(stack.outputs.get("ParameterValue")?.value, "db.internal");
+  });
+
+  it("names an unnamed parameter after its logical ID", async () => {
+    // Given a template leaving Name out, as CDK does for a parameter with no
+    // explicit name.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          FeatureFlags: {
+            Type: "AWS::SSM::Parameter",
+            Properties: { Type: "StringList", Value: "beta,canary" },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the parameter is named after its logical ID, as sim CloudFormation
+    // names other unnamed resources.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "FeatureFlags" }));
+
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Value, "beta,canary");
+    assertIdentical(read.Parameter.Type, "StringList");
+  });
+
+  it("backs the CloudFormation Resource with the simulated parameter", async () => {
+    // Given a deployed parameter.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "config-stack",
+      template: {
+        Resources: {
+          DbHost: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/prod/db-host",
+              Type: "String",
+              Value: "db.internal",
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Resource is inspected.
+    const resource = stack.getResource("DbHost");
+    assertNonNullable(resource);
+
+    // Then it is backed by the same simulated parameter the service holds.
+    const parameter = resource.simResource as SimSsmParameter | undefined;
+    assertNonNullable(parameter);
+    assertIdentical(
+      simAws.ssm().findParameter("/myapp/prod/db-host")?.arn.value,
+      parameter.arn.value,
+    );
+  });
+
+  it("creates the parameter in the stack's account and region", async () => {
+    // Given a simulated AWS whose default scope is not the stack's.
+    const simAws = new SimAws();
+
+    // When a template is deployed into another account and region.
+    const stack = await simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "config-stack",
+        template: {
+          Resources: {
+            DbHost: {
+              Type: "AWS::SSM::Parameter",
+              Properties: {
+                Name: "/myapp/prod/db-host",
+                Type: "String",
+                Value: "db.internal",
+              },
+            },
+          },
+        },
+      });
+    await stack.waitForDeployComplete();
+
+    // Then the parameter exists in that account and region, and nowhere else.
+    const scoped = simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .ssm()
+      .findParameter("/myapp/prod/db-host");
+
+    assertNonNullable(scoped);
+    assertIdentical(
+      scoped.arn.value,
+      "arn:aws:ssm:us-east-1:111111111111:parameter/myapp/prod/db-host",
+    );
+    assertUndefined(simAws.ssm().findParameter("/myapp/prod/db-host"));
+  });
+});

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
@@ -1,6 +1,7 @@
 import { GetParameterCommand } from "@aws-sdk/client-ssm";
 import {
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
   assertUndefined,
 } from "@kensio/smartass";
@@ -8,7 +9,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
+import { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
 
 const accountIdOneOnes = "111111111111" as SimAwsAccountId;
 
@@ -158,9 +159,10 @@ describe("SSM CloudFormation Parameter deployment", () => {
     const resource = stack.getResource("DbHost");
     assertNonNullable(resource);
 
-    // Then it is backed by the same simulated parameter the service holds.
-    const parameter = resource.simResource as SimSsmParameter | undefined;
-    assertNonNullable(parameter);
+    // Then it is backed by the same simulated parameter the service holds,
+    // rather than some other simulated resource that happens to have an ARN.
+    const parameter = resource.simResource;
+    assertInstanceOf(parameter, SimSsmParameter);
     assertIdentical(
       simAws.ssm().findParameter("/myapp/prod/db-host")?.arn.value,
       parameter.arn.value,

--- a/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
@@ -1,0 +1,51 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimSsm } from "../sim-ssm.js";
+import { SimCfnSsmParameterCreator } from "./parameter/sim-cfn-ssm-parameter-creator.js";
+
+interface SimSsmCfnResourceFactoryProperties {
+  readonly ssm: SimSsm;
+}
+
+/**
+ * CloudFormation Resource factory for simulated SSM resources.
+ */
+export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly parameterCreator: SimCfnSsmParameterCreator;
+
+  constructor(properties: SimSsmCfnResourceFactoryProperties) {
+    this.parameterCreator = new SimCfnSsmParameterCreator({
+      ssm: properties.ssm,
+    });
+  }
+
+  /**
+   * Create a simulated SSM resource from a CloudFormation Resource.
+   *
+   * Parameter Store is the only part of Systems Manager this simulation
+   * models, so the rest of the AWS::SSM::* Resource types are reported as
+   * unsupported and skipped rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Parameter": {
+        return await this.parameterCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim SSM CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -17,6 +17,7 @@ import { SimSsmGetParameterCommands } from "./command/parameter/sim-ssm-get-para
 import { SimSsmGetParametersByPath } from "./command/parameter/sim-ssm-get-parameters-by-path.js";
 import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js";
 import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
+import { SimSsmCfnResourceFactory } from "./cfn/sim-cfn-ssm-resource-factory.js";
 import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
 import { SimSsmParameterStore } from "./parameter/sim-ssm-parameter-store.js";
 import { SimSsmParameterWriter } from "./parameter/sim-ssm-parameter-writer.js";
@@ -51,6 +52,7 @@ export class SimSsm {
   private readonly describeParametersCommand: SimSsmDescribeParameters;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSsmSdkCommandRouter(this);
+  private readonly cfnFactory = new SimSsmCfnResourceFactory({ ssm: this });
 
   constructor(properties: SimSsmProperties = {}) {
     const {
@@ -176,6 +178,13 @@ export class SimSsm {
   ): Promise<simSsmCommands.SimDescribeParametersCommandOutput> {
     await this.background.sequence();
     return this.describeParametersCommand.handle(command, options);
+  }
+
+  /**
+   * Get the CloudFormation Resource factory for AWS::SSM::* Resources.
+   */
+  cfnResourceFactory(): SimSsmCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Deploying a template containing AWS::SSM::Parameter creates a parameter in the stack's account and region, written through PutParameter so it is the same thing an SDK caller would get. Ref gives the parameter name and Fn::GetAtt gives its Type and Value. Type: SecureString is refused, as real CloudFormation refuses it for this resource type. The rest of Systems Manager is reported unsupported and skipped.

Resolves https://github.com/KensioSoftware/yulin/issues/213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for creating and reading `AWS::SSM::Parameter`.
  * `Ref` and selected `Fn::GetAtt` values are now supported (parameter name plus type/value via outputs).
  * Introduced CloudFormation-based parameter creation with property handling, tags, and scoped deployments; includes IAM policy guidance using the parameter ARN.

* **Documentation**
  * Updated CloudFormation/SSM docs with supported properties, limitations (e.g., `SecureString` refused, dynamic references not supported, create-only behavior), and examples.

* **Tests**
  * Added integration and validation coverage, including Lambda permission/access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->