### PR TITLE
refactor: inline one-off helpers in the sim Lambda tests

### DIFF
--- a/.idea/yulin.iml
+++ b/.idea/yulin.iml
@@ -4,6 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.claude" />
       <excludeFolder url="file://$MODULE_DIR$/test/.coverage" />
+      <excludeFolder url="file://$MODULE_DIR$/yulin-demo" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.5.0",
-    "@kensio/part-factory": "^1.6.0",
+    "@kensio/part-factory": "^1.9.0",
     "lodash-es": "^4.18.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
       '@kensio/part-factory':
-        specifier: ^1.6.0
-        version: 1.7.0
+        specifier: ^1.9.0
+        version: 1.9.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -626,8 +626,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kensio/part-factory@1.7.0':
-    resolution: {integrity: sha512-LaRxufN/R3Up+YjwxY/zx0yyEaTOiPddPwvyL1sYK6UrkfuXTb++263q9s511gM9vIsNW3Ns/UDqCga19glbIQ==}
+  '@kensio/part-factory@1.9.0':
+    resolution: {integrity: sha512-vaVPwq9uUVvxAsr4K7l/Ux85+SpYFOXjzG+LcV/RYbrCON++mTy2wotwAPgVIzsH5LK3G/m2rM/qj8O7PZwYnQ==}
     engines: {node: '>=22.0.0'}
 
   '@kensio/smartass@1.36.0':
@@ -2591,7 +2591,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kensio/part-factory@1.7.0':
+  '@kensio/part-factory@1.9.0':
     dependencies:
       lodash: 4.18.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
   - '@kensio/smartass@1.33.0'
-  - '@kensio/part-factory@1.4.0'
+  - '@kensio/part-factory@1.4.0 || 1.9.0'
 useNodeVersion: 24.18.0

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-grant-invoke-url.loc.test.ts
@@ -1,8 +1,7 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { assertIdentical, assertTypeString } from "@kensio/smartass";
 import path from "node:path";
 import { describe, it } from "vitest";
-
-import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 
 /**
  * Slower local integration test. Calls the real CDK CLI to synth the output
@@ -12,6 +11,7 @@ import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-
 import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { simAwsCallerHeaderName } from "../../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
 import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
 
@@ -24,20 +24,6 @@ import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js"
 const accountId = "888888888888";
 
 const otherAccountId = "222222222222";
-
-/**
- * The calling Role in the other Account, allowed to invoke Function URLs by
- * that Account's own identity policy.
- */
-async function grantOtherAccountRole(simAws: SimAws): Promise<void> {
-  await createSimIamRoleWithPolicy({
-    simAws,
-    accountId: otherAccountId,
-    roleName: "Anything",
-    policyName: "InvokeUrl",
-    action: "lambda:InvokeFunctionUrl",
-  });
-}
 
 describe("Sim CDK Lambda grantInvokeUrl local integration", () => {
   it("deploys grantInvokeUrl grants that admit the granted principals", async () => {
@@ -104,7 +90,29 @@ app.synth();
     // And the other Account allows its own Role to invoke Function URLs. That
     // is the side a CDK app in this Account cannot write, and a cross-account
     // call needs an allow from each Account.
-    await grantOtherAccountRole(simAws);
+    // And the calling Role in the other Account, allowed to invoke Function
+    // URLs by that Account's own identity policy.
+    const otherIam = simAws.account(otherAccountId).iam();
+    await otherIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Anything",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${otherAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await otherIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Anything",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
+        }),
+      }),
+    );
 
     const srv = await serveSimAws({ simAws });
     const invokeAs = async (arn: string): Promise<Response> =>

--- a/src/service/iam/policy/sim-iam-policy-document.factory.ts
+++ b/src/service/iam/policy/sim-iam-policy-document.factory.ts
@@ -1,0 +1,48 @@
+import { MappedFactory } from "@kensio/part-factory";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimIamPolicyDocument } from "./sim-iam-policy.js";
+
+/**
+ * Builds the JSON string an IAM policy document is supplied as.
+ *
+ * A test states only the part of the statement it is about. The Version, and
+ * an Allow effect, come from the defaults, since a test that has to spell them
+ * out every time buries the Action and Resource it actually cares about.
+ *
+ * ```typescript
+ * await simAws.iam().putRolePolicy(
+ *   new PutRolePolicyCommand({
+ *     RoleName: "FunctionInvoker",
+ *     PolicyName: "InvokePolicy",
+ *     PolicyDocument: simIamPolicyDocumentFactory.make({
+ *       Statement: { Action: "lambda:InvokeFunction", Resource: functionArn },
+ *     }),
+ *   }),
+ * );
+ * ```
+ *
+ * This is equally the shape of a trust policy, a resource policy or a key
+ * policy, so the one factory covers all of them:
+ *
+ * ```typescript
+ * simIamPolicyDocumentFactory.make({
+ *   Statement: {
+ *     Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+ *     Action: "sts:AssumeRole",
+ *   },
+ * });
+ * ```
+ *
+ * There is no default Principal. Leaving it out keeps a statement that names
+ * one from merging with a default that names another.
+ */
+export const simIamPolicyDocumentFactory = new MappedFactory<
+  SimIamPolicyDocument,
+  string
+>(
+  () => ({
+    Version: "2012-10-17",
+    Statement: { Effect: "Allow" },
+  }),
+  (document) => jsonStringify(document),
+);

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
@@ -1,14 +1,15 @@
 import { GetPolicyCommand } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { assertTypeString } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
-import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { simAwsCallerHeaderName } from "../../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimLambdaPermission } from "../../function/policy/sim-lambda-permission.js";
@@ -16,23 +17,6 @@ import { SimCfnLambdaPermissionCreator } from "./sim-cfn-lambda-permission-creat
 
 const callerAccountId = "222222222222";
 const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
-
-/**
- * The calling Role in its own Account, allowed to invoke Function URLs there.
- *
- * A cross-Account call needs an allow from the caller's Account as well as the
- * grant on the function, so a template grant can only be shown to take effect
- * with this side in place too.
- */
-async function allowedCallerRole(simAws: SimAws): Promise<void> {
-  await createSimIamRoleWithPolicy({
-    simAws,
-    accountId: callerAccountId,
-    roleName: "Caller",
-    policyName: "InvokeUrl",
-    action: "lambda:InvokeFunctionUrl",
-  });
-}
 
 function greeterTemplate(
   permissionProperties: SimCfnTemplateValueRecord,
@@ -125,7 +109,31 @@ describe("Lambda CloudFormation Permission deployment", () => {
       }),
     });
     await stack.waitForDeployComplete();
-    await allowedCallerRole(simAws);
+    // And the calling Role in its own Account, allowed to invoke Function URLs
+    // there. A cross-Account call needs an allow from the caller's Account as
+    // well as the grant on the function, so the template grant can only be
+    // shown to take effect with this side in place too.
+    const callerIam = simAws.account(callerAccountId).iam();
+    await callerIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Caller",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await callerIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Caller",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
+        }),
+      }),
+    );
     const functionUrl = stack.outputs.get("FunctionUrl")?.value;
     assertTypeString(functionUrl);
     const url = new SimAwsLocalUrl({ input: functionUrl }).toString();

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.iso.test.ts
@@ -22,21 +22,17 @@ import {
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
-async function createGreeter(simLambda: SimLambda): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-}
-
 describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("creates a Function URL in the AWS endpoint format", async () => {
     // Given a sim Lambda function.
     const simAws = new SimAws();
-    await createGreeter(simAws.lambda());
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When a Function URL is created for it.
     const output = await simAws.lambda().createFunctionUrlConfig(
@@ -64,7 +60,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("keeps the same Function URL when read back", async () => {
     // Given a function with a Function URL.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     const created = await simLambda.createFunctionUrlConfig(
       new CreateFunctionUrlConfigCommand({
         FunctionName: "greeter",
@@ -84,7 +86,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("gives each function its own Function URL", async () => {
     // Given two sim Lambda functions.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     await simLambda.createFunction(
       new CreateFunctionCommand({
         FunctionName: "other",
@@ -117,7 +125,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("accepts an AWS_IAM Function URL and a RESPONSE_STREAM invoke mode", async () => {
     // Given a sim Lambda function.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When a Function URL is created with non-default configuration.
     const output = await simLambda.createFunctionUrlConfig(
@@ -155,7 +169,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("throws when the function already has a Function URL", async () => {
     // Given a function that already has a Function URL.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     await simLambda.createFunctionUrlConfig(
       new CreateFunctionUrlConfigCommand({
         FunctionName: "greeter",
@@ -181,7 +201,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("throws on a missing AuthType", async () => {
     // Given a sim Lambda function.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When a Function URL is created without an AuthType, which the SDK types
     // as required but a plain JavaScript caller can still omit.
@@ -197,7 +223,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("throws on an unknown AuthType", async () => {
     // Given a sim Lambda function.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When a Function URL is created with an AuthType AWS does not have.
     const error = await assertThrowsErrorAsync(async () =>
@@ -214,7 +246,13 @@ describe("Lambda CreateFunctionUrlConfigCommand", () => {
   it("throws on an unknown InvokeMode", async () => {
     // Given a sim Lambda function.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When a Function URL is created with an InvokeMode AWS does not have.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/lambda/command/create-function/create-function-iam.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-iam.iso.test.ts
@@ -10,20 +10,8 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { SimLambda } from "../../sim-lambda.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-
-function createFunctionCommand(
-  functionName: string,
-  roleArn: string,
-): CreateFunctionCommand {
-  return new CreateFunctionCommand({
-    FunctionName: functionName,
-    Role: roleArn,
-    Code: {
-      ZipFile: makeLambdaZipFileInput(() => null),
-    },
-  });
-}
 
 describe("Lambda CreateFunctionCommand IAM authorization", () => {
   it("allows the default Account root caller", async () => {
@@ -32,14 +20,13 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
     const simAws = new SimAws({ defaultAccountId: accountId });
 
     // When CreateFunction is called without an explicit caller.
-    const output = await simAws
-      .lambda()
-      .createFunction(
-        createFunctionCommand(
-          "root-function",
-          `arn:aws:iam::${accountId}:role/ExecutionRole`,
-        ),
-      );
+    const output = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "root-function",
+        Role: `arn:aws:iam::${accountId}:role/ExecutionRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
 
     // Then IAM defaults to Account root and Lambda creates the function.
     assertIdentical(output.FunctionName, "root-function");
@@ -56,10 +43,8 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
     const roleCreation = await simIam.createRole(
       new CreateRoleCommand({
         RoleName: "FunctionCreator",
-        AssumeRolePolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
           Statement: {
-            Effect: "Allow",
             Principal: { AWS: `arn:aws:iam::${accountId}:root` },
             Action: "sts:AssumeRole",
           },
@@ -71,10 +56,8 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
       new PutRolePolicyCommand({
         RoleName: "FunctionCreator",
         PolicyName: "CreateFunctionPolicy",
-        PolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
           Statement: {
-            Effect: "Allow",
             Action: "lambda:CreateFunction",
             Resource:
               `arn:aws:lambda:${simAws.defaultRegionName}:` +
@@ -85,15 +68,14 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
     );
 
     // When the Role creates the function it has permission for.
-    const output = await simAws
-      .lambda()
-      .createFunction(
-        createFunctionCommand(
-          "allowed-function",
-          `arn:aws:iam::${accountId}:role/ExecutionRole`,
-        ),
-        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
-      );
+    const output = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "allowed-function",
+        Role: `arn:aws:iam::${accountId}:role/ExecutionRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+      { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+    );
 
     // Then IAM allows the request and Lambda creates the function.
     assertIdentical(output.FunctionName, "allowed-function");
@@ -109,10 +91,8 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
     const roleCreation = await simAws.iam().createRole(
       new CreateRoleCommand({
         RoleName: "NoPermissionsRole",
-        AssumeRolePolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
           Statement: {
-            Effect: "Allow",
             Principal: { AWS: `arn:aws:iam::${accountId}:root` },
             Action: "sts:AssumeRole",
           },
@@ -122,15 +102,14 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
 
     // When the Role attempts to create a function.
     const error = await assertThrowsErrorAsync(async () =>
-      simAws
-        .lambda()
-        .createFunction(
-          createFunctionCommand(
-            "denied-function",
-            `arn:aws:iam::${accountId}:role/ExecutionRole`,
-          ),
-          { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
-        ),
+      simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "denied-function",
+          Role: `arn:aws:iam::${accountId}:role/ExecutionRole`,
+          Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+        }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
     );
 
     // Then IAM implicitly denies the request.
@@ -145,10 +124,11 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
     // When an anonymous caller creates a function through the standalone
     // service.
     const output = await simLambda.createFunction(
-      createFunctionCommand(
-        "standalone-function",
-        "arn:aws:iam::111111111111:role/ExecutionRole",
-      ),
+      new CreateFunctionCommand({
+        FunctionName: "standalone-function",
+        Role: "arn:aws:iam::111111111111:role/ExecutionRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
       { caller: { kind: "anonymous" } },
     );
 

--- a/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/delete-function-url-config/delete-function-url-config.iso.test.ts
@@ -20,28 +20,25 @@ import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
-async function createGreeterWithUrl(simLambda: SimLambda): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-
-  await simLambda.createFunctionUrlConfig(
-    new CreateFunctionUrlConfigCommand({
-      FunctionName: "greeter",
-      AuthType: "NONE",
-    }),
-  );
-}
-
 describe("Lambda DeleteFunctionUrlConfigCommand", () => {
   it("deletes a Function URL so it can no longer be read", async () => {
     // Given a function with a Function URL.
     const simLambda = new SimLambda();
-    await createGreeterWithUrl(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a Function URL for it.
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
 
     // When the Function URL is deleted.
     await simLambda.deleteFunctionUrlConfig(
@@ -60,7 +57,21 @@ describe("Lambda DeleteFunctionUrlConfigCommand", () => {
   it("stops the deleted URL id resolving to a Function URL", async () => {
     // Given a function with a Function URL.
     const simLambda = new SimLambda();
-    await createGreeterWithUrl(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a Function URL for it.
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
     const functionUrl = simLambda.getSimFunctionUrl("greeter");
     assertNonNullable(functionUrl);
 
@@ -76,7 +87,21 @@ describe("Lambda DeleteFunctionUrlConfigCommand", () => {
   it("allows a new Function URL after deleting the old one", async () => {
     // Given a function whose Function URL has been deleted.
     const simLambda = new SimLambda();
-    await createGreeterWithUrl(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a Function URL for it.
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
     await simLambda.deleteFunctionUrlConfig(
       new DeleteFunctionUrlConfigCommand({ FunctionName: "greeter" }),
     );

--- a/src/service/lambda/command/get-function-url-config/get-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/get-function-url-config/get-function-url-config.iso.test.ts
@@ -17,21 +17,17 @@ import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
-async function createGreeter(simLambda: SimLambda): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-}
-
 describe("Lambda GetFunctionUrlConfigCommand", () => {
   it("gets an existing Function URL configuration", async () => {
     // Given a function with an AWS_IAM Function URL.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     await simLambda.createFunctionUrlConfig(
       new CreateFunctionUrlConfigCommand({
         FunctionName: "greeter",
@@ -53,7 +49,13 @@ describe("Lambda GetFunctionUrlConfigCommand", () => {
   it("throws when the function has no Function URL", async () => {
     // Given a function without a Function URL.
     const simAws = new SimAws();
-    await createGreeter(simAws.lambda());
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When its Function URL config is read.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/lambda/command/invoke/invoke-iam.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke-iam.iso.test.ts
@@ -9,35 +9,12 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-
-async function createCallerRole(
-  simAws: SimAws,
-  accountId: string,
-  roleName: string,
-): Promise<string> {
-  const roleCreation = await simAws
-    .account(accountId)
-    .iam()
-    .createRole(
-      new CreateRoleCommand({
-        RoleName: roleName,
-        AssumeRolePolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
-          Statement: {
-            Effect: "Allow",
-            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-  return roleCreation.Role.Arn;
-}
 
 describe("Lambda InvokeCommand IAM authorization", () => {
   it("allows a Role when its policy permits lambda:InvokeFunction", async () => {
-    // Given a function and a Role allowed to invoke it.
+    // Given a function.
     const accountId = makeSimAwsAccountId();
     const simAws = new SimAws({ defaultAccountId: accountId });
     const simLambda = simAws.lambda();
@@ -45,25 +22,30 @@ describe("Lambda InvokeCommand IAM authorization", () => {
       new CreateFunctionCommand({
         FunctionName: "invokable",
         Role: `arn:aws:iam::${accountId}:role/ExecutionRole`,
-        Code: {
-          ZipFile: makeLambdaZipFileInput(() => "invoked"),
-        },
+        Code: { ZipFile: makeLambdaZipFileInput(() => "invoked") },
       }),
     );
 
-    const callerRoleArn = await createCallerRole(
-      simAws,
-      accountId,
-      "FunctionInvoker",
+    // And a Role in the same Account.
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "FunctionInvoker",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
     );
+
+    // And an identity policy allowing that Role to invoke the function.
     await simAws.iam().putRolePolicy(
       new PutRolePolicyCommand({
         RoleName: "FunctionInvoker",
         PolicyName: "InvokePolicy",
-        PolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
           Statement: {
-            Effect: "Allow",
             Action: "lambda:InvokeFunction",
             Resource:
               `arn:aws:lambda:${simAws.defaultRegionName}:` +
@@ -76,7 +58,7 @@ describe("Lambda InvokeCommand IAM authorization", () => {
     // When the Role invokes the function.
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "invokable" }),
-      { caller: { kind: "arn", arn: callerRoleArn } },
+      { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
     );
 
     // Then IAM allows the request and the handler runs.
@@ -86,7 +68,7 @@ describe("Lambda InvokeCommand IAM authorization", () => {
   });
 
   it("implicitly denies a Role with no matching policy", async () => {
-    // Given a function and a Role with no Lambda permissions.
+    // Given a function counting the times it runs.
     const accountId = makeSimAwsAccountId();
     const simAws = new SimAws({ defaultAccountId: accountId });
     const simLambda = simAws.lambda();
@@ -104,16 +86,23 @@ describe("Lambda InvokeCommand IAM authorization", () => {
       }),
     );
 
-    const callerRoleArn = await createCallerRole(
-      simAws,
-      accountId,
-      "NoPermissionsRole",
+    // And a Role with no Lambda permissions.
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoPermissionsRole",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
     );
 
     // When the Role attempts to invoke the function.
     const error = await assertThrowsErrorAsync(async () =>
       simLambda.invoke(new InvokeCommand({ FunctionName: "guarded" }), {
-        caller: { kind: "arn", arn: callerRoleArn },
+        caller: { kind: "arn", arn: roleCreation.Role.Arn },
       }),
     );
 

--- a/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke-resource-policy.iso.test.ts
@@ -3,11 +3,12 @@ import {
   CreateFunctionCommand,
   InvokeCommand,
 } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
 
-import { createSimIamRoleWithPolicy } from "../../../../../test/iam/create-role-with-policy.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 
 const ownerAccountId = "888888888888";
@@ -15,51 +16,19 @@ const callerAccountId = "222222222222";
 const ownAccountRoleArn = `arn:aws:iam::${ownerAccountId}:role/Caller`;
 const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
 
-async function serveGreeter(): Promise<SimAws> {
-  const simAws = new SimAws();
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-
-  return simAws;
-}
-
-/**
- * Grant a principal `lambda:InvokeFunction` on the function itself.
- */
-async function grantInvoke(simAws: SimAws, principal: string): Promise<void> {
-  await simAws.lambda().addPermission(
-    new AddPermissionCommand({
-      FunctionName: "greeter",
-      StatementId: "AllowInvoke",
-      Action: "lambda:InvokeFunction",
-      Principal: principal,
-    }),
-  );
-}
-
-/**
- * The calling Role, in its own Account, allowed to invoke by that Account.
- */
-async function allowedCallerRole(simAws: SimAws): Promise<void> {
-  await createSimIamRoleWithPolicy({
-    simAws,
-    accountId: callerAccountId,
-    roleName: "Caller",
-    policyName: "Invoke",
-    action: "lambda:InvokeFunction",
-  });
-}
+const greeterCode = { ZipFile: makeLambdaZipFileInput(() => "hello") };
 
 describe("Invoking a function through its resource policy", () => {
   it("refuses a caller with neither an identity nor a resource grant", async () => {
     // Given a function nobody has been granted anything on
-    const simAws = await serveGreeter();
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
+        Code: greeterCode,
+      }),
+    );
 
     // When a principal from another Account invokes it
     // Then it is denied, as nothing allows the call
@@ -71,9 +40,25 @@ describe("Invoking a function through its resource policy", () => {
   });
 
   it("allows a same-Account caller the function's resource policy grants", async () => {
-    // Given a principal in the function's own Account granted the invocation
-    const simAws = await serveGreeter();
-    await grantInvoke(simAws, ownAccountRoleArn);
+    // Given a function
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
+        Code: greeterCode,
+      }),
+    );
+
+    // And a principal in its own Account granted the invocation
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "greeter",
+        StatementId: "AllowInvoke",
+        Action: "lambda:InvokeFunction",
+        Principal: ownAccountRoleArn,
+      }),
+    );
 
     // When they invoke it
     const output = await simAws
@@ -88,9 +73,25 @@ describe("Invoking a function through its resource policy", () => {
   });
 
   it("refuses a cross-Account caller its own Account does not allow", async () => {
-    // Given a principal from another Account granted only by this function
-    const simAws = await serveGreeter();
-    await grantInvoke(simAws, callerRoleArn);
+    // Given a function
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
+        Code: greeterCode,
+      }),
+    );
+
+    // And a principal from another Account granted only by this function
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "greeter",
+        StatementId: "AllowInvoke",
+        Action: "lambda:InvokeFunction",
+        Principal: callerRoleArn,
+      }),
+    );
 
     // When they invoke it
     // Then it is denied: AWS also requires the caller's own Account to allow
@@ -103,10 +104,48 @@ describe("Invoking a function through its resource policy", () => {
   });
 
   it("allows a cross-Account caller both Accounts allow", async () => {
-    // Given the same grant, plus an identity policy in the caller's Account
-    const simAws = await serveGreeter();
-    await grantInvoke(simAws, callerRoleArn);
-    await allowedCallerRole(simAws);
+    // Given a function
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: `arn:aws:iam::${ownerAccountId}:role/GreeterRole`,
+        Code: greeterCode,
+      }),
+    );
+
+    // And a principal from another Account granted by this function
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "greeter",
+        StatementId: "AllowInvoke",
+        Action: "lambda:InvokeFunction",
+        Principal: callerRoleArn,
+      }),
+    );
+
+    // And that Account's own identity policy allowing it too
+    const callerIam = simAws.account(callerAccountId).iam();
+    await callerIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Caller",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await callerIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Caller",
+        PolicyName: "Invoke",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "lambda:InvokeFunction", Resource: "*" },
+        }),
+      }),
+    );
 
     // When they invoke it
     const output = await simAws

--- a/src/service/lambda/command/invoke/invoke.iso.test.ts
+++ b/src/service/lambda/command/invoke/invoke.iso.test.ts
@@ -10,27 +10,14 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimLambda } from "../../sim-lambda.js";
 import {
   SimLambdaError,
   SimLambdaInvalidRequestContentException,
   SimLambdaResourceNotFoundException,
 } from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-import type { SimLambdaHandler } from "../../function/sim-lambda-handler.type.js";
 
-async function createGreeter(
-  simLambda: SimLambda,
-  handlerFunction: SimLambdaHandler<{ name: string }>,
-): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(handlerFunction) },
-    }),
-  );
-}
+const greeterRoleArn = "arn:aws:iam::111111111111:role/GreeterRole";
 
 function parsePayload(payload: Uint8Array | undefined): unknown {
   assertNonNullable(payload);
@@ -39,12 +26,22 @@ function parsePayload(payload: Uint8Array | undefined): unknown {
 
 describe("Lambda InvokeCommand", () => {
   it("invokes the handler with the request payload event", async () => {
+    // Given a function greeting the name in its event.
     const simAws = new SimAws();
     const simLambda = simAws.lambda();
-    await createGreeter(simLambda, (event) => ({
-      greeting: `Hello ${event.name}`,
-    }));
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput<{ name: string }>((event) => ({
+            greeting: `Hello ${event.name}`,
+          })),
+        },
+      }),
+    );
 
+    // When it is invoked with a JSON payload.
     const output = await simLambda.invoke(
       new InvokeCommand({
         FunctionName: "greeter",
@@ -52,6 +49,7 @@ describe("Lambda InvokeCommand", () => {
       }),
     );
 
+    // Then the handler saw the payload as its event.
     assertIdentical(output.StatusCode, 200);
     assertIdentical(output.ExecutedVersion, "$LATEST");
     assertUndefined(output.FunctionError);
@@ -63,80 +61,129 @@ describe("Lambda InvokeCommand", () => {
   });
 
   it("invokes the handler with a Uint8Array request payload", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
-    await createGreeter(simLambda, (event) => ({
-      greeting: `Hello ${event.name}`,
-    }));
+    // Given a function greeting the name in its event.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput<{ name: string }>((event) => ({
+            greeting: `Hello ${event.name}`,
+          })),
+        },
+      }),
+    );
 
+    // When it is invoked with the payload as bytes.
     const bytesPayload = Buffer.from(JSON.stringify({ name: "Bytes" }));
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "greeter", Payload: bytesPayload }),
     );
 
+    // Then the bytes were read as the JSON event.
     assertObjectEquals(parsePayload(output.Payload) as object, {
       greeting: "Hello Bytes",
     });
   });
 
   it("invokes the handler with an empty object event for an empty payload", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
+    // Given a function recording the event it is given.
+    const simLambda = new SimAws().lambda();
     let observedEvent: unknown;
-    await createGreeter(simLambda, (event) => {
-      observedEvent = event;
-      return null;
-    });
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event) => {
+            observedEvent = event;
+            return null;
+          }),
+        },
+      }),
+    );
 
+    // When it is invoked with an empty payload.
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "greeter", Payload: "" }),
     );
 
+    // Then the handler saw an empty object.
     assertIdentical(output.StatusCode, 200);
     assertObjectEquals(observedEvent as object, {});
   });
 
   it("invokes the handler with an empty object event when no payload is given", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
+    // Given a function recording the event it is given.
+    const simLambda = new SimAws().lambda();
     let observedEvent: unknown;
-    await createGreeter(simLambda, (event) => {
-      observedEvent = event;
-      return null;
-    });
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event) => {
+            observedEvent = event;
+            return null;
+          }),
+        },
+      }),
+    );
 
+    // When it is invoked without a payload at all.
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "greeter" }),
     );
 
+    // Then the handler saw an empty object.
     assertIdentical(output.StatusCode, 200);
     assertObjectEquals(observedEvent as object, {});
     assertIdentical(parsePayload(output.Payload), null);
   });
 
   it("serialises an undefined handler result as a null payload", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
-    await createGreeter(simLambda, () => undefined);
+    // Given a function returning nothing.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: { ZipFile: makeLambdaZipFileInput(() => undefined) },
+      }),
+    );
 
+    // When it is invoked.
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "greeter", Payload: "{}" }),
     );
 
+    // Then the response payload is null.
     assertIdentical(parsePayload(output.Payload), null);
   });
 
   it("reports a handler error as an unhandled function error payload", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
-    await createGreeter(simLambda, () => {
-      throw new RangeError("greeting out of range");
-    });
+    // Given a function whose handler throws.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new RangeError("greeting out of range");
+          }),
+        },
+      }),
+    );
 
+    // When it is invoked.
     const output = await simLambda.invoke(
       new InvokeCommand({ FunctionName: "greeter", Payload: "{}" }),
     );
 
+    // Then the failure comes back as an unhandled function error, the way real
+    // Lambda reports one.
     assertIdentical(output.StatusCode, 200);
     assertIdentical(output.FunctionError, "Unhandled");
     const errorPayload = parsePayload(output.Payload) as {
@@ -150,25 +197,40 @@ describe("Lambda InvokeCommand", () => {
   });
 
   it("throws on a payload that is not valid JSON", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
-    await createGreeter(simLambda, () => null);
+    // Given a function.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
 
+    // When it is invoked with a payload that is not JSON.
     const error = await assertThrowsErrorAsync(async () =>
       simLambda.invoke(
         new InvokeCommand({ FunctionName: "greeter", Payload: "{not json" }),
       ),
     );
 
+    // Then the request content is rejected.
     assertInstanceOf(error, SimLambdaInvalidRequestContentException);
     assertIdentical(error.$metadata.httpStatusCode, 400);
   });
 
   it("throws on an unsupported payload input type", async () => {
-    const simAws = new SimAws();
-    const simLambda = simAws.lambda();
-    await createGreeter(simLambda, () => null);
+    // Given a function.
+    const simLambda = new SimAws().lambda();
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
 
+    // When it is invoked with a payload of a type the SDK does not send.
     const error = await assertThrowsErrorAsync(async () =>
       simLambda.invoke(
         new InvokeCommand({
@@ -178,17 +240,21 @@ describe("Lambda InvokeCommand", () => {
       ),
     );
 
+    // Then the unsupported type is reported.
     assertInstanceOf(error, SimLambdaError);
     assertStringIncludes(error.message, "string and Uint8Array");
   });
 
   it("throws on a function that does not exist", async () => {
+    // Given a simulated AWS with no functions.
     const simAws = new SimAws();
 
+    // When a missing function is invoked.
     const error = await assertThrowsErrorAsync(async () =>
       simAws.lambda().invoke(new InvokeCommand({ FunctionName: "missing" })),
     );
 
+    // Then the missing function is named in the failure.
     assertInstanceOf(error, SimLambdaResourceNotFoundException);
     assertStringIncludes(
       error.message,
@@ -199,12 +265,15 @@ describe("Lambda InvokeCommand", () => {
   });
 
   it("throws on undefined function name", async () => {
+    // Given a simulated AWS with no functions.
     const simAws = new SimAws();
 
+    // When an invocation names no function.
     const error = await assertThrowsErrorAsync(async () =>
       simAws.lambda().invoke(new InvokeCommand({ FunctionName: undefined })),
     );
 
+    // Then the missing input is reported.
     assertStringIncludes(
       error.message,
       "InvokeCommand.input.FunctionName required",

--- a/src/service/lambda/command/list-function-url-configs/list-function-url-configs.iso.test.ts
+++ b/src/service/lambda/command/list-function-url-configs/list-function-url-configs.iso.test.ts
@@ -19,21 +19,17 @@ import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
-async function createGreeter(simLambda: SimLambda): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-}
-
 describe("Lambda ListFunctionUrlConfigsCommand", () => {
   it("lists the Function URL a function has", async () => {
     // Given a function with a Function URL.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     const created = await simLambda.createFunctionUrlConfig(
       new CreateFunctionUrlConfigCommand({
         FunctionName: "greeter",
@@ -56,7 +52,13 @@ describe("Lambda ListFunctionUrlConfigsCommand", () => {
   it("lists nothing for a function without a Function URL", async () => {
     // Given a function without a Function URL.
     const simLambda = new SimLambda();
-    await createGreeter(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When its Function URL configs are listed.
     const output = await simLambda.listFunctionUrlConfigs(

--- a/src/service/lambda/command/permission/sim-lambda-permissions.iso.test.ts
+++ b/src/service/lambda/command/permission/sim-lambda-permissions.iso.test.ts
@@ -10,28 +10,20 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { SimLambdaResourceConflictException } from "../../error/sim-lambda.error.js";
 import { SimLambdaResourceNotFoundException } from "../../error/sim-lambda.error.js";
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
-import type { SimLambda } from "../../sim-lambda.js";
 
 const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:greeter";
-
-async function serveGreeter(): Promise<SimLambda> {
-  const simAws = new SimAws();
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::888888888888:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-
-  return simAws.lambda();
-}
 
 describe("Simulated Lambda function resource policies", () => {
   it("grants a permission and reports it back as a policy document", async () => {
     // Given a function with nothing granted on it
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When another Account is granted permission to invoke its Function URL
     const added = await lambda.addPermission(
@@ -70,7 +62,14 @@ describe("Simulated Lambda function resource policies", () => {
 
   it("expands each principal shorthand AddPermission accepts", async () => {
     // Given a function granted permissions naming a principal three ways
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     const grant = async (
       statementId: string,
       principal: string,
@@ -106,7 +105,14 @@ describe("Simulated Lambda function resource policies", () => {
 
   it("refuses a statement id already in use", async () => {
     // Given a function with a permission already granted
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     const command = new AddPermissionCommand({
       FunctionName: "greeter",
       StatementId: "AllowInvoke",
@@ -124,7 +130,14 @@ describe("Simulated Lambda function resource policies", () => {
 
   it("removes a permission by its statement id", async () => {
     // Given a function with one permission granted
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     await lambda.addPermission(
       new AddPermissionCommand({
         FunctionName: "greeter",
@@ -151,7 +164,14 @@ describe("Simulated Lambda function resource policies", () => {
 
   it("errors when removing a statement that was never granted", async () => {
     // Given a function with no permissions
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
 
     // When an unknown statement id is removed
     // Then it is reported as not found, as AWS does
@@ -167,7 +187,14 @@ describe("Simulated Lambda function resource policies", () => {
 
   it("changes the policy revision with every grant and revocation", async () => {
     // Given a function with one permission granted
-    const lambda = await serveGreeter();
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::888888888888:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
     const grant = (statementId: string): Promise<unknown> =>
       lambda.addPermission(
         new AddPermissionCommand({

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.iso.test.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.iso.test.ts
@@ -20,30 +20,25 @@ import {
 import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
 import { SimLambda } from "../../sim-lambda.js";
 
-async function createGreeterWithUrl(simLambda: SimLambda): Promise<string> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
-    }),
-  );
-
-  const created = await simLambda.createFunctionUrlConfig(
-    new CreateFunctionUrlConfigCommand({
-      FunctionName: "greeter",
-      AuthType: "NONE",
-    }),
-  );
-
-  return created.FunctionUrl;
-}
-
 describe("Lambda UpdateFunctionUrlConfigCommand", () => {
   it("updates the auth type without changing the URL", async () => {
     // Given a function with a public Function URL.
     const simLambda = new SimLambda();
-    const functionUrl = await createGreeterWithUrl(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const created = await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
 
     // When the auth type is updated.
     const output = await simLambda.updateFunctionUrlConfig(
@@ -55,16 +50,25 @@ describe("Lambda UpdateFunctionUrlConfigCommand", () => {
 
     // Then the new auth type applies to the same URL.
     assertIdentical(output.AuthType, "AWS_IAM");
-    assertIdentical(output.FunctionUrl, functionUrl);
+    assertIdentical(output.FunctionUrl, created.FunctionUrl);
   });
 
   it("leaves omitted values as they are", async () => {
     // Given a Function URL with a non-default invoke mode.
     const simLambda = new SimLambda();
-    await createGreeterWithUrl(simLambda);
-    await simLambda.updateFunctionUrlConfig(
-      new UpdateFunctionUrlConfigCommand({
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
         FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a Function URL for it with a non-default invoke mode.
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
         InvokeMode: "RESPONSE_STREAM",
       }),
     );
@@ -130,7 +134,21 @@ describe("Lambda UpdateFunctionUrlConfigCommand", () => {
   it("throws on an unknown auth type", async () => {
     // Given a function with a Function URL.
     const simLambda = new SimLambda();
-    await createGreeterWithUrl(simLambda);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a Function URL for it.
+    await simLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
 
     // When it is updated to an auth type AWS does not have.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code-errors.iso.test.ts
@@ -6,54 +6,17 @@ import {
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
-import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
-import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+import { simLambdaVmZipFunctionFactory } from "./sim-lambda-vm-zip-function.factory.js";
 import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
-import { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
-import { SimLambdaFunction } from "../sim-lambda-function.js";
-import {
-  type LambdaCodeZipFiles,
-  makeLambdaCodeZip,
-} from "./make-lambda-code-zip.js";
-import {
-  parseLambdaHandlerName,
-  SimLambdaVmZipCode,
-} from "./sim-lambda-vm-zip-code.js";
-
-const accountRegionScope = {
-  accountId: "111111111111" as SimAwsAccountId,
-  regionName: "eu-west-2" as AwsRegionName,
-};
-
-function makeVmFunction(
-  code: string | LambdaCodeZipFiles,
-  handlerName = "index.handler",
-): SimLambdaFunction {
-  const archive = SimZipArchive.fromBytes(makeLambdaCodeZip(code));
-  return new SimLambdaFunction({
-    name: "vm-error-test",
-    roleArn: "arn:aws:iam::111111111111:role/VmErrorRole",
-    accountRegionScope,
-    code: new SimLambdaVmZipCode({
-      archive,
-      handlerName,
-      environment: new SimLambdaEnvironment({
-        functionName: "vm-error-test",
-        regionName: "eu-west-2",
-        memorySizeMb: 128,
-      }),
-    }),
-  });
-}
+import { parseLambdaHandlerName } from "./sim-lambda-vm-zip-code.js";
 
 describe("sim Lambda vm zip code runtime errors", () => {
   it("reports a missing handler module as Runtime.ImportModuleError", async () => {
     // Given an archive without the module the handler name references.
-    const simFunction = makeVmFunction(
-      { "other.js": "exports.handler = async () => null;" },
-      "index.handler",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: { "other.js": "exports.handler = async () => null;" },
+      handlerName: "index.handler",
+    });
 
     // When the function is invoked, the cold start fails.
     const error = await assertThrowsErrorAsync(async () =>
@@ -68,10 +31,10 @@ describe("sim Lambda vm zip code runtime errors", () => {
   });
 
   it("reports an ES module handler file as unsupported", async () => {
-    const simFunction = makeVmFunction(
-      { "index.mjs": "export const handler = async () => null;" },
-      "index.handler",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: { "index.mjs": "export const handler = async () => null;" },
+      handlerName: "index.handler",
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -88,7 +51,13 @@ describe("sim Lambda vm zip code runtime errors", () => {
 
     const [nullExportError, undefinedExportError] = await Promise.all(
       sources.map(async (source) =>
-        assertThrowsErrorAsync(async () => makeVmFunction(source).invoke({})),
+        assertThrowsErrorAsync(async () =>
+          simLambdaVmZipFunctionFactory
+            .make({
+              code: source,
+            })
+            .invoke({}),
+        ),
       ),
     );
 
@@ -101,8 +70,9 @@ describe("sim Lambda vm zip code runtime errors", () => {
   it("re-attempts a failed module require, as Node.js does", async () => {
     // Given a module that fails at import time and code that catches the
     // require error and retries.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const attempts = [];
         for (let attempt = 0; attempt < 2; attempt += 1) {
           try {
@@ -114,7 +84,8 @@ describe("sim Lambda vm zip code runtime errors", () => {
         }
         exports.handler = async () => attempts.join(",");
       `,
-      "broken.js": "throw new Error('broken module');",
+        "broken.js": "throw new Error('broken module');",
+      },
     });
 
     // When the function is invoked.
@@ -126,9 +97,9 @@ describe("sim Lambda vm zip code runtime errors", () => {
   });
 
   it("reports a missing export as Runtime.HandlerNotFound", async () => {
-    const simFunction = makeVmFunction(
-      "exports.somethingElse = async () => null;",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "exports.somethingElse = async () => null;",
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -142,10 +113,10 @@ describe("sim Lambda vm zip code runtime errors", () => {
   it("reports an inherited property as Runtime.HandlerNotFound", async () => {
     // Given a module that does not export the named handler, where that name
     // happens to exist on Object.prototype.
-    const simFunction = makeVmFunction(
-      "exports.somethingElse = async () => null;",
-      "index.constructor",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "exports.somethingElse = async () => null;",
+      handlerName: "index.constructor",
+    });
 
     // When the function is invoked.
     const error = await assertThrowsErrorAsync(async () =>
@@ -159,7 +130,9 @@ describe("sim Lambda vm zip code runtime errors", () => {
   });
 
   it("reports invalid source as Runtime.UserCodeSyntaxError", async () => {
-    const simFunction = makeVmFunction("exports.handler = async ((( => null;");
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "exports.handler = async ((( => null;",
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -171,9 +144,9 @@ describe("sim Lambda vm zip code runtime errors", () => {
   });
 
   it("hints that ES module syntax needs CommonJS instead", async () => {
-    const simFunction = makeVmFunction(
-      "export const handler = async () => null;",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "export const handler = async () => null;",
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -185,9 +158,11 @@ describe("sim Lambda vm zip code runtime errors", () => {
   });
 
   it("reports a module top-level failure as Runtime.ImportModuleError", async () => {
-    const simFunction = makeVmFunction(`
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
       throw new Error("boom at init");
-    `);
+    `,
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -201,10 +176,12 @@ describe("sim Lambda vm zip code runtime errors", () => {
   it("reports an unbundled dependency as Runtime.ImportModuleError", async () => {
     // Given code requiring a dependency that is not in the archive; on real
     // Lambda dependencies must be bundled into the deployment package.
-    const simFunction = makeVmFunction(`
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
       const missing = require("not-bundled");
       exports.handler = async () => missing;
-    `);
+    `,
+    });
 
     const error = await assertThrowsErrorAsync(async () =>
       simFunction.invoke({}),
@@ -217,13 +194,15 @@ describe("sim Lambda vm zip code runtime errors", () => {
 
   it("reports an unreadable bundled package.json as an import error", async () => {
     // Given a bundled dependency whose package.json cannot be parsed.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const broken = require("broken");
         exports.handler = async () => broken;
       `,
-      "node_modules/broken/package.json": "{not json",
-      "node_modules/broken/index.js": "module.exports = 1;",
+        "node_modules/broken/package.json": "{not json",
+        "node_modules/broken/index.js": "module.exports = 1;",
+      },
     });
 
     const error = await assertThrowsErrorAsync(async () =>
@@ -237,12 +216,14 @@ describe("sim Lambda vm zip code runtime errors", () => {
 
   it("reports an unparseable JSON module as an import error", async () => {
     // Given code requiring a JSON module that cannot be parsed.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const config = require("./config.json");
         exports.handler = async () => config;
       `,
-      "config.json": "{not valid json",
+        "config.json": "{not valid json",
+      },
     });
 
     const error = await assertThrowsErrorAsync(async () =>
@@ -256,7 +237,9 @@ describe("sim Lambda vm zip code runtime errors", () => {
 
   it("keeps failing on repeated invocations after a failed cold start", async () => {
     // Given code that fails at import time.
-    const simFunction = makeVmFunction("throw new Error('boom at init');");
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "throw new Error('boom at init');",
+    });
 
     // When the function is invoked twice.
     const first = await assertThrowsErrorAsync(async () =>

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.iso.test.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.iso.test.ts
@@ -1,53 +1,21 @@
 import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
 import { describe, it } from "vitest";
-import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
-import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
-import { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
-import { SimLambdaFunction } from "../sim-lambda-function.js";
-import {
-  type LambdaCodeZipFiles,
-  makeLambdaCodeZip,
-} from "./make-lambda-code-zip.js";
-import { SimLambdaVmZipCode } from "./sim-lambda-vm-zip-code.js";
-
-const accountRegionScope = {
-  accountId: "111111111111" as SimAwsAccountId,
-  regionName: "eu-west-2" as AwsRegionName,
-};
-
-function makeVmFunction(
-  code: string | LambdaCodeZipFiles,
-  handlerName = "index.handler",
-): SimLambdaFunction {
-  const archive = SimZipArchive.fromBytes(makeLambdaCodeZip(code));
-  return new SimLambdaFunction({
-    name: "vm-test",
-    roleArn: "arn:aws:iam::111111111111:role/VmRole",
-    accountRegionScope,
-    code: new SimLambdaVmZipCode({
-      archive,
-      handlerName,
-      environment: new SimLambdaEnvironment({
-        functionName: "vm-test",
-        regionName: "eu-west-2",
-        memorySizeMb: 256,
-      }),
-    }),
-  });
-}
+import { simLambdaVmZipFunctionFactory } from "./sim-lambda-vm-zip-function.factory.js";
 
 describe("sim Lambda vm zip code", () => {
   it("runs a source string handler with the event, context and env", async () => {
     // Given zipped source using the event, context, and runtime env vars.
-    const simFunction = makeVmFunction(`
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
       exports.handler = async (event, context) => ({
         greeted: event.name,
         functionName: context.functionName,
         region: process.env.AWS_REGION,
         memory: process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE,
       });
-    `);
+    `,
+      memorySizeMb: 256,
+    });
 
     // When the function is invoked.
     const result = await simFunction.invoke({ name: "Yulin" });
@@ -63,9 +31,9 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("runs a synchronous vm handler", async () => {
-    const simFunction = makeVmFunction(
-      "exports.handler = (event) => event.value * 2;",
-    );
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: "exports.handler = (event) => event.value * 2;",
+    });
 
     const result = await simFunction.invoke({ value: 21 });
 
@@ -74,13 +42,15 @@ describe("sim Lambda vm zip code", () => {
 
   it("keeps module state warm across invocations", async () => {
     // Given module code with top-level state.
-    const simFunction = makeVmFunction(`
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
       let invocations = 0;
       exports.handler = async () => {
         invocations += 1;
         return invocations;
       };
-    `);
+    `,
+    });
 
     // When the function is invoked repeatedly.
     const first = await simFunction.invoke({});
@@ -92,12 +62,14 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("supports relative requires between archived modules", async () => {
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const { greet } = require("./lib/greeting.js");
         exports.handler = async (event) => greet(event.name);
       `,
-      "lib/greeting.js": "exports.greet = (name) => 'Hi ' + name;",
+        "lib/greeting.js": "exports.greet = (name) => 'Hi ' + name;",
+      },
     });
 
     const result = await simFunction.invoke({ name: "relative" });
@@ -107,11 +79,13 @@ describe("sim Lambda vm zip code", () => {
 
   it("supports requiring Node.js built-in modules", async () => {
     // Given code using a built-in, which the real runtime provides.
-    const simFunction = makeVmFunction(`
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: `
       const crypto = require("node:crypto");
       exports.handler = async (event) =>
         crypto.createHash("sha256").update(event.text).digest("hex");
-    `);
+    `,
+    });
 
     const result = await simFunction.invoke({ text: "hello" });
 
@@ -124,14 +98,16 @@ describe("sim Lambda vm zip code", () => {
   it("supports node_modules bundled in the archive", async () => {
     // Given a dependency with a package.json main, as SAM-style packaging
     // bundles.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const decorate = require("decorate");
         exports.handler = async (event) => decorate(event.text);
       `,
-      "node_modules/decorate/package.json": '{"main":"lib/main.js"}',
-      "node_modules/decorate/lib/main.js":
-        "module.exports = (text) => '** ' + text + ' **';",
+        "node_modules/decorate/package.json": '{"main":"lib/main.js"}',
+        "node_modules/decorate/lib/main.js":
+          "module.exports = (text) => '** ' + text + ' **';",
+      },
     });
 
     const result = await simFunction.invoke({ text: "packaged" });
@@ -140,12 +116,14 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("supports node_modules without a package.json main", async () => {
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const plain = require("plain");
         exports.handler = async () => plain;
       `,
-      "node_modules/plain/index.js": "module.exports = 'no package.json';",
+        "node_modules/plain/index.js": "module.exports = 'no package.json';",
+      },
     });
 
     const result = await simFunction.invoke({});
@@ -155,17 +133,19 @@ describe("sim Lambda vm zip code", () => {
 
   it("loads a module required from several places only once", async () => {
     // Given two modules both requiring a shared module with side effects.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const first = require("./first.js");
         const second = require("./second.js");
         exports.handler = async () => first.loads + second.loads;
       `,
-      "first.js": "exports.loads = require('./shared.js').loads;",
-      "second.js": "exports.loads = require('./shared.js').loads;",
-      "shared.js": `
+        "first.js": "exports.loads = require('./shared.js').loads;",
+        "second.js": "exports.loads = require('./shared.js').loads;",
+        "shared.js": `
         exports.loads = (globalThis.sharedLoads = (globalThis.sharedLoads ?? 0) + 1);
       `,
+      },
     });
 
     // When the function is invoked.
@@ -176,13 +156,15 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("falls back to index.js for a package.json without a main", async () => {
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const mainless = require("mainless");
         exports.handler = async () => mainless;
       `,
-      "node_modules/mainless/package.json": "{}",
-      "node_modules/mainless/index.js": "module.exports = 'main fallback';",
+        "node_modules/mainless/package.json": "{}",
+        "node_modules/mainless/index.js": "module.exports = 'main fallback';",
+      },
     });
 
     const result = await simFunction.invoke({});
@@ -192,12 +174,14 @@ describe("sim Lambda vm zip code", () => {
 
   it("supports requiring JSON modules", async () => {
     // Given code requiring a bundled JSON file, as Node.js CommonJS allows.
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const config = require("./config.json");
         exports.handler = async () => config.greeting;
       `,
-      "config.json": '{"greeting":"hello from json"}',
+        "config.json": '{"greeting":"hello from json"}',
+      },
     });
 
     const result = await simFunction.invoke({});
@@ -206,12 +190,14 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("resolves an extensionless require to a JSON module", async () => {
-    const simFunction = makeVmFunction({
-      "index.js": `
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
+        "index.js": `
         const config = require("./config");
         exports.handler = async () => config.greeting;
       `,
-      "config.json": '{"greeting":"extensionless json"}',
+        "config.json": '{"greeting":"extensionless json"}',
+      },
     });
 
     const result = await simFunction.invoke({});
@@ -220,12 +206,12 @@ describe("sim Lambda vm zip code", () => {
   });
 
   it("supports a nested handler module path", async () => {
-    const simFunction = makeVmFunction(
-      {
+    const simFunction = simLambdaVmZipFunctionFactory.make({
+      code: {
         "src/app.js": "exports.run = async () => 'nested';",
       },
-      "src/app.run",
-    );
+      handlerName: "src/app.run",
+    });
 
     const result = await simFunction.invoke({});
 

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-function.factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-function.factory.ts
@@ -1,0 +1,73 @@
+import { MappedFactory } from "@kensio/part-factory";
+import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { simLambdaEnvironmentFactory } from "../environment/sim-lambda-environment.factory.js";
+import { SimLambdaFunction } from "../sim-lambda-function.js";
+import {
+  type LambdaCodeZipFiles,
+  makeLambdaCodeZip,
+} from "./make-lambda-code-zip.js";
+import { SimLambdaVmZipCode } from "./sim-lambda-vm-zip-code.js";
+
+/**
+ * What a test asks for when it wants a function backed by zip code running in
+ * a vm sandbox.
+ *
+ * The code is either source for a single index.js module or a map of archive
+ * paths, as `makeLambdaCodeZip` accepts.
+ */
+export interface SimLambdaVmZipFunctionInput {
+  readonly name: string;
+  readonly roleArn: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly code: string | LambdaCodeZipFiles;
+  readonly handlerName: string;
+  readonly memorySizeMb: number;
+}
+
+/**
+ * Builds a simulated Lambda function whose code is a real zip archive run in a
+ * vm sandbox, without a simulated Lambda service to hold it.
+ *
+ * ```typescript
+ * const simFunction = simLambdaVmZipFunctionFactory.make({
+ *   code: "exports.handler = async () => null;",
+ * });
+ * ```
+ */
+export const simLambdaVmZipFunctionFactory = new MappedFactory<
+  SimLambdaVmZipFunctionInput,
+  SimLambdaFunction
+>(
+  () => ({
+    name: "vm-test",
+    roleArn: "arn:aws:iam::111111111111:role/VmRole",
+    accountRegionScope: {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    },
+    code: "exports.handler = async () => null;",
+    handlerName: "index.handler",
+    memorySizeMb: 128,
+  }),
+  (input) => {
+    const archive = SimZipArchive.fromBytes(makeLambdaCodeZip(input.code));
+    const environment = simLambdaEnvironmentFactory.make({
+      functionName: input.name,
+      regionName: input.accountRegionScope.regionName,
+      memorySizeMb: input.memorySizeMb,
+    });
+
+    return new SimLambdaFunction({
+      name: input.name,
+      roleArn: input.roleArn,
+      accountRegionScope: input.accountRegionScope,
+      code: new SimLambdaVmZipCode({
+        archive,
+        handlerName: input.handlerName,
+        environment,
+      }),
+    });
+  },
+);

--- a/src/service/lambda/function/code/store/sim-s3-lambda-code-store.iso.test.ts
+++ b/src/service/lambda/function/code/store/sim-s3-lambda-code-store.iso.test.ts
@@ -1,4 +1,3 @@
-import type { Readable } from "node:stream";
 import {
   assertIdentical,
   assertInstanceOf,
@@ -11,22 +10,14 @@ import {
   SimS3LambdaCodeStore,
 } from "./sim-s3-lambda-code-store.js";
 
-function makeStore(getObject: () => Promise<{ Body?: Readable }>): {
-  store: SimS3LambdaCodeStore;
-} {
-  const s3: SimLambdaCodeObjectSource = {
-    getObject: async () => await getObject(),
-  };
-  return { store: new SimS3LambdaCodeStore({ s3 }) };
-}
-
 describe("sim S3 Lambda code store", () => {
   it("wraps a non-Error S3 failure in an Error", async () => {
     // Given an object source failing with a non-Error value.
-    const { store } = makeStore(() =>
+    const s3: SimLambdaCodeObjectSource = {
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-      Promise.reject("catastrophic string failure"),
-    );
+      getObject: () => Promise.reject("catastrophic string failure"),
+    };
+    const store = new SimS3LambdaCodeStore({ s3 });
 
     // When the code zip fetch fails.
     const error = await assertThrowsErrorAsync(async () =>
@@ -40,7 +31,10 @@ describe("sim S3 Lambda code store", () => {
 
   it("requires the fetched S3 object to have a body", async () => {
     // Given an object source returning an object with no body stream.
-    const { store } = makeStore(() => Promise.resolve({}));
+    const s3: SimLambdaCodeObjectSource = {
+      getObject: () => Promise.resolve({}),
+    };
+    const store = new SimS3LambdaCodeStore({ s3 });
 
     // When the code zip fetch completes without a body.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-clock.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-clock.iso.test.ts
@@ -17,32 +17,16 @@ const instant = new Date("2026-01-01T00:00:00.000Z");
 const hostDate = Date;
 
 /**
- * A simulation stopped at a known instant, with a zip code function that
- * reports the time JavaScript gives it.
+ * Zip code reporting the time JavaScript gives it, every way of asking.
  */
-async function makeStamperSimulation(): Promise<SimAws> {
-  const simAws = new SimAws({ clock: new SimFixedClock(instant) });
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "stamper",
-      Role: "arn:aws:iam::111111111111:role/StamperRole",
-      Handler: "index.handler",
-      Code: {
-        ZipFile: makeLambdaCodeZip(`
-          exports.handler = async () => ({
-            built: new Date().toISOString(),
-            read: Date.now(),
-            stated: new Date("2020-03-12T19:03:58.000Z").toISOString(),
-            isADate: new Date() instanceof Date,
-          });
-        `),
-      },
-    }),
-  );
-
-  return simAws;
-}
+const stamperSource = `
+  exports.handler = async () => ({
+    built: new Date().toISOString(),
+    read: Date.now(),
+    stated: new Date("2020-03-12T19:03:58.000Z").toISOString(),
+    isADate: new Date() instanceof Date,
+  });
+`;
 
 async function invokeStamper(simAws: SimAws): Promise<Record<string, unknown>> {
   const output = await simAws
@@ -60,7 +44,15 @@ async function invokeStamper(simAws: SimAws): Promise<Record<string, unknown>> {
 describe("sim Lambda vm code clock", () => {
   it("gives zip function code the simulation's time", async () => {
     // Given a simulation stopped at a known instant.
-    const simAws = await makeStamperSimulation();
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: "arn:aws:iam::111111111111:role/StamperRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(stamperSource) },
+      }),
+    );
 
     // When function code in the vm sandbox asks JavaScript for the time.
     const stamped = await invokeStamper(simAws);
@@ -72,7 +64,15 @@ describe("sim Lambda vm code clock", () => {
 
   it("leaves the rest of Date alone in the sandbox", async () => {
     // Given a simulation stopped at a known instant.
-    const simAws = await makeStamperSimulation();
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: "arn:aws:iam::111111111111:role/StamperRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(stamperSource) },
+      }),
+    );
 
     // When function code builds a date from an instant it states itself.
     const stamped = await invokeStamper(simAws);
@@ -85,7 +85,15 @@ describe("sim Lambda vm code clock", () => {
 
   it("moves with the simulation's clock between invocations", async () => {
     // Given a function that has already reported the time once.
-    const simAws = await makeStamperSimulation();
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: "arn:aws:iam::111111111111:role/StamperRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(stamperSource) },
+      }),
+    );
     const before = await invokeStamper(simAws);
 
     // When the simulation's clock is advanced.
@@ -100,7 +108,15 @@ describe("sim Lambda vm code clock", () => {
 
   it("leaves the host process's own Date alone", async () => {
     // Given a simulation whose function code has run.
-    const simAws = await makeStamperSimulation();
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: "arn:aws:iam::111111111111:role/StamperRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(stamperSource) },
+      }),
+    );
     await invokeStamper(simAws);
 
     // When the host process reads its own Date.

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-bridge.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-bridge.iso.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
 import { makeLambdaCodeZip } from "../make-lambda-code-zip.js";
 import { SimLambda } from "../../../sim-lambda.js";
 
@@ -25,65 +26,6 @@ exports.handler = async (event) => {
 };
 `;
 
-async function createExecutionRole(
-  simAws: SimAws,
-  roleName: string,
-): Promise<string> {
-  const roleCreation = await simAws.iam().createRole(
-    new CreateRoleCommand({
-      RoleName: roleName,
-      AssumeRolePolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: { Service: "lambda.amazonaws.com" },
-          Action: "sts:AssumeRole",
-        },
-      }),
-    }),
-  );
-  return roleCreation.Role.Arn;
-}
-
-async function allowGetObject(
-  simAws: SimAws,
-  roleName: string,
-  bucketName: string,
-): Promise<void> {
-  await simAws.iam().putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: roleName,
-      PolicyName: "ReadCodeObject",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: "s3:GetObject",
-          Resource: `arn:aws:s3:::${bucketName}/*`,
-        },
-      }),
-    }),
-  );
-}
-
-async function putObject(
-  simAws: SimAws,
-  bucketName: string,
-  objectKey: string,
-  content: string,
-): Promise<void> {
-  await simAws
-    .s3()
-    .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
-  await simAws.s3().putObject(
-    new PutObjectCommand({
-      Bucket: bucketName,
-      Key: objectKey,
-      Body: content,
-    }),
-  );
-}
-
 function parsePayload(payload: Uint8Array | undefined): unknown {
   assertNonNullable(payload);
   return JSON.parse(Buffer.from(payload).toString()) as unknown;
@@ -91,18 +33,50 @@ function parsePayload(payload: Uint8Array | undefined): unknown {
 
 describe("Lambda vm runtime AWS SDK bridge", () => {
   it("lets vm function code read sim S3 with the provided SDK", async () => {
-    // Given a sim S3 object and an execution role allowed to read it.
+    // Given a sim S3 object.
     const simAws = new SimAws();
-    await putObject(simAws, "data-bucket", "greeting.txt", "Hello from S3");
-    const roleArn = await createExecutionRole(simAws, "ReaderRole");
-    await allowGetObject(simAws, "ReaderRole", "data-bucket");
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "data-bucket" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "data-bucket",
+        Key: "greeting.txt",
+        Body: "Hello from S3",
+      }),
+    );
+
+    // And an execution role allowed to read it.
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "ReaderRole",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ReaderRole",
+        PolicyName: "ReadCodeObject",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::data-bucket/*",
+          },
+        }),
+      }),
+    );
 
     // And a function whose zip code uses the runtime-provided AWS SDK.
     const simLambda = simAws.lambda();
     await simLambda.createFunction(
       new CreateFunctionCommand({
         FunctionName: "reader",
-        Role: roleArn,
+        Role: roleCreation.Role.Arn,
         Handler: "index.handler",
         Code: { ZipFile: makeLambdaCodeZip(readObjectHandlerSource) },
       }),
@@ -134,16 +108,37 @@ describe("Lambda vm runtime AWS SDK bridge", () => {
   });
 
   it("denies vm SDK calls the execution role has no permission for", async () => {
-    // Given a sim S3 object and an execution role with no S3 permissions.
+    // Given a sim S3 object.
     const simAws = new SimAws();
-    await putObject(simAws, "data-bucket", "greeting.txt", "Hello from S3");
-    const roleArn = await createExecutionRole(simAws, "NoReadRole");
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "data-bucket" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "data-bucket",
+        Key: "greeting.txt",
+        Body: "Hello from S3",
+      }),
+    );
+
+    // And an execution role with no S3 permissions.
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoReadRole",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
 
     const simLambda = simAws.lambda();
     await simLambda.createFunction(
       new CreateFunctionCommand({
         FunctionName: "denied-reader",
-        Role: roleArn,
+        Role: roleCreation.Role.Arn,
         Handler: "index.handler",
         Code: { ZipFile: makeLambdaCodeZip(readObjectHandlerSource) },
       }),

--- a/src/service/lambda/function/environment/sim-lambda-environment-conflicts.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment-conflicts.iso.test.ts
@@ -4,19 +4,7 @@
 import { assertArrayLength, assertStringIncludes } from "@kensio/smartass";
 import { describe, it, vi } from "vitest";
 import { SimLambdaEnvironmentConflicts } from "./sim-lambda-environment-conflicts.js";
-import { SimLambdaEnvironment } from "./sim-lambda-environment.js";
-
-function makeEnvironment(
-  functionName: string,
-  declaredVariables: Record<string, string>,
-): SimLambdaEnvironment {
-  return new SimLambdaEnvironment({
-    functionName,
-    regionName: "eu-west-2",
-    memorySizeMb: 128,
-    declaredVariables: new Map(Object.entries(declaredVariables)),
-  });
-}
+import { simLambdaEnvironmentFactory } from "./sim-lambda-environment.factory.js";
 
 /**
  * Collect the warnings a check emits, keeping them out of the test output.
@@ -40,8 +28,11 @@ describe("sim Lambda environment conflicts", () => {
     process.env["YULIN_CONFLICT"] = "host value";
 
     try {
-      const environment = makeEnvironment("greeter", {
-        YULIN_CONFLICT: "declared value",
+      const environment = simLambdaEnvironmentFactory.make({
+        functionName: "greeter",
+        declaredVariables: {
+          YULIN_CONFLICT: "declared value",
+        },
       });
 
       // When the new function's environment is checked.
@@ -64,8 +55,11 @@ describe("sim Lambda environment conflicts", () => {
     process.env["YULIN_AGREES"] = "same value";
 
     try {
-      const environment = makeEnvironment("greeter", {
-        YULIN_AGREES: "same value",
+      const environment = simLambdaEnvironmentFactory.make({
+        functionName: "greeter",
+        declaredVariables: {
+          YULIN_AGREES: "same value",
+        },
       });
 
       // When the new function's environment is checked.
@@ -83,8 +77,11 @@ describe("sim Lambda environment conflicts", () => {
 
   it("stays quiet when the host process does not set the name", () => {
     // Given a declared variable the host process knows nothing about.
-    const environment = makeEnvironment("greeter", {
-      YULIN_UNSET_ON_HOST: "declared value",
+    const environment = simLambdaEnvironmentFactory.make({
+      functionName: "greeter",
+      declaredVariables: {
+        YULIN_UNSET_ON_HOST: "declared value",
+      },
     });
 
     // When the new function's environment is checked.
@@ -98,8 +95,14 @@ describe("sim Lambda environment conflicts", () => {
 
   it("warns when another function declares the name differently", () => {
     // Given an existing function declaring a different value for the name.
-    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
-    const environment = makeEnvironment("writer", { TABLE_NAME: "gadgets" });
+    const existing = simLambdaEnvironmentFactory.make({
+      functionName: "reader",
+      declaredVariables: { TABLE_NAME: "widgets" },
+    });
+    const environment = simLambdaEnvironmentFactory.make({
+      functionName: "writer",
+      declaredVariables: { TABLE_NAME: "gadgets" },
+    });
 
     // When the new function's environment is checked against it.
     const warnings = warningsFrom(() => {
@@ -115,8 +118,14 @@ describe("sim Lambda environment conflicts", () => {
 
   it("stays quiet when functions agree on the value", () => {
     // Given two functions declaring the same value for the same name.
-    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
-    const environment = makeEnvironment("writer", { TABLE_NAME: "widgets" });
+    const existing = simLambdaEnvironmentFactory.make({
+      functionName: "reader",
+      declaredVariables: { TABLE_NAME: "widgets" },
+    });
+    const environment = simLambdaEnvironmentFactory.make({
+      functionName: "writer",
+      declaredVariables: { TABLE_NAME: "widgets" },
+    });
 
     // When the new function's environment is checked against it.
     const warnings = warningsFrom(() => {
@@ -129,8 +138,14 @@ describe("sim Lambda environment conflicts", () => {
 
   it("stays quiet when another function declares nothing in common", () => {
     // Given an existing function declaring an unrelated variable.
-    const existing = makeEnvironment("reader", { QUEUE_URL: "widgets" });
-    const environment = makeEnvironment("writer", { TABLE_NAME: "gadgets" });
+    const existing = simLambdaEnvironmentFactory.make({
+      functionName: "reader",
+      declaredVariables: { QUEUE_URL: "widgets" },
+    });
+    const environment = simLambdaEnvironmentFactory.make({
+      functionName: "writer",
+      declaredVariables: { TABLE_NAME: "gadgets" },
+    });
 
     // When the new function's environment is checked against it.
     const warnings = warningsFrom(() => {
@@ -144,16 +159,27 @@ describe("sim Lambda environment conflicts", () => {
   it("reports each variable name only once", () => {
     // Given a conflict that would be found again by a later function.
     const conflicts = new SimLambdaEnvironmentConflicts();
-    const existing = makeEnvironment("reader", { TABLE_NAME: "widgets" });
+    const existing = simLambdaEnvironmentFactory.make({
+      functionName: "reader",
+      declaredVariables: { TABLE_NAME: "widgets" },
+    });
 
     // When two more functions are checked against it.
     const warnings = warningsFrom(() => {
-      conflicts.check(makeEnvironment("writer", { TABLE_NAME: "gadgets" }), [
-        existing,
-      ]);
-      conflicts.check(makeEnvironment("deleter", { TABLE_NAME: "sprockets" }), [
-        existing,
-      ]);
+      conflicts.check(
+        simLambdaEnvironmentFactory.make({
+          functionName: "writer",
+          declaredVariables: { TABLE_NAME: "gadgets" },
+        }),
+        [existing],
+      );
+      conflicts.check(
+        simLambdaEnvironmentFactory.make({
+          functionName: "deleter",
+          declaredVariables: { TABLE_NAME: "sprockets" },
+        }),
+        [existing],
+      );
     });
 
     // Then the same variable name is only reported the first time.

--- a/src/service/lambda/function/environment/sim-lambda-environment.factory.ts
+++ b/src/service/lambda/function/environment/sim-lambda-environment.factory.ts
@@ -1,0 +1,38 @@
+import { MappedFactory } from "@kensio/part-factory";
+import { SimLambdaEnvironment } from "./sim-lambda-environment.js";
+
+/**
+ * What a test asks for when it wants a function environment.
+ *
+ * The declared variables are a plain object rather than the Map the
+ * environment keeps, because that is how a test writes them and how
+ * Environment.Variables arrives from the SDK.
+ */
+export interface SimLambdaEnvironmentInput {
+  readonly functionName: string;
+  readonly regionName: string;
+  readonly memorySizeMb: number;
+  readonly declaredVariables: Record<string, string>;
+}
+
+/**
+ * Builds the environment one simulated Lambda function runs with.
+ */
+export const simLambdaEnvironmentFactory = new MappedFactory<
+  SimLambdaEnvironmentInput,
+  SimLambdaEnvironment
+>(
+  () => ({
+    functionName: "greeter",
+    regionName: "eu-west-2",
+    memorySizeMb: 128,
+    declaredVariables: {},
+  }),
+  (input) =>
+    new SimLambdaEnvironment({
+      functionName: input.functionName,
+      regionName: input.regionName,
+      memorySizeMb: input.memorySizeMb,
+      declaredVariables: new Map(Object.entries(input.declaredVariables)),
+    }),
+);

--- a/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-function-environment.iso.test.ts
@@ -14,21 +14,7 @@ import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
 import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
 import type { SimLambda } from "../../sim-lambda.js";
 
-async function createFunctionWithEnvironment(
-  simLambda: SimLambda,
-  functionName: string,
-  variables: Record<string, string> | undefined,
-  handlerFunction: SimLambdaHandler,
-): Promise<void> {
-  await simLambda.createFunction(
-    new CreateFunctionCommand({
-      FunctionName: functionName,
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(handlerFunction) },
-      ...(variables !== undefined && { Environment: { Variables: variables } }),
-    }),
-  );
-}
+const greeterRoleArn = "arn:aws:iam::111111111111:role/GreeterRole";
 
 async function invoke(
   simLambda: SimLambda,
@@ -46,13 +32,19 @@ describe("sim Lambda in-process handler environment", () => {
     // Given a function declaring variables, backed by a real handler
     // function running in this process.
     const simLambda = new SimAws().lambda();
-    await createFunctionWithEnvironment(
-      simLambda,
-      "greeter",
-      { GREETING: "Hello", TABLE_NAME: "widgets" },
-      () => ({
-        greeting: process.env["GREETING"],
-        tableName: process.env["TABLE_NAME"],
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            greeting: process.env["GREETING"],
+            tableName: process.env["TABLE_NAME"],
+          })),
+        },
+        Environment: {
+          Variables: { GREETING: "Hello", TABLE_NAME: "widgets" },
+        },
       }),
     );
 
@@ -67,14 +59,18 @@ describe("sim Lambda in-process handler environment", () => {
     // Given a function declaring one variable of its own.
     const simAws = new SimAws();
     const simLambda = simAws.lambda();
-    await createFunctionWithEnvironment(
-      simLambda,
-      "greeter",
-      { TABLE_NAME: "widgets" },
-      () => ({
-        region: process.env["AWS_REGION"],
-        functionName: process.env["AWS_LAMBDA_FUNCTION_NAME"],
-        version: process.env["AWS_LAMBDA_FUNCTION_VERSION"],
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            region: process.env["AWS_REGION"],
+            functionName: process.env["AWS_LAMBDA_FUNCTION_NAME"],
+            version: process.env["AWS_LAMBDA_FUNCTION_VERSION"],
+          })),
+        },
+        Environment: { Variables: { TABLE_NAME: "widgets" } },
       }),
     );
 
@@ -95,11 +91,17 @@ describe("sim Lambda in-process handler environment", () => {
 
     try {
       const simLambda = new SimAws().lambda();
-      await createFunctionWithEnvironment(
-        simLambda,
-        "greeter",
-        { TABLE_NAME: "widgets" },
-        () => ({ hostOnly: process.env["YULIN_TEST_HOST_ONLY"] ?? null }),
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: greeterRoleArn,
+          Code: {
+            ZipFile: makeLambdaZipFileInput(() => ({
+              hostOnly: process.env["YULIN_TEST_HOST_ONLY"] ?? null,
+            })),
+          },
+          Environment: { Variables: { TABLE_NAME: "widgets" } },
+        }),
       );
 
       // When it is invoked.
@@ -119,12 +121,15 @@ describe("sim Lambda in-process handler environment", () => {
 
     try {
       const simLambda = new SimAws().lambda();
-      await createFunctionWithEnvironment(
-        simLambda,
-        "greeter",
-        undefined,
-        () => ({
-          shared: process.env["YULIN_TEST_SHARED"] ?? null,
+      await simLambda.createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "greeter",
+          Role: greeterRoleArn,
+          Code: {
+            ZipFile: makeLambdaZipFileInput(() => ({
+              shared: process.env["YULIN_TEST_SHARED"] ?? null,
+            })),
+          },
         }),
       );
 
@@ -151,17 +156,24 @@ describe("sim Lambda in-process handler environment", () => {
         return { tableName: process.env["TABLE_NAME"] };
       };
 
-    await createFunctionWithEnvironment(
-      simLambda,
-      "reader",
-      { TABLE_NAME: "widgets" },
-      readAfterDelay(6),
+    const slowRead = makeLambdaZipFileInput(readAfterDelay(6));
+    const fastRead = makeLambdaZipFileInput(readAfterDelay(2));
+
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reader",
+        Role: greeterRoleArn,
+        Code: { ZipFile: slowRead },
+        Environment: { Variables: { TABLE_NAME: "widgets" } },
+      }),
     );
-    await createFunctionWithEnvironment(
-      simLambda,
-      "writer",
-      { TABLE_NAME: "gadgets" },
-      readAfterDelay(2),
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "writer",
+        Role: greeterRoleArn,
+        Code: { ZipFile: fastRead },
+        Environment: { Variables: { TABLE_NAME: "gadgets" } },
+      }),
     );
 
     // When both are invoked at once, so their handlers interleave.
@@ -178,14 +190,18 @@ describe("sim Lambda in-process handler environment", () => {
   it("keeps a write by the handler out of the host environment", async () => {
     // Given a handler that writes to process.env, as function code may.
     const simLambda = new SimAws().lambda();
-    await createFunctionWithEnvironment(
-      simLambda,
-      "greeter",
-      { TABLE_NAME: "widgets" },
-      () => {
-        process.env["YULIN_TEST_WRITTEN"] = "written";
-        return { written: process.env["YULIN_TEST_WRITTEN"] };
-      },
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: greeterRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            process.env["YULIN_TEST_WRITTEN"] = "written";
+            return { written: process.env["YULIN_TEST_WRITTEN"] };
+          }),
+        },
+        Environment: { Variables: { TABLE_NAME: "widgets" } },
+      }),
     );
 
     // When it is invoked.

--- a/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
@@ -8,9 +8,10 @@ import { describe, it } from "vitest";
 import { SimFixedClock } from "../../../util/clock/sim-clock.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "./code/lambda-zip-file-input.js";
-import type { SimLambdaHandler } from "./sim-lambda-handler.type.js";
 
 const instant = new Date("2026-01-01T00:00:00.000Z");
+
+const stamperRoleArn = "arn:aws:iam::111111111111:role/StamperRole";
 
 /**
  * Captured before any invocation substitutes the global Date, so a test can
@@ -28,27 +29,6 @@ async function tick(milliseconds: number): Promise<void> {
   });
 }
 
-/**
- * A simulation stopped at a known instant, with a function backed by a real
- * in-process handler.
- */
-async function makeSimulation(
-  handlerFunction: SimLambdaHandler,
-  stoppedAt: Date = instant,
-): Promise<SimAws> {
-  const simAws = new SimAws({ clock: new SimFixedClock(stoppedAt) });
-
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "stamper",
-      Role: "arn:aws:iam::111111111111:role/StamperRole",
-      Code: { ZipFile: makeLambdaZipFileInput(handlerFunction) },
-    }),
-  );
-
-  return simAws;
-}
-
 async function invokeStamper(simAws: SimAws): Promise<unknown> {
   const output = await simAws
     .lambda()
@@ -63,7 +43,16 @@ describe("sim Lambda in-process handler clock", () => {
   it("gives the handler the simulation's time", async () => {
     // Given a simulation stopped at a known instant, with a handler that
     // asks JavaScript for the time rather than asking the simulator.
-    const simAws = await makeSimulation(() => new Date().toISOString());
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => new Date().toISOString()),
+        },
+      }),
+    );
 
     // When it is invoked.
     const stamped = await invokeStamper(simAws);
@@ -74,11 +63,20 @@ describe("sim Lambda in-process handler clock", () => {
 
   it("keeps the simulation's time across an await in the handler", async () => {
     // Given a handler reading the time on both sides of an await.
-    const simAws = await makeSimulation(async () => {
-      const before = Date.now();
-      await Promise.resolve();
-      return { before, after: Date.now() };
-    });
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            const before = Date.now();
+            await Promise.resolve();
+            return { before, after: Date.now() };
+          }),
+        },
+      }),
+    );
 
     // When it is invoked.
     const stamped = (await invokeStamper(simAws)) as Record<string, number>;
@@ -90,7 +88,16 @@ describe("sim Lambda in-process handler clock", () => {
 
   it("moves with the simulation's clock between invocations", async () => {
     // Given a handler that has already stamped the time once.
-    const simAws = await makeSimulation(() => new Date().toISOString());
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => new Date().toISOString()),
+        },
+      }),
+    );
     const before = await invokeStamper(simAws);
 
     // When the simulation's clock is advanced.
@@ -105,15 +112,34 @@ describe("sim Lambda in-process handler clock", () => {
   it("keeps each simulation's time to itself while they interleave", async () => {
     // Given two simulations with clocks stopped at different instants, each
     // with a handler that reads the time on the far side of an await.
+    const first = new SimAws({ clock: new SimFixedClock(instant) });
+    await first.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            await tick(5);
+            return new Date().toISOString();
+          }),
+        },
+      }),
+    );
+
     const laterInstant = new Date("2030-06-01T12:00:00.000Z");
-    const first = await makeSimulation(async () => {
-      await tick(5);
-      return new Date().toISOString();
-    });
-    const second = await makeSimulation(async () => {
-      await tick(1);
-      return new Date().toISOString();
-    }, laterInstant);
+    const second = new SimAws({ clock: new SimFixedClock(laterInstant) });
+    await second.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            await tick(1);
+            return new Date().toISOString();
+          }),
+        },
+      }),
+    );
 
     // When both are invoked at once, so each is suspended at its await while
     // the other runs.
@@ -130,7 +156,16 @@ describe("sim Lambda in-process handler clock", () => {
 
   it("leaves the host clock alone outside an invocation", async () => {
     // Given a simulation whose handler has run, installing the substitute.
-    const simAws = await makeSimulation(() => new Date().toISOString());
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "stamper",
+        Role: stamperRoleArn,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => new Date().toISOString()),
+        },
+      }),
+    );
     await invokeStamper(simAws);
 
     // When the test itself reads the time afterwards.

--- a/src/service/lambda/function/url/sim-lambda-function-url.factory.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url.factory.ts
@@ -1,0 +1,45 @@
+import { MappedFactory } from "@kensio/part-factory";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaFunctionName } from "../sim-lambda-function.js";
+import {
+  makeSimLambdaFunctionUrlId,
+  SimLambdaFunctionUrl,
+} from "./sim-lambda-function-url.js";
+
+/**
+ * What a test asks for when it wants a Function URL record.
+ */
+export interface SimLambdaFunctionUrlInput {
+  readonly functionName: string;
+  readonly functionArn: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Builds a Function URL record on its own, without a simulated Lambda service
+ * to hold it.
+ *
+ * A test that wants a Function URL a simulated Lambda knows about calls
+ * CreateFunctionUrlConfig instead, as an application would.
+ */
+export const simLambdaFunctionUrlFactory = new MappedFactory<
+  SimLambdaFunctionUrlInput,
+  SimLambdaFunctionUrl
+>(
+  () => ({
+    functionName: "greeter",
+    functionArn: "arn:aws:lambda:eu-west-2:111111111111:function:greeter",
+    accountRegionScope: {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    },
+  }),
+  (input) =>
+    new SimLambdaFunctionUrl({
+      urlId: makeSimLambdaFunctionUrlId(),
+      functionName: input.functionName as SimLambdaFunctionName,
+      functionArn: input.functionArn,
+      accountRegionScope: input.accountRegionScope,
+    }),
+);

--- a/src/service/lambda/function/url/sim-lambda-function-url.iso.test.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url.iso.test.ts
@@ -1,32 +1,12 @@
 import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
-import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import type { SimLambdaFunctionName } from "../sim-lambda-function.js";
-import {
-  makeSimLambdaFunctionUrlId,
-  SimLambdaFunctionUrl,
-} from "./sim-lambda-function-url.js";
-
-const accountRegionScope: SimAwsAccountRegionScope = {
-  accountId: "111111111111" as SimAwsAccountId,
-  regionName: "eu-west-2",
-};
-
-function makeFunctionUrl(): SimLambdaFunctionUrl {
-  return new SimLambdaFunctionUrl({
-    urlId: makeSimLambdaFunctionUrlId(),
-    functionName: "greeter" as SimLambdaFunctionName,
-    functionArn: "arn:aws:lambda:eu-west-2:111111111111:function:greeter",
-    accountRegionScope,
-  });
-}
+import { simLambdaFunctionUrlFactory } from "./sim-lambda-function-url.factory.js";
 
 describe("Sim Lambda Function URL", () => {
   it("builds the AWS endpoint URL for its scope", () => {
     // Given a Function URL in eu-west-2.
-    const functionUrl = makeFunctionUrl();
+    const functionUrl = simLambdaFunctionUrlFactory.make();
 
     // When its endpoint is read.
     const url = functionUrl.url;
@@ -41,7 +21,7 @@ describe("Sim Lambda Function URL", () => {
 
   it("defaults to a public buffered endpoint", () => {
     // Given a Function URL created without configuration.
-    const functionUrl = makeFunctionUrl();
+    const functionUrl = simLambdaFunctionUrlFactory.make();
 
     // When its configuration is read.
     const configuration = functionUrl.configuration();
@@ -54,7 +34,7 @@ describe("Sim Lambda Function URL", () => {
 
   it("keeps values that an update omits", () => {
     // Given a Function URL with a non-default invoke mode.
-    const functionUrl = makeFunctionUrl();
+    const functionUrl = simLambdaFunctionUrlFactory.make();
     functionUrl.update({ invokeMode: "RESPONSE_STREAM" });
 
     // When only the auth type is updated.
@@ -67,7 +47,7 @@ describe("Sim Lambda Function URL", () => {
 
   it("keeps its endpoint across updates", () => {
     // Given a Function URL.
-    const functionUrl = makeFunctionUrl();
+    const functionUrl = simLambdaFunctionUrlFactory.make();
     const url = functionUrl.url;
 
     // When it is updated.

--- a/src/service/lambda/serve/sim-lambda-url-cross-account-grant.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-cross-account-grant.iso.test.ts
@@ -2,11 +2,17 @@ import {
   AddPermissionCommand,
   CreateFunctionCommand,
   CreateFunctionUrlConfigCommand,
-  RemovePermissionCommand,
 } from "@aws-sdk/client-lambda";
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateAccessKeyCommand,
+  CreateRoleCommand,
+  CreateUserCommand,
+  PutRolePolicyCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
 import { describe, expect, it } from "vitest";
 
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -20,40 +26,17 @@ const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
 
 const reporterCode = { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) };
 
+const invokeUrlStatement = {
+  Action: "lambda:InvokeFunctionUrl",
+  Resource: "*",
+};
+
 function localUrl(functionUrl: string): string {
   return new SimAwsLocalUrl({ input: functionUrl }).toString();
 }
 
-describe("Cross-account invocation of an AWS_IAM Function URL", () => {
-  it("refuses a principal from another Account that was granted nothing", async () => {
-    // Given a Function URL in one Account with no resource policy
-    const simAws = new SimAws();
-    const ownerLambda = simAws.account(ownerAccountId).lambda();
-    await ownerLambda.createFunction(
-      new CreateFunctionCommand({
-        FunctionName: "reporter",
-        Role: `arn:aws:iam::${ownerAccountId}:role/ReporterRole`,
-        Code: reporterCode,
-      }),
-    );
-    const urlConfig = await ownerLambda.createFunctionUrlConfig(
-      new CreateFunctionUrlConfigCommand({
-        FunctionName: "reporter",
-        AuthType: "AWS_IAM",
-      }),
-    );
-
-    // When a principal from another Account calls it
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(urlConfig.FunctionUrl),
-      { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
-    );
-
-    // Then it is refused: neither Account allows the call
-    expect(response.status).toBe(403);
-  });
-
-  it("invokes for a principal both Accounts allow", async () => {
+describe("What a cross-account grant on a Function URL covers", () => {
+  it("admits a signed cross-account request", async () => {
     // Given a Function URL in one Account
     const simAws = new SimAws();
     const ownerLambda = simAws.account(ownerAccountId).lambda();
@@ -71,51 +54,51 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       }),
     );
 
-    // And the other Account's Role granted permission on the function
+    // And a User in the other Account holding an access key, allowed to invoke
+    // Function URLs by its own Account
+    const callerIam = simAws.account(callerAccountId).iam();
+    await callerIam.createUser(new CreateUserCommand({ UserName: "Caller" }));
+    await callerIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Caller",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: invokeUrlStatement,
+        }),
+      }),
+    );
+    const key = await callerIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Caller" }),
+    );
+
+    // And the function granting that User the URL
     await ownerLambda.addPermission(
       new AddPermissionCommand({
         FunctionName: "reporter",
-        StatementId: "AllowOtherAccount",
+        StatementId: "AllowOtherAccountUser",
         Action: "lambda:InvokeFunctionUrl",
-        Principal: callerRoleArn,
+        Principal: `arn:aws:iam::${callerAccountId}:user/Caller`,
+        FunctionUrlAuthType: "AWS_IAM",
       }),
     );
 
-    // And that Role allowed to invoke Function URLs by its own Account
-    const callerIam = simAws.account(callerAccountId).iam();
-    await callerIam.createRole(
-      new CreateRoleCommand({
-        RoleName: "Caller",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await callerIam.putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "Caller",
-        PolicyName: "InvokeUrl",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
-        }),
-      }),
+    // When they sign a request to the URL
+    const signed = await signAwsRequest({
+      url: localUrl(urlConfig.FunctionUrl),
+      credentials: {
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
+      },
+    });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
     );
 
-    // When that Role calls the URL
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(urlConfig.FunctionUrl),
-      { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
-    );
-
-    // Then it is admitted, which is the only way a cross-account call can be
-    // allowed: an allow from each side
+    // Then the signature identifies them and both Accounts admit them
     expect(response.status).toBe(200);
   });
 
-  it("refuses a principal its own Account does not allow", async () => {
+  it("does not let an Invoke grant open the Function URL", async () => {
     // Given a Function URL in one Account
     const simAws = new SimAws();
     const ownerLambda = simAws.account(ownerAccountId).lambda();
@@ -133,47 +116,8 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       }),
     );
 
-    // And only the function's own grant to the other Account's Role
-    await ownerLambda.addPermission(
-      new AddPermissionCommand({
-        FunctionName: "reporter",
-        StatementId: "AllowOtherAccount",
-        Action: "lambda:InvokeFunctionUrl",
-        Principal: callerRoleArn,
-      }),
-    );
-
-    // When that Role calls the URL
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(urlConfig.FunctionUrl),
-      { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
-    );
-
-    // Then it is refused: a resource policy delegates to the caller's Account
-    // rather than granting on its behalf, and nothing there allows the action
-    expect(response.status).toBe(403);
-  });
-
-  it("refuses a principal the function's Account did not grant", async () => {
-    // Given a Function URL in one Account
-    const simAws = new SimAws();
-    const ownerLambda = simAws.account(ownerAccountId).lambda();
-    await ownerLambda.createFunction(
-      new CreateFunctionCommand({
-        FunctionName: "reporter",
-        Role: `arn:aws:iam::${ownerAccountId}:role/ReporterRole`,
-        Code: reporterCode,
-      }),
-    );
-    const urlConfig = await ownerLambda.createFunctionUrlConfig(
-      new CreateFunctionUrlConfigCommand({
-        FunctionName: "reporter",
-        AuthType: "AWS_IAM",
-      }),
-    );
-
-    // And a Role its own Account allows to invoke any Function URL, with no
-    // grant on the function
+    // And the other Account's Role allowed to invoke Function URLs by its own
+    // Account
     const callerIam = simAws.account(callerAccountId).iam();
     await callerIam.createRole(
       new CreateRoleCommand({
@@ -191,8 +135,18 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
         RoleName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
+          Statement: invokeUrlStatement,
         }),
+      }),
+    );
+
+    // And a grant to it of only the Invoke API action
+    await ownerLambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "reporter",
+        StatementId: "AllowInvoke",
+        Action: "lambda:InvokeFunction",
+        Principal: callerRoleArn,
       }),
     );
 
@@ -202,12 +156,12 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
     );
 
-    // Then it is refused: an Account cannot grant itself access to another
-    // Account's function
+    // Then the grant does not carry across: real AWS keeps the two actions
+    // separate so a policy can grant one without the other
     expect(response.status).toBe(403);
   });
 
-  it("refuses again once the permission is removed", async () => {
+  it("honours a FunctionUrlAuthType condition on the grant", async () => {
     // Given a Function URL in one Account
     const simAws = new SimAws();
     const ownerLambda = simAws.account(ownerAccountId).lambda();
@@ -225,23 +179,19 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
       }),
     );
 
-    // And a granted permission that is then revoked
+    // And a grant conditioned on the URL being public, not IAM-authenticated
     await ownerLambda.addPermission(
       new AddPermissionCommand({
         FunctionName: "reporter",
         StatementId: "AllowOtherAccount",
         Action: "lambda:InvokeFunctionUrl",
         Principal: callerRoleArn,
-      }),
-    );
-    await ownerLambda.removePermission(
-      new RemovePermissionCommand({
-        FunctionName: "reporter",
-        StatementId: "AllowOtherAccount",
+        FunctionUrlAuthType: "NONE",
       }),
     );
 
-    // And the caller's own Account still allowing the action
+    // And the other Account's Role allowed to invoke Function URLs by its own
+    // Account
     const callerIam = simAws.account(callerAccountId).iam();
     await callerIam.createRole(
       new CreateRoleCommand({
@@ -259,18 +209,82 @@ describe("Cross-account invocation of an AWS_IAM Function URL", () => {
         RoleName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
+          Statement: invokeUrlStatement,
         }),
       }),
     );
 
-    // When that Role calls the URL
+    // When the Role calls the AWS_IAM URL
     const response = await new SimAwsHttp({ simAws }).fetch(
       localUrl(urlConfig.FunctionUrl),
       { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
     );
 
-    // Then the grant is gone with the statement
+    // Then the condition does not hold, so the grant does not apply: a
+    // permission for one auth type must not open a URL configured for another
     expect(response.status).toBe(403);
+  });
+
+  it("applies a grant whose FunctionUrlAuthType condition matches", async () => {
+    // Given a Function URL in one Account
+    const simAws = new SimAws();
+    const ownerLambda = simAws.account(ownerAccountId).lambda();
+    await ownerLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${ownerAccountId}:role/ReporterRole`,
+        Code: reporterCode,
+      }),
+    );
+    const urlConfig = await ownerLambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a grant conditioned on the auth type the URL actually has
+    await ownerLambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "reporter",
+        StatementId: "AllowOtherAccount",
+        Action: "lambda:InvokeFunctionUrl",
+        Principal: callerRoleArn,
+        FunctionUrlAuthType: "AWS_IAM",
+      }),
+    );
+
+    // And the other Account's Role allowed to invoke Function URLs by its own
+    // Account
+    const callerIam = simAws.account(callerAccountId).iam();
+    await callerIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Caller",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await callerIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Caller",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: invokeUrlStatement,
+        }),
+      }),
+    );
+
+    // When the Role calls the URL
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(urlConfig.FunctionUrl),
+      { headers: { [simAwsCallerHeaderName]: callerRoleArn } },
+    );
+
+    // Then the condition holds and the grant applies
+    expect(response.status).toBe(200);
   });
 });

--- a/src/service/lambda/serve/sim-lambda-url-cross-account-grant.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-cross-account-grant.iso.test.ts
@@ -26,11 +26,6 @@ const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
 
 const reporterCode = { ZipFile: makeLambdaZipFileInput(() => ({ ok: true })) };
 
-const invokeUrlStatement = {
-  Action: "lambda:InvokeFunctionUrl",
-  Resource: "*",
-};
-
 function localUrl(functionUrl: string): string {
   return new SimAwsLocalUrl({ input: functionUrl }).toString();
 }
@@ -63,7 +58,7 @@ describe("What a cross-account grant on a Function URL covers", () => {
         UserName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: invokeUrlStatement,
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
         }),
       }),
     );
@@ -135,7 +130,7 @@ describe("What a cross-account grant on a Function URL covers", () => {
         RoleName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: invokeUrlStatement,
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
         }),
       }),
     );
@@ -209,7 +204,7 @@ describe("What a cross-account grant on a Function URL covers", () => {
         RoleName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: invokeUrlStatement,
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
         }),
       }),
     );
@@ -273,7 +268,7 @@ describe("What a cross-account grant on a Function URL covers", () => {
         RoleName: "Caller",
         PolicyName: "InvokeUrl",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: invokeUrlStatement,
+          Statement: { Action: "lambda:InvokeFunctionUrl", Resource: "*" },
         }),
       }),
     );

--- a/src/service/lambda/serve/sim-lambda-url-iam-auth-role.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-iam-auth-role.iso.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { assertNonNullable } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
@@ -138,12 +139,18 @@ describe("Invoking an AWS_IAM Lambda Function URL as a Role", () => {
     );
 
     // When the session's temporary credentials sign a request to the URL
+    const credentials = assumed.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
     const signed = await signAwsRequest({
       url: localUrl(urlConfig.FunctionUrl),
       credentials: {
-        accessKeyId: assumed.Credentials?.AccessKeyId ?? "",
-        secretAccessKey: assumed.Credentials?.SecretAccessKey ?? "",
-        sessionToken: assumed.Credentials?.SessionToken ?? "",
+        accessKeyId: credentials.AccessKeyId,
+        secretAccessKey: credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken,
       },
     });
     const response = await new SimAwsHttp({ simAws }).handleRequest(

--- a/src/service/lambda/serve/sim-lambda-url-iam-auth-role.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-iam-auth-role.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { describe, expect, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type {
+  SimLambdaFunctionUrlEvent,
+  SimLambdaFunctionUrlRequestContext,
+} from "./event/sim-lambda-url-event.type.js";
+
+const accountId = "888888888888";
+
+/**
+ * Function code echoing the IAM caller its invocation event describes.
+ */
+const reportCallerCode = {
+  ZipFile: makeLambdaZipFileInput(
+    (event: SimLambdaFunctionUrlEvent) => event.requestContext,
+  ),
+};
+
+function localUrl(functionUrl: string): string {
+  return new SimAwsLocalUrl({ input: functionUrl }).toString();
+}
+
+describe("Invoking an AWS_IAM Lambda Function URL as a Role", () => {
+  it("authorizes a request as the principal its caller header names", async () => {
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    const reporter = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a Role named directly rather than signed for, allowed to invoke
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Reporter",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:InvokeFunctionUrl",
+            Resource: reporter.FunctionArn,
+          },
+        }),
+      }),
+    );
+
+    // When the URL is requested naming that Role
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(urlConfig.FunctionUrl),
+      { headers: { [simAwsCallerHeaderName]: roleCreation.Role.Arn } },
+    );
+
+    // Then the convenience path authorizes exactly as a signature would, so a
+    // curl one-liner can exercise an IAM-protected endpoint
+    expect(response.status).toBe(200);
+  });
+
+  it("authorizes an assumed-role session against the Role behind it", async () => {
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    const reporter = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a Role allowed to invoke it
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Deployer",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Deployer",
+        PolicyName: "InvokeUrl",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:InvokeFunctionUrl",
+            Resource: reporter.FunctionArn,
+          },
+        }),
+      }),
+    );
+
+    // And a session assumed from that Role
+    const assumed = await simAws.sts().assumeRole(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Deployer`,
+        RoleSessionName: "deploy-session",
+      }),
+    );
+
+    // When the session's temporary credentials sign a request to the URL
+    const signed = await signAwsRequest({
+      url: localUrl(urlConfig.FunctionUrl),
+      credentials: {
+        accessKeyId: assumed.Credentials?.AccessKeyId ?? "",
+        secretAccessKey: assumed.Credentials?.SecretAccessKey ?? "",
+        sessionToken: assumed.Credentials?.SessionToken ?? "",
+      },
+    });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then it is allowed: the session ARN owns no policies of its own, so the
+    // permission has to come from the Role it was assumed from
+    expect(response.status).toBe(200);
+    const context =
+      (await response.json()) as SimLambdaFunctionUrlRequestContext;
+    expect(context.authorizer?.iam.userArn).toBe(
+      `arn:aws:sts::${accountId}:assumed-role/Deployer/deploy-session`,
+    );
+  });
+});

--- a/src/service/lambda/serve/sim-lambda-url-iam-auth.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-iam-auth.iso.test.ts
@@ -4,19 +4,15 @@ import {
 } from "@aws-sdk/client-lambda";
 import {
   CreateAccessKeyCommand,
-  CreateRoleCommand,
   CreateUserCommand,
-  PutRolePolicyCommand,
   PutUserPolicyCommand,
 } from "@aws-sdk/client-iam";
-import { AssumeRoleCommand } from "@aws-sdk/client-sts";
 import { describe, expect, it } from "vitest";
 
 import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
-import type { SignAwsRequestCredentials } from "../../../../test/sigv4/sign-aws-request.js";
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
-import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
 import type {
@@ -26,91 +22,65 @@ import type {
 
 const accountId = "888888888888";
 
-interface IamProtectedFunction {
-  readonly simAws: SimAws;
-  readonly url: string;
-  readonly functionArn: string;
-}
-
 /**
- * A function behind an AWS_IAM Function URL, whose handler echoes the IAM
- * caller the invocation event describes.
+ * Function code echoing the IAM caller its invocation event describes.
  */
-async function serveIamFunction(
-  authType: "AWS_IAM" | "NONE" = "AWS_IAM",
-): Promise<IamProtectedFunction> {
-  const simAws = new SimAws();
+const reportCallerCode = {
+  ZipFile: makeLambdaZipFileInput(
+    (event: SimLambdaFunctionUrlEvent) => event.requestContext,
+  ),
+};
 
-  const created = await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "reporter",
-      Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
-      Code: {
-        ZipFile: makeLambdaZipFileInput(
-          (event: SimLambdaFunctionUrlEvent) => event.requestContext,
-        ),
-      },
-    }),
-  );
-
-  const urlConfig = await simAws.lambda().createFunctionUrlConfig(
-    new CreateFunctionUrlConfigCommand({
-      FunctionName: "reporter",
-      AuthType: authType,
-    }),
-  );
-
-  return {
-    simAws,
-    url: new SimAwsLocalUrl({ input: urlConfig.FunctionUrl }).toString(),
-    functionArn: created.FunctionArn,
-  };
+function localUrl(functionUrl: string): string {
+  return new SimAwsLocalUrl({ input: functionUrl }).toString();
 }
 
-/**
- * Give the simulation a User holding an access key, with one inline policy
- * statement, and return credentials that can sign as them.
- */
-async function signingUser(
-  simAws: SimAws,
-  statement: Record<string, unknown>,
-): Promise<SignAwsRequestCredentials> {
-  const iam = simAws.iam();
-
-  await iam.createUser(new CreateUserCommand({ UserName: "Invoker" }));
-  await iam.putUserPolicy(
-    new PutUserPolicyCommand({
-      UserName: "Invoker",
-      PolicyName: "InvokePolicy",
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: statement,
-      }),
-    }),
-  );
-
-  const key = await iam.createAccessKey(
-    new CreateAccessKeyCommand({ UserName: "Invoker" }),
-  );
-
-  return {
-    accessKeyId: key.AccessKey.AccessKeyId,
-    secretAccessKey: key.AccessKey.SecretAccessKey,
-  };
-}
-
-describe("Invoking an AWS_IAM Lambda Function URL", () => {
+describe("Invoking an AWS_IAM Lambda Function URL as a signed caller", () => {
   it("invokes for a signed caller allowed to invoke the Function URL", async () => {
-    // Given a User whose policy allows invoking this function's URL
-    const { simAws, url, functionArn } = await serveIamFunction();
-    const credentials = await signingUser(simAws, {
-      Effect: "Allow",
-      Action: "lambda:InvokeFunctionUrl",
-      Resource: functionArn,
-    });
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    const reporter = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a User whose policy allows invoking this function's URL
+    await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Invoker" }));
+    await simAws.iam().putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Invoker",
+        PolicyName: "InvokePolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:InvokeFunctionUrl",
+            Resource: reporter.FunctionArn,
+          },
+        }),
+      }),
+    );
+    const key = await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Invoker" }));
 
     // When they sign a request to the URL and it is served
-    const signed = await signAwsRequest({ url, credentials });
+    const signed = await signAwsRequest({
+      url: localUrl(urlConfig.FunctionUrl),
+      credentials: {
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
+      },
+    });
     const response = await new SimAwsHttp({ simAws }).handleRequest(
       signed.request,
     );
@@ -121,16 +91,47 @@ describe("Invoking an AWS_IAM Lambda Function URL", () => {
   });
 
   it("refuses a signed caller without the invoke permission", async () => {
-    // Given a User whose policy grants something else entirely
-    const { simAws, url } = await serveIamFunction();
-    const credentials = await signingUser(simAws, {
-      Effect: "Allow",
-      Action: "s3:GetObject",
-      Resource: "*",
-    });
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a User whose policy grants something else entirely
+    await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Invoker" }));
+    await simAws.iam().putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Invoker",
+        PolicyName: "InvokePolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "s3:GetObject", Resource: "*" },
+        }),
+      }),
+    );
+    const key = await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Invoker" }));
 
     // When they sign a request to the URL and it is served
-    const signed = await signAwsRequest({ url, credentials });
+    const signed = await signAwsRequest({
+      url: localUrl(urlConfig.FunctionUrl),
+      credentials: {
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
+      },
+    });
     const response = await new SimAwsHttp({ simAws }).handleRequest(
       signed.request,
     );
@@ -142,16 +143,50 @@ describe("Invoking an AWS_IAM Lambda Function URL", () => {
   });
 
   it("does not accept lambda:InvokeFunction as permission for the URL", async () => {
-    // Given a User allowed the Invoke API action rather than the URL one
-    const { simAws, url, functionArn } = await serveIamFunction();
-    const credentials = await signingUser(simAws, {
-      Effect: "Allow",
-      Action: "lambda:InvokeFunction",
-      Resource: functionArn,
-    });
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    const reporter = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a User allowed the Invoke API action rather than the URL one
+    await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Invoker" }));
+    await simAws.iam().putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Invoker",
+        PolicyName: "InvokePolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:InvokeFunction",
+            Resource: reporter.FunctionArn,
+          },
+        }),
+      }),
+    );
+    const key = await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Invoker" }));
 
     // When they sign a request to the URL and it is served
-    const signed = await signAwsRequest({ url, credentials });
+    const signed = await signAwsRequest({
+      url: localUrl(urlConfig.FunctionUrl),
+      credentials: {
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
+      },
+    });
     const response = await new SimAwsHttp({ simAws }).handleRequest(
       signed.request,
     );
@@ -161,119 +196,49 @@ describe("Invoking an AWS_IAM Lambda Function URL", () => {
     expect(response.status).toBe(403);
   });
 
-  it("authorizes a request as the principal its caller header names", async () => {
-    // Given a Role named directly rather than signed for, allowed to invoke
-    const { simAws, url, functionArn } = await serveIamFunction();
-    const roleArn = `arn:aws:iam::${accountId}:role/Reporter`;
-    await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "Reporter",
-        AssumeRolePolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
-          Statement: {
-            Effect: "Allow",
-            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
+  it("describes the caller of an AWS_IAM invocation in the event", async () => {
+    // Given a function behind an AWS_IAM Function URL
+    const simAws = new SimAws();
+    const reporter = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
       }),
     );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "Reporter",
-        PolicyName: "InvokeUrl",
-        PolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // And a signed, permitted invocation by a User
+    await simAws
+      .iam()
+      .createUser(new CreateUserCommand({ UserName: "Invoker" }));
+    await simAws.iam().putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Invoker",
+        PolicyName: "InvokePolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
           Statement: {
-            Effect: "Allow",
             Action: "lambda:InvokeFunctionUrl",
-            Resource: functionArn,
+            Resource: reporter.FunctionArn,
           },
         }),
       }),
     );
-
-    // When the URL is requested naming that Role
-    const response = await new SimAwsHttp({ simAws }).fetch(url, {
-      headers: { [simAwsCallerHeaderName]: roleArn },
-    });
-
-    // Then the convenience path authorizes exactly as a signature would, so a
-    // curl one-liner can exercise an IAM-protected endpoint
-    expect(response.status).toBe(200);
-  });
-
-  it("authorizes an assumed-role session against the Role behind it", async () => {
-    // Given a Role allowed to invoke, and a session assumed from it
-    const { simAws, url, functionArn } = await serveIamFunction();
-    await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "Deployer",
-        AssumeRolePolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
-          Statement: {
-            Effect: "Allow",
-            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "Deployer",
-        PolicyName: "InvokeUrl",
-        PolicyDocument: JSON.stringify({
-          Version: "2012-10-17",
-          Statement: {
-            Effect: "Allow",
-            Action: "lambda:InvokeFunctionUrl",
-            Resource: functionArn,
-          },
-        }),
-      }),
-    );
-    const assumed = await simAws.sts().assumeRole(
-      new AssumeRoleCommand({
-        RoleArn: `arn:aws:iam::${accountId}:role/Deployer`,
-        RoleSessionName: "deploy-session",
-      }),
-    );
-
-    // When the session's temporary credentials sign a request to the URL
+    const key = await simAws
+      .iam()
+      .createAccessKey(new CreateAccessKeyCommand({ UserName: "Invoker" }));
     const signed = await signAwsRequest({
-      url,
+      url: localUrl(urlConfig.FunctionUrl),
       credentials: {
-        accessKeyId: assumed.Credentials?.AccessKeyId ?? "",
-        secretAccessKey: assumed.Credentials?.SecretAccessKey ?? "",
-        sessionToken: assumed.Credentials?.SessionToken ?? "",
+        accessKeyId: key.AccessKey.AccessKeyId,
+        secretAccessKey: key.AccessKey.SecretAccessKey,
       },
     });
-    const response = await new SimAwsHttp({ simAws }).handleRequest(
-      signed.request,
-    );
-
-    // Then it is allowed: the session ARN owns no policies of its own, so the
-    // permission has to come from the Role it was assumed from
-    expect(response.status).toBe(200);
-    const context =
-      (await response.json()) as SimLambdaFunctionUrlRequestContext;
-    expect(context.authorizer?.iam.userArn).toBe(
-      `arn:aws:sts::${accountId}:assumed-role/Deployer/deploy-session`,
-    );
-  });
-});
-
-describe("The IAM caller in a Function URL invocation event", () => {
-  it("describes the caller of an AWS_IAM invocation", async () => {
-    // Given a signed, permitted invocation of an AWS_IAM Function URL
-    const { simAws, url, functionArn } = await serveIamFunction();
-    const credentials = await signingUser(simAws, {
-      Effect: "Allow",
-      Action: "lambda:InvokeFunctionUrl",
-      Resource: functionArn,
-    });
-    const signed = await signAwsRequest({ url, credentials });
 
     // When the handler reads its invocation event
     const response = await new SimAwsHttp({ simAws }).handleRequest(
@@ -293,10 +258,25 @@ describe("The IAM caller in a Function URL invocation event", () => {
 
   it("describes no caller for a NONE invocation", async () => {
     // Given a Function URL anyone may invoke
-    const { simAws, url } = await serveIamFunction("NONE");
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reporter",
+        Role: `arn:aws:iam::${accountId}:role/ReporterRole`,
+        Code: reportCallerCode,
+      }),
+    );
+    const urlConfig = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "reporter",
+        AuthType: "NONE",
+      }),
+    );
 
     // When the handler reads its invocation event
-    const response = await new SimAwsHttp({ simAws }).fetch(url);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(urlConfig.FunctionUrl),
+    );
     const context =
       (await response.json()) as SimLambdaFunctionUrlRequestContext;
 

--- a/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve-errors.iso.test.ts
@@ -2,7 +2,6 @@ import {
   CreateFunctionCommand,
   CreateFunctionUrlConfigCommand,
   DeleteFunctionUrlConfigCommand,
-  UpdateFunctionUrlConfigCommand,
 } from "@aws-sdk/client-lambda";
 import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -11,29 +10,6 @@ import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
-import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
-
-async function serveFunction(
-  simAws: SimAws,
-  handler: SimLambdaHandler,
-): Promise<string> {
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: "greeter",
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(handler) },
-    }),
-  );
-
-  const created = await simAws.lambda().createFunctionUrlConfig(
-    new CreateFunctionUrlConfigCommand({
-      FunctionName: "greeter",
-      AuthType: "NONE",
-    }),
-  );
-
-  return created.FunctionUrl;
-}
 
 function localUrl(functionUrl: string): string {
   return new SimAwsLocalUrl({ input: functionUrl }).toString();
@@ -59,7 +35,23 @@ describe("Serving sim Lambda Function URL failures", () => {
   it("returns 404 once the Function URL has been deleted", async () => {
     // Given a served Function URL that is then deleted.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => "hello");
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
     await simAws
       .lambda()
       .deleteFunctionUrlConfig(
@@ -78,7 +70,23 @@ describe("Serving sim Lambda Function URL failures", () => {
   it("returns 404 when the host names a different region", async () => {
     // Given a Function URL in the default region.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => "hello");
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the same URL id is requested in another region.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -92,13 +100,23 @@ describe("Serving sim Lambda Function URL failures", () => {
   it("refuses an AWS_IAM Function URL request", async () => {
     // Given a Function URL that requires IAM authentication.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => "hello");
-    await simAws.lambda().updateFunctionUrlConfig(
-      new UpdateFunctionUrlConfigCommand({
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
         FunctionName: "greeter",
-        AuthType: "AWS_IAM",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
       }),
     );
+
+    // And a Function URL for it that requires IAM authentication.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "AWS_IAM",
+        }),
+      );
 
     // When it is requested without a signature.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -113,9 +131,27 @@ describe("Serving sim Lambda Function URL failures", () => {
   it("returns 502 when the handler throws", async () => {
     // Given a function whose handler fails.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => {
-      throw new Error("handler exploded");
-    });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("handler exploded");
+          }),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(

--- a/src/service/lambda/serve/sim-lambda-url-serve-event.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve-event.iso.test.ts
@@ -22,6 +22,14 @@ import { SimFixedClock } from "../../../util/clock/sim-clock.js";
 import { SimLambdaServiceController } from "./sim-lambda-controller.js";
 import { SimLambdaUrlRouter } from "./sim-lambda-url-router.js";
 
+/**
+ * Function code echoing the invocation event straight back, so a test can
+ * assert on what the serving layer built.
+ */
+const echoEventCode = {
+  ZipFile: makeLambdaZipFileInput((event: SimLambdaFunctionUrlEvent) => event),
+};
+
 function localUrl(functionUrl: string, path = ""): string {
   return new SimAwsLocalUrl({ input: `${functionUrl}${path}` }).toString();
 }
@@ -34,11 +42,7 @@ describe("The event a served sim Lambda Function URL builds", () => {
       new CreateFunctionCommand({
         FunctionName: "greeter",
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(
-            (event: SimLambdaFunctionUrlEvent) => event,
-          ),
-        },
+        Code: echoEventCode,
       }),
     );
 
@@ -77,11 +81,7 @@ describe("The event a served sim Lambda Function URL builds", () => {
       new CreateFunctionCommand({
         FunctionName: "greeter",
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(
-            (event: SimLambdaFunctionUrlEvent) => event,
-          ),
-        },
+        Code: echoEventCode,
       }),
     );
 
@@ -115,11 +115,7 @@ describe("The event a served sim Lambda Function URL builds", () => {
       new CreateFunctionCommand({
         FunctionName: "greeter",
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(
-            (event: SimLambdaFunctionUrlEvent) => event,
-          ),
-        },
+        Code: echoEventCode,
       }),
     );
 
@@ -161,11 +157,7 @@ describe("The event a served sim Lambda Function URL builds", () => {
       new CreateFunctionCommand({
         FunctionName: "greeter",
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(
-            (event: SimLambdaFunctionUrlEvent) => event,
-          ),
-        },
+        Code: echoEventCode,
       }),
     );
 
@@ -203,11 +195,7 @@ describe("The event a served sim Lambda Function URL builds", () => {
       new CreateFunctionCommand({
         FunctionName: "greeter",
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
-        Code: {
-          ZipFile: makeLambdaZipFileInput(
-            (event: SimLambdaFunctionUrlEvent) => event,
-          ),
-        },
+        Code: echoEventCode,
       }),
     );
 

--- a/src/service/lambda/serve/sim-lambda-url-serve-event.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve-event.iso.test.ts
@@ -1,0 +1,287 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaFunctionUrlEvent } from "./event/sim-lambda-url-event.type.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimLambdaServiceController } from "./sim-lambda-controller.js";
+import { SimLambdaUrlRouter } from "./sim-lambda-url-router.js";
+
+function localUrl(functionUrl: string, path = ""): string {
+  return new SimAwsLocalUrl({ input: `${functionUrl}${path}` }).toString();
+}
+
+describe("The event a served sim Lambda Function URL builds", () => {
+  it("passes a payload format 2.0 event to the handler", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) => event,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+
+    // When the Function URL is requested with a query and a cookie.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl, "hello/world?name=yulin&name=again"),
+      { headers: { cookie: "session=abc; theme=dark", "X-Test": "yes" } },
+    );
+
+    // Then the event carries the payload format 2.0 request details.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.version, "2.0");
+    assertIdentical(event.rawPath, "/hello/world");
+    assertIdentical(event.rawQueryString, "name=yulin&name=again");
+    assertIdentical(event.queryStringParameters?.["name"], "yulin,again");
+    assertIdentical(event.headers["x-test"], "yes");
+    assertIdentical(event.requestContext.http.method, "GET");
+    assertIdentical(event.requestContext.http.path, "/hello/world");
+    assertFalse(event.isBase64Encoded);
+  });
+
+  it("delivers cookies in their own event field", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) => event,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+
+    // When the Function URL is requested with cookies.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      { headers: { cookie: "session=abc; theme=dark" } },
+    );
+
+    // Then the cookies are listed separately and not left in the headers.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertNonNullable(event.cookies);
+    assertArrayEquals(event.cookies, ["session=abc", "theme=dark"]);
+    assertUndefined(event.headers["cookie"]);
+  });
+
+  it("names the AWS endpoint in the event request context", async () => {
+    // Given a function served at a Function URL.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) => event,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+
+    // When the Function URL is requested on localhost.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+    );
+
+    // Then the request context describes the AWS-shaped endpoint.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(`https://${event.requestContext.domainName}/`, functionUrl);
+    assertIdentical(
+      event.requestContext.apiId,
+      event.requestContext.domainPrefix,
+    );
+    assertIdentical(event.requestContext.accountId, "anonymous");
+    assertTrue(
+      /^\d{2}\/[A-Z][a-z]{2}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000$/.test(
+        event.requestContext.time,
+      ),
+      `Unexpected request context time ${event.requestContext.time}`,
+    );
+  });
+
+  it("passes a text request body through as a string", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) => event,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+
+    // When JSON is posted to the Function URL.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"name":"yulin"}',
+      },
+    );
+
+    // Then the handler receives the body as text.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.body, '{"name":"yulin"}');
+    assertFalse(event.isBase64Encoded);
+    assertIdentical(event.requestContext.http.method, "POST");
+  });
+
+  it("base64-encodes a binary request body", async () => {
+    // Given a function that echoes its invocation event.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) => event,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+
+    // When binary content is posted to the Function URL.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(functionUrl),
+      {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new Uint8Array([1, 2, 3]),
+      },
+    );
+
+    // Then the handler receives base64, flagged as such.
+    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
+    assertIdentical(event.body, Buffer.from([1, 2, 3]).toString("base64"));
+    assertTrue(event.isBase64Encoded);
+  });
+
+  it("stamps the event from the clock of the router's simulation", async () => {
+    // Given a controller built from a router alone, with no separate SimAws,
+    // where that router's simulation has a stopped clock
+    const instant = new Date("2026-07-26T09:30:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: SimLambdaFunctionUrlEvent) =>
+              event.requestContext.timeEpoch,
+          ),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+    const controller = new SimLambdaServiceController({
+      router: new SimLambdaUrlRouter({ simAws }),
+    });
+
+    // When the Function URL is invoked through it
+    const url = new URL(localUrl(functionUrl));
+    const response = await controller.handleRequest(
+      new SimAwsServiceRequest({
+        target: {
+          service: "lambda",
+          resourceName: url.hostname.split(".", 1)[0] ?? "",
+          regionName: simAws.defaultRegionName,
+        },
+        request: new Request(url),
+      }),
+    );
+
+    // Then the event carries the router's simulated time, not the real time
+    assertIdentical(await response.text(), String(instant.getTime()));
+  });
+});

--- a/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-serve.iso.test.ts
@@ -2,53 +2,13 @@ import {
   CreateFunctionCommand,
   CreateFunctionUrlConfigCommand,
 } from "@aws-sdk/client-lambda";
-import {
-  assertArrayEquals,
-  assertFalse,
-  assertIdentical,
-  assertNonNullable,
-  assertTrue,
-  assertUndefined,
-} from "@kensio/smartass";
+import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
-import { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
-import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
-import type { SimLambdaFunctionUrlEvent } from "./event/sim-lambda-url-event.type.js";
-import { SimFixedClock } from "../../../util/clock/sim-clock.js";
-import { SimLambdaServiceController } from "./sim-lambda-controller.js";
-import { SimLambdaUrlRouter } from "./sim-lambda-url-router.js";
-
-/**
- * Create a function backed by a real in-process handler and give it a public
- * Function URL, returning the local URL that reaches it.
- */
-async function serveFunction(
-  simAws: SimAws,
-  handler: SimLambdaHandler,
-  functionName = "greeter",
-): Promise<string> {
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: functionName,
-      Role: "arn:aws:iam::111111111111:role/GreeterRole",
-      Code: { ZipFile: makeLambdaZipFileInput(handler) },
-    }),
-  );
-
-  const created = await simAws.lambda().createFunctionUrlConfig(
-    new CreateFunctionUrlConfigCommand({
-      FunctionName: functionName,
-      AuthType: "NONE",
-    }),
-  );
-
-  return created.FunctionUrl;
-}
 
 function localUrl(functionUrl: string, path = ""): string {
   return new SimAwsLocalUrl({ input: `${functionUrl}${path}` }).toString();
@@ -58,11 +18,29 @@ describe("Serving a sim Lambda Function URL", () => {
   it("invokes the function and returns its structured response", async () => {
     // Given a function served at a Function URL.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => ({
-      statusCode: 201,
-      headers: { "content-type": "text/plain", "x-greeting": "hello" },
-      body: "Hello from a sim Lambda",
-    }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 201,
+            headers: { "content-type": "text/plain", "x-greeting": "hello" },
+            body: "Hello from a sim Lambda",
+          })),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -79,9 +57,27 @@ describe("Serving a sim Lambda Function URL", () => {
   it("wraps a plain handler result in a JSON response", async () => {
     // Given a function returning a plain value.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => ({
-      greeting: "hello",
-    }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            greeting: "hello",
+          })),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -94,140 +90,33 @@ describe("Serving a sim Lambda Function URL", () => {
     assertIdentical(await response.text(), '{"greeting":"hello"}');
   });
 
-  it("passes a payload format 2.0 event to the handler", async () => {
-    // Given a function that echoes its invocation event.
-    const simAws = new SimAws();
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event,
-    );
-
-    // When the Function URL is requested with a query and a cookie.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(functionUrl, "hello/world?name=yulin&name=again"),
-      { headers: { cookie: "session=abc; theme=dark", "X-Test": "yes" } },
-    );
-
-    // Then the event carries the payload format 2.0 request details.
-    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
-    assertIdentical(event.version, "2.0");
-    assertIdentical(event.rawPath, "/hello/world");
-    assertIdentical(event.rawQueryString, "name=yulin&name=again");
-    assertIdentical(event.queryStringParameters?.["name"], "yulin,again");
-    assertIdentical(event.headers["x-test"], "yes");
-    assertIdentical(event.requestContext.http.method, "GET");
-    assertIdentical(event.requestContext.http.path, "/hello/world");
-    assertFalse(event.isBase64Encoded);
-  });
-
-  it("delivers cookies in their own event field", async () => {
-    // Given a function that echoes its invocation event.
-    const simAws = new SimAws();
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event,
-    );
-
-    // When the Function URL is requested with cookies.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(functionUrl),
-      { headers: { cookie: "session=abc; theme=dark" } },
-    );
-
-    // Then the cookies are listed separately and not left in the headers.
-    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
-    assertNonNullable(event.cookies);
-    assertArrayEquals(event.cookies, ["session=abc", "theme=dark"]);
-    assertUndefined(event.headers["cookie"]);
-  });
-
-  it("names the AWS endpoint in the event request context", async () => {
-    // Given a function served at a Function URL.
-    const simAws = new SimAws();
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event,
-    );
-
-    // When the Function URL is requested on localhost.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(functionUrl),
-    );
-
-    // Then the request context describes the AWS-shaped endpoint.
-    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
-    assertIdentical(`https://${event.requestContext.domainName}/`, functionUrl);
-    assertIdentical(
-      event.requestContext.apiId,
-      event.requestContext.domainPrefix,
-    );
-    assertIdentical(event.requestContext.accountId, "anonymous");
-    assertTrue(
-      /^\d{2}\/[A-Z][a-z]{2}\/\d{4}:\d{2}:\d{2}:\d{2} \+0000$/.test(
-        event.requestContext.time,
-      ),
-      `Unexpected request context time ${event.requestContext.time}`,
-    );
-  });
-
-  it("passes a text request body through as a string", async () => {
-    // Given a function that echoes its invocation event.
-    const simAws = new SimAws();
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event,
-    );
-
-    // When JSON is posted to the Function URL.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(functionUrl),
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: '{"name":"yulin"}',
-      },
-    );
-
-    // Then the handler receives the body as text.
-    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
-    assertIdentical(event.body, '{"name":"yulin"}');
-    assertFalse(event.isBase64Encoded);
-    assertIdentical(event.requestContext.http.method, "POST");
-  });
-
-  it("base64-encodes a binary request body", async () => {
-    // Given a function that echoes its invocation event.
-    const simAws = new SimAws();
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event,
-    );
-
-    // When binary content is posted to the Function URL.
-    const response = await new SimAwsHttp({ simAws }).fetch(
-      localUrl(functionUrl),
-      {
-        method: "POST",
-        headers: { "content-type": "application/octet-stream" },
-        body: new Uint8Array([1, 2, 3]),
-      },
-    );
-
-    // Then the handler receives base64, flagged as such.
-    const event = (await response.json()) as SimLambdaFunctionUrlEvent;
-    assertIdentical(event.body, Buffer.from([1, 2, 3]).toString("base64"));
-    assertTrue(event.isBase64Encoded);
-  });
-
   it("decodes a base64 handler response body", async () => {
     // Given a function returning base64-encoded bytes.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => ({
-      statusCode: 200,
-      headers: { "content-type": "application/octet-stream" },
-      body: Buffer.from([7, 8, 9]).toString("base64"),
-      isBase64Encoded: true,
-    }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 200,
+            headers: { "content-type": "application/octet-stream" },
+            body: Buffer.from([7, 8, 9]).toString("base64"),
+            isBase64Encoded: true,
+          })),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -242,11 +131,29 @@ describe("Serving a sim Lambda Function URL", () => {
   it("sends handler cookies as set-cookie headers", async () => {
     // Given a function returning cookies.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => ({
-      statusCode: 200,
-      cookies: ["session=abc; Path=/", "theme=dark"],
-      body: "ok",
-    }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 200,
+            cookies: ["session=abc; Path=/", "theme=dark"],
+            body: "ok",
+          })),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -263,9 +170,27 @@ describe("Serving a sim Lambda Function URL", () => {
   it("returns a bodiless response when the handler sends no body", async () => {
     // Given a function returning no content.
     const simAws = new SimAws();
-    const functionUrl = await serveFunction(simAws, () => ({
-      statusCode: 204,
-    }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 204,
+          })),
+        },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
 
     // When the Function URL is requested.
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -280,7 +205,23 @@ describe("Serving a sim Lambda Function URL", () => {
   it("routes same-named functions in different accounts separately", async () => {
     // Given two accounts with a same-named function, each with a Function URL.
     const simAws = new SimAws();
-    const firstUrl = await serveFunction(simAws, () => "first account");
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "first account") },
+      }),
+    );
+
+    // And a public Function URL for it.
+    const { FunctionUrl: firstUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
     const secondLambda = simAws.account("222222222222").lambda();
     await secondLambda.createFunction(
       new CreateFunctionCommand({
@@ -305,35 +246,5 @@ describe("Serving a sim Lambda Function URL", () => {
     // Then each reaches its own account's function.
     assertIdentical(await firstResponse.text(), '"first account"');
     assertIdentical(await secondResponse.text(), '"second account"');
-  });
-
-  it("stamps the event from the clock of the router's simulation", async () => {
-    // Given a controller built from a router alone, with no separate SimAws,
-    // where that router's simulation has a stopped clock
-    const instant = new Date("2026-07-26T09:30:00.000Z");
-    const simAws = new SimAws({ clock: new SimFixedClock(instant) });
-    const functionUrl = await serveFunction(
-      simAws,
-      (event: SimLambdaFunctionUrlEvent) => event.requestContext.timeEpoch,
-    );
-    const controller = new SimLambdaServiceController({
-      router: new SimLambdaUrlRouter({ simAws }),
-    });
-
-    // When the Function URL is invoked through it
-    const url = new URL(localUrl(functionUrl));
-    const response = await controller.handleRequest(
-      new SimAwsServiceRequest({
-        target: {
-          service: "lambda",
-          resourceName: url.hostname.split(".", 1)[0] ?? "",
-          regionName: simAws.defaultRegionName,
-        },
-        request: new Request(url),
-      }),
-    );
-
-    // Then the event carries the router's simulated time, not the real time
-    assertIdentical(await response.text(), String(instant.getTime()));
   });
 });


### PR DESCRIPTION
Replace the custom helper functions at the top of the Lambda test files with plain SDK calls in Given steps, so the tests read like the code a user writes. Add a shared IAM policy document factory for the JSON boilerplate no test is about, and shared factories for the internal model objects the unit tests build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced simulated Lambda Function URL support, covering request event translation (headers, cookies, query parameters, request body handling, timestamps, and payload encoding).
  * Added/strengthened cross-account and IAM-auth Function URL invocation scenarios.
  * Introduced reusable simulation utilities for IAM policy documents, Lambda environments, Function URLs, and VM-based Lambda code packaging.
* **Tests**
  * Expanded ISO test coverage for permissions, authorization/denial behavior, invocation results, runtime error cases, and environment isolation.
* **Chores**
  * Updated the part-factory dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->