### PR TITLE
feat: store SecureString parameters encrypted with a simulated KMS key

### DIFF
--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -451,6 +451,7 @@ Current documented limitations:
   real AWS, but disabling one is not, which real AWS does refuse.
 - Key material lives in process memory for the lifetime of the `SimAws` instance. That is not a
   security boundary: anything sharing the process can reach it.
-- No other simulated service encrypts anything with KMS yet. Sim S3, sim DynamoDB and sim Lambda
-  environment variables do not use simulated keys, and do not check `kms:Decrypt`.
+- Sim SSM encrypts `SecureString` parameters with simulated keys and checks `kms:Encrypt` and
+  `kms:Decrypt` for them. No other simulated service does: sim S3, sim DynamoDB, sim Secrets Manager
+  and sim Lambda environment variables do not use simulated keys, and do not check `kms:Decrypt`.
 - KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -392,7 +392,10 @@ Current documented limitations:
 
 - Secret values are not encrypted. `KmsKeyId` is accepted and reported by `DescribeSecret`, but
   nothing is encrypted with it and no `kms:Decrypt` check happens. That is looser than real AWS,
-  where a caller also needs permission on the key. Simulated KMS is not wired into this service yet.
+  where a caller also needs permission on the key. Sim SSM does encrypt its `SecureString`
+  parameters through simulated KMS, and the same wiring would fit here, but a secret has versions,
+  staging labels and rotation to carry through it, so it is a change of its own rather than a
+  follow-on.
 - A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than
   AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's
   resource part when a partial ARN is resolved. This rules out ordinary-looking names such as

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -18,7 +18,8 @@ Sim SSM currently supports:
 - `GetParametersByPathCommand`, with and without `Recursive`
 - `DeleteParameterCommand` and `DeleteParametersCommand`
 - `DescribeParametersCommand`
-- `String` and `StringList` parameter types
+- `String`, `StringList` and `SecureString` parameter types
+- `SecureString` values encrypted through simulated KMS, decrypted only with `WithDecryption`
 - The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
 - Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
@@ -533,14 +534,153 @@ console.log(read.Parameter?.ARN);
 // "arn:aws:ssm:eu-west-2:111111111111:parameter/myapp/db-host"
 ```
 
+## SecureString parameters
+
+A `SecureString` value is encrypted through simulated KMS, under the `aws/ssm` AWS managed key unless
+the request names a key of its own. Simulated KMS creates that managed key the first time something
+asks for it, so nothing has to set it up.
+
+A read returns the ciphertext unless it asks for decryption. This is the mistake that is easy to make
+and hard to see: a handler that forgets `WithDecryption` parses a base64 blob as if it were a
+password.
+
+```typescript sim-ssm-secure-string
+/**
+ * Writing and reading a simulated SecureString parameter.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const encrypted = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+);
+
+console.log(encrypted.Parameter?.Value); // a base64 ciphertext, not "hunter2"
+
+const decrypted = await ssm.getParameter(
+  new GetParameterCommand({
+    Name: "/myapp/prod/db-password",
+    WithDecryption: true,
+  }),
+);
+
+console.log(decrypted.Parameter?.Value); // "hunter2"
+```
+
+`WithDecryption` on a `String` or `StringList` parameter is ignored rather than refused, as real
+Parameter Store ignores it.
+
+Pass `KeyId` to encrypt under a customer managed key instead. A `KeyId` naming a key that does not
+exist, is disabled, or is pending deletion fails with `InvalidKeyId`, which is how real Parameter
+Store reports every KMS key problem.
+
+Each value is bound to its own parameter's ARN as the KMS encryption context, under the
+`PARAMETER_ARN` key, so a ciphertext lifted out of one parameter cannot be decrypted as another.
+
+### Decrypting needs its own permission
+
+Encrypting and decrypting go to simulated KMS as the caller, not as the service. A write needs
+`kms:Encrypt` on the key on top of `ssm:PutParameter` on the parameter, and a decrypting read needs
+`kms:Decrypt` on top of `ssm:GetParameter`. A role granted one and not the other fails here rather
+than in a deployment.
+
+```typescript sim-ssm-secure-string-permissions
+/**
+ * A Role allowed to read a simulated SecureString but not to decrypt it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const key = await simAws
+  .kms()
+  .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+    KeyId: key.KeyMetadata?.Arn,
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The parameter is allowed, the key is not.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbPassword",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+try {
+  await simAws.ssm().getParameter(
+    new GetParameterCommand({
+      Name: "/myapp/prod/db-password",
+      WithDecryption: true,
+    }),
+    { caller },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}
+```
+
+`DescribeParameters` reports the key each `SecureString` is encrypted under as `KeyId`.
+
 ## Limitations
 
 Current documented limitations:
 
-- `SecureString` is refused rather than stored. Nothing here would encrypt it, so a passing test
-  would say nothing about the KMS key, the `kms:Decrypt` permission or `WithDecryption`.
-  `WithDecryption` is accepted and ignored on reads, as real Parameter Store ignores it for `String`
-  and `StringList`.
+- Only standard tier `SecureString` encryption is simulated, which encrypts under the KMS key
+  directly. The advanced tier's envelope encryption through the AWS Encryption SDK is not, so
+  `kms:GenerateDataKey` is never needed.
+- A `SecureString` under the `aws/ssm` managed key can be decrypted by any caller allowed
+  `kms:Decrypt` on it. Real AWS gives that key a policy nobody can change; simulated KMS gives a
+  managed key the same default policy as a customer key.
 - Parameter labels are not simulated. `LabelParameterVersion` is not implemented, so nothing can
   create a label, and a `name:label` selector is refused with an error saying so.
 - `GetParameterHistory` is not simulated, though earlier versions stay readable by number.
@@ -552,7 +692,8 @@ Current documented limitations:
   `RemoveTagsFromResource` and `ListTagsForResource` are not supported.
 - `AllowedPattern` is refused rather than ignored, because a value it was meant to reject would
   otherwise be stored without complaint.
-- `KeyId` is refused, since it only applies to `SecureString` parameters.
+- `KeyId` on a `String` or `StringList` parameter is refused, since nothing would encrypt a value
+  stored in the clear.
 - `DataType` other than `text` is refused. Real Parameter Store validates an `aws:ec2:image` value
   against EC2, which this simulation cannot do.
 - Filters are refused rather than ignored. `GetParametersByPath` refuses `ParameterFilters`, and

--- a/docs/services/ssm/sim-ssm-secure-string-permissions.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-string-permissions.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A Role allowed to read a simulated SecureString but not to decrypt it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const key = await simAws
+  .kms()
+  .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+    KeyId: key.KeyMetadata?.Arn,
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The parameter is allowed, the key is not.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbPassword",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+try {
+  await simAws.ssm().getParameter(
+    new GetParameterCommand({
+      Name: "/myapp/prod/db-password",
+      WithDecryption: true,
+    }),
+    { caller },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}

--- a/docs/services/ssm/sim-ssm-secure-string.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-string.example.ts
@@ -1,0 +1,33 @@
+/**
+ * Writing and reading a simulated SecureString parameter.
+ */
+
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ssm = simAws.ssm();
+
+await ssm.putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const encrypted = await ssm.getParameter(
+  new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+);
+
+console.log(encrypted.Parameter?.Value); // a base64 ciphertext, not "hunter2"
+
+const decrypted = await ssm.getParameter(
+  new GetParameterCommand({
+    Name: "/myapp/prod/db-password",
+    WithDecryption: true,
+  }),
+);
+
+console.log(decrypted.Parameter?.Value); // "hunter2"

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -272,13 +272,15 @@ export class SimAwsServiceFactory {
    * Create simulated SSM for an Account Region scope.
    *
    * Parameters are Region-scoped on real AWS: a parameter name is unique
-   * within one Account and Region, and its ARN names the Region.
+   * within one Account and Region, and its ARN names the Region. SecureString
+   * values are encrypted through that same scope's simulated KMS.
    */
   createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
     return new SimSsm({
       accountRegionScope: scope.accountRegionScope,
       iam: this.createIam(scope),
       background: this.background,
+      kms: scope.kms(),
     });
   }
 

--- a/src/service/secretsmanager/README.md
+++ b/src/service/secretsmanager/README.md
@@ -115,7 +115,9 @@ way it does on real AWS.
 ## Divergences worth knowing
 
 - `KmsKeyId` is stored and reported but nothing is encrypted with it, and no `kms:Decrypt` check
-  happens. This is looser than real AWS and stands until simulated KMS is wired into this service.
+  happens. This is looser than real AWS. Sim SSM shows the shape the wiring would take for
+  `SecureString` parameters, but a secret has versions, staging labels and rotation to carry through
+  it, so it stands as its own change rather than a follow-on.
 - Names ending in a hyphen and six characters are refused, which is stricter than real AWS.
 - `ListSecrets` refuses `Filters` and `SortOrder` rather than ignoring them.
 - A version that has lost every staging label is kept rather than removed, so it stays readable by

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -45,9 +45,28 @@ because both name the same ARN, and no IAM policy could tell them apart.
 beside it because the name validator and the authorizer both need the prefix without needing a
 parameter.
 
-`SimSsmParameterValue` holds one version's value and enforces the standard tier's 4KB limit, in
-UTF-8 bytes. A `StringList` is one comma-separated string here, as it is on real AWS, rather than an
-array: handler code that splits it on commas is exercising the shape AWS would give it.
+`SimSsmParameterValue` holds one version's value as it is stored. A `StringList` is one
+comma-separated string here, as it is on real AWS, rather than an array: handler code that splits it
+on commas is exercising the shape AWS would give it. A `SecureString` is the base64 ciphertext,
+which is what a read without `WithDecryption` returns. It is made two ways for that reason: the 4KB
+standard tier limit applies to the plaintext a request submitted, not to the longer ciphertext kept
+in its place.
+
+`SimSsmParameterEncryption` is the whole of the KMS integration. Standard tier Parameter Store
+encrypts under the key directly rather than with a data key, so this is an `Encrypt` and a `Decrypt`
+call and nothing more. Two details matter:
+
+- the calls are made as the caller rather than as the service, so a write needs the caller's own
+  `kms:Encrypt` and a decrypting read needs `kms:Decrypt`, each on top of the SSM permission for the
+  parameter;
+- the parameter's ARN is bound in as the `PARAMETER_ARN` encryption context, as real Parameter Store
+  binds it, so a ciphertext moved into another parameter cannot be decrypted there.
+
+Every key problem KMS reports becomes `InvalidKeyId`, carrying the KMS message, which is how real
+Parameter Store reports a key that is missing, disabled or pending deletion. An access denial is not
+a KMS error and passes through untouched, so a missing `kms:Decrypt` still reads as a denial rather
+than a bad key. The default key is the `aws/ssm` alias, and simulated KMS creates the AWS managed key
+behind it on first use, which is how one appears in a real account.
 
 `SimSsmParameterSelector` parses the `name:version` and `name:label` forms a request may write. A
 parameter name cannot contain a colon, so the first one separates the two parts, and a selector of
@@ -114,8 +133,10 @@ There is no resource policy support, so cross-account access to a parameter cann
 
 ## Divergences worth knowing
 
-- `SecureString` is refused. Nothing here would encrypt it, so accepting it would let a test pass
-  while saying nothing about the KMS key, the `kms:Decrypt` permission or `WithDecryption`.
+- Only standard tier `SecureString` encryption is simulated. The advanced tier's envelope encryption
+  through the AWS Encryption SDK is not, so `kms:GenerateDataKey` is never needed.
+- The `aws/ssm` managed key gets simulated KMS's default customer key policy rather than the
+  unchangeable one real AWS gives it, so a caller allowed `kms:Decrypt` on it can decrypt.
 - Parameter labels are refused rather than looked up. `LabelParameterVersion` is not implemented, so
   nothing could create one, and a label selector says that instead of reporting the parameter as
   missing.

--- a/src/service/ssm/command/parameter/parameter.command.ts
+++ b/src/service/ssm/command/parameter/parameter.command.ts
@@ -26,6 +26,7 @@ export interface SimSsmParameterMetadata {
   readonly ARN?: string | undefined;
   readonly DataType?: string | undefined;
   readonly Description?: string | undefined;
+  readonly KeyId?: string | undefined;
   readonly LastModifiedDate?: Date | undefined;
   readonly LastModifiedUser?: string | undefined;
   readonly Name?: string | undefined;

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameter-commands.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameterEncryption } from "../../parameter/sim-ssm-parameter-encryption.js";
 import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
 import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
 import type {
@@ -9,13 +10,12 @@ import type {
   SimGetParametersCommandOutput,
 } from "./query.command.js";
 import { requireParameterNames } from "./sim-ssm-parameter-names.js";
-import {
-  type SimSsmFoundParameter,
-  SimSsmParameterReader,
-} from "./sim-ssm-parameter-reader.js";
+import type { SimSsmFoundParameter } from "./sim-ssm-parameter-read.js";
+import { SimSsmParameterReader } from "./sim-ssm-parameter-reader.js";
 
 interface SimSsmGetParameterCommandsProperties {
   readonly parameters: SimSsmParameterStore;
+  readonly encryption: SimSsmParameterEncryption;
   readonly authorizer: SimSsmAuthorizer;
 }
 
@@ -26,9 +26,9 @@ interface SimSsmGetParameterCommandsOptions {
 /**
  * The commands that read parameter values.
  *
- * `WithDecryption` is accepted and ignored, as real Parameter Store ignores it
- * for `String` and `StringList` parameters. Nothing else here is encrypted,
- * because `SecureString` is not simulated.
+ * `WithDecryption` decrypts a SecureString through simulated KMS and is
+ * ignored for the types stored in the clear, as real Parameter Store ignores
+ * it for them.
  */
 export class SimSsmGetParameterCommands {
   private readonly reader: SimSsmParameterReader;
@@ -40,10 +40,10 @@ export class SimSsmGetParameterCommands {
   /**
    * Read one parameter, refusing if it is not there.
    */
-  get(
+  async get(
     command: SimGetParameterCommand,
     options?: SimSsmGetParameterCommandsOptions,
-  ): SimGetParameterCommandOutput {
+  ): Promise<SimGetParameterCommandOutput> {
     const requested = command.input.Name;
 
     if (requested === undefined || requested.trim() === "") {
@@ -52,11 +52,12 @@ export class SimSsmGetParameterCommands {
       );
     }
 
-    const found = this.reader.read(
-      "ssm:GetParameter",
+    const found = await this.reader.read({
+      action: "ssm:GetParameter",
       requested,
-      options?.caller,
-    );
+      withDecryption: command.input.WithDecryption,
+      caller: options?.caller,
+    });
 
     return { $metadata: {}, Parameter: found.output };
   }
@@ -69,20 +70,22 @@ export class SimSsmGetParameterCommands {
    * nothing on real AWS, so a test that asserts on `Parameters` alone passes
    * while the application reads no configuration at all.
    */
-  getMany(
+  async getMany(
     command: SimGetParametersCommand,
     options?: SimSsmGetParameterCommandsOptions,
-  ): SimGetParametersCommandOutput {
+  ): Promise<SimGetParametersCommandOutput> {
     const names = requireParameterNames(command.input.Names, "GetParameters");
     const found: SimSsmFoundParameter[] = [];
     const invalid: string[] = [];
 
     for (const name of names) {
-      const parameter = this.reader.readOrInvalid(
-        "ssm:GetParameters",
-        name,
-        options?.caller,
-      );
+      // eslint-disable-next-line no-await-in-loop -- one name at a time, so a denial names the first name the caller may not read
+      const parameter = await this.reader.readOrInvalid({
+        action: "ssm:GetParameters",
+        requested: name,
+        withDecryption: command.input.WithDecryption,
+        caller: options?.caller,
+      });
 
       if (parameter === undefined) {
         invalid.push(name);

--- a/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-get-parameters-by-path.ts
@@ -1,11 +1,15 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimSsmValidationException } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameterEncryption } from "../../parameter/sim-ssm-parameter-encryption.js";
 import { SimSsmParameterPath } from "../../parameter/sim-ssm-parameter-path.js";
+import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
 import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
 import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
+import type { SimSsmParameterOutput } from "./parameter.command.js";
 import type {
   SimGetParametersByPathCommand,
+  SimGetParametersByPathCommandInput,
   SimGetParametersByPathCommandOutput,
 } from "./query.command.js";
 import { SimSsmParameterPage } from "./sim-ssm-parameter-page.js";
@@ -18,6 +22,7 @@ const maxResults = 10;
 
 interface SimSsmGetParametersByPathProperties {
   readonly parameters: SimSsmParameterStore;
+  readonly encryption: SimSsmParameterEncryption;
   readonly authorizer: SimSsmAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -36,12 +41,14 @@ interface SimSsmGetParametersByPathOptions {
  */
 export class SimSsmGetParametersByPath {
   private readonly parameters: SimSsmParameterStore;
+  private readonly encryption: SimSsmParameterEncryption;
   private readonly authorizer: SimSsmAuthorizer;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly view = new SimSsmParameterView();
 
   constructor(properties: SimSsmGetParametersByPathProperties) {
     this.parameters = properties.parameters;
+    this.encryption = properties.encryption;
     this.authorizer = properties.authorizer;
     this.accountRegionScope = properties.accountRegionScope;
   }
@@ -49,10 +56,10 @@ export class SimSsmGetParametersByPath {
   /**
    * List the parameters under one level of the hierarchy.
    */
-  handle(
+  async handle(
     command: SimGetParametersByPathCommand,
     options?: SimSsmGetParametersByPathOptions,
-  ): SimGetParametersByPathCommandOutput {
+  ): Promise<SimGetParametersByPathCommandOutput> {
     const { input } = command;
 
     if (input.ParameterFilters !== undefined) {
@@ -82,10 +89,31 @@ export class SimSsmGetParametersByPath {
 
     return {
       $metadata: {},
-      Parameters: page.items.map((parameter) =>
-        this.view.value(parameter, parameter.currentVersion),
+      Parameters: await Promise.all(
+        page.items.map(
+          async (parameter) => await this.listed(parameter, input, options),
+        ),
       ),
       NextToken: page.nextToken,
     };
+  }
+
+  /**
+   * One listed parameter, decrypted if the listing asked for it.
+   */
+  private async listed(
+    parameter: SimSsmParameter,
+    input: SimGetParametersByPathCommandInput,
+    options: SimSsmGetParametersByPathOptions | undefined,
+  ): Promise<SimSsmParameterOutput> {
+    const version = parameter.currentVersion;
+    const reportedValue = await this.encryption.reported(
+      parameter,
+      version,
+      input.WithDecryption,
+      options?.caller,
+    );
+
+    return this.view.value(parameter, version, reportedValue);
   }
 }

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-read.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-read.ts
@@ -1,0 +1,24 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSsmParameterOutput } from "./parameter.command.js";
+
+/**
+ * What one read of a parameter asks for.
+ */
+export interface SimSsmParameterReadRequest {
+  readonly action: string;
+  readonly requested: string;
+  readonly withDecryption: boolean | undefined;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * A parameter a read resolved, with the stored name it is ordered by.
+ *
+ * The name is carried separately rather than read back off the output because
+ * a batch read has to sort by it, and the reported shape leaves every field
+ * optional.
+ */
+export interface SimSsmFoundParameter {
+  readonly name: string;
+  readonly output: SimSsmParameterOutput;
+}

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-reader.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-reader.ts
@@ -1,29 +1,21 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import {
   SimSsmParameterNotFound,
   SimSsmParameterVersionNotFound,
 } from "../../error/sim-ssm.error.js";
+import type { SimSsmParameterEncryption } from "../../parameter/sim-ssm-parameter-encryption.js";
 import { SimSsmParameterName } from "../../parameter/sim-ssm-parameter-name.js";
 import { SimSsmParameterSelector } from "../../parameter/sim-ssm-parameter-selector.js";
 import type { SimSsmParameterStore } from "../../parameter/sim-ssm-parameter-store.js";
 import type { SimSsmAuthorizer } from "../authorize/sim-ssm-authorizer.js";
-import type { SimSsmParameterOutput } from "./parameter.command.js";
+import type {
+  SimSsmFoundParameter,
+  SimSsmParameterReadRequest,
+} from "./sim-ssm-parameter-read.js";
 import { SimSsmParameterView } from "./sim-ssm-parameter-view.js";
-
-/**
- * A parameter a read resolved, with the stored name it is ordered by.
- *
- * The name is carried separately rather than read back off the output because
- * a batch read has to sort by it, and the reported shape leaves every field
- * optional.
- */
-export interface SimSsmFoundParameter {
-  readonly name: string;
-  readonly output: SimSsmParameterOutput;
-}
 
 interface SimSsmParameterReaderProperties {
   readonly parameters: SimSsmParameterStore;
+  readonly encryption: SimSsmParameterEncryption;
   readonly authorizer: SimSsmAuthorizer;
 }
 
@@ -35,11 +27,13 @@ interface SimSsmParameterReaderProperties {
  */
 export class SimSsmParameterReader {
   private readonly parameters: SimSsmParameterStore;
+  private readonly encryption: SimSsmParameterEncryption;
   private readonly authorizer: SimSsmAuthorizer;
   private readonly view = new SimSsmParameterView();
 
   constructor(properties: SimSsmParameterReaderProperties) {
     this.parameters = properties.parameters;
+    this.encryption = properties.encryption;
     this.authorizer = properties.authorizer;
   }
 
@@ -48,28 +42,35 @@ export class SimSsmParameterReader {
    *
    * Authorization comes first because real IAM evaluates a request before the
    * service sees it: a caller with no permission is refused whether or not the
-   * parameter exists, rather than being told it is missing.
+   * parameter exists, rather than being told it is missing. Decrypting a
+   * SecureString authorizes again, this time `kms:Decrypt` against the key.
    */
-  read(
-    action: string,
-    requested: string,
-    caller: SimAwsCaller | undefined,
-  ): SimSsmFoundParameter {
-    const selector = new SimSsmParameterSelector(requested);
+  async read(
+    request: SimSsmParameterReadRequest,
+  ): Promise<SimSsmFoundParameter> {
+    const selector = new SimSsmParameterSelector(request.requested);
 
     this.authorizer.authorizeParameterResource(
-      action,
+      request.action,
       SimSsmParameterName.resourceFor(selector.name),
-      caller,
+      request.caller,
     );
 
     const parameter = this.parameters.require(selector.name);
+    const version = selector.versionOf(parameter);
+    const reportedValue = await this.encryption.reported(
+      parameter,
+      version,
+      request.withDecryption,
+      request.caller,
+    );
 
     return {
       name: parameter.name.value,
       output: this.view.value(
         parameter,
-        selector.versionOf(parameter),
+        version,
+        reportedValue,
         selector.selector,
       ),
     };
@@ -82,13 +83,11 @@ export class SimSsmParameterReader {
    * A refused authorization still throws, because one name the caller may not
    * read fails the whole batch on real AWS.
    */
-  readOrInvalid(
-    action: string,
-    requested: string,
-    caller: SimAwsCaller | undefined,
-  ): SimSsmFoundParameter | undefined {
+  async readOrInvalid(
+    request: SimSsmParameterReadRequest,
+  ): Promise<SimSsmFoundParameter | undefined> {
     try {
-      return this.read(action, requested, caller);
+      return await this.read(request);
     } catch (error: unknown) {
       if (
         error instanceof SimSsmParameterNotFound ||

--- a/src/service/ssm/command/parameter/sim-ssm-parameter-view.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-parameter-view.ts
@@ -24,19 +24,24 @@ export class SimSsmParameterView {
   /**
    * The parameter shape that carries a value.
    *
+   * The reported value is passed in rather than read off the version, because
+   * a SecureString reads back as its ciphertext or its plaintext depending on
+   * whether the request asked for decryption.
+   *
    * `Selector` is only reported when the request asked for a version or a
    * label, as real Parameter Store only reports it then.
    */
   value(
     parameter: SimSsmParameter,
     version: SimSsmParameterVersion,
+    reportedValue: string,
     selector?: string,
   ): SimSsmParameterOutput {
     return {
       ARN: parameter.arn.value,
       Name: parameter.name.value,
       Type: parameter.type.value,
-      Value: version.value.value,
+      Value: reportedValue,
       Version: version.version,
       DataType: version.dataType,
       LastModifiedDate: version.lastModifiedDate,
@@ -59,6 +64,7 @@ export class SimSsmParameterView {
       Version: version.version,
       DataType: version.dataType,
       Description: version.description,
+      KeyId: version.keyId,
       LastModifiedDate: version.lastModifiedDate,
       LastModifiedUser: version.lastModifiedUser,
       Policies: [],

--- a/src/service/ssm/command/parameter/sim-ssm-put-parameter.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-put-parameter.iso.test.ts
@@ -170,27 +170,6 @@ describe("SSM PutParameter", () => {
     assertIdentical(put.Version, 2);
   });
 
-  it("refuses a SecureString parameter", async () => {
-    // Given a simulated AWS.
-    const simAws = new SimAws();
-
-    // When a parameter asks to be encrypted.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.ssm().putParameter(
-        new PutParameterCommand({
-          Name: "db-password",
-          Type: "SecureString",
-          Value: "hunter2",
-        }),
-      ),
-    );
-
-    // Then it is refused rather than stored in the clear, because nothing here
-    // would encrypt it.
-    assertInstanceOf(error, SimSsmUnsupportedParameterType);
-    assertStringIncludes(error.message, "not simulated");
-  });
-
   it("refuses a type Parameter Store does not have", async () => {
     // Given a simulated AWS.
     const simAws = new SimAws();

--- a/src/service/ssm/command/parameter/sim-ssm-put-parameter.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-put-parameter.ts
@@ -43,10 +43,10 @@ export class SimSsmPutParameter {
   /**
    * Create or update a parameter.
    */
-  handle(
+  async handle(
     command: SimPutParameterCommand,
     options?: SimSsmPutParameterOptions,
-  ): SimPutParameterCommandOutput {
+  ): Promise<SimPutParameterCommandOutput> {
     const { input } = command;
 
     this.unsimulatedOptions.refuseIn(input);
@@ -61,14 +61,16 @@ export class SimSsmPutParameter {
       options?.caller,
     );
 
-    const version = this.writer.write({
+    const version = await this.writer.write({
       name,
       value: input.Value,
       type: input.Type,
       overwrite: input.Overwrite,
       description: input.Description,
       dataType: input.DataType,
+      keyId: input.KeyId,
       lastModifiedUser: caller.arn,
+      caller: options?.caller,
     });
 
     return {

--- a/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.iso.test.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.iso.test.ts
@@ -110,14 +110,4 @@ describe("SSM PutParameter options that are not simulated", () => {
     assertInstanceOf(error, SimSsmValidationException);
     assertStringIncludes(error.message, "Tags");
   });
-
-  it("refuses a KMS key id", async () => {
-    // When a request names a key to encrypt with.
-    const error = await refusedOption({ KeyId: "alias/aws/ssm" });
-
-    // Then it is refused, because only SecureString parameters are encrypted
-    // and those are not simulated either.
-    assertInstanceOf(error, SimSsmValidationException);
-    assertStringIncludes(error.message, "KeyId");
-  });
 });

--- a/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.ts
+++ b/src/service/ssm/command/parameter/sim-ssm-unsimulated-put-options.ts
@@ -21,11 +21,6 @@ export class SimSsmUnsimulatedPutOptions {
     this.refuse("AllowedPattern", input.AllowedPattern, "value validation");
     this.refuse("Policies", input.Policies, "parameter policies");
     this.refuse("Tags", input.Tags, "parameter tags");
-    this.refuse(
-      "KeyId",
-      input.KeyId,
-      "encryption, which only applies to SecureString parameters",
-    );
   }
 
   private refuseTier(tier: string | undefined): void {

--- a/src/service/ssm/error/sim-ssm.error.ts
+++ b/src/service/ssm/error/sim-ssm.error.ts
@@ -110,6 +110,21 @@ export class SimSsmUnsupportedParameterType extends SimSsmError {
 }
 
 /**
+ * Simulated SSM InvalidKeyId error.
+ *
+ * Real Parameter Store reports every KMS key problem this way: a key that does
+ * not exist, one that is disabled, and one that is pending deletion all reach
+ * the caller as InvalidKeyId with the KMS message behind it.
+ */
+export class SimSsmInvalidKeyId extends SimSsmError {
+  public override readonly name = "InvalidKeyId";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated SSM ValidationException error.
  *
  * Real Parameter Store reports a missing or malformed request input this way,

--- a/src/service/ssm/index.ts
+++ b/src/service/ssm/index.ts
@@ -1,6 +1,11 @@
 export { SimSsm, type SimSsmRequestOptions } from "./sim-ssm.js";
 export { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
 export { SimSsmParameterArn } from "./parameter/sim-ssm-parameter-arn.js";
+export { SimSsmParameterEncryption } from "./parameter/sim-ssm-parameter-encryption.js";
+export {
+  ssmDefaultKeyAlias,
+  type SimSsmKmsCrypto,
+} from "./parameter/sim-ssm-kms-crypto.js";
 export { SimSsmParameterName } from "./parameter/sim-ssm-parameter-name.js";
 export { SimSsmParameterPath } from "./parameter/sim-ssm-parameter-path.js";
 export {
@@ -16,6 +21,7 @@ export {
   SimSsmError,
   SimSsmHierarchyLevelLimitExceededException,
   SimSsmHierarchyTypeMismatchException,
+  SimSsmInvalidKeyId,
   SimSsmParameterAlreadyExists,
   SimSsmParameterNotFound,
   SimSsmParameterPatternMismatchException,

--- a/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
+++ b/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
@@ -1,0 +1,47 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The alias of the AWS managed key Parameter Store encrypts with when a
+ * request names no key of its own.
+ *
+ * Simulated KMS creates the key behind a reserved `alias/aws/` name the first
+ * time something asks for it, which is how such a key comes into existence on
+ * real AWS too: nobody creates it, the service that needs it does.
+ */
+export const ssmDefaultKeyAlias = "alias/aws/ssm";
+
+/**
+ * The narrow slice of simulated KMS that SecureString parameters need.
+ *
+ * Standard tier Parameter Store encrypts under the key directly rather than
+ * through a data key, so Encrypt and Decrypt are the whole of it.
+ * SimKms structurally implements this interface.
+ */
+export interface SimSsmKmsCrypto {
+  encrypt(
+    command: {
+      input: {
+        KeyId?: string | undefined;
+        Plaintext?: Uint8Array | undefined;
+        EncryptionContext?: Readonly<Record<string, string>> | undefined;
+      };
+    },
+    options?: { caller?: SimAwsCaller | undefined },
+  ): Promise<{
+    CiphertextBlob?: Uint8Array | undefined;
+    KeyId?: string | undefined;
+  }>;
+
+  decrypt(
+    command: {
+      input: {
+        CiphertextBlob?: Uint8Array | undefined;
+        EncryptionContext?: Readonly<Record<string, string>> | undefined;
+      };
+    },
+    options?: { caller?: SimAwsCaller | undefined },
+  ): Promise<{
+    Plaintext?: Uint8Array | undefined;
+    KeyId?: string | undefined;
+  }>;
+}

--- a/src/service/ssm/parameter/sim-ssm-kms-key-problems.ts
+++ b/src/service/ssm/parameter/sim-ssm-kms-key-problems.ts
@@ -1,0 +1,28 @@
+import { SimKmsError } from "../../kms/error/sim-kms.error.js";
+import { SimSsmInvalidKeyId } from "../error/sim-ssm.error.js";
+
+/**
+ * Run a KMS call, reporting a refusal about the key the way Parameter Store
+ * reports it.
+ *
+ * Every key problem KMS raises becomes InvalidKeyId carrying the KMS message,
+ * which is what real Parameter Store does for a key that is missing, disabled
+ * or pending deletion. An access denial is not a KMS error and passes through
+ * untouched, so a missing `kms:Decrypt` still reads as a denial rather than a
+ * bad key.
+ */
+export async function reportingKeyProblems<TResult>(
+  call: () => Promise<TResult>,
+): Promise<TResult> {
+  try {
+    return await call();
+  } catch (error: unknown) {
+    if (error instanceof SimKmsError) {
+      throw new SimSsmInvalidKeyId(
+        `The KMS key cannot be used for this parameter: ${error.message}`,
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-encryption.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-encryption.ts
@@ -1,0 +1,103 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimSsmValidationException } from "../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "./sim-ssm-parameter.js";
+import type { SimSsmKmsCrypto } from "./sim-ssm-kms-crypto.js";
+import { SimSsmParameterKms } from "./sim-ssm-parameter-kms.js";
+import type { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
+import { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
+import type { SimSsmParameterVersion } from "./sim-ssm-parameter-version.js";
+
+interface SimSsmParameterEncryptionProperties {
+  readonly kms: SimSsmKmsCrypto;
+}
+
+/**
+ * What a SecureString value is stored as, and which key protects it.
+ */
+export interface SimSsmEncryptedValue {
+  readonly value: SimSsmParameterValue;
+  readonly keyId: string | undefined;
+}
+
+/**
+ * Decides when a parameter value is encrypted and when it is decrypted.
+ *
+ * These rules are worth keeping apart from the KMS calls themselves, because
+ * they are what a caller actually trips over: a value stored in the clear
+ * because the type said so, and a read that gets a ciphertext back because it
+ * did not ask for decryption.
+ */
+export class SimSsmParameterEncryption {
+  private readonly kms: SimSsmParameterKms;
+
+  constructor(properties: SimSsmParameterEncryptionProperties) {
+    this.kms = new SimSsmParameterKms(properties);
+  }
+
+  /**
+   * The stored form of a submitted value, encrypted if the type calls for it.
+   */
+  async stored(
+    type: SimSsmParameterType,
+    parameterArn: string,
+    submitted: SimSsmParameterValue,
+    keyId: string | undefined,
+    caller: SimAwsCaller | undefined,
+  ): Promise<SimSsmEncryptedValue> {
+    if (!type.isSecure) {
+      this.refuseKeyIdWithoutSecureString(type, keyId);
+
+      return { value: submitted, keyId: undefined };
+    }
+
+    const encrypted = await this.kms.encrypt(
+      parameterArn,
+      submitted.value,
+      keyId,
+      caller,
+    );
+
+    return {
+      value: SimSsmParameterValue.encrypted(encrypted.ciphertext),
+      keyId: encrypted.keyId,
+    };
+  }
+
+  /**
+   * The value a read reports, decrypted only when it was asked for.
+   *
+   * `WithDecryption` on a parameter that is not encrypted is ignored rather
+   * than refused, as real Parameter Store ignores it.
+   */
+  async reported(
+    parameter: SimSsmParameter,
+    version: SimSsmParameterVersion,
+    withDecryption: boolean | undefined,
+    caller: SimAwsCaller | undefined,
+  ): Promise<string> {
+    if (!parameter.type.isSecure || withDecryption !== true) {
+      return version.value.value;
+    }
+
+    return await this.kms.decrypt(
+      parameter.arn.value,
+      version.value.value,
+      caller,
+    );
+  }
+
+  private refuseKeyIdWithoutSecureString(
+    type: SimSsmParameterType,
+    keyId: string | undefined,
+  ): void {
+    if (keyId === undefined) {
+      return;
+    }
+
+    throw new SimSsmValidationException(
+      `KeyId applies to a SecureString parameter, and this one is a ` +
+        `${type.value} parameter. A value stored in the clear is not ` +
+        `encrypted with anything.`,
+    );
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
@@ -1,0 +1,115 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { reportingKeyProblems } from "./sim-ssm-kms-key-problems.js";
+import {
+  ssmDefaultKeyAlias,
+  type SimSsmKmsCrypto,
+} from "./sim-ssm-kms-crypto.js";
+
+/**
+ * The encryption context key Parameter Store binds every SecureString value
+ * to, holding the ARN of the parameter being encrypted.
+ *
+ * Binding it means a ciphertext lifted out of one parameter cannot be
+ * decrypted as another, and it is what a `kms:EncryptionContext:PARAMETER_ARN`
+ * policy condition matches on real AWS.
+ */
+const parameterArnContextKey = "PARAMETER_ARN";
+
+/**
+ * What KMS produced for one parameter value.
+ */
+export interface SimSsmParameterCiphertext {
+  readonly ciphertext: string;
+  readonly keyId: string | undefined;
+}
+
+interface SimSsmParameterKmsProperties {
+  readonly kms: SimSsmKmsCrypto;
+}
+
+/**
+ * The KMS calls a SecureString parameter makes.
+ *
+ * The calls are made as the caller rather than as the service, which is the
+ * point: a standard tier write needs `kms:Encrypt` on the key and a decrypting
+ * read needs `kms:Decrypt`, each on top of the SSM permission for the
+ * parameter itself.
+ *
+ * Standard tier Parameter Store encrypts under the key directly rather than
+ * through a data key, so this is one Encrypt and one Decrypt and nothing more.
+ */
+export class SimSsmParameterKms {
+  private readonly kms: SimSsmKmsCrypto;
+
+  constructor(properties: SimSsmParameterKmsProperties) {
+    this.kms = properties.kms;
+  }
+
+  /**
+   * Encrypt a parameter value, bound to the ARN of the parameter holding it.
+   */
+  async encrypt(
+    parameterArn: string,
+    plaintext: string,
+    keyId: string | undefined,
+    caller: SimAwsCaller | undefined,
+  ): Promise<SimSsmParameterCiphertext> {
+    const encrypted = await reportingKeyProblems(
+      async () =>
+        await this.kms.encrypt(
+          {
+            input: {
+              KeyId: keyId ?? ssmDefaultKeyAlias,
+              Plaintext: Buffer.from(plaintext, "utf8"),
+              EncryptionContext: this.contextFor(parameterArn),
+            },
+          },
+          { caller },
+        ),
+    );
+
+    assertDefined(
+      encrypted.CiphertextBlob,
+      `Simulated KMS encrypted ${parameterArn} to nothing`,
+    );
+
+    return {
+      ciphertext: Buffer.from(encrypted.CiphertextBlob).toString("base64"),
+      keyId: encrypted.KeyId,
+    };
+  }
+
+  /**
+   * Decrypt a parameter value, which needs the same binding it was made with.
+   */
+  async decrypt(
+    parameterArn: string,
+    ciphertext: string,
+    caller: SimAwsCaller | undefined,
+  ): Promise<string> {
+    const decrypted = await reportingKeyProblems(
+      async () =>
+        await this.kms.decrypt(
+          {
+            input: {
+              CiphertextBlob: Buffer.from(ciphertext, "base64"),
+              EncryptionContext: this.contextFor(parameterArn),
+            },
+          },
+          { caller },
+        ),
+    );
+
+    assertDefined(
+      decrypted.Plaintext,
+      `Simulated KMS decrypted ${parameterArn} to nothing`,
+    );
+
+    return Buffer.from(decrypted.Plaintext).toString("utf8");
+  }
+
+  private contextFor(parameterArn: string): Readonly<Record<string, string>> {
+    return { [parameterArnContextKey]: parameterArn };
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-overwrite.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-overwrite.ts
@@ -1,0 +1,78 @@
+import {
+  SimSsmHierarchyTypeMismatchException,
+  SimSsmParameterAlreadyExists,
+} from "../error/sim-ssm.error.js";
+import type { SimSsmParameter } from "./sim-ssm-parameter.js";
+import { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
+
+/**
+ * What a write says about the type it wants and whether it may replace what
+ * is already there.
+ */
+export interface SimSsmParameterOverwriteRequest {
+  readonly type: string | undefined;
+  readonly overwrite: boolean | undefined;
+}
+
+/**
+ * The rules that only exist where a create and an overwrite meet.
+ *
+ * A name already in use and a type that cannot change are both about the
+ * relationship between a request and a stored parameter, rather than about
+ * either on its own, so they live together and away from the write itself.
+ */
+export class SimSsmParameterOverwrite {
+  /**
+   * The type the written version will belong to, refusing a request that may
+   * not replace the parameter it names.
+   */
+  typeFor(
+    request: SimSsmParameterOverwriteRequest,
+    existing: SimSsmParameter | undefined,
+  ): SimSsmParameterType {
+    if (existing === undefined) {
+      return SimSsmParameterType.forNewParameter(request.type);
+    }
+
+    this.requireAllowed(request, existing);
+
+    return existing.type;
+  }
+
+  /**
+   * Refuse an overwrite that real Parameter Store refuses.
+   *
+   * A request that leaves out Overwrite is a create, so a name already in use
+   * fails rather than quietly replacing what is there. A request naming a
+   * different type fails too: Parameter Store has no way to convert a stored
+   * parameter, so the caller has to delete it and make a new one.
+   */
+  private requireAllowed(
+    request: SimSsmParameterOverwriteRequest,
+    existing: SimSsmParameter,
+  ): void {
+    if (request.overwrite !== true) {
+      throw new SimSsmParameterAlreadyExists(
+        `The parameter '${existing.name.value}' already exists. To overwrite ` +
+          `this value, set the Overwrite option in the request to true.`,
+      );
+    }
+
+    if (request.type === undefined) {
+      return;
+    }
+
+    const requested = new SimSsmParameterType(request.type);
+
+    if (requested.value === existing.type.value) {
+      return;
+    }
+
+    throw new SimSsmHierarchyTypeMismatchException(
+      `Parameter '${existing.name.value}' is a ${existing.type.value} ` +
+        `parameter and cannot be changed to ${requested.value}. Parameter ` +
+        `Store does not support changing a parameter type: create a new, ` +
+        `unique parameter instead.`,
+    );
+  }
+}

--- a/src/service/ssm/parameter/sim-ssm-parameter-type.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-type.ts
@@ -6,17 +6,21 @@ import {
 /**
  * The parameter types this simulation stores.
  */
-export type SimSsmParameterTypeName = "String" | "StringList";
+export type SimSsmParameterTypeName = "String" | "StringList" | "SecureString";
 
-const simulatedTypes: ReadonlySet<string> = new Set(["String", "StringList"]);
+const simulatedTypes: ReadonlySet<string> = new Set([
+  "String",
+  "StringList",
+  "SecureString",
+]);
 
 /**
  * The type of one simulated parameter.
  *
- * `SecureString` is refused rather than stored. Nothing in this simulation
- * would encrypt it, so accepting it would let a test pass while proving
- * nothing about the KMS key, the `kms:Decrypt` permission or the
- * `WithDecryption` flag a real deployment depends on.
+ * A `SecureString` is encrypted through simulated KMS rather than stored in
+ * the clear, so the two failures a real deployment hits are reproducible here:
+ * a caller that may read the parameter but may not decrypt with its key, and
+ * a read that forgets `WithDecryption` and gets a ciphertext back.
  */
 export class SimSsmParameterType {
   public readonly value: SimSsmParameterTypeName;
@@ -42,22 +46,20 @@ export class SimSsmParameterType {
   }
 
   private static validated(type: string): SimSsmParameterTypeName {
-    if (type === "SecureString") {
-      throw new SimSsmUnsupportedParameterType(
-        "SecureString parameters are not simulated: nothing here would " +
-          "encrypt the value, so a passing test would say nothing about the " +
-          "KMS key or the kms:Decrypt permission the real parameter needs. " +
-          "Use String or StringList.",
-      );
-    }
-
     if (!simulatedTypes.has(type)) {
       throw new SimSsmUnsupportedParameterType(
-        `Parameter type '${type}' is not a Parameter Store type: use String ` +
-          `or StringList`,
+        `Parameter type '${type}' is not a Parameter Store type: use String, ` +
+          `StringList or SecureString`,
       );
     }
 
     return type as SimSsmParameterTypeName;
+  }
+
+  /**
+   * Whether values of this type are stored encrypted.
+   */
+  get isSecure(): boolean {
+    return this.value === "SecureString";
   }
 }

--- a/src/service/ssm/parameter/sim-ssm-parameter-value.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-value.ts
@@ -10,21 +10,29 @@ import { SimSsmValidationException } from "../error/sim-ssm.error.js";
 const maxValueBytes = 4096;
 
 /**
- * The value held by one version of a simulated parameter.
+ * The value held by one version of a simulated parameter, as it is stored.
  *
  * A `StringList` value is a single comma-separated string here, as it is on
  * real Parameter Store. It is stored and returned that way rather than split
  * into an array, so handler code that splits it on commas is exercising the
  * same shape it would get from AWS.
+ *
+ * A `SecureString` value is stored as the base64 ciphertext KMS produced,
+ * which is what a read without `WithDecryption` returns. The 4KB limit applies
+ * to the plaintext a request submitted rather than to that ciphertext, so the
+ * two ways of making one of these are separate.
  */
 export class SimSsmParameterValue {
   public readonly value: string;
 
-  constructor(value: string | undefined) {
-    this.value = SimSsmParameterValue.validated(value);
+  private constructor(value: string) {
+    this.value = value;
   }
 
-  private static validated(value: string | undefined): string {
+  /**
+   * The value a request submitted, checked against the standard tier limit.
+   */
+  static submitted(value: string | undefined): SimSsmParameterValue {
     if (value === undefined || value === "") {
       throw new SimSsmValidationException(
         "A parameter Value is required and cannot be empty",
@@ -41,6 +49,17 @@ export class SimSsmParameterValue {
       );
     }
 
-    return value;
+    return new SimSsmParameterValue(value);
+  }
+
+  /**
+   * The stored form of an encrypted value.
+   *
+   * This is longer than the plaintext it came from and is not subject to the
+   * limit that plaintext was checked against, because Parameter Store measures
+   * the request rather than what it keeps.
+   */
+  static encrypted(ciphertext: string): SimSsmParameterValue {
+    return new SimSsmParameterValue(ciphertext);
   }
 }

--- a/src/service/ssm/parameter/sim-ssm-parameter-version.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-version.ts
@@ -10,7 +10,7 @@ import type { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
 export const ssmTextDataType = "text";
 
 /**
- * The details one write of a parameter carries, beyond its value.
+ * The details one stored version of a parameter records, beyond its value.
  */
 export interface SimSsmParameterVersionDetails {
   readonly description?: string | undefined;

--- a/src/service/ssm/parameter/sim-ssm-parameter-version.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-version.ts
@@ -16,6 +16,12 @@ export interface SimSsmParameterVersionDetails {
   readonly description?: string | undefined;
   readonly dataType?: string | undefined;
   readonly lastModifiedUser?: string | undefined;
+
+  /**
+   * The ARN of the KMS key a SecureString value was encrypted under, and
+   * undefined for the types that are stored in the clear.
+   */
+  readonly keyId?: string | undefined;
 }
 
 interface SimSsmParameterVersionProperties extends SimSsmParameterVersionDetails {
@@ -37,6 +43,7 @@ export class SimSsmParameterVersion {
   public readonly lastModifiedDate: Date;
   public readonly lastModifiedUser: string | undefined;
   public readonly description: string | undefined;
+  public readonly keyId: string | undefined;
   public readonly dataType: string;
 
   constructor(properties: SimSsmParameterVersionProperties) {
@@ -45,6 +52,7 @@ export class SimSsmParameterVersion {
     this.lastModifiedDate = properties.lastModifiedDate;
     this.lastModifiedUser = properties.lastModifiedUser;
     this.description = properties.description;
+    this.keyId = properties.keyId;
     this.dataType = properties.dataType ?? ssmTextDataType;
   }
 }

--- a/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
@@ -9,19 +9,30 @@ import { SimSsmParameterOverwrite } from "./sim-ssm-parameter-overwrite.js";
 import type { SimSsmParameterStore } from "./sim-ssm-parameter-store.js";
 import type { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
 import { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
-import type {
-  SimSsmParameterVersion,
-  SimSsmParameterVersionDetails,
-} from "./sim-ssm-parameter-version.js";
+import type { SimSsmParameterVersion } from "./sim-ssm-parameter-version.js";
 
 /**
  * One write of a parameter, as PutParameter describes it.
+ *
+ * This is the request rather than what gets stored, which is why it does not
+ * share the version's details: the two differ on the key. Here it is whatever
+ * the request asked for, and on the version it is the ARN that answered.
  */
-export interface SimSsmParameterWrite extends SimSsmParameterVersionDetails {
+export interface SimSsmParameterWrite {
   readonly name: SimSsmParameterName;
   readonly value: string | undefined;
   readonly type: string | undefined;
   readonly overwrite: boolean | undefined;
+  readonly description: string | undefined;
+  readonly dataType: string | undefined;
+  readonly lastModifiedUser: string | undefined;
+
+  /**
+   * The key the request asked to encrypt with, in any form KMS accepts: an
+   * alias such as `alias/aws/ssm`, a key ID, or a key ARN. Undefined leaves
+   * Parameter Store to pick its own AWS managed key.
+   */
+  readonly keyId: string | undefined;
 
   /**
    * The caller the KMS call for a SecureString is made as, so that encrypting

--- a/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-writer.ts
@@ -1,13 +1,13 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import {
-  SimSsmHierarchyTypeMismatchException,
-  SimSsmParameterAlreadyExists,
-} from "../error/sim-ssm.error.js";
 import { SimSsmParameter } from "./sim-ssm-parameter.js";
+import { SimSsmParameterArn } from "./sim-ssm-parameter-arn.js";
+import type { SimSsmParameterEncryption } from "./sim-ssm-parameter-encryption.js";
 import type { SimSsmParameterName } from "./sim-ssm-parameter-name.js";
+import { SimSsmParameterOverwrite } from "./sim-ssm-parameter-overwrite.js";
 import type { SimSsmParameterStore } from "./sim-ssm-parameter-store.js";
-import { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
+import type { SimSsmParameterType } from "./sim-ssm-parameter-type.js";
 import { SimSsmParameterValue } from "./sim-ssm-parameter-value.js";
 import type {
   SimSsmParameterVersion,
@@ -22,10 +22,17 @@ export interface SimSsmParameterWrite extends SimSsmParameterVersionDetails {
   readonly value: string | undefined;
   readonly type: string | undefined;
   readonly overwrite: boolean | undefined;
+
+  /**
+   * The caller the KMS call for a SecureString is made as, so that encrypting
+   * needs the caller's own `kms:Encrypt` permission on the key.
+   */
+  readonly caller: SimAwsCaller | undefined;
 }
 
 interface SimSsmParameterWriterProperties {
   readonly parameters: SimSsmParameterStore;
+  readonly encryption: SimSsmParameterEncryption;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: SimClock;
 }
@@ -34,16 +41,18 @@ interface SimSsmParameterWriterProperties {
  * The single path by which a simulated parameter is created or updated.
  *
  * Keeping creation and overwrite in one collaborator is what stops the two
- * drifting apart on the rules that only show up when they meet: a name that is
- * already taken, and a type that cannot change once the parameter exists.
+ * drifting apart on the rules that only show up when they meet.
  */
 export class SimSsmParameterWriter {
   private readonly parameters: SimSsmParameterStore;
+  private readonly encryption: SimSsmParameterEncryption;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clock: SimClock;
+  private readonly overwrite = new SimSsmParameterOverwrite();
 
   constructor(properties: SimSsmParameterWriterProperties) {
     this.parameters = properties.parameters;
+    this.encryption = properties.encryption;
     this.accountRegionScope = properties.accountRegionScope;
     this.clock = properties.clock;
   }
@@ -51,78 +60,57 @@ export class SimSsmParameterWriter {
   /**
    * Write a new version of a parameter, creating it if it is new.
    *
-   * Everything is validated before anything is stored, so a request refused
-   * for its value leaves no half-made parameter behind.
+   * Everything is validated and encrypted before anything is stored, so a
+   * request refused for its value, or for a key the caller may not encrypt
+   * with, leaves no half-made parameter behind.
    */
-  write(request: SimSsmParameterWrite): SimSsmParameterVersion {
-    const value = new SimSsmParameterValue(request.value);
-    const parameter = this.parameterFor(request);
+  async write(request: SimSsmParameterWrite): Promise<SimSsmParameterVersion> {
+    const submitted = SimSsmParameterValue.submitted(request.value);
+    const existing = this.parameters.find(request.name.value);
+    const type = this.overwrite.typeFor(request, existing);
 
-    return parameter.addVersion(value, this.clock.now(), {
+    const stored = await this.encryption.stored(
+      type,
+      this.arnFor(request.name),
+      submitted,
+      request.keyId,
+      request.caller,
+    );
+    const parameter = existing ?? this.created(request.name, type);
+
+    return parameter.addVersion(stored.value, this.clock.now(), {
       description: request.description,
       dataType: request.dataType,
       lastModifiedUser: request.lastModifiedUser,
+      keyId: stored.keyId,
     });
   }
 
-  private parameterFor(request: SimSsmParameterWrite): SimSsmParameter {
-    const existing = this.parameters.find(request.name.value);
-
-    if (existing === undefined) {
-      return this.created(request);
-    }
-
-    this.requireOverwriteAllowed(request, existing);
-
-    return existing;
+  /**
+   * The ARN the parameter has or is about to have.
+   *
+   * It is needed before the parameter exists, because it is the encryption
+   * context a SecureString value is bound to.
+   */
+  private arnFor(name: SimSsmParameterName): string {
+    return new SimSsmParameterArn({
+      resource: name.resource,
+      accountRegionScope: this.accountRegionScope,
+    }).value;
   }
 
-  private created(request: SimSsmParameterWrite): SimSsmParameter {
+  private created(
+    name: SimSsmParameterName,
+    type: SimSsmParameterType,
+  ): SimSsmParameter {
     const parameter = new SimSsmParameter({
-      name: request.name,
-      type: SimSsmParameterType.forNewParameter(request.type),
+      name,
+      type,
       accountRegionScope: this.accountRegionScope,
     });
 
     this.parameters.add(parameter);
 
     return parameter;
-  }
-
-  /**
-   * Refuse an overwrite that real Parameter Store refuses.
-   *
-   * A request that leaves out Overwrite is a create, so a name already in use
-   * fails rather than quietly replacing what is there. A request naming a
-   * different type fails too: Parameter Store has no way to convert a stored
-   * parameter, so the caller has to delete it and make a new one.
-   */
-  private requireOverwriteAllowed(
-    request: SimSsmParameterWrite,
-    existing: SimSsmParameter,
-  ): void {
-    if (request.overwrite !== true) {
-      throw new SimSsmParameterAlreadyExists(
-        `The parameter '${existing.name.value}' already exists. To overwrite ` +
-          `this value, set the Overwrite option in the request to true.`,
-      );
-    }
-
-    if (request.type === undefined) {
-      return;
-    }
-
-    const requested = new SimSsmParameterType(request.type);
-
-    if (requested.value === existing.type.value) {
-      return;
-    }
-
-    throw new SimSsmHierarchyTypeMismatchException(
-      `Parameter '${existing.name.value}' is a ${existing.type.value} ` +
-        `parameter and cannot be changed to ${requested.value}. Parameter ` +
-        `Store does not support changing a parameter type: create a new, ` +
-        `unique parameter instead.`,
-    );
   }
 }

--- a/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
@@ -1,0 +1,217 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+
+interface SimAwsWithSecret {
+  readonly simAws: SimAws;
+  readonly keyArn: string;
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * A simulated AWS holding one SecureString parameter under a customer managed
+ * key, and a Role whose only permissions are the given statements.
+ */
+async function simAwsWithSecret(
+  policyStatements: (accountId: string, keyArn: string) => object,
+): Promise<SimAwsWithSecret> {
+  const simAws = new SimAws();
+  const accountId = simAws.defaultAccountId;
+
+  const key = await simAws
+    .kms()
+    .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+
+  assertNonNullable(key.KeyMetadata?.Arn);
+
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-password",
+      Type: "SecureString",
+      Value: "hunter2",
+      KeyId: key.KeyMetadata.Arn,
+    }),
+  );
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ConfigReader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  const policyDocument = JSON.stringify({
+    Version: "2012-10-17",
+    Statement: policyStatements(accountId, key.KeyMetadata.Arn),
+  });
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "ConfigReader",
+      PolicyName: "SecretPolicy",
+      PolicyDocument: policyDocument,
+    }),
+  );
+
+  return {
+    simAws,
+    keyArn: key.KeyMetadata.Arn,
+    caller: { kind: "arn", arn: role.Role.Arn },
+  };
+}
+
+const readParameter = {
+  Effect: "Allow",
+  Action: "ssm:GetParameter",
+  Resource: "*",
+};
+
+describe("SSM SecureString IAM authorization", () => {
+  it("decrypts for a caller allowed both the parameter and the key", async () => {
+    // Given a Role allowed to read the parameter and to decrypt with its key.
+    const { simAws, caller } = await simAwsWithSecret((_, keyArn) => [
+      readParameter,
+      { Effect: "Allow", Action: "kms:Decrypt", Resource: keyArn },
+    ]);
+
+    // When it reads the parameter with decryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+      { caller },
+    );
+
+    // Then it gets the plaintext.
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
+  it("denies a decrypting read to a caller with no key permission", async () => {
+    // Given a Role allowed to read the parameter but not to use its key.
+    const { simAws, caller } = await simAwsWithSecret(() => readParameter);
+
+    // When it reads the parameter with decryption.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameter(
+        new GetParameterCommand({
+          Name: "/myapp/prod/db-password",
+          WithDecryption: true,
+        }),
+        { caller },
+      ),
+    );
+
+    // Then it is denied, because kms:Decrypt is a separate permission from
+    // ssm:GetParameter and this is the failure a deployment actually hits.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("reads the ciphertext without any key permission", async () => {
+    // Given the same Role with no key permission.
+    const { simAws, caller } = await simAwsWithSecret(() => readParameter);
+
+    // When it reads the parameter without asking for decryption.
+    const read = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+        { caller },
+      );
+
+    // Then the read succeeds, because nothing decrypted, and what comes back
+    // is the ciphertext rather than the secret.
+    assertStringNotIncludes(String(read.Parameter?.Value), "hunter2");
+  });
+
+  it("denies a write to a caller with no key permission", async () => {
+    // Given a Role allowed to write parameters but not to use the key.
+    const { simAws, keyArn, caller } = await simAwsWithSecret(() => ({
+      Effect: "Allow",
+      Action: "ssm:PutParameter",
+      Resource: "*",
+    }));
+
+    // When it writes a SecureString under that key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/api-key",
+          Type: "SecureString",
+          Value: "secret",
+          KeyId: keyArn,
+        }),
+        { caller },
+      ),
+    );
+
+    // Then it is denied: a standard tier write needs kms:Encrypt as well.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("writes for a caller allowed both the parameter and the key", async () => {
+    // Given a Role allowed to write parameters and to encrypt with the key.
+    const { simAws, keyArn, caller } = await simAwsWithSecret((_, arn) => [
+      { Effect: "Allow", Action: "ssm:PutParameter", Resource: "*" },
+      { Effect: "Allow", Action: "kms:Encrypt", Resource: arn },
+    ]);
+
+    // When it writes a SecureString under that key.
+    const written = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/api-key",
+        Type: "SecureString",
+        Value: "secret",
+        KeyId: keyArn,
+      }),
+      { caller },
+    );
+
+    // Then the write succeeds.
+    assertIdentical(written.Version, 1);
+  });
+
+  it("leaves no parameter behind when the key permission is missing", async () => {
+    // Given a Role allowed to write parameters but not to use the key.
+    const { simAws, keyArn, caller } = await simAwsWithSecret(() => ({
+      Effect: "Allow",
+      Action: "ssm:PutParameter",
+      Resource: "*",
+    }));
+
+    // When a create is denied at the encryption step.
+    await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/api-key",
+          Type: "SecureString",
+          Value: "secret",
+          KeyId: keyArn,
+        }),
+        { caller },
+      ),
+    );
+
+    // Then no half-made parameter is left in the store.
+    assertUndefined(simAws.ssm().findParameter("/myapp/prod/api-key"));
+  });
+});

--- a/src/service/ssm/parameter/sim-ssm-secure-string.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string.iso.test.ts
@@ -1,0 +1,309 @@
+import { CreateKeyCommand, DecryptCommand } from "@aws-sdk/client-kms";
+import {
+  DescribeParametersCommand,
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  GetParametersCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimSsmInvalidKeyId,
+  SimSsmValidationException,
+} from "../error/sim-ssm.error.js";
+
+/**
+ * The encryption context key real Parameter Store binds a SecureString to.
+ */
+const parameterArnContextKey = "PARAMETER_ARN";
+
+async function simAwsWithSecret(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-password",
+      Type: "SecureString",
+      Value: "hunter2",
+    }),
+  );
+
+  return simAws;
+}
+
+describe("SSM SecureString parameters", () => {
+  it("stores the value encrypted rather than in the clear", async () => {
+    // Given a SecureString parameter.
+    const simAws = await simAwsWithSecret();
+
+    // When it is read without asking for decryption.
+    const read = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+      );
+
+    // Then the ciphertext comes back, which is what a handler that forgets
+    // WithDecryption ends up parsing as if it were a password.
+    assertNonNullable(read.Parameter);
+    assertIdentical(read.Parameter.Type, "SecureString");
+    assertStringNotIncludes(String(read.Parameter.Value), "hunter2");
+  });
+
+  it("returns the plaintext when the read asks for decryption", async () => {
+    // Given the same parameter.
+    const simAws = await simAwsWithSecret();
+
+    // When it is read with WithDecryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+    );
+
+    // Then the value is the plaintext that was written.
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
+  it("encrypts under the aws/ssm managed key when no key is named", async () => {
+    // Given a SecureString parameter written without a KeyId.
+    const simAws = await simAwsWithSecret();
+
+    // When the parameter is described.
+    const described = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}));
+
+    // Then it reports the AWS managed key Systems Manager creates on demand,
+    // as real Parameter Store does for a parameter that names no key.
+    const keyId = String(described.Parameters?.at(0)?.KeyId);
+
+    assertStringIncludes(keyId, ":key/");
+
+    const managedKey = simAws.kms().findKey("alias/aws/ssm");
+
+    assertNonNullable(managedKey);
+    assertIdentical(managedKey.arn, keyId);
+  });
+
+  it("encrypts under a customer managed key when one is named", async () => {
+    // Given a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // When a SecureString parameter names it.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata.Arn,
+      }),
+    );
+
+    // Then the parameter is encrypted under that key and reports it.
+    const described = await simAws
+      .ssm()
+      .describeParameters(new DescribeParametersCommand({}));
+
+    assertIdentical(described.Parameters?.at(0)?.KeyId, key.KeyMetadata.Arn);
+
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+    );
+
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
+  it("refuses a KeyId no key answers to", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a SecureString names a key that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/db-password",
+          Type: "SecureString",
+          Value: "hunter2",
+          KeyId: "alias/nothing-here",
+        }),
+      ),
+    );
+
+    // Then it is refused as an invalid key, as real Parameter Store reports
+    // every KMS key problem.
+    assertInstanceOf(error, SimSsmInvalidKeyId);
+  });
+
+  it("refuses a KeyId on a parameter stored in the clear", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a String parameter names a key to encrypt with.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/db-host",
+          Type: "String",
+          Value: "db.internal",
+          KeyId: "alias/aws/ssm",
+        }),
+      ),
+    );
+
+    // Then it is refused, because nothing would encrypt that value.
+    assertInstanceOf(error, SimSsmValidationException);
+    assertStringIncludes(error.message, "SecureString");
+  });
+
+  it("encrypts each version of an overwritten parameter", async () => {
+    // Given a SecureString parameter that has been overwritten.
+    const simAws = await simAwsWithSecret();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-password",
+        Value: "hunter3",
+        Overwrite: true,
+      }),
+    );
+
+    // When each version is read with decryption.
+    const first = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password:1",
+        WithDecryption: true,
+      }),
+    );
+    const current = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+    );
+
+    // Then each one decrypts to what it was written with.
+    assertIdentical(first.Parameter?.Value, "hunter2");
+    assertIdentical(current.Parameter?.Value, "hunter3");
+  });
+
+  it("binds a ciphertext to the ARN of the parameter holding it", async () => {
+    // Given a SecureString parameter and the ciphertext it stores.
+    const simAws = await simAwsWithSecret();
+    const stored = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+      );
+
+    assertNonNullable(stored.Parameter?.Value);
+    assertNonNullable(stored.Parameter.ARN);
+
+    const ciphertextBlob = Buffer.from(stored.Parameter.Value, "base64");
+    const { ARN: parameterArn } = stored.Parameter;
+
+    // When KMS decrypts it directly with the parameter's own ARN as the
+    // encryption context, as the AWS documentation describes.
+    const decrypted = await simAws.kms().decrypt(
+      new DecryptCommand({
+        CiphertextBlob: ciphertextBlob,
+        EncryptionContext: { [parameterArnContextKey]: parameterArn },
+      }),
+    );
+
+    // Then it decrypts, and the same ciphertext claimed as another parameter
+    // does not: Parameter Store binds each value to the parameter it belongs
+    // to, so one lifted into another parameter cannot be read.
+    assertIdentical(
+      Buffer.from(decrypted.Plaintext ?? new Uint8Array()).toString("utf8"),
+      "hunter2",
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: ciphertextBlob,
+          EncryptionContext: {
+            [parameterArnContextKey]: `${parameterArn}-elsewhere`,
+          },
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, Error);
+  });
+
+  it("decrypts in a batch read and in a path listing", async () => {
+    // Given a SecureString and a String parameter under one path.
+    const simAws = await simAwsWithSecret();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.internal",
+      }),
+    );
+
+    // When both are read in a batch and by path, asking for decryption.
+    const batch = await simAws.ssm().getParameters(
+      new GetParametersCommand({
+        Names: ["/myapp/prod/db-password", "/myapp/prod/db-host"],
+        WithDecryption: true,
+      }),
+    );
+    const listed = await simAws.ssm().getParametersByPath(
+      new GetParametersByPathCommand({
+        Path: "/myapp/prod",
+        WithDecryption: true,
+      }),
+    );
+
+    // Then the secret is plaintext in both, and the flag changed nothing for
+    // the parameter that was never encrypted.
+    const batched = batch.Parameters ?? [];
+    const byPath = listed.Parameters ?? [];
+
+    assertIdentical(batched.at(0)?.Value, "db.internal");
+    assertIdentical(batched.at(1)?.Value, "hunter2");
+    assertIdentical(byPath.at(0)?.Value, "db.internal");
+    assertIdentical(byPath.at(1)?.Value, "hunter2");
+  });
+
+  it("leaves a batch read and a path listing encrypted without the flag", async () => {
+    // Given a SecureString parameter.
+    const simAws = await simAwsWithSecret();
+
+    // When it is read in a batch and by path without asking for decryption.
+    const batch = await simAws.ssm().getParameters(
+      new GetParametersCommand({
+        Names: ["/myapp/prod/db-password"],
+      }),
+    );
+    const listed = await simAws
+      .ssm()
+      .getParametersByPath(
+        new GetParametersByPathCommand({ Path: "/myapp/prod" }),
+      );
+
+    // Then neither carries the plaintext.
+    assertStringNotIncludes(String(batch.Parameters?.at(0)?.Value), "hunter2");
+    assertStringNotIncludes(String(listed.Parameters?.at(0)?.Value), "hunter2");
+  });
+});

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -10,6 +10,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimKms } from "../kms/index.js";
 import { SimSsmAuthorizer } from "./command/authorize/sim-ssm-authorizer.js";
 import { SimSsmDeleteParameterCommands } from "./command/parameter/sim-ssm-delete-parameter-commands.js";
 import { SimSsmDescribeParameters } from "./command/parameter/sim-ssm-describe-parameters.js";
@@ -19,6 +20,8 @@ import { SimSsmPutParameter } from "./command/parameter/sim-ssm-put-parameter.js
 import type * as simSsmCommands from "./command/sim-ssm-command.types.js";
 import { SimSsmCfnResourceFactory } from "./cfn/sim-cfn-ssm-resource-factory.js";
 import type { SimSsmParameter } from "./parameter/sim-ssm-parameter.js";
+import { SimSsmParameterEncryption } from "./parameter/sim-ssm-parameter-encryption.js";
+import type { SimSsmKmsCrypto } from "./parameter/sim-ssm-kms-crypto.js";
 import { SimSsmParameterStore } from "./parameter/sim-ssm-parameter-store.js";
 import { SimSsmParameterWriter } from "./parameter/sim-ssm-parameter-writer.js";
 import { SimSsmSdkCommandRouter } from "./sdk/sim-ssm-sdk-command-router.js";
@@ -31,6 +34,13 @@ interface SimSsmProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * The simulated KMS that SecureString values are encrypted through. One is
+   * created for this scope when none is supplied, so a standalone SimSsm still
+   * encrypts rather than quietly storing secrets in the clear.
+   */
+  readonly kms?: SimSsmKmsCrypto;
 }
 
 /**
@@ -61,13 +71,18 @@ export class SimSsm {
       background = new BackgroundTasks(),
     } = properties;
 
+    const { kms = new SimKms({ accountRegionScope, iam, background }) } =
+      properties;
+
     const authorizer = new SimSsmAuthorizer({ iam, accountRegionScope });
+    const encryption = new SimSsmParameterEncryption({ kms });
 
     this.background = background;
     this.parameters = new SimSsmParameterStore();
     this.putParameterCommand = new SimSsmPutParameter({
       writer: new SimSsmParameterWriter({
         parameters: this.parameters,
+        encryption,
         accountRegionScope,
         clock: background,
       }),
@@ -76,10 +91,12 @@ export class SimSsm {
     });
     this.readCommands = new SimSsmGetParameterCommands({
       parameters: this.parameters,
+      encryption,
       authorizer,
     });
     this.pathCommand = new SimSsmGetParametersByPath({
       parameters: this.parameters,
+      encryption,
       authorizer,
       accountRegionScope,
     });
@@ -111,7 +128,7 @@ export class SimSsm {
     options?: SimSsmRequestOptions,
   ): Promise<simSsmCommands.SimPutParameterCommandOutput> {
     await this.background.sequence();
-    return this.putParameterCommand.handle(command, options);
+    return await this.putParameterCommand.handle(command, options);
   }
 
   /**
@@ -122,7 +139,7 @@ export class SimSsm {
     options?: SimSsmRequestOptions,
   ): Promise<simSsmCommands.SimGetParameterCommandOutput> {
     await this.background.sequence();
-    return this.readCommands.get(command, options);
+    return await this.readCommands.get(command, options);
   }
 
   /**
@@ -133,7 +150,7 @@ export class SimSsm {
     options?: SimSsmRequestOptions,
   ): Promise<simSsmCommands.SimGetParametersCommandOutput> {
     await this.background.sequence();
-    return this.readCommands.getMany(command, options);
+    return await this.readCommands.getMany(command, options);
   }
 
   /**
@@ -144,7 +161,7 @@ export class SimSsm {
     options?: SimSsmRequestOptions,
   ): Promise<simSsmCommands.SimGetParametersByPathCommandOutput> {
     await this.background.sequence();
-    return this.pathCommand.handle(command, options);
+    return await this.pathCommand.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
A SecureString parameter is encrypted through simulated KMS, under the aws/ssm managed key unless the request names its own, and GetParameter returns the ciphertext unless WithDecryption is passed.

The KMS calls are made as the caller, so a write needs kms:Encrypt and a decrypting read needs kms:Decrypt on top of the SSM permission for the parameter. Each value is bound to its parameter's ARN as the PARAMETER_ARN encryption context, as real Parameter Store binds it.

Resolves https://github.com/KensioSoftware/yulin/issues/214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated KMS encryption/decryption for SSM `SecureString` parameters.
  * `GetParameter(s)` and “by path” listings can return ciphertext, and can decrypt results when `WithDecryption` is enabled.
  * `KeyId` is surfaced for encrypted versions and key-related failures now map to `InvalidKeyId`.

* **Documentation**
  * Updated SSM/KMS/Secrets Manager docs to clarify `SecureString` encryption, encryption-context binding, and KMS permission expectations.

* **Tests**
  * Added ISO test suites covering `SecureString` behavior, IAM authorization boundaries, and encryption-context validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->