### PR TITLE
feat: create users in a simulated Cognito user pool

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -21,8 +21,8 @@ Sim Cognito currently supports:
   `AdminEnableUserCommand` and `ListUsersCommand`
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
-- The real user status lifecycle, so an admin-created user cannot sign in until it has a permanent
-  password
+- The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
+  has a permanent password
 - App client authentication flows, token lifetimes and generated client secrets
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
@@ -108,13 +108,14 @@ with `InvalidPasswordException`, saying which rule it broke.
 
 ## Users
 
-`AdminCreateUser` creates a user. The user it creates cannot sign in: its status is
-`FORCE_CHANGE_PASSWORD`, which is where real Cognito leaves a user an admin made. Setting a permanent
-password moves it to `CONFIRMED`.
+`AdminCreateUser` creates a user in `FORCE_CHANGE_PASSWORD`, which is where real Cognito leaves a
+user an admin made: it has a temporary password and cannot sign in with it. Setting a permanent
+password moves the user to `CONFIRMED`. Nothing signs in here yet, so that status is what a test can
+assert on now, and what the authentication flows will read when they arrive.
 
 ```typescript sim-cognito-create-user
 /**
- * Creating a simulated user that could actually sign in.
+ * Creating a simulated user and confirming it.
  */
 
 import {
@@ -513,6 +514,8 @@ Current documented limitations:
   `AdminUpdateUserAttributes` refuses `ClientMetadata` the same way.
 - `ListUsers` refuses `Filter` and `AttributesToGet` rather than ignoring them, and lists users in
   creation order. Real Cognito chooses its own order and does not promise one.
+- `ListUsers` refuses a `Limit` of zero, which the real operation accepts without saying what it
+  returns. Refusing it is better than guessing between an empty page and a full one.
 - Only the standard user attributes exist, because a pool is created without a `Schema`. A `custom:`
   attribute is refused, and so is a request setting `sub`. `AdminDeleteUserAttributes` is not
   implemented, so an attribute can be changed but not removed.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -16,14 +16,19 @@ Sim Cognito currently supports:
   `ListUserPoolsCommand`
 - `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `DeleteUserPoolClientCommand` and
   `ListUserPoolClientsCommand`
+- `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
+  `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
+  `AdminEnableUserCommand` and `ListUsersCommand`
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
-- The real default password policy, and a policy the request sets
+- The real default password policy, applied to the passwords users are given
+- The real user status lifecycle, so an admin-created user cannot sign in until it has a permanent
+  password
 - App client authentication flows, token lifetimes and generated client secrets
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
-There are no users yet, so nothing signs in. Users, groups, tokens and the authentication flows
-themselves are separate pieces of work.
+Nothing signs in yet. Groups, tokens and the authentication flows themselves are separate pieces of
+work.
 
 ## Creating a pool and an app client
 
@@ -98,7 +103,127 @@ console.log(passwordPolicy?.MinimumLength); // 12
 console.log(passwordPolicy?.RequireSymbols); // true, the default
 ```
 
-Nothing checks a password against the policy yet, because a pool holds no users.
+Every password a user is given is checked against this policy. A password that breaks it is refused
+with `InvalidPasswordException`, saying which rule it broke.
+
+## Users
+
+`AdminCreateUser` creates a user. The user it creates cannot sign in: its status is
+`FORCE_CHANGE_PASSWORD`, which is where real Cognito leaves a user an admin made. Setting a permanent
+password moves it to `CONFIRMED`.
+
+```typescript sim-cognito-create-user
+/**
+ * Creating a simulated user that could actually sign in.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+const created = await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+console.log(created.User?.UserStatus); // "FORCE_CHANGE_PASSWORD"
+
+// Without this the user stays in FORCE_CHANGE_PASSWORD and cannot sign in.
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const read = await cognito.adminGetUser(
+  new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+
+console.log(read.UserStatus); // "CONFIRMED"
+console.log(read.UserAttributes?.find((each) => each.Name === "sub")?.Value);
+// A UUID, and not "alice"
+```
+
+A password set without `Permanent: true` is temporary, and leaves the user in
+`FORCE_CHANGE_PASSWORD` again.
+
+A user's `sub` is a UUID Cognito allocates, reported among its attributes. It is not the username,
+and code treating the two as interchangeable fails here rather than in a deployment. Admin
+operations here name a user by its username only. Real Cognito also accepts a `sub` where an
+operation asks for a username, so that is one thing that works there and not here. The refusal says
+so when the username given is some user's `sub`.
+
+Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, and under
+`UserAttributes` from `AdminGetUser`, which is how the real API names them.
+
+`AdminUpdateUserAttributes` changes the attributes it names and leaves the rest alone.
+`AdminDisableUser` sets `Enabled` to `false` without changing the user's status, and
+`AdminEnableUser` sets it back.
+
+Only the standard attributes exist. A pool here is created without a `Schema` of its own, so a
+`custom:` attribute is refused, as it would be on a real pool created the same way.
+
+## Listing users
+
+`ListUsers` pages by `Limit` and `PaginationToken`, which is what the real operation calls them.
+
+```typescript sim-cognito-list-users
+/**
+ * Listing the users of a simulated user pool.
+ */
+
+import {
+  AdminCreateUserCommand,
+  CreateUserPoolCommand,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+);
+
+const listed = await cognito.listUsers(
+  new ListUsersCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(listed.Users?.map((user) => user.Username)); // [ "alice", "bob" ]
+```
+
+`Filter` is refused rather than ignored. A filter that was quietly dropped would answer with the
+wrong users rather than with an error, which is the kind of pass that turns into a failure in a
+deployment. List the users and filter them in the test instead.
 
 ## App clients
 
@@ -367,11 +492,34 @@ without `DeletionProtection` if the test needs to delete it.
 
 Current documented limitations:
 
-- There are no users. `AdminCreateUser`, `SignUp`, `AdminGetUser`, `ListUsers` and the rest are not
-  implemented, so a pool is a directory with nothing in it. `EstimatedNumberOfUsers` is always zero.
 - There are no groups, no tokens and no authentication. `InitiateAuth`, `AdminInitiateAuth`,
   `RespondToAuthChallenge` and `GetTokensFromRefreshToken` are not implemented. An app client's
-  `ExplicitAuthFlows` and token lifetimes are stored and reported, and nothing reads them yet.
+  `ExplicitAuthFlows` and token lifetimes are stored and reported, and nothing reads them yet. A
+  user's status and its `Enabled` flag are the same: they are kept as real Cognito keeps them, and
+  nothing signs in for them to stop.
+- A password is checked against the pool's policy and then discarded, because nothing authenticates
+  yet. Nothing reads a password back, so no operation reveals that.
+- Users are resolved by username only. Real Cognito also accepts a user's `sub` where an admin
+  operation asks for a username, and that fails here with `UserNotFoundException`.
+- Self-service sign-up is not simulated. `SignUp`, `ConfirmSignUp`, `ForgotPassword`,
+  `ChangePassword` and `ResendConfirmationCode` are not implemented, so the `UNCONFIRMED` and
+  `RESET_REQUIRED` statuses cannot be reached. `AdminCreateUser` is the only way to make a user.
+- No message is ever delivered. `AdminCreateUser` sends no invitation, so `MessageAction: SUPPRESS`
+  is accepted and changes nothing, `RESEND` is refused, and `DesiredDeliveryMediums` is refused.
+- A temporary password never expires. `TemporaryPasswordValidityDays` is stored on the pool and
+  nothing acts on it.
+- Unsimulated `AdminCreateUser` inputs are refused rather than ignored: `DesiredDeliveryMediums`,
+  `ForceAliasCreation`, `ValidationData`, `ClientMetadata`, and a `MessageAction` of `RESEND`.
+  `AdminUpdateUserAttributes` refuses `ClientMetadata` the same way.
+- `ListUsers` refuses `Filter` and `AttributesToGet` rather than ignoring them, and lists users in
+  creation order. Real Cognito chooses its own order and does not promise one.
+- Only the standard user attributes exist, because a pool is created without a `Schema`. A `custom:`
+  attribute is refused, and so is a request setting `sub`. `AdminDeleteUserAttributes` is not
+  implemented, so an attribute can be changed but not removed.
+- `EstimatedNumberOfUsers` is how many users the pool holds now. Real Cognito refreshes that number
+  periodically rather than on each write, so it can lag there in a way it never does here.
+- MFA is not simulated, so `AdminGetUser` reports no `UserMFASettingList`, `PreferredMfaSetting` or
+  `MFAOptions`.
 - Nothing updates a pool or an app client. `UpdateUserPool` and `UpdateUserPoolClient` are not
   implemented, so `LastModifiedDate` is always the creation date.
 - A pool with `DeletionProtection: ACTIVE` cannot be deleted at all, because deactivating the

--- a/docs/services/cognito/sim-cognito-create-user.example.ts
+++ b/docs/services/cognito/sim-cognito-create-user.example.ts
@@ -1,5 +1,5 @@
 /**
- * Creating a simulated user that could actually sign in.
+ * Creating a simulated user and confirming it.
  */
 
 import {

--- a/docs/services/cognito/sim-cognito-create-user.example.ts
+++ b/docs/services/cognito/sim-cognito-create-user.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Creating a simulated user that could actually sign in.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+const created = await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+  }),
+);
+
+console.log(created.User?.UserStatus); // "FORCE_CHANGE_PASSWORD"
+
+// Without this the user stays in FORCE_CHANGE_PASSWORD and cannot sign in.
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const read = await cognito.adminGetUser(
+  new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+
+console.log(read.UserStatus); // "CONFIRMED"
+console.log(read.UserAttributes?.find((each) => each.Name === "sub")?.Value);
+// A UUID, and not "alice"

--- a/docs/services/cognito/sim-cognito-list-users.example.ts
+++ b/docs/services/cognito/sim-cognito-list-users.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Listing the users of a simulated user pool.
+ */
+
+import {
+  AdminCreateUserCommand,
+  CreateUserPoolCommand,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool?.Id;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+);
+
+const listed = await cognito.listUsers(
+  new ListUsersCommand({ UserPoolId: userPoolId }),
+);
+
+console.log(listed.Users?.map((user) => user.Username)); // [ "alice", "bob" ]

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -96,8 +96,8 @@ rather than one class per command, so the `SimCognitoIdentityProvider` facade st
   and clock they share, so the service facade stays delegation
 
 `SimCognitoUserResolver` is what every user operation starts with: authorize against the pool's ARN,
-then find the pool, then find the user. A user has no ARN of its own, so the pool's is what IAM
-sees.
+then find the pool. A user has no ARN of its own, so the pool's is what IAM sees. An operation
+naming an existing user goes on to resolve it; `AdminCreateUser` and `ListUsers` stop at the pool.
 
 `SimCognitoUnsimulatedUserPoolOptions`, `SimCognitoUnsimulatedUserPoolClientOptions` and
 `SimCognitoUnsimulatedUserOptions` gather every input this simulation refuses, in one readable place

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -3,9 +3,9 @@
 This directory contains the simulated Cognito user pools implementation. Cognito identity pools,
 which exchange a token for AWS credentials, are a separate service and are not simulated at all.
 
-This is the foundation the rest of simulated Cognito is built on: the pool, the app client, and the
-authorizer. An app client's authentication flows are validated and stored here, and nothing acts on
-them: users, groups, tokens and sign-in itself are not here yet.
+The pool, the app client, the users in it and the authorizer are here. An app client's
+authentication flows are validated and stored, and nothing acts on them: groups, tokens and sign-in
+itself are not here yet.
 
 ## Entry points
 
@@ -36,8 +36,9 @@ ARN of its own.
 
 `SimCognitoPasswordPolicy` applies the defaults real Cognito applies when a request says nothing:
 eight characters, with an uppercase letter, a lowercase letter, a number and a symbol each required.
-Nothing checks a password against the policy yet, since there are no users, but the policy has to be
-right now because it is what those checks will read.
+`SimCognitoPasswordCheck` is what applies it to a password. The two are separate because the policy
+is part of the pool's state and the checking is not, and because both `AdminCreateUser` and
+`AdminSetUserPassword` need the same check.
 
 `SimCognitoExplicitAuthFlows` validates the authentication flows an app client supports. The values
 are checked rather than stored as written, because a typo in a flow name would otherwise turn into a
@@ -53,20 +54,54 @@ stops the pairing being got wrong when tokens are actually issued.
 `GenerateSecret` gets one. A public client has no secret at all rather than an empty one, which is
 what makes code computing a `SECRET_HASH` fail on the client it should fail on.
 
+## User model
+
+User state lives under `user-pool/user/`, and the pool owns its users for the same reason it owns
+its app clients: deleting a pool takes them with it, and a username means nothing outside the pool
+holding it.
+
+`SimCognitoUser` is the stored user: its username, its `sub`, its attributes, its status and whether
+it is enabled. The `sub` is a fresh UUID rather than anything derived from the username, because
+that is the difference most code gets wrong. A user holds no password. Passwords are checked against
+the pool's policy and discarded, since nothing authenticates yet and nothing reads one back.
+
+`SimCognitoUserStatus` holds the two statuses this simulation can reach, and the transition between
+them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent password
+reaches `CONFIRMED`. The rest of the real statuses belong to sign-up, resets and federation, none of
+which are simulated.
+
+`SimCognitoUserAttributes` validates attribute names against the pool's schema. Only the standard
+attributes exist, because `CreateUserPool` refuses a `Schema`, so a `custom:` attribute is refused
+here as it would be on a real pool created the same way. `sub` is refused too, and lives on the user
+rather than among its attributes, because Cognito allocates it and a request cannot set it.
+
+`SimCognitoUserStore` keys users by username. Its refusal for a username that reaches nothing says
+so when the value given is some user's `sub`, because real Cognito accepts a `sub` there and this
+simulation does not.
+
 ## Command handling
 
 AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
 rather than one class per command, so the `SimCognitoIdentityProvider` facade stays a delegation:
 
-- `command/user-pool/` — the pool commands, their structural input/output types and their output
+- `command/user-pool/`: the pool commands, their structural input/output types and their output
   views
-- `command/client/` — the same for app clients
-- `command/authorize/` — the shared IAM authorizer
-- `command/sim-cognito-page.ts` — the paging both listings share
+- `command/client/`: the same for app clients
+- `command/user/`: the same for users, split between the commands that create, read and delete one
+  and the commands that change one afterwards
+- `command/authorize/`: the shared IAM authorizer
+- `command/sim-cognito-page.ts`: the paging every listing shares, which takes the names of the
+  inputs it is reading because `ListUsers` calls them `Limit` and `PaginationToken`
+- `command/sim-cognito-commands.ts`: builds the command handlers with the authorizer, pool store
+  and clock they share, so the service facade stays delegation
 
-`SimCognitoUnsimulatedUserPoolOptions` and `SimCognitoUnsimulatedUserPoolClientOptions` gather every
-input this simulation refuses, in one readable place each, rather than scattering the refusals
-through the creation path.
+`SimCognitoUserResolver` is what every user operation starts with: authorize against the pool's ARN,
+then find the pool, then find the user. A user has no ARN of its own, so the pool's is what IAM
+sees.
+
+`SimCognitoUnsimulatedUserPoolOptions`, `SimCognitoUnsimulatedUserPoolClientOptions` and
+`SimCognitoUnsimulatedUserOptions` gather every input this simulation refuses, in one readable place
+each, rather than scattering the refusals through the creation path.
 
 As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
@@ -76,14 +111,15 @@ command instances.
 
 `SimCognitoAuthorizer` splits requests two ways, as real Cognito does:
 
-- operations on a pool, and on the app clients in it, authorize the real IAM action against that
-  pool's ARN, whether or not the pool exists, because real IAM evaluates a request before the service
-  handles it;
+- operations on a pool, and on the app clients and users in it, authorize the real IAM action
+  against that pool's ARN, whether or not the pool exists, because real IAM evaluates a request
+  before the service handles it;
 - `CreateUserPool` and `ListUserPools` authorize against `*`, because real Cognito gives those two
   actions no resource-level permissions, so a policy naming individual pool ARNs grants nothing.
 
-A policy granting an app client action on a pool therefore reaches every client in that pool. There
-is no way to narrow it to one client, here or on real AWS.
+A policy granting an app client action on a pool therefore reaches every client in that pool, and a
+policy granting a user action reaches every user in it. There is no way to narrow either to one
+resource, here or on real AWS.
 
 ## Divergences worth knowing
 
@@ -94,9 +130,15 @@ is no way to narrow it to one client, here or on real AWS.
 - A pool created with `DeletionProtection: ACTIVE` cannot be deleted at all, because `UpdateUserPool`
   is not simulated and that is the only way to deactivate the protection.
 - Nothing changes a pool or an app client after creation, so `LastModifiedDate` is always the
-  creation date.
-- `SchemaAttributes` is not reported on a pool. Real Cognito reports the standard attribute schema on
-  every pool; there are no user attributes here to describe.
-- Listings are in creation order and carry no filtering.
+  creation date. A user is different: every operation that changes one moves its
+  `UserLastModifiedDate` on.
+- `SchemaAttributes` is not reported on a pool, though every pool holds the standard schema and
+  validates user attributes against it.
+- Users are resolved by username only, and real Cognito also accepts a `sub` there.
+- A password is checked and discarded rather than stored, because nothing authenticates yet.
+- No message is delivered, so `AdminCreateUser` accepts `MessageAction: SUPPRESS` and refuses
+  `RESEND` and `DesiredDeliveryMediums`.
+- Listings are in creation order and carry no filtering. `ListUsers` refuses a `Filter` rather than
+  dropping it, because a dropped filter answers with the wrong users rather than with an error.
 
 The full list is in [docs/services/cognito](../../../docs/services/cognito/).

--- a/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
@@ -1,0 +1,188 @@
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolCommand,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const accountId = "111111111111" as SimAwsAccountId;
+const regionName = "eu-west-2";
+
+interface SimCognitoWithRole {
+  readonly simAws: SimAws;
+  readonly caller: SimAwsCaller;
+  readonly userPoolId: string;
+}
+
+function userPoolArn(userPoolId: string): string {
+  return `arn:aws:cognito-idp:${regionName}:${accountId}:userpool/${userPoolId}`;
+}
+
+/**
+ * A pool holding one user, and a Role whose only permissions are the statement
+ * given.
+ */
+async function simCognitoWithRole(
+  policyStatement: object,
+): Promise<SimCognitoWithRole> {
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+  const cognito = simAws.cognitoIdentityProvider();
+
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: created.UserPool.Id,
+      Username: "alice",
+    }),
+  );
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "UserReader",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "UserReader",
+      PolicyName: "UserPolicy",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: policyStatement,
+      }),
+    }),
+  );
+
+  return {
+    simAws,
+    caller: { kind: "arn", arn: role.Role.Arn },
+    userPoolId: created.UserPool.Id,
+  };
+}
+
+describe("sim Cognito user IAM authorization", () => {
+  it("allows a user operation the caller's policy permits on the pool", async () => {
+    // Given a Role allowed to read users in one pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: ["cognito-idp:AdminGetUser", "cognito-idp:ListUsers"],
+      Resource: userPoolArn("*"),
+    });
+    const cognito = simAws.cognitoIdentityProvider();
+
+    // When that Role reads and lists the pool's users.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+      { caller },
+    );
+    const listed = await cognito.listUsers(
+      new ListUsersCommand({ UserPoolId: userPoolId }),
+      { caller },
+    );
+
+    // Then both are allowed, because a user is reached through its pool's ARN.
+    assertIdentical(read.Username, "alice");
+    assertIdentical(listed.Users?.length, 1);
+  });
+
+  it("denies a user operation the caller's policy does not permit", async () => {
+    // Given a Role allowed to read users but not to change them.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:AdminGetUser",
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role sets a user's password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().adminSetUserPassword(
+        new AdminSetUserPasswordCommand({
+          UserPoolId: userPoolId,
+          Username: "alice",
+          Password: "Sup3rSecret!",
+          Permanent: true,
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied: each operation authorizes its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a user operation on a pool the policy does not name", async () => {
+    // Given a Role allowed everything on a different pool.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:*",
+      Resource: userPoolArn("eu-west-2_zZzZzZzZz"),
+    });
+
+    // When that Role creates a user in this one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: userPoolId,
+          Username: "bob",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("denies a caller with no permissions before saying whether a user exists", async () => {
+    // Given a Role with no Cognito permissions at all.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: "*",
+    });
+
+    // When that Role reads a user that was never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().adminGetUser(
+        new AdminGetUserCommand({
+          UserPoolId: userPoolId,
+          Username: "nobody",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied rather than reported missing, as real IAM evaluates
+    // the request before the service handles it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -37,3 +37,30 @@ export type {
   SimListUserPoolClientsCommandInput,
   SimListUserPoolClientsCommandOutput,
 } from "./client/list-user-pool-clients.command.js";
+export type {
+  SimAdminCreateUserCommand,
+  SimAdminCreateUserCommandInput,
+  SimAdminCreateUserCommandOutput,
+  SimAdminDeleteUserCommand,
+  SimAdminDeleteUserCommandOutput,
+  SimAdminDisableUserCommand,
+  SimAdminDisableUserCommandOutput,
+  SimAdminEnableUserCommand,
+  SimAdminEnableUserCommandOutput,
+  SimAdminGetUserCommand,
+  SimAdminGetUserCommandOutput,
+  SimAdminSetUserPasswordCommand,
+  SimAdminSetUserPasswordCommandInput,
+  SimAdminSetUserPasswordCommandOutput,
+  SimAdminUpdateUserAttributesCommand,
+  SimAdminUpdateUserAttributesCommandInput,
+  SimAdminUpdateUserAttributesCommandOutput,
+  SimCognitoAdminUserCommandInput,
+  SimCognitoDescribedUser,
+  SimCognitoUserType,
+} from "./user/user.command.js";
+export type {
+  SimListUsersCommand,
+  SimListUsersCommandInput,
+  SimListUsersCommandOutput,
+} from "./user/list-users.command.js";

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -1,0 +1,69 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCognitoUserPoolClientFactory } from "../user-pool/client/sim-cognito-user-pool-client-factory.js";
+import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
+import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
+import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
+import { SimCognitoAuthorizer } from "./authorize/sim-cognito-authorizer.js";
+import { SimCognitoListUserPoolClients } from "./client/sim-cognito-list-user-pool-clients.js";
+import { SimCognitoUserPoolClientCommands } from "./client/sim-cognito-user-pool-client-commands.js";
+import { SimCognitoListUsers } from "./user/sim-cognito-list-users.js";
+import { SimCognitoUserCommands } from "./user/sim-cognito-user-commands.js";
+import { SimCognitoUserResolver } from "./user/sim-cognito-user-resolver.js";
+import { SimCognitoUserUpdateCommands } from "./user/sim-cognito-user-update-commands.js";
+import { SimCognitoListUserPools } from "./user-pool/sim-cognito-list-user-pools.js";
+import { SimCognitoUserPoolCommands } from "./user-pool/sim-cognito-user-pool-commands.js";
+
+interface SimCognitoCommandsProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly clock: SimClock;
+  readonly pools: SimCognitoUserPoolStore;
+}
+
+/**
+ * The command handlers of one simulated Cognito scope.
+ *
+ * They share an authorizer, a pool store and a clock, so they are built
+ * together here rather than in the service facade, which is left as
+ * delegation.
+ */
+export class SimCognitoCommands {
+  public readonly userPools: SimCognitoUserPoolCommands;
+  public readonly listUserPools: SimCognitoListUserPools;
+  public readonly clients: SimCognitoUserPoolClientCommands;
+  public readonly listClients: SimCognitoListUserPoolClients;
+  public readonly users: SimCognitoUserCommands;
+  public readonly userUpdates: SimCognitoUserUpdateCommands;
+  public readonly listUsers: SimCognitoListUsers;
+
+  constructor(properties: SimCognitoCommandsProperties) {
+    const { accountRegionScope, iam, clock, pools } = properties;
+    const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
+    const resolver = new SimCognitoUserResolver({ pools, authorizer });
+
+    this.userPools = new SimCognitoUserPoolCommands({
+      pools,
+      poolFactory: new SimCognitoUserPoolFactory({
+        accountRegionScope,
+        pools,
+        clock,
+      }),
+      authorizer,
+    });
+    this.listUserPools = new SimCognitoListUserPools({ pools, authorizer });
+    this.clients = new SimCognitoUserPoolClientCommands({
+      pools,
+      clientFactory: new SimCognitoUserPoolClientFactory({ clock }),
+      authorizer,
+    });
+    this.listClients = new SimCognitoListUserPoolClients({ pools, authorizer });
+    this.users = new SimCognitoUserCommands({
+      resolver,
+      userFactory: new SimCognitoUserFactory({ clock }),
+    });
+    this.userUpdates = new SimCognitoUserUpdateCommands({ resolver });
+    this.listUsers = new SimCognitoListUsers({ resolver });
+  }
+}

--- a/src/service/cognito/command/sim-cognito-page.ts
+++ b/src/service/cognito/command/sim-cognito-page.ts
@@ -8,24 +8,38 @@ const maxMaxResults = 60;
 interface SimCognitoPageProperties {
   readonly maxResults: number;
   readonly nextToken: string | undefined;
+  /**
+   * What this operation calls its page size input. `ListUsers` calls it
+   * `Limit`, so a refusal has to name the input the caller actually wrote.
+   */
+  readonly maxResultsField?: string;
+  /**
+   * What this operation calls its continuation token. `ListUsers` calls it
+   * `PaginationToken`.
+   */
+  readonly nextTokenField?: string;
 }
 
 /**
  * One page of listed items, and the token that reaches the next one.
  *
- * Both Cognito listings page the same way, so the rules live here once. How
+ * Every Cognito listing pages the same way, so the rules live here once. How
  * many items a page holds by default is not shared, because `ListUserPools`
- * insists on being told and `ListUserPoolClients` does not.
+ * insists on being told and the others do not.
  */
 export class SimCognitoPage<TItem> {
   public readonly items: readonly TItem[];
   public readonly nextToken: string | undefined;
 
   constructor(listed: readonly TItem[], properties: SimCognitoPageProperties) {
-    const maxResults = SimCognitoPage.maxResults(properties.maxResults);
+    const maxResults = SimCognitoPage.maxResults(
+      properties.maxResults,
+      properties.maxResultsField ?? "MaxResults",
+    );
     const startIndex = SimCognitoPage.startIndex(
       properties.nextToken,
       listed.length,
+      properties.nextTokenField ?? "NextToken",
     );
     const nextIndex = startIndex + maxResults;
 
@@ -33,14 +47,14 @@ export class SimCognitoPage<TItem> {
     this.nextToken = SimCognitoPage.tokenFor(nextIndex, listed.length);
   }
 
-  private static maxResults(requested: number): number {
+  private static maxResults(requested: number, field: string): number {
     if (
       !Number.isSafeInteger(requested) ||
       requested < 1 ||
       requested > maxMaxResults
     ) {
       throw new SimCognitoInvalidParameterException(
-        `MaxResults must be a whole number between 1 and ${String(maxMaxResults)}`,
+        `${field} must be a whole number between 1 and ${String(maxMaxResults)}`,
       );
     }
 
@@ -58,6 +72,7 @@ export class SimCognitoPage<TItem> {
   private static startIndex(
     nextToken: string | undefined,
     listedCount: number,
+    field: string,
   ): number {
     if (nextToken === undefined) {
       return 0;
@@ -72,7 +87,7 @@ export class SimCognitoPage<TItem> {
       String(startIndex) !== nextToken
     ) {
       throw new SimCognitoInvalidParameterException(
-        "NextToken is not a token this simulation issued",
+        `${field} is not a token this simulation issued`,
       );
     }
 

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -12,9 +12,10 @@ export class SimCognitoUserPoolView {
   /**
    * A pool as `CreateUserPool` and `DescribeUserPool` report it.
    *
-   * `MfaConfiguration` is always `OFF` because MFA is not simulated, and
-   * `EstimatedNumberOfUsers` is always zero because a pool holds no users
-   * yet.
+   * `MfaConfiguration` is always `OFF` because MFA is not simulated.
+   * `EstimatedNumberOfUsers` is how many users the pool holds now. Real
+   * Cognito refreshes that number periodically rather than on each write, so
+   * it can lag there in a way it never does here.
    */
   describe(pool: SimCognitoUserPool): SimCognitoUserPoolType {
     return {
@@ -24,7 +25,7 @@ export class SimCognitoUserPoolView {
       Policies: { PasswordPolicy: pool.passwordPolicy.toOutput() },
       DeletionProtection: pool.deletionProtection.value,
       MfaConfiguration: "OFF",
-      EstimatedNumberOfUsers: 0,
+      EstimatedNumberOfUsers: pool.userCount,
       CreationDate: pool.creationDate,
       LastModifiedDate: pool.lastModifiedDate,
     };

--- a/src/service/cognito/command/user/list-users.command.ts
+++ b/src/service/cognito/command/user/list-users.command.ts
@@ -1,0 +1,32 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoUserType } from "./user.command.js";
+
+/**
+ * The ListUsers inputs this simulation reads, and the ones it refuses.
+ *
+ * This listing pages differently from the others: the page size is `Limit`
+ * rather than `MaxResults`, and the continuation token is `PaginationToken`
+ * rather than `NextToken`, as it is on real Cognito.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/ListUsersCommand/
+ */
+export interface SimListUsersCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly PaginationToken?: string | undefined;
+  readonly Filter?: string | undefined;
+  readonly AttributesToGet?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito ListUsers command.
+ */
+export interface SimListUsersCommand {
+  readonly input: SimListUsersCommandInput;
+}
+
+export interface SimListUsersCommandOutput {
+  readonly Users?: readonly SimCognitoUserType[] | undefined;
+  readonly PaginationToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/user/sim-cognito-list-users.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-list-users.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  AdminCreateUserCommand,
+  CreateUserPoolCommand,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithUsers {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+/**
+ * A pool holding alice, bob and carol, created in that order.
+ */
+async function simCognitoWithUsers(): Promise<SimCognitoWithUsers> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  const userPoolId = created.UserPool.Id;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+  );
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+  );
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "carol" }),
+  );
+
+  return { cognito, userPoolId };
+}
+
+describe("sim Cognito ListUsers", () => {
+  it("lists the users of one pool", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When its users are listed.
+    const listed = await cognito.listUsers(
+      new ListUsersCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then all three come back, with the status each was created in.
+    assertArrayEquals(
+      (listed.Users ?? []).map((user) => user.Username),
+      ["alice", "bob", "carol"],
+    );
+    assertIdentical(listed.Users?.[0]?.UserStatus, "FORCE_CHANGE_PASSWORD");
+    assertUndefined(listed.PaginationToken);
+  });
+
+  it("pages the listing by Limit and PaginationToken", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When two are asked for, then the rest.
+    const firstPage = await cognito.listUsers(
+      new ListUsersCommand({ UserPoolId: userPoolId, Limit: 2 }),
+    );
+    const secondPage = await cognito.listUsers(
+      new ListUsersCommand({
+        UserPoolId: userPoolId,
+        Limit: 2,
+        PaginationToken: firstPage.PaginationToken,
+      }),
+    );
+
+    // Then the pages carry the users between them, and the last one ends the
+    // listing.
+    assertArrayEquals(
+      (firstPage.Users ?? []).map((user) => user.Username),
+      ["alice", "bob"],
+    );
+    assertArrayEquals(
+      (secondPage.Users ?? []).map((user) => user.Username),
+      ["carol"],
+    );
+    assertUndefined(secondPage.PaginationToken);
+  });
+
+  it("refuses a Limit outside the range Cognito allows", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When more than sixty users are asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUsers(
+        new ListUsersCommand({ UserPoolId: userPoolId, Limit: 61 }),
+      );
+    });
+
+    // Then it is refused, naming the input the request used.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Limit must be a whole number");
+  });
+
+  it("refuses a PaginationToken it did not issue", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When a made up token is followed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUsers(
+        new ListUsersCommand({
+          UserPoolId: userPoolId,
+          PaginationToken: "somewhere-else",
+        }),
+      );
+    });
+
+    // Then it is refused rather than starting again from the beginning.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "PaginationToken");
+  });
+
+  it("refuses a Filter rather than ignoring it", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When the listing is filtered by email.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUsers(
+        new ListUsersCommand({
+          UserPoolId: userPoolId,
+          Filter: 'email = "alice@example.com"',
+        }),
+      );
+    });
+
+    // Then it is refused, because a dropped filter answers with the wrong
+    // users rather than with an error.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Filter is not simulated");
+  });
+
+  it("refuses returning only some of each user's attributes", async () => {
+    // Given a pool with three users.
+    const { cognito, userPoolId } = await simCognitoWithUsers();
+
+    // When only the email is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.listUsers(
+        new ListUsersCommand({
+          UserPoolId: userPoolId,
+          AttributesToGet: ["email"],
+        }),
+      );
+    });
+
+    // Then it is refused rather than answered with every attribute.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "AttributesToGet");
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-list-users.ts
+++ b/src/service/cognito/command/user/sim-cognito-list-users.ts
@@ -1,0 +1,73 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoPage } from "../sim-cognito-page.js";
+import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
+import type { SimCognitoUserResolver } from "./sim-cognito-user-resolver.js";
+import { SimCognitoUserView } from "./sim-cognito-user-view.js";
+import type {
+  SimListUsersCommand,
+  SimListUsersCommandOutput,
+} from "./list-users.command.js";
+
+interface SimCognitoListUsersProperties {
+  readonly resolver: SimCognitoUserResolver;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * How many users a page holds when the request does not say.
+ *
+ * Sixty is the most Cognito will return either way.
+ */
+const defaultLimit = 60;
+
+/**
+ * The ListUsers command.
+ *
+ * This pages by `Limit` and `PaginationToken` rather than by `MaxResults` and
+ * `NextToken`, which is how the real operation names them.
+ */
+export class SimCognitoListUsers {
+  private readonly resolver: SimCognitoUserResolver;
+  private readonly view = new SimCognitoUserView();
+  private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
+
+  constructor(properties: SimCognitoListUsersProperties) {
+    this.resolver = properties.resolver;
+  }
+
+  /**
+   * List the users of one pool, in creation order.
+   *
+   * Real Cognito chooses its own order and does not promise one, so nothing
+   * should depend on this order beyond a test reading back what it created.
+   */
+  handle(
+    command: SimListUsersCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimListUsersCommandOutput {
+    const { input } = command;
+    const pool = this.resolver.pool(
+      "cognito-idp:ListUsers",
+      input.UserPoolId,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseInList(input);
+
+    const page = new SimCognitoPage(pool.users, {
+      maxResults: input.Limit ?? defaultLimit,
+      nextToken: input.PaginationToken,
+      maxResultsField: "Limit",
+      nextTokenField: "PaginationToken",
+    });
+
+    return {
+      $metadata: {},
+      Users: page.items.map((user) => this.view.entry(user)),
+      PaginationToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
+++ b/src/service/cognito/command/user/sim-cognito-unsimulated-user-options.ts
@@ -1,0 +1,88 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type { SimListUsersCommandInput } from "./list-users.command.js";
+import type {
+  SimAdminCreateUserCommandInput,
+  SimAdminUpdateUserAttributesCommandInput,
+} from "./user.command.js";
+
+/**
+ * Refuses the user operation inputs this simulation does not model.
+ *
+ * Nothing here delivers a message, verifies an attribute or runs a Lambda
+ * trigger, so an input asking for any of those is refused rather than dropped.
+ */
+export class SimCognitoUnsimulatedUserOptions {
+  private readonly creation = new SimCognitoUnsimulatedInput("AdminCreateUser");
+  private readonly attributeUpdate = new SimCognitoUnsimulatedInput(
+    "AdminUpdateUserAttributes",
+  );
+  private readonly listing = new SimCognitoUnsimulatedInput("ListUsers");
+
+  /**
+   * Refuse an `AdminCreateUser` request this simulation cannot honour.
+   *
+   * `MessageAction: SUPPRESS` is allowed, and does nothing, because no
+   * invitation is ever sent here. `RESEND` is refused: there is no message to
+   * send again.
+   */
+  refuseInCreate(input: SimAdminCreateUserCommandInput): void {
+    this.creation.refuseUnless(
+      "MessageAction",
+      input.MessageAction,
+      "SUPPRESS",
+      "sending the invitation message again",
+    );
+    this.creation.refuse(
+      "DesiredDeliveryMediums",
+      input.DesiredDeliveryMediums,
+      "emailing or texting the user their temporary password",
+    );
+    this.creation.refuse(
+      "ForceAliasCreation",
+      input.ForceAliasCreation,
+      "moving an email or phone number alias to the new user",
+    );
+    this.creation.refuse(
+      "ValidationData",
+      input.ValidationData,
+      "passing data to a pre sign-up Lambda trigger",
+    );
+    this.creation.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+  }
+
+  /**
+   * Refuse an `AdminUpdateUserAttributes` request this simulation cannot
+   * honour.
+   */
+  refuseInUpdate(input: SimAdminUpdateUserAttributesCommandInput): void {
+    this.attributeUpdate.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+  }
+
+  /**
+   * Refuse a `ListUsers` request this simulation cannot honour.
+   *
+   * A `Filter` is refused rather than ignored because a dropped filter answers
+   * with the wrong users rather than with an error, which is the kind of pass
+   * that turns into a failure in a deployment.
+   */
+  refuseInList(input: SimListUsersCommandInput): void {
+    this.listing.refuse(
+      "Filter",
+      input.Filter,
+      "narrowing the listing to the users matching an attribute",
+    );
+    this.listing.refuse(
+      "AttributesToGet",
+      input.AttributesToGet,
+      "returning only some of each user's attributes",
+    );
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-user-attribute-validation.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-attribute-validation.iso.test.ts
@@ -1,0 +1,111 @@
+import { CreateUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+
+/**
+ * Create a user in a fresh pool with the attributes given.
+ *
+ * The SDK's own types insist on a Name and a Value, so these are the requests
+ * as they reach the simulator.
+ */
+async function createUserWith(
+  attributes: readonly SimCognitoAttributeType[],
+): Promise<void> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  await cognito.adminCreateUser({
+    input: {
+      UserPoolId: created.UserPool.Id,
+      Username: "alice",
+      UserAttributes: attributes,
+    },
+  });
+}
+
+describe("sim Cognito user attribute validation", () => {
+  it("refuses an attribute the pool's schema does not hold", async () => {
+    // Given a pool with the standard schema, which is the only one here.
+    // When a custom attribute is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createUserWith([{ Name: "custom:tenant", Value: "acme" }]);
+    });
+
+    // Then it is refused, because CreateUserPool refuses a Schema of its own
+    // and so no custom attribute can exist.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "not in the pool's schema");
+  });
+
+  it("refuses a request setting a user's sub", async () => {
+    // Given a pool.
+    // When a user is created with a sub of its own.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createUserWith([{ Name: "sub", Value: "chosen-by-the-caller" }]);
+    });
+
+    // Then it is refused: Cognito allocates a sub, and nothing else can.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "read-only");
+  });
+
+  it("refuses an attribute naming nothing", async () => {
+    // Given a pool.
+    // When an attribute arrives without a Name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createUserWith([{ Value: "alice@example.com" }]);
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "needs a Name");
+  });
+
+  it("refuses an attribute with no value", async () => {
+    // Given a pool.
+    // When an attribute arrives without a Value.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createUserWith([{ Name: "email" }]);
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "needs a Value");
+  });
+
+  it("refuses an attribute value longer than Cognito allows", async () => {
+    // Given a pool.
+    // When a 2049 character value arrives.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createUserWith([{ Name: "nickname", Value: "a".repeat(2049) }]);
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "2048");
+  });
+
+  it("accepts the standard attributes", async () => {
+    // Given a pool.
+    // When a user is created with standard attributes.
+    await createUserWith([
+      { Name: "email", Value: "alice@example.com" },
+      { Name: "phone_number", Value: "+447700900000" },
+      { Name: "email_verified", Value: "true" },
+    ]);
+
+    // Then they are accepted, because every pool's schema holds them.
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-user-commands.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.iso.test.ts
@@ -1,0 +1,233 @@
+import {
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import { SimCognitoUserNotFoundException } from "../../error/sim-cognito.error.js";
+
+function attributeValue(
+  attributes: readonly SimCognitoAttributeType[] | undefined,
+  name: string,
+): string | undefined {
+  return (attributes ?? []).find((attribute) => attribute.Name === name)?.Value;
+}
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
+  const simAws = new SimAws({
+    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultRegionName: "eu-west-2",
+  });
+  const cognito = simAws.cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+describe("sim Cognito user commands", () => {
+  it("creates a user that cannot sign in yet", async () => {
+    // Given a simulated user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When an admin creates a user in it.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+
+    // Then the user is enabled but left in FORCE_CHANGE_PASSWORD, as real
+    // Cognito leaves an admin-created user.
+    assertNonNullable(created.User);
+    assertObjectMatches(created.User, {
+      Username: "alice",
+      Enabled: true,
+      UserStatus: "FORCE_CHANGE_PASSWORD",
+    });
+    assertInstanceOf(created.User.UserCreateDate, Date);
+  });
+
+  it("gives a user a sub that is not its username", async () => {
+    // Given a simulated user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then its sub is a UUID reported among its attributes, and nothing like
+    // the username.
+    const sub = attributeValue(created.User?.Attributes, "sub");
+
+    assertNonNullable(sub);
+    assertUuidV4(sub);
+  });
+
+  it("refuses an admin operation naming a user's sub", async () => {
+    // Given a created user.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    const sub = attributeValue(created.User?.Attributes, "sub");
+
+    // When it is read by its sub rather than its username.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminGetUser(
+        new AdminGetUserCommand({ UserPoolId: userPoolId, Username: sub }),
+      );
+    });
+
+    // Then it is refused, and the refusal says which of the two this
+    // simulation resolves users by.
+    assertInstanceOf(error, SimCognitoUserNotFoundException);
+    assertStringIncludes(error.message, "that is the sub of user alice");
+  });
+
+  it("reads a user back with its attributes", async () => {
+    // Given a created user with an email.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [
+          { Name: "email", Value: "alice@example.com" },
+          { Name: "email_verified", Value: "true" },
+        ],
+      }),
+    );
+
+    // When it is read.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then the attributes come back under UserAttributes, which is what
+    // AdminGetUser calls them, with the sub among them.
+    assertIdentical(read.Username, "alice");
+    assertIdentical(read.UserStatus, "FORCE_CHANGE_PASSWORD");
+    assertIdentical(
+      attributeValue(read.UserAttributes, "email"),
+      "alice@example.com",
+    );
+    assertNonNullable(attributeValue(read.UserAttributes, "email_verified"));
+    assertNonNullable(attributeValue(read.UserAttributes, "sub"));
+  });
+
+  it("confirms a user given a permanent password", async () => {
+    // Given a created user, which cannot sign in yet.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // When an admin sets a permanent password on it.
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // Then the user is confirmed, which is what lets it sign in normally.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+  });
+
+  it("accepts a temporary password the pool's policy allows", async () => {
+    // Given a simulated user pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created with a temporary password.
+    const created = await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        TemporaryPassword: "Temp0rary!",
+        MessageAction: "SUPPRESS",
+      }),
+    );
+
+    // Then the user still has to change it before it can sign in.
+    assertIdentical(created.User?.UserStatus, "FORCE_CHANGE_PASSWORD");
+  });
+
+  it("deletes a user", async () => {
+    // Given a created user.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // When it is deleted.
+    await cognito.adminDeleteUser(
+      new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then it is gone.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminGetUser(
+        new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoUserNotFoundException);
+  });
+
+  it("counts the users a pool holds", async () => {
+    // Given a pool with two users.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+    );
+
+    // When the pool is described.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then it reports the users it holds.
+    assertIdentical(described.UserPool?.EstimatedNumberOfUsers, 2);
+    assertTrue(
+      cognito.findUserPool(userPoolId)?.findUser("alice") !== undefined,
+    );
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -1,0 +1,134 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
+import type { SimCognitoUserResolver } from "./sim-cognito-user-resolver.js";
+import { SimCognitoUserView } from "./sim-cognito-user-view.js";
+import type {
+  SimAdminCreateUserCommand,
+  SimAdminCreateUserCommandOutput,
+  SimAdminDeleteUserCommand,
+  SimAdminDeleteUserCommandOutput,
+  SimAdminGetUserCommand,
+  SimAdminGetUserCommandOutput,
+} from "./user.command.js";
+
+interface SimCognitoUserCommandsProperties {
+  readonly resolver: SimCognitoUserResolver;
+  readonly userFactory: SimCognitoUserFactory;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that create, read and delete a simulated user.
+ *
+ * Each one authorizes against the pool's ARN, because a user has no ARN of its
+ * own.
+ */
+export class SimCognitoUserCommands {
+  private readonly resolver: SimCognitoUserResolver;
+  private readonly userFactory: SimCognitoUserFactory;
+  private readonly view = new SimCognitoUserView();
+  private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
+
+  constructor(properties: SimCognitoUserCommandsProperties) {
+    this.resolver = properties.resolver;
+    this.userFactory = properties.userFactory;
+  }
+
+  /**
+   * Check a temporary password against the pool's policy.
+   *
+   * A request naming no temporary password is fine: real Cognito generates one
+   * and sends it to the user. Nothing is delivered here, and the generated
+   * password would be unusable anyway, so none is generated.
+   */
+  private static requireAllowedTemporaryPassword(
+    pool: SimCognitoUserPool,
+    temporaryPassword: string | undefined,
+  ): void {
+    if (temporaryPassword === undefined) {
+      return;
+    }
+
+    new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+      "TemporaryPassword",
+      temporaryPassword,
+    );
+  }
+
+  /**
+   * Create a user in a pool.
+   *
+   * The user is left in `FORCE_CHANGE_PASSWORD`, as real Cognito leaves an
+   * admin-created user: it has a temporary password and cannot sign in until
+   * that password is replaced. `AdminSetUserPassword` with `Permanent: true`
+   * is what moves it on.
+   */
+  create(
+    command: SimAdminCreateUserCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminCreateUserCommandOutput {
+    const { input } = command;
+    const pool = this.resolver.pool(
+      "cognito-idp:AdminCreateUser",
+      input.UserPoolId,
+      options,
+    );
+    const username = requireSimCognitoUsername(input.Username);
+
+    this.unsimulatedOptions.refuseInCreate(input);
+    SimCognitoUserCommands.requireAllowedTemporaryPassword(
+      pool,
+      input.TemporaryPassword,
+    );
+
+    const user = this.userFactory.make({
+      username,
+      attributes: input.UserAttributes,
+    });
+
+    pool.addUser(user);
+
+    return { $metadata: {}, User: this.view.entry(user) };
+  }
+
+  /**
+   * Read a user by username.
+   */
+  get(
+    command: SimAdminGetUserCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminGetUserCommandOutput {
+    const user = this.resolver.user(
+      "cognito-idp:AdminGetUser",
+      command.input,
+      options,
+    );
+
+    return { $metadata: {}, ...this.view.describe(user) };
+  }
+
+  /**
+   * Delete a user from a pool.
+   */
+  delete(
+    command: SimAdminDeleteUserCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminDeleteUserCommandOutput {
+    const { pool, user } = this.resolver.poolUser(
+      "cognito-idp:AdminDeleteUser",
+      command.input,
+      options,
+    );
+
+    pool.removeUser(user);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-user-password-validation.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-password-validation.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { PasswordPolicyType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoInvalidPasswordException,
+} from "../../error/sim-cognito.error.js";
+
+/**
+ * A pool holding one user, whose password policy the test chooses.
+ */
+async function setPassword(
+  password: string | undefined,
+  passwordPolicy?: PasswordPolicyType,
+): Promise<void> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({
+      PoolName: "myapp-users",
+      Policies: { PasswordPolicy: passwordPolicy },
+    }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: created.UserPool.Id,
+      Username: "alice",
+    }),
+  );
+
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: created.UserPool.Id,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+}
+
+describe("sim Cognito password policy", () => {
+  it("refuses a password with no uppercase letter", async () => {
+    // Given the default policy, which wants one.
+    // When a password without one is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("sup3rsecret!");
+    });
+
+    // Then it is refused, saying which rule it broke.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have uppercase characters");
+  });
+
+  it("refuses a password with no lowercase letter", async () => {
+    // Given the default policy, which wants one.
+    // When a password without one is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("SUP3RSECRET!");
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have lowercase characters");
+  });
+
+  it("refuses a password with no digit", async () => {
+    // Given the default policy, which wants one.
+    // When a password without one is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("SuperSecret!");
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have numeric characters");
+  });
+
+  it("refuses a password with no symbol", async () => {
+    // Given the default policy, which wants one.
+    // When a password without one is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("Sup3rSecret");
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have symbol characters");
+  });
+
+  it("refuses a password shorter than the pool wants", async () => {
+    // Given a pool wanting twelve characters.
+    // When a shorter password is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("Sh0rt!", { MinimumLength: 12 });
+    });
+
+    // Then it is refused for its length.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "not long enough");
+  });
+
+  it("refuses a password longer than Cognito allows", async () => {
+    // Given the default policy.
+    // When a 257 character password is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword(`Sup3rSecret!${"a".repeat(245)}`);
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "256");
+  });
+
+  it("refuses a password that is not there at all", async () => {
+    // Given the default policy.
+    // When the password is left out.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword(undefined);
+    });
+
+    // Then it is a validation error rather than a policy failure, as real
+    // Cognito rejects the request before it reaches the policy.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Password is required");
+  });
+
+  it("accepts a password a relaxed policy allows", async () => {
+    // Given a pool wanting six characters and nothing else.
+    // When a password meeting only that is set.
+    await setPassword("simple", {
+      MinimumLength: 6,
+      RequireUppercase: false,
+      RequireLowercase: false,
+      RequireNumbers: false,
+      RequireSymbols: false,
+    });
+
+    // Then it is accepted, because the pool's own policy is what applies.
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-user-password-validation.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-password-validation.iso.test.ts
@@ -100,6 +100,19 @@ describe("sim Cognito password policy", () => {
     assertStringIncludes(error.message, "must have symbol characters");
   });
 
+  it("refuses a password whose only letters are outside basic Latin", async () => {
+    // Given the default policy, which wants an uppercase letter.
+    // When a password of Greek letters is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setPassword("Δοκιμή1!");
+    });
+
+    // Then it is refused. Which characters count towards the uppercase and
+    // lowercase rules is not documented, so only basic Latin counts here.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have uppercase characters");
+  });
+
   it("refuses a password shorter than the pool wants", async () => {
     // Given a pool wanting twelve characters.
     // When a shorter password is set.

--- a/src/service/cognito/command/user/sim-cognito-user-resolver.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-resolver.ts
@@ -1,0 +1,86 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { requireSimCognitoUserPoolId } from "../../user-pool/sim-cognito-user-pool-id.js";
+import type { SimCognitoUserPoolStore } from "../../user-pool/sim-cognito-user-pool-store.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import type { SimCognitoAuthorizer } from "../authorize/sim-cognito-authorizer.js";
+import type { SimCognitoAdminUserCommandInput } from "./user.command.js";
+
+interface SimCognitoUserResolverProperties {
+  readonly pools: SimCognitoUserPoolStore;
+  readonly authorizer: SimCognitoAuthorizer;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * A user, and the pool holding it.
+ */
+export interface SimCognitoUserInPool {
+  readonly pool: SimCognitoUserPool;
+  readonly user: SimCognitoUser;
+}
+
+/**
+ * Resolves the pool and the user an admin operation names.
+ *
+ * Every user operation starts the same way: authorize against the pool's ARN,
+ * because a user has no ARN of its own, then find the pool, then find the user
+ * in it. Authorization comes first, as real IAM evaluates a request before the
+ * service handles it, so a caller with no permission is refused whether or not
+ * the user is there.
+ */
+export class SimCognitoUserResolver {
+  private readonly pools: SimCognitoUserPoolStore;
+  private readonly authorizer: SimCognitoAuthorizer;
+
+  constructor(properties: SimCognitoUserResolverProperties) {
+    this.pools = properties.pools;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Resolve the pool an operation names, once the caller may reach it.
+   */
+  pool(
+    action: string,
+    userPoolId: string | undefined,
+    options: SimCognitoCommandOptions | undefined,
+  ): SimCognitoUserPool {
+    const poolId = requireSimCognitoUserPoolId(userPoolId);
+
+    this.authorizer.authorizeUserPool(action, poolId, options?.caller);
+
+    return this.pools.require(poolId);
+  }
+
+  /**
+   * Resolve the user an operation names, and the pool holding it.
+   */
+  poolUser(
+    action: string,
+    input: SimCognitoAdminUserCommandInput,
+    options: SimCognitoCommandOptions | undefined,
+  ): SimCognitoUserInPool {
+    const pool = this.pool(action, input.UserPoolId, options);
+
+    return {
+      pool,
+      user: pool.requireUser(requireSimCognitoUsername(input.Username)),
+    };
+  }
+
+  /**
+   * Resolve the user an operation names, once the caller may reach its pool.
+   */
+  user(
+    action: string,
+    input: SimCognitoAdminUserCommandInput,
+    options: SimCognitoCommandOptions | undefined,
+  ): SimCognitoUser {
+    return this.poolUser(action, input, options).user;
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-user-update-commands.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-update-commands.iso.test.ts
@@ -1,0 +1,200 @@
+import {
+  AdminCreateUserCommand,
+  AdminDisableUserCommand,
+  AdminEnableUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  AdminUpdateUserAttributesCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithUser {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithUser(): Promise<SimCognitoWithUser> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: created.UserPool.Id,
+      Username: "alice",
+      UserAttributes: [
+        { Name: "email", Value: "alice@example.com" },
+        { Name: "given_name", Value: "Alice" },
+      ],
+    }),
+  );
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+function attributeValue(
+  attributes: readonly SimCognitoAttributeType[] | undefined,
+  name: string,
+): string | undefined {
+  return (attributes ?? []).find((attribute) => attribute.Name === name)?.Value;
+}
+
+describe("sim Cognito user update commands", () => {
+  it("leaves a user needing a new password when the password is temporary", async () => {
+    // Given a created user.
+    const { cognito, userPoolId } = await simCognitoWithUser();
+
+    // When a password is set without Permanent.
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Temp0rary!",
+      }),
+    );
+
+    // Then the user is still in FORCE_CHANGE_PASSWORD, which is what stops it
+    // signing in with a password an admin chose.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "FORCE_CHANGE_PASSWORD");
+  });
+
+  it("changes only the attributes the request names", async () => {
+    // Given a user with an email and a given name.
+    const { cognito, userPoolId } = await simCognitoWithUser();
+
+    // When one attribute is changed and another added.
+    await cognito.adminUpdateUserAttributes(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [
+          { Name: "email", Value: "alice@example.net" },
+          { Name: "family_name", Value: "Adams" },
+        ],
+      }),
+    );
+
+    // Then the untouched attribute keeps its value.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(
+      attributeValue(read.UserAttributes, "email"),
+      "alice@example.net",
+    );
+    assertIdentical(attributeValue(read.UserAttributes, "given_name"), "Alice");
+    assertIdentical(
+      attributeValue(read.UserAttributes, "family_name"),
+      "Adams",
+    );
+  });
+
+  it("notes when a user last changed", async () => {
+    // Given a created user.
+    const { cognito, userPoolId } = await simCognitoWithUser();
+    const created = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // When its attributes are updated.
+    await cognito.adminUpdateUserAttributes(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "nickname", Value: "ali" }],
+      }),
+    );
+
+    // Then it was last modified no earlier than when it was created.
+    const updated = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertNonNullable(created.UserLastModifiedDate);
+    assertNonNullable(updated.UserLastModifiedDate);
+    assertTrue(
+      updated.UserLastModifiedDate.getTime() >=
+        created.UserLastModifiedDate.getTime(),
+    );
+  });
+
+  it("disables and enables a user", async () => {
+    // Given a created user.
+    const { cognito, userPoolId } = await simCognitoWithUser();
+
+    // When it is disabled.
+    await cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    const disabled = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // Then it is no longer enabled, and enabling it again restores that.
+    assertFalse(disabled.Enabled);
+
+    await cognito.adminEnableUser(
+      new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    const enabled = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertTrue(enabled.Enabled);
+  });
+
+  it("keeps a disabled user's status and attributes", async () => {
+    // Given a confirmed user.
+    const { cognito, userPoolId } = await simCognitoWithUser();
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+
+    // When it is disabled.
+    await cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // Then only Enabled changed: disabling a user does not unconfirm it.
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+    assertIdentical(
+      attributeValue(read.UserAttributes, "email"),
+      "alice@example.com",
+    );
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
@@ -1,0 +1,119 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
+import type { SimCognitoUserResolver } from "./sim-cognito-user-resolver.js";
+import type {
+  SimAdminDisableUserCommand,
+  SimAdminDisableUserCommandOutput,
+  SimAdminEnableUserCommand,
+  SimAdminEnableUserCommandOutput,
+  SimAdminSetUserPasswordCommand,
+  SimAdminSetUserPasswordCommandOutput,
+  SimAdminUpdateUserAttributesCommand,
+  SimAdminUpdateUserAttributesCommandOutput,
+} from "./user.command.js";
+
+interface SimCognitoUserUpdateCommandsProperties {
+  readonly resolver: SimCognitoUserResolver;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that change a simulated user after it exists.
+ *
+ * These are the operations a test reaches for once a user has been created:
+ * giving it a usable password, changing its attributes, and turning it off and
+ * on again.
+ */
+export class SimCognitoUserUpdateCommands {
+  private readonly resolver: SimCognitoUserResolver;
+  private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
+
+  constructor(properties: SimCognitoUserUpdateCommandsProperties) {
+    this.resolver = properties.resolver;
+  }
+
+  /**
+   * Set a user's password.
+   *
+   * A permanent password confirms the user, which is what lets it sign in
+   * normally. Without `Permanent: true` the password is temporary and the user
+   * is left in `FORCE_CHANGE_PASSWORD`, exactly where `AdminCreateUser` left
+   * it.
+   */
+  setPassword(
+    command: SimAdminSetUserPasswordCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminSetUserPasswordCommandOutput {
+    const { input } = command;
+    const { pool, user } = this.resolver.poolUser(
+      "cognito-idp:AdminSetUserPassword",
+      input,
+      options,
+    );
+
+    new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+      "Password",
+      input.Password,
+    );
+
+    user.setPassword(input.Permanent);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Change a user's attributes.
+   *
+   * The request names only the attributes it changes. The rest keep their
+   * values, as they do on real Cognito.
+   */
+  updateAttributes(
+    command: SimAdminUpdateUserAttributesCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminUpdateUserAttributesCommandOutput {
+    const { input } = command;
+    const user = this.resolver.user(
+      "cognito-idp:AdminUpdateUserAttributes",
+      input,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseInUpdate(input);
+
+    user.updateAttributes(input.UserAttributes);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Disable a user, which stops it authenticating.
+   */
+  disable(
+    command: SimAdminDisableUserCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminDisableUserCommandOutput {
+    this.resolver
+      .user("cognito-idp:AdminDisableUser", command.input, options)
+      .disable();
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Enable a user again.
+   */
+  enable(
+    command: SimAdminEnableUserCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminEnableUserCommandOutput {
+    this.resolver
+      .user("cognito-idp:AdminEnableUser", command.input, options)
+      .enable();
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-user-validation.iso.test.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-validation.iso.test.ts
@@ -1,0 +1,217 @@
+import {
+  AdminCreateUserCommand,
+  AdminDisableUserCommand,
+  AdminUpdateUserAttributesCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoResourceNotFoundException,
+  SimCognitoUsernameExistsException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+interface SimCognitoWithPool {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+}
+
+async function simCognitoWithPool(): Promise<SimCognitoWithPool> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return { cognito, userPoolId: created.UserPool.Id };
+}
+
+describe("sim Cognito user validation", () => {
+  it("refuses a username the pool already holds", async () => {
+    // Given a pool holding a user.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+    const aliceCommand = new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+    });
+
+    await cognito.adminCreateUser(aliceCommand);
+
+    // When the same username is created again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(aliceCommand);
+    });
+
+    // Then it is refused, as real Cognito refuses it.
+    assertInstanceOf(error, SimCognitoUsernameExistsException);
+    assertStringIncludes(error.message, "already exists");
+  });
+
+  it("refuses an operation on a user the pool does not hold", async () => {
+    // Given an empty pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When an unknown user is disabled.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminDisableUser(
+        new AdminDisableUserCommand({
+          UserPoolId: userPoolId,
+          Username: "nobody",
+        }),
+      );
+    });
+
+    // Then it is a missing user rather than a missing resource.
+    assertInstanceOf(error, SimCognitoUserNotFoundException);
+    assertIdentical(error.name, "UserNotFoundException");
+  });
+
+  it("refuses a user operation on a pool that does not exist", async () => {
+    // Given simulated Cognito with no pools.
+    const cognito = new SimAws().cognitoIdentityProvider();
+
+    // When a user is created in a pool that was never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: "us-east-1_aBcDeFgHi",
+          Username: "alice",
+        }),
+      );
+    });
+
+    // Then the pool is reported missing.
+    assertInstanceOf(error, SimCognitoResourceNotFoundException);
+  });
+
+  it("refuses a username Cognito would not accept", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a username with a space in it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: userPoolId,
+          Username: "alice adams",
+        }),
+      );
+    });
+
+    // Then it is refused as a validation error.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "may not hold whitespace");
+  });
+
+  it("refuses a request naming no user at all", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created with no username. The SDK's own types insist on
+    // one, so this is the request as it reaches the simulator.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser({ input: { UserPoolId: userPoolId } });
+    });
+
+    // Then it is refused, naming the input the request left out.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Username is required");
+  });
+
+  it("refuses a username longer than Cognito allows", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created with a 129 character username.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: userPoolId,
+          Username: "a".repeat(129),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "128");
+  });
+
+  it("refuses an AdminCreateUser input this simulation does not model", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created asking for the temporary password to be emailed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: userPoolId,
+          Username: "alice",
+          DesiredDeliveryMediums: ["EMAIL"],
+        }),
+      );
+    });
+
+    // Then it is refused rather than ignored, because nothing here delivers a
+    // message.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "DesiredDeliveryMediums");
+  });
+
+  it("refuses resending an invitation nobody sent", async () => {
+    // Given a pool.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    // When a user is created with MessageAction RESEND.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminCreateUser(
+        new AdminCreateUserCommand({
+          UserPoolId: userPoolId,
+          Username: "alice",
+          MessageAction: "RESEND",
+        }),
+      );
+    });
+
+    // Then it is refused. SUPPRESS is the only value this simulation models,
+    // because it is the only one that changes nothing.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "MessageAction");
+  });
+
+  it("refuses passing metadata to a Lambda trigger", async () => {
+    // Given a pool with a user.
+    const { cognito, userPoolId } = await simCognitoWithPool();
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    // When attributes are updated with client metadata.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminUpdateUserAttributes(
+        new AdminUpdateUserAttributesCommand({
+          UserPoolId: userPoolId,
+          Username: "alice",
+          UserAttributes: [{ Name: "nickname", Value: "ali" }],
+          ClientMetadata: { source: "test" },
+        }),
+      );
+    });
+
+    // Then it is refused, because Lambda triggers are not simulated.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "ClientMetadata");
+  });
+});

--- a/src/service/cognito/command/user/sim-cognito-user-view.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-view.ts
@@ -1,0 +1,43 @@
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import type {
+  SimCognitoDescribedUser,
+  SimCognitoUserType,
+} from "./user.command.js";
+
+/**
+ * How a simulated user is reported back to a caller.
+ *
+ * `AdminGetUser` answers with the user's properties directly and calls the
+ * attributes `UserAttributes`. `AdminCreateUser` and `ListUsers` answer with a
+ * `UserType`, which calls the same attributes `Attributes`. Both shapes are
+ * built here so the difference is deliberate rather than accidental.
+ */
+export class SimCognitoUserView {
+  /**
+   * A user as `AdminCreateUser` and `ListUsers` report it.
+   */
+  entry(user: SimCognitoUser): SimCognitoUserType {
+    return {
+      Username: user.username,
+      Attributes: user.attributes,
+      UserCreateDate: user.creationDate,
+      UserLastModifiedDate: user.lastModifiedDate,
+      Enabled: user.enabled,
+      UserStatus: user.status.value,
+    };
+  }
+
+  /**
+   * A user as `AdminGetUser` reports it.
+   */
+  describe(user: SimCognitoUser): SimCognitoDescribedUser {
+    return {
+      Username: user.username,
+      UserAttributes: user.attributes,
+      UserCreateDate: user.creationDate,
+      UserLastModifiedDate: user.lastModifiedDate,
+      Enabled: user.enabled,
+      UserStatus: user.status.value,
+    };
+  }
+}

--- a/src/service/cognito/command/user/user.command.ts
+++ b/src/service/cognito/command/user/user.command.ts
@@ -1,0 +1,154 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCognitoAttributeType } from "../../user-pool/user/sim-cognito-user-attributes.js";
+
+/**
+ * A user as sim Cognito reports it in `AdminCreateUser` and `ListUsers`.
+ *
+ * The attributes arrive under `Attributes` here and under `UserAttributes` in
+ * an `AdminGetUser` response. Real Cognito names them differently in the two
+ * places, so code reading the wrong one finds nothing here as well.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html
+ */
+export interface SimCognitoUserType {
+  readonly Username?: string | undefined;
+  readonly Attributes?: readonly SimCognitoAttributeType[] | undefined;
+  readonly UserCreateDate?: Date | undefined;
+  readonly UserLastModifiedDate?: Date | undefined;
+  readonly Enabled?: boolean | undefined;
+  readonly UserStatus?: string | undefined;
+}
+
+/**
+ * A user as `AdminGetUser` reports it, which is a user pool response rather
+ * than a `UserType`.
+ */
+export interface SimCognitoDescribedUser {
+  readonly Username?: string | undefined;
+  readonly UserAttributes?: readonly SimCognitoAttributeType[] | undefined;
+  readonly UserCreateDate?: Date | undefined;
+  readonly UserLastModifiedDate?: Date | undefined;
+  readonly Enabled?: boolean | undefined;
+  readonly UserStatus?: string | undefined;
+}
+
+/**
+ * What every admin user operation names: the pool, and the user in it.
+ */
+export interface SimCognitoAdminUserCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly Username?: string | undefined;
+}
+
+/**
+ * The AdminCreateUser inputs this simulation reads, and the ones it refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/AdminCreateUserCommand/
+ */
+export interface SimAdminCreateUserCommandInput extends SimCognitoAdminUserCommandInput {
+  readonly UserAttributes?: readonly SimCognitoAttributeType[] | undefined;
+  readonly TemporaryPassword?: string | undefined;
+  readonly MessageAction?: string | undefined;
+  readonly DesiredDeliveryMediums?: readonly string[] | undefined;
+  readonly ForceAliasCreation?: boolean | undefined;
+  readonly ValidationData?: readonly SimCognitoAttributeType[] | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminCreateUser command.
+ */
+export interface SimAdminCreateUserCommand {
+  readonly input: SimAdminCreateUserCommandInput;
+}
+
+export interface SimAdminCreateUserCommandOutput {
+  readonly User?: SimCognitoUserType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito AdminGetUser command.
+ */
+export interface SimAdminGetUserCommand {
+  readonly input: SimCognitoAdminUserCommandInput;
+}
+
+export interface SimAdminGetUserCommandOutput extends SimCognitoDescribedUser {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito AdminDeleteUser command.
+ */
+export interface SimAdminDeleteUserCommand {
+  readonly input: SimCognitoAdminUserCommandInput;
+}
+
+export interface SimAdminDeleteUserCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The AdminSetUserPassword inputs, which are all simulated.
+ *
+ * `Permanent` is the one that matters: without it the password is temporary,
+ * and the user is left in `FORCE_CHANGE_PASSWORD` unable to sign in normally.
+ */
+export interface SimAdminSetUserPasswordCommandInput extends SimCognitoAdminUserCommandInput {
+  readonly Password?: string | undefined;
+  readonly Permanent?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminSetUserPassword command.
+ */
+export interface SimAdminSetUserPasswordCommand {
+  readonly input: SimAdminSetUserPasswordCommandInput;
+}
+
+export interface SimAdminSetUserPasswordCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The AdminUpdateUserAttributes inputs this simulation reads, and the one it
+ * refuses.
+ */
+export interface SimAdminUpdateUserAttributesCommandInput extends SimCognitoAdminUserCommandInput {
+  readonly UserAttributes?: readonly SimCognitoAttributeType[] | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminUpdateUserAttributes command.
+ */
+export interface SimAdminUpdateUserAttributesCommand {
+  readonly input: SimAdminUpdateUserAttributesCommandInput;
+}
+
+export interface SimAdminUpdateUserAttributesCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito AdminDisableUser command.
+ */
+export interface SimAdminDisableUserCommand {
+  readonly input: SimCognitoAdminUserCommandInput;
+}
+
+export interface SimAdminDisableUserCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Cognito AdminEnableUser command.
+ */
+export interface SimAdminEnableUserCommand {
+  readonly input: SimCognitoAdminUserCommandInput;
+}
+
+export interface SimAdminEnableUserCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -44,3 +44,45 @@ export class SimCognitoInvalidParameterException extends SimCognitoError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated Cognito UsernameExistsException error.
+ *
+ * Real Cognito reports a second user created with a username the pool already
+ * holds this way.
+ */
+export class SimCognitoUsernameExistsException extends SimCognitoError {
+  public override readonly name = "UsernameExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito UserNotFoundException error.
+ *
+ * Real Cognito reports an operation naming a user its pool does not hold this
+ * way, rather than as a missing resource.
+ */
+export class SimCognitoUserNotFoundException extends SimCognitoError {
+  public override readonly name = "UserNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Cognito InvalidPasswordException error.
+ *
+ * Real Cognito reports a password its pool's password policy does not allow
+ * this way, and says which rule the password broke.
+ */
+export class SimCognitoInvalidPasswordException extends SimCognitoError {
+  public override readonly name = "InvalidPasswordException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -30,8 +30,21 @@ export {
   type SimCognitoTokenValidityInput,
   type SimCognitoTokenValidityUnitsType,
 } from "./user-pool/client/sim-cognito-token-validity.js";
+export { SimCognitoUser } from "./user-pool/user/sim-cognito-user.js";
+export type { SimCognitoUsername } from "./user-pool/user/sim-cognito-username.js";
+export {
+  SimCognitoUserStatus,
+  type SimCognitoUserStatusValue,
+} from "./user-pool/user/sim-cognito-user-status.js";
+export {
+  SimCognitoUserAttributes,
+  type SimCognitoAttributeType,
+} from "./user-pool/user/sim-cognito-user-attributes.js";
 export {
   SimCognitoError,
   SimCognitoInvalidParameterException,
+  SimCognitoInvalidPasswordException,
   SimCognitoResourceNotFoundException,
+  SimCognitoUsernameExistsException,
+  SimCognitoUserNotFoundException,
 } from "./error/sim-cognito.error.js";

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
@@ -23,6 +23,14 @@ describe("SimCognitoSdkCommandRouter", () => {
       "DescribeUserPoolClientCommand",
       "DeleteUserPoolClientCommand",
       "ListUserPoolClientsCommand",
+      "AdminCreateUserCommand",
+      "AdminGetUserCommand",
+      "AdminDeleteUserCommand",
+      "AdminSetUserPasswordCommand",
+      "AdminUpdateUserAttributesCommand",
+      "AdminDisableUserCommand",
+      "AdminEnableUserCommand",
+      "ListUsersCommand",
     ]);
   });
 
@@ -34,7 +42,7 @@ describe("SimCognitoSdkCommandRouter", () => {
     const route = simAws
       .cognitoIdentityProvider()
       .sdkCommandRouter()
-      .route("AdminCreateUserCommand");
+      .route("AdminInitiateAuthCommand");
 
     // Then there is no route for it.
     assertUndefined(route);

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
@@ -9,6 +9,16 @@ import type {
   SimDescribeUserPoolClientCommand,
 } from "../command/client/user-pool-client.command.js";
 import type { SimListUserPoolClientsCommand } from "../command/client/list-user-pool-clients.command.js";
+import type { SimListUsersCommand } from "../command/user/list-users.command.js";
+import type {
+  SimAdminCreateUserCommand,
+  SimAdminDeleteUserCommand,
+  SimAdminDisableUserCommand,
+  SimAdminEnableUserCommand,
+  SimAdminGetUserCommand,
+  SimAdminSetUserPasswordCommand,
+  SimAdminUpdateUserAttributesCommand,
+} from "../command/user/user.command.js";
 import type { SimListUserPoolsCommand } from "../command/user-pool/list-user-pools.command.js";
 import type {
   SimCreateUserPoolCommand,
@@ -86,6 +96,70 @@ export class SimCognitoSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCognito.listUserPoolClients(
             command as SimListUserPoolClientsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminCreateUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminCreateUser(
+            command as SimAdminCreateUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminGetUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminGetUser(
+            command as SimAdminGetUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminDeleteUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminDeleteUser(
+            command as SimAdminDeleteUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminSetUserPasswordCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminSetUserPassword(
+            command as SimAdminSetUserPasswordCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminUpdateUserAttributesCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminUpdateUserAttributes(
+            command as SimAdminUpdateUserAttributesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminDisableUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminDisableUser(
+            command as SimAdminDisableUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminEnableUserCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminEnableUser(
+            command as SimAdminEnableUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListUsersCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.listUsers(
+            command as SimListUsersCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-user-routing.iso.test.ts
@@ -1,0 +1,96 @@
+import {
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminDisableUserCommand,
+  AdminEnableUserCommand,
+  AdminGetUserCommand,
+  AdminSetUserPasswordCommand,
+  AdminUpdateUserAttributesCommand,
+  CognitoIdentityProviderClient,
+  CreateUserPoolCommand,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("Cognito user SDK interception", () => {
+  it("routes every user Command through the intercepted client", async () => {
+    // Given an intercepted Cognito SDK client with a pool.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const userPoolId = pool.UserPool?.Id;
+
+    // When ordinary SDK code takes a user through its lifecycle.
+    const created = await client.send(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    await client.send(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecret!",
+        Permanent: true,
+      }),
+    );
+    await client.send(
+      new AdminUpdateUserAttributesCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+      }),
+    );
+    await client.send(
+      new AdminDisableUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    const disabled = await client.send(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    await client.send(
+      new AdminEnableUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    const listed = await client.send(
+      new ListUsersCommand({ UserPoolId: userPoolId }),
+    );
+
+    await client.send(
+      new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    const listedAfterDelete = await client.send(
+      new ListUsersCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then each Command reached simulated Cognito.
+    assertIdentical(created.User?.UserStatus, "FORCE_CHANGE_PASSWORD");
+    assertIdentical(disabled.UserStatus, "CONFIRMED");
+    assertFalse(disabled.Enabled);
+    assertTrue(
+      (disabled.UserAttributes ?? []).some(
+        (attribute) => attribute.Name === "email",
+      ),
+    );
+    assertArrayEquals(
+      listed.Users?.map((user) => user.Username),
+      ["alice"],
+    );
+    assertArrayEquals(listedAfterDelete.Users, []);
+  });
+});

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -10,16 +10,10 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimCognitoAuthorizer } from "./command/authorize/sim-cognito-authorizer.js";
-import { SimCognitoListUserPoolClients } from "./command/client/sim-cognito-list-user-pool-clients.js";
-import { SimCognitoUserPoolClientCommands } from "./command/client/sim-cognito-user-pool-client-commands.js";
 import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
-import { SimCognitoListUserPools } from "./command/user-pool/sim-cognito-list-user-pools.js";
-import { SimCognitoUserPoolCommands } from "./command/user-pool/sim-cognito-user-pool-commands.js";
+import { SimCognitoCommands } from "./command/sim-cognito-commands.js";
 import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
-import { SimCognitoUserPoolClientFactory } from "./user-pool/client/sim-cognito-user-pool-client-factory.js";
 import type { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
-import { SimCognitoUserPoolFactory } from "./user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolId } from "./user-pool/sim-cognito-user-pool-id.js";
 import { SimCognitoUserPoolStore } from "./user-pool/sim-cognito-user-pool-store.js";
 
@@ -45,11 +39,8 @@ interface SimCognitoIdentityProviderProperties {
  * credentials, are a different service and are not simulated at all.
  */
 export class SimCognitoIdentityProvider {
-  private readonly pools: SimCognitoUserPoolStore;
-  private readonly userPoolCommands: SimCognitoUserPoolCommands;
-  private readonly listUserPoolsCommand: SimCognitoListUserPools;
-  private readonly clientCommands: SimCognitoUserPoolClientCommands;
-  private readonly listClientsCommand: SimCognitoListUserPoolClients;
+  private readonly pools = new SimCognitoUserPoolStore();
+  private readonly commands: SimCognitoCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimCognitoSdkCommandRouter(this);
 
@@ -60,31 +51,12 @@ export class SimCognitoIdentityProvider {
       background = new BackgroundTasks(),
     } = properties;
 
-    const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
-
     this.background = background;
-    this.pools = new SimCognitoUserPoolStore();
-    this.userPoolCommands = new SimCognitoUserPoolCommands({
+    this.commands = new SimCognitoCommands({
+      accountRegionScope,
+      iam,
+      clock: background,
       pools: this.pools,
-      poolFactory: new SimCognitoUserPoolFactory({
-        accountRegionScope,
-        pools: this.pools,
-        clock: background,
-      }),
-      authorizer,
-    });
-    this.listUserPoolsCommand = new SimCognitoListUserPools({
-      pools: this.pools,
-      authorizer,
-    });
-    this.clientCommands = new SimCognitoUserPoolClientCommands({
-      pools: this.pools,
-      clientFactory: new SimCognitoUserPoolClientFactory({ clock: background }),
-      authorizer,
-    });
-    this.listClientsCommand = new SimCognitoListUserPoolClients({
-      pools: this.pools,
-      authorizer,
     });
   }
 
@@ -106,7 +78,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimCreateUserPoolCommandOutput> {
     await this.background.sequence();
-    return this.userPoolCommands.create(command, options);
+    return this.commands.userPools.create(command, options);
   }
 
   /**
@@ -117,7 +89,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimDescribeUserPoolCommandOutput> {
     await this.background.sequence();
-    return this.userPoolCommands.describe(command, options);
+    return this.commands.userPools.describe(command, options);
   }
 
   /**
@@ -128,7 +100,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimDeleteUserPoolCommandOutput> {
     await this.background.sequence();
-    return this.userPoolCommands.delete(command, options);
+    return this.commands.userPools.delete(command, options);
   }
 
   /**
@@ -139,7 +111,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimListUserPoolsCommandOutput> {
     await this.background.sequence();
-    return this.listUserPoolsCommand.handle(command, options);
+    return this.commands.listUserPools.handle(command, options);
   }
 
   /**
@@ -150,7 +122,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimCreateUserPoolClientCommandOutput> {
     await this.background.sequence();
-    return this.clientCommands.create(command, options);
+    return this.commands.clients.create(command, options);
   }
 
   /**
@@ -161,7 +133,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimDescribeUserPoolClientCommandOutput> {
     await this.background.sequence();
-    return this.clientCommands.describe(command, options);
+    return this.commands.clients.describe(command, options);
   }
 
   /**
@@ -172,7 +144,7 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimDeleteUserPoolClientCommandOutput> {
     await this.background.sequence();
-    return this.clientCommands.delete(command, options);
+    return this.commands.clients.delete(command, options);
   }
 
   /**
@@ -183,7 +155,95 @@ export class SimCognitoIdentityProvider {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimListUserPoolClientsCommandOutput> {
     await this.background.sequence();
-    return this.listClientsCommand.handle(command, options);
+    return this.commands.listClients.handle(command, options);
+  }
+
+  /**
+   * Handle an AdminCreateUser Command from the SDK.
+   */
+  async adminCreateUser(
+    command: simCognitoCommands.SimAdminCreateUserCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminCreateUserCommandOutput> {
+    await this.background.sequence();
+    return this.commands.users.create(command, options);
+  }
+
+  /**
+   * Handle an AdminGetUser Command from the SDK.
+   */
+  async adminGetUser(
+    command: simCognitoCommands.SimAdminGetUserCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminGetUserCommandOutput> {
+    await this.background.sequence();
+    return this.commands.users.get(command, options);
+  }
+
+  /**
+   * Handle an AdminDeleteUser Command from the SDK.
+   */
+  async adminDeleteUser(
+    command: simCognitoCommands.SimAdminDeleteUserCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminDeleteUserCommandOutput> {
+    await this.background.sequence();
+    return this.commands.users.delete(command, options);
+  }
+
+  /**
+   * Handle an AdminSetUserPassword Command from the SDK.
+   */
+  async adminSetUserPassword(
+    command: simCognitoCommands.SimAdminSetUserPasswordCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminSetUserPasswordCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userUpdates.setPassword(command, options);
+  }
+
+  /**
+   * Handle an AdminUpdateUserAttributes Command from the SDK.
+   */
+  async adminUpdateUserAttributes(
+    command: simCognitoCommands.SimAdminUpdateUserAttributesCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminUpdateUserAttributesCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userUpdates.updateAttributes(command, options);
+  }
+
+  /**
+   * Handle an AdminDisableUser Command from the SDK.
+   */
+  async adminDisableUser(
+    command: simCognitoCommands.SimAdminDisableUserCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminDisableUserCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userUpdates.disable(command, options);
+  }
+
+  /**
+   * Handle an AdminEnableUser Command from the SDK.
+   */
+  async adminEnableUser(
+    command: simCognitoCommands.SimAdminEnableUserCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminEnableUserCommandOutput> {
+    await this.background.sequence();
+    return this.commands.userUpdates.enable(command, options);
+  }
+
+  /**
+   * Handle a ListUsers Command from the SDK.
+   */
+  async listUsers(
+    command: simCognitoCommands.SimListUsersCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimListUsersCommandOutput> {
+    await this.background.sequence();
+    return this.commands.listUsers.handle(command, options);
   }
 
   /**

--- a/src/service/cognito/user-pool/sim-cognito-password-check.ts
+++ b/src/service/cognito/user-pool/sim-cognito-password-check.ts
@@ -11,8 +11,17 @@ const maxPasswordLength = 256;
  */
 const symbolPattern = /[\^$*.[\]{}()?"!@#%&/\\,><':;|_~`+= -]/u;
 
-const uppercasePattern = /\p{Lu}/u;
-const lowercasePattern = /\p{Ll}/u;
+/**
+ * The letters Cognito counts towards the uppercase and lowercase requirements.
+ *
+ * A password may hold any Unicode character, and which of them satisfy these
+ * two rules is not documented, so basic Latin is what counts here. That
+ * refuses a password of, say, Greek letters that real Cognito might accept.
+ * Refusing one it would have taken is a puzzling test failure; taking one it
+ * would have refused is a sign-up that fails in a deployment.
+ */
+const uppercasePattern = /[A-Z]/u;
+const lowercasePattern = /[a-z]/u;
 const numberPattern = /\d/u;
 
 /**

--- a/src/service/cognito/user-pool/sim-cognito-password-check.ts
+++ b/src/service/cognito/user-pool/sim-cognito-password-check.ts
@@ -1,0 +1,87 @@
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoInvalidPasswordException,
+} from "../error/sim-cognito.error.js";
+import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
+
+const maxPasswordLength = 256;
+
+/**
+ * The characters Cognito counts as symbols in a password.
+ */
+const symbolPattern = /[\^$*.[\]{}()?"!@#%&/\\,><':;|_~`+= -]/u;
+
+const uppercasePattern = /\p{Lu}/u;
+const lowercasePattern = /\p{Ll}/u;
+const numberPattern = /\d/u;
+
+/**
+ * Checks a password against one pool's password policy.
+ *
+ * A password is checked wherever one arrives, so the rules live here once
+ * rather than at `AdminCreateUser` and `AdminSetUserPassword` separately. The
+ * refusals say which rule the password broke, in the words real Cognito uses,
+ * because that message is often the only thing a test has to go on.
+ */
+export class SimCognitoPasswordCheck {
+  private readonly policy: SimCognitoPasswordPolicy;
+
+  constructor(policy: SimCognitoPasswordPolicy) {
+    this.policy = policy;
+  }
+
+  private static refuse(reason: string): never {
+    throw new SimCognitoInvalidPasswordException(
+      `Password did not conform with policy: ${reason}`,
+    );
+  }
+
+  /**
+   * Refuse a password this pool would not accept.
+   *
+   * A missing password is a validation error rather than a policy failure,
+   * because real Cognito rejects the request before it reaches the policy.
+   */
+  require(field: string, password: string | undefined): void {
+    if (password === undefined || password === "") {
+      throw new SimCognitoInvalidParameterException(
+        `${field} is required: give the user a password the pool's policy allows`,
+      );
+    }
+
+    if (password.length > maxPasswordLength) {
+      throw new SimCognitoInvalidPasswordException(
+        `${field} is longer than the ${String(maxPasswordLength)} characters ` +
+          `Cognito allows`,
+      );
+    }
+
+    this.requirePolicy(password);
+  }
+
+  private requirePolicy(password: string): void {
+    if (password.length < this.policy.minimumLength) {
+      SimCognitoPasswordCheck.refuse("Password not long enough");
+    }
+
+    this.requireCharacters(password);
+  }
+
+  private requireCharacters(password: string): void {
+    if (this.policy.requiresUppercase && !uppercasePattern.test(password)) {
+      SimCognitoPasswordCheck.refuse("Password must have uppercase characters");
+    }
+
+    if (this.policy.requiresLowercase && !lowercasePattern.test(password)) {
+      SimCognitoPasswordCheck.refuse("Password must have lowercase characters");
+    }
+
+    if (this.policy.requiresNumbers && !numberPattern.test(password)) {
+      SimCognitoPasswordCheck.refuse("Password must have numeric characters");
+    }
+
+    if (this.policy.requiresSymbols && !symbolPattern.test(password)) {
+      SimCognitoPasswordCheck.refuse("Password must have symbol characters");
+    }
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -6,6 +6,9 @@ import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import type { SimCognitoUser } from "./user/sim-cognito-user.js";
+import { SimCognitoUserStore } from "./user/sim-cognito-user-store.js";
+import type { SimCognitoUsername } from "./user/sim-cognito-username.js";
 
 interface SimCognitoUserPoolProperties {
   readonly id: SimCognitoUserPoolId;
@@ -32,6 +35,7 @@ export class SimCognitoUserPool {
   public readonly creationDate: Date;
 
   private readonly clientStore = new SimCognitoUserPoolClientStore();
+  private readonly userStore = new SimCognitoUserStore();
 
   constructor(properties: SimCognitoUserPoolProperties) {
     this.id = properties.id;
@@ -94,5 +98,47 @@ export class SimCognitoUserPool {
     clientId: SimCognitoUserPoolClientId,
   ): SimCognitoUserPoolClient {
     return this.clientStore.require(clientId);
+  }
+
+  /**
+   * Every user in this pool, in creation order.
+   */
+  get users(): readonly SimCognitoUser[] {
+    return this.userStore.all;
+  }
+
+  /**
+   * How many users this pool holds.
+   */
+  get userCount(): number {
+    return this.userStore.count;
+  }
+
+  /**
+   * Store a newly created user, refusing a username already in this pool.
+   */
+  addUser(user: SimCognitoUser): void {
+    this.userStore.add(user);
+  }
+
+  /**
+   * Forget a deleted user.
+   */
+  removeUser(user: SimCognitoUser): void {
+    this.userStore.remove(user);
+  }
+
+  /**
+   * Find a user of this pool by username.
+   */
+  findUser(username: string): SimCognitoUser | undefined {
+    return this.userStore.find(username);
+  }
+
+  /**
+   * Resolve a user of this pool by username, or refuse.
+   */
+  requireUser(username: SimCognitoUsername): SimCognitoUser {
+    return this.userStore.require(username);
   }
 }

--- a/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
@@ -1,0 +1,136 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+/**
+ * One user attribute, in the shape Cognito reads and reports it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AttributeType.html
+ */
+export interface SimCognitoAttributeType {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * The standard attributes every Cognito pool's schema holds.
+ *
+ * These are the OpenID Connect claims, plus the two verification flags. A pool
+ * here has no custom attributes, because `CreateUserPool` refuses a `Schema`
+ * of its own.
+ */
+const standardAttributeNames: ReadonlySet<string> = new Set([
+  "address",
+  "birthdate",
+  "email",
+  "email_verified",
+  "family_name",
+  "gender",
+  "given_name",
+  "locale",
+  "middle_name",
+  "name",
+  "nickname",
+  "phone_number",
+  "phone_number_verified",
+  "picture",
+  "preferred_username",
+  "profile",
+  "updated_at",
+  "website",
+  "zoneinfo",
+]);
+
+const maxAttributeValueLength = 2048;
+
+/**
+ * The attributes held on one simulated user.
+ *
+ * Attribute names are checked against the pool's schema rather than stored as
+ * written, because real Cognito refuses an attribute its schema does not hold.
+ * A pool created here has the standard schema and nothing else, so a
+ * `custom:` attribute is refused the same way it would be on a real pool
+ * created without it.
+ *
+ * `sub` is not among them. Cognito allocates it, and a request setting it is
+ * refused, so it lives on the user rather than in its attributes.
+ */
+export class SimCognitoUserAttributes {
+  private readonly byName = new Map<string, string>();
+
+  constructor(requested?: readonly SimCognitoAttributeType[]) {
+    this.update(requested);
+  }
+
+  private static requireName(name: string | undefined): string {
+    if (name === undefined || name === "") {
+      throw new SimCognitoInvalidParameterException(
+        "A user attribute needs a Name saying which attribute it sets",
+      );
+    }
+
+    if (name === "sub") {
+      throw new SimCognitoInvalidParameterException(
+        "User attribute 'sub' is read-only: Cognito allocates a user's sub " +
+          "when the user is created, and a request cannot set it",
+      );
+    }
+
+    if (!standardAttributeNames.has(name)) {
+      throw new SimCognitoInvalidParameterException(
+        `User attribute '${name}' is not in the pool's schema: a pool here ` +
+          `holds the standard attributes only, because CreateUserPool ` +
+          `refuses a Schema of its own, so custom attributes cannot exist`,
+      );
+    }
+
+    return name;
+  }
+
+  private static requireValue(name: string, value: string | undefined): string {
+    if (value === undefined) {
+      throw new SimCognitoInvalidParameterException(
+        `User attribute '${name}' needs a Value`,
+      );
+    }
+
+    if (value.length > maxAttributeValueLength) {
+      throw new SimCognitoInvalidParameterException(
+        `User attribute '${name}' is longer than the ` +
+          `${String(maxAttributeValueLength)} characters Cognito allows`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * The attributes, in the order they were first set.
+   */
+  get entries(): readonly SimCognitoAttributeType[] {
+    return this.byName
+      .entries()
+      .map(([name, value]) => ({ Name: name, Value: value }))
+      .toArray();
+  }
+
+  /**
+   * Apply requested attributes over the ones already held.
+   *
+   * An update names only the attributes it changes, as `AdminUpdateUserAttributes`
+   * does on real Cognito: an attribute the request says nothing about keeps its
+   * value rather than being cleared.
+   */
+  update(requested?: readonly SimCognitoAttributeType[]): void {
+    if (requested === undefined) {
+      return;
+    }
+
+    for (const attribute of requested) {
+      const name = SimCognitoUserAttributes.requireName(attribute.Name);
+
+      this.byName.set(
+        name,
+        SimCognitoUserAttributes.requireValue(name, attribute.Value),
+      );
+    }
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  type SimCognitoAttributeType,
+  SimCognitoUserAttributes,
+} from "./sim-cognito-user-attributes.js";
+import { SimCognitoUser } from "./sim-cognito-user.js";
+import type { SimCognitoUsername } from "./sim-cognito-username.js";
+
+interface SimCognitoUserFactoryProperties {
+  readonly clock: SimClock;
+}
+
+interface SimCognitoMakeUserProperties {
+  readonly username: SimCognitoUsername;
+  readonly attributes?: readonly SimCognitoAttributeType[] | undefined;
+}
+
+/**
+ * Builds simulated users, including the `sub` Cognito allocates.
+ */
+export class SimCognitoUserFactory {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoUserFactoryProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Make a new user for a pool.
+   *
+   * The `sub` is a fresh UUID rather than anything derived from the username,
+   * as it is on real Cognito. Code that treats the two as interchangeable
+   * therefore fails here rather than in a deployment.
+   */
+  make(properties: SimCognitoMakeUserProperties): SimCognitoUser {
+    return new SimCognitoUser({
+      username: properties.username,
+      sub: randomUUID(),
+      attributes: new SimCognitoUserAttributes(properties.attributes),
+      clock: this.clock,
+    });
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
@@ -1,0 +1,48 @@
+export type SimCognitoUserStatusValue = "FORCE_CHANGE_PASSWORD" | "CONFIRMED";
+
+/**
+ * The status of one simulated user.
+ *
+ * Only the two statuses this simulation can reach are modelled. A user created
+ * by `AdminCreateUser` starts in `FORCE_CHANGE_PASSWORD`, which is what stops
+ * it signing in normally on real Cognito, and reaches `CONFIRMED` when an
+ * admin sets a permanent password on it. The other real statuses
+ * (`UNCONFIRMED`, `RESET_REQUIRED`, `EXTERNAL_PROVIDER` and the rest) belong
+ * to sign-up, password resets and federation, none of which are simulated.
+ */
+export class SimCognitoUserStatus {
+  /**
+   * The status a user created by an admin starts in.
+   */
+  public static readonly forceChangePassword = new SimCognitoUserStatus(
+    "FORCE_CHANGE_PASSWORD",
+  );
+
+  /**
+   * The status a user with a password of its own reaches.
+   */
+  public static readonly confirmed = new SimCognitoUserStatus("CONFIRMED");
+
+  public readonly value: SimCognitoUserStatusValue;
+
+  private constructor(value: SimCognitoUserStatusValue) {
+    this.value = value;
+  }
+
+  /**
+   * The status a user reaches when an admin sets a password on it.
+   *
+   * A permanent password is the user's own, so the user is confirmed and can
+   * sign in with it. A temporary one leaves the user having to replace it,
+   * which is the same place `AdminCreateUser` leaves a new user.
+   */
+  static afterPasswordSet(
+    permanent: boolean | undefined,
+  ): SimCognitoUserStatus {
+    if (permanent === true) {
+      return this.confirmed;
+    }
+
+    return this.forceChangePassword;
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-store.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-store.ts
@@ -1,0 +1,94 @@
+import {
+  SimCognitoUsernameExistsException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoUser } from "./sim-cognito-user.js";
+import type { SimCognitoUsername } from "./sim-cognito-username.js";
+
+/**
+ * The users of one simulated user pool.
+ *
+ * Users are keyed by username, which is what every admin operation names one
+ * by. Usernames are case sensitive here, as they are on a pool created without
+ * a `UsernameConfiguration`, which this simulation refuses.
+ */
+export class SimCognitoUserStore {
+  private readonly users = new Map<string, SimCognitoUser>();
+
+  /**
+   * Every user in this pool, in creation order.
+   */
+  get all(): readonly SimCognitoUser[] {
+    return this.users.values().toArray();
+  }
+
+  /**
+   * How many users the pool holds.
+   */
+  get count(): number {
+    return this.users.size;
+  }
+
+  /**
+   * Store a newly created user, refusing a username the pool already holds.
+   */
+  add(user: SimCognitoUser): void {
+    if (this.users.has(user.username)) {
+      throw new SimCognitoUsernameExistsException(
+        `User account ${user.username} already exists in this user pool.`,
+      );
+    }
+
+    this.users.set(user.username, user);
+  }
+
+  /**
+   * Forget a deleted user.
+   */
+  remove(user: SimCognitoUser): void {
+    this.users.delete(user.username);
+  }
+
+  /**
+   * Find a user by username.
+   */
+  find(username: string): SimCognitoUser | undefined {
+    return this.users.get(username);
+  }
+
+  /**
+   * Resolve a user by username, or refuse.
+   */
+  require(username: SimCognitoUsername): SimCognitoUser {
+    const found = this.find(username);
+
+    if (found === undefined) {
+      throw new SimCognitoUserNotFoundException(this.missingMessage(username));
+    }
+
+    return found;
+  }
+
+  /**
+   * Say why a username reached no user.
+   *
+   * A value that is some user's `sub` gets its own message. Real Cognito
+   * accepts a `sub` where an admin operation asks for a username, and this
+   * simulation resolves users by username only, so the refusal explains
+   * itself rather than looking like the user was never created.
+   */
+  private missingMessage(username: SimCognitoUsername): string {
+    const bySub = this.all.find((user) => user.sub === username);
+
+    if (bySub !== undefined) {
+      return (
+        `User ${username} does not exist: that is the sub of user ` +
+        `${bySub.username}. Real Cognito also accepts a sub where an admin ` +
+        `operation asks for a username, and this simulation resolves users ` +
+        `by username only.`
+      );
+    }
+
+    return `User ${username} does not exist.`;
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -1,0 +1,124 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type {
+  SimCognitoAttributeType,
+  SimCognitoUserAttributes,
+} from "./sim-cognito-user-attributes.js";
+import { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
+import type { SimCognitoUsername } from "./sim-cognito-username.js";
+
+interface SimCognitoUserProperties {
+  readonly username: SimCognitoUsername;
+  readonly sub: string;
+  readonly attributes: SimCognitoUserAttributes;
+  readonly clock: SimClock;
+}
+
+/**
+ * One simulated Cognito user.
+ *
+ * The user's `sub` is a UUID Cognito allocates, and is not the username. Code
+ * that keys on the wrong one works only while the two happen to match, which
+ * they never do on a real pool.
+ *
+ * A user starts in `FORCE_CHANGE_PASSWORD`, because `AdminCreateUser` is the
+ * only way to make one here. That is the status that stops a user signing in
+ * with the temporary password it was given.
+ */
+export class SimCognitoUser {
+  public readonly username: SimCognitoUsername;
+  public readonly sub: string;
+  public readonly creationDate: Date;
+
+  private readonly clock: SimClock;
+  private readonly userAttributes: SimCognitoUserAttributes;
+  private userStatus = SimCognitoUserStatus.forceChangePassword;
+  private isEnabled = true;
+  private modifiedDate: Date;
+
+  constructor(properties: SimCognitoUserProperties) {
+    this.username = properties.username;
+    this.sub = properties.sub;
+    this.userAttributes = properties.attributes;
+    this.clock = properties.clock;
+    this.creationDate = this.clock.now();
+    this.modifiedDate = this.creationDate;
+  }
+
+  /**
+   * When the user last changed.
+   */
+  get lastModifiedDate(): Date {
+    return this.modifiedDate;
+  }
+
+  /**
+   * Where the user is in the status lifecycle.
+   */
+  get status(): SimCognitoUserStatus {
+    return this.userStatus;
+  }
+
+  /**
+   * Whether the user may authenticate at all.
+   *
+   * A disabled user keeps its password and its attributes, and real Cognito
+   * refuses to sign it in. Nothing signs in here yet, so this is stored and
+   * reported rather than acted on.
+   */
+  get enabled(): boolean {
+    return this.isEnabled;
+  }
+
+  /**
+   * The user's attributes, with the `sub` Cognito allocated among them.
+   *
+   * Real Cognito reports `sub` alongside the attributes a request set, which
+   * is where most code reads a user's identifier from.
+   */
+  get attributes(): readonly SimCognitoAttributeType[] {
+    return [{ Name: "sub", Value: this.sub }, ...this.userAttributes.entries];
+  }
+
+  /**
+   * Note that an admin has set a password on this user.
+   *
+   * The password itself is checked against the pool's policy and not kept,
+   * because nothing authenticates here yet. What it changes is the user's
+   * status: a permanent password is the user's own, and a temporary one
+   * leaves the user having to replace it before it can sign in.
+   */
+  setPassword(permanent: boolean | undefined): void {
+    this.userStatus = SimCognitoUserStatus.afterPasswordSet(permanent);
+    this.touch();
+  }
+
+  /**
+   * Apply an attribute update to this user.
+   */
+  updateAttributes(
+    requested: readonly SimCognitoAttributeType[] | undefined,
+  ): void {
+    this.userAttributes.update(requested);
+    this.touch();
+  }
+
+  /**
+   * Let the user authenticate again.
+   */
+  enable(): void {
+    this.isEnabled = true;
+    this.touch();
+  }
+
+  /**
+   * Stop the user authenticating.
+   */
+  disable(): void {
+    this.isEnabled = false;
+    this.touch();
+  }
+
+  private touch(): void {
+    this.modifiedDate = this.clock.now();
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-username.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-username.ts
@@ -1,0 +1,45 @@
+import type { Brand } from "../../../../util/brand.type.js";
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+export type SimCognitoUsername = Brand<string, "SimCognitoUsername">;
+
+const maxUsernameLength = 128;
+
+/**
+ * The characters Cognito allows in a username: letters, marks, symbols,
+ * numbers and punctuation, and no whitespace among them.
+ */
+const usernamePattern = /^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$/u;
+
+/**
+ * Read a requested username, or refuse a malformed one.
+ *
+ * A username is the identifier every admin operation names a user by, so it
+ * is validated before anything is looked up: a value real Cognito would reject
+ * fails as a validation error here too, rather than as a missing user.
+ */
+export function requireSimCognitoUsername(
+  value: string | undefined,
+): SimCognitoUsername {
+  if (value === undefined || value === "") {
+    throw new SimCognitoInvalidParameterException(
+      "Username is required: name the user the request is for",
+    );
+  }
+
+  if (value.length > maxUsernameLength) {
+    throw new SimCognitoInvalidParameterException(
+      `Username '${value}' is longer than the ${String(maxUsernameLength)} ` +
+        `characters Cognito allows`,
+    );
+  }
+
+  if (!usernamePattern.test(value)) {
+    throw new SimCognitoInvalidParameterException(
+      `Username '${value}' contains characters Cognito does not allow: a ` +
+        `username may not hold whitespace`,
+    );
+  }
+
+  return value as SimCognitoUsername;
+}


### PR DESCRIPTION
Adds AdminCreateUser, AdminGetUser, AdminDeleteUser, AdminSetUserPassword, AdminUpdateUserAttributes, AdminDisableUser, AdminEnableUser and ListUsers, with the real user status lifecycle: an admin-created user is left in FORCE_CHANGE_PASSWORD and only a permanent password confirms it. A user's sub is a UUID rather than its username, passwords are checked against the pool's password policy, and every operation authorizes against the pool ARN.

Resolves https://github.com/KensioSoftware/yulin/issues/218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added simulated Cognito admin user management (create/get/delete, set password, update attributes, enable/disable) with realistic user statuses and lifecycle dates.
  - Added `ListUsers` support with pagination and pool user-count reporting, plus expanded SDK command routing.
  - Introduced additional simulator exceptions for user-not-found, username-exists, and invalid-password cases.
- **Documentation**
  - Expanded Cognito simulation docs with detailed user workflows, password policy enforcement, attribute/lookup semantics, and limitations.
  - Added new “create user” and “list users” example scripts.
- **Tests**
  - Added ISO and validation suites covering IAM authorization, pagination, and input refusal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->