### PR TITLE
feat: serve the Cognito JWKS and OpenID configuration over HTTP

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -31,6 +31,8 @@ Sim Cognito currently supports:
 - `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
 - Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
   pool verifies them unchanged
+- A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
+  `serveSimAws`, anonymously, so a verifier fetches the keys rather than being handed them
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
@@ -973,6 +975,114 @@ Both listings are in creation order and hold at most sixty entries. Follow `Next
 rest. A listed pool carries no ARN and a listed app client carries no secret, as real Cognito leaves
 those out of a listing.
 
+## Serving a pool's JWKS on localhost
+
+`serveSimAws` serves the two public endpoints of every simulated pool:
+
+- `GET /<userPoolId>/.well-known/jwks.json`
+- `GET /<userPoolId>/.well-known/openid-configuration`
+
+Both are anonymous, as they are on real Cognito, so no SigV4 signature is needed to fetch them. The
+real hostname `cognito-idp.<region>.amazonaws.com` maps to `cognito-idp.<region>.sim-aws.localhost`,
+and `srv.localUrl(...)` does that rewriting for you. An unknown pool id gets a 404, as does a pool
+reached through another region's hostname.
+
+```typescript sim-cognito-serve-jwks
+/**
+ * Fetching a simulated user pool's JWKS over HTTP.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import type { Jwks } from "aws-jwt-verify/jwk";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  // The real Cognito JWKS URL, adapted for the local server.
+  const jwksUrl = srv.localUrl(
+    `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+  );
+  console.log(jwksUrl.pathname);
+  // "/eu-west-2_aBcDeFgHi/.well-known/jwks.json"
+
+  const response = await fetch(jwksUrl);
+  const jwks = (await response.json()) as Jwks;
+
+  const verifier = CognitoJwtVerifier.create({
+    userPoolId,
+    tokenUse: "access",
+    clientId,
+  });
+  verifier.cacheJwks(jwks);
+
+  const payload = await verifier.verify(AuthenticationResult!.AccessToken!);
+
+  console.log(payload.username); // "alice"
+} finally {
+  srv.close();
+}
+```
+
+`aws-jwt-verify` fetches over HTTPS only, and `CognitoJwtVerifier` builds its own JWKS URI from the
+pool id rather than taking one, so it cannot be pointed at the local URL. Fetching the document and
+calling `cacheJwks` with it is one way round that. The other is to hand the verifier a
+`SimpleJwksCache` from `aws-jwt-verify/jwk` whose fetcher passes the URI through `srv.localUrl`,
+which leaves the verifier setup in the application untouched. A verifier that takes a `jwksUri` and
+accepts plain HTTP can be pointed at the local URL as it is.
+
+The OpenID configuration names the origin the request arrived on in `issuer` and `jwks_uri`, so a
+client that discovers the document can go on to fetch the keys it points at. The tokens keep the
+real `https://cognito-idp.<region>.amazonaws.com/<userPoolId>` in `iss`, which is what a verifier
+built from a pool id checks against, so the two disagree here where they agree on real Cognito.
+
 ## Intercepting the SDK client
 
 Code that builds its own `CognitoIdentityProviderClient` needs no changes. Intercepting the client
@@ -1135,9 +1245,14 @@ Current documented limitations:
 - A pool does not report `SchemaAttributes`. Real Cognito reports the standard attribute schema on
   every pool, and there are no user attributes here to describe.
 - Managed login and the hosted UI are not simulated, and neither are the OAuth endpoints, the
-  `/oauth2/token` endpoint among them. Nothing is served over HTTP.
-- The JWKS endpoint at `.../.well-known/jwks.json` is not served. A pool's JWKS is read from the
-  simulator with `cognito.userPool(userPoolId).jwks()` and handed to a verifier directly.
+  `/oauth2/token` endpoint among them.
+- The served OpenID configuration therefore carries no `authorization_endpoint`, `token_endpoint` or
+  `userinfo_endpoint`, where real Cognito names all three. A client that needs one of them finds
+  nothing rather than an address that would not answer.
+- The served `issuer` and `jwks_uri` name the localhost origin the request arrived on, so a client
+  can fetch the keys they point at. A token's `iss` claim still names the real
+  `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`, so the two disagree here and agree on
+  real Cognito.
 - Identity providers, resource servers, user pool domains, MFA configuration, risk configuration and
   Lambda triggers are not simulated.
 - Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
@@ -1145,5 +1260,7 @@ Current documented limitations:
 - Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.
 - `AWS::Cognito::UserPool` and the other `AWS::Cognito::*` CloudFormation resource types are reported
   as unsupported and skipped rather than deployed.
-- Cognito is not served as an HTTP API by `serveSimAws`.
+- The Cognito API itself is not served as HTTP by `serveSimAws`, only the two public pool endpoints.
+  A `CognitoIdentityProviderClient` reaches the simulator through `SimSdk` rather than through an
+  endpoint override.
 - Cognito identity pools are a different service and nothing about them is simulated.

--- a/docs/services/cognito/sim-cognito-serve-jwks.example.ts
+++ b/docs/services/cognito/sim-cognito-serve-jwks.example.ts
@@ -1,0 +1,81 @@
+/**
+ * Fetching a simulated user pool's JWKS over HTTP.
+ */
+
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import type { Jwks } from "aws-jwt-verify/jwk";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const cognito = simAws.cognitoIdentityProvider();
+
+const pool = await cognito.createUserPool(
+  new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+);
+const userPoolId = pool.UserPool!.Id!;
+
+const appClient = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+  }),
+);
+const clientId = appClient.UserPoolClient!.ClientId!;
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecret!",
+    Permanent: true,
+  }),
+);
+
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+try {
+  // The real Cognito JWKS URL, adapted for the local server.
+  const jwksUrl = srv.localUrl(
+    `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+  );
+  console.log(jwksUrl.pathname);
+  // "/eu-west-2_aBcDeFgHi/.well-known/jwks.json"
+
+  const response = await fetch(jwksUrl);
+  const jwks = (await response.json()) as Jwks;
+
+  const verifier = CognitoJwtVerifier.create({
+    userPoolId,
+    tokenUse: "access",
+    clientId,
+  });
+  verifier.cacheJwks(jwks);
+
+  const payload = await verifier.verify(AuthenticationResult!.AccessToken!);
+
+  console.log(payload.username); // "alice"
+} finally {
+  srv.close();
+}

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceController } from "../sim-service-controller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
+import { SimCognitoServiceController } from "../../../service/cognito/serve/sim-cognito-controller.js";
 import { SimLambdaServiceController } from "../../../service/lambda/serve/sim-lambda-controller.js";
 import { SimRoute53ServiceController } from "../../../service/route53/serve/sim-route53-controller.js";
 import { SimS3ServiceController } from "../../../service/s3/serve/sim-s3-controller.js";
@@ -29,6 +30,9 @@ export class SimAwsServiceControllerFactory {
       }
       case "route53": {
         return new SimRoute53ServiceController({ simAws: this.simAws });
+      }
+      case "cognitoIdentityProvider": {
+        return new SimCognitoServiceController({ simAws: this.simAws });
       }
       default: {
         throw new Error(

--- a/src/serve/controller/sim-aws-service-signing-name.ts
+++ b/src/serve/controller/sim-aws-service-signing-name.ts
@@ -24,5 +24,8 @@ export function simAwsServiceSigningName(
     case "route53": {
       return "route53";
     }
+    case "cognitoIdentityProvider": {
+      return "cognito-idp";
+    }
   }
 }

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -16,7 +16,8 @@ import { SimAwsRequestCaller } from "../../service/iam/request/sim-aws-request-c
 export type SimAwsServiceEndpoint = "rest" | "website";
 
 export interface SimAwsServiceTarget {
-  readonly service: "s3" | "cloudFront" | "lambda" | "route53";
+  readonly service:
+    "s3" | "cloudFront" | "lambda" | "route53" | "cognitoIdentityProvider";
   readonly resourceName: string;
   // regionName is used for validation, not look-up
   readonly regionName?: AwsRegionName;

--- a/src/serve/http/url/sim-aws-local-url.iso.test.ts
+++ b/src/serve/http/url/sim-aws-local-url.iso.test.ts
@@ -41,6 +41,20 @@ describe("Simulated AWS local URL", () => {
     );
   });
 
+  it("replaces an AWS Cognito hostname suffix with the local hostname suffix", () => {
+    const url = new SimAwsLocalUrl({
+      input:
+        "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi/.well-known/jwks.json",
+      port: "12345",
+    });
+
+    assertIdentical(
+      url.toString(),
+      "http://cognito-idp.eu-west-2.sim-aws.localhost:12345" +
+        "/eu-west-2_aBcDeFgHi/.well-known/jwks.json",
+    );
+  });
+
   it("adds the local hostname suffix to other hostnames", () => {
     const url = new SimAwsLocalUrl({
       input: "https://www.example.test/foo/",

--- a/src/serve/http/url/sim-aws-local-url.ts
+++ b/src/serve/http/url/sim-aws-local-url.ts
@@ -74,6 +74,7 @@ export class SimAwsLocalUrl {
         hostname,
       ) ??
       /^(?<prefix>s3\.[^.]+)\.amazonaws\.com$/.exec(hostname) ??
+      /^(?<prefix>cognito-idp\.[^.]+)\.amazonaws\.com$/.exec(hostname) ??
       /^(?<prefix>.+\.lambda-url\.[^.]+)\.on\.aws$/.exec(hostname);
 
     return awsHostname?.groups?.["prefix"];

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -107,6 +107,9 @@ export class SimAwsAccountRegionServiceBuilder {
       accountRegionScope: scope.accountRegionScope,
       iam: this.accountServices.createIam(scope),
       background: this.background,
+      // Pool ids are unique across the simulation, and a pool is reachable by
+      // id alone from the serving layer, whichever scope created it.
+      userPoolRegistry: this.registries.cognito,
     });
   }
 

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -1,4 +1,5 @@
 import { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
+import { SimCognitoUserPoolRegistry } from "../../cognito/registry/sim-cognito-user-pool-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
 
@@ -17,6 +18,13 @@ export class SimAwsScopedServiceRegistries {
    * can resolve the Certificate it names.
    */
   public readonly acm = new SimAcmRegistry();
+
+  /**
+   * Indexes the user pools created in any Account and Region of one SimAws
+   * instance, so a served request naming only a pool id, such as one for a
+   * pool's JWKS, finds the pool it belongs to.
+   */
+  public readonly cognito = new SimCognitoUserPoolRegistry();
 
   /**
    * Owns hosted zone and DNS record state shared by the account-scoped Route53

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -141,6 +141,21 @@ hands out all three tokens and `reissue` signs a new access and id token for a r
 difference `REFRESH_TOKEN_AUTH` answers with. Everything it issues is recorded on the pool, because
 the pool is what a refresh or a sign-out presents a token back to.
 
+## Served pool endpoints
+
+`serve/` holds the localhost HTTP side, which is the two endpoints real Cognito serves without any
+authentication: `/<userPoolId>/.well-known/jwks.json` and
+`/<userPoolId>/.well-known/openid-configuration`. `SimCognitoServiceController` is the controller the
+serving layer dispatches to, `SimCognitoOpenIdConfiguration` builds the discovery document, and
+`SimCognitoEndpointResponse` builds the responses. The Cognito API itself is not served: an SDK
+client reaches the simulator through `SimSdk`.
+
+The request hostname is `cognito-idp.<region>`, which names the regional endpoint rather than one
+pool, so the pool id comes from the path. That id says nothing about the Account that owns the pool,
+so `SimCognitoUserPoolRegistry` in `registry/` indexes pools across every Account and Region of one
+simulation, in the same way `SimLambdaUrlRegistry` indexes Function URL ids. It is also what pool
+ids are allocated against, so no two Accounts can hold the same one.
+
 ## Authentication model
 
 Sign-in state lives under `user-pool/auth/`.
@@ -251,6 +266,12 @@ resource, here or on real AWS.
 - Users are resolved by username only, and real Cognito also accepts a `sub` there.
 - `AdminListGroupsForUser` sorts by precedence. Real Cognito does not document an order for it.
 - One signing key is published per pool, where real Cognito publishes two and rotates between them.
+- The served OpenID configuration names the localhost origin the request arrived on as its `issuer`,
+  because a client that discovers a document has to be able to fetch the keys it points at. A token's
+  `iss` claim still names the real AWS URL, which is what a verifier built from a pool id checks
+  against, so the two disagree here and agree on real Cognito. The document also names no
+  `authorization_endpoint`, `token_endpoint` or `userinfo_endpoint`, as the hosted UI and the OAuth
+  endpoints are not simulated.
 - The password and refresh flows run on both sides of the API, and only `NEW_PASSWORD_REQUIRED` is
   issued. SRP, `USER_AUTH`, custom authentication, MFA challenges and device tracking are refused
   rather than treated as a flow or challenge that is simulated.

--- a/src/service/cognito/registry/sim-cognito-user-pool-registry.ts
+++ b/src/service/cognito/registry/sim-cognito-user-pool-registry.ts
@@ -1,0 +1,47 @@
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolId } from "../user-pool/sim-cognito-user-pool-id.js";
+
+/**
+ * Simulated Cognito cross-Account registry of user pools.
+ *
+ * A served JWKS request carries the region in its hostname and the pool id in
+ * its path, and says nothing about the Account. Simulated Cognito state is per
+ * Account/Region, so the serving layer needs a way from a pool id to the pool
+ * that has it. This registry is that lookup, which is also why pool ids are
+ * allocated against it and are unique across every Account and Region of one
+ * simulated AWS environment.
+ */
+export class SimCognitoUserPoolRegistry {
+  private readonly poolsById = new Map<
+    SimCognitoUserPoolId,
+    SimCognitoUserPool
+  >();
+
+  /**
+   * The pool ids already in use in this simulated AWS.
+   */
+  get ids(): Set<string> {
+    return new Set(this.poolsById.keys());
+  }
+
+  /**
+   * Register a newly created pool, so its public endpoints resolve.
+   */
+  register(pool: SimCognitoUserPool): void {
+    this.poolsById.set(pool.id, pool);
+  }
+
+  /**
+   * Forget a deleted pool, so its public endpoints stop resolving.
+   */
+  deregister(pool: SimCognitoUserPool): void {
+    this.poolsById.delete(pool.id);
+  }
+
+  /**
+   * Find a pool by id, in whichever Account and Region created it.
+   */
+  find(userPoolId: string): SimCognitoUserPool | undefined {
+    return this.poolsById.get(userPoolId as SimCognitoUserPoolId);
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -1,0 +1,105 @@
+import type {
+  SimAwsServiceController,
+  SimAwsServiceRequest,
+  SimAwsServiceTarget,
+} from "../../../serve/controller/sim-service-controller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoEndpointResponse } from "./sim-cognito-endpoint-response.js";
+import { SimCognitoOpenIdConfiguration } from "./sim-cognito-openid-configuration.js";
+
+/**
+ * The path segment both public pool endpoints sit under.
+ */
+const wellKnownSegment = ".well-known";
+
+interface SimCognitoServiceControllerProperties {
+  readonly simAws?: SimAws;
+}
+
+/**
+ * Localhost HTTP controller for the public endpoints of a simulated user pool.
+ *
+ * Real Cognito serves a pool's JWKS and its OpenID configuration to anyone,
+ * with no SigV4 signature, because a token verifier holding no AWS credentials
+ * has to be able to fetch them. Both are anonymous here for the same reason,
+ * so a verifier pointed at the local URL fetches keys the way it does against
+ * real Cognito rather than being handed them.
+ *
+ * The Cognito API itself is not served. An SDK client reaches the simulator
+ * through `SimSdk` rather than through an endpoint override.
+ */
+export class SimCognitoServiceController implements SimAwsServiceController {
+  private readonly simAws: SimAws;
+  private readonly openIdConfiguration = new SimCognitoOpenIdConfiguration();
+  private readonly response = new SimCognitoEndpointResponse();
+
+  constructor(properties: SimCognitoServiceControllerProperties = {}) {
+    const { simAws = new SimAws() } = properties;
+    this.simAws = simAws;
+  }
+
+  /**
+   * Handle an HTTP request routed to a simulated Cognito regional endpoint.
+   */
+  handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
+    return Promise.resolve(this.respond(serviceRequest));
+  }
+
+  private respond(serviceRequest: SimAwsServiceRequest): Response {
+    const url = new URL(serviceRequest.request.url);
+    const [userPoolId, wellKnown, document] = url.pathname.slice(1).split("/");
+
+    if (userPoolId === undefined || wellKnown !== wellKnownSegment) {
+      return this.response.noSuchEndpoint(url.pathname);
+    }
+
+    const pool = this.servedPool(userPoolId, serviceRequest.target);
+
+    if (pool === undefined) {
+      return this.response.noSuchUserPool(userPoolId);
+    }
+
+    if (document === "jwks.json") {
+      return this.response.document(pool.jwks());
+    }
+
+    if (document === "openid-configuration") {
+      return this.response.document(
+        this.openIdConfiguration.document(pool, url.origin),
+      );
+    }
+
+    return this.response.noSuchEndpoint(url.pathname);
+  }
+
+  /**
+   * Find the pool a request names, if this endpoint serves it.
+   *
+   * A pool id is unique across the simulation and says nothing about the
+   * Account that owns the pool, so the lookup spans Accounts. It does name the
+   * pool's region, and real Cognito serves a pool only on that region's
+   * endpoint, so a pool reached through another region's hostname is not
+   * found here either.
+   */
+  private servedPool(
+    userPoolId: string,
+    target: SimAwsServiceTarget,
+  ): SimCognitoUserPool | undefined {
+    const pool = this.simAws
+      .cognitoIdentityProvider()
+      .findUserPoolInAnyAccount(userPoolId);
+
+    if (pool === undefined) {
+      return undefined;
+    }
+
+    const [poolRegionName] = pool.id.split("_", 1);
+
+    if (poolRegionName !== target.regionName) {
+      return undefined;
+    }
+
+    return pool;
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -68,6 +68,7 @@ export class SimCognitoServiceController implements SimAwsServiceController {
 
     if (
       userPoolId === undefined ||
+      userPoolId.length === 0 ||
       wellKnown !== wellKnownSegment ||
       rest.length > 0
     ) {
@@ -81,12 +82,13 @@ export class SimCognitoServiceController implements SimAwsServiceController {
     }
 
     if (document === "jwks.json") {
-      return this.response.document(pool.jwks());
+      return this.response.document(pool.jwks(), request.method);
     }
 
     if (document === "openid-configuration") {
       return this.response.document(
         this.openIdConfiguration.document(pool, url.origin),
+        request.method,
       );
     }
 

--- a/src/service/cognito/serve/sim-cognito-controller.ts
+++ b/src/service/cognito/serve/sim-cognito-controller.ts
@@ -13,6 +13,11 @@ import { SimCognitoOpenIdConfiguration } from "./sim-cognito-openid-configuratio
  */
 const wellKnownSegment = ".well-known";
 
+/**
+ * The methods a published document is read with.
+ */
+const readMethods = new Set(["GET", "HEAD"]);
+
 interface SimCognitoServiceControllerProperties {
   readonly simAws?: SimAws;
 }
@@ -47,10 +52,25 @@ export class SimCognitoServiceController implements SimAwsServiceController {
   }
 
   private respond(serviceRequest: SimAwsServiceRequest): Response {
-    const url = new URL(serviceRequest.request.url);
-    const [userPoolId, wellKnown, document] = url.pathname.slice(1).split("/");
+    const { request } = serviceRequest;
+    const url = new URL(request.url);
 
-    if (userPoolId === undefined || wellKnown !== wellKnownSegment) {
+    if (!readMethods.has(request.method)) {
+      return this.response.notRead(request.method);
+    }
+
+    // A path is exactly '<userPoolId>/.well-known/<document>'. Anything
+    // longer is a path real Cognito has nothing at, rather than a prefix of
+    // one it serves.
+    const [userPoolId, wellKnown, document, ...rest] = url.pathname
+      .slice(1)
+      .split("/");
+
+    if (
+      userPoolId === undefined ||
+      wellKnown !== wellKnownSegment ||
+      rest.length > 0
+    ) {
       return this.response.noSuchEndpoint(url.pathname);
     }
 

--- a/src/service/cognito/serve/sim-cognito-endpoint-response.ts
+++ b/src/service/cognito/serve/sim-cognito-endpoint-response.ts
@@ -23,6 +23,24 @@ export class SimCognitoEndpointResponse {
   }
 
   /**
+   * Refuse a method that does not read a published document.
+   *
+   * Both endpoints publish a document, so `GET` and `HEAD` are all they
+   * answer. The Cognito API is reached through `SimSdk` rather than by posting
+   * to this hostname, so a `POST` here is not the API either.
+   */
+  notRead(method: string): Response {
+    return Response.json(
+      {
+        message:
+          `Simulated Cognito answers ${method} at no user pool endpoint. ` +
+          `The JWKS and the OpenID configuration are read with GET.`,
+      },
+      { status: 405, headers: { allow: "GET, HEAD" } },
+    );
+  }
+
+  /**
    * Refuse a path that is neither of the two public endpoints.
    */
   noSuchEndpoint(pathname: string): Response {

--- a/src/service/cognito/serve/sim-cognito-endpoint-response.ts
+++ b/src/service/cognito/serve/sim-cognito-endpoint-response.ts
@@ -7,9 +7,22 @@
 export class SimCognitoEndpointResponse {
   /**
    * Serve a document the pool publishes.
+   *
+   * A HEAD asks for the headers a GET would answer with and no body, so the
+   * document is measured rather than sent.
    */
-  document(body: object): Response {
-    return Response.json(body);
+  document(body: object, method: string): Response {
+    const json = JSON.stringify(body);
+    const headers = {
+      "content-type": "application/json",
+      "content-length": String(Buffer.byteLength(json)),
+    };
+
+    if (method === "HEAD") {
+      return new Response(undefined, { status: 200, headers });
+    }
+
+    return new Response(json, { status: 200, headers });
   }
 
   /**

--- a/src/service/cognito/serve/sim-cognito-endpoint-response.ts
+++ b/src/service/cognito/serve/sim-cognito-endpoint-response.ts
@@ -1,0 +1,34 @@
+/**
+ * The responses a simulated user pool's public endpoints answer with.
+ *
+ * Both endpoints serve JSON, so a refusal is JSON too, carrying the `message`
+ * a Cognito error carries.
+ */
+export class SimCognitoEndpointResponse {
+  /**
+   * Serve a document the pool publishes.
+   */
+  document(body: object): Response {
+    return Response.json(body);
+  }
+
+  /**
+   * Refuse a pool id this endpoint has no pool for.
+   */
+  noSuchUserPool(userPoolId: string): Response {
+    return Response.json(
+      { message: `User pool ${userPoolId} does not exist.` },
+      { status: 404 },
+    );
+  }
+
+  /**
+   * Refuse a path that is neither of the two public endpoints.
+   */
+  noSuchEndpoint(pathname: string): Response {
+    return Response.json(
+      { message: `No simulated Cognito endpoint at ${pathname}` },
+      { status: 404 },
+    );
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
@@ -173,18 +173,47 @@ describe("Serving a sim Cognito user pool's public endpoints", () => {
     // Given a simulated user pool.
     const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
     const userPoolId = await poolIdIn(simAws);
+    const jwksUrl = localUrl(
+      `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+    );
+    const simAwsHttp = new SimAwsHttp({ simAws });
 
     // When its JWKS is asked for with a method that does not read one.
+    const posted = await simAwsHttp.fetch(jwksUrl, { method: "POST" });
+
+    // And when it is asked for with HEAD.
+    const headed = await simAwsHttp.fetch(jwksUrl, { method: "HEAD" });
+
+    // Then the write is refused, and says what the endpoint does answer.
+    assertIdentical(posted.status, 405);
+    assertIdentical(posted.headers.get("allow"), "GET, HEAD");
+
+    // And the HEAD answers the headers a GET would, with no document.
+    assertIdentical(headed.status, 200);
+    assertIdentical(headed.headers.get("content-type"), "application/json");
+    const jwks = simAws.cognitoIdentityProvider().userPool(userPoolId).jwks();
+    const jwksLength = Buffer.byteLength(JSON.stringify(jwks));
+    assertIdentical(headed.headers.get("content-length"), String(jwksLength));
+    assertIdentical(await headed.text(), "");
+  });
+
+  it("reports a path naming no pool as not found", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    await poolIdIn(simAws);
+
+    // When the JWKS path is requested with no pool id in it.
     const response = await new SimAwsHttp({ simAws }).fetch(
       localUrl(
-        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+        "https://cognito-idp.eu-west-2.amazonaws.com//.well-known/jwks.json",
       ),
-      { method: "POST" },
     );
 
-    // Then the endpoint refuses it and says what it does answer.
-    assertIdentical(response.status, 405);
-    assertIdentical(response.headers.get("allow"), "GET, HEAD");
+    // Then there is no endpoint there, rather than a pool with no name.
+    assertIdentical(response.status, 404);
+    assertObjectEquals(await response.json(), {
+      message: "No simulated Cognito endpoint at //.well-known/jwks.json",
+    });
   });
 
   it("stops serving a pool that has been deleted", async () => {

--- a/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
@@ -1,0 +1,173 @@
+import {
+  CreateUserPoolCommand,
+  DeleteUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+function localUrl(input: string): string {
+  return new SimAwsLocalUrl({ input }).toString();
+}
+
+async function poolIdIn(simAws: SimAws): Promise<string> {
+  const created = await simAws
+    .cognitoIdentityProvider()
+    .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+
+  assertNonNullable(created.UserPool?.Id);
+
+  return created.UserPool.Id;
+}
+
+describe("Serving a sim Cognito user pool's public endpoints", () => {
+  it("serves the pool's JWKS anonymously", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When its JWKS endpoint is requested with no credentials at all.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+      ),
+    );
+
+    // Then the pool answers with the keys it signs its tokens with.
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get("content-type"), "application/json");
+    assertObjectEquals(
+      await response.json(),
+      simAws.cognitoIdentityProvider().userPool(userPoolId).jwks(),
+    );
+  });
+
+  it("serves an OpenID configuration naming the requested hostname", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When its OpenID configuration is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/openid-configuration`,
+      ),
+    );
+
+    // Then the issuer and the JWKS URI are ones a client can go on to fetch,
+    // which means the local hostname rather than the real AWS one.
+    const issuer = `http://cognito-idp.eu-west-2.sim-aws.localhost/${userPoolId}`;
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      issuer,
+      /* eslint-disable-next-line @typescript-eslint/naming-convention -- an
+         OpenID discovery metadata name. */
+      jwks_uri: `${issuer}/.well-known/jwks.json`,
+    });
+  });
+
+  it("serves a pool created in another account", async () => {
+    // Given a pool created outside the default account, so its id is the only
+    // thing the request carries about where it lives.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const created = await simAws
+      .account("222222222222")
+      .region("eu-west-2")
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "other-account" }));
+    assertNonNullable(created.UserPool?.Id);
+
+    // When its JWKS endpoint is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${created.UserPool.Id}/.well-known/jwks.json`,
+      ),
+    );
+
+    // Then the pool is found by id alone.
+    assertIdentical(response.status, 200);
+  });
+
+  it("reports an unknown pool id as not found", async () => {
+    // Given a simulated AWS with no user pools.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+    // When an invented pool id's JWKS is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi/.well-known/jwks.json",
+      ),
+    );
+
+    // Then the endpoint reports it as not found.
+    assertIdentical(response.status, 404);
+    assertObjectEquals(await response.json(), {
+      message: "User pool eu-west-2_aBcDeFgHi does not exist.",
+    });
+  });
+
+  it("does not serve a pool through another region's endpoint", async () => {
+    // Given a pool in eu-west-2.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When its JWKS is requested from the us-east-1 endpoint.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.us-east-1.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+      ),
+    );
+
+    // Then the pool is not found there, because a pool id names its region.
+    assertIdentical(response.status, 404);
+  });
+
+  it("reports any other path on the endpoint as not found", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When something other than the two public endpoints is requested.
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const wellKnown = await simAwsHttp.fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/oauth-authorization-server`,
+      ),
+    );
+    const apiPath = await simAwsHttp.fetch(
+      localUrl("https://cognito-idp.eu-west-2.amazonaws.com/"),
+    );
+
+    // Then neither is served: the Cognito API itself is reached through SimSdk
+    // rather than over HTTP.
+    assertIdentical(wellKnown.status, 404);
+    assertIdentical(apiPath.status, 404);
+  });
+
+  it("stops serving a pool that has been deleted", async () => {
+    // Given a pool that is then deleted.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+    await simAws
+      .cognitoIdentityProvider()
+      .deleteUserPool(new DeleteUserPoolCommand({ UserPoolId: userPoolId }));
+
+    // When its JWKS is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+      ),
+    );
+
+    // Then the endpoint no longer answers for it.
+    assertIdentical(response.status, 404);
+  });
+});

--- a/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-jwks-serve.iso.test.ts
@@ -152,6 +152,41 @@ describe("Serving a sim Cognito user pool's public endpoints", () => {
     assertIdentical(apiPath.status, 404);
   });
 
+  it("reports a path below an endpoint as not found", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When something below the JWKS path is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json/keys`,
+      ),
+    );
+
+    // Then it is not served, rather than treated as the JWKS path with
+    // something after it.
+    assertIdentical(response.status, 404);
+  });
+
+  it("answers only the methods a document is read with", async () => {
+    // Given a simulated user pool.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const userPoolId = await poolIdIn(simAws);
+
+    // When its JWKS is asked for with a method that does not read one.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(
+        `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+      ),
+      { method: "POST" },
+    );
+
+    // Then the endpoint refuses it and says what it does answer.
+    assertIdentical(response.status, 405);
+    assertIdentical(response.headers.get("allow"), "GET, HEAD");
+  });
+
   it("stops serving a pool that has been deleted", async () => {
     // Given a pool that is then deleted.
     const simAws = new SimAws({ defaultRegionName: "eu-west-2" });

--- a/src/service/cognito/serve/sim-cognito-jwks-serve.loc.test.ts
+++ b/src/service/cognito/serve/sim-cognito-jwks-serve.loc.test.ts
@@ -1,0 +1,170 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import { type Jwks, SimpleJwksCache } from "aws-jwt-verify/jwk";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../serve/index.js";
+import type { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * A pool, an app client, and an access token for a user of it.
+ */
+interface SignedInPool {
+  readonly userPoolId: string;
+  readonly clientId: string;
+  readonly accessToken: string;
+}
+
+async function signInToNewPool(simAws: SimAws): Promise<SignedInPool> {
+  const cognito = simAws.cognitoIdentityProvider();
+
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+  assertNonNullable(pool.UserPool?.Id);
+  const userPoolId = pool.UserPool.Id;
+
+  const appClient = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+    }),
+  );
+  assertNonNullable(appClient.UserPoolClient?.ClientId);
+  const clientId = appClient.UserPoolClient.ClientId;
+
+  await cognito.adminCreateUser(
+    new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+  );
+  await cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: "alice",
+      Password: "Sup3rSecret!",
+      Permanent: true,
+    }),
+  );
+
+  const { AuthenticationResult: result } = await cognito.adminInitiateAuth(
+    new AdminInitiateAuthCommand({
+      UserPoolId: userPoolId,
+      ClientId: clientId,
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+    }),
+  );
+  assertNonNullable(result?.AccessToken);
+
+  return { userPoolId, clientId, accessToken: result.AccessToken };
+}
+
+/**
+ * The URL a pool's JWKS is served at on a local server.
+ */
+function jwksUrl(srv: SimAwsLocalServer, userPoolId: string): URL {
+  return srv.localUrl(
+    `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}/.well-known/jwks.json`,
+  );
+}
+
+describe("Serving a sim Cognito JWKS on localhost", () => {
+  it("verifies a token with a JWKS fetched over real localhost HTTP", async () => {
+    // Given a simulated user pool with a signed-in user, served on localhost.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const { userPoolId, clientId, accessToken } = await signInToNewPool(simAws);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the pool's JWKS is fetched from the served endpoint.
+      const response = await fetch(jwksUrl(srv, userPoolId));
+      const jwks = (await response.json()) as Jwks;
+
+      // And the verifier the application uses is given those keys.
+      const verifier = CognitoJwtVerifier.create({
+        userPoolId,
+        tokenUse: "access",
+        clientId,
+      });
+      verifier.cacheJwks(jwks);
+
+      // Then the token the simulator issued verifies against them.
+      const payload = await verifier.verify(accessToken);
+      assertIdentical(payload.username, "alice");
+    } finally {
+      srv.close();
+    }
+  });
+
+  it("lets a verifier fetch the JWKS for itself", async () => {
+    // Given a simulated user pool with a signed-in user, served on localhost.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const { userPoolId, clientId, accessToken } = await signInToNewPool(simAws);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When a verifier configured with nothing but the pool it trusts fetches
+      // its own keys, through a cache that sends the AWS URL it builds to the
+      // local server. aws-jwt-verify fetches over HTTPS only, so this is what
+      // stands in for the network rather than a change to the verifier setup.
+      const verifier = CognitoJwtVerifier.create(
+        { userPoolId, tokenUse: "access", clientId },
+        {
+          jwksCache: new SimpleJwksCache({
+            fetcher: {
+              fetch: async (uri: string): Promise<ArrayBuffer> => {
+                const served = await fetch(srv.localUrl(uri));
+                return served.arrayBuffer();
+              },
+            },
+          }),
+        },
+      );
+
+      // Then the token verifies against keys the verifier went and got.
+      const payload = await verifier.verify(accessToken);
+      assertIdentical(payload.username, "alice");
+    } finally {
+      srv.close();
+    }
+  });
+
+  it("serves an OpenID configuration pointing at the served JWKS", async () => {
+    // Given a simulated user pool served on localhost.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const pool = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "myapp-users" }));
+    assertNonNullable(pool.UserPool?.Id);
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the OpenID configuration is fetched over localhost.
+      const response = await fetch(
+        srv.localUrl(
+          `https://cognito-idp.eu-west-2.amazonaws.com/${pool.UserPool.Id}/.well-known/openid-configuration`,
+        ),
+      );
+      const document = (await response.json()) as {
+        /* eslint-disable-next-line @typescript-eslint/naming-convention --
+           an OpenID Connect discovery metadata name. */
+        jwks_uri: string;
+      };
+
+      // Then the JWKS URI it advertises is one that answers.
+      assertIdentical(response.status, 200);
+      const jwks = await fetch(document.jwks_uri);
+      assertIdentical(jwks.status, 200);
+    } finally {
+      srv.close();
+    }
+  });
+});

--- a/src/service/cognito/serve/sim-cognito-openid-configuration.ts
+++ b/src/service/cognito/serve/sim-cognito-openid-configuration.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/naming-convention -- OpenID Connect
+   discovery metadata names are the ones the specification defines, rather than
+   identifier names. */
+import type { SimCognitoUserPool } from "../user-pool/sim-cognito-user-pool.js";
+
+/**
+ * The OpenID Connect discovery metadata of a user pool, in the shape the real
+ * `.../.well-known/openid-configuration` endpoint serves.
+ */
+export interface SimCognitoOpenIdConfigurationDocument {
+  readonly issuer: string;
+  readonly jwks_uri: string;
+  readonly id_token_signing_alg_values_supported: readonly string[];
+  readonly response_types_supported: readonly string[];
+  readonly scopes_supported: readonly string[];
+  readonly subject_types_supported: readonly string[];
+  readonly token_endpoint_auth_methods_supported: readonly string[];
+}
+
+/**
+ * Builds the discovery document a simulated user pool publishes.
+ *
+ * The issuer and the JWKS URI name the origin the request arrived on rather
+ * than the real AWS one. A client that discovers a document has to be able to
+ * fetch the keys it points at, and pointing at `cognito-idp.<region>.amazonaws.com`
+ * would send it to real AWS. The tokens themselves still carry the real issuer
+ * in `iss`, which is what a verifier builds from a pool id and checks against,
+ * so the two disagree here and agree on real Cognito.
+ *
+ * No `authorization_endpoint`, `token_endpoint` or `userinfo_endpoint` is
+ * published, because the hosted UI and the OAuth endpoints are not simulated.
+ * A client discovering nothing there fails rather than calling an endpoint
+ * that would not answer.
+ */
+export class SimCognitoOpenIdConfiguration {
+  /**
+   * The discovery document for a pool, as served from an origin.
+   */
+  document(
+    pool: SimCognitoUserPool,
+    origin: string,
+  ): SimCognitoOpenIdConfigurationDocument {
+    const issuer = `${origin}/${pool.id}`;
+
+    return {
+      issuer,
+      jwks_uri: `${issuer}/.well-known/jwks.json`,
+      id_token_signing_alg_values_supported: ["RS256"],
+      response_types_supported: ["code", "token"],
+      scopes_supported: ["openid", "email", "phone", "profile"],
+      subject_types_supported: ["public"],
+      token_endpoint_auth_methods_supported: [
+        "client_secret_basic",
+        "client_secret_post",
+      ],
+    };
+  }
+}

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -11,6 +11,7 @@ import {
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
 import { SimCognitoCommands } from "./command/sim-cognito-commands.js";
+import { SimCognitoUserPoolRegistry } from "./registry/sim-cognito-user-pool-registry.js";
 import { SimCognitoSdkCommandRouter } from "./sdk/sim-cognito-sdk-command-router.js";
 import {
   type SimCognitoIdentityProviderRequestOptions,
@@ -30,6 +31,7 @@ interface SimCognitoIdentityProviderProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly userPoolRegistry?: SimCognitoUserPoolRegistry;
 }
 
 /**
@@ -49,6 +51,7 @@ interface SimCognitoIdentityProviderProperties {
  */
 export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
   private readonly pools: SimCognitoUserPoolStore;
+  private readonly userPoolRegistry: SimCognitoUserPoolRegistry;
   private readonly sdkRouter = new SimCognitoSdkCommandRouter(this);
 
   constructor(properties: SimCognitoIdentityProviderProperties = {}) {
@@ -56,8 +59,9 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      userPoolRegistry = new SimCognitoUserPoolRegistry(),
     } = properties;
-    const pools = new SimCognitoUserPoolStore();
+    const pools = new SimCognitoUserPoolStore({ registry: userPoolRegistry });
 
     super({
       commands: new SimCognitoCommands({
@@ -70,6 +74,19 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
     });
 
     this.pools = pools;
+    this.userPoolRegistry = userPoolRegistry;
+  }
+
+  /**
+   * Find a user pool by id, in whichever Account and Region created it.
+   *
+   * A pool id is unique across a simulation, as it is across real AWS, so this
+   * is what the served JWKS and OpenID configuration endpoints resolve a pool
+   * from: the request hostname carries the region and the path carries the id,
+   * and neither says which Account owns the pool.
+   */
+  findUserPoolInAnyAccount(userPoolId: string): SimCognitoUserPool | undefined {
+    return this.userPoolRegistry.find(userPoolId);
   }
 
   /**

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-store.ts
@@ -2,6 +2,7 @@ import {
   SimCognitoNotAuthorizedException,
   SimCognitoResourceNotFoundException,
 } from "../error/sim-cognito.error.js";
+import { SimCognitoUserPoolRegistry } from "../registry/sim-cognito-user-pool-registry.js";
 import type { SimCognitoIssuedToken } from "./auth/sim-cognito-issued-token.js";
 import type { SimCognitoUserPoolClient } from "./client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPoolClientId } from "./client/sim-cognito-user-pool-client-id.js";
@@ -24,14 +25,27 @@ export interface SimCognitoAccessTokenInPool {
   readonly token: SimCognitoIssuedToken;
 }
 
+interface SimCognitoUserPoolStoreProperties {
+  readonly registry?: SimCognitoUserPoolRegistry;
+}
+
 /**
  * The user pools of one simulated Cognito scope.
  *
  * Pools are keyed by id rather than by name, as real Cognito keys them: two
  * pools may share a name, and only the id ever identifies one.
+ *
+ * A store also keeps the simulation-wide registry up to date, because a pool
+ * id has to be unique beyond this one scope and the serving layer resolves a
+ * pool from its id alone.
  */
 export class SimCognitoUserPoolStore {
   private readonly pools = new Map<string, SimCognitoUserPool>();
+  private readonly registry: SimCognitoUserPoolRegistry;
+
+  constructor(properties: SimCognitoUserPoolStoreProperties = {}) {
+    this.registry = properties.registry ?? new SimCognitoUserPoolRegistry();
+  }
 
   private static unexpired(
     issued: SimCognitoIssuedToken,
@@ -53,9 +67,13 @@ export class SimCognitoUserPoolStore {
 
   /**
    * The pool ids already in use, so a new one can avoid them.
+   *
+   * These come from the whole simulation rather than from this scope, because
+   * a pool id is what the serving layer looks a pool up by and two Accounts
+   * sharing one would be ambiguous.
    */
   get ids(): Set<string> {
-    return new Set(this.pools.keys());
+    return this.registry.ids;
   }
 
   /**
@@ -63,6 +81,7 @@ export class SimCognitoUserPoolStore {
    */
   add(pool: SimCognitoUserPool): void {
     this.pools.set(pool.id, pool);
+    this.registry.register(pool);
   }
 
   /**
@@ -70,6 +89,7 @@ export class SimCognitoUserPoolStore {
    */
   remove(pool: SimCognitoUserPool): void {
     this.pools.delete(pool.id);
+    this.registry.deregister(pool);
   }
 
   /**

--- a/src/service/route53/resolve/sim-r53-s3-service-target.ts
+++ b/src/service/route53/resolve/sim-r53-s3-service-target.ts
@@ -1,0 +1,101 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+
+const s3WebsiteServiceLabel = "s3-website";
+const s3RestServiceLabel = "s3";
+
+/**
+ * Maps Yulin-local S3 hostnames to simulated S3 service targets.
+ *
+ * S3 is the one simulated service with two endpoints, and its REST endpoint
+ * has two hostname styles, so all of that hostname matching is here rather
+ * than alongside the services that have one form each.
+ */
+export class SimRoute53S3ServiceTargets {
+  /**
+   * Convert a logical S3 hostname into a simulated S3 service target.
+   */
+  resolve(logicalName: string): SimAwsServiceTarget | undefined {
+    return this.websiteTarget(logicalName) ?? this.restTarget(logicalName);
+  }
+
+  /**
+   * Resolve S3 website endpoint hostnames.
+   *
+   * Simulated S3 website hostnames use:
+   *
+   *   <bucket-name>.s3-website.<region>
+   *
+   * The bucket name can contain dots, so all labels before the service and region
+   * labels are joined back together as the resource name.
+   */
+  private websiteTarget(logicalName: string): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length < 3) {
+      return undefined;
+    }
+
+    const service = labels.at(-2);
+    const regionName = labels.at(-1) as AwsRegionName | undefined;
+
+    if (service !== s3WebsiteServiceLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    const resourceName = labels.slice(0, -2).join(".");
+
+    /* v8 ignore if -- defensive check */
+    if (resourceName.length === 0 || regionName.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "s3",
+      resourceName,
+      regionName,
+      endpoint: "website",
+    };
+  }
+
+  /**
+   * Resolve S3 REST API endpoint hostnames.
+   *
+   * Simulated S3 REST hostnames use either of the two forms real S3 offers:
+   *
+   *   <bucket-name>.s3.<region>    virtual-hosted style
+   *   s3.<region>                  path style, naming the Bucket in the path
+   *
+   * Both are needed because the AWS SDK chooses between them for itself. A
+   * Bucket name containing dots cannot be a single host label, so the SDK falls
+   * back to path style for those, and a URL signed one way cannot be served the
+   * other.
+   */
+  private restTarget(logicalName: string): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length < 2) {
+      return undefined;
+    }
+
+    const service = labels.at(-2);
+    const regionName = labels.at(-1) as AwsRegionName | undefined;
+
+    if (service !== s3RestServiceLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    /* v8 ignore if -- empty labels are rejected before resolution */
+    if (regionName.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "s3",
+      // Empty for path style, where the Bucket is the first path segment.
+      resourceName: labels.slice(0, -2).join("."),
+      regionName,
+      endpoint: "rest",
+    };
+  }
+}

--- a/src/service/route53/resolve/sim-r53-service-target-resolver.ts
+++ b/src/service/route53/resolve/sim-r53-service-target-resolver.ts
@@ -3,10 +3,10 @@ import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { lambdaFunctionUrlHostLabel } from "../../lambda/function/url/sim-lambda-function-url-host.js";
 import { simRoute53LogicalName } from "../local-name/sim-route53-local-name.js";
 import { simRoute53DnsHostName } from "../serve/sim-route53-dns-host.js";
+import { SimRoute53S3ServiceTargets } from "./sim-r53-s3-service-target.js";
 
-const s3WebsiteServiceLabel = "s3-website";
-const s3RestServiceLabel = "s3";
 const cloudFrontServiceLabel = "cloudfront";
+const cognitoIdpServiceLabel = "cognito-idp";
 
 /**
  * Maps Yulin-local service hostnames to simulated AWS service targets.
@@ -22,6 +22,8 @@ const cloudFrontServiceLabel = "cloudfront";
  * target.
  */
 export class SimRoute53ServiceTargetResolver {
+  private readonly s3Targets = new SimRoute53S3ServiceTargets();
+
   /**
    * Convert a Yulin-local hostname into a simulated service target.
    *
@@ -38,10 +40,10 @@ export class SimRoute53ServiceTargetResolver {
 
     return (
       this.route53DnsServiceTarget(logicalName) ??
-      this.s3WebsiteServiceTarget(logicalName) ??
-      this.s3RestServiceTarget(logicalName) ??
+      this.s3Targets.resolve(logicalName) ??
       this.cloudFrontServiceTarget(logicalName) ??
-      this.lambdaFunctionUrlServiceTarget(logicalName)
+      this.lambdaFunctionUrlServiceTarget(logicalName) ??
+      this.cognitoIdpServiceTarget(logicalName)
     );
   }
 
@@ -62,90 +64,6 @@ export class SimRoute53ServiceTargetResolver {
     return {
       service: "route53",
       resourceName: simRoute53DnsHostName,
-    };
-  }
-
-  /**
-   * Resolve S3 website endpoint hostnames.
-   *
-   * Simulated S3 website hostnames use:
-   *
-   *   <bucket-name>.s3-website.<region>
-   *
-   * The bucket name can contain dots, so all labels before the service and region
-   * labels are joined back together as the resource name.
-   */
-  private s3WebsiteServiceTarget(
-    logicalName: string,
-  ): SimAwsServiceTarget | undefined {
-    const labels = logicalName.split(".");
-
-    if (labels.length < 3) {
-      return undefined;
-    }
-
-    const service = labels.at(-2);
-    const regionName = labels.at(-1) as AwsRegionName | undefined;
-
-    if (service !== s3WebsiteServiceLabel || regionName === undefined) {
-      return undefined;
-    }
-
-    const resourceName = labels.slice(0, -2).join(".");
-
-    /* v8 ignore if -- defensive check */
-    if (resourceName.length === 0 || regionName.length === 0) {
-      return undefined;
-    }
-
-    return {
-      service: "s3",
-      resourceName,
-      regionName,
-      endpoint: "website",
-    };
-  }
-
-  /**
-   * Resolve S3 REST API endpoint hostnames.
-   *
-   * Simulated S3 REST hostnames use either of the two forms real S3 offers:
-   *
-   *   <bucket-name>.s3.<region>    virtual-hosted style
-   *   s3.<region>                  path style, naming the Bucket in the path
-   *
-   * Both are needed because the AWS SDK chooses between them for itself. A
-   * Bucket name containing dots cannot be a single host label, so the SDK falls
-   * back to path style for those, and a URL signed one way cannot be served the
-   * other.
-   */
-  private s3RestServiceTarget(
-    logicalName: string,
-  ): SimAwsServiceTarget | undefined {
-    const labels = logicalName.split(".");
-
-    if (labels.length < 2) {
-      return undefined;
-    }
-
-    const service = labels.at(-2);
-    const regionName = labels.at(-1) as AwsRegionName | undefined;
-
-    if (service !== s3RestServiceLabel || regionName === undefined) {
-      return undefined;
-    }
-
-    /* v8 ignore if -- empty labels are rejected before resolution */
-    if (regionName.length === 0) {
-      return undefined;
-    }
-
-    return {
-      service: "s3",
-      // Empty for path style, where the Bucket is the first path segment.
-      resourceName: labels.slice(0, -2).join("."),
-      regionName,
-      endpoint: "rest",
     };
   }
 
@@ -219,6 +137,45 @@ export class SimRoute53ServiceTargetResolver {
     return {
       service: "lambda",
       resourceName: urlId,
+      regionName: regionName as AwsRegionName,
+    };
+  }
+
+  /**
+   * Resolve Cognito user pool endpoint hostnames.
+   *
+   * Simulated Cognito hostnames use:
+   *
+   *   cognito-idp.<region>
+   *
+   * The hostname names the regional Cognito endpoint rather than one pool, as
+   * the real `cognito-idp.<region>.amazonaws.com` does, and the pool id is the
+   * first path segment. The resource name is therefore empty, in the same way
+   * it is for the path-style S3 endpoint.
+   */
+  private cognitoIdpServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    const labels = logicalName.split(".");
+
+    if (labels.length !== 2) {
+      return undefined;
+    }
+
+    const [service, regionName] = labels;
+
+    if (service !== cognitoIdpServiceLabel || regionName === undefined) {
+      return undefined;
+    }
+
+    /* v8 ignore if -- empty labels are rejected before resolution */
+    if (regionName.length === 0) {
+      return undefined;
+    }
+
+    return {
+      service: "cognitoIdentityProvider",
+      resourceName: "",
       regionName: regionName as AwsRegionName,
     };
   }


### PR DESCRIPTION
A simulated user pool answers GET /<userPoolId>/.well-known/jwks.json and /<userPoolId>/.well-known/openid-configuration on localhost, anonymously, as real Cognito serves both. A verifier fetches the pool's keys rather than being handed them.

Pool ids are now allocated against a simulation-wide registry, so a served request naming only a pool id finds the pool whichever Account created it.

Resolves https://github.com/KensioSoftware/yulin/issues/222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added anonymous local HTTP endpoints for simulated Cognito user pool JWKS and OpenID Connect discovery.
  * Enabled local JWT/JWKS verification workflows against the served Cognito endpoints.
  * Expanded simulator service routing and signing target support to include Cognito Identity Provider.
  * Enhanced Route 53 target resolution with Cognito user-pool hostname support.

* **Bug Fixes**
  * Hardened `.well-known` endpoint method/path handling (supports `GET`/`HEAD`, rejects unsupported patterns, returns expected 404/405).

* **Documentation**
  * Updated Cognito docs with served endpoints, issuer/jwks URI divergences, and limitations.

* **Tests**
  * Added/expanded JWKS and OpenID configuration server test coverage and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->