### PR TITLE
feat: deploy Cognito user pools from CloudFormation templates

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -963,6 +963,8 @@ Sim CloudFormation supports a subset of CloudFormation. The resource types it cr
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
 - `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`
+- `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
+  `AWS::Cognito::UserPoolGroup`
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -33,6 +33,9 @@ Sim Cognito currently supports:
   pool verifies them unchanged
 - A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
   `serveSimAws`, anonymously, so a verifier fetches the keys rather than being handed them
+- `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and `AWS::Cognito::UserPoolGroup`
+  deployed from a CloudFormation template, with the `Ref` and `Fn::GetAtt` values real
+  CloudFormation returns
 - Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
 - The real default password policy, applied to the passwords users are given
 - The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
@@ -975,6 +978,137 @@ Both listings are in creation order and hold at most sixty entries. Follow `Next
 rest. A listed pool carries no ARN and a listed app client carries no secret, as real Cognito leaves
 those out of a listing.
 
+## Deploying a pool from CloudFormation
+
+`AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
+`AWS::Cognito::UserPoolGroup` deploy into simulated Cognito, so a stack that already declares a pool
+does not have to be duplicated in SDK calls to be tested.
+
+```typescript sim-cognito-cloudformation
+/**
+ * Deploying a user pool, an app client and a group from a template.
+ */
+
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          Policies: { PasswordPolicy: { MinimumLength: 12 } },
+        },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ClientName: "web",
+          ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+        },
+      },
+      AdminsGroup: {
+        Type: "AWS::Cognito::UserPoolGroup",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          GroupName: "admins",
+          Precedence: 0,
+        },
+      },
+    },
+    Outputs: {
+      UserPoolId: { Value: { Ref: "AppPool" } },
+      ClientId: { Value: { Ref: "AppClient" } },
+      ProviderUrl: { Value: { "Fn::GetAtt": ["AppPool", "ProviderURL"] } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const userPoolId = stack.outputs.get("UserPoolId")?.value as string;
+const clientId = stack.outputs.get("ClientId")?.value as string;
+
+console.log(userPoolId); // "eu-west-2_aBcDeFgHi"
+console.log(stack.outputs.get("ProviderUrl")?.value);
+// "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi"
+
+// The deployed pool, client and group are what the test then works with.
+const cognito = simAws.cognitoIdentityProvider();
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+await cognito.adminAddUserToGroup(
+  new AdminAddUserToGroupCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    GroupName: "admins",
+  }),
+);
+
+// The sign-in runs through the flow the template opened on the app client.
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
+  }),
+);
+
+console.log(AuthenticationResult?.AccessToken !== undefined); // true
+```
+
+`Ref` and `Fn::GetAtt` answer what real CloudFormation answers:
+
+| Resource type                  | `Ref`      | `Fn::GetAtt`                                       |
+| ------------------------------ | ---------- | -------------------------------------------------- |
+| `AWS::Cognito::UserPool`       | pool id    | `Arn`, `ProviderName`, `ProviderURL`, `UserPoolId` |
+| `AWS::Cognito::UserPoolClient` | client id  | `ClientId`                                         |
+| `AWS::Cognito::UserPoolGroup`  | group name | none                                               |
+
+`ProviderName` is `cognito-idp.<region>.amazonaws.com/<userPoolId>` and `ProviderURL` is the same
+with an `https://` prefix, which is also the `iss` claim of the tokens the pool issues.
+
+An app client publishes no `ClientSecret` attribute, because real CloudFormation publishes none. Read
+the secret with `DescribeUserPoolClient`, which reports it here as it does on real Cognito.
+
+The properties each type reads are the ones this simulation models:
+
+- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `MfaConfiguration` and
+  `UserPoolTier`. The last two are accepted at their AWS defaults and refused otherwise, as
+  `CreateUserPool` refuses them.
+- `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
+  `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity` and
+  `TokenValidityUnits`.
+- `AWS::Cognito::UserPoolGroup`: `UserPoolId`, `GroupName`, `Description`, `Precedence` and
+  `RoleArn`.
+
+Any other property is refused at deploy time, naming the logical id and the property, rather than
+deploying a resource that would behave differently on AWS. A stack that forgets
+`ALLOW_ADMIN_USER_PASSWORD_AUTH` therefore fails at the sign-in here as it would in a deployment,
+which is the point of deploying the template rather than restating it.
+
 ## Serving a pool's JWKS on localhost
 
 `serveSimAws` serves the two public endpoints of every simulated pool:
@@ -1258,8 +1392,11 @@ Current documented limitations:
 - Tags are not simulated. `UserPoolTags` is refused, and `TagResource`, `UntagResource` and
   `ListTagsForResource` are not implemented.
 - Listings carry no filtering, and are in creation order rather than any order real Cognito chooses.
-- `AWS::Cognito::UserPool` and the other `AWS::Cognito::*` CloudFormation resource types are reported
-  as unsupported and skipped rather than deployed.
+- Of the CloudFormation resource types, only `AWS::Cognito::UserPool`,
+  `AWS::Cognito::UserPoolClient` and `AWS::Cognito::UserPoolGroup` deploy. The others, including
+  `AWS::Cognito::UserPoolDomain`, `AWS::Cognito::UserPoolIdentityProvider`,
+  `AWS::Cognito::UserPoolUser` and everything under `AWS::Cognito::IdentityPool`, are reported as
+  unsupported and skipped rather than deployed.
 - The Cognito API itself is not served as HTTP by `serveSimAws`, only the two public pool endpoints.
   A `CognitoIdentityProviderClient` reaches the simulator through `SimSdk` rather than through an
   endpoint override.

--- a/docs/services/cognito/sim-cognito-cloudformation.example.ts
+++ b/docs/services/cognito/sim-cognito-cloudformation.example.ts
@@ -1,0 +1,92 @@
+/**
+ * Deploying a user pool, an app client and a group from a template.
+ */
+
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          Policies: { PasswordPolicy: { MinimumLength: 12 } },
+        },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ClientName: "web",
+          ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+        },
+      },
+      AdminsGroup: {
+        Type: "AWS::Cognito::UserPoolGroup",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          GroupName: "admins",
+          Precedence: 0,
+        },
+      },
+    },
+    Outputs: {
+      UserPoolId: { Value: { Ref: "AppPool" } },
+      ClientId: { Value: { Ref: "AppClient" } },
+      ProviderUrl: { Value: { "Fn::GetAtt": ["AppPool", "ProviderURL"] } },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const userPoolId = stack.outputs.get("UserPoolId")?.value as string;
+const clientId = stack.outputs.get("ClientId")?.value as string;
+
+console.log(userPoolId); // "eu-west-2_aBcDeFgHi"
+console.log(stack.outputs.get("ProviderUrl")?.value);
+// "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_aBcDeFgHi"
+
+// The deployed pool, client and group are what the test then works with.
+const cognito = simAws.cognitoIdentityProvider();
+
+await cognito.adminCreateUser(
+  new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+);
+await cognito.adminSetUserPassword(
+  new AdminSetUserPasswordCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    Password: "Sup3rSecretPassw0rd!",
+    Permanent: true,
+  }),
+);
+await cognito.adminAddUserToGroup(
+  new AdminAddUserToGroupCommand({
+    UserPoolId: userPoolId,
+    Username: "alice",
+    GroupName: "admins",
+  }),
+);
+
+// The sign-in runs through the flow the template opened on the app client.
+const { AuthenticationResult } = await cognito.adminInitiateAuth(
+  new AdminInitiateAuthCommand({
+    UserPoolId: userPoolId,
+    ClientId: clientId,
+    AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecretPassw0rd!" },
+  }),
+);
+
+console.log(AuthenticationResult?.AccessToken !== undefined); // true

--- a/src/service/cloudformation/resource/cfn/cognito/sim-cognito-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cognito/sim-cognito-cfn-value-adapter.ts
@@ -1,0 +1,40 @@
+import { SimCognitoGroup } from "../../../../cognito/user-pool/group/sim-cognito-group.js";
+import { SimCognitoUserPoolClient } from "../../../../cognito/user-pool/client/sim-cognito-user-pool-client.js";
+import { SimCognitoUserPool } from "../../../../cognito/user-pool/sim-cognito-user-pool.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimCognitoUserPoolCfn } from "./sim-cognito-user-pool-cfn.js";
+import { SimCognitoUserPoolClientCfn } from "./sim-cognito-user-pool-client-cfn.js";
+import { SimCognitoUserPoolGroupCfn } from "./sim-cognito-user-pool-group-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Cognito Resource.
+ */
+export function cognitoValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Cognito::UserPool" &&
+    properties.simResource instanceof SimCognitoUserPool
+  ) {
+    return new SimCognitoUserPoolCfn({ pool: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Cognito::UserPoolClient" &&
+    properties.simResource instanceof SimCognitoUserPoolClient
+  ) {
+    return new SimCognitoUserPoolClientCfn({ client: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Cognito::UserPoolGroup" &&
+    properties.simResource instanceof SimCognitoGroup
+  ) {
+    return new SimCognitoUserPoolGroupCfn({ group: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-cfn.ts
@@ -1,0 +1,57 @@
+import type { SimCognitoUserPool } from "../../../../cognito/user-pool/sim-cognito-user-pool.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCognitoUserPoolCfnProperties {
+  readonly pool: SimCognitoUserPool;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Cognito user pool.
+ */
+export class SimCognitoUserPoolCfn implements SimCfnResourceValueAdapter {
+  private readonly pool: SimCognitoUserPool;
+
+  constructor(properties: SimCognitoUserPoolCfnProperties) {
+    this.pool = properties.pool;
+  }
+
+  /**
+   * AWS::Cognito::UserPool Ref returns the pool id, not the ARN. That is what
+   * an app client, a group and an SDK client all name the pool by, so a Ref is
+   * usable straight through as a `UserPoolId`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.pool.id;
+  }
+
+  /**
+   * AWS::Cognito::UserPool attributes supported by the simulator.
+   *
+   * `ProviderName` and `ProviderURL` are the same string with and without the
+   * scheme, which is the distinction that matters downstream: a JWT `iss`
+   * claim and an OIDC issuer take the URL, while an identity pool's provider
+   * name takes the bare one.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.pool.arn.value;
+      }
+      case "ProviderName": {
+        return this.pool.providerName;
+      }
+      case "ProviderURL": {
+        return this.pool.issuerUrl;
+      }
+      case "UserPoolId": {
+        return this.pool.id;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Cognito::UserPool attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-client-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-client-cfn.ts
@@ -1,0 +1,45 @@
+import type { SimCognitoUserPoolClient } from "../../../../cognito/user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCognitoUserPoolClientCfnProperties {
+  readonly client: SimCognitoUserPoolClient;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Cognito app client.
+ */
+export class SimCognitoUserPoolClientCfn implements SimCfnResourceValueAdapter {
+  private readonly client: SimCognitoUserPoolClient;
+
+  constructor(properties: SimCognitoUserPoolClientCfnProperties) {
+    this.client = properties.client;
+  }
+
+  /**
+   * AWS::Cognito::UserPoolClient Ref returns the client id, which is what an
+   * application is configured with and what a sign-in names.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.client.id;
+  }
+
+  /**
+   * AWS::Cognito::UserPoolClient publishes one attribute, and it is the client
+   * id that `Ref` already returns.
+   *
+   * The client secret is not among them on real CloudFormation, which is why
+   * CDK reaches for a custom resource to get one. `DescribeUserPoolClient`
+   * reports it, here as on real Cognito, so a test that needs the secret asks
+   * for it that way.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "ClientId") {
+      return this.client.id;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Cognito::UserPoolClient attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-group-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cognito/sim-cognito-user-pool-group-cfn.ts
@@ -1,0 +1,36 @@
+import type { SimCognitoGroup } from "../../../../cognito/user-pool/group/sim-cognito-group.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCognitoUserPoolGroupCfnProperties {
+  readonly group: SimCognitoGroup;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Cognito group.
+ */
+export class SimCognitoUserPoolGroupCfn implements SimCfnResourceValueAdapter {
+  private readonly group: SimCognitoGroup;
+
+  constructor(properties: SimCognitoUserPoolGroupCfnProperties) {
+    this.group = properties.group;
+  }
+
+  /**
+   * AWS::Cognito::UserPoolGroup Ref returns the group name, which is what
+   * every group operation names the group by. A group has no id or ARN of its
+   * own.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.group.name;
+  }
+
+  /**
+   * AWS::Cognito::UserPoolGroup publishes no Fn::GetAtt attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::Cognito::UserPoolGroup attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -1,6 +1,7 @@
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
+import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
@@ -46,6 +47,7 @@ export function simCfnResourceValueAdapter(
   return (
     acmValueAdapter(properties) ??
     cloudFrontValueAdapter(properties) ??
+    cognitoValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??
     lambdaValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -51,6 +51,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "CloudFront": {
       return scopedAws.cloudFront().cfnResourceFactory();
     }
+    case "Cognito": {
+      return scopedAws.cognitoIdentityProvider().cfnResourceFactory();
+    }
     case "IAM": {
       return scopedAws.iam().cfnResourceFactory();
     }

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -141,6 +141,29 @@ hands out all three tokens and `reissue` signs a new access and id token for a r
 difference `REFRESH_TOKEN_AUTH` answers with. Everything it issues is recorded on the pool, because
 the pool is what a refresh or a sign-out presents a token back to.
 
+## CloudFormation resources
+
+`cfn/` creates `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
+`AWS::Cognito::UserPoolGroup`, one creator per type behind
+`SimCognitoCfnResourceFactory`. Each creator goes through the ordinary Command rather than
+constructing the model, so a deployed pool is the same thing an SDK caller would have got, refusals
+included.
+
+A properties class per type turns the template's properties into that Command's input.
+`UserPoolName` is the one property whose CloudFormation name differs from the API's `PoolName`.
+`SimCfnCognitoPropertyParser` and the `SimCfnCognitoValueParser` it extends read the property
+shapes, accepting the quoted forms CloudFormation carries numbers and booleans in.
+
+Each type states the properties it simulates, and every other property is refused. That is an
+allow-list rather than a list of known-unsimulated properties, because CloudFormation has properties
+the Cognito API does not, `EnabledMfas` among them, and those would otherwise be dropped on the way
+to a Command that has nowhere to refuse them. Properties the API does know, such as
+`MfaConfiguration`, are passed through instead, so the refusal that reaches the reader is the one
+that says why.
+
+`Ref` and `Fn::GetAtt` live in `cloudformation/resource/cfn/cognito/`, one adapter per Resource
+type, rather than on the service objects.
+
 ## Served pool endpoints
 
 `serve/` holds the localhost HTTP side, which is the two endpoints real Cognito serves without any

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-creator.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-creator.ts
@@ -1,0 +1,59 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import { SimCfnCognitoClientProperties } from "./sim-cfn-cognito-client-properties.js";
+
+interface SimCfnCognitoClientCreatorProperties {
+  readonly cognito: SimCognitoIdentityProvider;
+}
+
+/**
+ * Creates simulated app clients from AWS::Cognito::UserPoolClient Resources.
+ *
+ * The client goes through the ordinary CreateUserPoolClient command, so a
+ * template gets the same validation an SDK caller would: the authentication
+ * flow names are checked, a secret is generated only when the template asks
+ * for one, and a pool that does not exist is refused.
+ */
+export class SimCfnCognitoClientCreator {
+  private readonly cognito: SimCognitoIdentityProvider;
+
+  constructor(properties: SimCfnCognitoClientCreatorProperties) {
+    this.cognito = properties.cognito;
+  }
+
+  /**
+   * Create an app client from an AWS::Cognito::UserPoolClient Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCognitoUserPoolClient> {
+    const clientProperties = new SimCfnCognitoClientProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.cognito.createUserPoolClient({
+      input: clientProperties.createUserPoolClientInput(),
+    });
+
+    const clientId = created.UserPoolClient?.ClientId;
+    assertDefined(
+      clientId,
+      `sim Cognito app client id after CloudFormation creation for ${resource.logicalId}`,
+    );
+
+    const client = this.cognito
+      .userPool(clientProperties.userPoolId())
+      .findClient(clientId);
+    assertDefined(
+      client,
+      `sim Cognito app client ${clientId} after CloudFormation creation`,
+    );
+
+    return client;
+  }
+}

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -26,6 +26,11 @@ const simulatedProperties = [
   "TokenValidityUnits",
 ];
 
+/**
+ * The `TokenValidityUnits` fields, which are all of them.
+ */
+const modelledValidityUnits = ["AccessToken", "IdToken", "RefreshToken"];
+
 interface SimCfnCognitoClientPropertiesProperties {
   readonly resource: SimCfnResource;
   readonly properties: SimCfnTemplateValueRecord;
@@ -112,6 +117,13 @@ export class SimCfnCognitoClientProperties {
     if (units === undefined) {
       return undefined;
     }
+
+    this.propertyParser.requireOnlyKeys(
+      this.resource,
+      units,
+      modelledValidityUnits,
+      "TokenValidityUnits ",
+    );
 
     return {
       AccessToken: this.unit(units["AccessToken"], "AccessToken"),

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -1,0 +1,143 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateUserPoolClientCommandInput } from "../../command/client/user-pool-client.command.js";
+import type { SimCognitoTokenValidityUnitsType } from "../../user-pool/client/sim-cognito-token-validity.js";
+import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The AWS::Cognito::UserPoolClient properties this simulation deploys.
+ *
+ * The OAuth and managed login properties are absent because the hosted UI is
+ * not simulated at all, so a client deployed with them would offer flows
+ * nothing here can run.
+ */
+const simulatedProperties = [
+  "UserPoolId",
+  "ClientName",
+  "GenerateSecret",
+  "ExplicitAuthFlows",
+  "PreventUserExistenceErrors",
+  "AccessTokenValidity",
+  "IdTokenValidity",
+  "RefreshTokenValidity",
+  "TokenValidityUnits",
+];
+
+interface SimCfnCognitoClientPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Cognito::UserPoolClient CloudFormation properties into the
+ * CreateUserPoolClient input the client creator needs.
+ */
+export class SimCfnCognitoClientProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnCognitoPropertyParser({
+    resourceType: "AWS::Cognito::UserPoolClient",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnCognitoClientPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The pool this client belongs to, which a template reaches with a `Ref` on
+   * its AWS::Cognito::UserPool.
+   */
+  userPoolId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["UserPoolId"],
+      "UserPoolId",
+    );
+  }
+
+  /**
+   * The CreateUserPoolClient input this Resource asks for.
+   */
+  createUserPoolClientInput(): SimCreateUserPoolClientCommandInput {
+    return {
+      UserPoolId: this.userPoolId(),
+      ClientName: this.string(this.properties["ClientName"], "ClientName"),
+      GenerateSecret: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["GenerateSecret"],
+        "GenerateSecret",
+      ),
+      ExplicitAuthFlows: this.propertyParser.optionalStringArray(
+        this.resource,
+        this.properties["ExplicitAuthFlows"],
+        "ExplicitAuthFlows",
+      ),
+      PreventUserExistenceErrors: this.string(
+        this.properties["PreventUserExistenceErrors"],
+        "PreventUserExistenceErrors",
+      ),
+      AccessTokenValidity: this.number(
+        this.properties["AccessTokenValidity"],
+        "AccessTokenValidity",
+      ),
+      IdTokenValidity: this.number(
+        this.properties["IdTokenValidity"],
+        "IdTokenValidity",
+      ),
+      RefreshTokenValidity: this.number(
+        this.properties["RefreshTokenValidity"],
+        "RefreshTokenValidity",
+      ),
+      TokenValidityUnits: this.tokenValidityUnits(),
+    };
+  }
+
+  /**
+   * The units the three validity numbers are counted in.
+   */
+  private tokenValidityUnits(): SimCognitoTokenValidityUnitsType | undefined {
+    const units = this.propertyParser.optionalRecord(
+      this.resource,
+      this.properties["TokenValidityUnits"],
+      "TokenValidityUnits",
+    );
+
+    if (units === undefined) {
+      return undefined;
+    }
+
+    return {
+      AccessToken: this.unit(units["AccessToken"], "AccessToken"),
+      IdToken: this.unit(units["IdToken"], "IdToken"),
+      RefreshToken: this.unit(units["RefreshToken"], "RefreshToken"),
+    };
+  }
+
+  private unit(
+    value: SimCfnTemplateValue | undefined,
+    field: string,
+  ): string | undefined {
+    return this.string(value, `TokenValidityUnits ${field}`);
+  }
+
+  private string(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(this.resource, value, label);
+  }
+
+  private number(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    return this.propertyParser.optionalNumber(this.resource, value, label);
+  }
+}

--- a/src/service/cognito/cfn/group/sim-cfn-cognito-group-creator.ts
+++ b/src/service/cognito/cfn/group/sim-cfn-cognito-group-creator.ts
@@ -1,0 +1,53 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import type { SimCognitoGroup } from "../../user-pool/group/sim-cognito-group.js";
+import { SimCfnCognitoGroupProperties } from "./sim-cfn-cognito-group-properties.js";
+
+interface SimCfnCognitoGroupCreatorProperties {
+  readonly cognito: SimCognitoIdentityProvider;
+}
+
+/**
+ * Creates simulated groups from AWS::Cognito::UserPoolGroup Resources.
+ *
+ * The group goes through the ordinary CreateGroup command, so the group name
+ * is validated and a name already in the pool is refused, as they are for an
+ * SDK caller.
+ */
+export class SimCfnCognitoGroupCreator {
+  private readonly cognito: SimCognitoIdentityProvider;
+
+  constructor(properties: SimCfnCognitoGroupCreatorProperties) {
+    this.cognito = properties.cognito;
+  }
+
+  /**
+   * Create a group from an AWS::Cognito::UserPoolGroup Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCognitoGroup> {
+    const groupProperties = new SimCfnCognitoGroupProperties({
+      resource,
+      properties,
+    });
+    const groupName = groupProperties.groupName();
+
+    await this.cognito.createGroup({
+      input: groupProperties.createGroupInput(),
+    });
+
+    const group = this.cognito
+      .userPool(groupProperties.userPoolId())
+      .findGroup(groupName);
+    assertDefined(
+      group,
+      `sim Cognito group ${groupName} after CloudFormation creation`,
+    );
+
+    return group;
+  }
+}

--- a/src/service/cognito/cfn/group/sim-cfn-cognito-group-properties.ts
+++ b/src/service/cognito/cfn/group/sim-cfn-cognito-group-properties.ts
@@ -1,0 +1,89 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateGroupCommandInput } from "../../command/group/group.command.js";
+import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The AWS::Cognito::UserPoolGroup properties this simulation deploys, which
+ * are all of them.
+ */
+const simulatedProperties = [
+  "UserPoolId",
+  "GroupName",
+  "Description",
+  "Precedence",
+  "RoleArn",
+];
+
+interface SimCfnCognitoGroupPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Cognito::UserPoolGroup CloudFormation properties into the
+ * CreateGroup input the group creator needs.
+ */
+export class SimCfnCognitoGroupProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnCognitoPropertyParser({
+    resourceType: "AWS::Cognito::UserPoolGroup",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnCognitoGroupPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The pool this group belongs to, which a template reaches with a `Ref` on
+   * its AWS::Cognito::UserPool.
+   */
+  userPoolId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["UserPoolId"],
+      "UserPoolId",
+    );
+  }
+
+  /**
+   * The group's name, which is also what a `Ref` on this Resource returns.
+   */
+  groupName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["GroupName"],
+      "GroupName",
+    );
+  }
+
+  /**
+   * The CreateGroup input this Resource asks for.
+   */
+  createGroupInput(): SimCreateGroupCommandInput {
+    return {
+      UserPoolId: this.userPoolId(),
+      GroupName: this.groupName(),
+      Description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+      Precedence: this.propertyParser.optionalNumber(
+        this.resource,
+        this.properties["Precedence"],
+        "Precedence",
+      ),
+      RoleArn: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["RoleArn"],
+        "RoleArn",
+      ),
+    };
+  }
+}

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -1,0 +1,285 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({ defaultRegionName: "eu-west-2" });
+}
+
+/**
+ * Deploy a template that is expected to fail, and give back the error.
+ */
+async function deployFailure(
+  simAws: SimAws,
+  resources: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const error = await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: { Resources: resources },
+    });
+    await stack.waitForDeployComplete();
+  });
+
+  assertInstanceOf(error, Error);
+
+  return error;
+}
+
+const appPool = {
+  Type: "AWS::Cognito::UserPool",
+  Properties: { UserPoolName: "myapp-users" },
+};
+
+describe("Cognito CloudFormation property shapes", () => {
+  it("reads the string forms CloudFormation carries values in", async () => {
+    // Given a template whose booleans and numbers are quoted, as
+    // CloudFormation carries them in places.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: {
+              UserPoolName: "myapp-users",
+              Policies: {
+                PasswordPolicy: {
+                  MinimumLength: "12",
+                  RequireSymbols: "false",
+                },
+              },
+            },
+          },
+          AppClient: {
+            Type: "AWS::Cognito::UserPoolClient",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              ClientName: "web",
+              GenerateSecret: "true",
+              AccessTokenValidity: "30",
+              TokenValidityUnits: { AccessToken: "minutes" },
+            },
+          },
+          AdminsGroup: {
+            Type: "AWS::Cognito::UserPoolGroup",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              GroupName: "admins",
+              Precedence: "5",
+            },
+          },
+        },
+        Outputs: { PoolId: { Value: { Ref: "AppPool" } } },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then each is read as the value it stands for.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    assertTypeString(userPoolId);
+
+    const pool = simAws.cognitoIdentityProvider().userPool(userPoolId);
+    assertIdentical(pool.passwordPolicy.minimumLength, 12);
+    assertFalse(pool.passwordPolicy.requiresSymbols);
+
+    const client = pool.clients[0];
+    assertNonNullable(client);
+    assertTrue(client.hasSecret);
+    assertIdentical(client.tokenValidity.accessToken.seconds, 30 * 60);
+
+    assertIdentical(pool.findGroup("admins")?.precedence, 5);
+  });
+
+  it("passes a sign-in policy through to the refusal that explains it", async () => {
+    // Given a template asking for a pool that chooses its first auth factor.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          Policies: {
+            SignInPolicy: { AllowedFirstAuthFactors: ["PASSWORD"] },
+          },
+        },
+      },
+    });
+
+    // Then the CreateUserPool refusal is what reports it, rather than the
+    // property being dropped on the way there.
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool Policies SignInPolicy is not simulated",
+    );
+  });
+
+  it("refuses a Policies value that is not an object", async () => {
+    // Given a template whose Policies is a string.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users", Policies: "strict" },
+      },
+    });
+
+    // Then the failure says what it should have been.
+    assertStringIncludes(
+      error.message,
+      "AWS::Cognito::UserPool AppPool: Policies must be an object",
+    );
+  });
+
+  it("refuses an ExplicitAuthFlows that is not a list of strings", async () => {
+    // Given a template whose ExplicitAuthFlows is a single string.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: appPool,
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ExplicitAuthFlows: "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+        },
+      },
+    });
+
+    // Then the failure says a list was expected.
+    assertStringIncludes(
+      error.message,
+      "ExplicitAuthFlows must be a list of strings",
+    );
+  });
+
+  it("refuses a list entry that is not a string", async () => {
+    // Given a template whose ExplicitAuthFlows holds a number.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: appPool,
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ExplicitAuthFlows: [7],
+        },
+      },
+    });
+
+    // Then the failure names the entry that was wrong.
+    assertStringIncludes(
+      error.message,
+      "ExplicitAuthFlows[0] must be a string",
+    );
+  });
+
+  it("refuses a number property that is not a number", async () => {
+    // Given templates whose Precedence is a word and a boolean, neither of
+    // which CloudFormation would carry a number as.
+    const groupWithPrecedence = (
+      precedence: string | boolean,
+    ): SimCfnTemplateValueRecord => ({
+      AppPool: appPool,
+      AdminsGroup: {
+        Type: "AWS::Cognito::UserPoolGroup",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          GroupName: "admins",
+          Precedence: precedence,
+        },
+      },
+    });
+
+    // When each is deployed.
+    const wordError = await deployFailure(
+      simAwsInEuWest2(),
+      groupWithPrecedence("highest"),
+    );
+    const booleanError = await deployFailure(
+      simAwsInEuWest2(),
+      groupWithPrecedence(true),
+    );
+
+    // Then both failures say what it should have been.
+    assertStringIncludes(wordError.message, "Precedence must be a number");
+    assertStringIncludes(booleanError.message, "Precedence must be a number");
+  });
+
+  it("refuses a boolean property that is not a boolean", async () => {
+    // Given a template whose GenerateSecret is a word.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: appPool,
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          GenerateSecret: "yes",
+        },
+      },
+    });
+
+    // Then the failure says what it should have been.
+    assertStringIncludes(error.message, "GenerateSecret must be a boolean");
+  });
+
+  it("refuses a TokenValidityUnits that is not an object", async () => {
+    // Given a template whose TokenValidityUnits is a list.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: appPool,
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          TokenValidityUnits: ["minutes"],
+        },
+      },
+    });
+
+    // Then the failure says what it should have been.
+    assertStringIncludes(error.message, "TokenValidityUnits must be an object");
+  });
+
+  it("refuses a client naming no user pool", async () => {
+    // Given a template whose client has no UserPoolId at all.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: { ClientName: "web" },
+      },
+    });
+
+    // Then the failure says the pool has to be named.
+    assertStringIncludes(error.message, "UserPoolId must be a string");
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-properties.iso.test.ts
@@ -1,41 +1,18 @@
 import {
   assertFalse,
   assertIdentical,
-  assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
-  assertThrowsErrorAsync,
   assertTrue,
   assertTypeString,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../../aws/sim-aws.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-
-function simAwsInEuWest2(): SimAws {
-  return new SimAws({ defaultRegionName: "eu-west-2" });
-}
-
-/**
- * Deploy a template that is expected to fail, and give back the error.
- */
-async function deployFailure(
-  simAws: SimAws,
-  resources: SimCfnTemplateValueRecord,
-): Promise<Error> {
-  const error = await assertThrowsErrorAsync(async () => {
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "app-stack",
-      template: { Resources: resources },
-    });
-    await stack.waitForDeployComplete();
-  });
-
-  assertInstanceOf(error, Error);
-
-  return error;
-}
+import {
+  deployFailure,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
 
 const appPool = {
   Type: "AWS::Cognito::UserPool",
@@ -130,6 +107,41 @@ describe("Cognito CloudFormation property shapes", () => {
     );
   });
 
+  it("refuses a nested property key it does not model", async () => {
+    // Given templates carrying a key nothing reads inside each of the nested
+    // objects.
+    const passwordPolicyError = await deployFailure(simAwsInEuWest2(), {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          Policies: { PasswordPolicy: { RequireEmoji: true } },
+        },
+      },
+    });
+    const unitsError = await deployFailure(simAwsInEuWest2(), {
+      AppPool: appPool,
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          TokenValidityUnits: { SessionToken: "minutes" },
+        },
+      },
+    });
+
+    // Then each is refused where it sits, rather than dropped on the way to
+    // the Command as the top-level properties would not be.
+    assertStringIncludes(
+      passwordPolicyError.message,
+      "property Policies PasswordPolicy RequireEmoji is not simulated",
+    );
+    assertStringIncludes(
+      unitsError.message,
+      "property TokenValidityUnits SessionToken is not simulated",
+    );
+  });
+
   it("refuses a Policies value that is not an object", async () => {
     // Given a template whose Policies is a string.
     const simAws = simAwsInEuWest2();
@@ -168,7 +180,8 @@ describe("Cognito CloudFormation property shapes", () => {
     // Then the failure says a list was expected.
     assertStringIncludes(
       error.message,
-      "ExplicitAuthFlows must be a list of strings",
+      "AWS::Cognito::UserPoolClient AppClient: ExplicitAuthFlows must be a " +
+        "list of strings",
     );
   });
 
@@ -191,7 +204,8 @@ describe("Cognito CloudFormation property shapes", () => {
     // Then the failure names the entry that was wrong.
     assertStringIncludes(
       error.message,
-      "ExplicitAuthFlows[0] must be a string",
+      "AWS::Cognito::UserPoolClient AppClient: ExplicitAuthFlows[0] must be " +
+        "a string",
     );
   });
 
@@ -223,8 +237,10 @@ describe("Cognito CloudFormation property shapes", () => {
     );
 
     // Then both failures say what it should have been.
-    assertStringIncludes(wordError.message, "Precedence must be a number");
-    assertStringIncludes(booleanError.message, "Precedence must be a number");
+    const expected =
+      "AWS::Cognito::UserPoolGroup AdminsGroup: Precedence must be a number";
+    assertStringIncludes(wordError.message, expected);
+    assertStringIncludes(booleanError.message, expected);
   });
 
   it("refuses a boolean property that is not a boolean", async () => {
@@ -244,7 +260,10 @@ describe("Cognito CloudFormation property shapes", () => {
     });
 
     // Then the failure says what it should have been.
-    assertStringIncludes(error.message, "GenerateSecret must be a boolean");
+    assertStringIncludes(
+      error.message,
+      "AWS::Cognito::UserPoolClient AppClient: GenerateSecret must be a boolean",
+    );
   });
 
   it("refuses a TokenValidityUnits that is not an object", async () => {
@@ -280,6 +299,9 @@ describe("Cognito CloudFormation property shapes", () => {
     });
 
     // Then the failure says the pool has to be named.
-    assertStringIncludes(error.message, "UserPoolId must be a string");
+    assertStringIncludes(
+      error.message,
+      "AWS::Cognito::UserPoolClient AppClient: UserPoolId must be a string",
+    );
   });
 });

--- a/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
@@ -1,0 +1,103 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnCognitoValueParser } from "./sim-cfn-cognito-value-parser.js";
+
+interface SimCfnCognitoPropertyParserProperties {
+  readonly resourceType: string;
+  readonly simulated: readonly string[];
+}
+
+/**
+ * Validates the AWS::Cognito::* CloudFormation properties of one Resource
+ * type, both which of them may appear and what shape each has to be.
+ *
+ * Each Resource type states the properties it simulates, and every other
+ * property is refused. An allow-list rather than a list of known-unsimulated
+ * properties is what keeps a template from quietly deploying something this
+ * simulation would ignore, including properties CloudFormation has that the
+ * Cognito API does not.
+ */
+export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
+  private readonly simulated: readonly string[];
+
+  constructor(properties: SimCfnCognitoPropertyParserProperties) {
+    super({ resourceType: properties.resourceType });
+    this.simulated = properties.simulated;
+  }
+
+  /**
+   * Refuse every property this Resource type does not simulate.
+   *
+   * A property whose only simulated value is its AWS default, such as
+   * `MfaConfiguration`, counts as simulated here and is refused further down
+   * by the Cognito command that receives it.
+   */
+  requireOnlySimulated(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    for (const name of Object.keys(properties)) {
+      if (!this.simulated.includes(name)) {
+        throw this.unsimulatedPropertyError(resource, name);
+      }
+    }
+  }
+
+  /**
+   * Parse a property value that must be a list of strings when present.
+   */
+  optionalStringArray(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): readonly string[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "a list of strings");
+    }
+
+    return value.map((item, index) =>
+      this.requiredString(resource, item, `${label}[${String(index)}]`),
+    );
+  }
+
+  /**
+   * Narrow a property value to an object, refusing anything else.
+   */
+  optionalRecord(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimCfnTemplateValueRecord | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "an object");
+    }
+
+    return value;
+  }
+
+  /**
+   * Build the diagnostic error for a property this simulator does not model.
+   */
+  private unsimulatedPropertyError(
+    resource: SimCfnResource,
+    label: string,
+  ): Error {
+    return new Error(
+      `${this.resourceType} ${resource.logicalId} property ${label} is not ` +
+        `simulated, and a deployed Resource ignoring it would behave ` +
+        `differently here than on AWS. The simulated properties are ` +
+        `${this.simulated.join(", ")}.`,
+    );
+  }
+}

--- a/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-property-parser.ts
@@ -39,9 +39,30 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): void {
-    for (const name of Object.keys(properties)) {
-      if (!this.simulated.includes(name)) {
-        throw this.unsimulatedPropertyError(resource, name);
+    this.requireOnlyKeys(resource, properties, this.simulated);
+  }
+
+  /**
+   * Refuse every key of a nested property object that is not modelled.
+   *
+   * A nested object is held to the same rule as the properties around it. A
+   * `Policies` or a `TokenValidityUnits` carrying a key nothing here reads
+   * would otherwise be dropped on the way to the Command, which is the quiet
+   * ignoring the top-level allow-list exists to prevent.
+   */
+  requireOnlyKeys(
+    resource: SimCfnResource,
+    record: SimCfnTemplateValueRecord,
+    modelled: readonly string[],
+    path = "",
+  ): void {
+    for (const name of Object.keys(record)) {
+      if (!modelled.includes(name)) {
+        throw this.unsimulatedPropertyError(
+          resource,
+          `${path}${name}`,
+          modelled,
+        );
       }
     }
   }
@@ -92,12 +113,13 @@ export class SimCfnCognitoPropertyParser extends SimCfnCognitoValueParser {
   private unsimulatedPropertyError(
     resource: SimCfnResource,
     label: string,
+    modelled: readonly string[],
   ): Error {
     return new Error(
       `${this.resourceType} ${resource.logicalId} property ${label} is not ` +
         `simulated, and a deployed Resource ignoring it would behave ` +
         `differently here than on AWS. The simulated properties are ` +
-        `${this.simulated.join(", ")}.`,
+        `${modelled.join(", ")}.`,
     );
   }
 }

--- a/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
@@ -1,0 +1,62 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
+import { SimCfnCognitoClientCreator } from "./client/sim-cfn-cognito-client-creator.js";
+import { SimCfnCognitoGroupCreator } from "./group/sim-cfn-cognito-group-creator.js";
+import { SimCfnCognitoUserPoolCreator } from "./user-pool/sim-cfn-cognito-user-pool-creator.js";
+
+interface SimCognitoCfnResourceFactoryProperties {
+  readonly cognito: SimCognitoIdentityProvider;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Cognito resources.
+ */
+export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly userPoolCreator: SimCfnCognitoUserPoolCreator;
+  private readonly clientCreator: SimCfnCognitoClientCreator;
+  private readonly groupCreator: SimCfnCognitoGroupCreator;
+
+  constructor(properties: SimCognitoCfnResourceFactoryProperties) {
+    const { cognito } = properties;
+
+    this.userPoolCreator = new SimCfnCognitoUserPoolCreator({ cognito });
+    this.clientCreator = new SimCfnCognitoClientCreator({ cognito });
+    this.groupCreator = new SimCfnCognitoGroupCreator({ cognito });
+  }
+
+  /**
+   * Create a simulated Cognito resource from a CloudFormation Resource.
+   *
+   * The hosted UI, identity providers, resource servers and the user Resource
+   * types are not simulated, so their Resource types are reported as
+   * unsupported rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "UserPool": {
+        return await this.userPoolCreator.create(resource, properties);
+      }
+      case "UserPoolClient": {
+        return await this.clientCreator.create(resource, properties);
+      }
+      case "UserPoolGroup": {
+        return await this.groupCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Cognito CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
@@ -1,0 +1,221 @@
+import {
+  AdminAddUserToGroupCommand,
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminListGroupsForUserCommand,
+  AdminSetUserPasswordCommand,
+  DescribeUserPoolClientCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+const userPoolTemplate = {
+  Resources: {
+    AppPool: {
+      Type: "AWS::Cognito::UserPool",
+      Properties: {
+        UserPoolName: "myapp-users",
+        Policies: { PasswordPolicy: { MinimumLength: 12 } },
+      },
+    },
+    AppClient: {
+      Type: "AWS::Cognito::UserPoolClient",
+      Properties: {
+        UserPoolId: { Ref: "AppPool" },
+        ClientName: "web",
+        ExplicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      },
+    },
+    AdminsGroup: {
+      Type: "AWS::Cognito::UserPoolGroup",
+      Properties: {
+        UserPoolId: { Ref: "AppPool" },
+        GroupName: "admins",
+        Precedence: 0,
+      },
+    },
+  },
+  Outputs: {
+    PoolId: { Value: { Ref: "AppPool" } },
+    PoolArn: { Value: { "Fn::GetAtt": ["AppPool", "Arn"] } },
+    ProviderName: { Value: { "Fn::GetAtt": ["AppPool", "ProviderName"] } },
+    ProviderUrl: { Value: { "Fn::GetAtt": ["AppPool", "ProviderURL"] } },
+    ClientId: { Value: { Ref: "AppClient" } },
+    ClientIdAttribute: { Value: { "Fn::GetAtt": ["AppClient", "ClientId"] } },
+    PoolIdAttribute: { Value: { "Fn::GetAtt": ["AppPool", "UserPoolId"] } },
+    GroupName: { Value: { Ref: "AdminsGroup" } },
+  },
+};
+
+async function deployUserPoolStack(simAws: SimAws): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "app-stack",
+    template: userPoolTemplate,
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * A resolved Stack Output, which every Output in this template is a string.
+ */
+function output(stack: SimCfnStack, outputKey: string): string {
+  const value = stack.outputs.get(outputKey)?.value;
+  assertTypeString(value);
+
+  return value;
+}
+
+describe("Cognito CloudFormation user pool deployment", () => {
+  it("creates a pool, an app client and a group from a template", async () => {
+    // Given a template declaring a pool, a client naming it by Ref, and a
+    // group in it.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await deployUserPoolStack(simAws);
+    const userPoolId = output(stack, "PoolId");
+
+    // Then the pool is the one an SDK caller would have created, with the
+    // password policy the template asked for.
+    const cognito = simAws.cognitoIdentityProvider();
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    assertNonNullable(described.UserPool);
+    assertIdentical(described.UserPool.Name, "myapp-users");
+    assertIdentical(
+      described.UserPool.Policies?.PasswordPolicy?.MinimumLength,
+      12,
+    );
+
+    // And the app client belongs to that pool, with the name the template
+    // gave it.
+    const client = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: output(stack, "ClientId"),
+      }),
+    );
+
+    assertNonNullable(client.UserPoolClient);
+    assertIdentical(client.UserPoolClient.ClientName, "web");
+    assertIdentical(client.UserPoolClient.UserPoolId, userPoolId);
+
+    // And the group was created in the pool its Ref named.
+    const group = cognito.userPool(userPoolId).findGroup("admins");
+    assertNonNullable(group);
+    assertIdentical(group.precedence, 0);
+  });
+
+  it("answers Ref and Fn::GetAtt as real CloudFormation does", async () => {
+    // Given the same template, whose Outputs read every supported value.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await deployUserPoolStack(simAws);
+
+    // Then a pool Ref is the pool id, as its own attribute also is, and its
+    // other attributes are the ARN and the two forms of the provider name.
+    const userPoolId = output(stack, "PoolId");
+    assertStringStartsWith(userPoolId, "eu-west-2_");
+    assertIdentical(output(stack, "PoolIdAttribute"), userPoolId);
+    assertIdentical(
+      output(stack, "PoolArn"),
+      `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/${userPoolId}`,
+    );
+    assertIdentical(
+      output(stack, "ProviderName"),
+      `cognito-idp.eu-west-2.amazonaws.com/${userPoolId}`,
+    );
+    assertIdentical(
+      output(stack, "ProviderUrl"),
+      `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}`,
+    );
+
+    // And a client Ref is the client id, which is also its one attribute.
+    const clientId = output(stack, "ClientId");
+    assertIdentical(
+      clientId,
+      simAws.cognitoIdentityProvider().userPool(userPoolId).clients[0]?.id,
+    );
+    assertIdentical(output(stack, "ClientIdAttribute"), clientId);
+
+    // And a group Ref is the group name, which is what names a group.
+    assertIdentical(output(stack, "GroupName"), "admins");
+  });
+
+  it("signs a user in through the deployed pool and client", async () => {
+    // Given the deployed stack.
+    const simAws = simAwsInEuWest2();
+    const stack = await deployUserPoolStack(simAws);
+    const userPoolId = output(stack, "PoolId");
+
+    // And a user of the pool who is in the deployed group.
+    const cognito = simAws.cognitoIdentityProvider();
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecretPassw0rd!",
+        Permanent: true,
+      }),
+    );
+    await cognito.adminAddUserToGroup(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        GroupName: "admins",
+      }),
+    );
+
+    // When they sign in through the client the template declared.
+    const { AuthenticationResult: result } = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: output(stack, "ClientId"),
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: "alice",
+          PASSWORD: "Sup3rSecretPassw0rd!",
+        },
+      }),
+    );
+
+    // Then the flow the template opened admitted them, and the deployed group
+    // is theirs.
+    assertNonNullable(result?.AccessToken);
+
+    const groups = await cognito.adminListGroupsForUser(
+      new AdminListGroupsForUserCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+      }),
+    );
+    assertIdentical(groups.Groups?.[0]?.GroupName, "admins");
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-user-pool.iso.test.ts
@@ -143,7 +143,7 @@ describe("Cognito CloudFormation user pool deployment", () => {
     assertIdentical(output(stack, "PoolIdAttribute"), userPoolId);
     assertIdentical(
       output(stack, "PoolArn"),
-      `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/${userPoolId}`,
+      `arn:aws:cognito-idp:eu-west-2:${accountIdOneOnes}:userpool/${userPoolId}`,
     );
     assertIdentical(
       output(stack, "ProviderName"),

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -5,43 +5,17 @@ import {
   assertNonNullable,
   assertStringIncludes,
   assertStringLength,
-  assertThrowsErrorAsync,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { DescribeUserPoolClientCommand } from "@aws-sdk/client-cognito-identity-provider";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-
-function simAwsInEuWest2(): SimAws {
-  return new SimAws({ defaultRegionName: "eu-west-2" });
-}
-
-/**
- * Deploy a template that is expected to fail, and give back the error.
- */
-async function deployFailure(
-  simAws: SimAws,
-  resources: SimCfnTemplateValueRecord,
-  outputs?: SimCfnTemplateValueRecord,
-): Promise<Error> {
-  const error = await assertThrowsErrorAsync(async () => {
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "app-stack",
-      template: {
-        Resources: resources,
-        ...(outputs !== undefined && { Outputs: outputs }),
-      },
-    });
-    await stack.waitForDeployComplete();
-  });
-
-  assertInstanceOf(error, Error);
-
-  return error;
-}
+import { SimCognitoUserPool } from "../../cognito/user-pool/sim-cognito-user-pool.js";
+import {
+  deployFailure,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
 
 describe("Cognito CloudFormation validation", () => {
   it("generates a client secret only when the template asks for one", async () => {
@@ -276,5 +250,9 @@ describe("Cognito CloudFormation validation", () => {
     // is created as usual.
     assertArrayLength(stack.skippedResources, 1);
     assertIdentical(stack.skippedResources[0].logicalId, "AppDomain");
+    assertInstanceOf(
+      stack.getResource("AppPool")?.simResource,
+      SimCognitoUserPool,
+    );
   });
 });

--- a/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-validation.iso.test.ts
@@ -1,0 +1,280 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringLength,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { DescribeUserPoolClientCommand } from "@aws-sdk/client-cognito-identity-provider";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({ defaultRegionName: "eu-west-2" });
+}
+
+/**
+ * Deploy a template that is expected to fail, and give back the error.
+ */
+async function deployFailure(
+  simAws: SimAws,
+  resources: SimCfnTemplateValueRecord,
+  outputs?: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const error = await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: resources,
+        ...(outputs !== undefined && { Outputs: outputs }),
+      },
+    });
+    await stack.waitForDeployComplete();
+  });
+
+  assertInstanceOf(error, Error);
+
+  return error;
+}
+
+describe("Cognito CloudFormation validation", () => {
+  it("generates a client secret only when the template asks for one", async () => {
+    // Given a template with one client asking for a secret and one not.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "secret-stack",
+      template: {
+        Resources: {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: { UserPoolName: "myapp-users" },
+          },
+          ServerClient: {
+            Type: "AWS::Cognito::UserPoolClient",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              ClientName: "server",
+              GenerateSecret: true,
+            },
+          },
+          BrowserClient: {
+            Type: "AWS::Cognito::UserPoolClient",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              ClientName: "browser",
+            },
+          },
+        },
+        Outputs: {
+          PoolId: { Value: { Ref: "AppPool" } },
+          ServerClientId: { Value: { Ref: "ServerClient" } },
+          BrowserClientId: { Value: { Ref: "BrowserClient" } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the server client was given one, which DescribeUserPoolClient
+    // reports as it does for a client the SDK created.
+    const poolId = stack.outputs.get("PoolId")?.value;
+    const serverClientId = stack.outputs.get("ServerClientId")?.value;
+    const browserClientId = stack.outputs.get("BrowserClientId")?.value;
+    assertTypeString(poolId);
+    assertTypeString(serverClientId);
+    assertTypeString(browserClientId);
+
+    const cognito = simAws.cognitoIdentityProvider();
+    const described = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: poolId,
+        ClientId: serverClientId,
+      }),
+    );
+    assertNonNullable(described.UserPoolClient?.ClientSecret);
+    assertStringLength(described.UserPoolClient.ClientSecret, 52);
+
+    // And the browser client has no secret at all, as none was asked for.
+    const browserClient = cognito.userPool(poolId).findClient(browserClientId);
+    assertNonNullable(browserClient);
+    assertUndefined(browserClient.secret);
+  });
+
+  it("refuses a user pool property it does not simulate", async () => {
+    // Given a template asking for a pool that signs users in by email.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          UsernameAttributes: ["email"],
+        },
+      },
+    });
+
+    // Then the failure names the logical ID and the property, rather than the
+    // pool being deployed without it.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(error.message, "UsernameAttributes is not simulated");
+    assertStringIncludes(error.message, "The simulated properties are");
+  });
+
+  it("refuses an app client property it does not simulate", async () => {
+    // Given a template asking for a client with the hosted UI OAuth flows.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users" },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          AllowedOAuthFlows: ["code"],
+        },
+      },
+    });
+
+    // Then the failure names that client and that property.
+    assertStringIncludes(error.message, "AppClient");
+    assertStringIncludes(error.message, "AllowedOAuthFlows is not simulated");
+  });
+
+  it("refuses a pool feature the Cognito API refuses", async () => {
+    // Given a template asking for MFA, which CreateUserPool does not simulate.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          MfaConfiguration: "ON",
+        },
+      },
+    });
+
+    // Then the refusal is the API's own, in the words that say why, with the
+    // logical ID in front of it.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPool MfaConfiguration 'ON' is not simulated",
+    );
+  });
+
+  it("refuses a property value of the wrong shape", async () => {
+    // Given a template whose GroupName is a number rather than a string.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users" },
+      },
+      AdminsGroup: {
+        Type: "AWS::Cognito::UserPoolGroup",
+        Properties: { UserPoolId: { Ref: "AppPool" }, GroupName: 7 },
+      },
+    });
+
+    // Then the failure says what the property should have been.
+    assertStringIncludes(
+      error.message,
+      "AWS::Cognito::UserPoolGroup AdminsGroup: GroupName must be a string",
+    );
+  });
+
+  it("refuses an Fn::GetAtt attribute it does not publish", async () => {
+    // Given a stack of all three Resource types, whose Output reads an
+    // attribute the simulator does not answer.
+    const attributeFailure = async (
+      logicalId: string,
+      attribute: string,
+    ): Promise<Error> =>
+      deployFailure(
+        simAwsInEuWest2(),
+        {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: { UserPoolName: "myapp-users" },
+          },
+          AppClient: {
+            Type: "AWS::Cognito::UserPoolClient",
+            Properties: { UserPoolId: { Ref: "AppPool" }, ClientName: "web" },
+          },
+          AdminsGroup: {
+            Type: "AWS::Cognito::UserPoolGroup",
+            Properties: {
+              UserPoolId: { Ref: "AppPool" },
+              GroupName: "admins",
+            },
+          },
+        },
+        { Attribute: { Value: { "Fn::GetAtt": [logicalId, attribute] } } },
+      );
+
+    // When one is deployed for each Resource type.
+    const poolError = await attributeFailure("AppPool", "Name");
+    const clientError = await attributeFailure("AppClient", "ClientSecret");
+    const groupError = await attributeFailure("AdminsGroup", "Id");
+
+    // Then each refusal names the Resource type and the attribute.
+    assertStringIncludes(
+      poolError.message,
+      "Unsupported AWS::Cognito::UserPool attribute Name",
+    );
+    assertStringIncludes(
+      clientError.message,
+      "Unsupported AWS::Cognito::UserPoolClient attribute ClientSecret",
+    );
+    assertStringIncludes(
+      groupError.message,
+      "Unsupported AWS::Cognito::UserPoolGroup attribute Id",
+    );
+  });
+
+  it("reports an unsimulated Cognito Resource type as unsupported", async () => {
+    // Given a template declaring a user pool domain, which is the hosted UI
+    // and is not simulated.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "domain-stack",
+      template: {
+        Resources: {
+          AppPool: {
+            Type: "AWS::Cognito::UserPool",
+            Properties: { UserPoolName: "myapp-users" },
+          },
+          AppDomain: {
+            Type: "AWS::Cognito::UserPoolDomain",
+            Properties: { UserPoolId: { Ref: "AppPool" }, Domain: "myapp" },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the domain is skipped rather than deployed, and the pool beside it
+    // is created as usual.
+    assertArrayLength(stack.skippedResources, 1);
+    assertIdentical(stack.skippedResources[0].logicalId, "AppDomain");
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-value-parser.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-value-parser.ts
@@ -1,0 +1,132 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface SimCfnCognitoValueParserProperties {
+  readonly resourceType: string;
+}
+
+/**
+ * Reads the scalar AWS::Cognito::* CloudFormation property values, failing
+ * with a diagnostic naming the Resource type and the property.
+ *
+ * The Resource type is carried here because Cognito creates three of them, and
+ * a message naming the wrong one would send a reader to the wrong template
+ * entry. The logical ID is not: the CloudFormation engine already prefixes a
+ * failed creation with it.
+ *
+ * `SimCfnCognitoPropertyParser` extends this with the lists and objects a
+ * template also carries. The split is only that this half is about one value
+ * at a time.
+ */
+export class SimCfnCognitoValueParser {
+  protected readonly resourceType: string;
+
+  constructor(properties: SimCfnCognitoValueParserProperties) {
+    this.resourceType = properties.resourceType;
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and "false"
+   * in places, so both forms are accepted, as CloudFormation itself accepts
+   * them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Parse a property value that must be a number when present.
+   *
+   * A numeric string is accepted for the same reason a boolean string is: a
+   * template that quoted the number is one CloudFormation would deploy.
+   */
+  optionalNumber(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    const parsed = typeof value === "string" ? Number(value) : NaN;
+
+    if (Number.isNaN(parsed)) {
+      throw this.invalidPropertyError(resource, label, "a number");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
@@ -1,0 +1,87 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoPasswordPolicyType } from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+interface SimCfnCognitoPasswordPolicyProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the `Policies PasswordPolicy` of an AWS::Cognito::UserPool Resource.
+ *
+ * `PasswordHistorySize` is read along with the rest rather than dropped, so a
+ * template asking for it reaches CreateUserPool and is refused there, in the
+ * words that say why.
+ */
+export class SimCfnCognitoPasswordPolicy {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoPasswordPolicyProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The password policy, or undefined when the template names none.
+   */
+  parse(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoPasswordPolicyType | undefined {
+    const policy = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "Policies PasswordPolicy",
+    );
+
+    if (policy === undefined) {
+      return undefined;
+    }
+
+    return {
+      MinimumLength: this.number(policy["MinimumLength"], "MinimumLength"),
+      RequireUppercase: this.boolean(
+        policy["RequireUppercase"],
+        "RequireUppercase",
+      ),
+      RequireLowercase: this.boolean(
+        policy["RequireLowercase"],
+        "RequireLowercase",
+      ),
+      RequireNumbers: this.boolean(policy["RequireNumbers"], "RequireNumbers"),
+      RequireSymbols: this.boolean(policy["RequireSymbols"], "RequireSymbols"),
+      TemporaryPasswordValidityDays: this.number(
+        policy["TemporaryPasswordValidityDays"],
+        "TemporaryPasswordValidityDays",
+      ),
+      PasswordHistorySize: this.number(
+        policy["PasswordHistorySize"],
+        "PasswordHistorySize",
+      ),
+    };
+  }
+
+  private number(
+    value: SimCfnTemplateValue | undefined,
+    field: string,
+  ): number | undefined {
+    return this.propertyParser.optionalNumber(
+      this.resource,
+      value,
+      `Policies PasswordPolicy ${field}`,
+    );
+  }
+
+  private boolean(
+    value: SimCfnTemplateValue | undefined,
+    field: string,
+  ): boolean | undefined {
+    return this.propertyParser.optionalBoolean(
+      this.resource,
+      value,
+      `Policies PasswordPolicy ${field}`,
+    );
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-password-policy.ts
@@ -3,6 +3,19 @@ import type { SimCfnTemplateValue } from "../../../cloudformation/template/value
 import type { SimCognitoPasswordPolicyType } from "../../user-pool/sim-cognito-password-policy.js";
 import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 
+/**
+ * The `PasswordPolicy` fields this simulation reads, which are all of them.
+ */
+const modelledFields = [
+  "MinimumLength",
+  "RequireUppercase",
+  "RequireLowercase",
+  "RequireNumbers",
+  "RequireSymbols",
+  "TemporaryPasswordValidityDays",
+  "PasswordHistorySize",
+];
+
 interface SimCfnCognitoPasswordPolicyProperties {
   readonly resource: SimCfnResource;
   readonly propertyParser: SimCfnCognitoPropertyParser;
@@ -39,6 +52,13 @@ export class SimCfnCognitoPasswordPolicy {
     if (policy === undefined) {
       return undefined;
     }
+
+    this.propertyParser.requireOnlyKeys(
+      this.resource,
+      policy,
+      modelledFields,
+      "Policies PasswordPolicy ",
+    );
 
     return {
       MinimumLength: this.number(policy["MinimumLength"], "MinimumLength"),

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
@@ -1,0 +1,77 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimCognitoSignInPolicyType,
+  SimCognitoUserPoolPoliciesType,
+} from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+import { SimCfnCognitoPasswordPolicy } from "./sim-cfn-cognito-password-policy.js";
+
+interface SimCfnCognitoPoliciesProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the `Policies` property of an AWS::Cognito::UserPool Resource into the
+ * shape CreateUserPool takes.
+ *
+ * The sign-in policy is read rather than dropped, so a template asking for one
+ * reaches CreateUserPool and is refused there, in the words that say why.
+ */
+export class SimCfnCognitoPolicies {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoPoliciesProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The pool's policies, or undefined when the template names none.
+   */
+  parse(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoUserPoolPoliciesType | undefined {
+    const policies = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "Policies",
+    );
+
+    if (policies === undefined) {
+      return undefined;
+    }
+
+    return {
+      PasswordPolicy: new SimCfnCognitoPasswordPolicy({
+        resource: this.resource,
+        propertyParser: this.propertyParser,
+      }).parse(policies["PasswordPolicy"]),
+      SignInPolicy: this.signInPolicy(policies["SignInPolicy"]),
+    };
+  }
+
+  private signInPolicy(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoSignInPolicyType | undefined {
+    const policy = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "Policies SignInPolicy",
+    );
+
+    if (policy === undefined) {
+      return undefined;
+    }
+
+    return {
+      AllowedFirstAuthFactors: this.propertyParser.optionalStringArray(
+        this.resource,
+        policy["AllowedFirstAuthFactors"],
+        "Policies SignInPolicy AllowedFirstAuthFactors",
+      ),
+    };
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-policies.ts
@@ -1,11 +1,14 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import type {
-  SimCognitoSignInPolicyType,
-  SimCognitoUserPoolPoliciesType,
-} from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
 import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 import { SimCfnCognitoPasswordPolicy } from "./sim-cfn-cognito-password-policy.js";
+import { SimCfnCognitoSignInPolicy } from "./sim-cfn-cognito-sign-in-policy.js";
+
+/**
+ * The `Policies` fields this simulation reads, which are all of them.
+ */
+const modelledFields = ["PasswordPolicy", "SignInPolicy"];
 
 interface SimCfnCognitoPoliciesProperties {
   readonly resource: SimCfnResource;
@@ -16,8 +19,9 @@ interface SimCfnCognitoPoliciesProperties {
  * Reads the `Policies` property of an AWS::Cognito::UserPool Resource into the
  * shape CreateUserPool takes.
  *
- * The sign-in policy is read rather than dropped, so a template asking for one
- * reaches CreateUserPool and is refused there, in the words that say why.
+ * The two policies inside it each have their own reader, because a password
+ * policy is state this simulation keeps and a sign-in policy is one it
+ * refuses.
  */
 export class SimCfnCognitoPolicies {
   private readonly resource: SimCfnResource;
@@ -44,33 +48,24 @@ export class SimCfnCognitoPolicies {
       return undefined;
     }
 
-    return {
-      PasswordPolicy: new SimCfnCognitoPasswordPolicy({
-        resource: this.resource,
-        propertyParser: this.propertyParser,
-      }).parse(policies["PasswordPolicy"]),
-      SignInPolicy: this.signInPolicy(policies["SignInPolicy"]),
-    };
-  }
-
-  private signInPolicy(
-    value: SimCfnTemplateValue | undefined,
-  ): SimCognitoSignInPolicyType | undefined {
-    const policy = this.propertyParser.optionalRecord(
+    this.propertyParser.requireOnlyKeys(
       this.resource,
-      value,
-      "Policies SignInPolicy",
+      policies,
+      modelledFields,
+      "Policies ",
     );
 
-    if (policy === undefined) {
-      return undefined;
-    }
+    const collaborators = {
+      resource: this.resource,
+      propertyParser: this.propertyParser,
+    };
 
     return {
-      AllowedFirstAuthFactors: this.propertyParser.optionalStringArray(
-        this.resource,
-        policy["AllowedFirstAuthFactors"],
-        "Policies SignInPolicy AllowedFirstAuthFactors",
+      PasswordPolicy: new SimCfnCognitoPasswordPolicy(collaborators).parse(
+        policies["PasswordPolicy"],
+      ),
+      SignInPolicy: new SimCfnCognitoSignInPolicy(collaborators).parse(
+        policies["SignInPolicy"],
       ),
     };
   }

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-sign-in-policy.ts
@@ -1,0 +1,62 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoSignInPolicyType } from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The `SignInPolicy` fields, which reach CreateUserPool to be refused there.
+ */
+const modelledFields = ["AllowedFirstAuthFactors"];
+
+interface SimCfnCognitoSignInPolicyProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the `Policies SignInPolicy` of an AWS::Cognito::UserPool Resource.
+ *
+ * Nothing here chooses a first authentication factor, so this is read only so
+ * that CreateUserPool receives it and refuses it in the words that say why.
+ */
+export class SimCfnCognitoSignInPolicy {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoSignInPolicyProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The sign-in policy, or undefined when the template names none.
+   */
+  parse(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoSignInPolicyType | undefined {
+    const policy = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "Policies SignInPolicy",
+    );
+
+    if (policy === undefined) {
+      return undefined;
+    }
+
+    this.propertyParser.requireOnlyKeys(
+      this.resource,
+      policy,
+      modelledFields,
+      "Policies SignInPolicy ",
+    );
+
+    return {
+      AllowedFirstAuthFactors: this.propertyParser.optionalStringArray(
+        this.resource,
+        policy["AllowedFirstAuthFactors"],
+        "Policies SignInPolicy AllowedFirstAuthFactors",
+      ),
+    };
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
@@ -1,0 +1,52 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { SimCfnCognitoUserPoolProperties } from "./sim-cfn-cognito-user-pool-properties.js";
+
+interface SimCfnCognitoUserPoolCreatorProperties {
+  readonly cognito: SimCognitoIdentityProvider;
+}
+
+/**
+ * Creates simulated user pools from AWS::Cognito::UserPool Resources.
+ *
+ * The pool is created through the ordinary CreateUserPool command rather than
+ * constructed directly, so a pool a template deployed is the same thing an SDK
+ * caller would have got: an id in the real form, the real password policy
+ * defaults, and the same refusal of the pool features this simulation does not
+ * model.
+ */
+export class SimCfnCognitoUserPoolCreator {
+  private readonly cognito: SimCognitoIdentityProvider;
+
+  constructor(properties: SimCfnCognitoUserPoolCreatorProperties) {
+    this.cognito = properties.cognito;
+  }
+
+  /**
+   * Create a user pool from an AWS::Cognito::UserPool Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimCognitoUserPool> {
+    const poolProperties = new SimCfnCognitoUserPoolProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.cognito.createUserPool({
+      input: poolProperties.createUserPoolInput(),
+    });
+
+    const userPoolId = created.UserPool?.Id;
+    assertDefined(
+      userPoolId,
+      `sim Cognito user pool id after CloudFormation creation for ${resource.logicalId}`,
+    );
+
+    return this.cognito.userPool(userPoolId);
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -1,0 +1,88 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateUserPoolCommandInput } from "../../command/user-pool/user-pool.command.js";
+import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
+
+/**
+ * The AWS::Cognito::UserPool properties this simulation deploys.
+ *
+ * `MfaConfiguration` and `UserPoolTier` are here because CreateUserPool
+ * accepts each at its AWS default and refuses it otherwise, in words that say
+ * why. A CDK stack states both routinely, so refusing them outright would
+ * refuse templates that ask for nothing unsimulated.
+ */
+const simulatedProperties = [
+  "UserPoolName",
+  "Policies",
+  "DeletionProtection",
+  "MfaConfiguration",
+  "UserPoolTier",
+];
+
+interface SimCfnCognitoUserPoolPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Cognito::UserPool CloudFormation properties into the CreateUserPool
+ * input the pool creator needs.
+ *
+ * The refusal of unsimulated properties runs on construction rather than when
+ * a property is read, so a Resource asking for something unmodelled cannot get
+ * as far as creating a pool that would then be wrong.
+ */
+export class SimCfnCognitoUserPoolProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnCognitoPropertyParser({
+    resourceType: "AWS::Cognito::UserPool",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnCognitoUserPoolPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The CreateUserPool input this Resource asks for.
+   *
+   * `UserPoolName` is CloudFormation's name for what the API calls `PoolName`,
+   * and it is the one property whose name differs between them.
+   */
+  createUserPoolInput(): SimCreateUserPoolCommandInput {
+    return {
+      PoolName: this.string(this.properties["UserPoolName"], "UserPoolName"),
+      Policies: new SimCfnCognitoPolicies({
+        resource: this.resource,
+        propertyParser: this.propertyParser,
+      }).parse(this.properties["Policies"]),
+      DeletionProtection: this.string(
+        this.properties["DeletionProtection"],
+        "DeletionProtection",
+      ),
+      MfaConfiguration: this.string(
+        this.properties["MfaConfiguration"],
+        "MfaConfiguration",
+      ),
+      UserPoolTier: this.string(
+        this.properties["UserPoolTier"],
+        "UserPoolTier",
+      ),
+    };
+  }
+
+  private string(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(this.resource, value, label);
+  }
+}

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -9,6 +9,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimCognitoCfnResourceFactory } from "./cfn/sim-cfn-cognito-resource-factory.js";
 import type * as simCognitoCommands from "./command/sim-cognito-command.types.js";
 import { SimCognitoCommands } from "./command/sim-cognito-commands.js";
 import { SimCognitoUserPoolRegistry } from "./registry/sim-cognito-user-pool-registry.js";
@@ -53,6 +54,9 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
   private readonly pools: SimCognitoUserPoolStore;
   private readonly userPoolRegistry: SimCognitoUserPoolRegistry;
   private readonly sdkRouter = new SimCognitoSdkCommandRouter(this);
+  private readonly cfnFactory = new SimCognitoCfnResourceFactory({
+    cognito: this,
+  });
 
   constructor(properties: SimCognitoIdentityProviderProperties = {}) {
     const {
@@ -195,6 +199,13 @@ export class SimCognitoIdentityProvider extends SimCognitoUserDirectory {
   ): Promise<simCognitoCommands.SimListUserPoolClientsCommandOutput> {
     await this.background.sequence();
     return this.commands.listClients.handle(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimCognitoCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -75,6 +75,17 @@ export class SimCognitoUserPool {
   }
 
   /**
+   * The name this pool is known by where a scheme would be wrong.
+   *
+   * This is the issuer URL without `https://`, and it is what an identity pool
+   * names a user pool provider by, and what `AWS::Cognito::UserPool` answers
+   * `Fn::GetAtt ProviderName` with.
+   */
+  get providerName(): string {
+    return this.issuerUrl.replace("https://", "");
+  }
+
+  /**
    * The key this pool signs its tokens with, generated on first use.
    *
    * The key belongs to the pool, as it does on real Cognito, so a token from

--- a/test/cognito/cfn-deploy.ts
+++ b/test/cognito/cfn-deploy.ts
@@ -1,0 +1,46 @@
+/**
+ * Deployment helpers the Cognito CloudFormation test files share.
+ *
+ * Both the property-shape and the validation suites deploy a template that is
+ * meant to fail and then read the error, and each was carrying the same
+ * arrangement. This lives under `test/` for the same reasons as `test/kms/`:
+ * eslint rejects a test file that exports helpers alongside its own `describe`
+ * calls, and `test/**` is type-checked with everything else, excluded from the
+ * published build, not collected as a suite, and not counted in coverage.
+ */
+
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * A simulated AWS in the region the Cognito CloudFormation tests deploy into.
+ */
+export function simAwsInEuWest2(): SimAws {
+  return new SimAws({ defaultRegionName: "eu-west-2" });
+}
+
+/**
+ * Deploy a template that is expected to fail, and give back the error.
+ */
+export async function deployFailure(
+  simAws: SimAws,
+  resources: SimCfnTemplateValueRecord,
+  outputs?: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const error = await assertThrowsErrorAsync(async () => {
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: {
+        Resources: resources,
+        ...(outputs !== undefined && { Outputs: outputs }),
+      },
+    });
+    await stack.waitForDeployComplete();
+  });
+
+  assertInstanceOf(error, Error);
+
+  return error;
+}


### PR DESCRIPTION
AWS::Cognito::UserPool, AWS::Cognito::UserPoolClient and AWS::Cognito::UserPoolGroup create simulated Cognito resources, with the Ref and Fn::GetAtt values real CloudFormation returns. Each type states the properties it simulates and refuses the rest, so a template asking for something unmodelled fails where it was declared.

Resolves https://github.com/KensioSoftware/yulin/issues/223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation simulation support for `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient`, and `AWS::Cognito::UserPoolGroup`, including appropriate `Ref` and supported `Fn::GetAtt` outputs.
  * Enabled Cognito-backed CloudFormation resource deployment end-to-end for pool creation, client/group setup, and authentication.

* **Documentation**
  * Expanded Cognito and CloudFormation docs with a new “CloudFormation resources” section, supported property guidance, and runnable TypeScript deployment examples.

* **Tests**
  * Added/extended ISO tests covering deployments, outputs, strict property parsing (including quoted booleans/numbers), and clearer refusal/error messages for unsupported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->