### PR TITLE
feat: encrypt Secrets Manager secret values with a simulated KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm i -D @kensio/yulin
 - [ACM](./docs/services/acm "Simulated ACM docs")
 - [CloudFormation](./docs/services/cloudformation "Simulated CloudFormation docs")
 - [CloudFront](./docs/services/cloudfront "Simulated CloudFront docs")
+- [Cognito user pools](./docs/services/cognito "Simulated Cognito user pools docs")
 - [IAM](./docs/services/iam "Simulated IAM docs")
 - [KMS](./docs/services/kms "Simulated KMS docs")
 - [Lambda](./docs/services/lambda "Simulated Lambda docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [ACM](./services/acm/ "Simulated ACM usage docs")
 - [CloudFormation](./services/cloudformation/ "Simulated CloudFormation usage docs")
 - [CloudFront](./services/cloudfront/ "Simulated CloudFront usage docs")
+- [Cognito user pools](./services/cognito/ "Simulated Cognito user pools usage docs")
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1,0 +1,409 @@
+# Simulated Cognito user pools
+
+Yulin includes a simulated Cognito user pool directory for tests and local development. Pools and
+their app clients are held in memory, and every operation is authorized by simulated IAM.
+
+Only user pools are simulated. Cognito identity pools, which exchange a token for AWS credentials,
+are a different service and are not simulated.
+
+Cognito-specific types are imported from the `@kensio/yulin/cognito` subpath.
+
+## Available functionality
+
+Sim Cognito currently supports:
+
+- `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `DeleteUserPoolCommand` and
+  `ListUserPoolsCommand`
+- `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `DeleteUserPoolClientCommand` and
+  `ListUserPoolClientsCommand`
+- Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
+- The real default password policy, and a policy the request sets
+- App client authentication flows, token lifetimes and generated client secrets
+- Authorization of every operation by simulated IAM, against the real IAM action and ARN
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+
+There are no users yet, so nothing signs in. Users, groups, tokens and the authentication flows
+themselves are separate pieces of work.
+
+## Creating a pool and an app client
+
+A pool needs a name. Everything else has a default, and the defaults here are the ones real Cognito
+applies.
+
+```typescript sim-cognito-create-user-pool
+/**
+ * Creating a simulated user pool and an app client in it.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+console.log(pool.UserPool?.Id); // "us-east-1_aBcDeFgHi"
+console.log(pool.UserPool?.Arn);
+// "arn:aws:cognito-idp:us-east-1:888888888888:userpool/us-east-1_aBcDeFgHi"
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+  }),
+);
+
+console.log(appClient.UserPoolClient?.ClientId); // 26 lowercase characters
+```
+
+A pool id names the region the pool was created in, as real pool ids do. Application code that
+splits the id on the underscore to find the region works here for the same reason it works on AWS.
+
+Two pools may share a name. Only the id identifies one.
+
+## Password policy
+
+A pool created without a `Policies` of its own gets the real default: eight characters, with an
+uppercase letter, a lowercase letter, a number and a symbol each required. A request setting some of
+those keeps the defaults for the rest.
+
+```typescript sim-cognito-password-policy
+/**
+ * Reading a simulated user pool's password policy.
+ */
+
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const pool = await simAws.cognitoIdentityProvider().createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    Policies: { PasswordPolicy: { MinimumLength: 12 } },
+  }),
+);
+
+const passwordPolicy = pool.UserPool?.Policies?.PasswordPolicy;
+
+console.log(passwordPolicy?.MinimumLength); // 12
+console.log(passwordPolicy?.RequireSymbols); // true, the default
+```
+
+Nothing checks a password against the policy yet, because a pool holds no users.
+
+## App clients
+
+An app client is how an application reaches a pool. What it holds decides what that application can
+do, so the settings later work depends on are stored and reported rather than dropped.
+
+```typescript sim-cognito-app-client
+/**
+ * A simulated app client with a secret, its authentication flows and its token
+ * lifetimes.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "server",
+    GenerateSecret: true,
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    AccessTokenValidity: 15,
+    TokenValidityUnits: { AccessToken: "minutes" },
+  }),
+);
+
+// The secret is readable again afterwards, as it is on real Cognito.
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+  }),
+);
+
+console.log(described.UserPoolClient?.ClientSecret?.length); // 52
+console.log(described.UserPoolClient?.RefreshTokenValidity); // 30, the default
+```
+
+A client created without `GenerateSecret` has no `ClientSecret` at all, rather than an empty one. A
+client created without `ExplicitAuthFlows` supports `ALLOW_REFRESH_TOKEN_AUTH`, `ALLOW_USER_SRP_AUTH`
+and `ALLOW_CUSTOM_AUTH`, which is what real Cognito gives it. Sign-in with a username and password is
+not among them, which on real AWS is why `USER_PASSWORD_AUTH` fails on a client nobody configured for
+it. Nothing signs in here yet, so the flows a client supports are validated and stored rather than
+acted on.
+
+Token lifetimes default to an hour for access and ID tokens and thirty days for refresh tokens. The
+units are separate inputs, so `AccessTokenValidity: 1` means an hour and `RefreshTokenValidity: 1`
+means a day unless `TokenValidityUnits` says otherwise.
+
+The legacy authentication flows (`ADMIN_NO_SRP_AUTH`, `CUSTOM_AUTH_FLOW_ONLY` and
+`USER_PASSWORD_AUTH`) work on their own, and a request mixing them with the `ALLOW_` prefixed values
+is refused, as real Cognito refuses it.
+
+## Pool ARNs and IAM policies
+
+A pool ARN is the pool id after `userpool/`, so the region appears twice:
+`arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi`.
+
+App clients have no ARN of their own. Every app client operation authorizes against the ARN of the
+pool the client belongs to, so a policy granting `cognito-idp:DescribeUserPoolClient` on a pool
+reaches every client in it. There is no way to narrow it to one client, here or on real AWS.
+
+```typescript sim-cognito-iam-policy
+/**
+ * A simulated IAM policy allowing a Role to read one user pool's app clients.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "AppClientReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "AppClientReader",
+    PolicyName: "ReadAppClients",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "cognito-idp:DescribeUserPoolClient",
+        // The app client is reached through its pool's ARN.
+        Resource: `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`,
+      },
+    }),
+  }),
+);
+
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientId: appClient.UserPoolClient?.ClientId,
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(described.UserPoolClient?.ClientName); // "web"
+```
+
+`CreateUserPool` and `ListUserPools` are the exception. Real Cognito gives those two actions no
+resource-level permissions, so they authorize against `*` here, and a policy naming individual pool
+ARNs grants nothing.
+
+## Listing pools and clients
+
+`ListUserPools` requires `MaxResults`, as the real API does. A request without it is refused rather
+than answered with a default.
+
+```typescript sim-cognito-list-user-pools
+/**
+ * Listing simulated user pools.
+ */
+
+import {
+  CreateUserPoolCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+await cognito.createUserPool(new CreateUserPoolCommand({ PoolName: "staff" }));
+await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "customers" }),
+);
+
+const listed = await cognito.listUserPools(
+  new ListUserPoolsCommand({ MaxResults: 60 }),
+);
+
+console.log(listed.UserPools?.map((pool) => pool.Name));
+// [ "staff", "customers" ]
+```
+
+Both listings are in creation order and hold at most sixty entries. Follow `NextToken` to read the
+rest. A listed pool carries no ARN and a listed app client carries no secret, as real Cognito leaves
+those out of a listing.
+
+## Intercepting the SDK client
+
+Code that builds its own `CognitoIdentityProviderClient` needs no changes. Intercepting the client
+class routes every Command through simulated Cognito.
+
+```typescript sim-cognito-sdk-interception
+/**
+ * Intercepting a CognitoIdentityProviderClient into simulated Cognito.
+ */
+
+import {
+  CognitoIdentityProviderClient,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(CognitoIdentityProviderClient);
+
+// The code under test uses the AWS SDK as normal.
+const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+
+const created = await client.send(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const described = await client.send(
+  new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+);
+
+console.log(described.UserPool?.Id); // "eu-west-2_aBcDeFgHi"
+
+simSdk.restoreAll();
+```
+
+The same applies inside a simulated Lambda handler. A client the handler builds is intercepted and
+dispatched with the function's execution role as the caller, so the role's policy decides whether the
+call succeeds.
+
+## Account and region scoping
+
+A pool belongs to one account and region, as it does on real AWS. A pool id from one scope reaches
+nothing in another.
+
+```typescript sim-cognito-scoping
+/**
+ * A simulated user pool in one Account and Region scope.
+ */
+
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const pool = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .cognitoIdentityProvider()
+  .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+console.log(pool.UserPool?.Id); // "eu-west-2_aBcDeFgHi"
+console.log(pool.UserPool?.Arn);
+// "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi"
+```
+
+## Deletion protection
+
+A pool created through the API is unprotected unless the request asks for protection, which is the
+opposite of what the console does. A pool created with `DeletionProtection: "ACTIVE"` refuses
+`DeleteUserPool` with `InvalidParameterException`.
+
+Real Cognito wants an `UpdateUserPool` request deactivating the protection before the pool can go.
+`UpdateUserPool` is not simulated, so a protected pool cannot be deleted here at all. Create the pool
+without `DeletionProtection` if the test needs to delete it.
+
+## Limitations
+
+Current documented limitations:
+
+- There are no users. `AdminCreateUser`, `SignUp`, `AdminGetUser`, `ListUsers` and the rest are not
+  implemented, so a pool is a directory with nothing in it. `EstimatedNumberOfUsers` is always zero.
+- There are no groups, no tokens and no authentication. `InitiateAuth`, `AdminInitiateAuth`,
+  `RespondToAuthChallenge` and `GetTokensFromRefreshToken` are not implemented. An app client's
+  `ExplicitAuthFlows` and token lifetimes are stored and reported, and nothing reads them yet.
+- Nothing updates a pool or an app client. `UpdateUserPool` and `UpdateUserPoolClient` are not
+  implemented, so `LastModifiedDate` is always the creation date.
+- A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the
+  protection needs `UpdateUserPool`.
+- Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
+  `AliasAttributes`, `AutoVerifiedAttributes`, `Schema`, `LambdaConfig`, `UsernameConfiguration`,
+  `UserAttributeUpdateSettings`, `DeviceConfiguration`, `AccountRecoverySetting`,
+  `AdminCreateUserConfig`, `UserPoolAddOns`, `KeyConfiguration`, `IssuerConfiguration`,
+  `UserPoolTags`, the email and SMS configurations, the message templates, an `MfaConfiguration`
+  other than `OFF`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
+  `PasswordHistorySize`.
+- `UsernameAttributes` is worth calling out among those. A pool that signs users in by email or phone
+  number stores a generated UUID as the username, so a pool created here without that would answer
+  with the wrong username and the right one on real AWS.
+- Unsimulated `CreateUserPoolClient` inputs are refused the same way: the OAuth and managed login
+  settings (`AllowedOAuthFlows`, `AllowedOAuthScopes`, `CallbackURLs`, `LogoutURLs`,
+  `DefaultRedirectURI`, and an `AllowedOAuthFlowsUserPoolClient` of `true`), a
+  `SupportedIdentityProviders` naming anything but `COGNITO`, a `ClientSecret` of your own,
+  `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
+  `RefreshTokenRotation`, `ReadAttributes`, `WriteAttributes`, an `EnableTokenRevocation` of `false`,
+  and a `PreventUserExistenceErrors` of `ENABLED`.
+- A pool does not report `SchemaAttributes`. Real Cognito reports the standard attribute schema on
+  every pool, and there are no user attributes here to describe.
+- Managed login and the hosted UI are not simulated, and neither are the OAuth endpoints, the
+  `/oauth2/token` endpoint among them. Nothing is served over HTTP.
+- The JWKS endpoint at `.../.well-known/jwks.json` is not served, because no tokens are signed yet.
+- Identity providers, resource servers, user pool domains, MFA configuration, risk configuration and
+  Lambda triggers are not simulated.
+- Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
+  `ListTagsForResource` are not implemented.
+- Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.
+- `AWS::Cognito::UserPool` and the other `AWS::Cognito::*` CloudFormation resource types are reported
+  as unsupported and skipped rather than deployed.
+- Cognito is not served as an HTTP API by `serveSimAws`.
+- Cognito identity pools are a different service and nothing about them is simulated.

--- a/docs/services/cognito/sim-cognito-app-client.example.ts
+++ b/docs/services/cognito/sim-cognito-app-client.example.ts
@@ -1,0 +1,41 @@
+/**
+ * A simulated app client with a secret, its authentication flows and its token
+ * lifetimes.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "server",
+    GenerateSecret: true,
+    ExplicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    AccessTokenValidity: 15,
+    TokenValidityUnits: { AccessToken: "minutes" },
+  }),
+);
+
+// The secret is readable again afterwards, as it is on real Cognito.
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientId: appClient.UserPoolClient?.ClientId,
+  }),
+);
+
+console.log(described.UserPoolClient?.ClientSecret?.length); // 52
+console.log(described.UserPoolClient?.RefreshTokenValidity); // 30, the default

--- a/docs/services/cognito/sim-cognito-create-user-pool.example.ts
+++ b/docs/services/cognito/sim-cognito-create-user-pool.example.ts
@@ -1,0 +1,30 @@
+/**
+ * Creating a simulated user pool and an app client in it.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+
+console.log(pool.UserPool?.Id); // "us-east-1_aBcDeFgHi"
+console.log(pool.UserPool?.Arn);
+// "arn:aws:cognito-idp:us-east-1:888888888888:userpool/us-east-1_aBcDeFgHi"
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: pool.UserPool?.Id,
+    ClientName: "web",
+  }),
+);
+
+console.log(appClient.UserPoolClient?.ClientId); // 26 lowercase characters

--- a/docs/services/cognito/sim-cognito-iam-policy.example.ts
+++ b/docs/services/cognito/sim-cognito-iam-policy.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A simulated IAM policy allowing a Role to read one user pool's app clients.
+ */
+
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "AppClientReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "AppClientReader",
+    PolicyName: "ReadAppClients",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "cognito-idp:DescribeUserPoolClient",
+        // The app client is reached through its pool's ARN.
+        Resource: `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`,
+      },
+    }),
+  }),
+);
+
+const described = await cognito.describeUserPoolClient(
+  new DescribeUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientId: appClient.UserPoolClient?.ClientId,
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(described.UserPoolClient?.ClientName); // "web"

--- a/docs/services/cognito/sim-cognito-list-user-pools.example.ts
+++ b/docs/services/cognito/sim-cognito-list-user-pools.example.ts
@@ -1,0 +1,25 @@
+/**
+ * Listing simulated user pools.
+ */
+
+import {
+  CreateUserPoolCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+await cognito.createUserPool(new CreateUserPoolCommand({ PoolName: "staff" }));
+await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "customers" }),
+);
+
+const listed = await cognito.listUserPools(
+  new ListUserPoolsCommand({ MaxResults: 60 }),
+);
+
+console.log(listed.UserPools?.map((pool) => pool.Name));
+// [ "staff", "customers" ]

--- a/docs/services/cognito/sim-cognito-password-policy.example.ts
+++ b/docs/services/cognito/sim-cognito-password-policy.example.ts
@@ -1,0 +1,21 @@
+/**
+ * Reading a simulated user pool's password policy.
+ */
+
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const pool = await simAws.cognitoIdentityProvider().createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    Policies: { PasswordPolicy: { MinimumLength: 12 } },
+  }),
+);
+
+const passwordPolicy = pool.UserPool?.Policies?.PasswordPolicy;
+
+console.log(passwordPolicy?.MinimumLength); // 12
+console.log(passwordPolicy?.RequireSymbols); // true, the default

--- a/docs/services/cognito/sim-cognito-scoping.example.ts
+++ b/docs/services/cognito/sim-cognito-scoping.example.ts
@@ -1,0 +1,19 @@
+/**
+ * A simulated user pool in one Account and Region scope.
+ */
+
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const pool = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .cognitoIdentityProvider()
+  .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+console.log(pool.UserPool?.Id); // "eu-west-2_aBcDeFgHi"
+console.log(pool.UserPool?.Arn);
+// "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi"

--- a/docs/services/cognito/sim-cognito-sdk-interception.example.ts
+++ b/docs/services/cognito/sim-cognito-sdk-interception.example.ts
@@ -1,0 +1,28 @@
+/**
+ * Intercepting a CognitoIdentityProviderClient into simulated Cognito.
+ */
+
+import {
+  CognitoIdentityProviderClient,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+const simSdk = new SimSdk();
+simSdk.intercept(CognitoIdentityProviderClient);
+
+// The code under test uses the AWS SDK as normal.
+const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+
+const created = await client.send(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const described = await client.send(
+  new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+);
+
+console.log(described.UserPool?.Id); // "eu-west-2_aBcDeFgHi"
+
+simSdk.restoreAll();

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -517,7 +517,8 @@ Current documented limitations:
   Yulin simulates.
 - Key material lives in process memory for the lifetime of the `SimAws` instance. That is not a
   security boundary: anything sharing the process can reach it.
-- Sim SSM encrypts `SecureString` parameters with simulated keys and checks `kms:Encrypt` and
-  `kms:Decrypt` for them. No other simulated service does: sim S3, sim DynamoDB, sim Secrets Manager
-  and sim Lambda environment variables do not use simulated keys, and do not check `kms:Decrypt`.
+- Sim SSM encrypts `SecureString` parameters with simulated keys, checking `kms:Encrypt` and
+  `kms:Decrypt`, and sim Secrets Manager encrypts every secret version, checking
+  `kms:GenerateDataKey` and `kms:Decrypt`. No other simulated service uses simulated keys: sim S3,
+  sim DynamoDB and sim Lambda environment variables do not, and do not check `kms:Decrypt`.
 - KMS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -18,6 +18,8 @@ Sim Secrets Manager currently supports:
 - Secret ARNs carrying the six random characters real Secrets Manager appends
 - Friendly names, full ARNs and partial ARNs as interchangeable ways to name a secret
 - Authorization of every operation by simulated IAM, against the real IAM action
+- Encryption of every version through simulated KMS, under `KmsKeyId` or the `aws/secretsmanager`
+  managed key
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - The `AWS::SecretsManager::Secret` CloudFormation resource, including `GenerateSecretString`
 
@@ -61,6 +63,102 @@ console.log(credentials.password); // "hunter2"
 
 `SecretString` and `SecretBinary` are mutually exclusive on write, and exactly one of them comes back
 on read.
+
+## Encryption and KMS permissions
+
+Every version is encrypted through simulated KMS when it is written and decrypted when
+`GetSecretValue` reads it. There is no flag for reading a secret without decrypting it: the read
+either returns the plaintext or fails.
+
+A secret naming no `KmsKeyId` uses the `aws/secretsmanager` AWS managed key, which asks the caller
+for no KMS permission at all. Secrets Manager supplies `kms:ViaService`, and that key's policy allows
+the account's principals to use it through Secrets Manager. A Lambda role granted only
+`secretsmanager:GetSecretValue` therefore reads the secret, as it does on real AWS.
+
+Pass `KmsKeyId` to encrypt under a customer managed key instead, and the caller's own permissions on
+that key start to matter. Secrets Manager uses envelope encryption, asking KMS for a data key per
+version, so a write needs `kms:GenerateDataKey` and a read needs `kms:Decrypt`. A role granted the
+secret but not the key fails here rather than in a deployment.
+
+```typescript sim-secrets-manager-customer-key
+/**
+ * A Role allowed to read a simulated secret but not to decrypt it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const key = await simAws
+  .kms()
+  .createKey(new CreateKeyCommand({ Description: "Secret key" }));
+
+await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "db-credentials",
+    SecretString: "hunter2",
+    KmsKeyId: key.KeyMetadata?.Arn,
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SecretReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The secret is allowed, the key is not.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SecretReader",
+    PolicyName: "ReadDbCredentials",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "secretsmanager:GetSecretValue",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+try {
+  await simAws
+    .secretsManager()
+    .getSecretValue(new GetSecretValueCommand({ SecretId: "db-credentials" }), {
+      caller,
+    });
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}
+```
+
+Each version is bound to its own secret ARN and version id as the KMS encryption context, as real
+Secrets Manager binds them. A `KmsKeyId` naming a key that does not exist, is disabled, or is pending
+deletion fails with `EncryptionFailure` when a value is written under it, and a version whose key has
+since become unusable fails with `DecryptionFailure` when it is read.
+
+Changing `KmsKeyId` applies to versions written afterwards. The versions already written keep the key
+they were made with and stay readable, which is what real AWS does too.
 
 ## Secret ARNs and IAM policies
 
@@ -390,12 +488,9 @@ code into the simulation with nothing touching the network. See
 
 Current documented limitations:
 
-- Secret values are not encrypted. `KmsKeyId` is accepted and reported by `DescribeSecret`, but
-  nothing is encrypted with it and no `kms:Decrypt` check happens. That is looser than real AWS,
-  where a caller also needs permission on the key. Sim SSM does encrypt its `SecureString`
-  parameters through simulated KMS, and the same wiring would fit here, but a secret has versions,
-  staging labels and rotation to carry through it, so it is a change of its own rather than a
-  follow-on.
+- A `KmsKeyId` is checked when a version is written under it, not when it is set on its own. An
+  `UpdateSecret` changing only the key accepts a key that does not exist, and the next write of a
+  value fails.
 - A secret name ending in a hyphen and six alphanumeric characters is refused, which is stricter than
   AWS. Real AWS only advises against such names, because they cannot be told apart from an ARN's
   resource part when a partial ARN is resolved. This rules out ordinary-looking names such as

--- a/docs/services/secretsmanager/sim-secrets-manager-customer-key.example.ts
+++ b/docs/services/secretsmanager/sim-secrets-manager-customer-key.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A Role allowed to read a simulated secret but not to decrypt it.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+
+const key = await simAws
+  .kms()
+  .createKey(new CreateKeyCommand({ Description: "Secret key" }));
+
+await simAws.secretsManager().createSecret(
+  new CreateSecretCommand({
+    Name: "db-credentials",
+    SecretString: "hunter2",
+    KmsKeyId: key.KeyMetadata?.Arn,
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "SecretReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// The secret is allowed, the key is not.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "SecretReader",
+    PolicyName: "ReadDbCredentials",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "secretsmanager:GetSecretValue",
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+try {
+  await simAws
+    .secretsManager()
+    .getSecretValue(new GetSecretValueCommand({ SecretId: "db-credentials" }), {
+      caller,
+    });
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -12,6 +12,7 @@
       "@kensio/yulin/cloudfront/globals": [
         "../src/service/cloudfront/globals.ts"
       ],
+      "@kensio/yulin/cognito": ["../src/service/cognito/index.ts"],
       "@kensio/yulin/dynamodb": ["../src/service/dynamodb/index.ts"],
       "@kensio/yulin/eslint": ["../src/config/eslint/index.ts"],
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "import": "./dist/service/cloudfront/globals.js",
       "types": "./dist/service/cloudfront/globals.d.ts"
     },
+    "./cognito": {
+      "import": "./dist/service/cognito/index.js",
+      "types": "./dist/service/cognito/index.d.ts"
+    },
     "./dynamodb": {
       "import": "./dist/service/dynamodb/index.js",
       "types": "./dist/service/dynamodb/index.d.ts"
@@ -113,6 +117,7 @@
     "@aws-sdk/client-acm": "^3.1095.0",
     "@aws-sdk/client-cloudformation": "^3.1095.0",
     "@aws-sdk/client-cloudfront": "^3.1095.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1096.0",
     "@aws-sdk/client-dynamodb": "^3.1095.0",
     "@aws-sdk/client-iam": "^3.1095.0",
     "@aws-sdk/client-kms": "^3.1095.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@aws-sdk/client-cloudfront':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3.1096.0
+        version: 3.1096.0
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1095.0
         version: 3.1095.0
@@ -189,6 +192,10 @@ packages:
     resolution: {integrity: sha512-ofoHG2WIRl/BzhB0Mme/yz7867fR6Bhxdz/MxQJc9Q1zxPOzX3Go9d5pUb2ESeUeYw16CPBdTYwNhX4ttRL5cg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cognito-identity-provider@3.1096.0':
+    resolution: {integrity: sha512-JU1Q8X5lF9aGMoLnxPghqpEeJ4powqo+Y1xaqtPBvS5SDnxjZSzrYyC6MN8smoiD6O4/mo6kEGySH+MhNR18CA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-dynamodb@3.1095.0':
     resolution: {integrity: sha512-b1Y9NW5U1mOpkmLMnjZeUCo5FchTYfE3ththqXX6MA0beHpDwPydm5UPCJ0gcyHGvlPEYCU7NwANZwGHy+zCzA==}
     engines: {node: '>=20.0.0'}
@@ -233,32 +240,64 @@ packages:
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.62':
+    resolution: {integrity: sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.63':
     resolution: {integrity: sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.64':
+    resolution: {integrity: sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.6':
     resolution: {integrity: sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    resolution: {integrity: sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.68':
     resolution: {integrity: sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.69':
+    resolution: {integrity: sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.72':
     resolution: {integrity: sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.73':
+    resolution: {integrity: sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.61':
     resolution: {integrity: sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.62':
+    resolution: {integrity: sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.5':
     resolution: {integrity: sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    resolution: {integrity: sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    resolution: {integrity: sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.35':
@@ -285,6 +324,10 @@ packages:
     resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.36':
+    resolution: {integrity: sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/s3-request-presigner@3.1095.0':
     resolution: {integrity: sha512-Xhzt3Okc8UrxOnOR8zE2/aG12g8A9I9f8DVF4LX9k3QVKt0c7d9wT4VcM5/6gfFRhtsflFMGdo49pEqawiAS2Q==}
     engines: {node: '>=20.0.0'}
@@ -295,6 +338,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1095.0':
     resolution: {integrity: sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1096.0':
+    resolution: {integrity: sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -1958,6 +2005,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-cognito-identity-provider@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-dynamodb@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2083,11 +2141,29 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.63':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/fetch-http-handler': 5.6.11
       '@smithy/node-http-handler': 4.9.11
       '@smithy/types': 4.16.1
@@ -2109,12 +2185,37 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-login': 3.972.69
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2132,11 +2233,33 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.73':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-ini': 3.973.7
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.61':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2150,12 +2273,31 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/token-providers': 3.1096.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2205,6 +2347,17 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.36':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/s3-request-presigner@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2227,6 +2380,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -32,6 +32,9 @@ export function resolveSimSdkCommandRouter(
     case "CloudFront": {
       return scoped.cloudFront().sdkCommandRouter();
     }
+    case "Cognito Identity Provider": {
+      return scoped.cognitoIdentityProvider().sdkCommandRouter();
+    }
     case "DynamoDB": {
       return scoped.dynamoDb().sdkCommandRouter();
     }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -257,14 +257,15 @@ export class SimAwsServiceFactory {
   /**
    * Create simulated Secrets Manager for an Account Region scope.
    *
-   * Secrets are Region-scoped on real AWS: a secret name is unique within one
-   * Account and Region rather than globally.
+   * Secrets are Region-scoped on real AWS, and their values are encrypted
+   * through that same scope's simulated KMS.
    */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return new SimSecretsManager({
       accountRegionScope: scope.accountRegionScope,
       iam: this.createIam(scope),
       background: this.background,
+      kms: scope.kms(),
     });
   }
 

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -258,10 +258,8 @@ export class SimAwsServiceFactory {
   }
 
   /**
-   * Create simulated Secrets Manager for an Account Region scope.
-   *
-   * Secrets are Region-scoped on real AWS, and their values are encrypted
-   * through that same scope's simulated KMS.
+   * Create simulated Secrets Manager for an Account Region scope, whose secret
+   * values are encrypted through that same scope's simulated KMS.
    */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return new SimSecretsManager({

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -5,6 +5,7 @@ import type {
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
 import { SimCloudFormation } from "../../cloudformation/index.js";
+import { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
@@ -132,9 +133,7 @@ export class SimAwsServiceFactory {
     });
   }
 
-  /**
-   * Create simulated ACM for an Account Region scope.
-   */
+  /** Create simulated ACM for an Account Region scope. */
   createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
     const iam = this.createIam(scope);
 
@@ -154,9 +153,7 @@ export class SimAwsServiceFactory {
     return acm;
   }
 
-  /**
-   * Create simulated CloudFormation for an Account Region scope.
-   */
+  /** Create simulated CloudFormation for an Account Region scope. */
   createCloudFormation(scope: SimAwsAccountRegionContainer): SimCloudFormation {
     return new SimCloudFormation({
       simAws: this.simAws,
@@ -166,16 +163,28 @@ export class SimAwsServiceFactory {
     });
   }
 
-  /**
-   * Create or get simulated CloudFront for an Account scope.
-   */
+  /** Create or get simulated CloudFront for an Account scope. */
   createCloudFront(scope: SimAwsAccountRegionContainer): SimCloudFront {
     return this.accountServices.createCloudFront(scope);
   }
 
   /**
-   * Create simulated DynamoDB for an Account Region scope.
+   * Create simulated Cognito user pools for an Account Region scope.
+   *
+   * User pools are Region-scoped on real AWS: a pool id names its Region, and
+   * a pool cannot be reached from another one.
    */
+  createCognitoIdentityProvider(
+    scope: SimAwsAccountRegionContainer,
+  ): SimCognitoIdentityProvider {
+    return new SimCognitoIdentityProvider({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
     const iam = this.createIam(scope);
 
@@ -186,9 +195,7 @@ export class SimAwsServiceFactory {
     });
   }
 
-  /**
-   * Create or get simulated IAM for an Account scope.
-   */
+  /** Create or get simulated IAM for an Account scope. */
   createIam(scope: SimAwsAccountRegionContainer): SimIam {
     return this.accountServices.createIam(scope);
   }
@@ -233,16 +240,12 @@ export class SimAwsServiceFactory {
     });
   }
 
-  /**
-   * Create or get simulated Route53 for an Account scope.
-   */
+  /** Create or get simulated Route53 for an Account scope. */
   createRoute53(scope: SimAwsAccountRegionContainer): SimRoute53 {
     return this.accountServices.createRoute53(scope);
   }
 
-  /**
-   * Create simulated S3 for an Account Region scope.
-   */
+  /** Create simulated S3 for an Account Region scope. */
   createS3(scope: SimAwsAccountRegionContainer): SimS3 {
     const iam = this.createIam(scope);
 
@@ -285,9 +288,7 @@ export class SimAwsServiceFactory {
     });
   }
 
-  /**
-   * Create simulated STS for an Account/Region scope.
-   */
+  /** Create simulated STS for an Account/Region scope. */
   createSts(scope: SimAwsAccountRegionContainer): SimSts {
     this.createIam(scope);
 

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -6,6 +6,7 @@ import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimIam } from "../iam/index.js";
@@ -76,6 +77,15 @@ export class SimAwsAccountRegionContainer {
   cloudFront(): SimCloudFront {
     return this.memo.getOrCreate("cloudFront", () =>
       this.simAws.serviceFactory.createCloudFront(this),
+    );
+  }
+
+  /**
+   * Get simulated Cognito user pools for this account and region.
+   */
+  cognitoIdentityProvider(): SimCognitoIdentityProvider {
+    return this.memo.getOrCreate("cognitoIdentityProvider", () =>
+      this.simAws.serviceFactory.createCognitoIdentityProvider(this),
     );
   }
 

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -17,6 +17,7 @@ import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
+import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
 import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
@@ -189,86 +190,67 @@ export class SimAws {
     return this.scopes.accountRegionScope(accountId, regionName);
   }
 
-  /**
-   * Get simulated ACM in the default Account Region scope.
-   */
+  /** Get simulated ACM in the default Account Region scope. */
   acm(): SimAcm {
     return this.accountRegionScope().acm();
   }
 
-  /**
-   * Get simulated CloudFormation in the default Account Region scope.
-   */
+  /** Get simulated CloudFormation in the default Account Region scope. */
   cloudFormation(): SimCloudFormation {
     return this.accountRegionScope().cloudFormation();
   }
 
-  /**
-   * Get simulated CloudFront in the default Account scope.
-   */
+  /** Get simulated CloudFront in the default Account scope. */
   cloudFront(): SimCloudFront {
     return this.accountRegionScope().cloudFront();
   }
 
-  /**
-   * Get simulated DynamoDB in the default Account Region scope.
-   */
+  /** Get simulated Cognito user pools in the default Account Region scope. */
+  cognitoIdentityProvider(): SimCognitoIdentityProvider {
+    return this.accountRegionScope().cognitoIdentityProvider();
+  }
+
+  /** Get simulated DynamoDB in the default Account Region scope. */
   dynamoDb(): SimDynamoDatabase {
     return this.accountRegionScope().dynamoDb();
   }
 
-  /**
-   * Get simulated IAM in the default Account scope.
-   */
+  /** Get simulated IAM in the default Account scope. */
   iam(): SimIam {
     return this.accountRegionScope().iam();
   }
 
-  /**
-   * Get simulated KMS in the default Account Region scope.
-   */
+  /** Get simulated KMS in the default Account Region scope. */
   kms(): SimKms {
     return this.accountRegionScope().kms();
   }
 
-  /**
-   * Get simulated Lambda in the default Account Region scope.
-   */
+  /** Get simulated Lambda in the default Account Region scope. */
   lambda(): SimLambda {
     return this.accountRegionScope().lambda();
   }
 
-  /**
-   * Get simulated Route53 in the default Account scope.
-   */
+  /** Get simulated Route53 in the default Account scope. */
   route53(): SimRoute53 {
     return this.accountRegionScope().route53();
   }
 
-  /**
-   * Get simulated S3 in the default Account Region scope.
-   */
+  /** Get simulated S3 in the default Account Region scope. */
   s3(): SimS3 {
     return this.accountRegionScope().s3();
   }
 
-  /**
-   * Get simulated Secrets Manager in the default Account Region scope.
-   */
+  /** Get simulated Secrets Manager in the default Account Region scope. */
   secretsManager(): SimSecretsManager {
     return this.accountRegionScope().secretsManager();
   }
 
-  /**
-   * Get simulated SSM in the default Account Region scope.
-   */
+  /** Get simulated SSM in the default Account Region scope. */
   ssm(): SimSsm {
     return this.accountRegionScope().ssm();
   }
 
-  /**
-   * Get simulated STS in the default Account Region scope.
-   */
+  /** Get simulated STS in the default Account Region scope. */
   sts(): SimSts {
     return this.accountRegionScope().sts();
   }

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -1,0 +1,102 @@
+# Simulated Cognito user pools implementation
+
+This directory contains the simulated Cognito user pools implementation. Cognito identity pools,
+which exchange a token for AWS credentials, are a separate service and are not simulated at all.
+
+This is the foundation the rest of simulated Cognito is built on: the pool, the app client, and the
+authorizer. An app client's authentication flows are validated and stored here, and nothing acts on
+them: users, groups, tokens and sign-in itself are not here yet.
+
+## Entry points
+
+- `sim-cognito-identity-provider.ts` is the main in-memory service object for one account/region
+  scope.
+- `index.ts` exports the public Cognito simulator API for `@kensio/yulin/cognito`.
+
+A `SimCognitoIdentityProvider` instance owns a `SimCognitoUserPoolStore` holding its pools. The
+simulator is scoped to an account and region because real pools are: a pool id names its region, and
+a pool in one region cannot be reached from another.
+
+## Pool and app client model
+
+Pool state lives under `user-pool/`, and app client state under `user-pool/client/`.
+
+`SimCognitoUserPool` is the stored resource: its id, its ARN, its password policy, its deletion
+protection, and its app clients. The pool owns the clients rather than a separate store owning them,
+because that is where they live on real Cognito: deleting a pool takes its clients with it, and a
+client id means nothing outside the pool that issued it.
+
+`makeSimCognitoUserPoolId` builds the `<region>_<nine characters>` form. The region is part of the id
+rather than decoration: SDK code splits a pool id on the underscore to work out which region to talk
+to, and the token issuer URL is built from it the same way.
+
+`SimCognitoUserPoolArn` is the ARN, which is the pool id after `userpool/`. It is the resource every
+Cognito IAM policy is written against, app client operations included, because an app client has no
+ARN of its own.
+
+`SimCognitoPasswordPolicy` applies the defaults real Cognito applies when a request says nothing:
+eight characters, with an uppercase letter, a lowercase letter, a number and a symbol each required.
+Nothing checks a password against the policy yet, since there are no users, but the policy has to be
+right now because it is what those checks will read.
+
+`SimCognitoExplicitAuthFlows` validates the authentication flows an app client supports. The values
+are checked rather than stored as written, because a typo in a flow name would otherwise turn into a
+puzzling sign-in failure much later, and the legacy and `ALLOW_` prefixed flows cannot be mixed, as
+real Cognito refuses to mix them.
+
+`SimCognitoTokenValidity` and `SimCognitoTokenLifetime` resolve the three token lifetimes. A validity
+is a number in a unit, and the two arrive in separate request inputs, so the same `1` means an hour
+for an access token and a day for a refresh token. Resolving both into seconds in one place is what
+stops the pairing being got wrong when tokens are actually issued.
+
+`makeSimCognitoClientSecret` generates a client secret, and only a client created with
+`GenerateSecret` gets one. A public client has no secret at all rather than an empty one, which is
+what makes code computing a `SECRET_HASH` fail on the client it should fail on.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
+rather than one class per command, so the `SimCognitoIdentityProvider` facade stays a delegation:
+
+- `command/user-pool/` — the pool commands, their structural input/output types and their output
+  views
+- `command/client/` — the same for app clients
+- `command/authorize/` — the shared IAM authorizer
+- `command/sim-cognito-page.ts` — the paging both listings share
+
+`SimCognitoUnsimulatedUserPoolOptions` and `SimCognitoUnsimulatedUserPoolClientOptions` gather every
+input this simulation refuses, in one readable place each, rather than scattering the refusals
+through the creation path.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances.
+
+## Authorization
+
+`SimCognitoAuthorizer` splits requests two ways, as real Cognito does:
+
+- operations on a pool, and on the app clients in it, authorize the real IAM action against that
+  pool's ARN, whether or not the pool exists, because real IAM evaluates a request before the service
+  handles it;
+- `CreateUserPool` and `ListUserPools` authorize against `*`, because real Cognito gives those two
+  actions no resource-level permissions, so a policy naming individual pool ARNs grants nothing.
+
+A policy granting an app client action on a pool therefore reaches every client in that pool. There
+is no way to narrow it to one client, here or on real AWS.
+
+## Divergences worth knowing
+
+- Every unsimulated `CreateUserPool` and `CreateUserPoolClient` input is refused rather than ignored.
+  `UsernameAttributes` is the one that matters most: a pool signing users in by email stores a
+  generated UUID as the username, so a pool quietly created without it would answer with the wrong
+  username here and the right one on real AWS.
+- A pool created with `DeletionProtection: ACTIVE` cannot be deleted at all, because `UpdateUserPool`
+  is not simulated and that is the only way to deactivate the protection.
+- Nothing changes a pool or an app client after creation, so `LastModifiedDate` is always the
+  creation date.
+- `SchemaAttributes` is not reported on a pool. Real Cognito reports the standard attribute schema on
+  every pool; there are no user attributes here to describe.
+- Listings are in creation order and carry no filtering.
+
+The full list is in [docs/services/cognito](../../../docs/services/cognito/).

--- a/src/service/cognito/command/authorize/sim-cognito-authorizer.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-authorizer.ts
@@ -1,0 +1,81 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { cognitoUserPoolArnPrefix } from "../../user-pool/sim-cognito-user-pool-arn.js";
+import type { SimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+
+/**
+ * The resource an operation with no particular pool authorizes against.
+ *
+ * Real Cognito gives `CreateUserPool` and `ListUserPools` no resource-level
+ * permissions, so a policy allowing either has to use a resource of `*`.
+ * Authorizing against `*` here is what makes a policy naming individual pool
+ * ARNs fail the same way it would on real AWS.
+ */
+const anyResource = "*";
+
+interface SimCognitoAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to Cognito user pool requests.
+ *
+ * App clients have no ARN of their own, so operations on one authorize
+ * against the ARN of the pool it belongs to. A policy granting
+ * `cognito-idp:DescribeUserPoolClient` on a pool therefore reaches every
+ * client in it, as it does on real AWS.
+ */
+export class SimCognitoAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimCognitoAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a user pool.
+   *
+   * The pool need not exist. Real IAM evaluates a request before the service
+   * handles it, so a caller with no permission is refused whether or not the
+   * pool is there, and never learns which it was.
+   */
+  authorizeUserPool(
+    action: string,
+    userPoolId: SimCognitoUserPoolId,
+    caller?: SimAwsCaller,
+  ): void {
+    this.authorizeResource(
+      action,
+      cognitoUserPoolArnPrefix(this.accountRegionScope) + userPoolId,
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular pool.
+   */
+  authorizeAny(action: string, caller?: SimAwsCaller): void {
+    this.authorizeResource(action, anyResource, caller);
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): void {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-iam.iso.test.ts
@@ -1,0 +1,256 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+  DescribeUserPoolClientCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const accountId = "111111111111" as SimAwsAccountId;
+const regionName = "eu-west-2";
+
+interface SimCognitoWithRole {
+  readonly simAws: SimAws;
+  readonly caller: SimAwsCaller;
+  readonly userPoolId: string;
+}
+
+/**
+ * A pool, and a Role whose only permissions are the statement given.
+ */
+async function simCognitoWithRole(
+  policyStatement: object,
+): Promise<SimCognitoWithRole> {
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+
+  const created = await simAws
+    .cognitoIdentityProvider()
+    .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+  assertNonNullable(created.UserPool?.Id);
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "PoolReader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "PoolReader",
+      PolicyName: "PoolPolicy",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: policyStatement,
+      }),
+    }),
+  );
+
+  return {
+    simAws,
+    caller: { kind: "arn", arn: role.Role.Arn },
+    userPoolId: created.UserPool.Id,
+  };
+}
+
+function userPoolArn(userPoolId: string): string {
+  return `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`;
+}
+
+describe("sim Cognito IAM authorization", () => {
+  it("allows an operation the caller's policy permits on the pool", async () => {
+    // Given a Role allowed to describe one pool by its ARN.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:DescribeUserPool",
+      Resource: "arn:aws:cognito-idp:eu-west-2:111111111111:userpool/*",
+    });
+
+    // When that Role describes the pool.
+    const described = await simAws
+      .cognitoIdentityProvider()
+      .describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+        {
+          caller,
+        },
+      );
+
+    // Then the request is allowed.
+    assertIdentical(described.UserPool?.Arn, userPoolArn(userPoolId));
+  });
+
+  it("denies an operation on a pool the caller's policy does not name", async () => {
+    // Given a Role allowed to describe a different pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:DescribeUserPool",
+      Resource: userPoolArn("eu-west-2_zZzZzZzZz"),
+    });
+
+    // When that Role describes this one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .cognitoIdentityProvider()
+        .describeUserPool(
+          new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+          { caller },
+        );
+    });
+
+    // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("authorizes an app client operation against the pool's ARN", async () => {
+    // Given a Role allowed to create app clients in one pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:*",
+      Resource: userPoolArn("eu-west-2_zZzZzZzZz"),
+    });
+
+    // When that Role creates an app client in another pool.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().createUserPoolClient(
+        new CreateUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientName: "web",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied, because an app client has no ARN of its own and is
+    // reached through its pool's.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("reaches every app client in a pool the policy allows", async () => {
+    // Given a Role allowed everything on one pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:*",
+      Resource: userPoolArn("*"),
+    });
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+      { caller },
+    );
+
+    // When that Role describes the client it made.
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient?.ClientId,
+      }),
+      { caller },
+    );
+
+    // Then it is allowed.
+    assertIdentical(described.UserPoolClient?.ClientName, "web");
+  });
+
+  it("denies creating a pool to a policy naming pool ARNs", async () => {
+    // Given a Role allowed to create pools, but only on a pool ARN.
+    const { simAws, caller } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: ["cognito-idp:CreateUserPool", "cognito-idp:ListUserPools"],
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role creates a pool and lists pools.
+    const poolCreationError = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .cognitoIdentityProvider()
+        .createUserPool(new CreateUserPoolCommand({ PoolName: "another" }), {
+          caller,
+        });
+    });
+    const poolListingError = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .cognitoIdentityProvider()
+        .listUserPools(new ListUserPoolsCommand({ MaxResults: 10 }), {
+          caller,
+        });
+    });
+
+    // Then both are denied, because real Cognito gives those two actions no
+    // resource-level permissions and they authorize against `*`.
+    assertInstanceOf(poolCreationError, SimIamAccessDenied);
+    assertInstanceOf(poolListingError, SimIamAccessDenied);
+  });
+
+  it("allows creating and listing pools to a policy using a resource of *", async () => {
+    // Given a Role allowed those actions on any resource.
+    const { simAws, caller } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: ["cognito-idp:CreateUserPool", "cognito-idp:ListUserPools"],
+      Resource: "*",
+    });
+
+    // When that Role creates a pool and lists pools.
+    const created = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "another" }), {
+        caller,
+      });
+    const listed = await simAws
+      .cognitoIdentityProvider()
+      .listUserPools(new ListUserPoolsCommand({ MaxResults: 10 }), { caller });
+
+    // Then both are allowed.
+    assertIdentical(created.UserPool?.Name, "another");
+    assertIdentical(listed.UserPools?.length, 2);
+  });
+
+  it("denies a caller with no permissions before saying whether a pool exists", async () => {
+    // Given a Role with no Cognito permissions at all.
+    const { simAws, caller } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    });
+
+    // When that Role describes a pool that was never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .cognitoIdentityProvider()
+        .describeUserPool(
+          new DescribeUserPoolCommand({ UserPoolId: "eu-west-2_aBcDeFgHi" }),
+          { caller },
+        );
+    });
+
+    // Then it is denied rather than reported missing, as real IAM evaluates
+    // the request before the service handles it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/cognito/command/client/list-user-pool-clients.command.ts
+++ b/src/service/cognito/command/client/list-user-pool-clients.command.ts
@@ -1,0 +1,33 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * An app client as sim Cognito reports it in a listing, which carries only
+ * enough to describe it with.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientDescription.html
+ */
+export interface SimCognitoUserPoolClientDescription {
+  readonly ClientId?: string | undefined;
+  readonly UserPoolId?: string | undefined;
+  readonly ClientName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ListUserPoolClients command.
+ */
+export interface SimListUserPoolClientsCommand {
+  readonly input: SimListUserPoolClientsCommandInput;
+}
+
+export interface SimListUserPoolClientsCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListUserPoolClientsCommandOutput {
+  readonly UserPoolClients?:
+    readonly SimCognitoUserPoolClientDescription[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
@@ -1,0 +1,179 @@
+import {
+  type CreateUserPoolClientCommandInput,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface RefusedInput {
+  readonly label: string;
+  readonly input: Partial<CreateUserPoolClientCommandInput>;
+  readonly says: string;
+}
+
+const refusedInputs: readonly RefusedInput[] = [
+  {
+    label: "SupportedIdentityProviders",
+    input: { SupportedIdentityProviders: ["COGNITO", "Google"] },
+    says: "federated sign-in happens at the provider",
+  },
+  {
+    label: "AllowedOAuthFlowsUserPoolClient",
+    input: { AllowedOAuthFlowsUserPoolClient: true },
+    says: "the OAuth 2.0 authorization server endpoints",
+  },
+  {
+    label: "EnableTokenRevocation",
+    input: { EnableTokenRevocation: false },
+    says: "token revocation",
+  },
+  {
+    label: "PreventUserExistenceErrors",
+    input: { PreventUserExistenceErrors: "ENABLED" },
+    says: "hiding whether a user exists",
+  },
+  {
+    label: "AllowedOAuthFlows",
+    input: { AllowedOAuthFlows: ["code"] },
+    says: "OAuth grants through managed login",
+  },
+  {
+    label: "AllowedOAuthScopes",
+    input: { AllowedOAuthScopes: ["openid"] },
+    says: "OAuth scopes",
+  },
+  {
+    label: "CallbackURLs",
+    input: { CallbackURLs: ["https://example.com"] },
+    says: "managed login redirects",
+  },
+  {
+    label: "LogoutURLs",
+    input: { LogoutURLs: ["https://example.com/out"] },
+    says: "managed login redirects",
+  },
+  {
+    label: "DefaultRedirectURI",
+    input: { DefaultRedirectURI: "https://example.com" },
+    says: "managed login redirects",
+  },
+  {
+    label: "ClientSecret",
+    input: { ClientSecret: "a".repeat(32) },
+    says: "a secret of your own",
+  },
+  {
+    label: "AnalyticsConfiguration",
+    input: { AnalyticsConfiguration: { ApplicationId: "app" } },
+    says: "Amazon Pinpoint analytics",
+  },
+  {
+    label: "AuthSessionValidity",
+    input: { AuthSessionValidity: 5 },
+    says: "the authentication session lifetime",
+  },
+  {
+    label: "EnablePropagateAdditionalUserContextData",
+    input: { EnablePropagateAdditionalUserContextData: true },
+    says: "threat protection context data",
+  },
+  {
+    label: "RefreshTokenRotation",
+    input: { RefreshTokenRotation: { Feature: "ENABLED" } },
+    says: "refresh token rotation",
+  },
+  {
+    label: "ReadAttributes",
+    input: { ReadAttributes: ["email"] },
+    says: "per-client attribute permissions",
+  },
+  {
+    label: "WriteAttributes",
+    input: { WriteAttributes: ["email"] },
+    says: "per-client attribute permissions",
+  },
+];
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+async function refusedClient(
+  withPool: SimCognitoWithPool,
+  input: Partial<CreateUserPoolClientCommandInput>,
+  label: string,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "web",
+        ...input,
+      }),
+    );
+  }, label);
+}
+
+describe("sim Cognito app client unsimulated options", () => {
+  it("refuses every CreateUserPoolClient input it does not simulate", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When each unsimulated input is used.
+    const outcomes = await Promise.all(
+      refusedInputs.map(async (refused) => ({
+        refused,
+        error: await refusedClient(withPool, refused.input, refused.label),
+      })),
+    );
+
+    // Then each request is refused, saying what it was that could not be
+    // honoured.
+    for (const { refused, error } of outcomes) {
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(error.message, refused.says);
+    }
+  });
+
+  it("accepts the inputs whose only simulated value is their default", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client asks for the settings this simulation does model.
+    const created = await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "web",
+        SupportedIdentityProviders: ["COGNITO"],
+        AllowedOAuthFlowsUserPoolClient: false,
+        EnableTokenRevocation: true,
+        PreventUserExistenceErrors: "LEGACY",
+      }),
+    );
+
+    // Then it is created rather than refused.
+    assertIdentical(created.UserPoolClient?.ClientName, "web");
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-client-validation.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-client-validation.iso.test.ts
@@ -1,0 +1,281 @@
+import {
+  type CreateUserPoolClientCommandInput,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+async function refusedClient(
+  withPool: SimCognitoWithPool,
+  input: Partial<CreateUserPoolClientCommandInput>,
+  label: string,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "web",
+        ...input,
+      }),
+    );
+  }, label);
+}
+
+describe("sim Cognito app client validation", () => {
+  it("refuses a client with no name", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client is created without a name.
+    const error = await refusedClient(
+      withPool,
+      { ClientName: undefined },
+      "no name",
+    );
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "ClientName is required");
+  });
+
+  it("refuses an authentication flow Cognito does not have", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client asks for a flow that does not exist. The SDK's own types
+    // insist on a known one, so this is the request as it reaches the
+    // simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await withPool.cognito.createUserPoolClient({
+        input: {
+          UserPoolId: withPool.userPoolId,
+          ClientName: "web",
+          ExplicitAuthFlows: ["ALLOW_USER_PASSWORD"],
+        },
+      });
+    });
+
+    // Then it is refused rather than stored to fail at sign-in.
+    assertStringIncludes(error.message, "is not a Cognito authentication flow");
+  });
+
+  it("refuses a client mixing legacy and current authentication flows", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client asks for both generations of flow at once.
+    const error = await refusedClient(
+      withPool,
+      {
+        ExplicitAuthFlows: ["USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+      },
+      "mixed flows",
+    );
+
+    // Then it is refused, as real Cognito refuses it.
+    assertStringIncludes(error.message, "cannot mix the legacy flows");
+  });
+
+  it("allows the legacy authentication flows on their own", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client asks only for legacy flows.
+    const created = await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "legacy",
+        ExplicitAuthFlows: ["USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    // Then it is created, as an app client made years ago would be.
+    assertIdentical(
+      created.UserPoolClient?.ExplicitAuthFlows?.[0],
+      "USER_PASSWORD_AUTH",
+    );
+  });
+
+  it("refuses token lifetimes outside the range Cognito allows", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When an access token is asked to last two days, and another one minute.
+    const tooLong = await refusedClient(
+      withPool,
+      {
+        AccessTokenValidity: 2,
+        TokenValidityUnits: { AccessToken: "days" },
+      },
+      "too long",
+    );
+    const tooShort = await refusedClient(
+      withPool,
+      {
+        AccessTokenValidity: 1,
+        TokenValidityUnits: { AccessToken: "minutes" },
+      },
+      "too short",
+    );
+
+    // Then both are refused, because an access token lasts between five
+    // minutes and a day.
+    assertStringIncludes(tooLong.message, "AccessTokenValidity of 2 days");
+    assertStringIncludes(tooShort.message, "AccessTokenValidity of 1 minutes");
+  });
+
+  it("refuses a token validity that is not a whole number", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When half an hour is asked for as a fraction.
+    const error = await refusedClient(
+      withPool,
+      { AccessTokenValidity: 0.5 },
+      "fractional",
+    );
+
+    // Then it is refused.
+    assertStringIncludes(
+      error.message,
+      "AccessTokenValidity must be a whole number of hours",
+    );
+  });
+
+  it("refuses a token validity unit Cognito does not have", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a lifetime is counted in weeks.
+    const error = await assertThrowsErrorAsync(async () => {
+      await withPool.cognito.createUserPoolClient({
+        input: {
+          UserPoolId: withPool.userPoolId,
+          ClientName: "web",
+          TokenValidityUnits: { IdToken: "weeks" },
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(
+      error.message,
+      "TokenValidityUnits for IdTokenValidity is 'weeks'",
+    );
+  });
+
+  it("refuses a refresh token unit Cognito does not have, with no validity counted in it", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client names a refresh token unit and no refresh token validity,
+    // so the thirty day default is what ends up being used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await withPool.cognito.createUserPoolClient({
+        input: {
+          UserPoolId: withPool.userPoolId,
+          ClientName: "web",
+          TokenValidityUnits: { RefreshToken: "weeks" },
+        },
+      });
+    });
+
+    // Then it is still refused, as real Cognito refuses the unit itself.
+    assertStringIncludes(
+      error.message,
+      "TokenValidityUnits for RefreshTokenValidity is 'weeks'",
+    );
+  });
+
+  it("substitutes the default for a refresh token validity of zero", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client asks for a refresh token validity of zero.
+    const created = await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "web",
+        RefreshTokenValidity: 0,
+      }),
+    );
+
+    // Then Cognito's thirty days is used instead, as real Cognito overrides
+    // it.
+    assertIdentical(created.UserPoolClient?.RefreshTokenValidity, 30);
+  });
+
+  it("refuses a request naming no app client, or one that is not a client id", async () => {
+    // Given a user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a client is described with a missing id and with a malformed one.
+    const missing = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPoolClient({
+        input: { UserPoolId: userPoolId },
+      });
+    });
+    const malformed = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPoolClient(
+        new DescribeUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientId: "web client",
+        }),
+      );
+    });
+
+    // Then both fail as validation errors rather than as missing clients.
+    assertInstanceOf(missing, SimCognitoInvalidParameterException);
+    assertStringIncludes(missing.message, "ClientId is required");
+    assertInstanceOf(malformed, SimCognitoInvalidParameterException);
+    assertStringIncludes(malformed.message, "is not an app client id");
+  });
+
+  it("reports an app client that does not exist as missing", async () => {
+    // Given a user pool with no clients.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a client that was never created is described.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPoolClient(
+        new DescribeUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientId: "1a2b3c4d5e6f7g8h9i0j1k2l3m",
+        }),
+      );
+    });
+
+    // Then it is missing.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+    assertStringIncludes(error.message, "does not exist");
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-list-user-pool-clients.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-list-user-pool-clients.iso.test.ts
@@ -1,0 +1,117 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  ListUserPoolClientsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithClients {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithClients(
+  ...clientNames: readonly string[]
+): Promise<SimCognitoWithClients> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  const userPoolId = created.UserPool.Id;
+
+  for (const clientName of clientNames) {
+    // eslint-disable-next-line no-await-in-loop -- clients are created in order
+    await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: clientName,
+      }),
+    );
+  }
+
+  return { cognito, userPoolId };
+}
+
+describe("sim Cognito ListUserPoolClients", () => {
+  it("lists the app clients of one pool in creation order", async () => {
+    // Given a pool with three clients.
+    const { cognito, userPoolId } = await simCognitoWithClients(
+      "web",
+      "mobile",
+      "server",
+    );
+
+    // When they are listed.
+    const listed = await cognito.listUserPoolClients(
+      new ListUserPoolClientsCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then each comes back, with no secret, as real Cognito leaves the secret
+    // out of a listing.
+    assertArrayEquals(
+      listed.UserPoolClients?.map((client) => client.ClientName),
+      ["web", "mobile", "server"],
+    );
+    assertIdentical(listed.UserPoolClients[0]?.UserPoolId, userPoolId);
+    assertUndefined(listed.NextToken);
+  });
+
+  it("pages the listing with a token", async () => {
+    // Given a pool with three clients.
+    const { cognito, userPoolId } = await simCognitoWithClients(
+      "web",
+      "mobile",
+      "server",
+    );
+
+    // When they are asked for two at a time.
+    const firstPage = await cognito.listUserPoolClients(
+      new ListUserPoolClientsCommand({ UserPoolId: userPoolId, MaxResults: 2 }),
+    );
+    const secondPage = await cognito.listUserPoolClients(
+      new ListUserPoolClientsCommand({
+        UserPoolId: userPoolId,
+        MaxResults: 2,
+        NextToken: firstPage.NextToken,
+      }),
+    );
+
+    // Then the token reaches the rest of them.
+    assertArrayEquals(
+      firstPage.UserPoolClients?.map((client) => client.ClientName),
+      ["web", "mobile"],
+    );
+    assertArrayEquals(
+      secondPage.UserPoolClients?.map((client) => client.ClientName),
+      ["server"],
+    );
+  });
+
+  it("refuses to list the clients of a pool that does not exist", async () => {
+    // Given simulated Cognito with one pool.
+    const { cognito } = await simCognitoWithClients("web");
+
+    // When another pool's clients are listed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUserPoolClients(
+        new ListUserPoolClientsCommand({ UserPoolId: "eu-west-2_aBcDeFgHi" }),
+      );
+    });
+
+    // Then the pool is missing.
+    assertStringIncludes(error.message, "does not exist");
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-list-user-pool-clients.ts
+++ b/src/service/cognito/command/client/sim-cognito-list-user-pool-clients.ts
@@ -1,0 +1,73 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoPage } from "../sim-cognito-page.js";
+import { SimCognitoUserPoolClientView } from "./sim-cognito-user-pool-client-view.js";
+import type {
+  SimListUserPoolClientsCommand,
+  SimListUserPoolClientsCommandOutput,
+} from "./list-user-pool-clients.command.js";
+
+interface SimCognitoListUserPoolClientsProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoListUserPoolClientsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * How many app clients a page holds when the request does not say.
+ *
+ * Unlike `ListUserPools`, this operation does not insist on being told, and
+ * sixty is the most Cognito will return either way.
+ */
+const defaultMaxResults = 60;
+
+/**
+ * The ListUserPoolClients command.
+ *
+ * This authorizes against the pool, not against `*`, because real Cognito
+ * gives the action a resource-level permission on the pool whose clients are
+ * being listed.
+ */
+export class SimCognitoListUserPoolClients {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly authorizer: SimCognitoAuthorizer;
+  private readonly view = new SimCognitoUserPoolClientView();
+
+  constructor(properties: SimCognitoListUserPoolClientsProperties) {
+    this.pools = properties.pools;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * List the app clients of one pool, in creation order.
+   */
+  handle(
+    command: SimListUserPoolClientsCommand,
+    options?: SimCognitoListUserPoolClientsOptions,
+  ): SimListUserPoolClientsCommandOutput {
+    const { input } = command;
+    const userPoolId = requireSimCognitoUserPoolId(input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:ListUserPoolClients",
+      userPoolId,
+      options?.caller,
+    );
+
+    const page = new SimCognitoPage(this.pools.require(userPoolId).clients, {
+      maxResults: input.MaxResults ?? defaultMaxResults,
+      nextToken: input.NextToken,
+    });
+
+    return {
+      $metadata: {},
+      UserPoolClients: page.items.map((client) => this.view.listEntry(client)),
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-client-options.ts
@@ -1,0 +1,71 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import { SimCognitoUnsimulatedManagedLogin } from "./sim-cognito-unsimulated-managed-login.js";
+import type { SimCreateUserPoolClientCommandInput } from "./user-pool-client.command.js";
+
+/**
+ * Refuses the CreateUserPoolClient inputs this simulation does not model.
+ *
+ * Storing any of them would suggest an app client that works here would work
+ * there.
+ */
+export class SimCognitoUnsimulatedUserPoolClientOptions {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPoolClient",
+  );
+  private readonly managedLogin = new SimCognitoUnsimulatedManagedLogin();
+
+  /**
+   * Refuse a request carrying an input this simulation cannot honour.
+   */
+  refuseIn(input: SimCreateUserPoolClientCommandInput): void {
+    this.managedLogin.refuseIn(input);
+
+    this.unsimulated.refuseUnless(
+      "EnableTokenRevocation",
+      input.EnableTokenRevocation,
+      true,
+      "token revocation",
+    );
+    this.unsimulated.refuseUnless(
+      "PreventUserExistenceErrors",
+      input.PreventUserExistenceErrors,
+      "LEGACY",
+      "hiding whether a user exists",
+    );
+    this.unsimulated.refuse(
+      "ClientSecret",
+      input.ClientSecret,
+      "a secret of your own instead of a generated one",
+    );
+    this.unsimulated.refuse(
+      "AnalyticsConfiguration",
+      input.AnalyticsConfiguration,
+      "Amazon Pinpoint analytics",
+    );
+    this.unsimulated.refuse(
+      "AuthSessionValidity",
+      input.AuthSessionValidity,
+      "the authentication session lifetime",
+    );
+    this.unsimulated.refuse(
+      "EnablePropagateAdditionalUserContextData",
+      input.EnablePropagateAdditionalUserContextData,
+      "threat protection context data",
+    );
+    this.unsimulated.refuse(
+      "RefreshTokenRotation",
+      input.RefreshTokenRotation,
+      "refresh token rotation",
+    );
+    this.unsimulated.refuse(
+      "ReadAttributes",
+      input.ReadAttributes,
+      "per-client attribute permissions",
+    );
+    this.unsimulated.refuse(
+      "WriteAttributes",
+      input.WriteAttributes,
+      "per-client attribute permissions",
+    );
+  }
+}

--- a/src/service/cognito/command/client/sim-cognito-unsimulated-managed-login.ts
+++ b/src/service/cognito/command/client/sim-cognito-unsimulated-managed-login.ts
@@ -1,0 +1,92 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimCreateUserPoolClientCommandInput } from "./user-pool-client.command.js";
+
+/**
+ * The only identity provider a simulated app client can support.
+ *
+ * `COGNITO` means the pool's own users, which is what a client supports when
+ * a request names no providers at all.
+ */
+const cognitoIdentityProvider = "COGNITO";
+
+/**
+ * Refuses the managed login inputs of an app client.
+ *
+ * Managed login is a hosted web application and a set of OAuth endpoints,
+ * rather than an API this simulation could stand in for, so none of its
+ * settings mean anything here.
+ */
+export class SimCognitoUnsimulatedManagedLogin {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPoolClient",
+  );
+
+  /**
+   * Refuse a request carrying a managed login setting.
+   */
+  refuseIn(input: SimCreateUserPoolClientCommandInput): void {
+    this.refuseSupportedIdentityProviders(input.SupportedIdentityProviders);
+
+    this.unsimulated.refuseUnless(
+      "AllowedOAuthFlowsUserPoolClient",
+      input.AllowedOAuthFlowsUserPoolClient,
+      false,
+      "the OAuth 2.0 authorization server endpoints",
+    );
+    this.unsimulated.refuse(
+      "AllowedOAuthFlows",
+      input.AllowedOAuthFlows,
+      "OAuth grants through managed login",
+    );
+    this.unsimulated.refuse(
+      "AllowedOAuthScopes",
+      input.AllowedOAuthScopes,
+      "OAuth scopes",
+    );
+    this.unsimulated.refuse(
+      "CallbackURLs",
+      input.CallbackURLs,
+      "managed login redirects",
+    );
+    this.unsimulated.refuse(
+      "LogoutURLs",
+      input.LogoutURLs,
+      "managed login redirects",
+    );
+    this.unsimulated.refuse(
+      "DefaultRedirectURI",
+      input.DefaultRedirectURI,
+      "managed login redirects",
+    );
+  }
+
+  /**
+   * Refuse a client federating to an external identity provider.
+   *
+   * A client supporting only `COGNITO` is asking for the pool's own users,
+   * which is what this simulation has, so that one is allowed through.
+   */
+  private refuseSupportedIdentityProviders(
+    providers: readonly string[] | undefined,
+  ): void {
+    if (providers === undefined) {
+      return;
+    }
+
+    const federated = providers.filter(
+      (provider) => provider !== cognitoIdentityProvider,
+    );
+
+    if (federated.length === 0) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `CreateUserPoolClient SupportedIdentityProviders ` +
+        `'${federated.join(", ")}' is not simulated: federated sign-in ` +
+        `happens at the provider rather than in this simulation. Only ` +
+        `'${cognitoIdentityProvider}' is supported.`,
+    );
+  }
+}

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.iso.test.ts
@@ -1,0 +1,257 @@
+import {
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DeleteUserPoolClientCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolClientCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringLength,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+describe("sim Cognito app client commands", () => {
+  it("creates an app client with the defaults real Cognito applies", async () => {
+    // Given a user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When an app client is created with nothing but a name.
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // Then it has an id, no secret, the three default authentication flows,
+    // and refresh tokens lasting thirty days.
+    assertNonNullable(created.UserPoolClient);
+    assertNonNullable(created.UserPoolClient.ClientId);
+    assertStringLength(created.UserPoolClient.ClientId, 26);
+    assertIdentical(created.UserPoolClient.UserPoolId, userPoolId);
+    assertUndefined(created.UserPoolClient.ClientSecret);
+    assertArrayEquals(created.UserPoolClient.ExplicitAuthFlows, [
+      "ALLOW_REFRESH_TOKEN_AUTH",
+      "ALLOW_USER_SRP_AUTH",
+      "ALLOW_CUSTOM_AUTH",
+    ]);
+    assertIdentical(created.UserPoolClient.RefreshTokenValidity, 30);
+    assertUndefined(created.UserPoolClient.AccessTokenValidity);
+  });
+
+  it("generates a client secret only for a client that asked for one", async () => {
+    // Given a user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When one client asks for a secret and another does not.
+    const withSecret = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "server",
+        GenerateSecret: true,
+      }),
+    );
+    const withoutSecret = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        GenerateSecret: false,
+      }),
+    );
+
+    // Then only the first has one, and it is the length Cognito generates.
+    assertNonNullable(withSecret.UserPoolClient?.ClientSecret);
+    assertStringLength(withSecret.UserPoolClient.ClientSecret, 52);
+    assertUndefined(withoutSecret.UserPoolClient?.ClientSecret);
+  });
+
+  it("stores the authentication flows and token lifetimes it is given", async () => {
+    // Given a user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a client names its flows and its token lifetimes.
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+        AccessTokenValidity: 15,
+        IdTokenValidity: 15,
+        RefreshTokenValidity: 1,
+        TokenValidityUnits: {
+          AccessToken: "minutes",
+          IdToken: "minutes",
+          RefreshToken: "days",
+        },
+      }),
+    );
+
+    // Then they are reported back as set, and resolve to the durations they
+    // name.
+    assertArrayEquals(created.UserPoolClient?.ExplicitAuthFlows, [
+      "ALLOW_USER_PASSWORD_AUTH",
+      "ALLOW_REFRESH_TOKEN_AUTH",
+    ]);
+    assertIdentical(created.UserPoolClient.AccessTokenValidity, 15);
+    assertIdentical(
+      created.UserPoolClient.TokenValidityUnits?.AccessToken,
+      "minutes",
+    );
+
+    const client = cognito
+      .findUserPool(userPoolId)
+      ?.findClient(created.UserPoolClient.ClientId ?? "");
+
+    assertNonNullable(client);
+    assertIdentical(client.tokenValidity.accessToken.seconds, 15 * 60);
+    assertIdentical(client.tokenValidity.refreshToken.seconds, 24 * 60 * 60);
+    assertFalse(client.hasSecret);
+    assertTrue(client.explicitAuthFlows.allows("ALLOW_USER_PASSWORD_AUTH"));
+    assertFalse(client.explicitAuthFlows.allows("ALLOW_USER_SRP_AUTH"));
+  });
+
+  it("gives an access token an hour when the client says nothing", async () => {
+    // Given a user pool and a client with no token settings.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // When the stored lifetimes are read.
+    const client = cognito
+      .findUserPool(userPoolId)
+      ?.findClient(created.UserPoolClient?.ClientId ?? "");
+
+    // Then they are the defaults real Cognito applies: an hour for access and
+    // ID tokens, thirty days for refresh tokens.
+    assertNonNullable(client);
+    assertIdentical(client.tokenValidity.accessToken.seconds, 60 * 60);
+    assertIdentical(client.tokenValidity.idToken.seconds, 60 * 60);
+    assertIdentical(
+      client.tokenValidity.refreshToken.seconds,
+      30 * 24 * 60 * 60,
+    );
+  });
+
+  it("describes an app client, including its secret", async () => {
+    // Given a client created with a secret.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "server",
+        GenerateSecret: true,
+      }),
+    );
+
+    // When it is described.
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: created.UserPoolClient?.ClientId,
+      }),
+    );
+
+    // Then the secret comes back, which is how an application reads the one
+    // it was given.
+    assertIdentical(
+      described.UserPoolClient?.ClientSecret,
+      created.UserPoolClient?.ClientSecret,
+    );
+    assertIdentical(described.UserPoolClient?.ClientName, "server");
+  });
+
+  it("deletes an app client", async () => {
+    // Given a client.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+    const clientId = created.UserPoolClient?.ClientId;
+
+    // When it is deleted.
+    await cognito.deleteUserPoolClient(
+      new DeleteUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+
+    // Then it is gone, while its pool is not.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPoolClient(
+        new DescribeUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+    assertNonNullable(cognito.findUserPool(userPoolId));
+  });
+
+  it("takes a pool's app clients with it when the pool is deleted", async () => {
+    // Given a pool with a client.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const created = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // When the pool is deleted.
+    await cognito.deleteUserPool(
+      new DeleteUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then its client cannot be reached either.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPoolClient(
+        new DescribeUserPoolClientCommand({
+          UserPoolId: userPoolId,
+          ClientId: created.UserPoolClient?.ClientId,
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+  });
+});

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
@@ -1,0 +1,138 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCognitoUserPoolClientFactory } from "../../user-pool/client/sim-cognito-user-pool-client-factory.js";
+import { requireSimCognitoUserPoolClientId } from "../../user-pool/client/sim-cognito-user-pool-client-id.js";
+import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoUnsimulatedUserPoolClientOptions } from "./sim-cognito-unsimulated-client-options.js";
+import { SimCognitoUserPoolClientView } from "./sim-cognito-user-pool-client-view.js";
+import type {
+  SimCreateUserPoolClientCommand,
+  SimCreateUserPoolClientCommandOutput,
+  SimDeleteUserPoolClientCommand,
+  SimDeleteUserPoolClientCommandOutput,
+  SimDescribeUserPoolClientCommand,
+  SimDescribeUserPoolClientCommandOutput,
+} from "./user-pool-client.command.js";
+
+interface SimCognitoUserPoolClientCommandsProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly clientFactory: SimCognitoUserPoolClientFactory;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that create, describe and delete a simulated app client.
+ *
+ * Each one authorizes against the pool's ARN, because an app client has no
+ * ARN of its own.
+ */
+export class SimCognitoUserPoolClientCommands {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly clientFactory: SimCognitoUserPoolClientFactory;
+  private readonly authorizer: SimCognitoAuthorizer;
+  private readonly view = new SimCognitoUserPoolClientView();
+  private readonly unsimulatedOptions =
+    new SimCognitoUnsimulatedUserPoolClientOptions();
+
+  constructor(properties: SimCognitoUserPoolClientCommandsProperties) {
+    this.pools = properties.pools;
+    this.clientFactory = properties.clientFactory;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Create an app client in a pool.
+   */
+  create(
+    command: SimCreateUserPoolClientCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimCreateUserPoolClientCommandOutput {
+    const { input } = command;
+    const pool = this.authorizedPool(
+      "cognito-idp:CreateUserPoolClient",
+      input.UserPoolId,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseIn(input);
+
+    const client = this.clientFactory.make({
+      pool,
+      name: input.ClientName,
+      generateSecret: input.GenerateSecret,
+      explicitAuthFlows: input.ExplicitAuthFlows,
+      tokenValidity: input,
+    });
+
+    pool.addClient(client);
+
+    return { $metadata: {}, UserPoolClient: this.view.describe(client) };
+  }
+
+  /**
+   * Describe an app client's settings, including its secret.
+   */
+  describe(
+    command: SimDescribeUserPoolClientCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimDescribeUserPoolClientCommandOutput {
+    const { input } = command;
+    const pool = this.authorizedPool(
+      "cognito-idp:DescribeUserPoolClient",
+      input.UserPoolId,
+      options,
+    );
+    const clientId = requireSimCognitoUserPoolClientId(input.ClientId);
+
+    return {
+      $metadata: {},
+      UserPoolClient: this.view.describe(pool.requireClient(clientId)),
+    };
+  }
+
+  /**
+   * Delete an app client from a pool.
+   */
+  delete(
+    command: SimDeleteUserPoolClientCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimDeleteUserPoolClientCommandOutput {
+    const { input } = command;
+    const pool = this.authorizedPool(
+      "cognito-idp:DeleteUserPoolClient",
+      input.UserPoolId,
+      options,
+    );
+    const clientId = requireSimCognitoUserPoolClientId(input.ClientId);
+
+    pool.removeClient(pool.requireClient(clientId));
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Resolve the pool an app client operation names, once the caller is
+   * allowed to reach it.
+   *
+   * Authorization comes before the lookup, as real IAM evaluates a request
+   * before the service handles it, so a caller with no permission is refused
+   * whether or not the pool is there.
+   */
+  private authorizedPool(
+    action: string,
+    requestedUserPoolId: string | undefined,
+    options: SimCognitoCommandOptions | undefined,
+  ): SimCognitoUserPool {
+    const userPoolId = requireSimCognitoUserPoolId(requestedUserPoolId);
+
+    this.authorizer.authorizeUserPool(action, userPoolId, options?.caller);
+
+    return this.pools.require(userPoolId);
+  }
+}

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
@@ -1,0 +1,52 @@
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPoolClientDescription } from "./list-user-pool-clients.command.js";
+import type { SimCognitoUserPoolClientType } from "./user-pool-client.command.js";
+
+/**
+ * How a simulated app client is reported back to a caller.
+ */
+export class SimCognitoUserPoolClientView {
+  /**
+   * A client as `CreateUserPoolClient` and `DescribeUserPoolClient` report
+   * it.
+   *
+   * The secret is included, as real Cognito includes it: `ClientSecret` on
+   * `DescribeUserPoolClient` is how an application reads the secret it was
+   * given, since nothing else ever shows it again.
+   *
+   * `AccessTokenValidity` and `IdTokenValidity` appear only when the request
+   * set them, which is what real Cognito does. `RefreshTokenValidity` always
+   * appears, defaulted to thirty days.
+   */
+  describe(client: SimCognitoUserPoolClient): SimCognitoUserPoolClientType {
+    const { tokenValidity } = client;
+
+    return {
+      ClientId: client.id,
+      ClientName: client.name,
+      UserPoolId: client.userPoolId,
+      ClientSecret: client.secret,
+      ExplicitAuthFlows: client.explicitAuthFlows.values,
+      AccessTokenValidity: tokenValidity.accessToken.validity,
+      IdTokenValidity: tokenValidity.idToken.validity,
+      RefreshTokenValidity: tokenValidity.refreshToken.validity,
+      TokenValidityUnits: tokenValidity.unitsOutput(),
+      CreationDate: client.creationDate,
+      LastModifiedDate: client.lastModifiedDate,
+    };
+  }
+
+  /**
+   * A client as `ListUserPoolClients` reports it, which carries no secret and
+   * no settings.
+   */
+  listEntry(
+    client: SimCognitoUserPoolClient,
+  ): SimCognitoUserPoolClientDescription {
+    return {
+      ClientId: client.id,
+      ClientName: client.name,
+      UserPoolId: client.userPoolId,
+    };
+  }
+}

--- a/src/service/cognito/command/client/user-pool-client.command.ts
+++ b/src/service/cognito/command/client/user-pool-client.command.ts
@@ -1,0 +1,106 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoTokenValidityUnitsType } from "../../user-pool/client/sim-cognito-token-validity.js";
+
+/**
+ * An app client as sim Cognito reports it.
+ *
+ * Only the properties this simulation models appear. Real Cognito reports
+ * more, including the OAuth and managed login settings.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientType.html
+ */
+export interface SimCognitoUserPoolClientType {
+  readonly ClientId?: string | undefined;
+  readonly ClientName?: string | undefined;
+  readonly UserPoolId?: string | undefined;
+  readonly ClientSecret?: string | undefined;
+  readonly ExplicitAuthFlows?: readonly string[] | undefined;
+  readonly AccessTokenValidity?: number | undefined;
+  readonly IdTokenValidity?: number | undefined;
+  readonly RefreshTokenValidity?: number | undefined;
+  readonly TokenValidityUnits?: SimCognitoTokenValidityUnitsType | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly LastModifiedDate?: Date | undefined;
+}
+
+/**
+ * The CreateUserPoolClient inputs this simulation reads, and the ones it
+ * refuses.
+ *
+ * Every input real Cognito accepts is named here, whether or not it is
+ * simulated, so a request carrying one this simulation does not model can be
+ * refused rather than silently ignored.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolClientCommand/
+ */
+export interface SimCreateUserPoolClientCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientName?: string | undefined;
+  readonly GenerateSecret?: boolean | undefined;
+  readonly ExplicitAuthFlows?: readonly string[] | undefined;
+  readonly AccessTokenValidity?: number | undefined;
+  readonly IdTokenValidity?: number | undefined;
+  readonly RefreshTokenValidity?: number | undefined;
+  readonly TokenValidityUnits?: SimCognitoTokenValidityUnitsType | undefined;
+  readonly AllowedOAuthFlows?: readonly string[] | undefined;
+  readonly AllowedOAuthFlowsUserPoolClient?: boolean | undefined;
+  readonly AllowedOAuthScopes?: readonly string[] | undefined;
+  readonly AnalyticsConfiguration?: object | undefined;
+  readonly AuthSessionValidity?: number | undefined;
+  readonly CallbackURLs?: readonly string[] | undefined;
+  readonly ClientSecret?: string | undefined;
+  readonly DefaultRedirectURI?: string | undefined;
+  readonly EnablePropagateAdditionalUserContextData?: boolean | undefined;
+  readonly EnableTokenRevocation?: boolean | undefined;
+  readonly LogoutURLs?: readonly string[] | undefined;
+  readonly PreventUserExistenceErrors?: string | undefined;
+  readonly ReadAttributes?: readonly string[] | undefined;
+  readonly RefreshTokenRotation?: object | undefined;
+  readonly SupportedIdentityProviders?: readonly string[] | undefined;
+  readonly WriteAttributes?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito CreateUserPoolClient command.
+ */
+export interface SimCreateUserPoolClientCommand {
+  readonly input: SimCreateUserPoolClientCommandInput;
+}
+
+export interface SimCreateUserPoolClientCommandOutput {
+  readonly UserPoolClient?: SimCognitoUserPoolClientType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito DescribeUserPoolClient command.
+ */
+export interface SimDescribeUserPoolClientCommand {
+  readonly input: SimDescribeUserPoolClientCommandInput;
+}
+
+export interface SimDescribeUserPoolClientCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientId?: string | undefined;
+}
+
+export interface SimDescribeUserPoolClientCommandOutput {
+  readonly UserPoolClient?: SimCognitoUserPoolClientType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito DeleteUserPoolClient command.
+ */
+export interface SimDeleteUserPoolClientCommand {
+  readonly input: SimDeleteUserPoolClientCommandInput;
+}
+
+export interface SimDeleteUserPoolClientCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientId?: string | undefined;
+}
+
+export interface SimDeleteUserPoolClientCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -1,0 +1,39 @@
+/**
+ * The sim Cognito Command types, gathered for the service facade.
+ */
+export type {
+  SimCognitoUserPoolType,
+  SimCreateUserPoolCommand,
+  SimCreateUserPoolCommandInput,
+  SimCreateUserPoolCommandOutput,
+  SimDeleteUserPoolCommand,
+  SimDeleteUserPoolCommandInput,
+  SimDeleteUserPoolCommandOutput,
+  SimDescribeUserPoolCommand,
+  SimDescribeUserPoolCommandInput,
+  SimDescribeUserPoolCommandOutput,
+} from "./user-pool/user-pool.command.js";
+export type {
+  SimCognitoUserPoolDescriptionType,
+  SimListUserPoolsCommand,
+  SimListUserPoolsCommandInput,
+  SimListUserPoolsCommandOutput,
+} from "./user-pool/list-user-pools.command.js";
+export type {
+  SimCognitoUserPoolClientType,
+  SimCreateUserPoolClientCommand,
+  SimCreateUserPoolClientCommandInput,
+  SimCreateUserPoolClientCommandOutput,
+  SimDeleteUserPoolClientCommand,
+  SimDeleteUserPoolClientCommandInput,
+  SimDeleteUserPoolClientCommandOutput,
+  SimDescribeUserPoolClientCommand,
+  SimDescribeUserPoolClientCommandInput,
+  SimDescribeUserPoolClientCommandOutput,
+} from "./client/user-pool-client.command.js";
+export type {
+  SimCognitoUserPoolClientDescription,
+  SimListUserPoolClientsCommand,
+  SimListUserPoolClientsCommandInput,
+  SimListUserPoolClientsCommandOutput,
+} from "./client/list-user-pool-clients.command.js";

--- a/src/service/cognito/command/sim-cognito-page.ts
+++ b/src/service/cognito/command/sim-cognito-page.ts
@@ -1,0 +1,92 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * The most Cognito will return in one page of either listing.
+ */
+const maxMaxResults = 60;
+
+interface SimCognitoPageProperties {
+  readonly maxResults: number;
+  readonly nextToken: string | undefined;
+}
+
+/**
+ * One page of listed items, and the token that reaches the next one.
+ *
+ * Both Cognito listings page the same way, so the rules live here once. How
+ * many items a page holds by default is not shared, because `ListUserPools`
+ * insists on being told and `ListUserPoolClients` does not.
+ */
+export class SimCognitoPage<TItem> {
+  public readonly items: readonly TItem[];
+  public readonly nextToken: string | undefined;
+
+  constructor(listed: readonly TItem[], properties: SimCognitoPageProperties) {
+    const maxResults = SimCognitoPage.maxResults(properties.maxResults);
+    const startIndex = SimCognitoPage.startIndex(
+      properties.nextToken,
+      listed.length,
+    );
+    const nextIndex = startIndex + maxResults;
+
+    this.items = listed.slice(startIndex, nextIndex);
+    this.nextToken = SimCognitoPage.tokenFor(nextIndex, listed.length);
+  }
+
+  private static maxResults(requested: number): number {
+    if (
+      !Number.isSafeInteger(requested) ||
+      requested < 1 ||
+      requested > maxMaxResults
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        `MaxResults must be a whole number between 1 and ${String(maxMaxResults)}`,
+      );
+    }
+
+    return requested;
+  }
+
+  /**
+   * Read a continuation token as its offset into the listed items.
+   *
+   * Tokens are the canonical non-negative integer representation this
+   * simulation emits, so anything else is rejected rather than silently
+   * starting again from the beginning. An offset past the end of the list is
+   * rejected for the same reason: no such token is ever issued.
+   */
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(nextToken);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex < 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        "NextToken is not a token this simulation issued",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private static tokenFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+
+    return String(nextIndex);
+  }
+}

--- a/src/service/cognito/command/sim-cognito-unsimulated-input.ts
+++ b/src/service/cognito/command/sim-cognito-unsimulated-input.ts
@@ -1,0 +1,51 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * Refuses a request input this simulation does not model.
+ *
+ * Both creation commands need the same two refusals, in the same words: one
+ * for an input nothing here honours at all, and one for an input whose only
+ * simulated value is the default. Keeping them in one place is what makes
+ * every refusal say why it happened rather than only that it did.
+ */
+export class SimCognitoUnsimulatedInput {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse an input this simulation does not model at all.
+   */
+  refuse(option: string, value: unknown, feature: string): void {
+    if (value === undefined) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `${this.operation} ${option} is not simulated: ${feature} would be ` +
+        `ignored here and applied on real AWS`,
+    );
+  }
+
+  /**
+   * Refuse an input set to anything but the one value this simulation models.
+   */
+  refuseUnless(
+    option: string,
+    value: string | boolean | undefined,
+    simulated: string | boolean,
+    feature: string,
+  ): void {
+    if (value === undefined || value === simulated) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `${this.operation} ${option} '${String(value)}' is not simulated: ` +
+        `${feature} would be ignored here and applied on real AWS. Only ` +
+        `'${String(simulated)}' is supported.`,
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/list-user-pools.command.ts
+++ b/src/service/cognito/command/user-pool/list-user-pools.command.ts
@@ -1,0 +1,32 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * A user pool as sim Cognito reports it in a listing, which carries less than
+ * a described pool does.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolDescriptionType.html
+ */
+export interface SimCognitoUserPoolDescriptionType {
+  readonly Id?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly LastModifiedDate?: Date | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ListUserPools command.
+ */
+export interface SimListUserPoolsCommand {
+  readonly input: SimListUserPoolsCommandInput;
+}
+
+export interface SimListUserPoolsCommandInput {
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListUserPoolsCommandOutput {
+  readonly UserPools?: readonly SimCognitoUserPoolDescriptionType[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-list-user-pools.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-list-user-pools.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  CreateUserPoolCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+async function simCognitoWithPools(
+  ...poolNames: readonly string[]
+): Promise<SimCognitoIdentityProvider> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+
+  for (const poolName of poolNames) {
+    // eslint-disable-next-line no-await-in-loop -- pools are created in order
+    await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: poolName }),
+    );
+  }
+
+  return cognito;
+}
+
+describe("sim Cognito ListUserPools", () => {
+  it("lists the pools in this scope in creation order", async () => {
+    // Given three pools.
+    const cognito = await simCognitoWithPools(
+      "myapp-users",
+      "myapp-staff",
+      "myapp-test",
+    );
+
+    // When they are listed.
+    const listed = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 60 }),
+    );
+
+    // Then each comes back, in the order they were created, with no ARN, as
+    // real Cognito leaves the ARN out of a listing.
+    assertArrayEquals(
+      listed.UserPools?.map((pool) => pool.Name),
+      ["myapp-users", "myapp-staff", "myapp-test"],
+    );
+    assertUndefined(listed.NextToken);
+
+    const first = listed.UserPools[0];
+
+    assertNonNullable(first);
+    assertNonNullable(first.Id);
+    assertNonNullable(first.CreationDate);
+  });
+
+  it("pages the listing with a token", async () => {
+    // Given three pools.
+    const cognito = await simCognitoWithPools(
+      "myapp-users",
+      "myapp-staff",
+      "myapp-test",
+    );
+
+    // When they are asked for two at a time.
+    const firstPage = await cognito.listUserPools(
+      new ListUserPoolsCommand({ MaxResults: 2 }),
+    );
+    const secondPage = await cognito.listUserPools(
+      new ListUserPoolsCommand({
+        MaxResults: 2,
+        NextToken: firstPage.NextToken,
+      }),
+    );
+
+    // Then the token reaches the rest of them.
+    assertArrayEquals(
+      firstPage.UserPools?.map((pool) => pool.Name),
+      ["myapp-users", "myapp-staff"],
+    );
+    assertArrayEquals(
+      secondPage.UserPools?.map((pool) => pool.Name),
+      ["myapp-test"],
+    );
+    assertUndefined(secondPage.NextToken);
+  });
+
+  it("insists on being told how many pools to return", async () => {
+    // Given simulated Cognito.
+    const cognito = await simCognitoWithPools("myapp-users");
+
+    // When a listing asks for no particular number.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUserPools(new ListUserPoolsCommand({} as never));
+    });
+
+    // Then it is refused, as real Cognito requires MaxResults.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(error.message, "MaxResults is required");
+  });
+
+  it("refuses a page size outside the range Cognito allows", async () => {
+    // Given simulated Cognito.
+    const cognito = await simCognitoWithPools("myapp-users");
+
+    // When more than sixty pools are asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUserPools(new ListUserPoolsCommand({ MaxResults: 61 }));
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "between 1 and 60");
+  });
+
+  it("refuses a token it did not issue", async () => {
+    // Given two pools.
+    const cognito = await simCognitoWithPools("myapp-users", "myapp-staff");
+
+    // When a listing carries a token from somewhere else.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUserPools(
+        new ListUserPoolsCommand({ MaxResults: 1, NextToken: "later" }),
+      );
+    });
+
+    // Then it is refused rather than quietly starting again.
+    assertStringIncludes(error.message, "not a token this simulation issued");
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-list-user-pools.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-list-user-pools.ts
@@ -1,0 +1,76 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoPage } from "../sim-cognito-page.js";
+import { SimCognitoUserPoolView } from "./sim-cognito-user-pool-view.js";
+import type {
+  SimListUserPoolsCommand,
+  SimListUserPoolsCommandOutput,
+} from "./list-user-pools.command.js";
+
+interface SimCognitoListUserPoolsProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoListUserPoolsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The ListUserPools command.
+ *
+ * Real Cognito gives this action no resource-level permissions, so it
+ * authorizes against `*` rather than against each pool, and it does not
+ * filter the list by what the caller can reach.
+ */
+export class SimCognitoListUserPools {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly authorizer: SimCognitoAuthorizer;
+  private readonly view = new SimCognitoUserPoolView();
+
+  constructor(properties: SimCognitoListUserPoolsProperties) {
+    this.pools = properties.pools;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Read the requested page size, which `ListUserPools` insists on.
+   *
+   * This is the one listing input real Cognito requires, and a request
+   * omitting it fails validation rather than falling back to a default.
+   */
+  private static requiredMaxResults(requested: number | undefined): number {
+    if (requested === undefined) {
+      throw new SimCognitoInvalidParameterException(
+        "ListUserPools MaxResults is required: ask for between 1 and 60 pools",
+      );
+    }
+
+    return requested;
+  }
+
+  /**
+   * List the user pools in this scope, in creation order.
+   */
+  handle(
+    command: SimListUserPoolsCommand,
+    options?: SimCognitoListUserPoolsOptions,
+  ): SimListUserPoolsCommandOutput {
+    const { input } = command;
+
+    this.authorizer.authorizeAny("cognito-idp:ListUserPools", options?.caller);
+
+    const page = new SimCognitoPage(this.pools.all, {
+      maxResults: SimCognitoListUserPools.requiredMaxResults(input.MaxResults),
+      nextToken: input.NextToken,
+    });
+
+    return {
+      $metadata: {},
+      UserPools: page.items.map((pool) => this.view.listEntry(pool)),
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
@@ -1,0 +1,78 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * Refuses the user pool features this simulation does not model.
+ *
+ * These are the settings that decide what a pool does with its users. None of
+ * them can be honoured here, and a pool created as if they had been would
+ * behave differently in a deployment.
+ */
+export class SimCognitoUnsimulatedUserPoolFeatures {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+
+  /**
+   * Refuse a request carrying a feature this simulation cannot honour.
+   */
+  refuseIn(input: SimCreateUserPoolCommandInput): void {
+    this.unsimulated.refuse(
+      "LambdaConfig",
+      input.LambdaConfig,
+      "Lambda triggers",
+    );
+    this.unsimulated.refuse(
+      "AliasAttributes",
+      input.AliasAttributes,
+      "sign-in aliases",
+    );
+    this.unsimulated.refuse(
+      "AutoVerifiedAttributes",
+      input.AutoVerifiedAttributes,
+      "automatic attribute verification",
+    );
+    this.unsimulated.refuse("Schema", input.Schema, "custom attributes");
+    this.unsimulated.refuse(
+      "UsernameConfiguration",
+      input.UsernameConfiguration,
+      "case-insensitive usernames",
+    );
+    this.unsimulated.refuse(
+      "UserAttributeUpdateSettings",
+      input.UserAttributeUpdateSettings,
+      "verification before an attribute changes",
+    );
+    this.unsimulated.refuse(
+      "DeviceConfiguration",
+      input.DeviceConfiguration,
+      "device remembering",
+    );
+    this.unsimulated.refuse(
+      "AccountRecoverySetting",
+      input.AccountRecoverySetting,
+      "account recovery",
+    );
+    this.unsimulated.refuse(
+      "AdminCreateUserConfig",
+      input.AdminCreateUserConfig,
+      "the AdminCreateUser settings",
+    );
+    this.unsimulated.refuse(
+      "UserPoolAddOns",
+      input.UserPoolAddOns,
+      "threat protection",
+    );
+    this.unsimulated.refuse(
+      "KeyConfiguration",
+      input.KeyConfiguration,
+      "encryption under a customer managed key",
+    );
+    this.unsimulated.refuse(
+      "IssuerConfiguration",
+      input.IssuerConfiguration,
+      "a custom token issuer",
+    );
+    this.unsimulated.refuse("UserPoolTags", input.UserPoolTags, "tags");
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
@@ -1,0 +1,56 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * Refuses the message delivery inputs this simulation does not model.
+ *
+ * Nothing here sends an email or a text message, so a template or a delivery
+ * configuration would be stored and never used.
+ */
+export class SimCognitoUnsimulatedUserPoolMessaging {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+
+  /**
+   * Refuse a request carrying a message setting this simulation cannot
+   * honour.
+   */
+  refuseIn(input: SimCreateUserPoolCommandInput): void {
+    this.unsimulated.refuse(
+      "EmailConfiguration",
+      input.EmailConfiguration,
+      "email delivery",
+    );
+    this.unsimulated.refuse(
+      "SmsConfiguration",
+      input.SmsConfiguration,
+      "SMS delivery",
+    );
+    this.unsimulated.refuse(
+      "VerificationMessageTemplate",
+      input.VerificationMessageTemplate,
+      "verification messages",
+    );
+    this.unsimulated.refuse(
+      "EmailVerificationMessage",
+      input.EmailVerificationMessage,
+      "verification messages",
+    );
+    this.unsimulated.refuse(
+      "EmailVerificationSubject",
+      input.EmailVerificationSubject,
+      "verification messages",
+    );
+    this.unsimulated.refuse(
+      "SmsVerificationMessage",
+      input.SmsVerificationMessage,
+      "verification messages",
+    );
+    this.unsimulated.refuse(
+      "SmsAuthenticationMessage",
+      input.SmsAuthenticationMessage,
+      "multi-factor authentication messages",
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-options.ts
@@ -1,0 +1,77 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import { SimCognitoUnsimulatedUserPoolFeatures } from "./sim-cognito-unsimulated-pool-features.js";
+import { SimCognitoUnsimulatedUserPoolMessaging } from "./sim-cognito-unsimulated-pool-messaging.js";
+import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * Refuses the CreateUserPool inputs this simulation does not model.
+ *
+ * Every one of these changes what the pool does on real AWS, so ignoring any
+ * of them would let a request succeed here and behave differently in a
+ * deployment. `UsernameAttributes` is the one that would hurt most, and it
+ * gets its own refusal saying why.
+ */
+export class SimCognitoUnsimulatedUserPoolOptions {
+  private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+  private readonly features = new SimCognitoUnsimulatedUserPoolFeatures();
+  private readonly messaging = new SimCognitoUnsimulatedUserPoolMessaging();
+
+  /**
+   * Refuse a request carrying an input this simulation cannot honour.
+   */
+  refuseIn(input: SimCreateUserPoolCommandInput): void {
+    this.refuseUsernameAttributes(input.UsernameAttributes);
+
+    this.unsimulated.refuseUnless(
+      "MfaConfiguration",
+      input.MfaConfiguration,
+      "OFF",
+      "multi-factor authentication",
+    );
+    this.unsimulated.refuseUnless(
+      "UserPoolTier",
+      input.UserPoolTier,
+      "ESSENTIALS",
+      "the Lite and Plus feature plans",
+    );
+    this.unsimulated.refuse(
+      "Policies SignInPolicy",
+      input.Policies?.SignInPolicy,
+      "choosing which factors a user may sign in with first",
+    );
+    this.unsimulated.refuse(
+      "Policies PasswordPolicy PasswordHistorySize",
+      input.Policies?.PasswordPolicy?.PasswordHistorySize,
+      "refusing a password the user has used before",
+    );
+
+    this.features.refuseIn(input);
+    this.messaging.refuseIn(input);
+  }
+
+  /**
+   * Refuse a pool that signs users in by an attribute rather than by
+   * username.
+   *
+   * Such a pool stores a generated UUID as the username, so code written
+   * against it looks users up by something this simulation would not have
+   * given them.
+   */
+  private refuseUsernameAttributes(
+    attributes: readonly string[] | undefined,
+  ): void {
+    if (attributes === undefined) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      "CreateUserPool UsernameAttributes is not simulated: a pool that signs " +
+        "users in by email or phone number stores a generated UUID as the " +
+        "username, so simulating the pool without that would answer with the " +
+        "wrong username here and the right one on real AWS",
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.iso.test.ts
@@ -1,0 +1,199 @@
+import {
+  CreateUserPoolCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertStringLength,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
+
+function simCognitoInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("sim Cognito user pool commands", () => {
+  it("creates a user pool with an id naming its region", async () => {
+    // Given simulated Cognito in one account and region.
+    const simAws = simCognitoInEuWest2();
+
+    // When a pool is created.
+    const created = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+    // Then the id takes the real '<region>_<nine characters>' form, and the
+    // ARN names that id.
+    assertNonNullable(created.UserPool);
+    assertNonNullable(created.UserPool.Id);
+    assertStringStartsWith(created.UserPool.Id, "eu-west-2_");
+    assertStringLength(created.UserPool.Id.split("_", 2)[1] ?? "", 9);
+    assertIdentical(
+      created.UserPool.Arn,
+      `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/${created.UserPool.Id}`,
+    );
+    assertIdentical(created.UserPool.Name, "myapp-users");
+    assertInstanceOf(created.UserPool.CreationDate, Date);
+  });
+
+  it("defaults a new pool to the real Cognito defaults", async () => {
+    // Given simulated Cognito.
+    const simAws = simCognitoInEuWest2();
+
+    // When a pool is created with nothing but a name.
+    const created = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+    // Then its password policy is the eight character one real Cognito
+    // applies, it has no MFA, and it is not protected against deletion.
+    assertNonNullable(created.UserPool);
+    assertObjectMatches(created.UserPool, {
+      Policies: {
+        PasswordPolicy: {
+          MinimumLength: 8,
+          RequireUppercase: true,
+          RequireLowercase: true,
+          RequireNumbers: true,
+          RequireSymbols: true,
+          TemporaryPasswordValidityDays: 7,
+        },
+      },
+      MfaConfiguration: "OFF",
+      DeletionProtection: "INACTIVE",
+      EstimatedNumberOfUsers: 0,
+    });
+  });
+
+  it("keeps the parts of a password policy the request sets", async () => {
+    // Given simulated Cognito.
+    const simAws = simCognitoInEuWest2();
+
+    // When a pool is created with a longer minimum and no symbol required.
+    const created = await simAws.cognitoIdentityProvider().createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        Policies: {
+          PasswordPolicy: { MinimumLength: 12, RequireSymbols: false },
+        },
+      }),
+    );
+
+    // Then those are stored, and the rest keep their defaults.
+    assertNonNullable(created.UserPool);
+    assertObjectMatches(created.UserPool, {
+      Policies: {
+        PasswordPolicy: {
+          MinimumLength: 12,
+          RequireSymbols: false,
+          RequireUppercase: true,
+          TemporaryPasswordValidityDays: 7,
+        },
+      },
+    });
+  });
+
+  it("describes a pool by its id", async () => {
+    // Given a created pool.
+    const simAws = simCognitoInEuWest2();
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    // When it is described.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+    );
+
+    // Then the same pool comes back.
+    assertNonNullable(described.UserPool);
+    assertIdentical(described.UserPool.Id, created.UserPool?.Id);
+    assertIdentical(described.UserPool.Name, "myapp-users");
+  });
+
+  it("deletes a pool", async () => {
+    // Given a created pool.
+    const simAws = simCognitoInEuWest2();
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = created.UserPool?.Id;
+
+    // When it is deleted.
+    await cognito.deleteUserPool(
+      new DeleteUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then it is gone.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses to delete a pool protected against deletion", async () => {
+    // Given a pool created with deletion protection active.
+    const simAws = simCognitoInEuWest2();
+    const cognito = simAws.cognitoIdentityProvider();
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        DeletionProtection: "ACTIVE",
+      }),
+    );
+
+    // When deleting it is tried.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.deleteUserPool(
+        new DeleteUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+      );
+    });
+
+    // Then it is refused, as real Cognito refuses it.
+    assertIdentical(error.name, "InvalidParameterException");
+    assertStringIncludes(error.message, "protected against deletion");
+  });
+
+  it("keeps pools in one account and region out of another", async () => {
+    // Given a pool in one account and region.
+    const simAws = new SimAws();
+    const created = await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+    // When another scope is asked for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account("222222222222")
+        .region("us-east-1")
+        .cognitoIdentityProvider()
+        .describeUserPool(
+          new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+        );
+    });
+
+    // Then it is not there, as a pool belongs to one account and region.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -1,0 +1,122 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolFactory } from "../../user-pool/sim-cognito-user-pool-factory.js";
+import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import { SimCognitoUnsimulatedUserPoolOptions } from "./sim-cognito-unsimulated-pool-options.js";
+import { SimCognitoUserPoolView } from "./sim-cognito-user-pool-view.js";
+import type {
+  SimCreateUserPoolCommand,
+  SimCreateUserPoolCommandOutput,
+  SimDeleteUserPoolCommand,
+  SimDeleteUserPoolCommandOutput,
+  SimDescribeUserPoolCommand,
+  SimDescribeUserPoolCommandOutput,
+} from "./user-pool.command.js";
+
+interface SimCognitoUserPoolCommandsProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly poolFactory: SimCognitoUserPoolFactory;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that create, describe and delete a simulated user pool.
+ */
+export class SimCognitoUserPoolCommands {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly poolFactory: SimCognitoUserPoolFactory;
+  private readonly authorizer: SimCognitoAuthorizer;
+  private readonly view = new SimCognitoUserPoolView();
+  private readonly unsimulatedOptions =
+    new SimCognitoUnsimulatedUserPoolOptions();
+
+  constructor(properties: SimCognitoUserPoolCommandsProperties) {
+    this.pools = properties.pools;
+    this.poolFactory = properties.poolFactory;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Create a user pool.
+   *
+   * The pool's id is allocated here rather than asked for, as it is on real
+   * Cognito, so nothing can rely on a pool id being predictable.
+   */
+  create(
+    command: SimCreateUserPoolCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimCreateUserPoolCommandOutput {
+    const { input } = command;
+
+    this.authorizer.authorizeAny("cognito-idp:CreateUserPool", options?.caller);
+    this.unsimulatedOptions.refuseIn(input);
+
+    const pool = this.poolFactory.make({
+      name: input.PoolName,
+      policies: input.Policies,
+      deletionProtection: input.DeletionProtection,
+    });
+
+    this.pools.add(pool);
+
+    return { $metadata: {}, UserPool: this.view.describe(pool) };
+  }
+
+  /**
+   * Describe a user pool's settings.
+   */
+  describe(
+    command: SimDescribeUserPoolCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimDescribeUserPoolCommandOutput {
+    const userPoolId = requireSimCognitoUserPoolId(command.input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:DescribeUserPool",
+      userPoolId,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      UserPool: this.view.describe(this.pools.require(userPoolId)),
+    };
+  }
+
+  /**
+   * Delete a user pool, and with it every app client in it.
+   */
+  delete(
+    command: SimDeleteUserPoolCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimDeleteUserPoolCommandOutput {
+    const userPoolId = requireSimCognitoUserPoolId(command.input.UserPoolId);
+
+    this.authorizer.authorizeUserPool(
+      "cognito-idp:DeleteUserPool",
+      userPoolId,
+      options?.caller,
+    );
+
+    const pool = this.pools.require(userPoolId);
+
+    if (pool.deletionProtection.isActive) {
+      throw new SimCognitoInvalidParameterException(
+        `User pool ${userPoolId} is protected against deletion. Real ` +
+          `Cognito wants an UpdateUserPool request deactivating the ` +
+          `protection first, which this simulation does not support, so ` +
+          `create the pool without DeletionProtection instead.`,
+      );
+    }
+
+    this.pools.remove(pool);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -1,0 +1,347 @@
+import {
+  type CreateUserPoolCommandInput,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface RefusedInput {
+  readonly label: string;
+  readonly input: Partial<CreateUserPoolCommandInput>;
+  readonly says: string;
+}
+
+/**
+ * Each of these changes what a real pool does, so a request carrying one is
+ * refused rather than answered with a pool that behaves differently.
+ */
+const refusedInputs: readonly RefusedInput[] = [
+  {
+    label: "UsernameAttributes",
+    input: { UsernameAttributes: ["email"] },
+    says: "stores a generated UUID as the username",
+  },
+  {
+    label: "MfaConfiguration",
+    input: { MfaConfiguration: "OPTIONAL" },
+    says: "multi-factor authentication",
+  },
+  {
+    label: "UserPoolTier",
+    input: { UserPoolTier: "PLUS" },
+    says: "the Lite and Plus feature plans",
+  },
+  {
+    label: "SignInPolicy",
+    input: {
+      Policies: { SignInPolicy: { AllowedFirstAuthFactors: ["EMAIL_OTP"] } },
+    },
+    says: "which factors a user may sign in with first",
+  },
+  {
+    label: "PasswordHistorySize",
+    input: { Policies: { PasswordPolicy: { PasswordHistorySize: 3 } } },
+    says: "a password the user has used before",
+  },
+  {
+    label: "LambdaConfig",
+    input: {
+      LambdaConfig: { PreSignUp: "arn:aws:lambda:eu-west-2:1:function:f" },
+    },
+    says: "Lambda triggers",
+  },
+  {
+    label: "AliasAttributes",
+    input: { AliasAttributes: ["email"] },
+    says: "sign-in aliases",
+  },
+  {
+    label: "AutoVerifiedAttributes",
+    input: { AutoVerifiedAttributes: ["email"] },
+    says: "automatic attribute verification",
+  },
+  {
+    label: "Schema",
+    input: { Schema: [{ Name: "tenant", AttributeDataType: "String" }] },
+    says: "custom attributes",
+  },
+  {
+    label: "UsernameConfiguration",
+    input: { UsernameConfiguration: { CaseSensitive: false } },
+    says: "case-insensitive usernames",
+  },
+  {
+    label: "UserAttributeUpdateSettings",
+    input: {
+      UserAttributeUpdateSettings: {
+        AttributesRequireVerificationBeforeUpdate: ["email"],
+      },
+    },
+    says: "verification before an attribute changes",
+  },
+  {
+    label: "DeviceConfiguration",
+    input: { DeviceConfiguration: { ChallengeRequiredOnNewDevice: true } },
+    says: "device remembering",
+  },
+  {
+    label: "AccountRecoverySetting",
+    input: {
+      AccountRecoverySetting: {
+        RecoveryMechanisms: [{ Name: "verified_email", Priority: 1 }],
+      },
+    },
+    says: "account recovery",
+  },
+  {
+    label: "AdminCreateUserConfig",
+    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: true } },
+    says: "the AdminCreateUser settings",
+  },
+  {
+    label: "UserPoolAddOns",
+    input: { UserPoolAddOns: { AdvancedSecurityMode: "ENFORCED" } },
+    says: "threat protection",
+  },
+  {
+    label: "KeyConfiguration",
+    input: { KeyConfiguration: { KeyType: "CUSTOMER_MANAGED_KEY" } },
+    says: "encryption under a customer managed key",
+  },
+  {
+    label: "IssuerConfiguration",
+    input: { IssuerConfiguration: { Type: "UPDATED" } },
+    says: "a custom token issuer",
+  },
+  {
+    label: "UserPoolTags",
+    input: { UserPoolTags: { team: "platform" } },
+    says: "tags",
+  },
+  {
+    label: "EmailConfiguration",
+    input: { EmailConfiguration: { EmailSendingAccount: "DEVELOPER" } },
+    says: "email delivery",
+  },
+  {
+    label: "SmsConfiguration",
+    input: {
+      SmsConfiguration: { SnsCallerArn: "arn:aws:iam::1:role/sms" },
+    },
+    says: "SMS delivery",
+  },
+  {
+    label: "VerificationMessageTemplate",
+    input: {
+      VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_CODE" },
+    },
+    says: "verification messages",
+  },
+  {
+    label: "EmailVerificationMessage",
+    input: { EmailVerificationMessage: "Your code is {####}" },
+    says: "verification messages",
+  },
+  {
+    label: "EmailVerificationSubject",
+    input: { EmailVerificationSubject: "Verify your email" },
+    says: "verification messages",
+  },
+  {
+    label: "SmsVerificationMessage",
+    input: { SmsVerificationMessage: "Your code is {####}" },
+    says: "verification messages",
+  },
+  {
+    label: "SmsAuthenticationMessage",
+    input: { SmsAuthenticationMessage: "Your code is {####}" },
+    says: "multi-factor authentication messages",
+  },
+];
+
+function simCognito(): SimCognitoIdentityProvider {
+  return new SimAws().cognitoIdentityProvider();
+}
+
+async function refusedPool(
+  cognito: SimCognitoIdentityProvider,
+  input: Partial<CreateUserPoolCommandInput>,
+  label: string,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users", ...input }),
+    );
+  }, label);
+}
+
+describe("sim Cognito user pool validation", () => {
+  it("refuses every CreateUserPool input it does not simulate", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When each unsimulated input is used.
+    const outcomes = await Promise.all(
+      refusedInputs.map(async (refused) => ({
+        refused,
+        error: await refusedPool(cognito, refused.input, refused.label),
+      })),
+    );
+
+    // Then each request is refused, saying what it was that could not be
+    // honoured.
+    for (const { refused, error } of outcomes) {
+      assertInstanceOf(error, SimCognitoInvalidParameterException);
+      assertStringIncludes(error.message, refused.says);
+    }
+  });
+
+  it("accepts the inputs whose only simulated value is their default", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool asks for the settings this simulation does model.
+    const created = await cognito.createUserPool(
+      new CreateUserPoolCommand({
+        PoolName: "myapp-users",
+        MfaConfiguration: "OFF",
+        UserPoolTier: "ESSENTIALS",
+      }),
+    );
+
+    // Then it is created rather than refused.
+    assertIdentical(created.UserPool?.Name, "myapp-users");
+  });
+
+  it("refuses a request with no pool name", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool is created without a name. The SDK's own types insist on
+    // one, so this is the request as it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPool({ input: {} });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "PoolName is required");
+  });
+
+  it("refuses a pool name Cognito would refuse", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When names Cognito does not allow are used.
+    const tooLong = await refusedPool(
+      cognito,
+      { PoolName: "a".repeat(129) },
+      "too long",
+    );
+    const badCharacters = await refusedPool(
+      cognito,
+      { PoolName: "myapp/users" },
+      "bad characters",
+    );
+
+    // Then both are refused before anything is created.
+    assertStringIncludes(tooLong.message, "longer than the 128 characters");
+    assertStringIncludes(
+      badCharacters.message,
+      "contains characters Cognito does not allow",
+    );
+  });
+
+  it("refuses a password policy outside the range Cognito allows", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a minimum length below six and a temporary password validity over
+    // a year are asked for.
+    const tooShort = await refusedPool(
+      cognito,
+      { Policies: { PasswordPolicy: { MinimumLength: 4 } } },
+      "minimum length",
+    );
+    const tooLong = await refusedPool(
+      cognito,
+      {
+        Policies: {
+          PasswordPolicy: { TemporaryPasswordValidityDays: 400 },
+        },
+      },
+      "temporary password validity",
+    );
+
+    // Then both are refused.
+    assertStringIncludes(tooShort.message, "MinimumLength must be a whole");
+    assertStringIncludes(
+      tooLong.message,
+      "TemporaryPasswordValidityDays must be a whole",
+    );
+  });
+
+  it("refuses a deletion protection value Cognito does not have", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool asks for protection in a word Cognito does not use.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.createUserPool({
+        input: { PoolName: "myapp-users", DeletionProtection: "ENABLED" },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "use ACTIVE or INACTIVE");
+  });
+
+  it("refuses a request naming no pool, or one that is not a pool id", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool is described with a missing id and with a malformed one.
+    const missing = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPool({ input: {} });
+    });
+    const malformed = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: "myapp-users" }),
+      );
+    });
+
+    // Then both fail as validation errors rather than as missing pools.
+    assertInstanceOf(missing, SimCognitoInvalidParameterException);
+    assertStringIncludes(missing.message, "UserPoolId is required");
+    assertInstanceOf(malformed, SimCognitoInvalidParameterException);
+    assertStringIncludes(malformed.message, "is not a user pool id");
+  });
+
+  it("reports a well-formed id for a pool that does not exist as missing", async () => {
+    // Given simulated Cognito with no pools.
+    const cognito = simCognito();
+
+    // When a pool that was never created is described.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.describeUserPool(
+        new DescribeUserPoolCommand({ UserPoolId: "eu-west-2_aBcDeFgHi" }),
+      );
+    });
+
+    // Then it is missing rather than malformed.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+    assertStringIncludes(error.message, "eu-west-2_aBcDeFgHi does not exist");
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -1,0 +1,45 @@
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolDescriptionType } from "./list-user-pools.command.js";
+import type { SimCognitoUserPoolType } from "./user-pool.command.js";
+
+/**
+ * How a simulated user pool is reported back to a caller.
+ *
+ * A described pool and a listed one carry different properties on real
+ * Cognito, so both shapes are built here rather than at each command.
+ */
+export class SimCognitoUserPoolView {
+  /**
+   * A pool as `CreateUserPool` and `DescribeUserPool` report it.
+   *
+   * `MfaConfiguration` is always `OFF` because MFA is not simulated, and
+   * `EstimatedNumberOfUsers` is always zero because a pool holds no users
+   * yet.
+   */
+  describe(pool: SimCognitoUserPool): SimCognitoUserPoolType {
+    return {
+      Id: pool.id,
+      Name: pool.name,
+      Arn: pool.arn.value,
+      Policies: { PasswordPolicy: pool.passwordPolicy.toOutput() },
+      DeletionProtection: pool.deletionProtection.value,
+      MfaConfiguration: "OFF",
+      EstimatedNumberOfUsers: 0,
+      CreationDate: pool.creationDate,
+      LastModifiedDate: pool.lastModifiedDate,
+    };
+  }
+
+  /**
+   * A pool as `ListUserPools` reports it, which carries no ARN and no
+   * settings.
+   */
+  listEntry(pool: SimCognitoUserPool): SimCognitoUserPoolDescriptionType {
+    return {
+      Id: pool.id,
+      Name: pool.name,
+      CreationDate: pool.creationDate,
+      LastModifiedDate: pool.lastModifiedDate,
+    };
+  }
+}

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -1,0 +1,103 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
+
+/**
+ * A user pool as sim Cognito reports it.
+ *
+ * Only the properties this simulation models appear. Real Cognito reports
+ * more, including the pool's schema attributes and its message templates.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html
+ */
+export interface SimCognitoUserPoolType {
+  readonly Id?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Arn?: string | undefined;
+  readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
+  readonly DeletionProtection?: string | undefined;
+  readonly MfaConfiguration?: string | undefined;
+  readonly EstimatedNumberOfUsers?: number | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly LastModifiedDate?: Date | undefined;
+}
+
+/**
+ * The CreateUserPool inputs this simulation reads, and the ones it refuses.
+ *
+ * Every input real Cognito accepts is named here, whether or not it is
+ * simulated, so a request carrying one this simulation does not model can be
+ * refused rather than silently ignored.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/CreateUserPoolCommand/
+ */
+export interface SimCreateUserPoolCommandInput {
+  readonly PoolName?: string | undefined;
+  readonly Policies?: SimCognitoUserPoolPoliciesType | undefined;
+  readonly DeletionProtection?: string | undefined;
+  readonly MfaConfiguration?: string | undefined;
+  readonly UserPoolTier?: string | undefined;
+  readonly AccountRecoverySetting?: object | undefined;
+  readonly AdminCreateUserConfig?: object | undefined;
+  readonly AliasAttributes?: readonly string[] | undefined;
+  readonly AutoVerifiedAttributes?: readonly string[] | undefined;
+  readonly DeviceConfiguration?: object | undefined;
+  readonly EmailConfiguration?: object | undefined;
+  readonly EmailVerificationMessage?: string | undefined;
+  readonly EmailVerificationSubject?: string | undefined;
+  readonly IssuerConfiguration?: object | undefined;
+  readonly KeyConfiguration?: object | undefined;
+  readonly LambdaConfig?: object | undefined;
+  readonly Schema?: readonly object[] | undefined;
+  readonly SmsAuthenticationMessage?: string | undefined;
+  readonly SmsConfiguration?: object | undefined;
+  readonly SmsVerificationMessage?: string | undefined;
+  readonly UserAttributeUpdateSettings?: object | undefined;
+  readonly UsernameAttributes?: readonly string[] | undefined;
+  readonly UsernameConfiguration?: object | undefined;
+  readonly UserPoolAddOns?: object | undefined;
+  readonly UserPoolTags?: Readonly<Record<string, string>> | undefined;
+  readonly VerificationMessageTemplate?: object | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito CreateUserPool command.
+ */
+export interface SimCreateUserPoolCommand {
+  readonly input: SimCreateUserPoolCommandInput;
+}
+
+export interface SimCreateUserPoolCommandOutput {
+  readonly UserPool?: SimCognitoUserPoolType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito DescribeUserPool command.
+ */
+export interface SimDescribeUserPoolCommand {
+  readonly input: SimDescribeUserPoolCommandInput;
+}
+
+export interface SimDescribeUserPoolCommandInput {
+  readonly UserPoolId?: string | undefined;
+}
+
+export interface SimDescribeUserPoolCommandOutput {
+  readonly UserPool?: SimCognitoUserPoolType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito DeleteUserPool command.
+ */
+export interface SimDeleteUserPoolCommand {
+  readonly input: SimDeleteUserPoolCommandInput;
+}
+
+export interface SimDeleteUserPoolCommandInput {
+  readonly UserPoolId?: string | undefined;
+}
+
+export interface SimDeleteUserPoolCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal metadata shape for simulated Cognito errors.
+ */
+export interface SimCognitoErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Cognito user pools errors.
+ */
+export class SimCognitoError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimCognitoErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Cognito ResourceNotFoundException error.
+ *
+ * Real Cognito reports an unknown user pool id and an unknown app client id
+ * this way.
+ */
+export class SimCognitoResourceNotFoundException extends SimCognitoError {
+  public override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito InvalidParameterException error.
+ *
+ * Real Cognito reports a missing or malformed request input this way, and it
+ * is also what this simulation refuses an unsimulated input with.
+ */
+export class SimCognitoInvalidParameterException extends SimCognitoError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -1,0 +1,37 @@
+export {
+  SimCognitoIdentityProvider,
+  type SimCognitoIdentityProviderRequestOptions,
+} from "./sim-cognito-identity-provider.js";
+export { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
+export {
+  SimCognitoUserPoolArn,
+  cognitoUserPoolArnPrefix,
+} from "./user-pool/sim-cognito-user-pool-arn.js";
+export type { SimCognitoUserPoolId } from "./user-pool/sim-cognito-user-pool-id.js";
+export {
+  SimCognitoDeletionProtection,
+  type SimCognitoDeletionProtectionValue,
+} from "./user-pool/sim-cognito-deletion-protection.js";
+export {
+  SimCognitoPasswordPolicy,
+  type SimCognitoPasswordPolicyType,
+  type SimCognitoSignInPolicyType,
+  type SimCognitoUserPoolPoliciesType,
+} from "./user-pool/sim-cognito-password-policy.js";
+export { SimCognitoUserPoolClient } from "./user-pool/client/sim-cognito-user-pool-client.js";
+export type { SimCognitoUserPoolClientId } from "./user-pool/client/sim-cognito-user-pool-client-id.js";
+export { SimCognitoExplicitAuthFlows } from "./user-pool/client/sim-cognito-explicit-auth-flows.js";
+export {
+  SimCognitoTokenLifetime,
+  type SimCognitoTokenValidityUnit,
+} from "./user-pool/client/sim-cognito-token-lifetime.js";
+export {
+  SimCognitoTokenValidity,
+  type SimCognitoTokenValidityInput,
+  type SimCognitoTokenValidityUnitsType,
+} from "./user-pool/client/sim-cognito-token-validity.js";
+export {
+  SimCognitoError,
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+} from "./error/sim-cognito.error.js";

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
@@ -1,0 +1,42 @@
+import { assertArrayIncludesAll, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimCognitoSdkCommandRouter", () => {
+  it("names every Command simulated Cognito handles", () => {
+    // Given a scoped simulated Cognito.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws
+      .cognitoIdentityProvider()
+      .sdkCommandRouter()
+      .supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateUserPoolCommand",
+      "DescribeUserPoolCommand",
+      "DeleteUserPoolCommand",
+      "ListUserPoolsCommand",
+      "CreateUserPoolClientCommand",
+      "DescribeUserPoolClientCommand",
+      "DeleteUserPoolClientCommand",
+      "ListUserPoolClientsCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated Cognito.
+    const simAws = new SimAws();
+
+    // When a user pool Command this simulation does not support is looked up.
+    const route = simAws
+      .cognitoIdentityProvider()
+      .sdkCommandRouter()
+      .route("AdminCreateUserCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
@@ -1,0 +1,108 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimCreateUserPoolClientCommand,
+  SimDeleteUserPoolClientCommand,
+  SimDescribeUserPoolClientCommand,
+} from "../command/client/user-pool-client.command.js";
+import type { SimListUserPoolClientsCommand } from "../command/client/list-user-pool-clients.command.js";
+import type { SimListUserPoolsCommand } from "../command/user-pool/list-user-pools.command.js";
+import type {
+  SimCreateUserPoolCommand,
+  SimDeleteUserPoolCommand,
+  SimDescribeUserPoolCommand,
+} from "../command/user-pool/user-pool.command.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Cognito.
+ */
+export class SimCognitoSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simCognito: SimCognitoIdentityProvider) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateUserPoolCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.createUserPool(
+            command as SimCreateUserPoolCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeUserPoolCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.describeUserPool(
+            command as SimDescribeUserPoolCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteUserPoolCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.deleteUserPool(
+            command as SimDeleteUserPoolCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListUserPoolsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.listUserPools(
+            command as SimListUserPoolsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateUserPoolClientCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.createUserPoolClient(
+            command as SimCreateUserPoolClientCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeUserPoolClientCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.describeUserPoolClient(
+            command as SimDescribeUserPoolClientCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteUserPoolClientCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.deleteUserPoolClient(
+            command as SimDeleteUserPoolClientCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListUserPoolClientsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.listUserPoolClients(
+            command as SimListUserPoolClientsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Cognito can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Cognito supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-routing.iso.test.ts
@@ -1,0 +1,250 @@
+import {
+  CognitoIdentityProviderClient,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  DeleteUserPoolClientCommand,
+  DeleteUserPoolCommand,
+  DescribeUserPoolClientCommand,
+  DescribeUserPoolCommand,
+  ListUserPoolClientsCommand,
+  ListUserPoolsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+} from "../../aws/sim-aws-account.js";
+import { makeLambdaCodeZip } from "../../lambda/function/code/make-lambda-code-zip.js";
+
+const emptyBytes = new Uint8Array();
+
+const describeClientCode = [
+  'const { CognitoIdentityProviderClient, DescribeUserPoolClientCommand } = require("@aws-sdk/client-cognito-identity-provider");',
+  "exports.handler = async (event) => {",
+  "  const client = new CognitoIdentityProviderClient({});",
+  "  const out = await client.send(new DescribeUserPoolClientCommand({",
+  "    UserPoolId: event.userPoolId,",
+  "    ClientId: event.clientId,",
+  "  }));",
+  "  return out.UserPoolClient.ClientName;",
+  "};",
+].join("\n");
+
+interface SimAwsWithPoolAndRole {
+  readonly simAws: SimAws;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+async function simAwsWithPoolAndRole(
+  accountId: SimAwsAccountId,
+  policyStatement?: object,
+): Promise<SimAwsWithPoolAndRole> {
+  const simAws = new SimAws({ defaultAccountId: accountId });
+  const cognito = simAws.cognitoIdentityProvider();
+
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const appClient = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: pool.UserPool.Id,
+      ClientName: "web",
+    }),
+  );
+
+  assertNonNullable(appClient.UserPoolClient?.ClientId);
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "PoolReaderRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "PoolReaderRole",
+        PolicyName: "ReadAppClient",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "client-reader",
+      Role: role.Role.Arn,
+      Handler: "index.handler",
+      Code: { ZipFile: makeLambdaCodeZip({ "index.js": describeClientCode }) },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return {
+    simAws,
+    userPoolId: pool.UserPool.Id,
+    clientId: appClient.UserPoolClient.ClientId,
+  };
+}
+
+describe("Cognito SDK interception", () => {
+  it("routes an intercepted CognitoIdentityProviderClient to simulated Cognito", async () => {
+    // Given an intercepted Cognito SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a pool and describes it.
+    const created = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const described = await client.send(
+      new DescribeUserPoolCommand({ UserPoolId: created.UserPool?.Id }),
+    );
+
+    // Then it works with nothing touching the network, and the pool id names
+    // the Region the client was configured for.
+    assertNonNullable(described.UserPool?.Id);
+    assertStringStartsWith(described.UserPool.Id, "eu-west-2_");
+    assertStringIncludes(
+      String(described.UserPool.Arn),
+      "arn:aws:cognito-idp:eu-west-2:",
+    );
+  });
+
+  it("routes every supported Command through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client with a pool and an app client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+      }),
+    );
+    const clientId = appClient.UserPoolClient?.ClientId;
+
+    // When each of the remaining operations is used.
+    const describedClient = await client.send(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+    const listedPools = await client.send(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+    const listedClients = await client.send(
+      new ListUserPoolClientsCommand({ UserPoolId: userPoolId }),
+    );
+
+    await client.send(
+      new DeleteUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+    await client.send(new DeleteUserPoolCommand({ UserPoolId: userPoolId }));
+
+    const listedAfterDelete = await client.send(
+      new ListUserPoolsCommand({ MaxResults: 10 }),
+    );
+
+    // Then each one reached simulated Cognito.
+    assertIdentical(describedClient.UserPoolClient?.ClientName, "web");
+    assertArrayEquals(
+      listedPools.UserPools?.map((listed) => listed.Name),
+      ["myapp-users"],
+    );
+    assertArrayEquals(
+      listedClients.UserPoolClients?.map((listed) => listed.ClientName),
+      ["web"],
+    );
+    assertArrayEquals(listedAfterDelete.UserPools, []);
+  });
+
+  it("describes an app client inside a Lambda handler as the execution Role", async () => {
+    // Given a function whose code reads an app client's configuration,
+    // running as a Role allowed to read it.
+    const accountId = makeSimAwsAccountId();
+    const { simAws, userPoolId, clientId } = await simAwsWithPoolAndRole(
+      accountId,
+      {
+        Effect: "Allow",
+        Action: "cognito-idp:DescribeUserPoolClient",
+        Resource: `arn:aws:cognito-idp:us-east-1:${accountId}:userpool/*`,
+      },
+    );
+
+    // When the function is invoked.
+    const invoked = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "client-reader",
+        Payload: JSON.stringify({ userPoolId, clientId }),
+      }),
+    );
+
+    // Then the handler's own SDK call reached simulated Cognito as the
+    // execution Role, and that Role's policy allowed it.
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "web");
+  });
+
+  it("denies a Lambda handler whose Role may not read the app client", async () => {
+    // Given the same function, running as a Role with no Cognito permissions.
+    const { simAws, userPoolId, clientId } = await simAwsWithPoolAndRole(
+      makeSimAwsAccountId(),
+    );
+
+    // When the function is invoked.
+    const invoked = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "client-reader",
+        Payload: JSON.stringify({ userPoolId, clientId }),
+      }),
+    );
+
+    // Then the handler fails the way it would on real AWS, rather than
+    // reading the configuration anyway.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "not authorized");
+  });
+});

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -1,0 +1,195 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCognitoAuthorizer } from "./command/authorize/sim-cognito-authorizer.js";
+import { SimCognitoListUserPoolClients } from "./command/client/sim-cognito-list-user-pool-clients.js";
+import { SimCognitoUserPoolClientCommands } from "./command/client/sim-cognito-user-pool-client-commands.js";
+import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
+import { SimCognitoListUserPools } from "./command/user-pool/sim-cognito-list-user-pools.js";
+import { SimCognitoUserPoolCommands } from "./command/user-pool/sim-cognito-user-pool-commands.js";
+import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
+import { SimCognitoUserPoolClientFactory } from "./user-pool/client/sim-cognito-user-pool-client-factory.js";
+import type { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
+import { SimCognitoUserPoolFactory } from "./user-pool/sim-cognito-user-pool-factory.js";
+import type { SimCognitoUserPoolId } from "./user-pool/sim-cognito-user-pool-id.js";
+import { SimCognitoUserPoolStore } from "./user-pool/sim-cognito-user-pool-store.js";
+
+export interface SimCognitoIdentityProviderRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface SimCognitoIdentityProviderProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Cognito user pools. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * Pools are scoped to an account and region, as they are on real AWS: a pool
+ * id names the region it was created in, and an app client id is only
+ * meaningful inside its pool.
+ *
+ * Only user pools are simulated. Cognito identity pools, which hand out AWS
+ * credentials, are a different service and are not simulated at all.
+ */
+export class SimCognitoIdentityProvider {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly userPoolCommands: SimCognitoUserPoolCommands;
+  private readonly listUserPoolsCommand: SimCognitoListUserPools;
+  private readonly clientCommands: SimCognitoUserPoolClientCommands;
+  private readonly listClientsCommand: SimCognitoListUserPoolClients;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimCognitoSdkCommandRouter(this);
+
+  constructor(properties: SimCognitoIdentityProviderProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
+
+    this.background = background;
+    this.pools = new SimCognitoUserPoolStore();
+    this.userPoolCommands = new SimCognitoUserPoolCommands({
+      pools: this.pools,
+      poolFactory: new SimCognitoUserPoolFactory({
+        accountRegionScope,
+        pools: this.pools,
+        clock: background,
+      }),
+      authorizer,
+    });
+    this.listUserPoolsCommand = new SimCognitoListUserPools({
+      pools: this.pools,
+      authorizer,
+    });
+    this.clientCommands = new SimCognitoUserPoolClientCommands({
+      pools: this.pools,
+      clientFactory: new SimCognitoUserPoolClientFactory({ clock: background }),
+      authorizer,
+    });
+    this.listClientsCommand = new SimCognitoListUserPoolClients({
+      pools: this.pools,
+      authorizer,
+    });
+  }
+
+  /**
+   * Find a user pool by id.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * pool state without going through a Command and its authorization.
+   */
+  findUserPool(userPoolId: string): SimCognitoUserPool | undefined {
+    return this.pools.find(userPoolId as SimCognitoUserPoolId);
+  }
+
+  /**
+   * Handle a CreateUserPool Command from the SDK.
+   */
+  async createUserPool(
+    command: simCognitoCommands.SimCreateUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimCreateUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.userPoolCommands.create(command, options);
+  }
+
+  /**
+   * Handle a DescribeUserPool Command from the SDK.
+   */
+  async describeUserPool(
+    command: simCognitoCommands.SimDescribeUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDescribeUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.userPoolCommands.describe(command, options);
+  }
+
+  /**
+   * Handle a DeleteUserPool Command from the SDK.
+   */
+  async deleteUserPool(
+    command: simCognitoCommands.SimDeleteUserPoolCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDeleteUserPoolCommandOutput> {
+    await this.background.sequence();
+    return this.userPoolCommands.delete(command, options);
+  }
+
+  /**
+   * Handle a ListUserPools Command from the SDK.
+   */
+  async listUserPools(
+    command: simCognitoCommands.SimListUserPoolsCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimListUserPoolsCommandOutput> {
+    await this.background.sequence();
+    return this.listUserPoolsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a CreateUserPoolClient Command from the SDK.
+   */
+  async createUserPoolClient(
+    command: simCognitoCommands.SimCreateUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimCreateUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.clientCommands.create(command, options);
+  }
+
+  /**
+   * Handle a DescribeUserPoolClient Command from the SDK.
+   */
+  async describeUserPoolClient(
+    command: simCognitoCommands.SimDescribeUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDescribeUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.clientCommands.describe(command, options);
+  }
+
+  /**
+   * Handle a DeleteUserPoolClient Command from the SDK.
+   */
+  async deleteUserPoolClient(
+    command: simCognitoCommands.SimDeleteUserPoolClientCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimDeleteUserPoolClientCommandOutput> {
+    await this.background.sequence();
+    return this.clientCommands.delete(command, options);
+  }
+
+  /**
+   * Handle a ListUserPoolClients Command from the SDK.
+   */
+  async listUserPoolClients(
+    command: simCognitoCommands.SimListUserPoolClientsCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimListUserPoolClientsCommandOutput> {
+    await this.background.sequence();
+    return this.listClientsCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-client-secret.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-client-secret.ts
@@ -1,0 +1,23 @@
+import { faker } from "@faker-js/faker";
+
+/**
+ * Real client secrets are fifty-two lowercase alphanumerics. The length is
+ * worth matching because application code sometimes carries an assertion or a
+ * configuration check on it.
+ */
+const clientSecretLength = 52;
+
+/**
+ * Generate an app client secret.
+ *
+ * Only a client created with `GenerateSecret` has one. A client without a
+ * secret reports no `ClientSecret` at all rather than an empty one, which is
+ * what makes code computing a `SECRET_HASH` fail on the client it should fail
+ * on.
+ */
+export function makeSimCognitoClientSecret(): string {
+  return faker.string.alphanumeric({
+    length: clientSecretLength,
+    casing: "lower",
+  });
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-explicit-auth-flows.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-explicit-auth-flows.ts
@@ -1,0 +1,95 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+/**
+ * The authentication flows Cognito has replaced, kept for app clients made
+ * before the `ALLOW_` prefixed values existed.
+ */
+const legacyAuthFlows: readonly string[] = [
+  "ADMIN_NO_SRP_AUTH",
+  "CUSTOM_AUTH_FLOW_ONLY",
+  "USER_PASSWORD_AUTH",
+];
+
+const currentAuthFlows: readonly string[] = [
+  "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+  "ALLOW_CUSTOM_AUTH",
+  "ALLOW_REFRESH_TOKEN_AUTH",
+  "ALLOW_USER_AUTH",
+  "ALLOW_USER_PASSWORD_AUTH",
+  "ALLOW_USER_SRP_AUTH",
+];
+
+/**
+ * The flows an app client supports when its request named none.
+ *
+ * Sign-in with a username and password is deliberately not among them, which
+ * is why `USER_PASSWORD_AUTH` fails on a client nobody configured.
+ */
+const defaultAuthFlows: readonly string[] = [
+  "ALLOW_REFRESH_TOKEN_AUTH",
+  "ALLOW_USER_SRP_AUTH",
+  "ALLOW_CUSTOM_AUTH",
+];
+
+/**
+ * The authentication flows one simulated app client supports.
+ *
+ * This is the setting that decides whether an authentication request reaches
+ * the pool at all, so the values are validated rather than stored as written:
+ * a typo in a flow name would otherwise turn into a puzzling sign-in failure
+ * much later.
+ */
+export class SimCognitoExplicitAuthFlows {
+  public readonly values: readonly string[];
+
+  constructor(requested: readonly string[] | undefined) {
+    if (requested === undefined || requested.length === 0) {
+      this.values = defaultAuthFlows;
+      return;
+    }
+
+    for (const flow of requested) {
+      SimCognitoExplicitAuthFlows.requireKnown(flow);
+    }
+
+    SimCognitoExplicitAuthFlows.refuseMixedGenerations(requested);
+
+    this.values = [...requested];
+  }
+
+  private static requireKnown(flow: string): void {
+    if (legacyAuthFlows.includes(flow) || currentAuthFlows.includes(flow)) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `ExplicitAuthFlows '${flow}' is not a Cognito authentication flow: ` +
+        `use one of ${currentAuthFlows.join(", ")}`,
+    );
+  }
+
+  /**
+   * Refuse a request naming both a legacy flow and an `ALLOW_` prefixed one,
+   * as real Cognito refuses it.
+   */
+  private static refuseMixedGenerations(requested: readonly string[]): void {
+    const hasLegacy = requested.some((flow) => legacyAuthFlows.includes(flow));
+    const hasCurrent = requested.some((flow) =>
+      currentAuthFlows.includes(flow),
+    );
+
+    if (hasLegacy && hasCurrent) {
+      throw new SimCognitoInvalidParameterException(
+        "ExplicitAuthFlows cannot mix the legacy flows " +
+          `(${legacyAuthFlows.join(", ")}) with the ALLOW_ prefixed ones`,
+      );
+    }
+  }
+
+  /**
+   * Whether the client supports an authentication flow.
+   */
+  allows(flow: string): boolean {
+    return this.values.includes(flow);
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-refresh-token-lifetime.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-refresh-token-lifetime.ts
@@ -1,0 +1,43 @@
+import {
+  requireCognitoTokenValidityUnit,
+  SimCognitoTokenLifetime,
+} from "./sim-cognito-token-lifetime.js";
+import {
+  defaultRefreshTokenValidityDays,
+  refreshTokenLifetimeSpec,
+} from "./sim-cognito-token-lifetime-specs.js";
+
+/**
+ * Build an app client's refresh token lifetime.
+ *
+ * This is the one lifetime with a rule of its own: Cognito substitutes thirty
+ * days both for an absent validity and for a zero. The substituted default is
+ * thirty days whatever unit the request named, so the unit is left out along
+ * with the value it would have counted. It is still checked first, because
+ * real Cognito refuses a unit it does not have whether or not the unit ends
+ * up counting anything.
+ */
+export function makeSimCognitoRefreshTokenLifetime(
+  requested: number | undefined,
+  unit: string | undefined,
+): SimCognitoTokenLifetime {
+  requireCognitoTokenValidityUnit(
+    refreshTokenLifetimeSpec.field,
+    unit,
+    refreshTokenLifetimeSpec.defaultUnit,
+  );
+
+  if (requested === undefined || requested === 0) {
+    return new SimCognitoTokenLifetime({
+      ...refreshTokenLifetimeSpec,
+      validity: defaultRefreshTokenValidityDays,
+      unit: undefined,
+    });
+  }
+
+  return new SimCognitoTokenLifetime({
+    ...refreshTokenLifetimeSpec,
+    validity: requested,
+    unit,
+  });
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-token-lifetime-specs.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-token-lifetime-specs.ts
@@ -1,0 +1,55 @@
+import type { SimCognitoTokenLifetimeProperties } from "./sim-cognito-token-lifetime.js";
+
+/**
+ * What Cognito allows one kind of token, apart from the validity a request
+ * asks for.
+ */
+type SimCognitoTokenLifetimeSpec = Omit<
+  SimCognitoTokenLifetimeProperties,
+  "validity" | "unit"
+>;
+
+const oneHourSeconds = 60 * 60;
+const oneDaySeconds = 24 * oneHourSeconds;
+const fiveMinutesSeconds = 5 * 60;
+const tenYearsSeconds = 315_360_000;
+
+/**
+ * The number of days a refresh token lasts when the request says nothing.
+ *
+ * Cognito reports this default on the client rather than leaving the field
+ * out, and it overwrites a requested `0` with it.
+ */
+export const defaultRefreshTokenValidityDays = 30;
+
+/**
+ * Access tokens are counted in hours, last an hour by default, and may last
+ * between five minutes and a day.
+ */
+export const accessTokenLifetimeSpec: SimCognitoTokenLifetimeSpec = {
+  field: "AccessTokenValidity",
+  defaultUnit: "hours",
+  defaultSeconds: oneHourSeconds,
+  leastSeconds: fiveMinutesSeconds,
+  mostSeconds: oneDaySeconds,
+};
+
+/**
+ * ID tokens follow the same rules as access tokens.
+ */
+export const idTokenLifetimeSpec: SimCognitoTokenLifetimeSpec = {
+  ...accessTokenLifetimeSpec,
+  field: "IdTokenValidity",
+};
+
+/**
+ * Refresh tokens are counted in days, last thirty by default, and may last
+ * between an hour and ten years.
+ */
+export const refreshTokenLifetimeSpec: SimCognitoTokenLifetimeSpec = {
+  field: "RefreshTokenValidity",
+  defaultUnit: "days",
+  defaultSeconds: defaultRefreshTokenValidityDays * oneDaySeconds,
+  leastSeconds: oneHourSeconds,
+  mostSeconds: tenYearsSeconds,
+};

--- a/src/service/cognito/user-pool/client/sim-cognito-token-lifetime.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-token-lifetime.ts
@@ -1,0 +1,114 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+export type SimCognitoTokenValidityUnit =
+  "seconds" | "minutes" | "hours" | "days";
+
+const secondsPerUnit: Readonly<Record<SimCognitoTokenValidityUnit, number>> = {
+  seconds: 1,
+  minutes: 60,
+  hours: 60 * 60,
+  days: 24 * 60 * 60,
+};
+
+/**
+ * What one token lifetime is made of: the validity a request asked for, the
+ * unit it is counted in, and what Cognito allows for that kind of token.
+ */
+export interface SimCognitoTokenLifetimeProperties {
+  /**
+   * The request input the validity came from, such as `AccessTokenValidity`.
+   */
+  readonly field: string;
+  readonly validity: number | undefined;
+  readonly unit: string | undefined;
+  readonly defaultUnit: SimCognitoTokenValidityUnit;
+  readonly defaultSeconds: number;
+  readonly leastSeconds: number;
+  readonly mostSeconds: number;
+}
+
+/**
+ * How long one kind of token from an app client lasts.
+ *
+ * A validity is a number in a unit, and the two arrive in separate request
+ * inputs, so the same `1` means an hour for an access token and a day for a
+ * refresh token. Resolving both into seconds in one place is what stops the
+ * pairing being got wrong somewhere later.
+ */
+export class SimCognitoTokenLifetime {
+  /**
+   * The validity as the request wrote it, which is what Cognito reports back.
+   */
+  public readonly validity: number | undefined;
+
+  /**
+   * The unit the validity is counted in, defaulted as Cognito defaults it.
+   */
+  public readonly unit: SimCognitoTokenValidityUnit;
+
+  /**
+   * How long the token lasts, in seconds.
+   */
+  public readonly seconds: number;
+
+  constructor(properties: SimCognitoTokenLifetimeProperties) {
+    const { field, validity, defaultSeconds, leastSeconds, mostSeconds } =
+      properties;
+
+    this.unit = requireCognitoTokenValidityUnit(
+      field,
+      properties.unit,
+      properties.defaultUnit,
+    );
+    this.validity = validity;
+
+    if (validity === undefined) {
+      this.seconds = defaultSeconds;
+      return;
+    }
+
+    if (!Number.isSafeInteger(validity) || validity < 0) {
+      throw new SimCognitoInvalidParameterException(
+        `${field} must be a whole number of ${this.unit}`,
+      );
+    }
+
+    const seconds = validity * secondsPerUnit[this.unit];
+
+    if (seconds < leastSeconds || seconds > mostSeconds) {
+      throw new SimCognitoInvalidParameterException(
+        `${field} of ${String(validity)} ${this.unit} is outside the range ` +
+          `Cognito allows: between ${String(leastSeconds)} and ` +
+          `${String(mostSeconds)} seconds`,
+      );
+    }
+
+    this.seconds = seconds;
+  }
+}
+
+/**
+ * Read a requested token validity unit, or refuse one Cognito does not have.
+ *
+ * This is separate from the lifetime it belongs to because a unit is refused
+ * whether or not the validity counted in it is used. A request naming a unit
+ * and no validity still fails on real Cognito, so it fails here.
+ */
+export function requireCognitoTokenValidityUnit(
+  field: string,
+  unit: string | undefined,
+  fallback: SimCognitoTokenValidityUnit,
+): SimCognitoTokenValidityUnit {
+  if (unit === undefined) {
+    return fallback;
+  }
+
+  if (!Object.hasOwn(secondsPerUnit, unit)) {
+    throw new SimCognitoInvalidParameterException(
+      `TokenValidityUnits for ${field} is '${unit}', which is not a ` +
+        `Cognito token validity unit: use seconds, minutes, hours or days`,
+    );
+  }
+
+  return unit as SimCognitoTokenValidityUnit;
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-token-validity.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-token-validity.ts
@@ -1,0 +1,71 @@
+import { makeSimCognitoRefreshTokenLifetime } from "./sim-cognito-refresh-token-lifetime.js";
+import { SimCognitoTokenLifetime } from "./sim-cognito-token-lifetime.js";
+import {
+  accessTokenLifetimeSpec,
+  idTokenLifetimeSpec,
+} from "./sim-cognito-token-lifetime-specs.js";
+
+/**
+ * The units an app client's token validities are counted in.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_TokenValidityUnitsType.html
+ */
+export interface SimCognitoTokenValidityUnitsType {
+  readonly AccessToken?: string | undefined;
+  readonly IdToken?: string | undefined;
+  readonly RefreshToken?: string | undefined;
+}
+
+/**
+ * The token lifetime inputs of a CreateUserPoolClient request.
+ */
+export interface SimCognitoTokenValidityInput {
+  readonly AccessTokenValidity?: number | undefined;
+  readonly IdTokenValidity?: number | undefined;
+  readonly RefreshTokenValidity?: number | undefined;
+  readonly TokenValidityUnits?: SimCognitoTokenValidityUnitsType | undefined;
+}
+
+/**
+ * How long each kind of token from one simulated app client lasts.
+ *
+ * Access and ID tokens last an hour unless the request says otherwise, and
+ * refresh tokens last thirty days. Those are the values real Cognito applies,
+ * and the hour is the one that catches people out: an access token outliving
+ * a test is a test that never sees expiry handling run.
+ */
+export class SimCognitoTokenValidity {
+  public readonly accessToken: SimCognitoTokenLifetime;
+  public readonly idToken: SimCognitoTokenLifetime;
+  public readonly refreshToken: SimCognitoTokenLifetime;
+
+  private readonly requestedUnits: SimCognitoTokenValidityUnitsType | undefined;
+
+  constructor(input: SimCognitoTokenValidityInput = {}) {
+    const units = input.TokenValidityUnits;
+
+    this.requestedUnits = units;
+    this.accessToken = new SimCognitoTokenLifetime({
+      ...accessTokenLifetimeSpec,
+      validity: input.AccessTokenValidity,
+      unit: units?.AccessToken,
+    });
+    this.idToken = new SimCognitoTokenLifetime({
+      ...idTokenLifetimeSpec,
+      validity: input.IdTokenValidity,
+      unit: units?.IdToken,
+    });
+    this.refreshToken = makeSimCognitoRefreshTokenLifetime(
+      input.RefreshTokenValidity,
+      units?.RefreshToken,
+    );
+  }
+
+  /**
+   * The units as Cognito reports them, which is only when the request set
+   * them.
+   */
+  unitsOutput(): SimCognitoTokenValidityUnitsType | undefined {
+    return this.requestedUnits;
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
@@ -1,0 +1,70 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoName } from "../sim-cognito-name.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import { makeSimCognitoClientSecret } from "./sim-cognito-client-secret.js";
+import { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
+import {
+  SimCognitoTokenValidity,
+  type SimCognitoTokenValidityInput,
+} from "./sim-cognito-token-validity.js";
+import { SimCognitoUserPoolClient } from "./sim-cognito-user-pool-client.js";
+import { makeSimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
+
+interface SimCognitoUserPoolClientFactoryProperties {
+  readonly clock: SimClock;
+}
+
+interface SimCognitoMakeUserPoolClientProperties {
+  readonly pool: SimCognitoUserPool;
+  readonly name: string | undefined;
+  readonly generateSecret?: boolean | undefined;
+  readonly explicitAuthFlows?: readonly string[] | undefined;
+  readonly tokenValidity: SimCognitoTokenValidityInput;
+}
+
+/**
+ * Builds simulated app clients, including their id and their secret.
+ */
+export class SimCognitoUserPoolClientFactory {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoUserPoolClientFactoryProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Make a new app client for a pool.
+   *
+   * A secret is generated only for a request that asked for one, because
+   * whether a client has a secret changes what its application has to send:
+   * Cognito wants a `SECRET_HASH` on requests from a client that has one.
+   */
+  make(
+    properties: SimCognitoMakeUserPoolClientProperties,
+  ): SimCognitoUserPoolClient {
+    const { pool } = properties;
+
+    return new SimCognitoUserPoolClient({
+      id: makeSimCognitoUserPoolClientId(pool.clientIds),
+      userPoolId: pool.id,
+      name: new SimCognitoName({
+        field: "ClientName",
+        value: properties.name,
+      }),
+      secret: this.secretFor(properties.generateSecret),
+      explicitAuthFlows: new SimCognitoExplicitAuthFlows(
+        properties.explicitAuthFlows,
+      ),
+      tokenValidity: new SimCognitoTokenValidity(properties.tokenValidity),
+      createdDate: this.clock.now(),
+    });
+  }
+
+  private secretFor(generateSecret: boolean | undefined): string | undefined {
+    if (generateSecret !== true) {
+      return undefined;
+    }
+
+    return makeSimCognitoClientSecret();
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-id.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-id.ts
@@ -1,0 +1,60 @@
+import { faker } from "@faker-js/faker";
+import type { Brand } from "../../../../util/brand.type.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+export type SimCognitoUserPoolClientId = Brand<
+  string,
+  "SimCognitoUserPoolClientId"
+>;
+
+/**
+ * Real app client ids are twenty-six lowercase alphanumerics, with nothing in
+ * them naming the pool they belong to. That is why every app client operation
+ * takes the pool id as well as the client id.
+ */
+const clientIdLength = 26;
+
+const clientIdPattern = /^[\w+]+$/u;
+const maxClientIdLength = 128;
+
+/**
+ * Allocate an app client id.
+ */
+export function makeSimCognitoUserPoolClientId(
+  existing = new Set<string>(),
+): SimCognitoUserPoolClientId {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const clientId = faker.string.alphanumeric({
+      length: clientIdLength,
+      casing: "lower",
+    }) as SimCognitoUserPoolClientId;
+
+    if (!existing.has(clientId)) {
+      return clientId;
+    }
+  }
+
+  /* v8 ignore next -- unlikely to happen in practice */
+  throw new Error("Could not allocate unique Cognito app client id");
+}
+
+/**
+ * Read a requested app client id, or refuse a malformed one.
+ */
+export function requireSimCognitoUserPoolClientId(
+  value: string | undefined,
+): SimCognitoUserPoolClientId {
+  if (value === undefined || value === "") {
+    throw new SimCognitoInvalidParameterException(
+      "ClientId is required: name the app client the request is for",
+    );
+  }
+
+  if (value.length > maxClientIdLength || !clientIdPattern.test(value)) {
+    throw new SimCognitoInvalidParameterException(
+      `ClientId '${value}' is not an app client id`,
+    );
+  }
+
+  return value as SimCognitoUserPoolClientId;
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-store.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-store.ts
@@ -1,0 +1,64 @@
+import { SimCognitoResourceNotFoundException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClient } from "./sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
+
+/**
+ * The app clients of one simulated user pool.
+ *
+ * Clients belong to a pool rather than to an account: a client id is only
+ * meaningful alongside the pool id it was created in, which is why every app
+ * client operation takes both.
+ */
+export class SimCognitoUserPoolClientStore {
+  private readonly clients = new Map<string, SimCognitoUserPoolClient>();
+
+  /**
+   * Every app client of this pool, in creation order.
+   */
+  get all(): readonly SimCognitoUserPoolClient[] {
+    return this.clients.values().toArray();
+  }
+
+  /**
+   * The ids already in use, so a new one can avoid them.
+   */
+  get ids(): Set<string> {
+    return new Set(this.clients.keys());
+  }
+
+  /**
+   * Store a newly created app client.
+   */
+  add(client: SimCognitoUserPoolClient): void {
+    this.clients.set(client.id, client);
+  }
+
+  /**
+   * Forget a deleted app client.
+   */
+  remove(client: SimCognitoUserPoolClient): void {
+    this.clients.delete(client.id);
+  }
+
+  /**
+   * Find an app client by id.
+   */
+  find(clientId: string): SimCognitoUserPoolClient | undefined {
+    return this.clients.get(clientId);
+  }
+
+  /**
+   * Resolve an app client by id, or refuse.
+   */
+  require(clientId: SimCognitoUserPoolClientId): SimCognitoUserPoolClient {
+    const found = this.find(clientId);
+
+    if (found === undefined) {
+      throw new SimCognitoResourceNotFoundException(
+        `App client ${clientId} does not exist.`,
+      );
+    }
+
+    return found;
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
@@ -1,0 +1,66 @@
+import type { SimCognitoName } from "../sim-cognito-name.js";
+import type { SimCognitoUserPoolId } from "../sim-cognito-user-pool-id.js";
+import type { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
+import type { SimCognitoTokenValidity } from "./sim-cognito-token-validity.js";
+import type { SimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
+
+interface SimCognitoUserPoolClientProperties {
+  readonly id: SimCognitoUserPoolClientId;
+  readonly userPoolId: SimCognitoUserPoolId;
+  readonly name: SimCognitoName;
+  readonly secret: string | undefined;
+  readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
+  readonly tokenValidity: SimCognitoTokenValidity;
+  readonly createdDate: Date;
+}
+
+/**
+ * One simulated app client of a user pool.
+ *
+ * An app client is how an application reaches a pool, and what it holds
+ * decides what that application can do: which authentication flows are open
+ * to it, how long the tokens it receives last, and whether it has a secret
+ * that requests have to be signed with.
+ */
+export class SimCognitoUserPoolClient {
+  public readonly id: SimCognitoUserPoolClientId;
+  public readonly userPoolId: SimCognitoUserPoolId;
+  public readonly name: string;
+  public readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
+  public readonly tokenValidity: SimCognitoTokenValidity;
+  public readonly creationDate: Date;
+
+  /**
+   * The generated client secret, or undefined for a client created without
+   * one. A public client has no secret at all rather than an empty one.
+   */
+  public readonly secret: string | undefined;
+
+  constructor(properties: SimCognitoUserPoolClientProperties) {
+    this.id = properties.id;
+    this.userPoolId = properties.userPoolId;
+    this.name = properties.name.value;
+    this.secret = properties.secret;
+    this.explicitAuthFlows = properties.explicitAuthFlows;
+    this.tokenValidity = properties.tokenValidity;
+    this.creationDate = properties.createdDate;
+  }
+
+  /**
+   * When the client last changed.
+   *
+   * Nothing can change an app client here, as `UpdateUserPoolClient` is not
+   * simulated, so this is its creation date.
+   */
+  get lastModifiedDate(): Date {
+    return this.creationDate;
+  }
+
+  /**
+   * Whether the client was created with a secret, and so whether requests
+   * made with it need a `SECRET_HASH`.
+   */
+  get hasSecret(): boolean {
+    return this.secret !== undefined;
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-deletion-protection.ts
+++ b/src/service/cognito/user-pool/sim-cognito-deletion-protection.ts
@@ -1,0 +1,45 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+export type SimCognitoDeletionProtectionValue = "ACTIVE" | "INACTIVE";
+
+const deletionProtectionValues: ReadonlySet<SimCognitoDeletionProtectionValue> =
+  new Set(["ACTIVE", "INACTIVE"]);
+
+/**
+ * Whether a user pool is protected against deletion.
+ *
+ * A pool created through the API is unprotected unless the request asks for
+ * protection, which is the opposite of what the console does. A protected pool
+ * refuses `DeleteUserPool` with `InvalidParameterException` until the
+ * protection is turned off.
+ */
+export class SimCognitoDeletionProtection {
+  public readonly value: SimCognitoDeletionProtectionValue;
+
+  constructor(requested: string | undefined) {
+    if (requested === undefined) {
+      this.value = "INACTIVE";
+      return;
+    }
+
+    if (
+      !deletionProtectionValues.has(
+        requested as SimCognitoDeletionProtectionValue,
+      )
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        `DeletionProtection '${requested}' is not a Cognito deletion ` +
+          `protection value: use ACTIVE or INACTIVE`,
+      );
+    }
+
+    this.value = requested as SimCognitoDeletionProtectionValue;
+  }
+
+  /**
+   * Whether deletion is currently refused.
+   */
+  get isActive(): boolean {
+    return this.value === "ACTIVE";
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-name.ts
+++ b/src/service/cognito/user-pool/sim-cognito-name.ts
@@ -1,0 +1,49 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+const namePattern = /^[\w\s+=,.@-]+$/u;
+const maxNameLength = 128;
+
+interface SimCognitoNameProperties {
+  /**
+   * The request input the name came from, such as `PoolName`, so a refusal
+   * names the field the caller wrote rather than a term only this simulation
+   * uses.
+   */
+  readonly field: string;
+  readonly value: string | undefined;
+}
+
+/**
+ * The friendly name of a user pool or of an app client.
+ *
+ * Both take the same form on real Cognito: required, at most 128 characters,
+ * and limited to word characters, whitespace and `+=,.@-`. A name is not an
+ * identifier, so nothing stops two pools sharing one.
+ */
+export class SimCognitoName {
+  public readonly value: string;
+
+  constructor(properties: SimCognitoNameProperties) {
+    const { field, value } = properties;
+
+    if (value === undefined || value === "") {
+      throw new SimCognitoInvalidParameterException(`${field} is required`);
+    }
+
+    if (value.length > maxNameLength) {
+      throw new SimCognitoInvalidParameterException(
+        `${field} '${value}' is longer than the ${String(maxNameLength)} ` +
+          `characters Cognito allows`,
+      );
+    }
+
+    if (!namePattern.test(value)) {
+      throw new SimCognitoInvalidParameterException(
+        `${field} '${value}' contains characters Cognito does not allow: a ` +
+          `name may hold letters, digits, underscores, whitespace and +=,.@-`,
+      );
+    }
+
+    this.value = value;
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-password-policy.ts
+++ b/src/service/cognito/user-pool/sim-cognito-password-policy.ts
@@ -1,0 +1,107 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+/**
+ * A user pool password policy, in the shape Cognito reports it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_PasswordPolicyType.html
+ */
+export interface SimCognitoPasswordPolicyType {
+  readonly MinimumLength?: number | undefined;
+  readonly RequireUppercase?: boolean | undefined;
+  readonly RequireLowercase?: boolean | undefined;
+  readonly RequireNumbers?: boolean | undefined;
+  readonly RequireSymbols?: boolean | undefined;
+  readonly PasswordHistorySize?: number | undefined;
+  readonly TemporaryPasswordValidityDays?: number | undefined;
+}
+
+/**
+ * The sign-in policy of a user pool, which chooses the first factor a user
+ * may authenticate with.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignInPolicyType.html
+ */
+export interface SimCognitoSignInPolicyType {
+  readonly AllowedFirstAuthFactors?: readonly string[] | undefined;
+}
+
+/**
+ * The policies of a user pool, as Cognito groups them.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolPolicyType.html
+ */
+export interface SimCognitoUserPoolPoliciesType {
+  readonly PasswordPolicy?: SimCognitoPasswordPolicyType | undefined;
+  readonly SignInPolicy?: SimCognitoSignInPolicyType | undefined;
+}
+
+const minimumLengthRange = { least: 6, most: 99 };
+const temporaryPasswordValidityDaysRange = { least: 0, most: 365 };
+
+/**
+ * The password policy of one simulated user pool.
+ *
+ * The defaults are the ones real Cognito applies when a `CreateUserPool`
+ * request says nothing about passwords: eight characters, with an uppercase
+ * letter, a lowercase letter, a number and a symbol each required. A pool
+ * created here therefore rejects the same passwords a pool created with the
+ * SDK and no arguments would.
+ */
+export class SimCognitoPasswordPolicy {
+  public readonly minimumLength: number;
+  public readonly requiresUppercase: boolean;
+  public readonly requiresLowercase: boolean;
+  public readonly requiresNumbers: boolean;
+  public readonly requiresSymbols: boolean;
+  public readonly temporaryPasswordValidityDays: number;
+
+  constructor(policy: SimCognitoPasswordPolicyType = {}) {
+    this.minimumLength = SimCognitoPasswordPolicy.wholeNumberIn(
+      "MinimumLength",
+      policy.MinimumLength ?? 8,
+      minimumLengthRange,
+    );
+    this.requiresUppercase = policy.RequireUppercase ?? true;
+    this.requiresLowercase = policy.RequireLowercase ?? true;
+    this.requiresNumbers = policy.RequireNumbers ?? true;
+    this.requiresSymbols = policy.RequireSymbols ?? true;
+    this.temporaryPasswordValidityDays = SimCognitoPasswordPolicy.wholeNumberIn(
+      "TemporaryPasswordValidityDays",
+      policy.TemporaryPasswordValidityDays ?? 7,
+      temporaryPasswordValidityDaysRange,
+    );
+  }
+
+  private static wholeNumberIn(
+    field: string,
+    value: number,
+    range: { readonly least: number; readonly most: number },
+  ): number {
+    if (
+      !Number.isSafeInteger(value) ||
+      value < range.least ||
+      value > range.most
+    ) {
+      throw new SimCognitoInvalidParameterException(
+        `PasswordPolicy ${field} must be a whole number between ` +
+          `${String(range.least)} and ${String(range.most)}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * The policy as Cognito reports it on the pool.
+   */
+  toOutput(): SimCognitoPasswordPolicyType {
+    return {
+      MinimumLength: this.minimumLength,
+      RequireUppercase: this.requiresUppercase,
+      RequireLowercase: this.requiresLowercase,
+      RequireNumbers: this.requiresNumbers,
+      RequireSymbols: this.requiresSymbols,
+      TemporaryPasswordValidityDays: this.temporaryPasswordValidityDays,
+    };
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-arn.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-arn.ts
@@ -1,0 +1,38 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+
+/**
+ * The part of a user pool ARN that comes before the pool's own id.
+ */
+export function cognitoUserPoolArnPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/`;
+}
+
+interface SimCognitoUserPoolArnProperties {
+  readonly userPoolId: SimCognitoUserPoolId;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The ARN of one simulated user pool.
+ *
+ * A pool ARN is the pool id after `userpool/`, and the id already names its
+ * region, so the region appears twice:
+ * `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi`.
+ * This is the resource every user pool IAM policy is written against,
+ * including the policies for app client operations, which have no ARN of
+ * their own.
+ */
+export class SimCognitoUserPoolArn {
+  public readonly value: string;
+
+  constructor(properties: SimCognitoUserPoolArnProperties) {
+    this.value =
+      cognitoUserPoolArnPrefix(properties.accountRegionScope) +
+      properties.userPoolId;
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -1,0 +1,72 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
+import { SimCognitoName } from "./sim-cognito-name.js";
+import {
+  SimCognitoPasswordPolicy,
+  type SimCognitoUserPoolPoliciesType,
+} from "./sim-cognito-password-policy.js";
+import { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
+import { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
+import { makeSimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
+
+interface SimCognitoUserPoolFactoryProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly pools: SimCognitoUserPoolStore;
+  readonly clock: SimClock;
+}
+
+interface SimCognitoMakeUserPoolProperties {
+  readonly name: string | undefined;
+  readonly policies?: SimCognitoUserPoolPoliciesType | undefined;
+  readonly deletionProtection?: string | undefined;
+}
+
+/**
+ * Builds simulated user pools, including their id, ARN and defaults.
+ *
+ * Creation has to produce an id carrying the region, an ARN built from that
+ * id, a validated name and the password policy defaults, so it happens in one
+ * place rather than at each call site that needs a pool.
+ */
+export class SimCognitoUserPoolFactory {
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoUserPoolFactoryProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.pools = properties.pools;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Make a new pool with no app clients yet.
+   */
+  make(properties: SimCognitoMakeUserPoolProperties): SimCognitoUserPool {
+    const userPoolId = makeSimCognitoUserPoolId(
+      this.accountRegionScope.regionName,
+      this.pools.ids,
+    );
+
+    return new SimCognitoUserPool({
+      id: userPoolId,
+      arn: new SimCognitoUserPoolArn({
+        userPoolId,
+        accountRegionScope: this.accountRegionScope,
+      }),
+      name: new SimCognitoName({
+        field: "PoolName",
+        value: properties.name,
+      }),
+      passwordPolicy: new SimCognitoPasswordPolicy(
+        properties.policies?.PasswordPolicy,
+      ),
+      deletionProtection: new SimCognitoDeletionProtection(
+        properties.deletionProtection,
+      ),
+      createdDate: this.clock.now(),
+    });
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-id.ts
@@ -1,0 +1,69 @@
+import { faker } from "@faker-js/faker";
+import type { Brand } from "../../../util/brand.type.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+
+export type SimCognitoUserPoolId = Brand<string, "SimCognitoUserPoolId">;
+
+/**
+ * The number of random characters a user pool id carries after its region.
+ *
+ * Real Cognito ids look like `eu-west-2_aBcDeFgHi`: the region the pool lives
+ * in, an underscore, then nine mixed-case alphanumerics.
+ */
+const userPoolIdSuffixLength = 9;
+
+const userPoolIdPattern = /^[\w-]+_[0-9a-zA-Z]+$/u;
+
+const maxUserPoolIdLength = 55;
+
+/**
+ * Allocate a user pool id for a region.
+ *
+ * The region is part of the id rather than decoration: SDK code routinely
+ * splits a pool id on the underscore to work out which region to talk to, and
+ * the hosted issuer URL is built from it the same way.
+ */
+export function makeSimCognitoUserPoolId(
+  regionName: AwsRegionName,
+  existing = new Set<string>(),
+): SimCognitoUserPoolId {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const userPoolId = `${regionName}_${faker.string.alphanumeric({
+      length: userPoolIdSuffixLength,
+    })}` as SimCognitoUserPoolId;
+
+    if (!existing.has(userPoolId)) {
+      return userPoolId;
+    }
+  }
+
+  /* v8 ignore next -- unlikely to happen in practice */
+  throw new Error("Could not allocate unique Cognito user pool id");
+}
+
+/**
+ * Read a requested user pool id, or refuse a malformed one.
+ *
+ * Real Cognito validates the id's shape before it looks anything up, so a
+ * value that is not a pool id at all fails as a validation error rather than
+ * as a missing pool.
+ */
+export function requireSimCognitoUserPoolId(
+  value: string | undefined,
+): SimCognitoUserPoolId {
+  if (value === undefined || value === "") {
+    throw new SimCognitoInvalidParameterException(
+      "UserPoolId is required: name the pool the request is for",
+    );
+  }
+
+  if (value.length > maxUserPoolIdLength || !userPoolIdPattern.test(value)) {
+    throw new SimCognitoInvalidParameterException(
+      `UserPoolId '${value}' is not a user pool id: ids take the ` +
+        `'<region>_<characters>' form, such as 'eu-west-2_aBcDeFgHi'`,
+    );
+  }
+
+  return value as SimCognitoUserPoolId;
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
@@ -1,0 +1,63 @@
+import { SimCognitoResourceNotFoundException } from "../error/sim-cognito.error.js";
+import type { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+
+/**
+ * The user pools of one simulated Cognito scope.
+ *
+ * Pools are keyed by id rather than by name, as real Cognito keys them: two
+ * pools may share a name, and only the id ever identifies one.
+ */
+export class SimCognitoUserPoolStore {
+  private readonly pools = new Map<string, SimCognitoUserPool>();
+
+  /**
+   * Every pool in this scope, in creation order.
+   */
+  get all(): readonly SimCognitoUserPool[] {
+    return this.pools.values().toArray();
+  }
+
+  /**
+   * The pool ids already in use, so a new one can avoid them.
+   */
+  get ids(): Set<string> {
+    return new Set(this.pools.keys());
+  }
+
+  /**
+   * Store a newly created pool.
+   */
+  add(pool: SimCognitoUserPool): void {
+    this.pools.set(pool.id, pool);
+  }
+
+  /**
+   * Forget a deleted pool.
+   */
+  remove(pool: SimCognitoUserPool): void {
+    this.pools.delete(pool.id);
+  }
+
+  /**
+   * Find a pool by id.
+   */
+  find(userPoolId: SimCognitoUserPoolId): SimCognitoUserPool | undefined {
+    return this.pools.get(userPoolId);
+  }
+
+  /**
+   * Resolve a pool by id, or refuse.
+   */
+  require(userPoolId: SimCognitoUserPoolId): SimCognitoUserPool {
+    const found = this.find(userPoolId);
+
+    if (found === undefined) {
+      throw new SimCognitoResourceNotFoundException(
+        `User pool ${userPoolId} does not exist.`,
+      );
+    }
+
+    return found;
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -1,0 +1,98 @@
+import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPoolClientId } from "./client/sim-cognito-user-pool-client-id.js";
+import { SimCognitoUserPoolClientStore } from "./client/sim-cognito-user-pool-client-store.js";
+import type { SimCognitoDeletionProtection } from "./sim-cognito-deletion-protection.js";
+import type { SimCognitoName } from "./sim-cognito-name.js";
+import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
+import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
+import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+
+interface SimCognitoUserPoolProperties {
+  readonly id: SimCognitoUserPoolId;
+  readonly arn: SimCognitoUserPoolArn;
+  readonly name: SimCognitoName;
+  readonly passwordPolicy: SimCognitoPasswordPolicy;
+  readonly deletionProtection: SimCognitoDeletionProtection;
+  readonly createdDate: Date;
+}
+
+/**
+ * One simulated Cognito user pool.
+ *
+ * The pool owns its app clients, because that is where they live on real
+ * Cognito: deleting a pool takes its clients with it, and a client id means
+ * nothing outside the pool that issued it.
+ */
+export class SimCognitoUserPool {
+  public readonly id: SimCognitoUserPoolId;
+  public readonly arn: SimCognitoUserPoolArn;
+  public readonly name: string;
+  public readonly passwordPolicy: SimCognitoPasswordPolicy;
+  public readonly deletionProtection: SimCognitoDeletionProtection;
+  public readonly creationDate: Date;
+
+  private readonly clientStore = new SimCognitoUserPoolClientStore();
+
+  constructor(properties: SimCognitoUserPoolProperties) {
+    this.id = properties.id;
+    this.arn = properties.arn;
+    this.name = properties.name.value;
+    this.passwordPolicy = properties.passwordPolicy;
+    this.deletionProtection = properties.deletionProtection;
+    this.creationDate = properties.createdDate;
+  }
+
+  /**
+   * When the pool last changed.
+   *
+   * Nothing can change a pool here, as `UpdateUserPool` is not simulated, so
+   * this is its creation date.
+   */
+  get lastModifiedDate(): Date {
+    return this.creationDate;
+  }
+
+  /**
+   * Every app client of this pool, in creation order.
+   */
+  get clients(): readonly SimCognitoUserPoolClient[] {
+    return this.clientStore.all;
+  }
+
+  /**
+   * The app client ids already in use in this pool.
+   */
+  get clientIds(): Set<string> {
+    return this.clientStore.ids;
+  }
+
+  /**
+   * Store a newly created app client.
+   */
+  addClient(client: SimCognitoUserPoolClient): void {
+    this.clientStore.add(client);
+  }
+
+  /**
+   * Forget a deleted app client.
+   */
+  removeClient(client: SimCognitoUserPoolClient): void {
+    this.clientStore.remove(client);
+  }
+
+  /**
+   * Find an app client of this pool by id.
+   */
+  findClient(clientId: string): SimCognitoUserPoolClient | undefined {
+    return this.clientStore.find(clientId);
+  }
+
+  /**
+   * Resolve an app client of this pool by id, or refuse.
+   */
+  requireClient(
+    clientId: SimCognitoUserPoolClientId,
+  ): SimCognitoUserPoolClient {
+    return this.clientStore.require(clientId);
+  }
+}

--- a/src/service/secretsmanager/README.md
+++ b/src/service/secretsmanager/README.md
@@ -41,7 +41,26 @@ the data model: a label names exactly one version at a time, and making a versio
 the one that was to `AWSPREVIOUS` while whatever held `AWSPREVIOUS` loses it.
 
 `SimSecretsManagerSecretValue` holds one content field rather than two optional ones, so the
-invariant that a version is either text or binary and never both is true by construction.
+invariant that a version is either text or binary and never both is true by construction. It is the
+plaintext form: a request carries one in, and a read hands one back, but nothing stores one.
+
+`SimSecretsManagerEncryptedValue` is what a version does store. Encryption is envelope encryption,
+as it is on real Secrets Manager: `SimSecretsManagerValueEncryption` asks KMS for a data key per
+version, `SimSecretsManagerValueCipher` encrypts the value with the plaintext copy, and the
+encrypted copy is kept beside the ciphertext. That is why a write needs `kms:GenerateDataKey` and a
+read needs `kms:Decrypt`, rather than the `kms:Encrypt` a direct encryption would ask for. The
+encrypted data key names the KMS key that made it, so a version stays readable after the secret is
+pointed at a different key.
+
+The encryption context is `SecretARN` and `SecretVersionId`, which real Secrets Manager binds too.
+KMS binds it to the data key, so a data key lifted out of one version cannot be recovered as
+another, and the cipher out here needs no binding of its own.
+
+An encrypted value also keeps a digest of its plaintext. A repeated `ClientRequestToken` is a no-op
+when it carries the same value and a failure when it does not, and the two have to be told apart
+without the stored one being readable: decrypting it would need a `kms:Decrypt` that real AWS does
+not ask a writer for. The digest is a modelling shortcut rather than a security boundary, which is
+the same footing as key material living in process memory.
 
 `SimSecretsManagerSecretStore` owns `SecretId` resolution and name availability.
 `SimSecretsManagerSecretIdParser` is the part that turns the three forms a `SecretId` can take into
@@ -53,9 +72,12 @@ simulation's clock rather than the host's. This is what makes advancing simulate
 name up again, which is the behaviour a redeployed stack actually depends on.
 
 `SimSecretsManagerVersionWriter` is shared by every write. `CreateSecret`, `PutSecretValue` and
-`UpdateSecret` all end in the same place — a new version carrying the value, labelled `AWSCURRENT`
-unless told otherwise — so keeping it in one collaborator is what stops the three commands drifting
-apart on staging labels or on request-token idempotency.
+`UpdateSecret` all end in the same place — a new version carrying the encrypted value, labelled
+`AWSCURRENT` unless told otherwise — so keeping it in one collaborator is what stops the three
+commands drifting apart on staging labels, on request-token idempotency or on which key the value is
+encrypted under. The key comes in with the write rather than being read off the secret, because
+`UpdateSecret` can change the key and the value in one request and the new version belongs to the
+new key.
 
 ## Command handling
 
@@ -84,6 +106,13 @@ command instances.
   all;
 - `ListSecrets` authorizes against `*`, because real Secrets Manager gives that action no
   resource-level permissions, so a policy naming individual secret ARNs grants nothing.
+
+The KMS call a value makes is authorized separately, by KMS, as the same caller. A secret under a
+customer managed key therefore needs `kms:GenerateDataKey` to write and `kms:Decrypt` to read, on top
+of the Secrets Manager permission. A secret under the `aws/secretsmanager` managed key needs neither,
+because the calls carry `kms:ViaService` and that key's policy admits the account's principals
+reaching it through this service. Both are what real AWS asks for, and the second is why the common
+case stays as convenient as it was before anything was encrypted.
 
 There is no resource policy support yet, so unlike KMS this service passes no resource policies into
 the IAM decision. Cross-account access to a secret therefore cannot be granted, which is documented
@@ -114,10 +143,9 @@ way it does on real AWS.
 
 ## Divergences worth knowing
 
-- `KmsKeyId` is stored and reported but nothing is encrypted with it, and no `kms:Decrypt` check
-  happens. This is looser than real AWS. Sim SSM shows the shape the wiring would take for
-  `SecureString` parameters, but a secret has versions, staging labels and rotation to carry through
-  it, so it stands as its own change rather than a follow-on.
+- A `KmsKeyId` is checked when a version is written under it, not when it is set on its own. An
+  `UpdateSecret` that changes only the key accepts a key that does not exist; the next write of a
+  value fails.
 - Names ending in a hyphen and six characters are refused, which is stricter than real AWS.
 - `ListSecrets` refuses `Filters` and `SortOrder` rather than ignoring them.
 - A version that has lost every staging label is kept rather than removed, so it stays readable by

--- a/src/service/secretsmanager/command/authorize/sim-secrets-manager-kms-iam.iso.test.ts
+++ b/src/service/secretsmanager/command/authorize/sim-secrets-manager-kms-iam.iso.test.ts
@@ -1,0 +1,209 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  PutSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface SimAwsWithSecret {
+  readonly simAws: SimAws;
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * A simulated AWS holding one secret, and a Role allowed the given actions and
+ * nothing else.
+ *
+ * The secret is created by the Account root, so what the Role is allowed only
+ * decides whether it can read the secret afterwards.
+ */
+async function simAwsWithSecret(
+  actions: readonly string[],
+  keyed: "default-key" | "customer-key",
+): Promise<SimAwsWithSecret> {
+  const simAws = new SimAws();
+  const accountId = simAws.defaultAccountId;
+
+  const key = await simAws
+    .kms()
+    .createKey(new CreateKeyCommand({ Description: "Secret key" }));
+
+  await simAws.secretsManager().createSecret(
+    new CreateSecretCommand({
+      Name: "db-credentials",
+      SecretString: "hunter2",
+      KmsKeyId: keyed === "customer-key" ? key.KeyMetadata?.Arn : undefined,
+    }),
+  );
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SecretReader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SecretReader",
+      PolicyName: "SecretPolicy",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: actions, Resource: "*" },
+      }),
+    }),
+  );
+
+  return { simAws, caller: { kind: "arn", arn: role.Role.Arn } };
+}
+
+describe("Secrets Manager KMS authorization", () => {
+  it("reads a secret under the default key with no KMS permission", async () => {
+    // Given a secret under the aws/secretsmanager key and a Role allowed only
+    // to read it.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:GetSecretValue"],
+      "default-key",
+    );
+
+    // When it reads the secret.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+        {
+          caller,
+        },
+      );
+
+    // Then it gets the value with no KMS grant of its own, because the managed
+    // key's policy admits the Account's principals through Secrets Manager.
+    assertIdentical(read.SecretString, "hunter2");
+  });
+
+  it("denies a read under a customer managed key with no kms:Decrypt", async () => {
+    // Given the same Role, and a secret under a customer managed key.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:GetSecretValue"],
+      "customer-key",
+    );
+
+    // When it reads the secret.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .secretsManager()
+        .getSecretValue(
+          new GetSecretValueCommand({ SecretId: "db-credentials" }),
+          { caller },
+        ),
+    );
+
+    // Then it is denied, which is the deployment failure worth reproducing:
+    // the secret is allowed and the key is not.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Decrypt");
+  });
+
+  it("reads under a customer managed key once kms:Decrypt is granted", async () => {
+    // Given a Role allowed both the secret and the key.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:GetSecretValue", "kms:Decrypt"],
+      "customer-key",
+    );
+
+    // When it reads the secret.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "db-credentials" }),
+        {
+          caller,
+        },
+      );
+
+    // Then it gets the value.
+    assertIdentical(read.SecretString, "hunter2");
+  });
+
+  it("denies a write under a customer managed key with no kms:GenerateDataKey", async () => {
+    // Given a Role allowed to write the secret but nothing on its key.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:PutSecretValue"],
+      "customer-key",
+    );
+
+    // When it writes a new version.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.secretsManager().putSecretValue(
+        new PutSecretValueCommand({
+          SecretId: "db-credentials",
+          SecretString: "hunter3",
+        }),
+        { caller },
+      ),
+    );
+
+    // Then it is denied. Secrets Manager encrypts each version with a data key
+    // from KMS, so a write needs kms:GenerateDataKey rather than kms:Encrypt.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:GenerateDataKey");
+  });
+
+  it("writes under a customer managed key once kms:GenerateDataKey is granted", async () => {
+    // Given a Role allowed the secret and the data key.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:PutSecretValue", "kms:GenerateDataKey"],
+      "customer-key",
+    );
+
+    // When it writes a new version.
+    const written = await simAws.secretsManager().putSecretValue(
+      new PutSecretValueCommand({
+        SecretId: "db-credentials",
+        SecretString: "hunter3",
+      }),
+      { caller },
+    );
+
+    // Then the write succeeds.
+    assertNonNullable(written.VersionId);
+  });
+
+  it("writes under the default key with no KMS permission", async () => {
+    // Given a Role allowed only to write the secret, under the managed key.
+    const { simAws, caller } = await simAwsWithSecret(
+      ["secretsmanager:PutSecretValue"],
+      "default-key",
+    );
+
+    // When it writes a new version.
+    const written = await simAws.secretsManager().putSecretValue(
+      new PutSecretValueCommand({
+        SecretId: "db-credentials",
+        SecretString: "hunter3",
+      }),
+      { caller },
+    );
+
+    // Then the write succeeds, for the same reason the read does.
+    assertNonNullable(written.VersionId);
+  });
+});

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-metadata-update.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-metadata-update.ts
@@ -1,0 +1,41 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimSecretsManagerSecret } from "../../secret/sim-secrets-manager-secret.js";
+import type { SimUpdateSecretCommandInput } from "./secret.command.js";
+
+interface SimSecretsManagerMetadataUpdateProperties {
+  readonly clock: SimClock;
+}
+
+/**
+ * Applies the metadata fields an UpdateSecret request carries.
+ *
+ * Omitting a field leaves it as it was, which is how real Secrets Manager
+ * treats an absent Description or KmsKeyId. A new KmsKeyId applies to versions
+ * written afterwards; the ones already written keep the key they were made
+ * with and stay readable.
+ */
+export class SimSecretsManagerMetadataUpdate {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimSecretsManagerMetadataUpdateProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Apply a request's metadata to the secret.
+   */
+  apply(
+    secret: SimSecretsManagerSecret,
+    input: SimUpdateSecretCommandInput,
+  ): void {
+    if (input.Description !== undefined) {
+      secret.description = input.Description;
+    }
+
+    if (input.KmsKeyId !== undefined) {
+      secret.kmsKeyId = input.KmsKeyId;
+    }
+
+    secret.lastChangedDate = this.clock.now();
+  }
+}

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.iso.test.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.iso.test.ts
@@ -1,3 +1,4 @@
+import { CreateAliasCommand, CreateKeyCommand } from "@aws-sdk/client-kms";
 import {
   CreateSecretCommand,
   DescribeSecretCommand,
@@ -122,6 +123,14 @@ describe("Secrets Manager DescribeSecret", () => {
   it("reports the metadata a secret was created with", async () => {
     // Given a secret created with a description, a KMS key and tags.
     const simAws = new SimAws();
+    const key = await simAws.kms().createKey(new CreateKeyCommand({}));
+    await simAws.kms().createAlias(
+      new CreateAliasCommand({
+        AliasName: "alias/app-key",
+        TargetKeyId: key.KeyMetadata?.KeyId,
+      }),
+    );
+
     await simAws.secretsManager().createSecret(
       new CreateSecretCommand({
         Name: "described",

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.ts
@@ -51,10 +51,10 @@ export class SimSecretsManagerSecretCommands {
    * and all, so a policy allowing `secretsmanager:CreateSecret` on a bare name
    * fails here just as it would on real AWS.
    */
-  create(
+  async create(
     command: SimCreateSecretCommand,
     options?: SimSecretsManagerCommandOptions,
-  ): SimCreateSecretCommandOutput {
+  ): Promise<SimCreateSecretCommandOutput> {
     const { input } = command;
     const secret = this.secretFactory.make({
       name: input.Name,
@@ -71,7 +71,17 @@ export class SimSecretsManagerSecretCommands {
     );
     this.secrets.requireNameAvailable(secret.name);
 
-    const version = this.versionWriter.write(secret, value, input);
+    // The first version is written, and so encrypted, before the secret is
+    // stored, so a create refused for a key it cannot use leaves no secret
+    // holding the name.
+    const version = await this.versionWriter.write({
+      secret,
+      value,
+      input,
+      keyId: secret.kmsKeyId,
+      caller: options?.caller,
+    });
+
     this.secrets.add(secret);
 
     return {

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-secret-commands.ts
@@ -69,27 +69,33 @@ export class SimSecretsManagerSecretCommands {
       secret,
       options?.caller,
     );
-    this.secrets.requireNameAvailable(secret.name);
+    // The name is claimed for the whole of the create, because the first
+    // version is encrypted through KMS in between: another create of the same
+    // name is refused rather than overwriting this one. The secret itself is
+    // stored only once that version exists, so a create refused for a key it
+    // cannot use leaves nothing behind.
+    this.secrets.claimName(secret.name);
 
-    // The first version is written, and so encrypted, before the secret is
-    // stored, so a create refused for a key it cannot use leaves no secret
-    // holding the name.
-    const version = await this.versionWriter.write({
-      secret,
-      value,
-      input,
-      keyId: secret.kmsKeyId,
-      caller: options?.caller,
-    });
+    try {
+      const version = await this.versionWriter.write({
+        secret,
+        value,
+        input,
+        keyId: secret.kmsKeyId,
+        caller: options?.caller,
+      });
 
-    this.secrets.add(secret);
+      this.secrets.add(secret);
 
-    return {
-      $metadata: {},
-      ARN: secret.arn.value,
-      Name: secret.name,
-      VersionId: version.versionId,
-    };
+      return {
+        $metadata: {},
+        ARN: secret.arn.value,
+        Name: secret.name,
+        VersionId: version.versionId,
+      };
+    } finally {
+      this.secrets.releaseName(secret.name);
+    }
   }
 
   /**

--- a/src/service/secretsmanager/command/secret/sim-secrets-manager-update-secret.ts
+++ b/src/service/secretsmanager/command/secret/sim-secrets-manager-update-secret.ts
@@ -5,6 +5,7 @@ import type { SimSecretsManagerSecretStore } from "../../secret/sim-secrets-mana
 import { SimSecretsManagerSecretValue } from "../../secret/sim-secrets-manager-secret-value.js";
 import type { SimSecretsManagerVersionWriter } from "../../secret/sim-secrets-manager-version-writer.js";
 import type { SimSecretsManagerAuthorizer } from "../authorize/sim-secrets-manager-authorizer.js";
+import { SimSecretsManagerMetadataUpdate } from "./sim-secrets-manager-metadata-update.js";
 import type {
   SimUpdateSecretCommand,
   SimUpdateSecretCommandInput,
@@ -33,13 +34,15 @@ export class SimSecretsManagerUpdateSecret {
   private readonly secrets: SimSecretsManagerSecretStore;
   private readonly versionWriter: SimSecretsManagerVersionWriter;
   private readonly authorizer: SimSecretsManagerAuthorizer;
-  private readonly clock: SimClock;
+  private readonly metadata: SimSecretsManagerMetadataUpdate;
 
   constructor(properties: SimSecretsManagerUpdateSecretProperties) {
     this.secrets = properties.secrets;
     this.versionWriter = properties.versionWriter;
     this.authorizer = properties.authorizer;
-    this.clock = properties.clock;
+    this.metadata = new SimSecretsManagerMetadataUpdate({
+      clock: properties.clock,
+    });
   }
 
   /**
@@ -48,10 +51,10 @@ export class SimSecretsManagerUpdateSecret {
    * Supplying a value writes a new version and makes it current, the same as
    * PutSecretValue does.
    */
-  handle(
+  async handle(
     command: SimUpdateSecretCommand,
     options?: SimSecretsManagerUpdateSecretOptions,
-  ): SimUpdateSecretCommandOutput {
+  ): Promise<SimUpdateSecretCommandOutput> {
     const { input } = command;
     const secret = this.secrets.require(input.SecretId);
 
@@ -68,8 +71,13 @@ export class SimSecretsManagerUpdateSecret {
     // client request token already used for a different value. Applying the
     // metadata first would leave the secret half updated by a request that
     // then reported an error.
-    const versionId = this.writtenVersionId(secret, value, input);
-    this.applyMetadata(secret, input);
+    const versionId = await this.writtenVersionId(
+      secret,
+      value,
+      input,
+      options?.caller,
+    );
+    this.metadata.apply(secret, input);
 
     return {
       $metadata: {},
@@ -80,35 +88,30 @@ export class SimSecretsManagerUpdateSecret {
   }
 
   /**
-   * Apply the metadata fields an UpdateSecret request carries.
+   * Write the new version, if the request carried a value.
    *
-   * Omitting a field leaves it as it was, which is how real Secrets Manager
-   * treats an absent Description or KmsKeyId.
+   * A request changing the key and the value together encrypts the new version
+   * under the new key, as real AWS does. The versions already written keep the
+   * key they were made with, so they stay readable.
    */
-  private applyMetadata(
-    secret: SimSecretsManagerSecret,
-    input: SimUpdateSecretCommandInput,
-  ): void {
-    if (input.Description !== undefined) {
-      secret.description = input.Description;
-    }
-
-    if (input.KmsKeyId !== undefined) {
-      secret.kmsKeyId = input.KmsKeyId;
-    }
-
-    secret.lastChangedDate = this.clock.now();
-  }
-
-  private writtenVersionId(
+  private async writtenVersionId(
     secret: SimSecretsManagerSecret,
     value: SimSecretsManagerSecretValue | undefined,
     input: SimUpdateSecretCommandInput,
-  ): string | undefined {
+    caller: SimAwsCaller | undefined,
+  ): Promise<string | undefined> {
     if (value === undefined) {
       return undefined;
     }
 
-    return this.versionWriter.write(secret, value, input).versionId;
+    const version = await this.versionWriter.write({
+      secret,
+      value,
+      input,
+      keyId: input.KmsKeyId ?? secret.kmsKeyId,
+      caller,
+    });
+
+    return version.versionId;
   }
 }

--- a/src/service/secretsmanager/command/value/sim-secrets-manager-value-commands.ts
+++ b/src/service/secretsmanager/command/value/sim-secrets-manager-value-commands.ts
@@ -2,6 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimSecretsManagerSecretStore } from "../../secret/sim-secrets-manager-secret-store.js";
 import { SimSecretsManagerSecretValue } from "../../secret/sim-secrets-manager-secret-value.js";
 import { SimSecretsManagerVersionSelector } from "../../secret/sim-secrets-manager-version-selector.js";
+import type { SimSecretsManagerValueEncryption } from "../../secret/sim-secrets-manager-value-encryption.js";
 import type { SimSecretsManagerVersionWriter } from "../../secret/sim-secrets-manager-version-writer.js";
 import type { SimSecretsManagerAuthorizer } from "../authorize/sim-secrets-manager-authorizer.js";
 import type {
@@ -14,6 +15,7 @@ import type {
 interface SimSecretsManagerValueCommandsProperties {
   readonly secrets: SimSecretsManagerSecretStore;
   readonly versionWriter: SimSecretsManagerVersionWriter;
+  readonly encryption: SimSecretsManagerValueEncryption;
   readonly authorizer: SimSecretsManagerAuthorizer;
 }
 
@@ -30,22 +32,29 @@ interface SimSecretsManagerValueCommandOptions {
 export class SimSecretsManagerValueCommands {
   private readonly secrets: SimSecretsManagerSecretStore;
   private readonly versionWriter: SimSecretsManagerVersionWriter;
+  private readonly encryption: SimSecretsManagerValueEncryption;
   private readonly authorizer: SimSecretsManagerAuthorizer;
   private readonly versionSelector = new SimSecretsManagerVersionSelector();
 
   constructor(properties: SimSecretsManagerValueCommandsProperties) {
     this.secrets = properties.secrets;
     this.versionWriter = properties.versionWriter;
+    this.encryption = properties.encryption;
     this.authorizer = properties.authorizer;
   }
 
   /**
    * Read a secret's value, defaulting to the version labelled AWSCURRENT.
+   *
+   * Decryption goes to KMS as the caller, so a secret under a customer managed
+   * key needs `kms:Decrypt` on top of `secretsmanager:GetSecretValue`. There is
+   * no flag for reading a secret without decrypting it: GetSecretValue either
+   * returns the plaintext or fails.
    */
-  get(
+  async get(
     command: SimGetSecretValueCommand,
     options?: SimSecretsManagerValueCommandOptions,
-  ): SimGetSecretValueCommandOutput {
+  ): Promise<SimGetSecretValueCommandOutput> {
     const { input } = command;
     const secret = this.secrets.require(input.SecretId);
 
@@ -57,14 +66,19 @@ export class SimSecretsManagerValueCommands {
     secret.requireNotScheduledForDeletion();
 
     const version = this.versionSelector.select(secret, input);
+    const value = await this.encryption.decrypt(
+      { secretArn: secret.arn.value, versionId: version.versionId },
+      version.value,
+      options?.caller,
+    );
 
     return {
       $metadata: {},
       ARN: secret.arn.value,
       Name: secret.name,
       VersionId: version.versionId,
-      SecretString: version.value.secretString,
-      SecretBinary: version.value.secretBinary,
+      SecretString: value.secretString,
+      SecretBinary: value.secretBinary,
       VersionStages: version.stages,
       CreatedDate: version.createdDate,
     };
@@ -76,10 +90,10 @@ export class SimSecretsManagerValueCommands {
    * The new version becomes AWSCURRENT unless VersionStages says otherwise,
    * and the version that was current becomes AWSPREVIOUS.
    */
-  put(
+  async put(
     command: SimPutSecretValueCommand,
     options?: SimSecretsManagerValueCommandOptions,
-  ): SimPutSecretValueCommandOutput {
+  ): Promise<SimPutSecretValueCommandOutput> {
     const { input } = command;
     const secret = this.secrets.require(input.SecretId);
 
@@ -91,7 +105,13 @@ export class SimSecretsManagerValueCommands {
     secret.requireNotScheduledForDeletion();
 
     const value = SimSecretsManagerSecretValue.required(input);
-    const version = this.versionWriter.write(secret, value, input);
+    const version = await this.versionWriter.write({
+      secret,
+      value,
+      input,
+      keyId: secret.kmsKeyId,
+      caller: options?.caller,
+    });
 
     return {
       $metadata: {},

--- a/src/service/secretsmanager/error/sim-secrets-manager.error.ts
+++ b/src/service/secretsmanager/error/sim-secrets-manager.error.ts
@@ -60,6 +60,36 @@ export class SimSecretsManagerInvalidRequestException extends SimSecretsManagerE
 }
 
 /**
+ * Simulated Secrets Manager EncryptionFailure error.
+ *
+ * Real Secrets Manager reports a KMS key it cannot encrypt a new version with
+ * this way, whether the key is missing, disabled or pending deletion. A
+ * caller not allowed to use the key is denied by KMS instead, and that denial
+ * passes through as itself.
+ */
+export class SimSecretsManagerEncryptionFailure extends SimSecretsManagerError {
+  public override readonly name = "EncryptionFailure";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Secrets Manager DecryptionFailure error.
+ *
+ * The counterpart of EncryptionFailure, for a version whose key can no longer
+ * decrypt it.
+ */
+export class SimSecretsManagerDecryptionFailure extends SimSecretsManagerError {
+  public override readonly name = "DecryptionFailure";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Secrets Manager InvalidParameterException error.
  *
  * This is the failure a malformed or contradictory request input produces,

--- a/src/service/secretsmanager/index.ts
+++ b/src/service/secretsmanager/index.ts
@@ -7,12 +7,15 @@ export {
   type SimSecretsManagerTag,
 } from "./secret/sim-secrets-manager-secret.js";
 export { SimSecretsManagerSecretArn } from "./secret/sim-secrets-manager-secret-arn.js";
+export { SimSecretsManagerEncryptedValue } from "./secret/sim-secrets-manager-encrypted-value.js";
 export { SimSecretsManagerSecretValue } from "./secret/sim-secrets-manager-secret-value.js";
 export {
   SimSecretsManagerSecretVersion,
   SimSecretsManagerStagingLabel,
 } from "./secret/sim-secrets-manager-secret-version.js";
 export {
+  SimSecretsManagerDecryptionFailure,
+  SimSecretsManagerEncryptionFailure,
   SimSecretsManagerError,
   SimSecretsManagerInvalidParameterException,
   SimSecretsManagerInvalidRequestException,

--- a/src/service/secretsmanager/secret/sim-secrets-manager-encrypted-value.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-encrypted-value.ts
@@ -1,0 +1,46 @@
+import type { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
+
+interface SimSecretsManagerEncryptedValueProperties {
+  readonly dataKeyCiphertext: Uint8Array;
+  readonly iv: Uint8Array;
+  readonly authTag: Uint8Array;
+  readonly ciphertext: Uint8Array;
+  readonly digest: string;
+}
+
+/**
+ * The stored form of one secret version's value.
+ *
+ * This is what a version holds: the value's ciphertext, and beside it the
+ * encrypted copy of the data key that produced it. Nothing here can be read
+ * without a KMS call, which is the point. The encrypted data key names the KMS
+ * key it came from, so a version stays readable after the secret is pointed at
+ * a different key, as it does on real AWS.
+ */
+export class SimSecretsManagerEncryptedValue {
+  public readonly dataKeyCiphertext: Uint8Array;
+  public readonly iv: Uint8Array;
+  public readonly authTag: Uint8Array;
+  public readonly ciphertext: Uint8Array;
+
+  private readonly digest: string;
+
+  constructor(properties: SimSecretsManagerEncryptedValueProperties) {
+    this.dataKeyCiphertext = properties.dataKeyCiphertext;
+    this.iv = properties.iv;
+    this.authTag = properties.authTag;
+    this.ciphertext = properties.ciphertext;
+    this.digest = properties.digest;
+  }
+
+  /**
+   * Whether this is the encrypted form of the given value.
+   *
+   * A write repeating a client request token is a no-op when it carries the
+   * same value and a failure when it does not, so the two have to be compared
+   * without the stored one being readable.
+   */
+  holds(value: SimSecretsManagerSecretValue): boolean {
+    return this.digest === value.digest;
+  }
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-encryption.iso.test.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-encryption.iso.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/client-secrets-manager";
 import {
   assertArrayEquals,
+  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
@@ -21,6 +22,7 @@ import type { SimSecretsManagerSecretVersion } from "./sim-secrets-manager-secre
 import {
   SimSecretsManagerDecryptionFailure,
   SimSecretsManagerEncryptionFailure,
+  SimSecretsManagerResourceExistsException,
 } from "../error/sim-secrets-manager.error.js";
 
 /**
@@ -246,6 +248,57 @@ describe("Secrets Manager value encryption", () => {
 
     // And no half-made secret is left holding the name.
     assertUndefined(simAws.secretsManager().findSecret("no-such-key"));
+  });
+
+  it("frees the name again after a create the key refused", async () => {
+    // Given a create that failed on its key.
+    const simAws = new SimAws();
+    await assertThrowsErrorAsync(async () =>
+      simAws.secretsManager().createSecret(
+        new CreateSecretCommand({
+          Name: "second-attempt",
+          SecretString: "hunter2",
+          KmsKeyId: "alias/nothing-here",
+        }),
+      ),
+    );
+
+    // When the same name is created again, this time under the default key.
+    const created = await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "second-attempt",
+        SecretString: "hunter2",
+      }),
+    );
+
+    // Then it succeeds: the failed attempt let the name go.
+    assertNonNullable(created.ARN);
+  });
+
+  it("refuses a second create of the same name racing the first", async () => {
+    // Given two creates of one name, started before either has finished
+    // encrypting its first version.
+    const simAws = new SimAws();
+    const create = async (): Promise<unknown> =>
+      await simAws
+        .secretsManager()
+        .createSecret(
+          new CreateSecretCommand({ Name: "raced", SecretString: "hunter2" }),
+        );
+
+    // When both are run together.
+    const outcomes = await Promise.allSettled([create(), create()]);
+
+    // Then one wins and the other is refused, rather than the second quietly
+    // replacing the first.
+    assertArrayLength(
+      outcomes.filter((outcome) => outcome.status === "fulfilled"),
+      1,
+    );
+
+    const rejected = outcomes.find((outcome) => outcome.status === "rejected");
+    assertNonNullable(rejected);
+    assertInstanceOf(rejected.reason, SimSecretsManagerResourceExistsException);
   });
 
   it("refuses a read of a version whose key is gone", async () => {

--- a/src/service/secretsmanager/secret/sim-secrets-manager-encryption.iso.test.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-encryption.iso.test.ts
@@ -1,0 +1,316 @@
+import { CreateKeyCommand, DecryptCommand } from "@aws-sdk/client-kms";
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  PutSecretValueCommand,
+  UpdateSecretCommand,
+} from "@aws-sdk/client-secrets-manager";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimSecretsManagerSecret } from "./sim-secrets-manager-secret.js";
+import type { SimSecretsManagerSecretVersion } from "./sim-secrets-manager-secret-version.js";
+import {
+  SimSecretsManagerDecryptionFailure,
+  SimSecretsManagerEncryptionFailure,
+} from "../error/sim-secrets-manager.error.js";
+
+/**
+ * The stored current version of a secret, reached through the simulator's own
+ * accessor rather than the API, since the API only ever hands back plaintext.
+ */
+function storedCurrentVersion(
+  simAws: SimAws,
+  secretId: string,
+): SimSecretsManagerSecretVersion {
+  const version = storedSecret(simAws, secretId).versions.current;
+  assertNonNullable(version);
+
+  return version;
+}
+
+function storedSecret(
+  simAws: SimAws,
+  secretId: string,
+): SimSecretsManagerSecret {
+  const secret = simAws.secretsManager().findSecret(secretId);
+  assertNonNullable(secret);
+
+  return secret;
+}
+
+/**
+ * The KMS key a version's data key came from, found by asking KMS to recover
+ * that data key with the binding Secrets Manager made it under.
+ */
+async function dataKeyKeyId(
+  simAws: SimAws,
+  secretId: string,
+): Promise<string | undefined> {
+  const secret = storedSecret(simAws, secretId);
+  const version = storedCurrentVersion(simAws, secretId);
+
+  const dataKey = await simAws.kms().decrypt(
+    new DecryptCommand({
+      CiphertextBlob: version.value.dataKeyCiphertext,
+      EncryptionContext: {
+        SecretARN: secret.arn.value,
+        SecretVersionId: version.versionId,
+      },
+    }),
+    { viaService: "secretsmanager" },
+  );
+
+  return dataKey.KeyId;
+}
+
+describe("Secrets Manager value encryption", () => {
+  it("stores a version encrypted rather than in the clear", async () => {
+    // Given a secret naming no key of its own.
+    const simAws = new SimAws();
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "db-credentials",
+        SecretString: "hunter2",
+      }),
+    );
+
+    // When the stored version is inspected.
+    const version = storedCurrentVersion(simAws, "db-credentials");
+
+    // Then the value is a ciphertext, and the key that made it is the AWS
+    // managed key Secrets Manager creates on demand.
+    assertStringNotIncludes(
+      Buffer.from(version.value.ciphertext).toString("utf8"),
+      "hunter2",
+    );
+    assertNonNullable(simAws.kms().findKey("alias/aws/secretsmanager"));
+  });
+
+  it("binds a version's data key to the secret and the version", async () => {
+    // Given a secret with one version.
+    const simAws = new SimAws();
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "bound-value",
+        SecretString: "hunter2",
+      }),
+    );
+
+    const secret = storedSecret(simAws, "bound-value");
+    const version = storedCurrentVersion(simAws, "bound-value");
+
+    // When KMS is asked for the data key under a different version's binding.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().decrypt(
+        new DecryptCommand({
+          CiphertextBlob: version.value.dataKeyCiphertext,
+          EncryptionContext: {
+            SecretARN: secret.arn.value,
+            SecretVersionId: "some-other-version",
+          },
+        }),
+        { viaService: "secretsmanager" },
+      ),
+    );
+
+    // Then it refuses, because Secrets Manager binds both the secret ARN and
+    // the version id as the encryption context, as real AWS does.
+    assertInstanceOf(error, Error);
+  });
+
+  it("round-trips a binary value through encryption", async () => {
+    // Given a secret holding bytes rather than text.
+    const simAws = new SimAws();
+    const bytes = Uint8Array.from([0, 1, 250, 255, 13, 10]);
+
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "certificate.p12",
+        SecretBinary: bytes,
+      }),
+    );
+
+    // When it is read back.
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "certificate.p12" }),
+      );
+
+    // Then the bytes come back unchanged and as binary, not as text.
+    assertUndefined(read.SecretString);
+    assertNonNullable(read.SecretBinary);
+    assertArrayEquals([...read.SecretBinary], [...bytes]);
+  });
+
+  it("encrypts under a customer managed key when the secret names one", async () => {
+    // Given a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Secret key" }));
+
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // When a secret names it.
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "customer-keyed",
+        SecretString: "hunter2",
+        KmsKeyId: key.KeyMetadata.Arn,
+      }),
+    );
+
+    // Then the version's data key came from that key, and the value still
+    // reads back.
+    assertIdentical(
+      await dataKeyKeyId(simAws, "customer-keyed"),
+      key.KeyMetadata.Arn,
+    );
+
+    const read = await simAws
+      .secretsManager()
+      .getSecretValue(
+        new GetSecretValueCommand({ SecretId: "customer-keyed" }),
+      );
+
+    assertIdentical(read.SecretString, "hunter2");
+  });
+
+  it("leaves earlier versions readable when the key changes", async () => {
+    // Given a secret written under the default key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "New secret key" }));
+
+    await simAws
+      .secretsManager()
+      .createSecret(
+        new CreateSecretCommand({ Name: "rekeyed", SecretString: "old" }),
+      );
+
+    // When the key and the value are changed together.
+    await simAws.secretsManager().updateSecret(
+      new UpdateSecretCommand({
+        SecretId: "rekeyed",
+        KmsKeyId: key.KeyMetadata?.Arn,
+        SecretString: "new",
+      }),
+    );
+
+    // Then the new version is under the new key and the old one is still
+    // readable under the key it was written with, as on real AWS.
+    assertIdentical(
+      await dataKeyKeyId(simAws, "rekeyed"),
+      key.KeyMetadata?.Arn,
+    );
+
+    const previous = await simAws.secretsManager().getSecretValue(
+      new GetSecretValueCommand({
+        SecretId: "rekeyed",
+        VersionStage: "AWSPREVIOUS",
+      }),
+    );
+
+    assertIdentical(previous.SecretString, "old");
+  });
+
+  it("refuses a KmsKeyId no key answers to", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a secret names a key that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.secretsManager().createSecret(
+        new CreateSecretCommand({
+          Name: "no-such-key",
+          SecretString: "hunter2",
+          KmsKeyId: "alias/nothing-here",
+        }),
+      ),
+    );
+
+    // Then the write fails as an encryption failure, which is how real Secrets
+    // Manager reports a key it cannot encrypt with.
+    assertInstanceOf(error, SimSecretsManagerEncryptionFailure);
+
+    // And no half-made secret is left holding the name.
+    assertUndefined(simAws.secretsManager().findSecret("no-such-key"));
+  });
+
+  it("refuses a read of a version whose key is gone", async () => {
+    // Given a secret under a customer managed key that is later disabled.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Doomed key" }));
+
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "unreadable",
+        SecretString: "hunter2",
+        KmsKeyId: key.KeyMetadata?.Arn,
+      }),
+    );
+
+    await simAws.kms().disableKey({ input: { KeyId: key.KeyMetadata?.Arn } });
+
+    // When the secret is read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .secretsManager()
+        .getSecretValue(new GetSecretValueCommand({ SecretId: "unreadable" })),
+    );
+
+    // Then it fails as a decryption failure rather than handing back a value
+    // the key can no longer protect.
+    assertInstanceOf(error, SimSecretsManagerDecryptionFailure);
+  });
+
+  it("keeps a repeated write with the same value a no-op", async () => {
+    // Given a secret written with a client request token.
+    const simAws = new SimAws();
+    await simAws.secretsManager().createSecret(
+      new CreateSecretCommand({
+        Name: "retried-write",
+        SecretString: "hunter2",
+        ClientRequestToken: "the-token",
+      }),
+    );
+
+    // When the same token is used again with the same value, and then with a
+    // different one.
+    const repeated = await simAws.secretsManager().putSecretValue(
+      new PutSecretValueCommand({
+        SecretId: "retried-write",
+        SecretString: "hunter2",
+        ClientRequestToken: "the-token",
+      }),
+    );
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.secretsManager().putSecretValue(
+        new PutSecretValueCommand({
+          SecretId: "retried-write",
+          SecretString: "something else",
+          ClientRequestToken: "the-token",
+        }),
+      ),
+    );
+
+    // Then the retry is accepted and the conflicting write is refused, which
+    // still holds now that the stored version is a ciphertext.
+    assertIdentical(repeated.VersionId, "the-token");
+    assertInstanceOf(error, Error);
+  });
+});

--- a/src/service/secretsmanager/secret/sim-secrets-manager-kms-crypto.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-kms-crypto.ts
@@ -1,0 +1,73 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The alias of the AWS managed key Secrets Manager encrypts with when a secret
+ * names no key of its own.
+ *
+ * Simulated KMS creates the key behind a reserved `alias/aws/` name the first
+ * time something asks for it, which is how such a key comes into existence on
+ * real AWS too: nobody creates it, the service that needs it does.
+ */
+export const secretsManagerDefaultKeyAlias = "alias/aws/secretsmanager";
+
+/**
+ * The service Secrets Manager's KMS calls are made through, as
+ * `kms:ViaService` names it.
+ *
+ * Supplying it is what keeps the common case as convenient here as it is on
+ * real AWS: the `aws/secretsmanager` key's policy admits the account's
+ * principals when the request reaches KMS through Secrets Manager, so a caller
+ * allowed only `secretsmanager:GetSecretValue` reads the secret.
+ */
+export const secretsManagerKmsViaService = "secretsmanager";
+
+/**
+ * The data key length Secrets Manager asks KMS for.
+ */
+export const secretsManagerDataKeySpec = "AES_256";
+
+interface SimSecretsManagerKmsOptions {
+  readonly caller?: SimAwsCaller | undefined;
+  readonly viaService?: string | undefined;
+}
+
+/**
+ * The narrow slice of simulated KMS that secret values need.
+ *
+ * Real Secrets Manager uses envelope encryption: it asks KMS for a data key
+ * per version, encrypts the value with the plaintext copy and keeps the
+ * encrypted copy beside the ciphertext. That is why a write needs
+ * `kms:GenerateDataKey` and a read needs `kms:Decrypt`, rather than both
+ * needing `kms:Encrypt` and `kms:Decrypt` as a direct encryption would.
+ *
+ * SimKms structurally implements this interface.
+ */
+export interface SimSecretsManagerKmsCrypto {
+  generateDataKey(
+    command: {
+      input: {
+        KeyId?: string | undefined;
+        KeySpec?: string | undefined;
+        EncryptionContext?: Readonly<Record<string, string>> | undefined;
+      };
+    },
+    options?: SimSecretsManagerKmsOptions,
+  ): Promise<{
+    Plaintext?: Uint8Array | undefined;
+    CiphertextBlob?: Uint8Array | undefined;
+    KeyId?: string | undefined;
+  }>;
+
+  decrypt(
+    command: {
+      input: {
+        CiphertextBlob?: Uint8Array | undefined;
+        EncryptionContext?: Readonly<Record<string, string>> | undefined;
+      };
+    },
+    options?: SimSecretsManagerKmsOptions,
+  ): Promise<{
+    Plaintext?: Uint8Array | undefined;
+    KeyId?: string | undefined;
+  }>;
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-kms-key-problems.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-kms-key-problems.ts
@@ -1,0 +1,52 @@
+import { SimKmsError } from "../../kms/error/sim-kms.error.js";
+import {
+  SimSecretsManagerDecryptionFailure,
+  SimSecretsManagerEncryptionFailure,
+  type SimSecretsManagerError,
+} from "../error/sim-secrets-manager.error.js";
+
+/**
+ * Which way round a KMS call went wrong, since Secrets Manager has an error
+ * for each.
+ */
+export type SimSecretsManagerKeyFailure = "encrypting" | "decrypting";
+
+/**
+ * Run a KMS call, reporting a refusal about the key the way Secrets Manager
+ * reports it.
+ *
+ * Every key problem KMS raises becomes EncryptionFailure or DecryptionFailure
+ * carrying the KMS message, which is what real Secrets Manager does for a key
+ * that is missing, disabled or pending deletion. An access denial is not a KMS
+ * error and passes through untouched, so a missing `kms:Decrypt` still reads
+ * as a denial rather than a broken key.
+ */
+export async function reportingKeyProblems<TResult>(
+  failure: SimSecretsManagerKeyFailure,
+  call: () => Promise<TResult>,
+): Promise<TResult> {
+  try {
+    return await call();
+  } catch (error: unknown) {
+    if (error instanceof SimKmsError) {
+      throw keyFailure(failure, error.message);
+    }
+
+    throw error;
+  }
+}
+
+function keyFailure(
+  failure: SimSecretsManagerKeyFailure,
+  message: string,
+): SimSecretsManagerError {
+  if (failure === "encrypting") {
+    return new SimSecretsManagerEncryptionFailure(
+      `Secrets Manager cannot encrypt the secret value with its KMS key: ${message}`,
+    );
+  }
+
+  return new SimSecretsManagerDecryptionFailure(
+    `Secrets Manager cannot decrypt the secret value with its KMS key: ${message}`,
+  );
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret-store.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret-store.ts
@@ -22,6 +22,12 @@ interface SimSecretsManagerSecretStoreProperties {
  */
 export class SimSecretsManagerSecretStore {
   private readonly secrets = new Map<string, SimSecretsManagerSecret>();
+
+  /**
+   * The names of secrets being created, which are taken but not yet stored.
+   */
+  private readonly claimedNames = new Set<string>();
+
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly secretIds: SimSecretsManagerSecretIdParser;
 
@@ -97,6 +103,30 @@ export class SimSecretsManagerSecretStore {
   }
 
   /**
+   * Take a name for a secret being created, refusing one already taken.
+   *
+   * The name is held from here rather than from when the secret is stored,
+   * because creating one is not instant: its first version is encrypted
+   * through KMS in between. Two creates racing for the same name would
+   * otherwise both get past the check and the second would overwrite the
+   * first, where real Secrets Manager refuses it.
+   */
+  claimName(name: string): void {
+    this.requireNameAvailable(name);
+    this.claimedNames.add(name);
+  }
+
+  /**
+   * Give up a claimed name.
+   *
+   * A create that failed leaves the name free again, and one that succeeded
+   * has the stored secret holding it from then on.
+   */
+  releaseName(name: string): void {
+    this.claimedNames.delete(name);
+  }
+
+  /**
    * Refuse a name that is already taken, saying which way it is taken.
    *
    * A name held by a secret waiting out its recovery window is the failure
@@ -104,6 +134,12 @@ export class SimSecretsManagerSecretStore {
    * telling apart from a name held by a live secret.
    */
   requireNameAvailable(name: string): void {
+    if (this.claimedNames.has(name)) {
+      throw new SimSecretsManagerResourceExistsException(
+        `The secret '${name}' already exists`,
+      );
+    }
+
     const existing = this.secrets
       .values()
       .find((secret) => secret.name === name);

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret-value.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret-value.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { SimSecretsManagerInvalidParameterException } from "../error/sim-secrets-manager.error.js";
 
 /**
@@ -7,6 +8,17 @@ export interface SimSecretsManagerSecretValueInput {
   readonly SecretString?: string | undefined;
   readonly SecretBinary?: Uint8Array | undefined;
 }
+
+/**
+ * The markers that tell the two kinds of value apart once a value is bytes.
+ *
+ * A value is encrypted as bytes, and what comes back out has to say which of
+ * SecretString and SecretBinary it was, since the two are different fields on
+ * the way out and a caller storing UTF-8 bytes as binary must not get text
+ * back.
+ */
+const textMarker = 0;
+const binaryMarker = 1;
 
 /**
  * The value held by one version of a simulated secret.
@@ -65,12 +77,18 @@ export class SimSecretsManagerSecretValue {
     return undefined;
   }
 
-  private static bytesEqual(mine: Uint8Array, theirs: Uint8Array): boolean {
-    if (mine.length !== theirs.length) {
-      return false;
+  /**
+   * Read a value back from the bytes it was encrypted as.
+   */
+  static fromBytes(bytes: Uint8Array): SimSecretsManagerSecretValue {
+    const buffer = Buffer.from(bytes);
+    const content = buffer.subarray(1);
+
+    if (buffer.at(0) === textMarker) {
+      return new SimSecretsManagerSecretValue(content.toString("utf8"));
     }
 
-    return mine.every((byte, index) => byte === theirs.at(index));
+    return new SimSecretsManagerSecretValue(Uint8Array.from(content));
   }
 
   /**
@@ -99,16 +117,31 @@ export class SimSecretsManagerSecretValue {
   }
 
   /**
-   * Whether another value holds exactly the same content.
-   *
-   * This is what makes a retried write with the same client request token a
-   * no-op rather than a failure, as it is on real AWS.
+   * The value as the bytes it is encrypted as, marked with its kind.
    */
-  equals(other: SimSecretsManagerSecretValue): boolean {
-    if (typeof this.content === "string" || typeof other.content === "string") {
-      return this.content === other.content;
+  get bytes(): Uint8Array {
+    if (typeof this.content === "string") {
+      return this.markedBytes(textMarker, Buffer.from(this.content, "utf8"));
     }
 
-    return SimSecretsManagerSecretValue.bytesEqual(this.content, other.content);
+    return this.markedBytes(binaryMarker, Buffer.from(this.content));
+  }
+
+  /**
+   * A digest of the value, standing in for the value itself where two of them
+   * have to be compared.
+   *
+   * This is what makes a retried write with the same client request token a
+   * no-op rather than a failure, as it is on real AWS. Real Secrets Manager
+   * compares the two values; a stored version here holds only ciphertext, and
+   * decrypting it would need a `kms:Decrypt` that real AWS does not ask a
+   * writer for.
+   */
+  get digest(): string {
+    return createHash("sha256").update(this.bytes).digest("hex");
+  }
+
+  private markedBytes(marker: number, content: Buffer): Uint8Array {
+    return Uint8Array.from(Buffer.concat([Buffer.of(marker), content]));
   }
 }

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret-version.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret-version.ts
@@ -1,4 +1,4 @@
-import type { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
+import type { SimSecretsManagerEncryptedValue } from "./sim-secrets-manager-encrypted-value.js";
 
 /**
  * The staging labels Secrets Manager gives a meaning of its own.
@@ -16,7 +16,7 @@ export type SimSecretsManagerStagingLabel =
 
 interface SimSecretsManagerSecretVersionProperties {
   readonly versionId: string;
-  readonly value: SimSecretsManagerSecretValue;
+  readonly value: SimSecretsManagerEncryptedValue;
   readonly createdDate: Date;
 }
 
@@ -29,7 +29,13 @@ interface SimSecretsManagerSecretVersionProperties {
  */
 export class SimSecretsManagerSecretVersion {
   public readonly versionId: string;
-  public readonly value: SimSecretsManagerSecretValue;
+
+  /**
+   * The version's value, as it is stored: encrypted under a data key of the
+   * secret's KMS key. Reading it back is a KMS call.
+   */
+  public readonly value: SimSecretsManagerEncryptedValue;
+
   public readonly createdDate: Date;
 
   private readonly labels = new Set<string>();

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret.ts
@@ -33,12 +33,12 @@ export class SimSecretsManagerSecret {
   public description: string | undefined;
 
   /**
-   * The KMS key the secret says it is encrypted under.
+   * The KMS key new versions of the secret are encrypted under, in any form
+   * KMS accepts. Undefined means the `aws/secretsmanager` managed key.
    *
-   * Nothing is actually encrypted with it and no kms:Decrypt check happens, so
-   * this is looser than real AWS. Simulated KMS is not wired into this service
-   * yet; the value is stored and reported so that code reading it behaves the
-   * same, and the divergence is documented.
+   * Changing it applies to versions written afterwards. The versions already
+   * written keep the key they were made with, as they do on real AWS, so they
+   * stay readable.
    */
   public kmsKeyId: string | undefined;
 

--- a/src/service/secretsmanager/secret/sim-secrets-manager-value-cipher.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-value-cipher.ts
@@ -1,0 +1,66 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { SimSecretsManagerEncryptedValue } from "./sim-secrets-manager-encrypted-value.js";
+import { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
+
+/**
+ * The cipher a data key encrypts a secret value with.
+ *
+ * This is the half of envelope encryption that does not happen inside KMS.
+ * KMS produces and later recovers the data key; the value itself is encrypted
+ * out here with AES-256-GCM, which is what the AWS Encryption SDK does with a
+ * data key too.
+ */
+const algorithm = "aes-256-gcm";
+const ivLength = 12;
+
+/**
+ * Encrypts and decrypts a secret value under a plaintext data key.
+ *
+ * The encryption context is not bound in here. KMS binds it to the data key,
+ * so a decryption naming a different secret or version fails at the KMS call
+ * rather than at this cipher, which is where real Secrets Manager fails too.
+ */
+export class SimSecretsManagerValueCipher {
+  /**
+   * Encrypt a value under a data key.
+   */
+  seal(
+    value: SimSecretsManagerSecretValue,
+    dataKey: Uint8Array,
+    dataKeyCiphertext: Uint8Array,
+  ): SimSecretsManagerEncryptedValue {
+    const iv = randomBytes(ivLength);
+    const cipher = createCipheriv(algorithm, dataKey, iv);
+
+    const ciphertext = Buffer.concat([
+      cipher.update(value.bytes),
+      cipher.final(),
+    ]);
+
+    return new SimSecretsManagerEncryptedValue({
+      dataKeyCiphertext,
+      iv: Uint8Array.from(iv),
+      authTag: Uint8Array.from(cipher.getAuthTag()),
+      ciphertext: Uint8Array.from(ciphertext),
+      digest: value.digest,
+    });
+  }
+
+  /**
+   * Decrypt a value with the data key KMS recovered for it.
+   */
+  open(
+    encrypted: SimSecretsManagerEncryptedValue,
+    dataKey: Uint8Array,
+  ): SimSecretsManagerSecretValue {
+    const decipher = createDecipheriv(algorithm, dataKey, encrypted.iv);
+    decipher.setAuthTag(encrypted.authTag);
+
+    const plaintext = Buffer.concat([
+      decipher.update(encrypted.ciphertext),
+      decipher.final(),
+    ]);
+
+    return SimSecretsManagerSecretValue.fromBytes(Uint8Array.from(plaintext));
+  }
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-value-encryption.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-value-encryption.ts
@@ -1,0 +1,123 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimSecretsManagerEncryptedValue } from "./sim-secrets-manager-encrypted-value.js";
+import {
+  secretsManagerDataKeySpec,
+  secretsManagerDefaultKeyAlias,
+  secretsManagerKmsViaService,
+  type SimSecretsManagerKmsCrypto,
+} from "./sim-secrets-manager-kms-crypto.js";
+import { reportingKeyProblems } from "./sim-secrets-manager-kms-key-problems.js";
+import type { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
+import { SimSecretsManagerValueCipher } from "./sim-secrets-manager-value-cipher.js";
+
+/**
+ * What a secret version's encryption is bound to.
+ *
+ * Real Secrets Manager binds both the secret and the version, so a ciphertext
+ * lifted out of one version cannot be decrypted as another, and a
+ * `kms:EncryptionContext:SecretARN` policy condition matches on the secret it
+ * belongs to.
+ */
+export interface SimSecretsManagerEncryptionBinding {
+  readonly secretArn: string;
+  readonly versionId: string;
+}
+
+interface SimSecretsManagerValueEncryptionProperties {
+  readonly kms: SimSecretsManagerKmsCrypto;
+}
+
+/**
+ * The KMS calls a secret version's value makes.
+ *
+ * The calls are made as the caller rather than as the service, which is what
+ * puts a customer managed key's permissions in the way: a write needs the
+ * caller's own `kms:GenerateDataKey` and a read needs `kms:Decrypt`, each on
+ * top of the Secrets Manager permission for the secret itself. They are made
+ * through the service as well, so the `aws/secretsmanager` managed key needs
+ * no KMS permission at all, as on real AWS.
+ */
+export class SimSecretsManagerValueEncryption {
+  private readonly kms: SimSecretsManagerKmsCrypto;
+  private readonly cipher = new SimSecretsManagerValueCipher();
+
+  constructor(properties: SimSecretsManagerValueEncryptionProperties) {
+    this.kms = properties.kms;
+  }
+
+  /**
+   * Encrypt a value as a new version, under the secret's key.
+   */
+  async encrypt(
+    binding: SimSecretsManagerEncryptionBinding,
+    value: SimSecretsManagerSecretValue,
+    keyId: string | undefined,
+    caller: SimAwsCaller | undefined,
+  ): Promise<SimSecretsManagerEncryptedValue> {
+    const dataKey = await reportingKeyProblems(
+      "encrypting",
+      async () =>
+        await this.kms.generateDataKey(
+          {
+            input: {
+              KeyId: keyId ?? secretsManagerDefaultKeyAlias,
+              KeySpec: secretsManagerDataKeySpec,
+              EncryptionContext: this.contextFor(binding),
+            },
+          },
+          { caller, viaService: secretsManagerKmsViaService },
+        ),
+    );
+
+    assertDefined(
+      dataKey.Plaintext,
+      `Simulated KMS generated no data key for ${binding.secretArn}`,
+    );
+    assertDefined(
+      dataKey.CiphertextBlob,
+      `Simulated KMS encrypted no data key for ${binding.secretArn}`,
+    );
+
+    return this.cipher.seal(value, dataKey.Plaintext, dataKey.CiphertextBlob);
+  }
+
+  /**
+   * Decrypt a stored version, which needs the same binding it was made with.
+   */
+  async decrypt(
+    binding: SimSecretsManagerEncryptionBinding,
+    encrypted: SimSecretsManagerEncryptedValue,
+    caller: SimAwsCaller | undefined,
+  ): Promise<SimSecretsManagerSecretValue> {
+    const dataKey = await reportingKeyProblems(
+      "decrypting",
+      async () =>
+        await this.kms.decrypt(
+          {
+            input: {
+              CiphertextBlob: encrypted.dataKeyCiphertext,
+              EncryptionContext: this.contextFor(binding),
+            },
+          },
+          { caller, viaService: secretsManagerKmsViaService },
+        ),
+    );
+
+    assertDefined(
+      dataKey.Plaintext,
+      `Simulated KMS recovered no data key for ${binding.secretArn}`,
+    );
+
+    return this.cipher.open(encrypted, dataKey.Plaintext);
+  }
+
+  private contextFor(
+    binding: SimSecretsManagerEncryptionBinding,
+  ): Readonly<Record<string, string>> {
+    return {
+      SecretARN: binding.secretArn,
+      SecretVersionId: binding.versionId,
+    };
+  }
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-version-write.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-version-write.ts
@@ -1,0 +1,40 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimSecretsManagerSecret } from "./sim-secrets-manager-secret.js";
+import type { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
+
+/**
+ * The version-shaping fields a write request can carry.
+ */
+export interface SimSecretsManagerVersionWriteInput {
+  readonly ClientRequestToken?: string | undefined;
+  readonly VersionStages?: readonly string[] | undefined;
+}
+
+/**
+ * One write of a secret version, as the three writing commands describe it.
+ *
+ * CreateSecret, PutSecretValue and UpdateSecret differ in what they do around
+ * the write and agree on the write itself, so what they have to say about it
+ * is one shape rather than three argument lists.
+ */
+export interface SimSecretsManagerVersionWrite {
+  readonly secret: SimSecretsManagerSecret;
+  readonly value: SimSecretsManagerSecretValue;
+  readonly input: SimSecretsManagerVersionWriteInput;
+
+  /**
+   * The key the new version is encrypted under, in any form KMS accepts.
+   * Undefined leaves Secrets Manager to use its own AWS managed key.
+   *
+   * It is passed rather than read off the secret because UpdateSecret can
+   * change the key and the value in one request, and the new version belongs
+   * to the new key.
+   */
+  readonly keyId: string | undefined;
+
+  /**
+   * The caller the KMS call is made as, so that writing a version needs the
+   * caller's own `kms:GenerateDataKey` on a customer managed key.
+   */
+  readonly caller: SimAwsCaller | undefined;
+}

--- a/src/service/secretsmanager/secret/sim-secrets-manager-version-writer.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-version-writer.ts
@@ -4,38 +4,35 @@ import {
   SimSecretsManagerInvalidParameterException,
   SimSecretsManagerResourceExistsException,
 } from "../error/sim-secrets-manager.error.js";
-import type { SimSecretsManagerSecret } from "./sim-secrets-manager-secret.js";
 import {
   SimSecretsManagerSecretVersion,
   SimSecretsManagerStagingLabel,
 } from "./sim-secrets-manager-secret-version.js";
 import type { SimSecretsManagerSecretValue } from "./sim-secrets-manager-secret-value.js";
-
-/**
- * The version-shaping fields a write request can carry.
- */
-export interface SimSecretsManagerVersionWriteInput {
-  readonly ClientRequestToken?: string | undefined;
-  readonly VersionStages?: readonly string[] | undefined;
-}
+import type { SimSecretsManagerValueEncryption } from "./sim-secrets-manager-value-encryption.js";
+import type { SimSecretsManagerVersionWrite } from "./sim-secrets-manager-version-write.js";
 
 interface SimSecretsManagerVersionWriterProperties {
   readonly clock: SimClock;
+  readonly encryption: SimSecretsManagerValueEncryption;
 }
 
 /**
  * Writes a new version of a secret, the way every Secrets Manager write does.
  *
- * CreateSecret, PutSecretValue and UpdateSecret all end in the same place:
- * a new version carrying the value, labelled AWSCURRENT unless told otherwise.
- * Keeping that in one collaborator is what stops the three commands drifting
- * apart on staging labels or on request-token idempotency.
+ * CreateSecret, PutSecretValue and UpdateSecret all end in the same place: a
+ * new version carrying the encrypted value, labelled AWSCURRENT unless told
+ * otherwise. Keeping that in one collaborator is what stops the three commands
+ * drifting apart on staging labels, on request-token idempotency or on which
+ * key the value is encrypted under.
  */
 export class SimSecretsManagerVersionWriter {
   private readonly clock: SimClock;
+  private readonly encryption: SimSecretsManagerValueEncryption;
 
   constructor(properties: SimSecretsManagerVersionWriterProperties) {
     this.clock = properties.clock;
+    this.encryption = properties.encryption;
   }
 
   /**
@@ -45,12 +42,14 @@ export class SimSecretsManagerVersionWriter {
    * repeat of the same token with the same value is ignored, which is what
    * makes a retried write safe; the same token with a different value is
    * refused, because a version's value never changes once written.
+   *
+   * The value is encrypted before anything is stored, so a write refused for
+   * a key the caller may not use leaves no version behind.
    */
-  write(
-    secret: SimSecretsManagerSecret,
-    value: SimSecretsManagerSecretValue,
-    input: SimSecretsManagerVersionWriteInput,
-  ): SimSecretsManagerSecretVersion {
+  async write(
+    request: SimSecretsManagerVersionWrite,
+  ): Promise<SimSecretsManagerSecretVersion> {
+    const { secret, value, input } = request;
     const versionId = input.ClientRequestToken ?? randomUUID();
     const existing = secret.versions.byId(versionId);
 
@@ -60,7 +59,12 @@ export class SimSecretsManagerVersionWriter {
 
     const version = new SimSecretsManagerSecretVersion({
       versionId,
-      value,
+      value: await this.encryption.encrypt(
+        { secretArn: secret.arn.value, versionId },
+        value,
+        request.keyId,
+        request.caller,
+      ),
       createdDate: this.clock.now(),
     });
 
@@ -91,7 +95,7 @@ export class SimSecretsManagerVersionWriter {
     existing: SimSecretsManagerSecretVersion,
     value: SimSecretsManagerSecretValue,
   ): SimSecretsManagerSecretVersion {
-    if (existing.value.equals(value)) {
+    if (existing.value.holds(value)) {
       return existing;
     }
 

--- a/src/service/secretsmanager/sim-secrets-manager.ts
+++ b/src/service/secretsmanager/sim-secrets-manager.ts
@@ -10,6 +10,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimKms } from "../kms/index.js";
 import { SimSecretsManagerCfnResourceFactory } from "./cfn/sim-cfn-secrets-manager-resource-factory.js";
 import { SimSecretsManagerAuthorizer } from "./command/authorize/sim-secrets-manager-authorizer.js";
 import { SimSecretsManagerLifecycleCommands } from "./command/secret/sim-secrets-manager-lifecycle-commands.js";
@@ -22,6 +23,8 @@ import type { SimSecretsManagerSecret } from "./secret/sim-secrets-manager-secre
 import { SimSecretsManagerSecretExpiry } from "./secret/sim-secrets-manager-secret-expiry.js";
 import { SimSecretsManagerSecretFactory } from "./secret/sim-secrets-manager-secret-factory.js";
 import { SimSecretsManagerSecretStore } from "./secret/sim-secrets-manager-secret-store.js";
+import type { SimSecretsManagerKmsCrypto } from "./secret/sim-secrets-manager-kms-crypto.js";
+import { SimSecretsManagerValueEncryption } from "./secret/sim-secrets-manager-value-encryption.js";
 import { SimSecretsManagerVersionWriter } from "./secret/sim-secrets-manager-version-writer.js";
 import { SimSecretsManagerSdkCommandRouter } from "./sdk/sim-secrets-manager-sdk-command-router.js";
 
@@ -33,6 +36,13 @@ interface SimSecretsManagerProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * The simulated KMS that secret values are encrypted through. One is created
+   * for this scope when none is supplied, so a standalone SimSecretsManager
+   * still encrypts rather than quietly storing secrets in the clear.
+   */
+  readonly kms?: SimSecretsManagerKmsCrypto;
 }
 
 /**
@@ -62,9 +72,14 @@ export class SimSecretsManager {
       background = new BackgroundTasks(),
     } = properties;
 
+    const { kms = new SimKms({ accountRegionScope, iam, background }) } =
+      properties;
+
     const authorizer = new SimSecretsManagerAuthorizer({ iam });
+    const encryption = new SimSecretsManagerValueEncryption({ kms });
     const versionWriter = new SimSecretsManagerVersionWriter({
       clock: background,
+      encryption,
     });
 
     this.background = background;
@@ -100,6 +115,7 @@ export class SimSecretsManager {
     this.valueCommands = new SimSecretsManagerValueCommands({
       secrets: this.secrets,
       versionWriter,
+      encryption,
       authorizer,
     });
   }
@@ -122,7 +138,7 @@ export class SimSecretsManager {
     options?: SimSecretsManagerRequestOptions,
   ): Promise<simSecretsManagerCommands.SimCreateSecretCommandOutput> {
     await this.background.sequence();
-    return this.secretCommands.create(command, options);
+    return await this.secretCommands.create(command, options);
   }
 
   /**
@@ -144,7 +160,7 @@ export class SimSecretsManager {
     options?: SimSecretsManagerRequestOptions,
   ): Promise<simSecretsManagerCommands.SimUpdateSecretCommandOutput> {
     await this.background.sequence();
-    return this.updateSecretCommand.handle(command, options);
+    return await this.updateSecretCommand.handle(command, options);
   }
 
   /**
@@ -166,7 +182,7 @@ export class SimSecretsManager {
     options?: SimSecretsManagerRequestOptions,
   ): Promise<simSecretsManagerCommands.SimGetSecretValueCommandOutput> {
     await this.background.sequence();
-    return this.valueCommands.get(command, options);
+    return await this.valueCommands.get(command, options);
   }
 
   /**
@@ -177,7 +193,7 @@ export class SimSecretsManager {
     options?: SimSecretsManagerRequestOptions,
   ): Promise<simSecretsManagerCommands.SimPutSecretValueCommandOutput> {
     await this.background.sequence();
-    return this.valueCommands.put(command, options);
+    return await this.valueCommands.put(command, options);
   }
 
   /**


### PR DESCRIPTION
Every secret version is now encrypted through simulated KMS when written and decrypted when read, under the secret's KmsKeyId or the aws/secretsmanager managed key. Encryption is envelope encryption as on real AWS, so a customer managed key needs kms:GenerateDataKey to write and kms:Decrypt to read, while the default key needs no KMS permission at all.

Resolves https://github.com/KensioSoftware/yulin/issues/227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secrets Manager simulation now encrypts stored secret values via simulated KMS, including customer-managed keys and binary secrets.
  * Enforced KMS permission checks for both reads (decrypt) and writes (data key generation), with clear encryption/decryption failure behavior.
  * Added simulated Cognito user pools (user pools and app clients) with SDK command routing.
* **Documentation**
  * Refined Secrets Manager/KMS limitation and encryption/permission explanations.
  * Expanded Secrets Manager model details and added customer-key access-denial example.
  * Added Cognito simulation documentation and runnable examples.
* **Tests**
  * Added/expanded end-to-end Secrets Manager encryption and KMS authorization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->