### PR TITLE
feat: derive kms:ViaService and give AWS managed keys their real policy

### DIFF
--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -238,6 +238,72 @@ try {
 Replacing a key policy with `PutKeyPolicyCommand` can lock an account out of its own key, as it can
 on real KMS.
 
+## AWS managed keys and `kms:ViaService`
+
+An alias beginning `alias/aws/` names an AWS managed key, and the key is created the first time
+something references it. Such a key gets the policy real AWS gives it, which is not the customer
+default:
+
+- Use of the key is allowed to any principal in the owning account, but only when `kms:ViaService`
+  names the service that owns the key, such as `ssm.us-east-1.amazonaws.com` for `aws/ssm`.
+- The account root is allowed to read the key's metadata, and nothing more. Nothing about using the
+  key is delegated to IAM.
+
+That is why a role holding only `ssm:GetParameter` reads a decrypted `SecureString` under `aws/ssm`,
+and why a role holding `kms:Decrypt` on that key still cannot use it by calling KMS itself.
+
+`kms:ViaService` is set by the service making the call on the caller's behalf. Sim SSM does this for
+`SecureString` parameters. Code calling simulated KMS directly sets it with the `viaService` request
+option, naming the service on its own rather than as an endpoint, since the region is the key's.
+
+```typescript sim-kms-aws-managed-key
+/**
+ * An AWS managed key, usable only through the service that owns it.
+ */
+
+import { EncryptCommand, GetKeyPolicyCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimIamAccessDenied } from "@kensio/yulin/iam";
+
+const simAws = new SimAws();
+
+// A request reaching the key through Systems Manager, as Parameter Store makes
+// it. No KMS permission is involved.
+const encrypted = await simAws.kms().encrypt(
+  new EncryptCommand({
+    KeyId: "alias/aws/ssm",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+  { viaService: "ssm" },
+);
+
+console.log(encrypted.KeyId); // the ARN of the aws/ssm key
+
+// The same request made directly is denied, whatever IAM allows.
+try {
+  await simAws.kms().encrypt(
+    new EncryptCommand({
+      KeyId: "alias/aws/ssm",
+      Plaintext: Buffer.from("hunter2", "utf8"),
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof SimIamAccessDenied); // true
+}
+
+// Reading the key's metadata is allowed, because that much is delegated.
+const policy = await simAws
+  .kms()
+  .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: "alias/aws/ssm" }));
+
+console.log(policy.Policy); // the via-service-scoped policy
+```
+
+A key policy of your own can use `kms:ViaService` too, with the ordinary condition operators, and it
+matches for requests carrying the option. A request that names no service has no value for the key,
+so a condition on it does not match.
+
 ## Naming a key
 
 Every operation takes its target as a `KeyId`, and any of the four forms real KMS accepts will do: a
@@ -443,12 +509,12 @@ Current documented limitations:
 - Aliases cannot be updated or deleted; `UpdateAlias` and `DeleteAlias` are not supported.
 - Tags, `ListResourceTags` and the `aws:ResourceTag` condition key are not simulated. An
   `AWS::KMS::Key` declaring `Tags` is refused rather than deploying with the tags dropped.
-- `kms:ViaService`, `kms:EncryptionContext:*` and other KMS-specific condition keys are not derived,
-  so a policy relying on them will not match. Ordinary condition operators on values sim IAM does
-  supply work as usual.
-- AWS managed keys created on demand get the same default key policy as a customer key, rather than
-  the via-service-scoped policy real AWS gives them. Scheduling one for deletion is refused, as on
-  real AWS, but disabling one is not, which real AWS does refuse.
+- `kms:EncryptionContext:*` and other KMS-specific condition keys beyond `kms:ViaService` and
+  `kms:CallerAccount` are not derived, so a policy relying on them will not match. Ordinary condition
+  operators on values sim IAM does supply work as usual.
+- The service an AWS managed key belongs to is taken from its alias, so `alias/aws/ebs` is scoped to
+  `ebs.<region>.amazonaws.com`. Real AWS scopes that one to EC2. The two agree for every service
+  Yulin simulates.
 - Key material lives in process memory for the lifetime of the `SimAws` instance. That is not a
   security boundary: anything sharing the process can reach it.
 - Sim SSM encrypts `SecureString` parameters with simulated keys and checks `kms:Encrypt` and

--- a/docs/services/kms/sim-kms-aws-managed-key.example.ts
+++ b/docs/services/kms/sim-kms-aws-managed-key.example.ts
@@ -1,0 +1,41 @@
+/**
+ * An AWS managed key, usable only through the service that owns it.
+ */
+
+import { EncryptCommand, GetKeyPolicyCommand } from "@aws-sdk/client-kms";
+
+import { SimAws } from "@kensio/yulin";
+import { SimIamAccessDenied } from "@kensio/yulin/iam";
+
+const simAws = new SimAws();
+
+// A request reaching the key through Systems Manager, as Parameter Store makes
+// it. No KMS permission is involved.
+const encrypted = await simAws.kms().encrypt(
+  new EncryptCommand({
+    KeyId: "alias/aws/ssm",
+    Plaintext: Buffer.from("hunter2", "utf8"),
+  }),
+  { viaService: "ssm" },
+);
+
+console.log(encrypted.KeyId); // the ARN of the aws/ssm key
+
+// The same request made directly is denied, whatever IAM allows.
+try {
+  await simAws.kms().encrypt(
+    new EncryptCommand({
+      KeyId: "alias/aws/ssm",
+      Plaintext: Buffer.from("hunter2", "utf8"),
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof SimIamAccessDenied); // true
+}
+
+// Reading the key's metadata is allowed, because that much is delegated.
+const policy = await simAws
+  .kms()
+  .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: "alias/aws/ssm" }));
+
+console.log(policy.Policy); // the via-service-scoped policy

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -590,12 +590,12 @@ Store reports every KMS key problem.
 Each value is bound to its own parameter's ARN as the KMS encryption context, under the
 `PARAMETER_ARN` key, so a ciphertext lifted out of one parameter cannot be decrypted as another.
 
-### Decrypting needs its own permission
+### A customer managed key needs its own permission
 
-Encrypting and decrypting go to simulated KMS as the caller, not as the service. A write needs
-`kms:Encrypt` on the key on top of `ssm:PutParameter` on the parameter, and a decrypting read needs
-`kms:Decrypt` on top of `ssm:GetParameter`. A role granted one and not the other fails here rather
-than in a deployment.
+Encrypting and decrypting go to simulated KMS as the caller, not as the service. Under a customer
+managed key a write needs `kms:Encrypt` on the key on top of `ssm:PutParameter` on the parameter, and
+a decrypting read needs `kms:Decrypt` on top of `ssm:GetParameter`. A role granted one and not the
+other fails here rather than in a deployment.
 
 ```typescript sim-ssm-secure-string-permissions
 /**
@@ -669,6 +669,78 @@ try {
 }
 ```
 
+### The aws/ssm managed key needs no permission
+
+A parameter naming no key is encrypted under the `aws/ssm` AWS managed key, and that key asks the
+caller for nothing. Parameter Store supplies `kms:ViaService`, and the managed key's policy allows
+the account's principals to use it through Systems Manager. A role holding only `ssm:GetParameter`
+therefore reads the decrypted value, as it does on real AWS.
+
+The same role cannot take the ciphertext to KMS itself, because that policy allows nothing to a
+request arriving directly.
+
+```typescript sim-ssm-secure-string-managed-key
+/**
+ * Reading a simulated SecureString under the aws/ssm managed key.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The parameter, and no KMS permission at all.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbPassword",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const read = await simAws.ssm().getParameter(
+  new GetParameterCommand({
+    Name: "/myapp/prod/db-password",
+    WithDecryption: true,
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(read.Parameter?.Value); // "hunter2"
+```
+
 `DescribeParameters` reports the key each `SecureString` is encrypted under as `KeyId`.
 
 ## Limitations
@@ -678,9 +750,6 @@ Current documented limitations:
 - Only standard tier `SecureString` encryption is simulated, which encrypts under the KMS key
   directly. The advanced tier's envelope encryption through the AWS Encryption SDK is not, so
   `kms:GenerateDataKey` is never needed.
-- A `SecureString` under the `aws/ssm` managed key can be decrypted by any caller allowed
-  `kms:Decrypt` on it. Real AWS gives that key a policy nobody can change; simulated KMS gives a
-  managed key the same default policy as a customer key.
 - Parameter labels are not simulated. `LabelParameterVersion` is not implemented, so nothing can
   create a label, and a `name:label` selector is refused with an error saying so.
 - `GetParameterHistory` is not simulated, though earlier versions stay readable by number.

--- a/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
@@ -1,0 +1,59 @@
+/**
+ * Reading a simulated SecureString under the aws/ssm managed key.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+await simAws.ssm().putParameter(
+  new PutParameterCommand({
+    Name: "/myapp/prod/db-password",
+    Type: "SecureString",
+    Value: "hunter2",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ConfigReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The parameter, and no KMS permission at all.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ConfigReader",
+    PolicyName: "ReadDbPassword",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "ssm:GetParameter",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const read = await simAws.ssm().getParameter(
+  new GetParameterCommand({
+    Name: "/myapp/prod/db-password",
+    WithDecryption: true,
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(read.Parameter?.Value); // "hunter2"

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -14,6 +14,7 @@ import type {
   SimIamPolicyDocument,
 } from "../../policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "../../role/sim-iam-role.js";
+import type { SimIamCallerConditionSource } from "./sim-iam-caller-condition-source.js";
 import type {
   SimIamAuthZContext,
   SimIamAuthZPolicySource,
@@ -58,6 +59,15 @@ export interface SimIamAuthorizationInput {
    */
   readonly conditionContext?:
     Readonly<Record<string, SimIamConditionValue>> | undefined;
+
+  /**
+   * Condition values the service can only supply once IAM has resolved the
+   * caller, such as the Account a KMS request came from.
+   *
+   * These are combined with the values supplied directly, and IAM-derived
+   * values still take precedence over both.
+   */
+  readonly callerConditions?: SimIamCallerConditionSource | undefined;
 
   /**
    * Simulated request caller.
@@ -211,25 +221,41 @@ export class SimIamAuthZContextBuilder {
 
   /**
    * Combine service-provided condition values with global values that IAM can
-   * derive from the resolved caller. AWS:PrincipalArn identifies the IAM
-   * identity whose policies apply; for temporary Role credentials this is the
-   * underlying Role ARN, rather than the STS assumed-role session ARN retained
-   * as the effective caller for diagnostics.
+   * derive from the resolved caller.
+   *
+   * A service supplies values it knows from the request, and values it can
+   * only work out once the caller is resolved. IAM's own values are applied
+   * last, so nothing a service supplies can overwrite them.
    */
   private conditionContext(
     input: SimIamAuthorizationInput,
     caller: SimAwsResolvedCaller,
   ): Readonly<Record<string, SimIamConditionValue>> {
+    return {
+      ...input.conditionContext,
+      ...input.callerConditions?.conditionValuesFor(caller),
+      ...this.callerDerivedConditions(caller),
+    };
+  }
+
+  /**
+   * The condition values IAM derives from the caller itself.
+   *
+   * AWS:PrincipalArn identifies the IAM identity whose policies apply; for
+   * temporary Role credentials this is the underlying Role ARN, rather than
+   * the STS assumed-role session ARN retained as the effective caller for
+   * diagnostics.
+   */
+  private callerDerivedConditions(
+    caller: SimAwsResolvedCaller,
+  ): Readonly<Record<string, SimIamConditionValue>> {
     const principalArn = caller.identityPolicyArn ?? caller.arn;
 
     if (principalArn === undefined) {
-      return input.conditionContext ?? {};
+      return {};
     }
 
-    return {
-      ...input.conditionContext,
-      "aws:PrincipalArn": principalArn,
-    };
+    return { "aws:PrincipalArn": principalArn };
   }
 
   /**

--- a/src/service/iam/authorize/context/sim-iam-caller-condition-source.ts
+++ b/src/service/iam/authorize/context/sim-iam-caller-condition-source.ts
@@ -1,0 +1,23 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamConditionValue } from "../../policy/sim-iam-policy.js";
+
+/**
+ * Condition values a service can only work out once IAM has resolved the
+ * caller.
+ *
+ * Most condition values a service supplies are properties of the request, so
+ * it has them before it asks IAM anything. A few are properties of whoever
+ * turns out to be making the request, and only IAM can say who that is: a
+ * caller may arrive as credentials to authenticate or be omitted altogether.
+ * `kms:CallerAccount` is one, naming the Account a KMS request came from.
+ *
+ * The values stay with the service that owns the condition key rather than
+ * being derived by IAM for every request, since a key such as
+ * `kms:CallerAccount` exists only in KMS and matching it elsewhere would be
+ * looser than AWS.
+ */
+export interface SimIamCallerConditionSource {
+  conditionValuesFor(
+    caller: SimAwsResolvedCaller,
+  ): Readonly<Record<string, SimIamConditionValue>>;
+}

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -117,6 +117,21 @@ a pre-existing divergence in shared IAM rather than something this service intro
 generally would change S3 bucket policy, Lambda function policy and role trust policy behaviour, so
 it wants its own change.
 
+Two KMS condition keys are supplied with every request, and they are what makes an AWS managed key
+behave like one. `SimKmsCallerAccountCondition` supplies `kms:CallerAccount`, which can only be
+worked out once IAM has resolved the caller, so it reaches IAM through the `callerConditions` input
+rather than the ordinary condition context. `SimKmsViaService` supplies `kms:ViaService` from the
+`viaService` request option, set by a service calling KMS on a caller's behalf. It holds a service
+name rather than an endpoint, and builds the endpoint with the key's own region, since a key is only
+usable in its own region.
+
+`SimKmsKeyPolicy.awsManaged` is the policy those two exist for. It is the policy real AWS gives an
+AWS managed key: use of the key allowed to `*` conditioned on both keys, and a second statement
+delegating only the key's metadata to the account. Nothing about using the key is delegated, so an
+identity policy granting `kms:Decrypt` on such a key reaches nothing, and a caller with no KMS
+permission at all reaches it through the owning service. The key factory builds it whenever a key is
+made for a service, which the key store does on first reference to a reserved `alias/aws/` name.
+
 Operations with no key to speak of, `CreateKey`, `ListKeys` and `ListAliases`, authorize against the
 region's keys with identity policies alone, because real KMS gives those actions no resource-level
 permissions.

--- a/src/service/kms/command/alias/sim-kms-alias-commands.ts
+++ b/src/service/kms/command/alias/sim-kms-alias-commands.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import { SimKmsValidationException } from "../../error/sim-kms.error.js";
 import { SimKmsAliasName } from "../../key/sim-kms-alias.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
@@ -13,10 +13,6 @@ import type {
 interface SimKmsAliasCommandsProperties {
   readonly keys: SimKmsKeyStore;
   readonly authorizer: SimKmsAuthorizer;
-}
-
-interface SimKmsAliasCommandOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -41,7 +37,7 @@ export class SimKmsAliasCommands {
    */
   create(
     command: SimCreateAliasCommand,
-    options?: SimKmsAliasCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimCreateAliasCommandOutput {
     const aliasName = command.input.AliasName;
 
@@ -52,7 +48,7 @@ export class SimKmsAliasCommands {
     this.aliasName.validateCustomerAlias(aliasName);
 
     const key = this.keys.require(command.input.TargetKeyId);
-    this.authorizer.authorizeKey("kms:CreateAlias", key, options?.caller);
+    this.authorizer.authorizeKey("kms:CreateAlias", key, options);
     this.keys.addAlias(aliasName, key);
 
     return { $metadata: {} };
@@ -63,9 +59,9 @@ export class SimKmsAliasCommands {
    */
   list(
     command: SimListAliasesCommand,
-    options?: SimKmsAliasCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimListAliasesCommandOutput {
-    this.authorizer.authorizeAccount("kms:ListAliases", options?.caller);
+    this.authorizer.authorizeAccount("kms:ListAliases", options);
 
     const keyId = command.input?.KeyId;
     const aliases = this.keys

--- a/src/service/kms/command/authorize/sim-kms-authorizer.ts
+++ b/src/service/kms/command/authorize/sim-kms-authorizer.ts
@@ -1,8 +1,10 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimKmsCallerAccountCondition } from "../../key/sim-kms-caller-account.js";
 import type { SimKmsKey } from "../../key/sim-kms-key.js";
+import { SimKmsViaService } from "../../key/sim-kms-via-service.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 
 interface SimKmsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -19,10 +21,16 @@ interface SimKmsAuthorizerProperties {
  * - operations with no key to speak of, such as CreateKey and ListKeys, which
  *   real KMS gives no resource-level permissions and so are authorized against
  *   `*` with identity policies alone.
+ *
+ * Both carry the KMS condition values a key policy can be written against:
+ * `kms:CallerAccount` for the Account the request came from, and
+ * `kms:ViaService` where another service made the request on the caller's
+ * behalf.
  */
 export class SimKmsAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly callerAccount = new SimKmsCallerAccountCondition();
 
   constructor(properties: SimKmsAuthorizerProperties) {
     this.iam = properties.iam;
@@ -36,11 +44,17 @@ export class SimKmsAuthorizer {
    * allow: this is the rule that makes a KMS key policy the root of trust for
    * its key rather than one more input to the decision.
    */
-  authorizeKey(action: string, key: SimKmsKey, caller?: SimAwsCaller): void {
+  authorizeKey(
+    action: string,
+    key: SimKmsKey,
+    options: SimKmsRequestOptions = {},
+  ): void {
     const decision = this.iam.authorize({
       action,
       resource: key.arn,
-      caller,
+      caller: options.caller,
+      conditionContext: this.conditionContext(options),
+      callerConditions: this.callerAccount,
       resourcePolicies: [key.policy.asResourcePolicy()],
       requiresResourcePolicyAllow: true,
     });
@@ -57,10 +71,16 @@ export class SimKmsAuthorizer {
   /**
    * Ensure the caller may perform an action that names no particular key.
    */
-  authorizeAccount(action: string, caller?: SimAwsCaller): void {
+  authorizeAccount(action: string, options: SimKmsRequestOptions = {}): void {
     const resource = `arn:aws:kms:${this.accountRegionScope.regionName}:${this.accountRegionScope.accountId}:key/*`;
 
-    const decision = this.iam.authorize({ action, resource, caller });
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options.caller,
+      conditionContext: this.conditionContext(options),
+      callerConditions: this.callerAccount,
+    });
 
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
@@ -69,5 +89,24 @@ export class SimKmsAuthorizer {
         resource,
       });
     }
+  }
+
+  /**
+   * The condition values this request carries.
+   *
+   * A request the caller made itself supplies no `kms:ViaService`, so a policy
+   * conditioned on it fails to match rather than matching anything.
+   */
+  private conditionContext(
+    options: SimKmsRequestOptions,
+  ): Readonly<Record<string, string>> {
+    if (options.viaService === undefined) {
+      return {};
+    }
+
+    return new SimKmsViaService(
+      options.viaService,
+      this.accountRegionScope.regionName,
+    ).asConditionContext();
   }
 }

--- a/src/service/kms/command/authorize/sim-kms-aws-managed-key-authz.iso.test.ts
+++ b/src/service/kms/command/authorize/sim-kms-aws-managed-key-authz.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  DecryptCommand,
+  DescribeKeyCommand,
+  EncryptCommand,
+  GetKeyPolicyCommand,
+} from "@aws-sdk/client-kms";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const managedKeyAlias = "alias/aws/ssm";
+const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
+
+/**
+ * A Role in the given Account allowed one action and nothing else.
+ */
+async function roleAllowed(
+  simAws: SimAws,
+  accountId: string,
+  action: string,
+): Promise<string> {
+  return await createSimIamRoleWithPolicy({
+    simAws,
+    accountId,
+    roleName: `Role-${action.replace(":", "-")}`,
+    policyName: "OnlyPolicy",
+    action,
+  });
+}
+
+describe("KMS AWS managed key authorization", () => {
+  it("lets a caller with no KMS permission use the key through its service", async () => {
+    // Given a Role allowed to read parameters and nothing else.
+    const simAws = new SimAws();
+    const roleArn = await roleAllowed(
+      simAws,
+      simAws.defaultAccountId,
+      "ssm:GetParameter",
+    );
+
+    // When a request reaches the aws/ssm key through Systems Manager.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+        {
+          caller: { kind: "arn", arn: roleArn },
+          viaService: "ssm",
+        },
+      );
+
+    // Then the key policy admits it on its own, which is why a Role holding
+    // only ssm:GetParameter reads a SecureString on real AWS.
+    assertNonNullable(encrypted.KeyId);
+  });
+
+  it("denies a caller reaching the key directly, despite an identity grant", async () => {
+    // Given a Role IAM allows kms:Decrypt on everything, and a ciphertext made
+    // through the owning service.
+    const simAws = new SimAws();
+    const roleArn = await roleAllowed(
+      simAws,
+      simAws.defaultAccountId,
+      "kms:Decrypt",
+    );
+
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+        { viaService: "ssm" },
+      );
+
+    // When the Role decrypts it by calling KMS itself.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .decrypt(
+          new DecryptCommand({ CiphertextBlob: encrypted.CiphertextBlob }),
+          { caller: { kind: "arn", arn: roleArn } },
+        ),
+    );
+
+    // Then it is denied: an AWS managed key policy does not delegate use of
+    // the key to IAM, so an identity grant reaches nothing.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Decrypt");
+  });
+
+  it("denies a request that came through a different service", async () => {
+    // Given the aws/ssm key.
+    const simAws = new SimAws();
+
+    // When a request reaches it through S3 instead.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(
+          new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+          { viaService: "s3" },
+        ),
+    );
+
+    // Then the policy's kms:ViaService condition does not match, and the key
+    // stays reachable only through the service that owns it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a caller from another Account reaching the key through the service", async () => {
+    // Given a Role in another Account whose own IAM allows every KMS action.
+    const simAws = new SimAws();
+    const foreignRoleArn = await roleAllowed(simAws, "222222222222", "kms:*");
+
+    // When it reaches the key through Systems Manager.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(
+          new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+          {
+            caller: { kind: "arn", arn: foreignRoleArn },
+            viaService: "ssm",
+          },
+        ),
+    );
+
+    // Then the policy's kms:CallerAccount condition refuses it: the key admits
+    // its own Account's principals, not everyone using the service.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("lets the Account read the key's metadata but not use it", async () => {
+    // Given the aws/ssm key and the Account root, which IAM allows everything.
+    const simAws = new SimAws();
+
+    // When the Account describes the key and then tries to encrypt with it.
+    const described = await simAws
+      .kms()
+      .describeKey(new DescribeKeyCommand({ KeyId: managedKeyAlias }));
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(
+          new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+        ),
+    );
+
+    // Then the metadata comes back and the encryption does not: the policy
+    // delegates reading the key to IAM and nothing more.
+    assertIdentical(described.KeyMetadata?.KeyManager, "AWS");
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("gives the key the via-service policy rather than the customer default", async () => {
+    // Given the aws/ssm key.
+    const simAws = new SimAws();
+
+    // When its policy is read.
+    const read = await simAws
+      .kms()
+      .getKeyPolicy(new GetKeyPolicyCommand({ KeyId: managedKeyAlias }));
+
+    // Then it is the policy real AWS gives an AWS managed key: use of the key
+    // scoped to the owning service and the owning Account, and a second
+    // statement covering the key's metadata and no more.
+    assertNonNullable(read.Policy);
+    assertStringIncludes(read.Policy, `"Id":"auto-ssm-1"`);
+    assertStringIncludes(read.Policy, `"kms:ViaService":"ssm.us-east-1`);
+    assertStringIncludes(
+      read.Policy,
+      `"kms:CallerAccount":"${simAws.defaultAccountId}"`,
+    );
+    assertStringIncludes(read.Policy, `"kms:Describe*"`);
+  });
+
+  it("refuses a via-service endpoint where a service name is wanted", async () => {
+    // Given the aws/ssm key.
+    const simAws = new SimAws();
+
+    // When a request names the service by endpoint.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(
+          new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+          { viaService: "ssm.us-east-1.amazonaws.com" },
+        ),
+    );
+
+    // Then it is refused rather than producing a value nothing can match. The
+    // region comes from the key, so the caller supplies the service alone.
+    assertStringIncludes(error.message, "rather than by endpoint");
+  });
+});

--- a/src/service/kms/command/crypto/sim-kms-crypto-commands.ts
+++ b/src/service/kms/command/crypto/sim-kms-crypto-commands.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import { SimKmsValidationException } from "../../error/sim-kms.error.js";
 import { SimKmsCiphertextBlob } from "../../key/sim-kms-ciphertext-blob.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
@@ -28,10 +28,6 @@ interface SimKmsCryptoCommandsProperties {
   readonly authorizer: SimKmsAuthorizer;
 }
 
-interface SimKmsCryptoCommandOptions {
-  readonly caller?: SimAwsCaller;
-}
-
 /**
  * The Encrypt and Decrypt commands of one simulated KMS scope.
  *
@@ -55,7 +51,7 @@ export class SimKmsCryptoCommands {
    */
   encrypt(
     command: SimEncryptCommand,
-    options?: SimKmsCryptoCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimEncryptCommandOutput {
     const plaintext = command.input.Plaintext;
 
@@ -74,7 +70,7 @@ export class SimKmsCryptoCommands {
     }
 
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:Encrypt", key, options?.caller);
+    this.authorizer.authorizeKey("kms:Encrypt", key, options);
 
     return {
       $metadata: {},
@@ -93,7 +89,7 @@ export class SimKmsCryptoCommands {
    */
   decrypt(
     command: SimDecryptCommand,
-    options?: SimKmsCryptoCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimDecryptCommandOutput {
     const ciphertextBlob = command.input.CiphertextBlob;
 
@@ -108,7 +104,7 @@ export class SimKmsCryptoCommands {
     const parts = this.blob.decode(ciphertextBlob);
     const key = this.ciphertextKey.behind(parts.keyArn);
 
-    this.authorizer.authorizeKey("kms:Decrypt", key, options?.caller);
+    this.authorizer.authorizeKey("kms:Decrypt", key, options);
     this.ciphertextKey.requireExpected(command.input.KeyId, key);
 
     return {

--- a/src/service/kms/command/crypto/sim-kms-generate-data-key.ts
+++ b/src/service/kms/command/crypto/sim-kms-generate-data-key.ts
@@ -1,5 +1,5 @@
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import { randomBytes } from "node:crypto";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
 import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
 import type {
@@ -11,10 +11,6 @@ import { SimKmsDataKeySpec } from "./sim-kms-data-key-spec.js";
 interface SimKmsGenerateDataKeyProperties {
   readonly keys: SimKmsKeyStore;
   readonly authorizer: SimKmsAuthorizer;
-}
-
-interface SimKmsGenerateDataKeyOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -40,7 +36,7 @@ export class SimKmsGenerateDataKey {
    */
   handle(
     command: SimGenerateDataKeyCommand,
-    options?: SimKmsGenerateDataKeyOptions,
+    options?: SimKmsRequestOptions,
   ): SimGenerateDataKeyCommandOutput {
     const length = this.dataKeySpec.lengthFor(
       command.input.KeySpec,
@@ -48,7 +44,7 @@ export class SimKmsGenerateDataKey {
     );
     const key = this.keys.require(command.input.KeyId);
 
-    this.authorizer.authorizeKey("kms:GenerateDataKey", key, options?.caller);
+    this.authorizer.authorizeKey("kms:GenerateDataKey", key, options);
 
     const dataKey = Uint8Array.from(randomBytes(length));
 

--- a/src/service/kms/command/key/sim-kms-key-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-commands.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import type { SimKmsKeyFactory } from "../../key/sim-kms-key-factory.js";
 import { SimKmsPolicyDocument } from "../../key/sim-kms-policy-document.js";
 import { SimKmsKeyType } from "./sim-kms-key-type.js";
@@ -17,10 +17,6 @@ interface SimKmsKeyCommandsProperties {
   readonly keyFactory: SimKmsKeyFactory;
   readonly authorizer: SimKmsAuthorizer;
   readonly metadata: SimKmsKeyMetadataView;
-}
-
-interface SimKmsKeyCommandOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -50,14 +46,14 @@ export class SimKmsKeyCommands {
    */
   create(
     command: SimCreateKeyCommand,
-    options?: SimKmsKeyCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimCreateKeyCommandOutput {
     this.keyType.require(
       command.input.KeyUsage,
       command.input.KeySpec,
       command.input.Origin,
     );
-    this.authorizer.authorizeAccount("kms:CreateKey", options?.caller);
+    this.authorizer.authorizeAccount("kms:CreateKey", options);
 
     const key = this.keyFactory.make({
       description: command.input.Description,
@@ -74,10 +70,10 @@ export class SimKmsKeyCommands {
    */
   describe(
     command: SimDescribeKeyCommand,
-    options?: SimKmsKeyCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimDescribeKeyCommandOutput {
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:DescribeKey", key, options?.caller);
+    this.authorizer.authorizeKey("kms:DescribeKey", key, options);
 
     return { $metadata: {}, KeyMetadata: this.metadata.describe(key) };
   }

--- a/src/service/kms/command/key/sim-kms-key-lifecycle-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-lifecycle-commands.ts
@@ -1,5 +1,5 @@
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
 import { SimKmsPendingWindow } from "./sim-kms-pending-window.js";
 import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
@@ -18,10 +18,6 @@ interface SimKmsKeyLifecycleCommandsProperties {
   readonly keys: SimKmsKeyStore;
   readonly authorizer: SimKmsAuthorizer;
   readonly clock: SimClock;
-}
-
-interface SimKmsKeyLifecycleCommandOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -47,10 +43,10 @@ export class SimKmsKeyLifecycleCommands {
    */
   enable(
     command: SimEnableKeyCommand,
-    options?: SimKmsKeyLifecycleCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimEnableKeyCommandOutput {
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:EnableKey", key, options?.caller);
+    this.authorizer.authorizeKey("kms:EnableKey", key, options);
     key.enable();
 
     return { $metadata: {} };
@@ -61,10 +57,10 @@ export class SimKmsKeyLifecycleCommands {
    */
   disable(
     command: SimDisableKeyCommand,
-    options?: SimKmsKeyLifecycleCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimDisableKeyCommandOutput {
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:DisableKey", key, options?.caller);
+    this.authorizer.authorizeKey("kms:DisableKey", key, options);
     key.disable();
 
     return { $metadata: {} };
@@ -79,15 +75,11 @@ export class SimKmsKeyLifecycleCommands {
    */
   scheduleDeletion(
     command: SimScheduleKeyDeletionCommand,
-    options?: SimKmsKeyLifecycleCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimScheduleKeyDeletionCommandOutput {
     const window = new SimKmsPendingWindow(command.input.PendingWindowInDays);
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey(
-      "kms:ScheduleKeyDeletion",
-      key,
-      options?.caller,
-    );
+    this.authorizer.authorizeKey("kms:ScheduleKeyDeletion", key, options);
 
     const deletionDate = window.deletionDateFrom(this.clock.now());
     key.scheduleDeletion(deletionDate);
@@ -106,10 +98,10 @@ export class SimKmsKeyLifecycleCommands {
    */
   cancelDeletion(
     command: SimCancelKeyDeletionCommand,
-    options?: SimKmsKeyLifecycleCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimCancelKeyDeletionCommandOutput {
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:CancelKeyDeletion", key, options?.caller);
+    this.authorizer.authorizeKey("kms:CancelKeyDeletion", key, options);
     key.cancelDeletion();
 
     return { $metadata: {}, KeyId: key.arn };

--- a/src/service/kms/command/key/sim-kms-key-policy-commands.ts
+++ b/src/service/kms/command/key/sim-kms-key-policy-commands.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import { SimKmsValidationException } from "../../error/sim-kms.error.js";
 import { simKmsKeyPolicyName } from "../../key/sim-kms-key-policy.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
@@ -14,10 +14,6 @@ import type {
 interface SimKmsKeyPolicyCommandsProperties {
   readonly keys: SimKmsKeyStore;
   readonly authorizer: SimKmsAuthorizer;
-}
-
-interface SimKmsKeyPolicyCommandOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -43,12 +39,12 @@ export class SimKmsKeyPolicyCommands {
    */
   get(
     command: SimGetKeyPolicyCommand,
-    options?: SimKmsKeyPolicyCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimGetKeyPolicyCommandOutput {
     this.requireDefaultPolicyName(command.input.PolicyName);
 
     const key = this.keys.require(command.input.KeyId);
-    this.authorizer.authorizeKey("kms:GetKeyPolicy", key, options?.caller);
+    this.authorizer.authorizeKey("kms:GetKeyPolicy", key, options);
 
     return {
       $metadata: {},
@@ -62,7 +58,7 @@ export class SimKmsKeyPolicyCommands {
    */
   put(
     command: SimPutKeyPolicyCommand,
-    options?: SimKmsKeyPolicyCommandOptions,
+    options?: SimKmsRequestOptions,
   ): SimPutKeyPolicyCommandOutput {
     this.requireDefaultPolicyName(command.input.PolicyName);
 
@@ -75,7 +71,7 @@ export class SimKmsKeyPolicyCommands {
     const document = this.policyDocument.parse(policy);
     const key = this.keys.require(command.input.KeyId);
 
-    this.authorizer.authorizeKey("kms:PutKeyPolicy", key, options?.caller);
+    this.authorizer.authorizeKey("kms:PutKeyPolicy", key, options);
     key.policy.replaceWith(document);
 
     return { $metadata: {} };

--- a/src/service/kms/command/key/sim-kms-list-keys.ts
+++ b/src/service/kms/command/key/sim-kms-list-keys.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimKmsRequestOptions } from "../sim-kms-request-options.js";
 import type { SimKmsKeyStore } from "../../key/sim-kms-key-store.js";
 import type { SimKmsAuthorizer } from "../authorize/sim-kms-authorizer.js";
 import type {
@@ -9,10 +9,6 @@ import type {
 interface SimKmsListKeysProperties {
   readonly keys: SimKmsKeyStore;
   readonly authorizer: SimKmsAuthorizer;
-}
-
-interface SimKmsListKeysOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -36,9 +32,9 @@ export class SimKmsListKeys {
    */
   handle(
     command: SimListKeysCommand,
-    options?: SimKmsListKeysOptions,
+    options?: SimKmsRequestOptions,
   ): SimListKeysCommandOutput {
-    this.authorizer.authorizeAccount("kms:ListKeys", options?.caller);
+    this.authorizer.authorizeAccount("kms:ListKeys", options);
 
     const limit = command.input?.Limit;
     const entries = this.keys.keys

--- a/src/service/kms/command/sim-kms-request-options.ts
+++ b/src/service/kms/command/sim-kms-request-options.ts
@@ -1,0 +1,25 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The request context a simulated KMS operation is made in.
+ *
+ * Both parts are request metadata the simulator takes on trust, in the way a
+ * real KMS request carries them: who is making the call, and whether it
+ * arrived through another AWS service rather than from the caller directly.
+ */
+export interface SimKmsRequestOptions {
+  /**
+   * The principal making the request. Defaults to the Account root.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The service making the request on the caller's behalf, named as a service
+   * such as `ssm` rather than as an endpoint.
+   *
+   * It becomes the `kms:ViaService` condition value for the request, using the
+   * region the key belongs to. A caller reaching KMS directly leaves it unset,
+   * and a policy conditioned on `kms:ViaService` then does not match.
+   */
+  readonly viaService?: string | undefined;
+}

--- a/src/service/kms/index.ts
+++ b/src/service/kms/index.ts
@@ -1,4 +1,5 @@
-export { SimKms, type SimKmsRequestOptions } from "./sim-kms.js";
+export { SimKms } from "./sim-kms.js";
+export type { SimKmsRequestOptions } from "./command/sim-kms-request-options.js";
 export {
   SimKmsKey,
   SimKmsKeyManager,

--- a/src/service/kms/key/sim-kms-alias.iso.test.ts
+++ b/src/service/kms/key/sim-kms-alias.iso.test.ts
@@ -17,6 +17,8 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { SimKms } from "../sim-kms.js";
 import {
   SimKmsAlreadyExistsException,
   SimKmsInvalidStateException,
@@ -243,11 +245,13 @@ describe("KMS AWS managed keys", () => {
     // Given a simulation where nothing has created a key.
     const simAws = new SimAws();
 
-    // When a reserved AWS alias is used to encrypt.
+    // When a reserved AWS alias is used to encrypt through the service that
+    // owns it, which is the only way that key can be used.
     const encrypted = await simAws
       .kms()
       .encrypt(
         new EncryptCommand({ KeyId: "alias/aws/s3", Plaintext: plaintext }),
+        { viaService: "s3" },
       );
 
     // Then the key exists, as an AWS managed one, the way it appears on real
@@ -282,13 +286,31 @@ describe("KMS AWS managed keys", () => {
   });
 
   it("refuses to schedule deletion of an AWS managed key", async () => {
-    // Given an AWS managed key materialised by referencing its alias.
+    // Given an AWS managed key in a KMS with no IAM to consult, so nothing
+    // stands between the request and the key itself.
+    const kms = new SimKms();
+    await kms.describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
+
+    // When deletion is scheduled for it.
+    const error = await assertThrowsErrorAsync(async () =>
+      kms.scheduleKeyDeletion(
+        new ScheduleKeyDeletionCommand({ KeyId: "alias/aws/s3" }),
+      ),
+    );
+
+    // Then the key refuses: the owning service created it and only that
+    // service can remove it.
+    assertInstanceOf(error, SimKmsInvalidStateException);
+  });
+
+  it("denies scheduling deletion of an AWS managed key to the Account", async () => {
+    // Given an AWS managed key in a simulation with IAM.
     const simAws = new SimAws();
     await simAws
       .kms()
       .describeKey(new DescribeKeyCommand({ KeyId: "alias/aws/s3" }));
 
-    // When deletion is scheduled for it.
+    // When the Account schedules deletion for it.
     const error = await assertThrowsErrorAsync(async () =>
       simAws
         .kms()
@@ -297,8 +319,9 @@ describe("KMS AWS managed keys", () => {
         ),
     );
 
-    // Then it is refused: the owning service created it and only that service
-    // can remove it.
-    assertInstanceOf(error, SimKmsInvalidStateException);
+    // Then the key policy denies it before the key is asked, as on real AWS:
+    // the policy of an AWS managed key delegates nothing beyond reading its
+    // metadata.
+    assertInstanceOf(error, SimIamAccessDenied);
   });
 });

--- a/src/service/kms/key/sim-kms-caller-account.ts
+++ b/src/service/kms/key/sim-kms-caller-account.ts
@@ -1,0 +1,34 @@
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamCallerConditionSource } from "../../iam/authorize/context/sim-iam-caller-condition-source.js";
+import type { SimIamConditionValue } from "../../iam/policy/sim-iam-policy.js";
+
+/**
+ * The condition key naming the Account a KMS request came from.
+ */
+export const simKmsCallerAccountConditionKey = "kms:CallerAccount";
+
+/**
+ * Supplies `kms:CallerAccount` from the caller IAM resolved.
+ *
+ * This is the other half of the AWS managed key policy: the policy admits any
+ * principal reaching the key through the owning service, so it has to say
+ * which Account those principals may belong to.
+ *
+ * A caller with no Account, such as an anonymous or service principal, leaves
+ * the key out of the condition context, and a policy conditioned on it then
+ * fails to match rather than matching anything.
+ */
+export class SimKmsCallerAccountCondition implements SimIamCallerConditionSource {
+  /**
+   * The Account of the resolved caller, where it has one.
+   */
+  conditionValuesFor(
+    caller: SimAwsResolvedCaller,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    if (caller.accountId === undefined) {
+      return {};
+    }
+
+    return { [simKmsCallerAccountConditionKey]: caller.accountId };
+  }
+}

--- a/src/service/kms/key/sim-kms-key-factory.ts
+++ b/src/service/kms/key/sim-kms-key-factory.ts
@@ -3,9 +3,10 @@ import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { SimKmsCiphertextBlob } from "./sim-kms-ciphertext-blob.js";
-import { SimKmsKey, type SimKmsKeyManager } from "./sim-kms-key.js";
+import { SimKmsKey, SimKmsKeyManager } from "./sim-kms-key.js";
 import { SimKmsKeyMaterial } from "./sim-kms-key-material.js";
 import { SimKmsKeyPolicy } from "./sim-kms-key-policy.js";
+import { SimKmsViaService } from "./sim-kms-via-service.js";
 
 interface SimKmsKeyFactoryProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -15,7 +16,15 @@ interface SimKmsKeyFactoryProperties {
 interface SimKmsMakeKeyProperties {
   readonly description?: string | undefined;
   readonly policy?: SimIamPolicyDocument | undefined;
-  readonly keyManager?: SimKmsKeyManager | undefined;
+
+  /**
+   * The service an AWS managed key belongs to, such as `ssm`.
+   *
+   * Naming it is what makes the key an AWS managed one: it decides both the
+   * key manager and the via-service-scoped policy real AWS gives such a key,
+   * so the two cannot disagree.
+   */
+  readonly awsManagedService?: string | undefined;
 }
 
 /**
@@ -49,21 +58,51 @@ export class SimKmsKeyFactory {
       keyId,
       accountRegionScope: this.accountRegionScope,
       material: new SimKmsKeyMaterial({ keyArn: arn, blob: this.blob }),
-      policy: this.keyPolicy(arn, properties.policy),
+      policy: this.keyPolicy(arn, properties),
       creationDate: this.clock.now(),
       description: properties.description,
-      keyManager: properties.keyManager,
+      keyManager: this.keyManager(properties),
     });
   }
 
-  private keyPolicy(
-    keyArn: string,
-    document: SimIamPolicyDocument | undefined,
-  ): SimKmsKeyPolicy {
-    if (document === undefined) {
-      return SimKmsKeyPolicy.default(keyArn, this.accountRegionScope.accountId);
+  /**
+   * Who manages the key, which is decided by whether a service owns it.
+   */
+  private keyManager(
+    properties: SimKmsMakeKeyProperties,
+  ): SimKmsKeyManager | undefined {
+    if (properties.awsManagedService === undefined) {
+      return undefined;
     }
 
-    return new SimKmsKeyPolicy(keyArn, document);
+    return SimKmsKeyManager.Aws;
+  }
+
+  /**
+   * The policy the key starts with: the one asked for, the AWS managed one, or
+   * the customer default.
+   */
+  private keyPolicy(
+    keyArn: string,
+    properties: SimKmsMakeKeyProperties,
+  ): SimKmsKeyPolicy {
+    if (properties.policy !== undefined) {
+      return new SimKmsKeyPolicy(keyArn, properties.policy);
+    }
+
+    const accountId = this.accountRegionScope.accountId;
+
+    if (properties.awsManagedService !== undefined) {
+      return SimKmsKeyPolicy.awsManaged(
+        keyArn,
+        accountId,
+        new SimKmsViaService(
+          properties.awsManagedService,
+          this.accountRegionScope.regionName,
+        ),
+      );
+    }
+
+    return SimKmsKeyPolicy.default(keyArn, accountId);
   }
 }

--- a/src/service/kms/key/sim-kms-key-policy.ts
+++ b/src/service/kms/key/sim-kms-key-policy.ts
@@ -1,6 +1,11 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimIamResourcePolicyInput } from "../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import { simKmsCallerAccountConditionKey } from "./sim-kms-caller-account.js";
+import {
+  simKmsViaServiceConditionKey,
+  type SimKmsViaService,
+} from "./sim-kms-via-service.js";
 
 /**
  * The name real KMS reports a key's policy under. A KMS key has exactly one
@@ -45,6 +50,58 @@ export class SimKmsKeyPolicy {
           Effect: "Allow",
           Principal: { AWS: `arn:aws:iam::${accountId}:root` },
           Action: "kms:*",
+          Resource: "*",
+        },
+      ],
+    });
+  }
+
+  /**
+   * Build the policy real AWS gives an AWS managed key.
+   *
+   * It is not the customer default with a different name on it. It grants use
+   * of the key to the Account's principals only when the request reaches KMS
+   * through the service that owns the key, and it delegates nothing else to
+   * IAM: the second statement covers reading the key's metadata and no more.
+   *
+   * That is what makes an AWS managed key usable by a caller holding no KMS
+   * permission at all, and unusable by a caller holding kms:Decrypt on it who
+   * calls KMS directly.
+   */
+  static awsManaged(
+    keyArn: string,
+    accountId: SimAwsAccountId,
+    viaService: SimKmsViaService,
+  ): SimKmsKeyPolicy {
+    return new SimKmsKeyPolicy(keyArn, {
+      Version: "2012-10-17",
+      Id: `auto-${viaService.serviceName}-1`,
+      Statement: [
+        {
+          Sid: `Allow access through ${viaService.serviceName} for all principals in the account that are authorized to use ${viaService.serviceName}`,
+          Effect: "Allow",
+          Principal: { AWS: "*" },
+          Action: [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:CreateGrant",
+            "kms:DescribeKey",
+          ],
+          Resource: "*",
+          Condition: {
+            StringEquals: {
+              [simKmsCallerAccountConditionKey]: accountId,
+              [simKmsViaServiceConditionKey]: viaService.value,
+            },
+          },
+        },
+        {
+          Sid: "Allow direct access to key metadata to the account",
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: ["kms:Describe*", "kms:Get*", "kms:List*", "kms:RevokeGrant"],
           Resource: "*",
         },
       ],

--- a/src/service/kms/key/sim-kms-key-store.ts
+++ b/src/service/kms/key/sim-kms-key-store.ts
@@ -6,11 +6,7 @@ import {
 } from "../error/sim-kms.error.js";
 import { SimKmsAlias, simKmsAwsAliasPrefix } from "./sim-kms-alias.js";
 import { SimKmsKeyIdentifierParser } from "./sim-kms-key-identifier.js";
-import {
-  SimKmsKeyManager,
-  type SimKmsKey,
-  type SimKmsKeyId,
-} from "./sim-kms-key.js";
+import type { SimKmsKey, SimKmsKeyId } from "./sim-kms-key.js";
 import type { SimKmsKeyFactory } from "./sim-kms-key-factory.js";
 
 interface SimKmsKeyStoreProperties {
@@ -153,11 +149,17 @@ export class SimKmsKeyStore {
 
   /**
    * Create an AWS managed key on first reference to its reserved alias.
+   *
+   * The service that owns the key is the part of the alias after the reserved
+   * prefix, so `alias/aws/ssm` is the key Systems Manager owns. That is also
+   * the service its policy is scoped to through `kms:ViaService`.
    */
   private makeAwsManagedKey(aliasName: string): SimKmsKey {
+    const serviceName = aliasName.slice(simKmsAwsAliasPrefix.length);
+
     const key = this.keyFactory.make({
-      description: `Default key that protects my ${aliasName.slice(simKmsAwsAliasPrefix.length)} resources when no other key is defined`,
-      keyManager: SimKmsKeyManager.Aws,
+      description: `Default key that protects my ${serviceName} resources when no other key is defined`,
+      awsManagedService: serviceName,
     });
 
     this.add(key);

--- a/src/service/kms/key/sim-kms-via-service.ts
+++ b/src/service/kms/key/sim-kms-via-service.ts
@@ -1,0 +1,58 @@
+/**
+ * The condition key naming the service a KMS request was made through.
+ */
+export const simKmsViaServiceConditionKey = "kms:ViaService";
+
+/**
+ * The service a KMS request reached KMS through, as `kms:ViaService` names it.
+ *
+ * A request a caller makes itself has no value for this key. It is set when
+ * another service calls KMS on the caller's behalf, which is how a caller with
+ * no KMS permission of its own can use an AWS managed key through the service
+ * that owns it, and only through that service.
+ *
+ * The value is always the service's endpoint in the key's own region, since a
+ * key can only be used in the region it belongs to.
+ */
+export class SimKmsViaService {
+  public readonly serviceName: string;
+
+  private readonly regionName: string;
+
+  constructor(serviceName: string, regionName: string) {
+    this.refuseEndpoint(serviceName);
+
+    this.serviceName = serviceName;
+    this.regionName = regionName;
+  }
+
+  /**
+   * The `kms:ViaService` condition value, such as `ssm.eu-west-2.amazonaws.com`.
+   */
+  get value(): string {
+    return `${this.serviceName}.${this.regionName}.amazonaws.com`;
+  }
+
+  /**
+   * This value as a condition context entry.
+   */
+  asConditionContext(): Readonly<Record<string, string>> {
+    return { [simKmsViaServiceConditionKey]: this.value };
+  }
+
+  /**
+   * Refuse a whole endpoint where a service name is wanted.
+   *
+   * The region is the key's own, so a caller passing `ssm.us-east-1.amazonaws.com`
+   * would otherwise produce a value naming a region twice, and every policy
+   * condition would quietly stop matching.
+   */
+  private refuseEndpoint(serviceName: string): void {
+    if (serviceName.includes(".")) {
+      throw new Error(
+        `A simulated KMS request names the service it came through by name, ` +
+          `such as 'ssm', rather than by endpoint: ${serviceName}`,
+      );
+    }
+  }
+}

--- a/src/service/kms/sim-kms.ts
+++ b/src/service/kms/sim-kms.ts
@@ -2,7 +2,6 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../util/background/background.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import {
@@ -12,6 +11,7 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import { SimKmsAliasCommands } from "./command/alias/sim-kms-alias-commands.js";
 import type * as simKmsCommands from "./command/sim-kms-command.types.js";
+import type { SimKmsRequestOptions } from "./command/sim-kms-request-options.js";
 import { SimKmsAuthorizer } from "./command/authorize/sim-kms-authorizer.js";
 import { SimKmsCryptoCommands } from "./command/crypto/sim-kms-crypto-commands.js";
 import { SimKmsGenerateDataKey } from "./command/crypto/sim-kms-generate-data-key.js";
@@ -26,10 +26,6 @@ import { SimKmsKeyFactory } from "./key/sim-kms-key-factory.js";
 import { SimKmsKeyMetadataView } from "./key/sim-kms-key-metadata.js";
 import { SimKmsKeyStore } from "./key/sim-kms-key-store.js";
 import { SimKmsSdkCommandRouter } from "./sdk/sim-kms-sdk-command-router.js";
-
-export interface SimKmsRequestOptions {
-  readonly caller?: SimAwsCaller;
-}
 
 interface SimKmsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -56,9 +56,12 @@ in its place.
 encrypts under the key directly rather than with a data key, so this is an `Encrypt` and a `Decrypt`
 call and nothing more. Two details matter:
 
-- the calls are made as the caller rather than as the service, so a write needs the caller's own
-  `kms:Encrypt` and a decrypting read needs `kms:Decrypt`, each on top of the SSM permission for the
-  parameter;
+- the calls are made as the caller rather than as the service, so under a customer managed key a
+  write needs the caller's own `kms:Encrypt` and a decrypting read needs `kms:Decrypt`, each on top
+  of the SSM permission for the parameter;
+- they are made through the service as well, carrying `kms:ViaService`, which is what lets the
+  `aws/ssm` managed key be used by a caller with no KMS permission at all and by nothing calling KMS
+  directly;
 - the parameter's ARN is bound in as the `PARAMETER_ARN` encryption context, as real Parameter Store
   binds it, so a ciphertext moved into another parameter cannot be decrypted there.
 
@@ -135,8 +138,6 @@ There is no resource policy support, so cross-account access to a parameter cann
 
 - Only standard tier `SecureString` encryption is simulated. The advanced tier's envelope encryption
   through the AWS Encryption SDK is not, so `kms:GenerateDataKey` is never needed.
-- The `aws/ssm` managed key gets simulated KMS's default customer key policy rather than the
-  unchangeable one real AWS gives it, so a caller allowed `kms:Decrypt` on it can decrypt.
 - Parameter labels are refused rather than looked up. `LabelParameterVersion` is not implemented, so
   nothing could create one, and a label selector says that instead of reporting the parameter as
   missing.

--- a/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
+++ b/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
@@ -11,6 +11,17 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 export const ssmDefaultKeyAlias = "alias/aws/ssm";
 
 /**
+ * The service Parameter Store's KMS calls are made through, as
+ * `kms:ViaService` names it.
+ *
+ * Supplying it is what lets a caller read a `SecureString` under the
+ * `aws/ssm` managed key with no KMS permission of its own: that key's policy
+ * admits the Account's principals only when the request reached KMS through
+ * Systems Manager.
+ */
+export const ssmKmsViaService = "ssm";
+
+/**
  * The narrow slice of simulated KMS that SecureString parameters need.
  *
  * Standard tier Parameter Store encrypts under the key directly rather than
@@ -26,7 +37,10 @@ export interface SimSsmKmsCrypto {
         EncryptionContext?: Readonly<Record<string, string>> | undefined;
       };
     },
-    options?: { caller?: SimAwsCaller | undefined },
+    options?: {
+      caller?: SimAwsCaller | undefined;
+      viaService?: string | undefined;
+    },
   ): Promise<{
     CiphertextBlob?: Uint8Array | undefined;
     KeyId?: string | undefined;
@@ -39,7 +53,10 @@ export interface SimSsmKmsCrypto {
         EncryptionContext?: Readonly<Record<string, string>> | undefined;
       };
     },
-    options?: { caller?: SimAwsCaller | undefined },
+    options?: {
+      caller?: SimAwsCaller | undefined;
+      viaService?: string | undefined;
+    },
   ): Promise<{
     Plaintext?: Uint8Array | undefined;
     KeyId?: string | undefined;

--- a/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
@@ -3,6 +3,7 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { reportingKeyProblems } from "./sim-ssm-kms-key-problems.js";
 import {
   ssmDefaultKeyAlias,
+  ssmKmsViaService,
   type SimSsmKmsCrypto,
 } from "./sim-ssm-kms-crypto.js";
 
@@ -32,9 +33,14 @@ interface SimSsmParameterKmsProperties {
  * The KMS calls a SecureString parameter makes.
  *
  * The calls are made as the caller rather than as the service, which is the
- * point: a standard tier write needs `kms:Encrypt` on the key and a decrypting
- * read needs `kms:Decrypt`, each on top of the SSM permission for the
- * parameter itself.
+ * point: under a customer managed key a standard tier write needs
+ * `kms:Encrypt` on the key and a decrypting read needs `kms:Decrypt`, each on
+ * top of the SSM permission for the parameter itself.
+ *
+ * They are also made through the service, which is why the `aws/ssm` managed
+ * key needs no KMS permission at all: its policy admits the Account's
+ * principals when `kms:ViaService` names Systems Manager, and Parameter Store
+ * is what supplies that.
  *
  * Standard tier Parameter Store encrypts under the key directly rather than
  * through a data key, so this is one Encrypt and one Decrypt and nothing more.
@@ -65,7 +71,7 @@ export class SimSsmParameterKms {
               EncryptionContext: this.contextFor(parameterArn),
             },
           },
-          { caller },
+          { caller, viaService: ssmKmsViaService },
         ),
     );
 
@@ -97,7 +103,7 @@ export class SimSsmParameterKms {
               EncryptionContext: this.contextFor(parameterArn),
             },
           },
-          { caller },
+          { caller, viaService: ssmKmsViaService },
         ),
     );
 

--- a/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
@@ -1,5 +1,5 @@
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
-import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { CreateKeyCommand, DecryptCommand } from "@aws-sdk/client-kms";
 import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
 import {
   assertIdentical,
@@ -10,6 +10,7 @@ import {
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
+import { createSimIamRoleWithPolicy } from "../../../../test/iam/create-role-with-policy.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
@@ -84,6 +85,42 @@ const readParameter = {
   Action: "ssm:GetParameter",
   Resource: "*",
 };
+
+/**
+ * A simulated AWS holding one SecureString parameter under the aws/ssm managed
+ * key, and a Role allowed the given SSM action and nothing else.
+ */
+async function simAwsWithManagedKeySecret(
+  action: string,
+): Promise<SimAwsWithSecret> {
+  const simAws = new SimAws();
+  const accountId = simAws.defaultAccountId;
+
+  await simAws.ssm().putParameter(
+    new PutParameterCommand({
+      Name: "/myapp/prod/db-password",
+      Type: "SecureString",
+      Value: "hunter2",
+    }),
+  );
+
+  const roleArn = await createSimIamRoleWithPolicy({
+    simAws,
+    accountId,
+    roleName: "ConfigReader",
+    policyName: "SsmOnly",
+    action,
+  });
+
+  const managedKey = simAws.kms().findKey("alias/aws/ssm");
+  assertNonNullable(managedKey);
+
+  return {
+    simAws,
+    keyArn: managedKey.arn,
+    caller: { kind: "arn", arn: roleArn },
+  };
+}
 
 describe("SSM SecureString IAM authorization", () => {
   it("decrypts for a caller allowed both the parameter and the key", async () => {
@@ -213,5 +250,76 @@ describe("SSM SecureString IAM authorization", () => {
 
     // Then no half-made parameter is left in the store.
     assertUndefined(simAws.ssm().findParameter("/myapp/prod/api-key"));
+  });
+});
+
+describe("SSM SecureString under the aws/ssm managed key", () => {
+  it("decrypts for a caller holding no KMS permission", async () => {
+    // Given a parameter under the managed key and a Role allowed only
+    // ssm:GetParameter.
+    const { simAws, caller } =
+      await simAwsWithManagedKeySecret("ssm:GetParameter");
+
+    // When it reads the parameter with decryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+      { caller },
+    );
+
+    // Then it gets the plaintext with no kms:Decrypt of its own, because the
+    // managed key's policy admits the Account's principals reaching it through
+    // Systems Manager. Asking for that grant is what real AWS does not.
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
+  it("writes for a caller holding no KMS permission", async () => {
+    // Given a Role allowed only ssm:PutParameter.
+    const { simAws, caller } =
+      await simAwsWithManagedKeySecret("ssm:PutParameter");
+
+    // When it writes a SecureString naming no key of its own.
+    const written = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/api-key",
+        Type: "SecureString",
+        Value: "secret",
+      }),
+      { caller },
+    );
+
+    // Then the write succeeds: the same rule covers the encrypting side.
+    assertIdentical(written.Version, 1);
+  });
+
+  it("denies the same caller decrypting the value through KMS", async () => {
+    // Given the same parameter, read as its stored ciphertext.
+    const { simAws, caller } =
+      await simAwsWithManagedKeySecret("ssm:GetParameter");
+
+    const stored = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
+        { caller },
+      );
+
+    assertNonNullable(stored.Parameter?.Value);
+
+    // When the Role takes the ciphertext to KMS itself.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: Buffer.from(stored.Parameter?.Value ?? "", "base64"),
+        }),
+        { caller },
+      ),
+    );
+
+    // Then it is denied. The managed key is usable through Parameter Store and
+    // not otherwise, so the parameter's own permissions stay in charge of it.
+    assertInstanceOf(error, SimIamAccessDenied);
   });
 });

--- a/src/service/ssm/parameter/sim-ssm-secure-string.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string.iso.test.ts
@@ -205,8 +205,22 @@ describe("SSM SecureString parameters", () => {
   });
 
   it("binds a ciphertext to the ARN of the parameter holding it", async () => {
-    // Given a SecureString parameter and the ciphertext it stores.
-    const simAws = await simAwsWithSecret();
+    // Given a SecureString parameter under a customer managed key, which is
+    // the kind a caller can also use directly, and the ciphertext it stores.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata?.Arn,
+      }),
+    );
+
     const stored = await simAws
       .ssm()
       .getParameter(


### PR DESCRIPTION
An AWS managed key now gets the via-service-scoped policy real AWS gives it rather than the customer default, and a simulated service calling KMS on a caller's behalf supplies kms:ViaService. A caller holding only ssm:GetParameter reads a decrypted SecureString under aws/ssm, and a caller holding kms:Decrypt on that key cannot use it directly.

Resolves https://github.com/KensioSoftware/yulin/issues/226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added realistic support for AWS-managed KMS keys, including service-scoped usage through `kms:ViaService`.
  * SSM SecureString values encrypted with the AWS-managed key can be read with only the required SSM permissions.
  * KMS operations now support request context for caller identity and service routing.

* **Bug Fixes**
  * Direct KMS access to AWS-managed keys is correctly denied when requests bypass the owning service.
  * Caller-account and service-mismatch authorization checks now reflect AWS behavior.

* **Documentation**
  * Expanded KMS and SSM guidance with managed-key behavior, permission requirements, limitations, and runnable examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->