### PR TITLE
refactor: split SimAwsServiceFactory into scope collaborators

### DIFF
--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -1,0 +1,209 @@
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../util/background/background.js";
+import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
+import type { SimAws } from "../sim-aws.js";
+import { SimAcm } from "../../acm/sim-acm.js";
+import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
+import { SimCloudFormation } from "../../cloudformation/index.js";
+import { SimCognitoIdentityProvider } from "../../cognito/index.js";
+import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import { SimKms } from "../../kms/index.js";
+import { SimLambda } from "../../lambda/index.js";
+import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
+import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
+import { SimS3 } from "../../s3/sim-s3.js";
+import { SimSecretsManager } from "../../secretsmanager/index.js";
+import { SimSsm } from "../../ssm/index.js";
+import { SimSts } from "../../sts/sim-sts.js";
+import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
+import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
+
+interface SimAwsAccountRegionServiceBuilderProperties {
+  readonly simAws: SimAws;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly registries: SimAwsScopedServiceRegistries;
+  readonly iamRegistry: SimIamRegistry;
+  readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
+  readonly accountServices: SimAwsAccountServiceCache;
+}
+
+/**
+ * Builder for simulated AWS services scoped to one Account and Region.
+ *
+ * SimAwsServiceFactory owns the top-level policy of which scope a service
+ * belongs to. This class is the half of that split holding the services whose
+ * AWS state is scoped to an account/region pair, as SimAwsAccountServiceCache
+ * is the half holding the services scoped to a whole account.
+ *
+ * Nothing is cached here, which is the point of the split: a service in this
+ * class is built fresh for the scope that asks for it, because on real AWS its
+ * state does not cross a Region boundary. Each build method is therefore just
+ * the wiring for one service, and says in its own doc comment what makes that
+ * service Region-scoped.
+ *
+ * Services here reach account-scoped ones, IAM above all, through the same
+ * account cache the factory uses, so a Region's services decide against the
+ * one IAM its Account owns.
+ */
+export class SimAwsAccountRegionServiceBuilder {
+  private readonly simAws: SimAws;
+  private readonly background: BackgroundScheduler & BackgroundCompleter;
+  private readonly registries: SimAwsScopedServiceRegistries;
+  private readonly iamRegistry: SimIamRegistry;
+  private readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
+  private readonly accountServices: SimAwsAccountServiceCache;
+
+  constructor(properties: SimAwsAccountRegionServiceBuilderProperties) {
+    this.simAws = properties.simAws;
+    this.background = properties.background;
+    this.registries = properties.registries;
+    this.iamRegistry = properties.iamRegistry;
+    this.lambdaUrlRegistry = properties.lambdaUrlRegistry;
+    this.accountServices = properties.accountServices;
+  }
+
+  /** Create simulated ACM for an Account Region scope. */
+  createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
+    const acm = new SimAcm({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+      // Certificates validate against Hosted Zones from any simulated Account,
+      // as real ACM validates against public DNS.
+      dnsRecords: new SimRoute53AcmDnsRecords({
+        route53Registry: this.registries.route53,
+      }),
+    });
+
+    this.registries.acm.register(scope.accountRegionScope, acm);
+
+    return acm;
+  }
+
+  /** Create simulated CloudFormation for an Account Region scope. */
+  createCloudFormation(scope: SimAwsAccountRegionContainer): SimCloudFormation {
+    return new SimCloudFormation({
+      simAws: this.simAws,
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /**
+   * Create simulated Cognito user pools for an Account Region scope.
+   *
+   * User pools are Region-scoped on real AWS: a pool id names its Region, and
+   * a pool cannot be reached from another one.
+   */
+  createCognitoIdentityProvider(
+    scope: SimAwsAccountRegionContainer,
+  ): SimCognitoIdentityProvider {
+    return new SimCognitoIdentityProvider({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /** Create simulated DynamoDB for an Account Region scope. */
+  createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
+    return new SimDynamoDatabase({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /**
+   * Create simulated KMS for an Account Region scope.
+   *
+   * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
+   * ciphertext produced in one Region cannot be decrypted in another.
+   */
+  createKms(scope: SimAwsAccountRegionContainer): SimKms {
+    return new SimKms({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /**
+   * Create simulated Lambda for an Account Region scope.
+   *
+   * S3-located function code is fetched from the same Account/Region scope's
+   * simulated S3, as real Lambda requires same-region code buckets. Function
+   * code running in the vm runtime is provided host-installed AWS SDK
+   * packages intercepted into this SimAws, as the real Lambda runtime
+   * provides the SDK.
+   */
+  createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
+    return new SimLambda({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+      runAsOwner: this.simAws,
+      urlRegistry: this.lambdaUrlRegistry,
+      codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
+      vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
+        simAws: this.simAws,
+        regionName: scope.accountRegionScope.regionName,
+      }),
+    });
+  }
+
+  /** Create simulated S3 for an Account Region scope. */
+  createS3(scope: SimAwsAccountRegionContainer): SimS3 {
+    return new SimS3({
+      accountRegionScope: scope.accountRegionScope,
+      s3GlobalRegistry: this.registries.s3,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+    });
+  }
+
+  /**
+   * Create simulated Secrets Manager for an Account Region scope, whose secret
+   * values are encrypted through that same scope's simulated KMS.
+   */
+  createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
+    return new SimSecretsManager({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+      kms: scope.kms(),
+    });
+  }
+
+  /**
+   * Create simulated SSM for an Account Region scope.
+   *
+   * Parameters are Region-scoped on real AWS: a parameter name is unique
+   * within one Account and Region, and its ARN names the Region. SecureString
+   * values are encrypted through that same scope's simulated KMS.
+   */
+  createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
+    return new SimSsm({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+      kms: scope.kms(),
+    });
+  }
+
+  /** Create simulated STS for an Account/Region scope. */
+  createSts(scope: SimAwsAccountRegionContainer): SimSts {
+    this.accountServices.createIam(scope);
+
+    return new SimSts({
+      accountRegionScope: scope.accountRegionScope,
+      background: this.background,
+      iamResolver: this.iamRegistry,
+    });
+  }
+}

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -36,7 +36,8 @@ interface SimAwsAccountServiceCacheProperties {
  * SimAwsServiceFactory owns the top-level service construction policy and the
  * shared registries for one SimAws instance. This class is the narrower cache
  * it delegates to for services whose AWS state is scoped to an account rather
- * than to an account/region pair.
+ * than to an account/region pair, as SimAwsAccountRegionServiceBuilder is the
+ * one it delegates to for the rest.
  *
  * This class is the account-scoped service catalog: it records which simulated
  * AWS services share one instance across all regions in an account. A single

--- a/src/service/aws/factory/sim-aws-request-auth-wiring.ts
+++ b/src/service/aws/factory/sim-aws-request-auth-wiring.ts
@@ -1,0 +1,60 @@
+import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import { SimIamAccessKeyRegistry } from "../../iam/registry/sim-iam-access-key-registry.js";
+import { SimIamGlobalCredentialResolver } from "../../iam/registry/sim-iam-global-credential-resolver.js";
+import { SimIamSigV4Verifier } from "../../iam/sigv4/sim-iam-sigv4-verifier.js";
+import { SimAwsRequestCallerResolver } from "../../iam/request/sim-aws-request-caller-resolver.js";
+
+interface SimAwsRequestAuthWiringProperties {
+  readonly iamRegistry: SimIamRegistry;
+}
+
+/**
+ * The request authentication collaborators shared by one SimAws instance.
+ *
+ * SimAwsServiceFactory constructs simulated services for an Account/Region
+ * scope. This class holds the one graph that deliberately spans every scope
+ * instead: a signed request names an access key rather than an Account, so
+ * verifying it has to start from a simulation-wide index and only then reach
+ * the IAM that issued the key.
+ *
+ * Keeping the three pieces together means they are wired once, in the order
+ * they depend on each other, rather than as separate fields that happen to
+ * refer to one another.
+ * @internal
+ */
+export class SimAwsRequestAuthWiring {
+  /**
+   * Shared index of which Account owns each simulated access key.
+   *
+   * A SigV4 signed request names an access key but not an Account, so this is
+   * what lets a signature be traced back to the IAM that issued it.
+   */
+  public readonly accessKeyRegistry = new SimIamAccessKeyRegistry();
+
+  /**
+   * Verifies SigV4 signatures made with any access key in this simulation.
+   */
+  public readonly signedRequests: SimIamSigV4Verifier;
+
+  /**
+   * Resolves the principal behind an HTTP request into this simulation.
+   *
+   * This is the single request authentication boundary: everything arriving
+   * over HTTP, including the in-process `SimAwsHttp.fetch()` path, gets its
+   * caller from here.
+   */
+  public readonly requestCallers: SimAwsRequestCallerResolver;
+
+  constructor(properties: SimAwsRequestAuthWiringProperties) {
+    this.signedRequests = new SimIamSigV4Verifier({
+      credentials: new SimIamGlobalCredentialResolver({
+        accessKeys: this.accessKeyRegistry,
+        iam: properties.iamRegistry,
+      }),
+    });
+
+    this.requestCallers = new SimAwsRequestCallerResolver({
+      signedRequests: this.signedRequests,
+    });
+  }
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -4,31 +4,26 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
-import { SimCloudFormation } from "../../cloudformation/index.js";
-import { SimCognitoIdentityProvider } from "../../cognito/index.js";
+import type { SimAcm } from "../../acm/sim-acm.js";
+import type { SimCloudFormation } from "../../cloudformation/index.js";
+import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
-import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
-import { SimS3 } from "../../s3/sim-s3.js";
-import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
-import { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
-import { SimAcm } from "../../acm/sim-acm.js";
-import { SimRoute53AcmDnsRecords } from "../../acm/validation/sim-route53-acm-dns-records.js";
+import type { SimS3 } from "../../s3/sim-s3.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
-import { SimIamAccessKeyRegistry } from "../../iam/registry/sim-iam-access-key-registry.js";
-import { SimIamGlobalCredentialResolver } from "../../iam/registry/sim-iam-global-credential-resolver.js";
-import { SimIamSigV4Verifier } from "../../iam/sigv4/sim-iam-sigv4-verifier.js";
-import { SimAwsRequestCallerResolver } from "../../iam/request/sim-aws-request-caller-resolver.js";
-import { SimKms } from "../../kms/index.js";
-import { SimLambda } from "../../lambda/index.js";
+import type { SimKms } from "../../kms/index.js";
+import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
-import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
-import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
-import { SimSecretsManager } from "../../secretsmanager/index.js";
-import { SimSsm } from "../../ssm/index.js";
-import { SimSts } from "../../sts/sim-sts.js";
+import type { SimSecretsManager } from "../../secretsmanager/index.js";
+import type { SimSsm } from "../../ssm/index.js";
+import type { SimSts } from "../../sts/sim-sts.js";
+import { SimAwsAccountRegionServiceBuilder } from "./sim-aws-account-region-service-builder.js";
+import { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
+import { SimAwsRequestAuthWiring } from "./sim-aws-request-auth-wiring.js";
+import { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 
 interface SimAwsServiceFactoryProperties {
   readonly simAws: SimAws;
@@ -39,15 +34,17 @@ interface SimAwsServiceFactoryProperties {
  * Factory for simulated AWS services used by one SimAws instance.
  *
  * This class is the top-level construction boundary behind the SimAws facade.
- * It wires shared collaborators such as background tasks and service
- * registries, creates new account/region-scoped service instances, and
- * delegates account-scoped singleton lifetimes to SimAwsAccountServiceCache.
+ * It owns the collaborators shared by every scope, such as the cross-scope
+ * registries and request authentication, and it decides which scope each
+ * simulated service belongs to.
  *
- * SimAwsAccountServiceCache is narrower: it only caches services that should be
- * reused for an entire account. This factory decides whether a service should
- * be created fresh for the requested account/region scope, such as ACM,
- * CloudFormation, DynamoDB, and S3, or routed through that account-level cache,
- * such as IAM, Route53, and CloudFront.
+ * That decision is all this class states, one line per service, and the two
+ * collaborators it routes between are what the two answers mean. A service
+ * scoped to an account, such as IAM, Route53, and CloudFront, is reused for
+ * every Region in that account by SimAwsAccountServiceCache. A service scoped
+ * to an account and region, such as ACM, DynamoDB, and S3, is built fresh for
+ * the asking scope by SimAwsAccountRegionServiceBuilder, which is also where
+ * the wiring for one of those services lives.
  */
 export class SimAwsServiceFactory {
   /**
@@ -68,35 +65,11 @@ export class SimAwsServiceFactory {
   public readonly iamRegistry = new SimIamRegistry();
 
   /**
-   * Shared index of which Account owns each simulated access key.
-   *
-   * A SigV4 signed request names an access key but not an Account, so this is
-   * what lets a signature be traced back to the IAM that issued it.
+   * Shared request authentication collaborators for this simulation.
    * @internal
    */
-  public readonly accessKeyRegistry = new SimIamAccessKeyRegistry();
-
-  /**
-   * Verifies SigV4 signatures made with any access key in this simulation.
-   * @internal
-   */
-  public readonly signedRequests = new SimIamSigV4Verifier({
-    credentials: new SimIamGlobalCredentialResolver({
-      accessKeys: this.accessKeyRegistry,
-      iam: this.iamRegistry,
-    }),
-  });
-
-  /**
-   * Resolves the principal behind an HTTP request into this simulation.
-   *
-   * This is the single request authentication boundary: everything arriving
-   * over HTTP, including the in-process `SimAwsHttp.fetch()` path, gets its
-   * caller from here.
-   * @internal
-   */
-  public readonly requestCallers = new SimAwsRequestCallerResolver({
-    signedRequests: this.signedRequests,
+  public readonly requestAuth = new SimAwsRequestAuthWiring({
+    iamRegistry: this.iamRegistry,
   });
 
   /**
@@ -109,19 +82,15 @@ export class SimAwsServiceFactory {
    */
   public readonly lambdaUrlRegistry = new SimLambdaUrlRegistry();
 
-  private readonly simAws: SimAws;
-  private readonly background: BackgroundScheduler & BackgroundCompleter;
-
   /**
    * The registries this simulation's scoped services share between them.
    */
   private readonly registries = new SimAwsScopedServiceRegistries();
 
   private readonly accountServices: SimAwsAccountServiceCache;
+  private readonly accountRegionServices: SimAwsAccountRegionServiceBuilder;
 
   constructor(properties: SimAwsServiceFactoryProperties) {
-    this.simAws = properties.simAws;
-    this.background = properties.background;
     this.accountServices = new SimAwsAccountServiceCache({
       simAws: properties.simAws,
       background: properties.background,
@@ -129,38 +98,26 @@ export class SimAwsServiceFactory {
       cloudFrontRegistry: this.cloudFrontRegistry,
       route53Registry: this.registries.route53,
       iamRegistry: this.iamRegistry,
-      accessKeyRegistry: this.accessKeyRegistry,
+      accessKeyRegistry: this.requestAuth.accessKeyRegistry,
+    });
+    this.accountRegionServices = new SimAwsAccountRegionServiceBuilder({
+      simAws: properties.simAws,
+      background: properties.background,
+      registries: this.registries,
+      iamRegistry: this.iamRegistry,
+      lambdaUrlRegistry: this.lambdaUrlRegistry,
+      accountServices: this.accountServices,
     });
   }
 
   /** Create simulated ACM for an Account Region scope. */
   createAcm(scope: SimAwsAccountRegionContainer): SimAcm {
-    const iam = this.createIam(scope);
-
-    const acm = new SimAcm({
-      accountRegionScope: scope.accountRegionScope,
-      iam,
-      background: this.background,
-      // Certificates validate against Hosted Zones from any simulated Account,
-      // as real ACM validates against public DNS.
-      dnsRecords: new SimRoute53AcmDnsRecords({
-        route53Registry: this.registries.route53,
-      }),
-    });
-
-    this.registries.acm.register(scope.accountRegionScope, acm);
-
-    return acm;
+    return this.accountRegionServices.createAcm(scope);
   }
 
   /** Create simulated CloudFormation for an Account Region scope. */
   createCloudFormation(scope: SimAwsAccountRegionContainer): SimCloudFormation {
-    return new SimCloudFormation({
-      simAws: this.simAws,
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.createIam(scope),
-      background: this.background,
-    });
+    return this.accountRegionServices.createCloudFormation(scope);
   }
 
   /** Create or get simulated CloudFront for an Account scope. */
@@ -168,31 +125,16 @@ export class SimAwsServiceFactory {
     return this.accountServices.createCloudFront(scope);
   }
 
-  /**
-   * Create simulated Cognito user pools for an Account Region scope.
-   *
-   * User pools are Region-scoped on real AWS: a pool id names its Region, and
-   * a pool cannot be reached from another one.
-   */
+  /** Create simulated Cognito user pools for an Account Region scope. */
   createCognitoIdentityProvider(
     scope: SimAwsAccountRegionContainer,
   ): SimCognitoIdentityProvider {
-    return new SimCognitoIdentityProvider({
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.createIam(scope),
-      background: this.background,
-    });
+    return this.accountRegionServices.createCognitoIdentityProvider(scope);
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */
   createDynamoDb(scope: SimAwsAccountRegionContainer): SimDynamoDatabase {
-    const iam = this.createIam(scope);
-
-    return new SimDynamoDatabase({
-      accountRegionScope: scope.accountRegionScope,
-      iam,
-      background: this.background,
-    });
+    return this.accountRegionServices.createDynamoDb(scope);
   }
 
   /** Create or get simulated IAM for an Account scope. */
@@ -200,44 +142,14 @@ export class SimAwsServiceFactory {
     return this.accountServices.createIam(scope);
   }
 
-  /**
-   * Create simulated KMS for an Account Region scope.
-   *
-   * KMS keys are Region-scoped on real AWS: a key ARN names its Region, and a
-   * ciphertext produced in one Region cannot be decrypted in another.
-   */
+  /** Create simulated KMS for an Account Region scope. */
   createKms(scope: SimAwsAccountRegionContainer): SimKms {
-    return new SimKms({
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.createIam(scope),
-      background: this.background,
-    });
+    return this.accountRegionServices.createKms(scope);
   }
 
-  /**
-   * Create simulated Lambda for an Account Region scope.
-   *
-   * S3-located function code is fetched from the same Account/Region scope's
-   * simulated S3, as real Lambda requires same-region code buckets. Function
-   * code running in the vm runtime is provided host-installed AWS SDK
-   * packages intercepted into this SimAws, as the real Lambda runtime
-   * provides the SDK.
-   */
+  /** Create simulated Lambda for an Account Region scope. */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
-    const iam = this.createIam(scope);
-
-    return new SimLambda({
-      accountRegionScope: scope.accountRegionScope,
-      iam,
-      background: this.background,
-      runAsOwner: this.simAws,
-      urlRegistry: this.lambdaUrlRegistry,
-      codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
-      vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
-        simAws: this.simAws,
-        regionName: scope.accountRegionScope.regionName,
-      }),
-    });
+    return this.accountRegionServices.createLambda(scope);
   }
 
   /** Create or get simulated Route53 for an Account scope. */
@@ -247,53 +159,21 @@ export class SimAwsServiceFactory {
 
   /** Create simulated S3 for an Account Region scope. */
   createS3(scope: SimAwsAccountRegionContainer): SimS3 {
-    const iam = this.createIam(scope);
-
-    return new SimS3({
-      accountRegionScope: scope.accountRegionScope,
-      s3GlobalRegistry: this.registries.s3,
-      iam,
-      background: this.background,
-    });
+    return this.accountRegionServices.createS3(scope);
   }
 
-  /**
-   * Create simulated Secrets Manager for an Account Region scope, whose secret
-   * values are encrypted through that same scope's simulated KMS.
-   */
+  /** Create simulated Secrets Manager for an Account Region scope. */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
-    return new SimSecretsManager({
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.createIam(scope),
-      background: this.background,
-      kms: scope.kms(),
-    });
+    return this.accountRegionServices.createSecretsManager(scope);
   }
 
-  /**
-   * Create simulated SSM for an Account Region scope.
-   *
-   * Parameters are Region-scoped on real AWS: a parameter name is unique
-   * within one Account and Region, and its ARN names the Region. SecureString
-   * values are encrypted through that same scope's simulated KMS.
-   */
+  /** Create simulated SSM for an Account Region scope. */
   createSsm(scope: SimAwsAccountRegionContainer): SimSsm {
-    return new SimSsm({
-      accountRegionScope: scope.accountRegionScope,
-      iam: this.createIam(scope),
-      background: this.background,
-      kms: scope.kms(),
-    });
+    return this.accountRegionServices.createSsm(scope);
   }
 
   /** Create simulated STS for an Account/Region scope. */
   createSts(scope: SimAwsAccountRegionContainer): SimSts {
-    this.createIam(scope);
-
-    return new SimSts({
-      accountRegionScope: scope.accountRegionScope,
-      background: this.background,
-      iamResolver: this.iamRegistry,
-    });
+    return this.accountRegionServices.createSts(scope);
   }
 }

--- a/src/service/aws/sim-aws-request-authentication.ts
+++ b/src/service/aws/sim-aws-request-authentication.ts
@@ -1,11 +1,11 @@
 import type { SimIamCredentialIdentity } from "../iam/credential/sim-aws-credentials.js";
 import type { SimAwsRequestCaller } from "../iam/request/sim-aws-request-caller.js";
 import { simIamSigV4SignedRequest } from "../iam/sigv4/sim-iam-sigv4-signed-request.js";
-import type { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
+import type { SimAwsRequestAuthWiring } from "./factory/sim-aws-request-auth-wiring.js";
 import type { SimAwsRequestCallerOptions } from "./sim-aws-properties.js";
 
 interface SimAwsRequestAuthenticationProperties {
-  readonly serviceFactory: SimAwsServiceFactory;
+  readonly requestAuth: SimAwsRequestAuthWiring;
   readonly clock: { now(): Date };
 }
 
@@ -20,11 +20,11 @@ interface SimAwsRequestAuthenticationProperties {
  * this is the one place that has to remember it.
  */
 export class SimAwsRequestAuthentication {
-  private readonly serviceFactory: SimAwsServiceFactory;
+  private readonly requestAuth: SimAwsRequestAuthWiring;
   private readonly clock: { now(): Date };
 
   constructor(properties: SimAwsRequestAuthenticationProperties) {
-    this.serviceFactory = properties.serviceFactory;
+    this.requestAuth = properties.requestAuth;
     this.clock = properties.clock;
   }
 
@@ -35,7 +35,7 @@ export class SimAwsRequestAuthentication {
     request: Request,
     body: Uint8Array | undefined,
   ): SimIamCredentialIdentity {
-    return this.serviceFactory.signedRequests.verify(
+    return this.requestAuth.signedRequests.verify(
       simIamSigV4SignedRequest(request, body),
       { now: this.clock.now() },
     );
@@ -48,7 +48,7 @@ export class SimAwsRequestAuthentication {
     request: Request,
     options: SimAwsRequestCallerOptions,
   ): SimAwsRequestCaller {
-    return this.serviceFactory.requestCallers.resolve(
+    return this.requestAuth.requestCallers.resolve(
       simIamSigV4SignedRequest(request, options.body),
       { expectedScope: options.expectedScope, now: this.clock.now() },
     );

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -90,7 +90,7 @@ export class SimAws {
     this.iamRegistry = this.serviceFactory.iamRegistry;
     this.scopes = new SimAwsScopeRegistry({ simAws: this });
     this.requestAuthentication = new SimAwsRequestAuthentication({
-      serviceFactory: this.serviceFactory,
+      requestAuth: this.serviceFactory.requestAuth,
       clock: background,
     });
   }


### PR DESCRIPTION
Account/region-scoped service construction moves to SimAwsAccountRegionServiceBuilder, mirroring the existing SimAwsAccountServiceCache, and the shared request authentication graph moves to SimAwsRequestAuthWiring. The factory is left stating only which scope each simulated service belongs to, one line per service.

That takes it from 299 lines to 179, against the 300-line lint cap it was about to cross, so the next simulated service costs about six lines there rather than eighteen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for constructing simulated AWS services scoped to a specific account and region.
  * Improved request authentication wiring for access-key lookup, signature verification, and caller resolution.
  * Added consistent regional integrations for ACM, Lambda, Secrets Manager, SSM, and STS.

* **Refactor**
  * Centralized service creation and authentication setup for more consistent simulation behavior.
  * Preserved existing service-creation interfaces while streamlining their internal coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->