### PR TITLE
feat: sign real JWTs for simulated Cognito users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,3 @@ dmypy.json
 tmp/
 *.tmp
 *.tmp.*
-
-# Video demo project (see .claude/video/HOUSE-STYLE.md)
-/yulin-demo/

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -22,16 +22,21 @@ Sim Cognito currently supports:
 - `CreateGroupCommand`, `GetGroupCommand`, `UpdateGroupCommand`, `DeleteGroupCommand`,
   `ListGroupsCommand`, `AdminAddUserToGroupCommand`, `AdminRemoveUserFromGroupCommand`,
   `AdminListGroupsForUserCommand` and `ListUsersInGroupCommand`
+- `AdminInitiateAuthCommand` and `AdminRespondToAuthChallengeCommand`, for the
+  `ADMIN_USER_PASSWORD_AUTH` flow and the `NEW_PASSWORD_REQUIRED` challenge
+- Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
+  pool verifies them unchanged
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
   has a permanent password
-- Group membership, and the precedence order the `cognito:groups` claim will use
+- Group membership, and the precedence order the `cognito:groups` claim uses
 - App client authentication flows, token lifetimes and generated client secrets
 - Authorization of every operation by simulated IAM, against the real IAM action and ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
-Nothing signs in yet. Tokens and the authentication flows themselves are a separate piece of work.
+The client-side flows are a separate piece of work: `InitiateAuth`, SRP and the hosted UI are not
+implemented.
 
 ## Creating a pool and an app client
 
@@ -387,6 +392,253 @@ The legacy authentication flows (`ADMIN_NO_SRP_AUTH`, `CUSTOM_AUTH_FLOW_ONLY` an
 `USER_PASSWORD_AUTH`) work on their own, and a request mixing them with the `ALLOW_` prefixed values
 is refused, as real Cognito refuses it.
 
+## Signing in and verifying tokens
+
+`AdminInitiateAuth` runs the `ADMIN_USER_PASSWORD_AUTH` flow and answers with real signed tokens. The
+app client has to be created with `ALLOW_ADMIN_USER_PASSWORD_AUTH` among its `ExplicitAuthFlows`, as
+it does on real Cognito, and a request against a client without it is refused whatever the password
+was.
+
+The tokens are RS256 JWTs signed by a key the pool publishes. Hand that JWKS to a verifier and it
+verifies them with nothing stubbed and nothing on the network.
+
+```typescript sim-cognito-sign-in
+/**
+ * Signing a simulated user in, and verifying the token with aws-jwt-verify.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+// The verifier is the one the application uses, configured as it is there.
+const verifier = CognitoJwtVerifier.create({
+  userPoolId,
+  tokenUse: "access",
+  clientId,
+});
+
+// The pool's own JWKS, so nothing reaches for the network.
+verifier.cacheJwks(cognito.userPool(userPoolId).jwks());
+
+const payload = await verifier.verify(AuthenticationResult!.AccessToken!);
+
+console.log(payload.username); // "alice"
+console.log(payload.sub); // a UUID, and not "alice"
+```
+
+An `AuthenticationResult` carries an `AccessToken`, an `IdToken`, a `RefreshToken`, an `ExpiresIn` of
+3600 and a `TokenType` of `Bearer`. The refresh token is an opaque string rather than a JWT, as it is
+on real Cognito, and nothing here consumes it: `REFRESH_TOKEN_AUTH` is not simulated.
+
+The claim split is the real one. The id token carries `aud`, `token_use: "id"`, `cognito:username`
+and the user's attributes. The access token carries `client_id` and no `aud`, `token_use: "access"`,
+`username` and a `scope` of `aws.cognito.signin.user.admin`. Both carry the same `sub`, and both
+carry `cognito:groups` in precedence order when the user is in any groups. Code reading the wrong
+token for a claim fails here the way it would in production.
+
+The `iss` claim is `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`, and the JWT header
+names `RS256` and a `kid` the pool's JWKS holds. That is everything a verifier checks.
+
+## The new password challenge
+
+A user an admin created is in `FORCE_CHANGE_PASSWORD` and cannot sign in. Signing in with its
+temporary password answers with the `NEW_PASSWORD_REQUIRED` challenge and a session rather than
+tokens, and `AdminRespondToAuthChallenge` completes it.
+
+```typescript sim-cognito-new-password-challenge
+/**
+ * Getting a simulated user past the NEW_PASSWORD_REQUIRED challenge.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    TemporaryPassword: "Temp0rary!",
+  }),
+);
+
+const challenged = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+  }),
+);
+
+console.log(challenged.ChallengeName); // "NEW_PASSWORD_REQUIRED"
+
+const signedIn = await cognito.adminRespondToAuthChallenge(
+  new AdminRespondToAuthChallengeCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    ChallengeName: "NEW_PASSWORD_REQUIRED",
+    Session: challenged.Session,
+    ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.IdToken?.split(".").length); // 3
+```
+
+Name a `TemporaryPassword` on `AdminCreateUser` when the test means to sign the user in. Real Cognito
+generates one and emails it, and nothing here delivers a message, so a user created without one has
+no password that works.
+
+The new password is checked against the pool's policy and confirms the user, which signs in normally
+from then on. A session is single use and lasts three minutes of simulated time, so a replayed one
+and one left too long both fail with `NotAuthorizedException`.
+
+A wrong password and a disabled user fail with `NotAuthorizedException` too, saying no more than real
+Cognito says. An app client created with `GenerateSecret: true` needs a correct `SECRET_HASH` in
+`AuthParameters`, which is the HMAC-SHA256 of the username and client id keyed by the client secret.
+
+## Token timestamps and expiry
+
+`iat`, `exp` and `auth_time` come from the simulation's clock rather than the host's, and the tokens
+last the hour a pool's tokens last unless the app client says otherwise.
+
+That makes an expired token something a test can produce: sign the user in with the simulated clock
+set far enough in the past, and the token a verifier gets is already expired.
+
+```typescript sim-cognito-expired-token
+/**
+ * Producing a simulated token that a verifier rejects as expired.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+// Sign in two hours ago, so the hour the token lasts is already over.
+await simAws.clock().setTo(new Date(Date.now() - 2 * 60 * 60 * 1000));
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+// A verifier now refuses this token, because its exp has passed.
+console.log(signedIn.AuthenticationResult?.ExpiresIn); // 3600
+```
+
+Advancing the clock after a sign-in is a different thing. It moves what the simulation calls now, and
+the timestamps on tokens issued after it, but a verifier reading the host clock still judges a token
+it already holds by host time. Signing in in the past is what produces a token such a verifier
+refuses.
+
 ## Pool ARNs and IAM policies
 
 A pool ARN is the pool id after `userpool/`, so the region appears twice:
@@ -590,14 +842,19 @@ without `DeletionProtection` if the test needs to delete it.
 
 Current documented limitations:
 
-- There are no tokens and no authentication. `InitiateAuth`, `AdminInitiateAuth`,
-  `RespondToAuthChallenge` and `GetTokensFromRefreshToken` are not implemented, and neither are the
-  `cognito:groups` and `cognito:preferred_role` claims. An app client's `ExplicitAuthFlows` and token
-  lifetimes are stored and reported, and nothing reads them yet. A user's status, its `Enabled` flag
-  and its group membership are the same: they are kept as real Cognito keeps them, and nothing signs
-  in for them to act on.
-- A password is checked against the pool's policy and then discarded, because nothing authenticates
-  yet. Nothing reads a password back, so no operation reveals that.
+- Only the admin authentication flow is simulated. `InitiateAuth`, `RespondToAuthChallenge`,
+  `GetTokensFromRefreshToken` and `GlobalSignOut` are not implemented, so the client-side flows, SRP,
+  MFA challenges, custom authentication challenges and device tracking are all out. `AuthFlow` values
+  other than `ADMIN_USER_PASSWORD_AUTH` are refused rather than run as that one.
+- A refresh token is issued and nothing consumes it. `REFRESH_TOKEN_AUTH` is not simulated, and no
+  token can be revoked.
+- The `cognito:preferred_role` and `cognito:roles` claims are not on the tokens. A group's `RoleArn`
+  is stored and reported, and nothing assumes that role.
+- A pool publishes one signing key where real Cognito publishes two and rotates between them, and
+  every pool in a process publishes the same key. Code assuming a single JWKS entry passes here and
+  is still wrong against real AWS. The key is generated with `node:crypto` on first use and kept in
+  memory for the process.
+- A password is kept so a user can sign in with it, and nothing reads one back.
 - Users are resolved by username only. Real Cognito also accepts a user's `sub` where an admin
   operation asks for a username, and that fails here with `UserNotFoundException`.
 - Self-service sign-up is not simulated. `SignUp`, `ConfirmSignUp`, `ForgotPassword`,

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -850,10 +850,10 @@ Current documented limitations:
   token can be revoked.
 - The `cognito:preferred_role` and `cognito:roles` claims are not on the tokens. A group's `RoleArn`
   is stored and reported, and nothing assumes that role.
-- A pool publishes one signing key where real Cognito publishes two and rotates between them, and
-  every pool in a process publishes the same key. Code assuming a single JWKS entry passes here and
-  is still wrong against real AWS. The key is generated with `node:crypto` on first use and kept in
-  memory for the process.
+- A pool publishes one signing key where real Cognito publishes two and rotates between them, so
+  code assuming a single JWKS entry passes here and is still wrong against real AWS. The key is
+  generated with `node:crypto` the first time the pool signs or publishes one, and kept in memory
+  for the life of the simulation.
 - A password is kept so a user can sign in with it, and nothing reads one back.
 - Users are resolved by username only. Real Cognito also accepts a user's `sub` where an admin
   operation asks for a username, and that fails here with `UserNotFoundException`.

--- a/docs/services/cognito/sim-cognito-expired-token.example.ts
+++ b/docs/services/cognito/sim-cognito-expired-token.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Producing a simulated token that a verifier rejects as expired.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+// Sign in two hours ago, so the hour the token lasts is already over.
+await simAws.clock().setTo(new Date(Date.now() - 2 * 60 * 60 * 1000));
+
+const signedIn = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: appClient.UserPoolClient!.ClientId!,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+// A verifier now refuses this token, because its exp has passed.
+console.log(signedIn.AuthenticationResult?.ExpiresIn); // 3600

--- a/docs/services/cognito/sim-cognito-new-password-challenge.example.ts
+++ b/docs/services/cognito/sim-cognito-new-password-challenge.example.ts
@@ -1,0 +1,61 @@
+/**
+ * Getting a simulated user past the NEW_PASSWORD_REQUIRED challenge.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    TemporaryPassword: "Temp0rary!",
+  }),
+);
+
+const challenged = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+  }),
+);
+
+console.log(challenged.ChallengeName); // "NEW_PASSWORD_REQUIRED"
+
+const signedIn = await cognito.adminRespondToAuthChallenge(
+  new AdminRespondToAuthChallengeCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    ChallengeName: "NEW_PASSWORD_REQUIRED",
+    Session: challenged.Session,
+    ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+console.log(signedIn.AuthenticationResult?.IdToken?.split(".").length); // 3

--- a/docs/services/cognito/sim-cognito-sign-in.example.ts
+++ b/docs/services/cognito/sim-cognito-sign-in.example.ts
@@ -1,0 +1,67 @@
+/**
+ * Signing a simulated user in, and verifying the token with aws-jwt-verify.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+// The verifier is the one the application uses, configured as it is there.
+const verifier = CognitoJwtVerifier.create({
+  userPoolId,
+  tokenUse: "access",
+  clientId,
+});
+
+// The pool's own JWKS, so nothing reaches for the network.
+verifier.cacheJwks(cognito.userPool(userPoolId).jwks());
+
+const payload = await verifier.verify(AuthenticationResult!.AccessToken!);
+
+console.log(payload.username); // "alice"
+console.log(payload.sub); // a UUID, and not "alice"

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@vitest/eslint-plugin": "^1.6.23",
     "aws-cdk": "^2.1130.0",
     "aws-cdk-lib": "^2.261.0",
+    "aws-jwt-verify": "^5.2.1",
     "aws-sdk-client-mock": "^4.1.0",
     "constructs": "^10.6.0",
     "eslint": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       aws-cdk-lib:
         specifier: ^2.261.0
         version: 2.262.0(constructs@10.7.1)
+      aws-jwt-verify:
+        specifier: ^5.2.1
+        version: 5.2.1
       aws-sdk-client-mock:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1131,6 +1134,10 @@ packages:
     resolution: {integrity: sha512-qOueRxzoOQzqziGK8ON0P+YCW5gkm+SLnSXni2E1IgblBybscrhvp5bKkA0PDoTESZM9nceN5O5+7qK24jjYUg==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
+
+  aws-jwt-verify@5.2.1:
+    resolution: {integrity: sha512-J+buA4M+qvQDk58WXFBLkDodkEX3DDL1ac5XFQPW3opxAsaLXYu5hYnlSHsaBRDBUXBAn695kE/cw/mdyJKwJg==}
+    engines: {node: '>=18.0.0'}
 
   aws-sdk-client-mock@4.1.0:
     resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
@@ -3029,6 +3036,8 @@ snapshots:
       constructs: 10.7.1
 
   aws-cdk@2.1132.1: {}
+
+  aws-jwt-verify@5.2.1: {}
 
   aws-sdk-client-mock@4.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2109,9 +2109,9 @@ snapshots:
   '@aws-sdk/client-ssm@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
-      '@aws-sdk/credential-provider-node': 3.972.72
+      '@aws-sdk/credential-provider-node': 3.972.73
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/fetch-http-handler': 5.6.11
       '@smithy/node-http-handler': 4.9.11
       '@smithy/types': 4.16.1
@@ -2152,7 +2152,7 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2170,7 +2170,7 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/fetch-http-handler': 5.6.11
       '@smithy/node-http-handler': 4.9.11
       '@smithy/types': 4.16.1
@@ -2203,7 +2203,7 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.68
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/credential-provider-imds': 4.4.14
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -2222,7 +2222,7 @@ snapshots:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2249,7 +2249,7 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.973.6
       '@aws-sdk/credential-provider-web-identity': 3.972.68
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/credential-provider-imds': 4.4.14
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -2266,7 +2266,7 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2286,7 +2286,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/token-providers': 3.1096.0
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2304,7 +2304,7 @@ snapshots:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2359,7 +2359,7 @@ snapshots:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/signature-v4-multi-region': 3.996.42
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/fetch-http-handler': 5.6.11
       '@smithy/node-http-handler': 4.9.11
       '@smithy/types': 4.16.1
@@ -2395,7 +2395,7 @@ snapshots:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2714,7 +2714,7 @@ snapshots:
 
   '@smithy/signature-v4@5.6.10':
     dependencies:
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -3,9 +3,9 @@
 This directory contains the simulated Cognito user pools implementation. Cognito identity pools,
 which exchange a token for AWS credentials, are a separate service and are not simulated at all.
 
-The pool, the app client, the users and groups in it, and the authorizer are here. An app client's
-authentication flows are validated and stored, and nothing acts on them: tokens and sign-in itself
-are not here yet.
+The pool, the app client, the users and groups in it, the admin sign-in flow, the tokens it issues
+and the authorizer are all here. The client-side flows are not: `InitiateAuth`, SRP and the hosted
+UI are a separate piece of work.
 
 ## Entry points
 
@@ -105,7 +105,43 @@ callers towards.
 
 `SimCognitoGroupStore.forUser` is where precedence ordering happens: lowest value first, groups with
 no precedence last, and groups sharing one in creation order. That is the order the `cognito:groups`
-claim will use, so `AdminListGroupsForUser` reads the same way the claim will.
+claim uses, so `AdminListGroupsForUser` reads the same way the claim does.
+
+## Token model
+
+Token state lives under `user-pool/token/`.
+
+`SimCognitoSigningKey` holds a real RSA key pair generated with `node:crypto`, and signs real RS256
+JWTs. The pair is generated on first use and shared for the process: 2048-bit generation takes long
+enough to notice, and a suite makes many pools. Every pool therefore publishes the same key, which a
+verifier cannot tell, because it reaches the right pool through the `iss` claim and the JWKS it was
+given rather than through the key. Nothing is written to disk and no key material is in the
+repository.
+
+`SimCognitoIdToken` and `SimCognitoAccessToken` build the claims of each token, and
+`SimCognitoSharedTokenClaims` builds what both carry. They are separate because the difference
+between them is the point: an id token has `aud`, `cognito:username` and the user's attributes, and
+an access token has `client_id`, `username` and a `scope`. Code reading the wrong one for a claim
+fails here the way it fails in production.
+
+`SimCognitoTokenIssuer` ties them together and takes every timestamp from the injectable clock, so a
+sign-in in the simulated past produces a token a verifier already considers expired. It also mints
+the refresh token, which is an opaque string rather than a JWT, as it is on real Cognito.
+
+## Authentication model
+
+Sign-in state lives under `user-pool/auth/`.
+
+`SimCognitoAuthSession` is what an unfinished authentication carries between the request that started
+it and the response that completes it. A session is opaque, single use, tied to its user and app
+client, and lasts the three minutes real Cognito gives one.
+
+`requireSimCognitoSecretHash` checks the `SECRET_HASH` a client with a secret has to send, computed
+the way the AWS SDKs compute it. Checking it is what makes a test notice a client secret it forgot to
+use.
+
+`SimCognitoUserPassword` holds what a user signs in with. It answers whether a candidate matches and
+nothing exposes it, the same modelling choice simulated KMS key material makes.
 
 ## Command handling
 
@@ -119,6 +155,8 @@ rather than one class per command, so the `SimCognitoIdentityProvider` facade st
   and the commands that change one afterwards
 - `command/group/`: the same for groups, split between the commands that act on a group and the
   commands that move users in and out of one
+- `command/auth/`: `AdminInitiateAuth` and `AdminRespondToAuthChallenge`, the flow and challenge
+  names they accept, and the parameters they read
 - `command/authorize/`: the shared IAM authorizer
 - `command/sim-cognito-page.ts`: the paging every listing shares, which takes the names of the
   inputs it is reading because `ListUsers` calls its page size `Limit` and its token
@@ -168,6 +206,13 @@ resource, here or on real AWS.
   validates user attributes against it.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
+- One signing key is published per pool where real Cognito publishes two and rotates between them,
+  and every pool in a process shares it.
+- Only `ADMIN_USER_PASSWORD_AUTH` runs, and only `NEW_PASSWORD_REQUIRED` is issued. Every other flow
+  and challenge is refused rather than treated as one of those.
+- A verifier reading the host clock judges an already-issued token by host time. Advancing the
+  simulated clock moves the timestamps of tokens issued after it, and signing in in the simulated
+  past is what produces a token such a verifier refuses.
 - `UpdateGroup` replaces all three group properties rather than merging an omitted one.
 - A password is checked and discarded rather than stored, because nothing authenticates yet.
 - No message is delivered, so `AdminCreateUser` accepts `MessageAction: SUPPRESS` and refuses

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -63,10 +63,12 @@ User state lives under `user-pool/user/`, and the pool owns its users for the sa
 its app clients: deleting a pool takes them with it, and a username means nothing outside the pool
 holding it.
 
-`SimCognitoUser` is the stored user: its username, its `sub`, its attributes, its status and whether
-it is enabled. The `sub` is a fresh UUID rather than anything derived from the username, because
-that is the difference most code gets wrong. A user holds no password. Passwords are checked against
-the pool's policy and discarded, since nothing authenticates yet and nothing reads one back.
+`SimCognitoUser` is the stored user: its username, its `sub`, its attributes, its status, whether it
+is enabled and the password it signs in with. The `sub` is a fresh UUID rather than anything derived
+from the username, because that is the difference most code gets wrong. The password is checked
+against the pool's policy when it is set, and held as a `SimCognitoUserPassword` that answers
+whether a candidate matches and exposes nothing, the same modelling choice simulated KMS key
+material makes.
 
 `SimCognitoUserStatus` holds the two statuses this simulation can reach, and the transition between
 them. `AdminCreateUser` leaves a user in `FORCE_CHANGE_PASSWORD`, and only a permanent password
@@ -112,10 +114,10 @@ claim uses, so `AdminListGroupsForUser` reads the same way the claim does.
 Token state lives under `user-pool/token/`.
 
 `SimCognitoSigningKey` holds a real RSA key pair generated with `node:crypto`, and signs real RS256
-JWTs. The pair is generated on first use and shared for the process: 2048-bit generation takes long
-enough to notice, and a suite makes many pools. Every pool therefore publishes the same key, which a
-verifier cannot tell, because it reaches the right pool through the `iss` claim and the JWKS it was
-given rather than through the key. Nothing is written to disk and no key material is in the
+JWTs. Each pool has its own, as each real pool does, so a token from one pool carries a signature
+another pool's JWKS cannot verify. A pool generates its key the first time it signs or publishes
+one, rather than when it is created, because 2048-bit generation takes long enough to notice and
+most pools in a suite never sign anything. Nothing is written to disk and no key material is in the
 repository.
 
 `SimCognitoIdToken` and `SimCognitoAccessToken` build the claims of each token, and
@@ -206,15 +208,14 @@ resource, here or on real AWS.
   validates user attributes against it.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
-- One signing key is published per pool where real Cognito publishes two and rotates between them,
-  and every pool in a process shares it.
+- One signing key is published per pool, where real Cognito publishes two and rotates between them.
 - Only `ADMIN_USER_PASSWORD_AUTH` runs, and only `NEW_PASSWORD_REQUIRED` is issued. Every other flow
   and challenge is refused rather than treated as one of those.
 - A verifier reading the host clock judges an already-issued token by host time. Advancing the
   simulated clock moves the timestamps of tokens issued after it, and signing in in the simulated
   past is what produces a token such a verifier refuses.
 - `UpdateGroup` replaces all three group properties rather than merging an omitted one.
-- A password is checked and discarded rather than stored, because nothing authenticates yet.
+- A password is held so a user can sign in with it, and nothing reads one back.
 - No message is delivered, so `AdminCreateUser` accepts `MessageAction: SUPPRESS` and refuses
   `RESEND` and `DesiredDeliveryMediums`.
 - Listings are in creation order and carry no filtering. `ListUsers` refuses a `Filter` rather than

--- a/src/service/cognito/command/auth/auth.command.ts
+++ b/src/service/cognito/command/auth/auth.command.ts
@@ -1,0 +1,83 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * The tokens a successful authentication answers with.
+ *
+ * `AccessToken` and `IdToken` are real RS256 JWTs, signed by the key the pool
+ * publishes in its JWKS. `RefreshToken` is an opaque string, as it is on real
+ * Cognito, and nothing here consumes it.
+ *
+ * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AuthenticationResultType.html
+ */
+export interface SimCognitoAuthenticationResultType {
+  readonly AccessToken?: string | undefined;
+  readonly IdToken?: string | undefined;
+  readonly RefreshToken?: string | undefined;
+  readonly ExpiresIn?: number | undefined;
+  readonly TokenType?: string | undefined;
+}
+
+/**
+ * The AdminInitiateAuth inputs this simulation reads, and the ones it refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/AdminInitiateAuthCommand/
+ */
+export interface SimAdminInitiateAuthCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientId?: string | undefined;
+  readonly AuthFlow?: string | undefined;
+  readonly AuthParameters?: Readonly<Record<string, string>> | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly AnalyticsMetadata?: object | undefined;
+  readonly ContextData?: object | undefined;
+  readonly Session?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminInitiateAuth command.
+ */
+export interface SimAdminInitiateAuthCommand {
+  readonly input: SimAdminInitiateAuthCommandInput;
+}
+
+export interface SimAdminInitiateAuthCommandOutput {
+  readonly ChallengeName?: string | undefined;
+  readonly Session?: string | undefined;
+  readonly ChallengeParameters?: Readonly<Record<string, string>> | undefined;
+  readonly AuthenticationResult?:
+    SimCognitoAuthenticationResultType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * The AdminRespondToAuthChallenge inputs this simulation reads, and the ones
+ * it refuses.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cognito-identity-provider/command/AdminRespondToAuthChallengeCommand/
+ */
+export interface SimAdminRespondToAuthChallengeCommandInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientId?: string | undefined;
+  readonly ChallengeName?: string | undefined;
+  readonly ChallengeResponses?: Readonly<Record<string, string>> | undefined;
+  readonly Session?: string | undefined;
+  readonly ClientMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly AnalyticsMetadata?: object | undefined;
+  readonly ContextData?: object | undefined;
+}
+
+/**
+ * Minimal structural sim Cognito AdminRespondToAuthChallenge command.
+ */
+export interface SimAdminRespondToAuthChallengeCommand {
+  readonly input: SimAdminRespondToAuthChallengeCommandInput;
+}
+
+export interface SimAdminRespondToAuthChallengeCommandOutput {
+  readonly ChallengeName?: string | undefined;
+  readonly Session?: string | undefined;
+  readonly ChallengeParameters?: Readonly<Record<string, string>> | undefined;
+  readonly AuthenticationResult?:
+    SimCognitoAuthenticationResultType | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.iso.test.ts
@@ -1,0 +1,369 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import { createHmac } from "node:crypto";
+import {
+  AdminCreateUserCommand,
+  AdminDisableUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { ExplicitAuthFlowsType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidParameterException,
+  SimCognitoNotAuthorizedException,
+  SimCognitoUserNotFoundException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+
+interface SimCognitoWithClient {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+/**
+ * A pool with an app client, and a user that has to change its password.
+ */
+async function simCognitoWithClient(
+  authFlows: ExplicitAuthFlowsType[] = ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+): Promise<SimCognitoWithClient> {
+  const cognito = new SimAws().cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: authFlows,
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      TemporaryPassword: "Temp0rary!",
+    }),
+  );
+
+  return { cognito, userPoolId, clientId: client.UserPoolClient.ClientId };
+}
+
+/**
+ * Give the user a password of its own, which confirms it.
+ */
+async function confirmAlice(
+  cognito: SimCognitoIdentityProvider,
+  userPoolId: string,
+): Promise<void> {
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+}
+
+function signIn(
+  userPoolId: string,
+  clientId: string,
+  candidate: string,
+): AdminInitiateAuthCommand {
+  return new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: candidate },
+  });
+}
+
+describe("sim Cognito AdminInitiateAuth", () => {
+  it("answers a confirmed user with tokens", async () => {
+    // Given a confirmed user.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    await confirmAlice(cognito, userPoolId);
+
+    // When it signs in.
+    const signedIn = await cognito.adminInitiateAuth(
+      signIn(userPoolId, clientId, password),
+    );
+
+    // Then the tokens come back, with the access token's hour reported and a
+    // refresh token that is not a JWT.
+    const result = signedIn.AuthenticationResult;
+
+    assertNonNullable(result?.AccessToken);
+    assertNonNullable(result.IdToken);
+    assertNonNullable(result.RefreshToken);
+    assertIdentical(result.ExpiresIn, 3600);
+    assertIdentical(result.TokenType, "Bearer");
+    assertArrayLength(result.RefreshToken.split("."), 1);
+    assertUndefined(signedIn.ChallengeName);
+  });
+
+  it("challenges a user that has to change its password", async () => {
+    // Given a user an admin created, still in FORCE_CHANGE_PASSWORD.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When it signs in with its temporary password.
+    const signedIn = await cognito.adminInitiateAuth(
+      signIn(userPoolId, clientId, "Temp0rary!"),
+    );
+
+    // Then it gets the challenge and a session rather than tokens.
+    assertIdentical(signedIn.ChallengeName, "NEW_PASSWORD_REQUIRED");
+    assertNonNullable(signedIn.Session);
+    assertIdentical(signedIn.ChallengeParameters?.["USER_ID_FOR_SRP"], "alice");
+    assertUndefined(signedIn.AuthenticationResult);
+  });
+
+  it("refuses a flow the app client is not configured for", async () => {
+    // Given an app client without the admin flow among its ExplicitAuthFlows.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient([
+      "ALLOW_USER_SRP_AUTH",
+      "ALLOW_REFRESH_TOKEN_AUTH",
+    ]);
+
+    await confirmAlice(cognito, userPoolId);
+
+    // When a sign-in is tried anyway.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(signIn(userPoolId, clientId, password));
+    });
+
+    // Then it is refused before the password is looked at, as real Cognito
+    // refuses it.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "is not enabled for the client");
+  });
+
+  it("refuses a wrong password", async () => {
+    // Given a confirmed user.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    await confirmAlice(cognito, userPoolId);
+
+    // When it signs in with the wrong password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        signIn(userPoolId, clientId, "Wr0ngPassword!"),
+      );
+    });
+
+    // Then it is refused, saying no more than real Cognito says.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Incorrect username or password");
+  });
+
+  it("refuses a disabled user", async () => {
+    // Given a confirmed user that has been disabled.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    await confirmAlice(cognito, userPoolId);
+    await cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+
+    // When it signs in with the right password.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(signIn(userPoolId, clientId, password));
+    });
+
+    // Then it is refused: disabling a user is what stops it authenticating.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "User is disabled");
+  });
+
+  it("refuses a user the pool does not hold", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When an unknown user signs in.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "nobody", PASSWORD: password },
+        }),
+      );
+    });
+
+    // Then the user is reported missing, as an admin flow reports it.
+    assertInstanceOf(error, SimCognitoUserNotFoundException);
+  });
+
+  it("refuses a user created without a temporary password", async () => {
+    // Given a user created with no password at all.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+    );
+
+    // When it signs in.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "bob", PASSWORD: password },
+        }),
+      );
+    });
+
+    // Then nothing matches: real Cognito emails a generated password, and
+    // nothing here delivers one.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses an authentication flow this simulation does not run", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When a refresh token flow is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "REFRESH_TOKEN_AUTH",
+          AuthParameters: { REFRESH_TOKEN: "whatever" },
+        }),
+      );
+    });
+
+    // Then it is refused rather than run as the one flow that is simulated.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "is not simulated");
+  });
+
+  it("refuses a request carrying no parameters at all", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When a sign-in arrives without AuthParameters.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        }),
+      );
+    });
+
+    // Then the username it needed is what it names.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Missing required parameter USERNAME");
+  });
+
+  it("wants a SECRET_HASH from an app client with a secret", async () => {
+    // Given a pool whose app client was created with a secret.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    assertNonNullable(pool.UserPool?.Id);
+
+    const userPoolId = pool.UserPool.Id;
+    const client = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "server",
+        GenerateSecret: true,
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    assertNonNullable(client.UserPoolClient?.ClientId);
+    assertNonNullable(client.UserPoolClient.ClientSecret);
+
+    const clientId = client.UserPoolClient.ClientId;
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    await confirmAlice(cognito, userPoolId);
+
+    // When a sign-in arrives without one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(signIn(userPoolId, clientId, password));
+    });
+
+    // Then it is refused, and the hash the SDKs compute is what gets in.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Unable to verify secret hash");
+
+    const secretHash = createHmac("sha256", client.UserPoolClient.ClientSecret)
+      .update(`alice${clientId}`)
+      .digest("base64");
+
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: "alice",
+          PASSWORD: password,
+          SECRET_HASH: secretHash,
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("refuses a request missing a parameter the flow needs", async () => {
+    // Given a pool with an app client.
+    const { cognito, userPoolId, clientId } = await simCognitoWithClient();
+
+    // When the password is left out.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice" },
+        }),
+      );
+    });
+
+    // Then it is refused, naming what was missing.
+    assertInstanceOf(error, SimCognitoInvalidParameterException);
+    assertStringIncludes(error.message, "Missing required parameter PASSWORD");
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-initiate-auth.ts
@@ -1,0 +1,87 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoSignIn } from "../../user-pool/auth/sim-cognito-sign-in.js";
+import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
+import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
+import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import {
+  requireSimCognitoAdminUserPasswordFlow,
+  requireSimCognitoFlowEnabled,
+} from "./sim-cognito-auth-flow.js";
+import type { SimCognitoNewPasswordChallenge } from "./sim-cognito-new-password-challenge.js";
+import { SimCognitoUnsimulatedAuthOptions } from "./sim-cognito-unsimulated-auth-options.js";
+import type {
+  SimAdminInitiateAuthCommand,
+  SimAdminInitiateAuthCommandOutput,
+} from "./auth.command.js";
+
+interface SimCognitoAdminInitiateAuthProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly tokenIssuer: SimCognitoTokenIssuer;
+  readonly challenge: SimCognitoNewPasswordChallenge;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The AdminInitiateAuth command.
+ *
+ * Only `ADMIN_USER_PASSWORD_AUTH` runs. A user that gets past its password
+ * either receives tokens or, if it still has to replace that password, the
+ * `NEW_PASSWORD_REQUIRED` challenge and a session.
+ */
+export class SimCognitoAdminInitiateAuth {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly tokenIssuer: SimCognitoTokenIssuer;
+  private readonly challenge: SimCognitoNewPasswordChallenge;
+  private readonly result = new SimCognitoAuthenticationResult();
+  private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
+
+  constructor(properties: SimCognitoAdminInitiateAuthProperties) {
+    this.authResolver = properties.authResolver;
+    this.tokenIssuer = properties.tokenIssuer;
+    this.challenge = properties.challenge;
+  }
+
+  /**
+   * Start an authentication.
+   */
+  handle(
+    command: SimAdminInitiateAuthCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminInitiateAuthCommandOutput {
+    const { input } = command;
+    const { pool, client } = this.authResolver.poolClient(
+      "cognito-idp:AdminInitiateAuth",
+      input,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseInInitiate(input);
+    requireSimCognitoAdminUserPasswordFlow(input.AuthFlow);
+    requireSimCognitoFlowEnabled(client);
+
+    const parameters = new SimCognitoAuthParameters(
+      "AuthParameters",
+      input.AuthParameters,
+    );
+    const username = this.authResolver.username(client, parameters);
+    const user = pool.requireUser(requireSimCognitoUsername(username));
+
+    requireSimCognitoSignIn(user, parameters.require("PASSWORD"));
+
+    if (user.status.mustChangePassword) {
+      return this.challenge.issue({ pool, clientId: client.id, user });
+    }
+
+    return {
+      $metadata: {},
+      AuthenticationResult: this.result.of(
+        this.tokenIssuer.issue({ pool, client, user }),
+      ),
+    };
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
@@ -226,6 +226,66 @@ describe("sim Cognito AdminRespondToAuthChallenge", () => {
     assertStringIncludes(error.message, "Invalid session");
   });
 
+  it("keeps a session that is still live when another is issued", async () => {
+    // Given a user challenged twice, so two sessions are outstanding.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: temporaryPassword },
+      }),
+    );
+
+    // When the first one is answered.
+    const signedIn = await cognito.adminRespondToAuthChallenge(
+      respond(userPoolId, clientId, session, newPassword),
+    );
+
+    // Then it still works: issuing a session does not cancel one that has not
+    // run out.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("drops a session nobody answered once it has run out", async () => {
+    // Given a challenge that was left for four minutes of simulated time.
+    const { simAws, cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    await simAws.clock().advanceBy({ minutes: 4 });
+
+    // When the user starts again and answers the new challenge.
+    const challenged = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: temporaryPassword },
+      }),
+    );
+
+    assertNonNullable(challenged.Session);
+
+    const signedIn = await cognito.adminRespondToAuthChallenge(
+      respond(userPoolId, clientId, challenged.Session, newPassword),
+    );
+
+    // Then that works, and the session left behind is gone rather than kept
+    // for a simulation that runs for a long time.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        respond(userPoolId, clientId, session, newPassword),
+      );
+    });
+
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
   it("refuses a new password the pool's policy does not allow", async () => {
     // Given a user waiting on the challenge.
     const { cognito, userPoolId, clientId, session } =

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.iso.test.ts
@@ -1,0 +1,267 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import {
+  AdminCreateUserCommand,
+  AdminGetUserCommand,
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimCognitoInvalidPasswordException,
+  SimCognitoNotAuthorizedException,
+} from "../../error/sim-cognito.error.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const temporaryPassword = "Temp0rary!";
+const newPassword = "Sup3rSecret!";
+
+interface SimCognitoChallenged {
+  readonly simAws: SimAws;
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+  readonly session: string;
+}
+
+/**
+ * A user an admin created, one sign-in in, waiting on the challenge.
+ */
+async function simCognitoChallenged(): Promise<SimCognitoChallenged> {
+  const simAws = new SimAws();
+  const cognito = simAws.cognitoIdentityProvider();
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  const clientId = client.UserPoolClient.ClientId;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      TemporaryPassword: temporaryPassword,
+    }),
+  );
+
+  const challenged = await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: userPoolId,
+      ClientId: clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: temporaryPassword },
+    }),
+  );
+
+  assertNonNullable(challenged.Session);
+
+  return {
+    simAws,
+    cognito,
+    userPoolId,
+    clientId,
+    session: challenged.Session,
+  };
+}
+
+function respond(
+  userPoolId: string,
+  clientId: string,
+  session: string,
+  password: string,
+): AdminRespondToAuthChallengeCommand {
+  return new AdminRespondToAuthChallengeCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    ChallengeName: "NEW_PASSWORD_REQUIRED",
+    Session: session,
+    ChallengeResponses: { USERNAME: "alice", NEW_PASSWORD: password },
+  });
+}
+
+describe("sim Cognito AdminRespondToAuthChallenge", () => {
+  it("completes the challenge and answers with tokens", async () => {
+    // Given a user waiting on the new password challenge.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    // When it answers with a new password.
+    const signedIn = await cognito.adminRespondToAuthChallenge(
+      respond(userPoolId, clientId, session, newPassword),
+    );
+
+    // Then it gets tokens, and the user is confirmed from then on.
+    assertNonNullable(signedIn.AuthenticationResult?.IdToken);
+
+    const read = await cognito.adminGetUser(
+      new AdminGetUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+
+    assertIdentical(read.UserStatus, "CONFIRMED");
+  });
+
+  it("leaves the user signing in with the new password", async () => {
+    // Given a user that answered the challenge.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    await cognito.adminRespondToAuthChallenge(
+      respond(userPoolId, clientId, session, newPassword),
+    );
+
+    // When it signs in again with that password.
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: newPassword },
+      }),
+    );
+
+    // Then it gets tokens without a challenge this time.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  });
+
+  it("refuses a session it did not issue", async () => {
+    // Given a user waiting on the challenge.
+    const { cognito, userPoolId, clientId } = await simCognitoChallenged();
+
+    // When a made up session answers it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        respond(userPoolId, clientId, "not-a-session", newPassword),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Invalid session");
+  });
+
+  it("refuses a response carrying no session", async () => {
+    // Given a user waiting on the challenge.
+    const { cognito, userPoolId, clientId } = await simCognitoChallenged();
+
+    // When it answers without the session it was given.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        new AdminRespondToAuthChallengeCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          ChallengeName: "NEW_PASSWORD_REQUIRED",
+          ChallengeResponses: {
+            USERNAME: "alice",
+            NEW_PASSWORD: newPassword,
+          },
+        }),
+      );
+    });
+
+    // Then it is refused: the session is what ties the response to the
+    // challenge that asked for it.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses a session that has already been used", async () => {
+    // Given a challenge that has been answered.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    await cognito.adminRespondToAuthChallenge(
+      respond(userPoolId, clientId, session, newPassword),
+    );
+
+    // When the same session is replayed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        respond(userPoolId, clientId, session, "An0therPassword!"),
+      );
+    });
+
+    // Then it is refused: a session is single use.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+  });
+
+  it("refuses a session that has run out", async () => {
+    // Given a challenge issued four minutes of simulated time ago.
+    const { simAws, cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    await simAws.clock().advanceBy({ minutes: 4 });
+
+    // When it is answered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        respond(userPoolId, clientId, session, newPassword),
+      );
+    });
+
+    // Then it is refused, as a session lasts the three minutes real Cognito
+    // gives it.
+    assertInstanceOf(error, SimCognitoNotAuthorizedException);
+    assertStringIncludes(error.message, "Invalid session");
+  });
+
+  it("refuses a new password the pool's policy does not allow", async () => {
+    // Given a user waiting on the challenge.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    // When it answers with a password with no symbol in it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        respond(userPoolId, clientId, session, "Password1"),
+      );
+    });
+
+    // Then it is refused, saying which rule it broke.
+    assertInstanceOf(error, SimCognitoInvalidPasswordException);
+    assertStringIncludes(error.message, "must have symbol characters");
+  });
+
+  it("refuses a challenge this simulation does not issue", async () => {
+    // Given a user waiting on the challenge.
+    const { cognito, userPoolId, clientId, session } =
+      await simCognitoChallenged();
+
+    // When an SMS challenge is answered instead.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cognito.adminRespondToAuthChallenge(
+        new AdminRespondToAuthChallengeCommand({
+          UserPoolId: userPoolId,
+          ClientId: clientId,
+          ChallengeName: "SMS_MFA",
+          Session: session,
+          ChallengeResponses: { USERNAME: "alice", SMS_MFA_CODE: "123456" },
+        }),
+      );
+    });
+
+    // Then it is refused rather than treated as the one challenge simulated.
+    assertStringIncludes(error.message, "is not simulated");
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
@@ -1,0 +1,93 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCognitoPasswordCheck } from "../../user-pool/sim-cognito-password-check.js";
+import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import { SimCognitoAuthenticationResult } from "./sim-cognito-authentication-result.js";
+import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
+import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import { requireSimCognitoNewPasswordChallenge } from "./sim-cognito-auth-flow.js";
+import { SimCognitoUnsimulatedAuthOptions } from "./sim-cognito-unsimulated-auth-options.js";
+import type {
+  SimAdminRespondToAuthChallengeCommand,
+  SimAdminRespondToAuthChallengeCommandOutput,
+} from "./auth.command.js";
+
+interface SimCognitoAdminRespondToChallengeProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly tokenIssuer: SimCognitoTokenIssuer;
+  readonly clock: SimClock;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The AdminRespondToAuthChallenge command.
+ *
+ * Only `NEW_PASSWORD_REQUIRED` is answered. The new password is checked
+ * against the pool's policy, confirms the user, and is what the user signs in
+ * with from then on. The session is single use, so a replayed one fails.
+ */
+export class SimCognitoAdminRespondToChallenge {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly tokenIssuer: SimCognitoTokenIssuer;
+  private readonly clock: SimClock;
+  private readonly result = new SimCognitoAuthenticationResult();
+  private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
+
+  constructor(properties: SimCognitoAdminRespondToChallengeProperties) {
+    this.authResolver = properties.authResolver;
+    this.tokenIssuer = properties.tokenIssuer;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Answer a challenge.
+   */
+  handle(
+    command: SimAdminRespondToAuthChallengeCommand,
+    options?: SimCognitoCommandOptions,
+  ): SimAdminRespondToAuthChallengeCommandOutput {
+    const { input } = command;
+    const { pool, client } = this.authResolver.poolClient(
+      "cognito-idp:AdminRespondToAuthChallenge",
+      input,
+      options,
+    );
+
+    this.unsimulatedOptions.refuseInResponse(input);
+    requireSimCognitoNewPasswordChallenge(input.ChallengeName);
+
+    const responses = new SimCognitoAuthParameters(
+      "ChallengeResponses",
+      input.ChallengeResponses,
+    );
+    const username = this.authResolver.username(client, responses);
+    const session = pool.requireAuthSession({
+      sessionId: input.Session,
+      username,
+      clientId: client.id,
+      now: this.clock.now(),
+    });
+    const user = pool.requireUser(requireSimCognitoUsername(username));
+
+    user.setPassword(
+      new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+        "NEW_PASSWORD",
+        responses.find("NEW_PASSWORD"),
+      ),
+      true,
+    );
+
+    pool.removeAuthSession(session);
+
+    return {
+      $metadata: {},
+      AuthenticationResult: this.result.of(
+        this.tokenIssuer.issue({ pool, client, user }),
+      ),
+    };
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-auth-flow.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-flow.ts
@@ -1,0 +1,76 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+
+/**
+ * The one authentication flow this simulation runs.
+ */
+export const adminUserPasswordFlow = "ADMIN_USER_PASSWORD_AUTH";
+
+/**
+ * The app client setting that opens that flow.
+ */
+const adminUserPasswordAuthFlow = "ALLOW_ADMIN_USER_PASSWORD_AUTH";
+
+/**
+ * The challenge this simulation can answer.
+ */
+export const newPasswordRequiredChallenge = "NEW_PASSWORD_REQUIRED";
+
+/**
+ * Refuse an authentication flow this simulation does not run.
+ *
+ * The others are refused rather than treated as this one, because which flow
+ * a request uses decides what the app client has to be configured for and
+ * what the caller has to send.
+ */
+export function requireSimCognitoAdminUserPasswordFlow(
+  authFlow: string | undefined,
+): void {
+  if (authFlow === adminUserPasswordFlow) {
+    return;
+  }
+
+  throw new SimCognitoInvalidParameterException(
+    `AuthFlow '${String(authFlow)}' is not simulated: ` +
+      `${adminUserPasswordFlow} is the only flow this simulation runs. SRP, ` +
+      `custom authentication and refresh token flows are not implemented.`,
+  );
+}
+
+/**
+ * Refuse a challenge this simulation cannot answer.
+ */
+export function requireSimCognitoNewPasswordChallenge(
+  challengeName: string | undefined,
+): void {
+  if (challengeName === newPasswordRequiredChallenge) {
+    return;
+  }
+
+  throw new SimCognitoInvalidParameterException(
+    `ChallengeName '${String(challengeName)}' is not simulated: ` +
+      `${newPasswordRequiredChallenge} is the only challenge this ` +
+      `simulation issues.`,
+  );
+}
+
+/**
+ * Refuse a flow the app client is not configured for.
+ *
+ * Real Cognito refuses this before it looks at the user at all, which is why
+ * a client created without the flow fails the same way whatever the password
+ * was.
+ */
+export function requireSimCognitoFlowEnabled(
+  client: SimCognitoUserPoolClient,
+): void {
+  if (client.explicitAuthFlows.allows(adminUserPasswordAuthFlow)) {
+    return;
+  }
+
+  throw new SimCognitoInvalidParameterException(
+    `${adminUserPasswordFlow} is not enabled for the client ${client.id}: ` +
+      `create the app client with ${adminUserPasswordAuthFlow} among its ` +
+      `ExplicitAuthFlows`,
+  );
+}

--- a/src/service/cognito/command/auth/sim-cognito-auth-parameters.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-parameters.ts
@@ -1,0 +1,43 @@
+import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+
+/**
+ * The values an authentication request carries alongside the flow.
+ *
+ * `AdminInitiateAuth` calls them `AuthParameters` and
+ * `AdminRespondToAuthChallenge` calls them `ChallengeResponses`, so a refusal
+ * names whichever the caller wrote.
+ */
+export class SimCognitoAuthParameters {
+  private readonly field: string;
+  private readonly values: ReadonlyMap<string, string>;
+
+  constructor(
+    field: string,
+    values: Readonly<Record<string, string>> | undefined,
+  ) {
+    this.field = field;
+    this.values = new Map(Object.entries(values ?? {}));
+  }
+
+  /**
+   * Read a value the flow needs, or refuse.
+   */
+  require(name: string): string {
+    const value = this.find(name);
+
+    if (value === undefined || value === "") {
+      throw new SimCognitoInvalidParameterException(
+        `Missing required parameter ${name} in ${this.field}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * Read a value that may or may not be there.
+   */
+  find(name: string): string | undefined {
+    return this.values.get(name);
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
@@ -1,0 +1,86 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import { requireSimCognitoUserPoolClientId } from "../../user-pool/client/sim-cognito-user-pool-client-id.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
+
+interface SimCognitoAuthResolverProperties {
+  readonly resolver: SimCognitoRequestResolver;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface SimCognitoAuthRequestInput {
+  readonly UserPoolId?: string | undefined;
+  readonly ClientId?: string | undefined;
+}
+
+/**
+ * The pool an authentication request runs against, and the app client it runs
+ * through.
+ */
+export interface SimCognitoAuthenticatingClient {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+}
+
+/**
+ * Resolves what an authentication request names before the flow itself runs.
+ *
+ * Both authentication commands start the same way, and both end up needing the
+ * same three things: the pool, the app client, and a username whose
+ * `SECRET_HASH` has been checked.
+ */
+export class SimCognitoAuthResolver {
+  private readonly resolver: SimCognitoRequestResolver;
+
+  constructor(properties: SimCognitoAuthResolverProperties) {
+    this.resolver = properties.resolver;
+  }
+
+  /**
+   * Resolve the pool and app client, once the caller may reach the pool.
+   *
+   * An app client has no ARN of its own, so authorization is against the
+   * pool's, as it is everywhere else in this simulation.
+   */
+  poolClient(
+    action: string,
+    input: SimCognitoAuthRequestInput,
+    options: SimCognitoCommandOptions | undefined,
+  ): SimCognitoAuthenticatingClient {
+    const pool = this.resolver.pool(action, input.UserPoolId, options);
+
+    return {
+      pool,
+      client: pool.requireClient(
+        requireSimCognitoUserPoolClientId(input.ClientId),
+      ),
+    };
+  }
+
+  /**
+   * Read the username a request names, with its `SECRET_HASH` checked.
+   *
+   * The hash covers the username, so it can only be checked once the username
+   * is known, and it is checked before anything looks the user up.
+   */
+  username(
+    client: SimCognitoUserPoolClient,
+    parameters: SimCognitoAuthParameters,
+  ): string {
+    const username = parameters.require("USERNAME");
+
+    requireSimCognitoSecretHash(
+      username,
+      client,
+      parameters.find("SECRET_HASH"),
+    );
+
+    return username;
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-authentication-result.ts
+++ b/src/service/cognito/command/auth/sim-cognito-authentication-result.ts
@@ -1,0 +1,23 @@
+import type { SimCognitoIssuedTokens } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoAuthenticationResultType } from "./auth.command.js";
+
+/**
+ * How issued tokens are reported back to a caller.
+ */
+export class SimCognitoAuthenticationResult {
+  /**
+   * The tokens as an `AuthenticationResult`.
+   *
+   * `ExpiresIn` is the access token's lifetime in seconds, which is what real
+   * Cognito reports there, and `TokenType` is always `Bearer`.
+   */
+  of(tokens: SimCognitoIssuedTokens): SimCognitoAuthenticationResultType {
+    return {
+      AccessToken: tokens.accessToken,
+      IdToken: tokens.idToken,
+      RefreshToken: tokens.refreshToken,
+      ExpiresIn: tokens.expiresIn,
+      TokenType: "Bearer",
+    };
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-new-password-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-new-password-challenge.ts
@@ -1,0 +1,59 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { SimCognitoAuthSession } from "../../user-pool/auth/sim-cognito-auth-session.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { newPasswordRequiredChallenge } from "./sim-cognito-auth-flow.js";
+import type { SimAdminInitiateAuthCommandOutput } from "./auth.command.js";
+
+interface SimCognitoNewPasswordChallengeProperties {
+  readonly clock: SimClock;
+}
+
+interface SimCognitoChallengeProperties {
+  readonly pool: SimCognitoUserPool;
+  readonly clientId: string;
+  readonly user: SimCognitoUser;
+}
+
+/**
+ * Issues the challenge a user has to get past before it can sign in.
+ *
+ * The session it hands back is what ties the response to this request, so it
+ * is remembered on the pool rather than only returned.
+ */
+export class SimCognitoNewPasswordChallenge {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoNewPasswordChallengeProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Answer with `NEW_PASSWORD_REQUIRED` and a session.
+   */
+  issue(
+    properties: SimCognitoChallengeProperties,
+  ): SimAdminInitiateAuthCommandOutput {
+    const { pool, clientId, user } = properties;
+    const session = new SimCognitoAuthSession({
+      username: user.username,
+      clientId,
+      challengeName: newPasswordRequiredChallenge,
+      issuedAt: this.clock.now(),
+    });
+
+    pool.addAuthSession(session);
+
+    return {
+      $metadata: {},
+      ChallengeName: newPasswordRequiredChallenge,
+      Session: session.id,
+      ChallengeParameters: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the challenge parameter names are Cognito's own.
+        USER_ID_FOR_SRP: user.username,
+        requiredAttributes: "[]",
+        userAttributes: "{}",
+      },
+    };
+  }
+}

--- a/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
@@ -11,6 +11,7 @@ import {
   assertArrayEquals,
   assertIdentical,
   assertNonNullable,
+  assertTrue,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -157,6 +158,34 @@ describe("sim Cognito token claims", () => {
     assertIdentical(header["kid"], key.kid);
     assertIdentical(key.kty, "RSA");
     assertIdentical(key.use, "sig");
+  });
+
+  it("gives each pool its own key", async () => {
+    // Given two pools in one simulation.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const first = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "first" }),
+    );
+    const second = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "second" }),
+    );
+
+    assertNonNullable(first.UserPool?.Id);
+    assertNonNullable(second.UserPool?.Id);
+
+    // When each publishes its JWKS.
+    const [firstKey] = cognito.userPool(first.UserPool.Id).jwks().keys;
+    const [secondKey] = cognito.userPool(second.UserPool.Id).jwks().keys;
+
+    // Then the keys are different, as they are on two real pools, and each
+    // pool keeps the one it generated.
+    assertNonNullable(firstKey);
+    assertNonNullable(secondKey);
+    assertTrue(firstKey.kid !== secondKey.kid);
+    assertIdentical(
+      cognito.userPool(first.UserPool.Id).jwks().keys[0]?.kid,
+      firstKey.kid,
+    );
   });
 
   it("names the pool as the issuer", async () => {

--- a/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-token-claims.iso.test.ts
@@ -1,0 +1,263 @@
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateGroupCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { JSONObject } from "../../../../util/type-guard/json.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+const password = "Sup3rSecret!";
+
+interface SimCognitoTokens {
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+  readonly accessToken: string;
+  readonly idToken: string;
+}
+
+/**
+ * Read one part of a JWT, which is base64url encoded JSON.
+ */
+function decodePart(part: string | undefined): JSONObject {
+  return JSON.parse(
+    Buffer.from(part ?? "", "base64url").toString("utf8"),
+  ) as JSONObject;
+}
+
+function tokenHeader(token: string): JSONObject {
+  const [header] = token.split(".");
+
+  return decodePart(header);
+}
+
+function tokenClaims(token: string): JSONObject {
+  const [, claims] = token.split(".");
+
+  return decodePart(claims);
+}
+
+/**
+ * A user in two groups, signed in.
+ */
+async function simCognitoTokens(): Promise<SimCognitoTokens> {
+  const cognito = new SimAws({
+    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultRegionName: "eu-west-2",
+  }).cognitoIdentityProvider();
+
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  const clientId = client.UserPoolClient.ClientId;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+  );
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+
+  await cognito.createGroup(
+    new CreateGroupCommand({
+      UserPoolId: userPoolId,
+      GroupName: "readers",
+      Precedence: 10,
+    }),
+  );
+  await cognito.createGroup(
+    new CreateGroupCommand({
+      UserPoolId: userPoolId,
+      GroupName: "admins",
+      Precedence: 1,
+    }),
+  );
+  await cognito.adminAddUserToGroup(
+    new AdminAddUserToGroupCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      GroupName: "readers",
+    }),
+  );
+  await cognito.adminAddUserToGroup(
+    new AdminAddUserToGroupCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      GroupName: "admins",
+    }),
+  );
+
+  const signedIn = await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: userPoolId,
+      ClientId: clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: password },
+    }),
+  );
+
+  assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  assertNonNullable(signedIn.AuthenticationResult.IdToken);
+
+  return {
+    cognito,
+    userPoolId,
+    clientId,
+    accessToken: signedIn.AuthenticationResult.AccessToken,
+    idToken: signedIn.AuthenticationResult.IdToken,
+  };
+}
+
+describe("sim Cognito token claims", () => {
+  it("signs with RS256 and a key the pool publishes", async () => {
+    // Given a signed-in user.
+    const { cognito, userPoolId, accessToken } = await simCognitoTokens();
+
+    // When the token's header is read.
+    const header = tokenHeader(accessToken);
+
+    // Then it names RS256 and a key id the pool's JWKS holds.
+    const [key] = cognito.userPool(userPoolId).jwks().keys;
+
+    assertNonNullable(key);
+    assertIdentical(header["alg"], "RS256");
+    assertIdentical(header["kid"], key.kid);
+    assertIdentical(key.kty, "RSA");
+    assertIdentical(key.use, "sig");
+  });
+
+  it("names the pool as the issuer", async () => {
+    // Given a signed-in user.
+    const { userPoolId, accessToken, idToken } = await simCognitoTokens();
+
+    // When each token's issuer is read.
+    const accessClaims = tokenClaims(accessToken);
+    const idClaims = tokenClaims(idToken);
+
+    // Then both name the pool's own issuer URL, which is where a verifier
+    // looks the keys up.
+    const issuer = `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}`;
+
+    assertIdentical(accessClaims["iss"], issuer);
+    assertIdentical(idClaims["iss"], issuer);
+  });
+
+  it("splits the claims between the two tokens the way Cognito does", async () => {
+    // Given a signed-in user.
+    const { clientId, accessToken, idToken } = await simCognitoTokens();
+
+    // When both sets of claims are read.
+    const accessClaims = tokenClaims(accessToken);
+    const idClaims = tokenClaims(idToken);
+
+    // Then the id token names its audience and the access token names its
+    // client, and neither carries the other's claim.
+    assertIdentical(idClaims["aud"], clientId);
+    assertIdentical(idClaims["token_use"], "id");
+    assertIdentical(idClaims["cognito:username"], "alice");
+    assertUndefined(idClaims["client_id"]);
+
+    assertIdentical(accessClaims["client_id"], clientId);
+    assertIdentical(accessClaims["token_use"], "access");
+    assertIdentical(accessClaims["username"], "alice");
+    assertIdentical(accessClaims["scope"], "aws.cognito.signin.user.admin");
+    assertUndefined(accessClaims["aud"]);
+  });
+
+  it("carries the same user and groups on both tokens", async () => {
+    // Given a signed-in user in two groups.
+    const { accessToken, idToken } = await simCognitoTokens();
+
+    // When both sets of claims are read.
+    const accessClaims = tokenClaims(accessToken);
+    const idClaims = tokenClaims(idToken);
+
+    // Then the sub is the same on both, and the groups are on both in
+    // precedence order.
+    assertTypeString(accessClaims["sub"]);
+    assertIdentical(accessClaims["sub"], idClaims["sub"]);
+    assertArrayEquals(accessClaims["cognito:groups"], ["admins", "readers"]);
+    assertArrayEquals(idClaims["cognito:groups"], ["admins", "readers"]);
+  });
+
+  it("leaves the group claim out for a user in no groups", async () => {
+    // Given a pool with a user in no groups.
+    const cognito = new SimAws().cognitoIdentityProvider();
+    const pool = await cognito.createUserPool(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+
+    assertNonNullable(pool.UserPool?.Id);
+
+    const userPoolId = pool.UserPool.Id;
+    const client = await cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      }),
+    );
+
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "bob",
+        Password: password,
+        Permanent: true,
+      }),
+    );
+
+    // When that user signs in.
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: client.UserPoolClient?.ClientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "bob", PASSWORD: password },
+      }),
+    );
+
+    // Then there is no group claim at all, rather than an empty list, which
+    // is what real Cognito leaves out.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+    assertUndefined(
+      tokenClaims(signedIn.AuthenticationResult.AccessToken)["cognito:groups"],
+    );
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-token-verification.iso.test.ts
+++ b/src/service/cognito/command/auth/sim-cognito-token-verification.iso.test.ts
@@ -1,0 +1,231 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+const password = "Sup3rSecret!";
+
+interface SimCognitoSignedIn {
+  readonly simAws: SimAws;
+  readonly userPoolId: string;
+  readonly clientId: string;
+  readonly accessToken: string;
+  readonly idToken: string;
+}
+
+/**
+ * A pool with a confirmed user signed in through the admin flow.
+ *
+ * A test that cares when the sign-in happened passes the instant to hold the
+ * simulation's clock at while the tokens are issued.
+ */
+async function simCognitoSignedIn(
+  signedInAt?: Date,
+): Promise<SimCognitoSignedIn> {
+  const simAws = new SimAws({
+    defaultAccountId: "111111111111" as SimAwsAccountId,
+    defaultRegionName: "eu-west-2",
+  });
+  const cognito = simAws.cognitoIdentityProvider();
+
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  const clientId = client.UserPoolClient.ClientId;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      UserAttributes: [{ Name: "email", Value: "alice@example.com" }],
+    }),
+  );
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: password,
+      Permanent: true,
+    }),
+  );
+
+  if (signedInAt !== undefined) {
+    await simAws.clock().setTo(signedInAt);
+  }
+
+  const signedIn = await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: userPoolId,
+      ClientId: clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: password },
+    }),
+  );
+
+  assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+  assertNonNullable(signedIn.AuthenticationResult.IdToken);
+
+  return {
+    simAws,
+    userPoolId,
+    clientId,
+    accessToken: signedIn.AuthenticationResult.AccessToken,
+    idToken: signedIn.AuthenticationResult.IdToken,
+  };
+}
+
+describe("sim Cognito token verification", () => {
+  it("verifies an access token with aws-jwt-verify and no network", async () => {
+    // Given a signed-in user, and a verifier configured for the pool.
+    const { simAws, userPoolId, clientId, accessToken } =
+      await simCognitoSignedIn();
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: "access",
+      clientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+
+    // When the verifier verifies the token it was given.
+    const payload = await verifier.verify(accessToken);
+
+    // Then it passes, having checked the signature, the issuer and the claims
+    // rather than having been stubbed.
+    assertIdentical(payload.username, "alice");
+    assertIdentical(payload.token_use, "access");
+    assertIdentical(payload.client_id, clientId);
+  });
+
+  it("verifies an id token for the same user", async () => {
+    // Given a signed-in user, and a verifier for id tokens.
+    const { simAws, userPoolId, clientId, idToken } =
+      await simCognitoSignedIn();
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: "id",
+      clientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+
+    // When the id token is verified.
+    const payload = await verifier.verify(idToken);
+
+    // Then the audience is the app client, and the user's attributes are on
+    // it, as they are on a real id token.
+    assertIdentical(payload.aud, clientId);
+    assertIdentical(payload["cognito:username"], "alice");
+    assertIdentical(payload["email"], "alice@example.com");
+  });
+
+  it("refuses an access token where an id token belongs", async () => {
+    // Given a signed-in user, and a verifier expecting an id token.
+    const { simAws, userPoolId, clientId, accessToken } =
+      await simCognitoSignedIn();
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: "id",
+      clientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+
+    // When the access token is verified as an id token.
+    const error = await assertThrowsErrorAsync(async () => {
+      await verifier.verify(accessToken);
+    });
+
+    // Then the verifier refuses it, because the claim split here is the real
+    // one: code reading the wrong token fails as it would in production.
+    assertStringIncludes(error.message, "Token use not allowed");
+  });
+
+  it("stamps a token with the time the simulation signed the user in", async () => {
+    // Given a simulation whose clock is held still, and a user signed in then.
+    const signedInAt = new Date();
+
+    signedInAt.setMilliseconds(0);
+
+    const { simAws, userPoolId, clientId, accessToken } =
+      await simCognitoSignedIn(signedInAt);
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: "access",
+      clientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+
+    // When the token is verified.
+    const payload = await verifier.verify(accessToken);
+
+    // Then its timestamps came from the simulation's clock rather than from
+    // the host's, and it lasts the hour a pool's tokens last by default.
+    const issuedAtSeconds = Math.floor(signedInAt.getTime() / 1000);
+
+    assertIdentical(payload.iat, issuedAtSeconds);
+    assertIdentical(payload.auth_time, issuedAtSeconds);
+    assertIdentical(payload.exp, issuedAtSeconds + 3600);
+  });
+
+  it("issues an expired token when the simulation signs in far enough in the past", async () => {
+    // Given a user signed in two hours ago in simulated time.
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const { simAws, userPoolId, clientId, accessToken } =
+      await simCognitoSignedIn(twoHoursAgo);
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: "access",
+      clientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+
+    // When that token is verified now.
+    const error = await assertThrowsErrorAsync(async () => {
+      await verifier.verify(accessToken);
+    });
+
+    // Then it is refused as expired, which is how a test exercises the expiry
+    // handling in its own code without waiting an hour for it.
+    assertStringIncludes(error.message, "expired");
+  });
+});

--- a/src/service/cognito/command/auth/sim-cognito-unsimulated-auth-options.ts
+++ b/src/service/cognito/command/auth/sim-cognito-unsimulated-auth-options.ts
@@ -1,0 +1,69 @@
+import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import type {
+  SimAdminInitiateAuthCommandInput,
+  SimAdminRespondToAuthChallengeCommandInput,
+} from "./auth.command.js";
+
+/**
+ * Refuses the authentication inputs this simulation does not model.
+ *
+ * All of them change what real Cognito does with a sign-in, and none of them
+ * can be honoured here, so a request carrying one is refused rather than
+ * signed in as if it had not.
+ */
+export class SimCognitoUnsimulatedAuthOptions {
+  private readonly initiation = new SimCognitoUnsimulatedInput(
+    "AdminInitiateAuth",
+  );
+  private readonly response = new SimCognitoUnsimulatedInput(
+    "AdminRespondToAuthChallenge",
+  );
+
+  /**
+   * Refuse an `AdminInitiateAuth` request this simulation cannot honour.
+   */
+  refuseInInitiate(input: SimAdminInitiateAuthCommandInput): void {
+    this.initiation.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+    this.initiation.refuse(
+      "AnalyticsMetadata",
+      input.AnalyticsMetadata,
+      "Pinpoint analytics",
+    );
+    this.initiation.refuse(
+      "ContextData",
+      input.ContextData,
+      "threat protection, which reads the caller's device and address",
+    );
+    this.initiation.refuse(
+      "Session",
+      input.Session,
+      "continuing a USER_AUTH flow that offered a choice of factors",
+    );
+  }
+
+  /**
+   * Refuse an `AdminRespondToAuthChallenge` request this simulation cannot
+   * honour.
+   */
+  refuseInResponse(input: SimAdminRespondToAuthChallengeCommandInput): void {
+    this.response.refuse(
+      "ClientMetadata",
+      input.ClientMetadata,
+      "passing data to a Lambda trigger",
+    );
+    this.response.refuse(
+      "AnalyticsMetadata",
+      input.AnalyticsMetadata,
+      "Pinpoint analytics",
+    );
+    this.response.refuse(
+      "ContextData",
+      input.ContextData,
+      "threat protection, which reads the caller's device and address",
+    );
+  }
+}

--- a/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-user-iam.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
   AdminGetUserCommand,
   AdminSetUserPasswordCommand,
   CreateUserPoolCommand,
@@ -90,6 +91,32 @@ async function simCognitoWithRole(
 }
 
 describe("sim Cognito user IAM authorization", () => {
+  it("denies an authentication the caller's policy does not permit", async () => {
+    // Given a Role allowed to read users but not to sign them in.
+    const { simAws, caller, userPoolId } = await simCognitoWithRole({
+      Effect: "Allow",
+      Action: "cognito-idp:AdminGetUser",
+      Resource: userPoolArn("*"),
+    });
+
+    // When that Role starts an authentication.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cognitoIdentityProvider().adminInitiateAuth(
+        new AdminInitiateAuthCommand({
+          UserPoolId: userPoolId,
+          ClientId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+          AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+          AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is denied against the pool's ARN, before the app client or the
+    // password is looked at.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
   it("allows a user operation the caller's policy permits on the pool", async () => {
     // Given a Role allowed to read users in one pool.
     const { simAws, caller, userPoolId } = await simCognitoWithRole({

--- a/src/service/cognito/command/sim-cognito-command.types.ts
+++ b/src/service/cognito/command/sim-cognito-command.types.ts
@@ -94,3 +94,12 @@ export type {
   SimListUsersInGroupCommandInput,
   SimListUsersInGroupCommandOutput,
 } from "./group/group-membership.command.js";
+export type {
+  SimAdminInitiateAuthCommand,
+  SimAdminInitiateAuthCommandInput,
+  SimAdminInitiateAuthCommandOutput,
+  SimAdminRespondToAuthChallengeCommand,
+  SimAdminRespondToAuthChallengeCommandInput,
+  SimAdminRespondToAuthChallengeCommandOutput,
+  SimCognitoAuthenticationResultType,
+} from "./auth/auth.command.js";

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -6,6 +6,11 @@ import { SimCognitoGroupFactory } from "../user-pool/group/sim-cognito-group-fac
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
 import { SimCognitoUserFactory } from "../user-pool/user/sim-cognito-user-factory.js";
+import { SimCognitoTokenIssuer } from "../user-pool/token/sim-cognito-token-issuer.js";
+import { SimCognitoAdminInitiateAuth } from "./auth/sim-cognito-admin-initiate-auth.js";
+import { SimCognitoAdminRespondToChallenge } from "./auth/sim-cognito-admin-respond-to-challenge.js";
+import { SimCognitoAuthResolver } from "./auth/sim-cognito-auth-resolver.js";
+import { SimCognitoNewPasswordChallenge } from "./auth/sim-cognito-new-password-challenge.js";
 import { SimCognitoAuthorizer } from "./authorize/sim-cognito-authorizer.js";
 import { SimCognitoListUserPoolClients } from "./client/sim-cognito-list-user-pool-clients.js";
 import { SimCognitoGroupCommands } from "./group/sim-cognito-group-commands.js";
@@ -44,6 +49,8 @@ export class SimCognitoCommands {
   public readonly groups: SimCognitoGroupCommands;
   public readonly groupMembership: SimCognitoGroupMembershipCommands;
   public readonly listGroups: SimCognitoListGroups;
+  public readonly initiateAuth: SimCognitoAdminInitiateAuth;
+  public readonly respondToChallenge: SimCognitoAdminRespondToChallenge;
 
   constructor(properties: SimCognitoCommandsProperties) {
     const { accountRegionScope, iam, clock, pools } = properties;
@@ -78,5 +85,18 @@ export class SimCognitoCommands {
     });
     this.groupMembership = new SimCognitoGroupMembershipCommands({ resolver });
     this.listGroups = new SimCognitoListGroups({ resolver });
+    const authResolver = new SimCognitoAuthResolver({ resolver });
+    const tokenIssuer = new SimCognitoTokenIssuer({ clock });
+
+    this.initiateAuth = new SimCognitoAdminInitiateAuth({
+      authResolver,
+      tokenIssuer,
+      challenge: new SimCognitoNewPasswordChallenge({ clock }),
+    });
+    this.respondToChallenge = new SimCognitoAdminRespondToChallenge({
+      authResolver,
+      tokenIssuer,
+      clock,
+    });
   }
 }

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -42,21 +42,23 @@ export class SimCognitoUserCommands {
   }
 
   /**
-   * Check a temporary password against the pool's policy.
+   * Read the temporary password the request named, or none.
    *
-   * A request naming no temporary password is fine: real Cognito generates one
-   * and sends it to the user. Nothing is delivered here, and the generated
-   * password would be unusable anyway, so none is generated.
+   * A request naming none is fine, and leaves the user with no password at
+   * all: real Cognito generates one and sends it to the user, and nothing
+   * here delivers a message for the user to read it from. Such a user reaches
+   * the `NEW_PASSWORD_REQUIRED` challenge with no password to get past it, so
+   * name a `TemporaryPassword` when the test means to sign in.
    */
-  private static requireAllowedTemporaryPassword(
+  private static allowedTemporaryPassword(
     pool: SimCognitoUserPool,
     temporaryPassword: string | undefined,
-  ): void {
+  ): string | undefined {
     if (temporaryPassword === undefined) {
-      return;
+      return undefined;
     }
 
-    new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+    return new SimCognitoPasswordCheck(pool.passwordPolicy).require(
       "TemporaryPassword",
       temporaryPassword,
     );
@@ -83,14 +85,14 @@ export class SimCognitoUserCommands {
     const username = requireSimCognitoUsername(input.Username);
 
     this.unsimulatedOptions.refuseInCreate(input);
-    SimCognitoUserCommands.requireAllowedTemporaryPassword(
-      pool,
-      input.TemporaryPassword,
-    );
 
     const user = this.userFactory.make({
       username,
       attributes: input.UserAttributes,
+      temporaryPassword: SimCognitoUserCommands.allowedTemporaryPassword(
+        pool,
+        input.TemporaryPassword,
+      ),
     });
 
     pool.addUser(user);

--- a/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-update-commands.ts
@@ -55,12 +55,12 @@ export class SimCognitoUserUpdateCommands {
       options,
     );
 
-    new SimCognitoPasswordCheck(pool.passwordPolicy).require(
+    const password = new SimCognitoPasswordCheck(pool.passwordPolicy).require(
       "Password",
       input.Password,
     );
 
-    user.setPassword(input.Permanent);
+    user.setPassword(password, input.Permanent);
 
     return { $metadata: {} };
   }

--- a/src/service/cognito/error/sim-cognito.error.ts
+++ b/src/service/cognito/error/sim-cognito.error.ts
@@ -88,6 +88,21 @@ export class SimCognitoUserNotFoundException extends SimCognitoError {
 }
 
 /**
+ * Simulated Cognito NotAuthorizedException error.
+ *
+ * Real Cognito reports a failed sign-in this way, whether the password was
+ * wrong, the user was disabled or the request could not be verified. It says
+ * no more than that on purpose, and neither does this.
+ */
+export class SimCognitoNotAuthorizedException extends SimCognitoError {
+  public override readonly name = "NotAuthorizedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated Cognito InvalidPasswordException error.
  *
  * Real Cognito reports a password its pool's password policy does not allow

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -48,10 +48,21 @@ export {
   type SimCognitoGroupSettingsInput,
 } from "./user-pool/group/sim-cognito-group-settings.js";
 export {
+  SimCognitoSigningKey,
+  type SimCognitoJwk,
+  type SimCognitoJwks,
+} from "./user-pool/token/sim-cognito-signing-key.js";
+export {
+  SimCognitoTokenIssuer,
+  type SimCognitoIssuedTokens,
+} from "./user-pool/token/sim-cognito-token-issuer.js";
+export { SimCognitoAuthSession } from "./user-pool/auth/sim-cognito-auth-session.js";
+export {
   SimCognitoError,
   SimCognitoGroupExistsException,
   SimCognitoInvalidParameterException,
   SimCognitoInvalidPasswordException,
+  SimCognitoNotAuthorizedException,
   SimCognitoResourceNotFoundException,
   SimCognitoUsernameExistsException,
   SimCognitoUserNotFoundException,

--- a/src/service/cognito/sdk/sim-cognito-sdk-auth-routing.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-auth-routing.iso.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/naming-convention -- the authentication
+   parameter names are Cognito's own, rather than identifier names. */
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminRespondToAuthChallengeCommand,
+  CognitoIdentityProviderClient,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("Cognito authentication SDK interception", () => {
+  it("signs a user in through an intercepted client and verifies the token", async () => {
+    // Given an intercepted Cognito SDK client, and a simulation to read the
+    // pool's JWKS from.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    using simSdk = new SimSdk({ simAws });
+    simSdk.intercept(CognitoIdentityProviderClient);
+
+    const client = new CognitoIdentityProviderClient({ region: "eu-west-2" });
+    const pool = await client.send(
+      new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+    );
+    const UserPoolId = pool.UserPool?.Id;
+    const appClient = await client.send(
+      new CreateUserPoolClientCommand({
+        UserPoolId,
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      }),
+    );
+    const ClientId = appClient.UserPoolClient?.ClientId;
+
+    await client.send(
+      new AdminCreateUserCommand({
+        UserPoolId,
+        Username: "alice",
+        TemporaryPassword: "Temp0rary!",
+      }),
+    );
+
+    // When ordinary SDK code signs the user in and answers the challenge.
+    const challenged = await client.send(
+      new AdminInitiateAuthCommand({
+        UserPoolId,
+        ClientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: { USERNAME: "alice", PASSWORD: "Temp0rary!" },
+      }),
+    );
+
+    assertIdentical(challenged.ChallengeName, "NEW_PASSWORD_REQUIRED");
+
+    const signedIn = await client.send(
+      new AdminRespondToAuthChallengeCommand({
+        UserPoolId,
+        ClientId,
+        ChallengeName: "NEW_PASSWORD_REQUIRED",
+        Session: challenged.Session,
+        ChallengeResponses: {
+          USERNAME: "alice",
+          NEW_PASSWORD: "Sup3rSecret!",
+        },
+      }),
+    );
+
+    // Then the token it got back verifies against the pool's JWKS, with
+    // nothing having touched the network.
+    assertNonNullable(UserPoolId);
+    assertNonNullable(ClientId);
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    const verifier = CognitoJwtVerifier.create({
+      userPoolId: UserPoolId,
+      tokenUse: "access",
+      clientId: ClientId,
+    });
+
+    verifier.cacheJwks(
+      simAws.cognitoIdentityProvider().userPool(UserPoolId).jwks(),
+    );
+
+    const payload = await verifier.verify(
+      signedIn.AuthenticationResult.AccessToken,
+    );
+
+    assertIdentical(payload.username, "alice");
+  });
+});

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.iso.test.ts
@@ -40,6 +40,8 @@ describe("SimCognitoSdkCommandRouter", () => {
       "AdminRemoveUserFromGroupCommand",
       "AdminListGroupsForUserCommand",
       "ListUsersInGroupCommand",
+      "AdminInitiateAuthCommand",
+      "AdminRespondToAuthChallengeCommand",
     ]);
   });
 
@@ -51,7 +53,7 @@ describe("SimCognitoSdkCommandRouter", () => {
     const route = simAws
       .cognitoIdentityProvider()
       .sdkCommandRouter()
-      .route("AdminInitiateAuthCommand");
+      .route("InitiateAuthCommand");
 
     // Then there is no route for it.
     assertUndefined(route);

--- a/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
+++ b/src/service/cognito/sdk/sim-cognito-sdk-command-router.ts
@@ -10,6 +10,10 @@ import type {
 } from "../command/client/user-pool-client.command.js";
 import type { SimListUserPoolClientsCommand } from "../command/client/list-user-pool-clients.command.js";
 import type {
+  SimAdminInitiateAuthCommand,
+  SimAdminRespondToAuthChallengeCommand,
+} from "../command/auth/auth.command.js";
+import type {
   SimAdminAddUserToGroupCommand,
   SimAdminListGroupsForUserCommand,
   SimAdminRemoveUserFromGroupCommand,
@@ -237,6 +241,22 @@ export class SimCognitoSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCognito.adminListGroupsForUser(
             command as SimAdminListGroupsForUserCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminInitiateAuthCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminInitiateAuth(
+            command as SimAdminInitiateAuthCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "AdminRespondToAuthChallengeCommand",
+        async (command, context): Promise<unknown> =>
+          await simCognito.adminRespondToAuthChallenge(
+            command as SimAdminRespondToAuthChallengeCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -18,7 +18,10 @@ import {
 } from "./sim-cognito-user-directory.js";
 
 import type { SimCognitoUserPool } from "./user-pool/sim-cognito-user-pool.js";
-import type { SimCognitoUserPoolId } from "./user-pool/sim-cognito-user-pool-id.js";
+import {
+  requireSimCognitoUserPoolId,
+  type SimCognitoUserPoolId,
+} from "./user-pool/sim-cognito-user-pool-id.js";
 import { SimCognitoUserPoolStore } from "./user-pool/sim-cognito-user-pool-store.js";
 
 export type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-user-directory.js";
@@ -77,6 +80,16 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
    */
   findUserPool(userPoolId: string): SimCognitoUserPool | undefined {
     return this.pools.find(userPoolId as SimCognitoUserPoolId);
+  }
+
+  /**
+   * Get a user pool by id, or refuse.
+   *
+   * This is the simulator's own accessor too, and it is what a test reaches
+   * for to hand a pool's JWKS to a token verifier.
+   */
+  userPool(userPoolId: string): SimCognitoUserPool {
+    return this.pools.require(requireSimCognitoUserPoolId(userPoolId));
   }
 
   /**

--- a/src/service/cognito/sim-cognito-user-directory.ts
+++ b/src/service/cognito/sim-cognito-user-directory.ts
@@ -120,6 +120,28 @@ export abstract class SimCognitoUserDirectory {
   }
 
   /**
+   * Handle an AdminInitiateAuth Command from the SDK.
+   */
+  async adminInitiateAuth(
+    command: simCognitoCommands.SimAdminInitiateAuthCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminInitiateAuthCommandOutput> {
+    await this.background.sequence();
+    return this.commands.initiateAuth.handle(command, options);
+  }
+
+  /**
+   * Handle an AdminRespondToAuthChallenge Command from the SDK.
+   */
+  async adminRespondToAuthChallenge(
+    command: simCognitoCommands.SimAdminRespondToAuthChallengeCommand,
+    options?: SimCognitoIdentityProviderRequestOptions,
+  ): Promise<simCognitoCommands.SimAdminRespondToAuthChallengeCommandOutput> {
+    await this.background.sequence();
+    return this.commands.respondToChallenge.handle(command, options);
+  }
+
+  /**
    * Handle a CreateGroup Command from the SDK.
    */
   async createGroup(

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
@@ -22,8 +22,13 @@ export class SimCognitoAuthSessionStore {
 
   /**
    * Remember a session a challenge was issued with.
+   *
+   * A session nobody answered is dropped here once it has run out, so a
+   * simulation left running does not hold every abandoned sign-in. The new
+   * session's own issue time is the simulation's now, so no clock is needed.
    */
   add(session: SimCognitoAuthSession): void {
+    this.forgetExpired(session.issuedAt);
     this.sessions.set(session.id, session);
   }
 
@@ -66,5 +71,13 @@ export class SimCognitoAuthSessionStore {
    */
   remove(session: SimCognitoAuthSession): void {
     this.sessions.delete(session.id);
+  }
+
+  private forgetExpired(now: Date): void {
+    for (const session of this.sessions.values()) {
+      if (session.isExpiredAt(now)) {
+        this.remove(session);
+      }
+    }
   }
 }

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session-store.ts
@@ -1,0 +1,70 @@
+import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoAuthSession } from "./sim-cognito-auth-session.js";
+
+/**
+ * What a challenge response has to match for its session to be accepted.
+ */
+export interface SimCognitoAuthSessionRequest {
+  readonly sessionId: string | undefined;
+  readonly username: string;
+  readonly clientId: string;
+  readonly now: Date;
+}
+
+/**
+ * The unfinished authentications of one simulated user pool.
+ *
+ * A session is forgotten as soon as it is used, so a replayed one fails the
+ * way it does on real Cognito.
+ */
+export class SimCognitoAuthSessionStore {
+  private readonly sessions = new Map<string, SimCognitoAuthSession>();
+
+  /**
+   * Remember a session a challenge was issued with.
+   */
+  add(session: SimCognitoAuthSession): void {
+    this.sessions.set(session.id, session);
+  }
+
+  /**
+   * Find a session by the opaque string it was issued as.
+   */
+  find(sessionId: string | undefined): SimCognitoAuthSession | undefined {
+    if (sessionId === undefined) {
+      return undefined;
+    }
+
+    return this.sessions.get(sessionId);
+  }
+
+  /**
+   * Resolve the session a challenge response carries, or refuse.
+   *
+   * A session this pool never issued, one already used, one for another user
+   * or app client, and one that has run out all fail the same way, as they do
+   * on real Cognito.
+   */
+  require(request: SimCognitoAuthSessionRequest): SimCognitoAuthSession {
+    const session = this.find(request.sessionId);
+
+    if (
+      session === undefined ||
+      !session.belongsTo(request.username, request.clientId) ||
+      session.isExpiredAt(request.now)
+    ) {
+      throw new SimCognitoNotAuthorizedException(
+        "Invalid session for the user.",
+      );
+    }
+
+    return session;
+  }
+
+  /**
+   * Forget a session that has been used.
+   */
+  remove(session: SimCognitoAuthSession): void {
+    this.sessions.delete(session.id);
+  }
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-auth-session.ts
@@ -1,0 +1,60 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * How long a challenge session lasts.
+ *
+ * Real Cognito gives an app client an `AuthSessionValidity` of three minutes
+ * unless the client says otherwise, and `CreateUserPoolClient` refuses that
+ * input here, so three minutes is what every session gets.
+ */
+const sessionMinutes = 3;
+
+const sessionBytes = 48;
+
+interface SimCognitoAuthSessionProperties {
+  readonly username: string;
+  readonly clientId: string;
+  readonly challengeName: string;
+  readonly issuedAt: Date;
+}
+
+/**
+ * One challenge session, which is what an unfinished authentication carries
+ * between the request that started it and the response that completes it.
+ *
+ * The session is opaque, single use, and tied to the user and app client that
+ * got it: a session from one sign-in cannot complete another.
+ */
+export class SimCognitoAuthSession {
+  public readonly id: string;
+  public readonly username: string;
+  public readonly clientId: string;
+  public readonly challengeName: string;
+  public readonly issuedAt: Date;
+
+  constructor(properties: SimCognitoAuthSessionProperties) {
+    this.id = randomBytes(sessionBytes).toString("base64url");
+    this.username = properties.username;
+    this.clientId = properties.clientId;
+    this.challengeName = properties.challengeName;
+    this.issuedAt = properties.issuedAt;
+  }
+
+  /**
+   * Whether this session has run out by a given moment.
+   */
+  isExpiredAt(now: Date): boolean {
+    const expiresAt = new Date(
+      this.issuedAt.getTime() + sessionMinutes * 60 * 1000,
+    );
+
+    return now.getTime() >= expiresAt.getTime();
+  }
+
+  /**
+   * Whether this session belongs to a user and app client.
+   */
+  belongsTo(username: string, clientId: string): boolean {
+    return this.username === username && this.clientId === clientId;
+  }
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-secret-hash.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-secret-hash.ts
@@ -1,0 +1,48 @@
+/* eslint-disable security/detect-possible-timing-attacks -- this is a
+   simulator in one process, where the secret hash is checked so a test notices
+   a client secret it forgot to use, rather than as a defence against anyone
+   measuring how long the check took. */
+import { createHmac } from "node:crypto";
+import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+
+/**
+ * Compute the `SECRET_HASH` a request from an app client should carry.
+ *
+ * It is the HMAC-SHA256 of the username and the client id, keyed by the client
+ * secret, which is what the AWS SDKs compute.
+ */
+export function simCognitoSecretHash(
+  username: string,
+  clientId: string,
+  clientSecret: string,
+): string {
+  return createHmac("sha256", clientSecret)
+    .update(`${username}${clientId}`)
+    .digest("base64");
+}
+
+/**
+ * Refuse a request whose `SECRET_HASH` is missing or wrong.
+ *
+ * Checking it is what makes a test notice a client secret it forgot to use,
+ * rather than finding out on a real pool. A client without a secret needs
+ * none, and one sent anyway is ignored, as real Cognito ignores it.
+ */
+export function requireSimCognitoSecretHash(
+  username: string,
+  client: SimCognitoUserPoolClient,
+  secretHash: string | undefined,
+): void {
+  const { secret } = client;
+
+  if (secret === undefined) {
+    return;
+  }
+
+  if (secretHash !== simCognitoSecretHash(username, client.id, secret)) {
+    throw new SimCognitoNotAuthorizedException(
+      `Unable to verify secret hash for client ${client.id}.`,
+    );
+  }
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-sign-in.ts
@@ -1,0 +1,26 @@
+import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+
+/**
+ * Refuse a sign-in the user cannot make.
+ *
+ * A disabled user and a wrong password both fail as `NotAuthorizedException`,
+ * saying no more than real Cognito says. A user created without a
+ * `TemporaryPassword` has no password at all, so nothing matches: real Cognito
+ * generates one and sends it to the user, and nothing here delivers a message
+ * for the user to read it from.
+ */
+export function requireSimCognitoSignIn(
+  user: SimCognitoUser,
+  password: string,
+): void {
+  if (!user.enabled) {
+    throw new SimCognitoNotAuthorizedException("User is disabled.");
+  }
+
+  if (!user.hasPassword(password)) {
+    throw new SimCognitoNotAuthorizedException(
+      "Incorrect username or password.",
+    );
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-password-check.ts
+++ b/src/service/cognito/user-pool/sim-cognito-password-check.ts
@@ -46,12 +46,12 @@ export class SimCognitoPasswordCheck {
   }
 
   /**
-   * Refuse a password this pool would not accept.
+   * Read a password this pool accepts, or refuse it.
    *
    * A missing password is a validation error rather than a policy failure,
    * because real Cognito rejects the request before it reaches the policy.
    */
-  require(field: string, password: string | undefined): void {
+  require(field: string, password: string | undefined): string {
     if (password === undefined || password === "") {
       throw new SimCognitoInvalidParameterException(
         `${field} is required: give the user a password the pool's policy allows`,
@@ -66,6 +66,8 @@ export class SimCognitoPasswordCheck {
     }
 
     this.requirePolicy(password);
+
+    return password;
   }
 
   private requirePolicy(password: string): void {

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -51,6 +51,8 @@ export class SimCognitoUserPool {
   private readonly groupStore = new SimCognitoGroupStore();
   private readonly authSessions = new SimCognitoAuthSessionStore();
 
+  #signingKey: SimCognitoSigningKey | undefined;
+
   constructor(properties: SimCognitoUserPoolProperties) {
     this.id = properties.id;
     this.arn = properties.arn;
@@ -73,10 +75,15 @@ export class SimCognitoUserPool {
   }
 
   /**
-   * The key this pool signs its tokens with.
+   * The key this pool signs its tokens with, generated on first use.
+   *
+   * The key belongs to the pool, as it does on real Cognito, so a token from
+   * one pool does not carry a signature another pool's JWKS can verify.
    */
   get signingKey(): SimCognitoSigningKey {
-    return SimCognitoSigningKey.shared();
+    this.#signingKey ??= SimCognitoSigningKey.generate();
+
+    return this.#signingKey;
   }
 
   /**

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -1,3 +1,8 @@
+import type { SimCognitoAuthSession } from "./auth/sim-cognito-auth-session.js";
+import {
+  SimCognitoAuthSessionStore,
+  type SimCognitoAuthSessionRequest,
+} from "./auth/sim-cognito-auth-session-store.js";
 import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPoolClientId } from "./client/sim-cognito-user-pool-client-id.js";
 import { SimCognitoUserPoolClientStore } from "./client/sim-cognito-user-pool-client-store.js";
@@ -9,6 +14,10 @@ import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import {
+  SimCognitoSigningKey,
+  type SimCognitoJwks,
+} from "./token/sim-cognito-signing-key.js";
 import type { SimCognitoUser } from "./user/sim-cognito-user.js";
 import { SimCognitoUserStore } from "./user/sim-cognito-user-store.js";
 import type { SimCognitoUsername } from "./user/sim-cognito-username.js";
@@ -40,6 +49,7 @@ export class SimCognitoUserPool {
   private readonly clientStore = new SimCognitoUserPoolClientStore();
   private readonly userStore = new SimCognitoUserStore();
   private readonly groupStore = new SimCognitoGroupStore();
+  private readonly authSessions = new SimCognitoAuthSessionStore();
 
   constructor(properties: SimCognitoUserPoolProperties) {
     this.id = properties.id;
@@ -48,6 +58,38 @@ export class SimCognitoUserPool {
     this.passwordPolicy = properties.passwordPolicy;
     this.deletionProtection = properties.deletionProtection;
     this.creationDate = properties.createdDate;
+  }
+
+  /**
+   * The URL a token from this pool names as its issuer.
+   *
+   * The region comes out of the pool id, which is where SDK code and token
+   * verifiers get it from too.
+   */
+  get issuerUrl(): string {
+    const [regionName] = this.id.split("_", 1);
+
+    return `https://cognito-idp.${String(regionName)}.amazonaws.com/${this.id}`;
+  }
+
+  /**
+   * The key this pool signs its tokens with.
+   */
+  get signingKey(): SimCognitoSigningKey {
+    return SimCognitoSigningKey.shared();
+  }
+
+  /**
+   * The public keys this pool publishes, in the shape its JWKS endpoint
+   * serves.
+   *
+   * A verifier configured for this pool takes this document and verifies the
+   * pool's tokens with nothing else needed. Real Cognito publishes two keys
+   * and rotates between them, and this publishes one, so code assuming a
+   * single entry passes here and is still wrong against real AWS.
+   */
+  jwks(): SimCognitoJwks {
+    return { keys: [this.signingKey.publicJwk()] };
   }
 
   /**
@@ -190,5 +232,28 @@ export class SimCognitoUserPool {
    */
   groupsOf(username: string): readonly SimCognitoGroup[] {
     return this.groupStore.forUser(username);
+  }
+
+  /**
+   * Remember a challenge session an authentication was left waiting on.
+   */
+  addAuthSession(session: SimCognitoAuthSession): void {
+    this.authSessions.add(session);
+  }
+
+  /**
+   * Resolve the challenge session a response carries, or refuse.
+   */
+  requireAuthSession(
+    request: SimCognitoAuthSessionRequest,
+  ): SimCognitoAuthSession {
+    return this.authSessions.require(request);
+  }
+
+  /**
+   * Forget a challenge session that has been used.
+   */
+  removeAuthSession(session: SimCognitoAuthSession): void {
+    this.authSessions.remove(session);
   }
 }

--- a/src/service/cognito/user-pool/token/sim-cognito-access-token.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-access-token.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/naming-convention -- JWT claim names are the
+   ones RFC 7519 and Cognito define, rather than identifier names. */
+import {
+  SimCognitoSharedTokenClaims,
+  type SimCognitoTokenClaims,
+  type SimCognitoTokenClaimsProperties,
+} from "./sim-cognito-token-claims.js";
+
+/**
+ * The scope an access token from an admin authentication flow carries.
+ *
+ * Real Cognito issues this scope for sign-in through the user pool API. The
+ * scopes a resource server defines reach a token through the hosted UI and
+ * client credentials flows, neither of which is simulated.
+ */
+const userPoolAdminScope = "aws.cognito.signin.user.admin";
+
+/**
+ * The claims of a simulated access token.
+ *
+ * An access token says what the caller may do, so it names the app client in
+ * `client_id`, carries a `scope`, and has no `aud`. Its `username` is the
+ * user's username, where an id token calls the same thing `cognito:username`.
+ */
+export class SimCognitoAccessToken {
+  private readonly properties: SimCognitoTokenClaimsProperties;
+  private readonly shared: SimCognitoSharedTokenClaims;
+
+  constructor(properties: SimCognitoTokenClaimsProperties) {
+    this.properties = properties;
+    this.shared = new SimCognitoSharedTokenClaims(properties);
+  }
+
+  /**
+   * The claims this token is signed with.
+   */
+  claims(): SimCognitoTokenClaims {
+    const { client, user } = this.properties;
+
+    return {
+      ...this.shared.build(),
+      client_id: client.id,
+      token_use: "access",
+      scope: userPoolAdminScope,
+      username: user.username,
+    };
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-id-token.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-id-token.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/naming-convention -- JWT claim names are the
+   ones RFC 7519 and Cognito define, rather than identifier names. */
+import {
+  SimCognitoSharedTokenClaims,
+  type SimCognitoTokenClaims,
+  type SimCognitoTokenClaimsProperties,
+} from "./sim-cognito-token-claims.js";
+
+/**
+ * The claims of a simulated id token.
+ *
+ * An id token says who the user is, so it carries the user's attributes and
+ * names the app client it was issued to in `aud`. An access token names the
+ * same client in `client_id` and has no `aud` at all, which is the difference
+ * verification libraries check and the one code most often gets wrong.
+ */
+export class SimCognitoIdToken {
+  private readonly properties: SimCognitoTokenClaimsProperties;
+  private readonly shared: SimCognitoSharedTokenClaims;
+
+  constructor(properties: SimCognitoTokenClaimsProperties) {
+    this.properties = properties;
+    this.shared = new SimCognitoSharedTokenClaims(properties);
+  }
+
+  /**
+   * The claims this token is signed with.
+   */
+  claims(): SimCognitoTokenClaims {
+    const { client, user } = this.properties;
+
+    return {
+      ...this.shared.build(),
+      ...this.attributeClaims(),
+      aud: client.id,
+      token_use: "id",
+      "cognito:username": user.username,
+    };
+  }
+
+  /**
+   * The user's attributes, as an id token carries them.
+   *
+   * Each is reported under its own name, as real Cognito reports them. `sub`
+   * is not among them, because the shared claims already hold it.
+   */
+  private attributeClaims(): SimCognitoTokenClaims {
+    return Object.fromEntries(this.properties.user.attributeValues);
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-signing-key.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-signing-key.ts
@@ -48,21 +48,6 @@ const modulusLength = 2048;
  * runs in production.
  */
 export class SimCognitoSigningKey {
-  /**
-   * The one key pair this process signs with.
-   *
-   * Generating 2048-bit RSA takes long enough to notice, and a test suite
-   * makes many pools, so the pair is generated once on first use and shared.
-   * Every pool publishes it under the same `kid`, which is a divergence from
-   * real Cognito: there, each pool has its own keys. Nothing that verifies a
-   * token can tell, because a verifier reaches the right pool through the
-   * `iss` claim and its own JWKS rather than through the key.
-   *
-   * Nothing is written to disk, and no key material is committed: a private
-   * key in the repository would set off secret scanners for no gain.
-   */
-  static #shared: SimCognitoSigningKey | undefined;
-
   public readonly kid: string;
 
   private readonly privateKey: KeyObject;
@@ -85,12 +70,16 @@ export class SimCognitoSigningKey {
   }
 
   /**
-   * Get the key this process signs with, generating it on first use.
+   * Generate a key pair for a pool.
+   *
+   * A pool generates its own on first use rather than at creation, because
+   * generating 2048-bit RSA takes long enough to notice and most pools in a
+   * test suite never sign anything. Nothing is written to disk, and no key
+   * material is committed: a private key in the repository would set off
+   * secret scanners for no gain.
    */
-  static shared(): SimCognitoSigningKey {
-    this.#shared ??= new SimCognitoSigningKey();
-
-    return this.#shared;
+  static generate(): SimCognitoSigningKey {
+    return new SimCognitoSigningKey();
   }
 
   /**

--- a/src/service/cognito/user-pool/token/sim-cognito-signing-key.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-signing-key.ts
@@ -1,0 +1,145 @@
+import {
+  createHash,
+  createSign,
+  generateKeyPairSync,
+  type KeyObject,
+} from "node:crypto";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+
+/* eslint-disable @typescript-eslint/consistent-type-definitions -- these are
+   type aliases rather than interfaces on purpose: a JWKS has to stay
+   assignable to the index-signature types verification libraries declare for
+   it, and an interface is not. */
+
+/**
+ * One public key as a user pool publishes it.
+ */
+export type SimCognitoJwk = {
+  readonly kty: "RSA";
+  readonly use: "sig";
+  readonly alg: "RS256";
+  readonly kid: string;
+  readonly n: string;
+  readonly e: string;
+};
+
+/**
+ * A user pool's JWKS document, in the shape the real
+ * `.../.well-known/jwks.json` endpoint serves.
+ */
+export type SimCognitoJwks = {
+  keys: SimCognitoJwk[];
+};
+
+/* eslint-enable @typescript-eslint/consistent-type-definitions */
+
+/**
+ * The RSA modulus size real Cognito signs with.
+ */
+const modulusLength = 2048;
+
+/**
+ * The key a simulated user pool signs its tokens with.
+ *
+ * The key material is real, generated with `node:crypto`, and the signature is
+ * a real RS256 signature over the real signing input. A token from here
+ * verifies in `aws-jwt-verify` or `jose` with nothing stubbed, which is the
+ * point: a test that verifies a simulated token has exercised the verifier it
+ * runs in production.
+ */
+export class SimCognitoSigningKey {
+  /**
+   * The one key pair this process signs with.
+   *
+   * Generating 2048-bit RSA takes long enough to notice, and a test suite
+   * makes many pools, so the pair is generated once on first use and shared.
+   * Every pool publishes it under the same `kid`, which is a divergence from
+   * real Cognito: there, each pool has its own keys. Nothing that verifies a
+   * token can tell, because a verifier reaches the right pool through the
+   * `iss` claim and its own JWKS rather than through the key.
+   *
+   * Nothing is written to disk, and no key material is committed: a private
+   * key in the repository would set off secret scanners for no gain.
+   */
+  static #shared: SimCognitoSigningKey | undefined;
+
+  public readonly kid: string;
+
+  private readonly privateKey: KeyObject;
+  private readonly modulus: string;
+  private readonly exponent: string;
+
+  private constructor() {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength,
+    });
+    const { n, e } = publicKey.export({ format: "jwk" });
+
+    assertDefined(n, "RSA public key modulus");
+    assertDefined(e, "RSA public key exponent");
+
+    this.privateKey = privateKey;
+    this.modulus = n;
+    this.exponent = e;
+    this.kid = SimCognitoSigningKey.thumbprint(n, e);
+  }
+
+  /**
+   * Get the key this process signs with, generating it on first use.
+   */
+  static shared(): SimCognitoSigningKey {
+    this.#shared ??= new SimCognitoSigningKey();
+
+    return this.#shared;
+  }
+
+  /**
+   * The key id, which is the RFC 7638 thumbprint of the public key.
+   *
+   * Real Cognito's key ids are opaque. A thumbprint is opaque enough, and it
+   * means the id names the key it actually belongs to.
+   */
+  private static thumbprint(modulus: string, exponent: string): string {
+    return createHash("sha256")
+      .update(`{"e":"${exponent}","kty":"RSA","n":"${modulus}"}`)
+      .digest("base64url");
+  }
+
+  private static encode(claims: object): string {
+    return Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  }
+
+  /**
+   * The public half of the key, as a pool publishes it in its JWKS.
+   */
+  publicJwk(): SimCognitoJwk {
+    return {
+      kty: "RSA",
+      use: "sig",
+      alg: "RS256",
+      kid: this.kid,
+      n: this.modulus,
+      e: this.exponent,
+    };
+  }
+
+  /**
+   * Sign claims into a JWT.
+   *
+   * The header names RS256 and the key id, as a real Cognito token's header
+   * does, so a verifier finds the key in the pool's JWKS the same way.
+   */
+  sign(claims: object): string {
+    const signingInput = [
+      SimCognitoSigningKey.encode({ alg: "RS256", kid: this.kid }),
+      SimCognitoSigningKey.encode(claims),
+    ].join(".");
+
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(this.privateKey)
+      .toString("base64url");
+
+    return `${signingInput}.${signature}`;
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-token-claims.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-token-claims.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/naming-convention -- JWT claim names are the
+   ones RFC 7519 and Cognito define, rather than identifier names. */
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+
+export type SimCognitoClaimValue = string | number | readonly string[];
+
+/**
+ * The claims of one token, in the shape they are signed in.
+ */
+export type SimCognitoTokenClaims = Readonly<
+  Record<string, SimCognitoClaimValue>
+>;
+
+export interface SimCognitoTokenClaimsProperties {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+  readonly issuedAt: Date;
+  readonly expiresAt: Date;
+  /**
+   * A fresh id for this token, which becomes its `jti` claim.
+   */
+  readonly tokenId: string;
+}
+
+function epochSeconds(instant: Date): number {
+  return Math.floor(instant.getTime() / 1000);
+}
+
+/**
+ * The claims a simulated id token and access token share.
+ *
+ * `sub` is the same on both, as it is on real Cognito, so code keying on it
+ * gets the same user whichever token it read. `cognito:groups` is on both too,
+ * in precedence order, and is left out entirely when the user is in no groups
+ * rather than reported as an empty list.
+ */
+export class SimCognitoSharedTokenClaims {
+  private readonly properties: SimCognitoTokenClaimsProperties;
+
+  constructor(properties: SimCognitoTokenClaimsProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * The claims every token from this pool carries.
+   */
+  build(): SimCognitoTokenClaims {
+    const { pool, user, issuedAt, expiresAt, tokenId } = this.properties;
+
+    return {
+      sub: user.sub,
+      iss: pool.issuerUrl,
+      auth_time: epochSeconds(issuedAt),
+      iat: epochSeconds(issuedAt),
+      exp: epochSeconds(expiresAt),
+      jti: tokenId,
+      ...this.groupClaim(),
+    };
+  }
+
+  private groupClaim(): SimCognitoTokenClaims {
+    const { pool, user } = this.properties;
+    const groups = pool.groupsOf(user.username).map((group) => group.name);
+
+    if (groups.length === 0) {
+      return {};
+    }
+
+    return { "cognito:groups": groups };
+  }
+}

--- a/src/service/cognito/user-pool/token/sim-cognito-token-issuer.ts
+++ b/src/service/cognito/user-pool/token/sim-cognito-token-issuer.ts
@@ -1,0 +1,92 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import { SimCognitoAccessToken } from "./sim-cognito-access-token.js";
+import { SimCognitoIdToken } from "./sim-cognito-id-token.js";
+
+/**
+ * How many bytes a refresh token carries.
+ *
+ * A real refresh token is an opaque string rather than a JWT, so this is one
+ * too. Nothing here consumes it: `REFRESH_TOKEN_AUTH` is not simulated.
+ */
+const refreshTokenBytes = 48;
+
+/**
+ * The tokens one authentication produced.
+ */
+export interface SimCognitoIssuedTokens {
+  readonly idToken: string;
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn: number;
+}
+
+interface SimCognitoTokenIssuerProperties {
+  readonly clock: SimClock;
+}
+
+interface SimCognitoIssueTokensProperties {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+}
+
+/**
+ * Issues the tokens a successful authentication answers with.
+ *
+ * Every timestamp comes from the simulation's clock rather than from
+ * `new Date()`, so advancing simulated time expires a token that was valid
+ * before it, and a test can exercise the expiry handling it would otherwise
+ * have to wait an hour for.
+ */
+export class SimCognitoTokenIssuer {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimCognitoTokenIssuerProperties) {
+    this.clock = properties.clock;
+  }
+
+  private static expiryOf(issuedAt: Date, seconds: number): Date {
+    return new Date(issuedAt.getTime() + seconds * 1000);
+  }
+
+  /**
+   * Sign an id token and an access token for a user, and mint a refresh
+   * token to go with them.
+   *
+   * The two JWTs last as long as the app client says, which is an hour each
+   * unless the client was created with its own validity.
+   */
+  issue(properties: SimCognitoIssueTokensProperties): SimCognitoIssuedTokens {
+    const { pool, client } = properties;
+    const issuedAt = this.clock.now();
+    const accessTokenSeconds = client.tokenValidity.accessToken.seconds;
+
+    const idToken = new SimCognitoIdToken({
+      ...properties,
+      issuedAt,
+      expiresAt: SimCognitoTokenIssuer.expiryOf(
+        issuedAt,
+        client.tokenValidity.idToken.seconds,
+      ),
+      tokenId: randomUUID(),
+    });
+
+    const accessToken = new SimCognitoAccessToken({
+      ...properties,
+      issuedAt,
+      expiresAt: SimCognitoTokenIssuer.expiryOf(issuedAt, accessTokenSeconds),
+      tokenId: randomUUID(),
+    });
+
+    return {
+      idToken: pool.signingKey.sign(idToken.claims()),
+      accessToken: pool.signingKey.sign(accessToken.claims()),
+      refreshToken: randomBytes(refreshTokenBytes).toString("base64url"),
+      expiresIn: accessTokenSeconds,
+    };
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-attributes.ts
@@ -103,6 +103,13 @@ export class SimCognitoUserAttributes {
   }
 
   /**
+   * The attributes by name, in the order they were first set.
+   */
+  get values(): ReadonlyMap<string, string> {
+    return this.byName;
+  }
+
+  /**
    * The attributes, in the order they were first set.
    */
   get entries(): readonly SimCognitoAttributeType[] {

--- a/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-factory.ts
@@ -5,6 +5,7 @@ import {
   SimCognitoUserAttributes,
 } from "./sim-cognito-user-attributes.js";
 import { SimCognitoUser } from "./sim-cognito-user.js";
+import { SimCognitoUserPassword } from "./sim-cognito-user-password.js";
 import type { SimCognitoUsername } from "./sim-cognito-username.js";
 
 interface SimCognitoUserFactoryProperties {
@@ -14,6 +15,11 @@ interface SimCognitoUserFactoryProperties {
 interface SimCognitoMakeUserProperties {
   readonly username: SimCognitoUsername;
   readonly attributes?: readonly SimCognitoAttributeType[] | undefined;
+  /**
+   * The password the user starts with, already checked against the pool's
+   * policy. A user made without one has no password at all.
+   */
+  readonly temporaryPassword?: string | undefined;
 }
 
 /**
@@ -24,6 +30,16 @@ export class SimCognitoUserFactory {
 
   constructor(properties: SimCognitoUserFactoryProperties) {
     this.clock = properties.clock;
+  }
+
+  private static passwordFor(
+    temporaryPassword: string | undefined,
+  ): SimCognitoUserPassword | undefined {
+    if (temporaryPassword === undefined) {
+      return undefined;
+    }
+
+    return new SimCognitoUserPassword(temporaryPassword);
   }
 
   /**
@@ -38,6 +54,7 @@ export class SimCognitoUserFactory {
       username: properties.username,
       sub: randomUUID(),
       attributes: new SimCognitoUserAttributes(properties.attributes),
+      password: SimCognitoUserFactory.passwordFor(properties.temporaryPassword),
       clock: this.clock,
     });
   }

--- a/src/service/cognito/user-pool/user/sim-cognito-user-password.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-password.ts
@@ -1,0 +1,22 @@
+/**
+ * The password one simulated user can authenticate with.
+ *
+ * The value is held rather than hashed, and nothing exposes it: a caller can
+ * only ask whether a candidate matches. That is a modelling choice rather than
+ * a security boundary, as it is for simulated KMS key material, since this all
+ * runs in one process and anything sharing that process can reach the object.
+ */
+export class SimCognitoUserPassword {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * Whether a candidate password is this one.
+   */
+  matches(candidate: string | undefined): boolean {
+    return candidate === this.value;
+  }
+}

--- a/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user-status.ts
@@ -45,4 +45,14 @@ export class SimCognitoUserStatus {
 
     return this.forceChangePassword;
   }
+
+  /**
+   * Whether the user has to replace its password before it can sign in.
+   *
+   * This is what turns an authentication into the `NEW_PASSWORD_REQUIRED`
+   * challenge rather than into tokens.
+   */
+  get mustChangePassword(): boolean {
+    return this.value === "FORCE_CHANGE_PASSWORD";
+  }
 }

--- a/src/service/cognito/user-pool/user/sim-cognito-user.ts
+++ b/src/service/cognito/user-pool/user/sim-cognito-user.ts
@@ -3,6 +3,7 @@ import type {
   SimCognitoAttributeType,
   SimCognitoUserAttributes,
 } from "./sim-cognito-user-attributes.js";
+import { SimCognitoUserPassword } from "./sim-cognito-user-password.js";
 import { SimCognitoUserStatus } from "./sim-cognito-user-status.js";
 import type { SimCognitoUsername } from "./sim-cognito-username.js";
 
@@ -10,6 +11,7 @@ interface SimCognitoUserProperties {
   readonly username: SimCognitoUsername;
   readonly sub: string;
   readonly attributes: SimCognitoUserAttributes;
+  readonly password?: SimCognitoUserPassword | undefined;
   readonly clock: SimClock;
 }
 
@@ -32,6 +34,7 @@ export class SimCognitoUser {
   private readonly clock: SimClock;
   private readonly userAttributes: SimCognitoUserAttributes;
   private userStatus = SimCognitoUserStatus.forceChangePassword;
+  private userPassword: SimCognitoUserPassword | undefined;
   private isEnabled = true;
   private modifiedDate: Date;
 
@@ -39,6 +42,7 @@ export class SimCognitoUser {
     this.username = properties.username;
     this.sub = properties.sub;
     this.userAttributes = properties.attributes;
+    this.userPassword = properties.password;
     this.clock = properties.clock;
     this.creationDate = this.clock.now();
     this.modifiedDate = this.creationDate;
@@ -80,16 +84,38 @@ export class SimCognitoUser {
   }
 
   /**
-   * Note that an admin has set a password on this user.
+   * The user's attributes by name, without the `sub` Cognito allocated.
    *
-   * The password itself is checked against the pool's policy and not kept,
-   * because nothing authenticates here yet. What it changes is the user's
-   * status: a permanent password is the user's own, and a temporary one
-   * leaves the user having to replace it before it can sign in.
+   * This is what an id token's claims are built from: every attribute there
+   * has a value, and the sub is a claim of its own.
    */
-  setPassword(permanent: boolean | undefined): void {
+  get attributeValues(): ReadonlyMap<string, string> {
+    return this.userAttributes.values;
+  }
+
+  /**
+   * Set the password an admin gave this user.
+   *
+   * A permanent password is the user's own, and confirms it. A temporary one
+   * leaves the user in `FORCE_CHANGE_PASSWORD`, having to replace it through
+   * the `NEW_PASSWORD_REQUIRED` challenge before it can sign in normally.
+   */
+  setPassword(password: string, permanent: boolean | undefined): void {
+    this.userPassword = new SimCognitoUserPassword(password);
     this.userStatus = SimCognitoUserStatus.afterPasswordSet(permanent);
     this.touch();
+  }
+
+  /**
+   * Whether a candidate password is this user's.
+   *
+   * A user with no password at all matches nothing. `AdminCreateUser` leaves
+   * one that way when the request named no `TemporaryPassword`: real Cognito
+   * generates one and sends it to the user, and nothing here delivers a
+   * message for the user to read it from.
+   */
+  hasPassword(candidate: string | undefined): boolean {
+    return this.userPassword?.matches(candidate) ?? false;
   }
 
   /**


### PR DESCRIPTION
AdminInitiateAuth runs the ADMIN_USER_PASSWORD_AUTH flow and answers with RS256 tokens signed by a key the pool publishes as a JWKS, so aws-jwt-verify verifies them unchanged with nothing on the network. A user in FORCE_CHANGE_PASSWORD gets the NEW_PASSWORD_REQUIRED challenge, and AdminRespondToAuthChallenge completes it.

Token timestamps come from the simulated clock, so signing in in the past produces a token a verifier rejects as expired. A user's password is now kept rather than discarded, since sign-in reads it.

Resolves https://github.com/KensioSoftware/yulin/issues/220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated Cognito admin sign-in with `ADMIN_USER_PASSWORD_AUTH`.
  * Added signed RS256 access and ID tokens with locally available JWKS verification.
  * Added `NEW_PASSWORD_REQUIRED` challenge handling and password completion.
  * Added password validation, user status transitions, token claims, expiry, and session handling.
  * Added IAM authorization coverage for authentication requests.

* **Documentation**
  * Expanded Cognito documentation with sign-in, token verification, challenge, expiry, and limitation guidance.
  * Added examples demonstrating sign-in, token verification, expired tokens, and password challenges.

* **Tests**
  * Added comprehensive coverage for authentication flows, JWT claims, verification, sessions, routing, and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->