### PR TITLE
docs: move the feature lists off the top of the docs pages

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -172,8 +172,8 @@ throw a diagnostic error.
 
 ## Supported services and Commands
 
-All simulated services support SDK interception: ACM, CloudFormation, CloudFront, DynamoDB, IAM, KMS,
-Lambda, Route53, S3, Secrets Manager and STS. Each service's own docs under
+All simulated services support SDK interception: ACM, CloudFormation, CloudFront, Cognito, DynamoDB,
+IAM, KMS, Lambda, Route53, S3, Secrets Manager, SSM and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:

--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -2,26 +2,6 @@
 
 Yulin includes a simulated AWS Certificate Manager (ACM) service for tests and local development.
 
-## Available functionality
-
-Sim ACM currently supports:
-
-- `RequestCertificateCommand`, `DescribeCertificateCommand` and `ListCertificatesCommand`
-- DNS validation against records in sim Route53
-- CloudFormation-published validation records from `DomainValidationOptions[].HostedZoneId`
-- EMAIL validation method shapes, though validation always succeeds regardless
-- Subject alternative names
-- Certificate tags, up to the ACM limit of 50 tags
-- Deterministic certificate ARNs scoped to account and region
-- Deterministic DNS validation CNAME records
-- Background certificate issuance from `PENDING_VALIDATION` to `ISSUED`
-- Per-domain validation status for multi-domain certificates
-- The `AWS::CertificateManager::Certificate` CloudFormation resource, with `Ref` and `Fn::GetAtt`
-
-The simulator focuses on useful behaviour for tests and local development rather than full ACM
-feature parity. Unsupported ACM options may be ignored or may throw errors depending on whether the
-simulator needs them to model the requested behaviour.
-
 ## Basic certificate request
 
 Create a simulated AWS environment, get simulated ACM, and request a certificate.
@@ -710,6 +690,25 @@ nothing authoritative for its domain, it is issued without validation.
 If a hosted zone does cover the domain but the validation record never appears, the stack fails
 rather than hanging. Real CloudFormation sits in `CREATE_IN_PROGRESS` for hours before timing out
 here, which is no use in a test, so the resource fails immediately naming the record it waited for.
+
+## Available functionality
+
+Sim ACM currently supports:
+
+- `RequestCertificateCommand`, `DescribeCertificateCommand` and `ListCertificatesCommand`
+- DNS validation against records in sim Route53
+- CloudFormation-published validation records from `DomainValidationOptions[].HostedZoneId`
+- EMAIL validation method shapes, though validation always succeeds regardless
+- Subject alternative names
+- Certificate tags, up to the ACM limit of 50 tags
+- Deterministic certificate ARNs scoped to account and region
+- Deterministic DNS validation CNAME records
+- Background certificate issuance from `PENDING_VALIDATION` to `ISSUED`
+- Per-domain validation status for multi-domain certificates
+- The `AWS::CertificateManager::Certificate` CloudFormation resource, with `Ref` and `Fn::GetAtt`
+
+Unsupported ACM options may be ignored or may throw errors depending on whether the simulator needs
+them to model the requested behaviour.
 
 ## Limitations
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -5,26 +5,6 @@ Yulin includes a simulated CloudFormation service for tests and local developmen
 Sim CloudFormation creates simulated AWS resources from CloudFormation templates. It can be used with
 hand-written templates, AWS SDK-style `CreateStackCommand` calls, or synthesized CDK template files.
 
-The simulator focuses on useful behaviour for tests and local development rather than full
-CloudFormation feature parity. Unsupported resources may be skipped or may fail depending on how
-safely the simulator can model the requested behaviour.
-
-## Available functionality
-
-Sim CloudFormation currently supports:
-
-- `CreateStackCommand` and `DescribeStacksCommand`
-- Waiting for simulated stack deployment completion
-- `deployTemplate(...)` for parsed template objects
-- `deployTemplateFile(...)` for synthesized JSON template files
-- Template `Parameters` with supplied values and defaults
-- Template `Outputs`, resolved after resource creation and read from `stack.outputs`
-- The `Ref`, `Fn::GetAtt`, `Fn::Join` and `Fn::Sub` intrinsic functions
-- Explicit resource dependencies with `DependsOn`
-- Implicit dependencies from resource `Ref` expressions
-- The resource types listed under [Supported resources](#supported-resources-and-limitations) below,
-  including selected CDK custom resources such as CDK S3 BucketDeployment
-
 ## Basic usage
 
 Create a simulated AWS environment, get simulated CloudFormation, and deploy a template.
@@ -956,9 +936,36 @@ try {
 }
 ```
 
-## Supported resources and limitations
+## Standalone SimCloudFormation
 
-Sim CloudFormation supports a subset of CloudFormation. The resource types it creates are:
+Most users should access CloudFormation through `SimAws` so that CloudFormation can create resources
+in the same simulated AWS environment as S3, CloudFront, and other services.
+
+```typescript
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+```
+
+`SimCloudFormation` is also exported from `@kensio/yulin/cloudformation` for advanced cases. In
+normal application tests, prefer the `SimAws` entry point.
+
+## Available functionality
+
+Sim CloudFormation currently supports:
+
+- `CreateStackCommand` and `DescribeStacksCommand`
+- Waiting for simulated stack deployment completion
+- `deployTemplate(...)` for parsed template objects
+- `deployTemplateFile(...)` for synthesized JSON template files
+- Template `Parameters` with supplied values and defaults
+- Template `Outputs`, resolved after resource creation and read from `stack.outputs`
+- The `Ref`, `Fn::GetAtt`, `Fn::Join` and `Fn::Sub` intrinsic functions
+- Explicit resource dependencies with `DependsOn`
+- Implicit dependencies from resource `Ref` expressions
+
+The resource types it creates are:
 
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
@@ -974,26 +981,14 @@ Sim CloudFormation supports a subset of CloudFormation. The resource types it cr
 - `AWS::SSM::Parameter`
 - selected CDK custom resources, including CDK S3 BucketDeployment
 
-Each service's own docs describe what its resource types support. Notable limitations:
+Each service's own docs describe what its resource types support.
+
+## Limitations
 
 - `TemplateBody` must be JSON when using `CreateStackCommand`. YAML parsing is not currently provided
   by the CloudFormation service.
-- Only supported resource types create simulated service resources.
+- Only supported resource types create simulated service resources. An unsupported resource may be
+  skipped or may fail the stack, depending on how safely the simulator can model it.
 - Unsupported resource properties may be ignored or rejected depending on the resource simulator.
 - Stack updates and deletes are not supported.
 - Mappings, conditions, and many advanced CloudFormation features are not supported.
-
-## Standalone SimCloudFormation
-
-Most users should access CloudFormation through `SimAws` so that CloudFormation can create resources
-in the same simulated AWS environment as S3, CloudFront, and other services.
-
-```typescript
-import { SimAws } from "@kensio/yulin";
-
-const simAws = new SimAws();
-const simCfn = simAws.cloudFormation();
-```
-
-`SimCloudFormation` is also exported from `@kensio/yulin/cloudformation` for advanced cases. In
-normal application tests, prefer the `SimAws` entry point.

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -9,22 +9,6 @@ CloudFront-like layer without talking to real AWS.
 `SimCloudFront` can also be instantiated on its own, in which case it has its own isolated state that
 is not connected to a wider simulated AWS environment.
 
-## Available functionality
-
-Sim CloudFront currently supports:
-
-- `CreateDistributionCommand` and `GetDistributionCommand`
-- S3 Origins backed by sim S3 Buckets
-- CloudFront Distribution hostnames such as `distro123.cloudfront.net`
-- Default cache Behavior and path-based cache Behaviors
-- `viewer-request` and `viewer-response` CloudFront Functions
-- Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
-- Serving simulated CloudFront traffic on localhost with `serveSimAws`
-
-The simulator focuses on useful behaviour for tests and local development rather than full CloudFront
-feature parity. Unsupported CloudFront options may be ignored or may throw errors depending on
-whether the simulator needs them to model the requested behaviour safely.
-
 ## Basic Distribution setup
 
 Create a simulated AWS environment, add a sim S3 Bucket, and create a sim CloudFront Distribution
@@ -401,3 +385,19 @@ export function handler(event) {
   return request;
 }
 ```
+
+## Available functionality
+
+Sim CloudFront currently supports:
+
+- `CreateDistributionCommand` and `GetDistributionCommand`
+- S3 Origins backed by sim S3 Buckets
+- CloudFront Distribution hostnames such as `distro123.cloudfront.net`
+- Default cache Behavior and path-based cache Behaviors
+- `viewer-request` and `viewer-response` CloudFront Functions
+- Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
+- Serving simulated CloudFront traffic on localhost with `serveSimAws`
+
+The simulator focuses on useful behaviour for tests and local development rather than full CloudFront
+feature parity. Unsupported CloudFront options may be ignored or may throw errors depending on
+whether the simulator needs them to model the requested behaviour safely.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -8,50 +8,6 @@ are a different service and are not simulated.
 
 Cognito-specific types are imported from the `@kensio/yulin/cognito` subpath.
 
-## Available functionality
-
-Sim Cognito currently supports:
-
-- `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `DeleteUserPoolCommand` and
-  `ListUserPoolsCommand`
-- `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `DeleteUserPoolClientCommand` and
-  `ListUserPoolClientsCommand`
-- `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
-  `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
-  `AdminEnableUserCommand` and `ListUsersCommand`
-- `CreateGroupCommand`, `GetGroupCommand`, `UpdateGroupCommand`, `DeleteGroupCommand`,
-  `ListGroupsCommand`, `AdminAddUserToGroupCommand`, `AdminRemoveUserFromGroupCommand`,
-  `AdminListGroupsForUserCommand` and `ListUsersInGroupCommand`
-- `AdminInitiateAuthCommand` and `AdminRespondToAuthChallengeCommand`, for the
-  `ADMIN_USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` flows and the `NEW_PASSWORD_REQUIRED`
-  challenge
-- `InitiateAuthCommand` and `RespondToAuthChallengeCommand`, for the client-side
-  `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` flows, authorized by no IAM policy as they are on
-  real Cognito
-- `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
-- Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
-  pool verifies them unchanged
-- A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
-  `serveSimAws`, anonymously, so a verifier fetches the keys rather than being handed them
-- `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and `AWS::Cognito::UserPoolGroup`
-  deployed from a CloudFormation template, with the `Ref` and `Fn::GetAtt` values real
-  CloudFormation returns
-- Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
-- The real default password policy, applied to the passwords users are given
-- The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
-  has a permanent password
-- Group membership, and the precedence order the `cognito:groups` claim uses
-- App client authentication flows, token lifetimes, generated client secrets and
-  `PreventUserExistenceErrors`
-- Refresh tokens that expire at the app client's `RefreshTokenValidity`, thirty days by default on
-  the simulated clock
-- Authorization of the administrative operations by simulated IAM, against the real IAM action and
-  ARN
-- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
-
-SRP, the hosted UI and managed login, MFA, custom authentication challenges and device tracking are
-not implemented.
-
 ## Creating a pool and an app client
 
 A pool needs a name. Everything else has a default, and the defaults here are the ones real Cognito
@@ -1293,6 +1249,47 @@ opposite of what the console does. A pool created with `DeletionProtection: "ACT
 Real Cognito wants an `UpdateUserPool` request deactivating the protection before the pool can go.
 `UpdateUserPool` is not simulated, so a protected pool cannot be deleted here at all. Create the pool
 without `DeletionProtection` if the test needs to delete it.
+
+## Available functionality
+
+Sim Cognito currently supports:
+
+- `CreateUserPoolCommand`, `DescribeUserPoolCommand`, `DeleteUserPoolCommand` and
+  `ListUserPoolsCommand`
+- `CreateUserPoolClientCommand`, `DescribeUserPoolClientCommand`, `DeleteUserPoolClientCommand` and
+  `ListUserPoolClientsCommand`
+- `AdminCreateUserCommand`, `AdminGetUserCommand`, `AdminDeleteUserCommand`,
+  `AdminSetUserPasswordCommand`, `AdminUpdateUserAttributesCommand`, `AdminDisableUserCommand`,
+  `AdminEnableUserCommand` and `ListUsersCommand`
+- `CreateGroupCommand`, `GetGroupCommand`, `UpdateGroupCommand`, `DeleteGroupCommand`,
+  `ListGroupsCommand`, `AdminAddUserToGroupCommand`, `AdminRemoveUserFromGroupCommand`,
+  `AdminListGroupsForUserCommand` and `ListUsersInGroupCommand`
+- `AdminInitiateAuthCommand` and `AdminRespondToAuthChallengeCommand`, for the
+  `ADMIN_USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` flows and the `NEW_PASSWORD_REQUIRED`
+  challenge
+- `InitiateAuthCommand` and `RespondToAuthChallengeCommand`, for the client-side
+  `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` flows, authorized by no IAM policy as they are on
+  real Cognito
+- `GlobalSignOutCommand` and `AdminUserGlobalSignOutCommand`, which revoke the tokens a user holds
+- Real RS256 JWTs, signed by a key the pool publishes as a JWKS, so a verifier configured for the
+  pool verifies them unchanged
+- A pool's `.well-known/jwks.json` and `.well-known/openid-configuration` served over HTTP by
+  `serveSimAws`, anonymously, so a verifier fetches the keys rather than being handed them
+- `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and `AWS::Cognito::UserPoolGroup`
+  deployed from a CloudFormation template, with the `Ref` and `Fn::GetAtt` values real
+  CloudFormation returns
+- Pool ids in the real `<region>_<nine characters>` form, and pool ARNs built from them
+- The real default password policy, applied to the passwords users are given
+- The real user status lifecycle, so an admin-created user stays in `FORCE_CHANGE_PASSWORD` until it
+  has a permanent password
+- Group membership, and the precedence order the `cognito:groups` claim uses
+- App client authentication flows, token lifetimes, generated client secrets and
+  `PreventUserExistenceErrors`
+- Refresh tokens that expire at the app client's `RefreshTokenValidity`, thirty days by default on
+  the simulated clock
+- Authorization of the administrative operations by simulated IAM, against the real IAM action and
+  ARN
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 ## Limitations
 

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -7,30 +7,6 @@ for them. Other simulated services use it to authorize their own actions, simula
 issue temporary Role sessions, and sim CloudFormation can create IAM resources from templates. It can
 also be instantiated on its own as `SimIam` with isolated state.
 
-## Available functionality
-
-Sim IAM currently supports:
-
-- `CreateRoleCommand`, including trust-policy validation
-- `GetRoleCommand` and `ListRolesCommand`, with pagination
-- `PutRolePolicyCommand`, for inline Role policies
-- `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
-- `AttachRolePolicyCommand`
-- `CreateUserCommand` and `PutUserPolicyCommand`
-- `CreateAccessKeyCommand`, registering access keys for credential authentication
-- Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
-  service-supplied resource policies, and policy conditions with explicit-deny precedence
-- IAM authorization at simulated service boundaries, such as Route53 actions
-- Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
-  signature, defaulting to anonymous
-- Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
-  policies
-- The `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` CloudFormation resources
-
-The simulator focuses on useful behaviour for tests and local development rather than full IAM
-feature parity. Unsupported IAM options may be ignored or may throw errors depending on whether the
-simulator needs them to model the requested behaviour.
-
 ## Basic usage
 
 Create a simulated AWS environment, get simulated IAM, create a Role with an inline policy, and
@@ -923,6 +899,29 @@ A standalone `SimIam` instance has its own isolated state, scoped to a generated
 not connected to a wider `SimAws` environment. Other services instantiated standalone, such as
 `new SimRoute53()`, fall back to allow-all authorization. Connect services through a shared `SimAws`
 instance when a test should exercise real IAM enforcement.
+
+## Available functionality
+
+Sim IAM currently supports:
+
+- `CreateRoleCommand`, including trust-policy validation
+- `GetRoleCommand` and `ListRolesCommand`, with pagination
+- `PutRolePolicyCommand`, for inline Role policies
+- `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
+- `AttachRolePolicyCommand`
+- `CreateUserCommand` and `PutUserPolicyCommand`
+- `CreateAccessKeyCommand`, registering access keys for credential authentication
+- Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
+  service-supplied resource policies, and policy conditions with explicit-deny precedence
+- IAM authorization at simulated service boundaries, such as Route53 actions
+- Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
+  signature, defaulting to anonymous
+- Temporary Role sessions through simulated STS `AssumeRoleCommand`, evaluated against Role trust
+  policies
+- The `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` CloudFormation resources
+
+Unsupported IAM options may be ignored or may throw errors depending on whether the simulator needs
+them to model the requested behaviour.
 
 ## Limitations
 

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -8,25 +8,6 @@ wrong encryption context fails.
 
 KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
 
-## Available functionality
-
-Sim KMS currently supports:
-
-- `CreateKeyCommand`, for symmetric encryption keys
-- `DescribeKeyCommand` and `ListKeysCommand`
-- `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
-- `EncryptCommand` and `DecryptCommand`, including encryption context
-- `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
-- `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases
-- `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand`, `CancelKeyDeletionCommand`
-- Key policy evaluation by simulated IAM
-- Key ARNs, key IDs, alias names and alias ARNs as interchangeable ways to name a key
-- The `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources
-- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
-
-The simulator focuses on useful behaviour for tests and local development rather than full KMS
-feature parity.
-
 ## Encrypting and decrypting
 
 Create a key and use it. `Decrypt` needs no `KeyId` for a symmetric key, because the ciphertext already names the key that produced it.
@@ -484,6 +465,22 @@ Function code requiring `@aws-sdk/client-kms` is routed into the same simulated 
 the function's execution role as the caller. A handler that decrypts a value therefore has to be
 allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See
 [simulated Lambda](../lambda/) for how function code and execution roles work.
+
+## Available functionality
+
+Sim KMS currently supports:
+
+- `CreateKeyCommand`, for symmetric encryption keys
+- `DescribeKeyCommand` and `ListKeysCommand`
+- `GetKeyPolicyCommand` and `PutKeyPolicyCommand`
+- `EncryptCommand` and `DecryptCommand`, including encryption context
+- `GenerateDataKeyCommand`, by `KeySpec` or `NumberOfBytes`
+- `CreateAliasCommand` and `ListAliasesCommand`, including AWS managed key aliases
+- `EnableKeyCommand`, `DisableKeyCommand`, `ScheduleKeyDeletionCommand`, `CancelKeyDeletionCommand`
+- Key policy evaluation by simulated IAM
+- Key ARNs, key IDs, alias names and alias ARNs as interchangeable ways to name a key
+- The `AWS::KMS::Key` and `AWS::KMS::Alias` CloudFormation resources
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 ## Limitations
 

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -6,40 +6,9 @@ and invoked in-process and in memory, with no containers and no real AWS infrast
 Handlers run with their execution role as the simulated caller, so AWS calls made inside a handler
 are authorized by simulated IAM, as on real Lambda.
 
-Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath.
-
-## Available functionality
-
-Sim Lambda currently supports:
-
-- `CreateFunctionCommand` and `GetFunctionCommand`
-- `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
-- Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
-  with `serveSimAws`
-- `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
-  resolved from the request
-- `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
-  policies evaluated alongside identity policies
-- Function code from three sources:
-  - an in-process handler function passed via `makeLambdaZipFileInput(...)`
-  - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
-  - a zip object stored in sim S3 via `Code.S3Bucket`/`S3Key`
-- A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations
-- Per-function environment variables with `Environment.Variables`
-- Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
-  environment
-- Execution roles, evaluated against simulated IAM
-- IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
-  `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
-- AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
-- The `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission` CloudFormation
-  resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
-
-Real `LambdaClient` instances can also be routed into sim Lambda with
+Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath. Real `LambdaClient`
+instances can be routed into sim Lambda with
 [SDK interception](../../sdk/ "Simulated AWS SDK interception docs").
-
-The simulator focuses on useful behaviour for tests and local development rather than full Lambda
-feature parity.
 
 ## Creating and invoking a function
 
@@ -1138,6 +1107,33 @@ A binding can target the function by `logicalId` (which also matches a CDK const
 omit template `Code` and `Handler` entirely; unbound functions in the same template keep their
 template code on the vm path. A binding that does not resolve to any template resource fails the
 deploy with the unmatched target named for diagnosis.
+
+## Available functionality
+
+Sim Lambda currently supports:
+
+- `CreateFunctionCommand` and `GetFunctionCommand`
+- `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
+- Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
+  with `serveSimAws`
+- `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
+  resolved from the request
+- `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
+  policies evaluated alongside identity policies
+- Function code from three sources:
+  - an in-process handler function passed via `makeLambdaZipFileInput(...)`
+  - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
+  - a zip object stored in sim S3 via `Code.S3Bucket`/`S3Key`
+- A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations
+- Per-function environment variables with `Environment.Variables`
+- Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
+  environment
+- Execution roles, evaluated against simulated IAM
+- IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
+  `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
+- AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
+- The `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission` CloudFormation
+  resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
 
 ## Limitations
 

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -7,26 +7,6 @@ by sim CloudFormation when deploying Route53 resources from CloudFormation or CD
 served on localhost, Route53 records can route custom local hostnames to other simulated AWS
 services, such as simulated CloudFront distributions or simulated S3 bucket websites.
 
-## Available functionality
-
-Sim Route53 currently supports:
-
-- `CreateHostedZoneCommand`, `GetHostedZoneCommand` and `ListHostedZonesByNameCommand`
-- `ChangeResourceRecordSetsCommand` and `ListResourceRecordSetsCommand`
-- `CREATE`, `UPSERT` and `DELETE` record changes
-- Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`
-- Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
-- Alias records, with `AliasTarget.DNSName` stored as the record value
-- Local hostname resolution through `*.sim-aws.localhost`
-- A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
-- DNS answers over UDP, so records can be queried with `dig` or any DNS client
-- The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources
-- CDK-created Route53 Hosted Zones and records in synthesized templates
-
-The simulator focuses on useful behaviour for tests and local development rather than full Route53
-feature parity. Unsupported Route53 options may be ignored or may throw errors depending on whether
-the simulator needs them to model the requested behaviour.
-
 ## Basic Hosted Zone usage
 
 Create a simulated AWS environment, get simulated Route53, and create a Hosted Zone.
@@ -959,3 +939,23 @@ console.log(hostedZoneCreation.HostedZone?.Id);
 
 A standalone `SimRoute53` instance has its own isolated state and is not connected to a wider
 `SimAws` environment. Use `SimAws` when Route53 needs to resolve names to other simulated services.
+
+## Available functionality
+
+Sim Route53 currently supports:
+
+- `CreateHostedZoneCommand`, `GetHostedZoneCommand` and `ListHostedZonesByNameCommand`
+- `ChangeResourceRecordSetsCommand` and `ListResourceRecordSetsCommand`
+- `CREATE`, `UPSERT` and `DELETE` record changes
+- Stored record types: `A`, `AAAA`, `CNAME`, `TXT`, `NS` and `SOA`
+- Local HTTP hostname routing through `CNAME` records that point to simulated service hostnames
+- Alias records, with `AliasTarget.DNSName` stored as the record value
+- Local hostname resolution through `*.sim-aws.localhost`
+- A browser-viewable hosted zone and record summary at `dns.sim-aws.localhost`
+- DNS answers over UDP, so records can be queried with `dig` or any DNS client
+- The `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet` CloudFormation resources
+- CDK-created Route53 Hosted Zones and records in synthesized templates
+
+The simulator focuses on useful behaviour for tests and local development rather than full Route53
+feature parity. Unsupported Route53 options may be ignored or may throw errors depending on whether
+the simulator needs them to model the requested behaviour.

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -5,31 +5,6 @@ Yulin includes a simulated S3 service for tests and local development.
 Sim S3 can be used directly through `SimAws` or instantiated on its own as `SimS3` with isolated
 state. Yulin can serve a simulated S3 service on localhost.
 
-## Available functionality
-
-Sim S3 currently supports:
-
-- `CreateBucketCommand` and `ListBucketsCommand`
-- `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
-- `PutBucketWebsiteCommand`, for static website hosting
-- `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
-  sim IAM alongside identity policies
-- The `AWS::S3::Bucket` and `AWS::S3::BucketPolicy` CloudFormation resources
-- Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the Bucket
-  opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
-- Serving static website requests on localhost with `serveSimAws`
-- Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
-- Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
-- Bucket website index documents, error documents, trailing-slash redirects, redirect-all
-  configuration, and routing-rule redirects
-- Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
-- In-memory Object storage by default
-- Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`
-
-The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
-parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
-needs them to model the requested behaviour.
-
 ## Basic usage
 
 Create a simulated AWS environment, get simulated S3, create a Bucket, and put an Object into it.
@@ -942,3 +917,28 @@ await simS3.putObject(
 
 A standalone `SimS3` instance has its own isolated state and is not connected to a wider `SimAws`
 environment.
+
+## Available functionality
+
+Sim S3 currently supports:
+
+- `CreateBucketCommand` and `ListBucketsCommand`
+- `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
+- `PutBucketWebsiteCommand`, for static website hosting
+- `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
+  sim IAM alongside identity policies
+- The `AWS::S3::Bucket` and `AWS::S3::BucketPolicy` CloudFormation resources
+- Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the Bucket
+  opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
+- Serving static website requests on localhost with `serveSimAws`
+- Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
+- Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
+- Bucket website index documents, error documents, trailing-slash redirects, redirect-all
+  configuration, and routing-rule redirects
+- Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
+- In-memory Object storage by default
+- Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`
+
+The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
+parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
+needs them to model the requested behaviour.

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -5,27 +5,6 @@ in memory, versioned by staging label, and every operation is authorized by simu
 
 Secrets Manager-specific types are imported from the `@kensio/yulin/secretsmanager` subpath.
 
-## Available functionality
-
-Sim Secrets Manager currently supports:
-
-- `CreateSecretCommand`, holding either a string or binary
-- `GetSecretValueCommand`, by staging label or by version id
-- `PutSecretValueCommand` and `UpdateSecretCommand`, each writing a new version
-- `DescribeSecretCommand` and `ListSecretsCommand`
-- `DeleteSecretCommand`, with a recovery window, and `RestoreSecretCommand`
-- `AWSCURRENT` and `AWSPREVIOUS` staging labels, and custom labels
-- Secret ARNs carrying the six random characters real Secrets Manager appends
-- Friendly names, full ARNs and partial ARNs as interchangeable ways to name a secret
-- Authorization of every operation by simulated IAM, against the real IAM action
-- Encryption of every version through simulated KMS, under `KmsKeyId` or the `aws/secretsmanager`
-  managed key
-- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
-- The `AWS::SecretsManager::Secret` CloudFormation resource, including `GenerateSecretString`
-
-The simulator focuses on useful behaviour for tests and local development rather than full Secrets
-Manager feature parity.
-
 ## Creating and reading a secret
 
 ```typescript sim-secrets-manager-create-and-read
@@ -483,6 +462,24 @@ work.
 The same applies to `SimSdk` interception: intercepting `SecretsManagerClient` routes ordinary SDK
 code into the simulation with nothing touching the network. See
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
+
+## Available functionality
+
+Sim Secrets Manager currently supports:
+
+- `CreateSecretCommand`, holding either a string or binary
+- `GetSecretValueCommand`, by staging label or by version id
+- `PutSecretValueCommand` and `UpdateSecretCommand`, each writing a new version
+- `DescribeSecretCommand` and `ListSecretsCommand`
+- `DeleteSecretCommand`, with a recovery window, and `RestoreSecretCommand`
+- `AWSCURRENT` and `AWSPREVIOUS` staging labels, and custom labels
+- Secret ARNs carrying the six random characters real Secrets Manager appends
+- Friendly names, full ARNs and partial ARNs as interchangeable ways to name a secret
+- Authorization of every operation by simulated IAM, against the real IAM action
+- Encryption of every version through simulated KMS, under `KmsKeyId` or the `aws/secretsmanager`
+  managed key
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+- The `AWS::SecretsManager::Secret` CloudFormation resource, including `GenerateSecretString`
 
 ## Limitations
 

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -8,26 +8,6 @@ Only Parameter Store is simulated. Nothing else in Systems Manager is.
 
 SSM-specific types are imported from the `@kensio/yulin/ssm` subpath.
 
-## Available functionality
-
-Sim SSM currently supports:
-
-- `PutParameterCommand`, creating a parameter or overwriting one
-- `GetParameterCommand`, by name, by `name:version` or by `name:label`
-- `GetParametersCommand`, reporting names it could not resolve in `InvalidParameters`
-- `GetParametersByPathCommand`, with and without `Recursive`
-- `DeleteParameterCommand` and `DeleteParametersCommand`
-- `DescribeParametersCommand`
-- `String`, `StringList` and `SecureString` parameter types
-- `SecureString` values encrypted through simulated KMS, decrypted only with `WithDecryption`
-- The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
-- Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
-- Authorization of every operation by simulated IAM, against the real IAM action and ARN
-- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
-
-The simulator focuses on useful behaviour for tests and local development rather than full Parameter
-Store feature parity.
-
 ## Writing and reading a parameter
 
 `PutParameter` needs a `Type` when the parameter is new. `GetParameter` returns the current version.
@@ -742,6 +722,23 @@ console.log(read.Parameter?.Value); // "hunter2"
 ```
 
 `DescribeParameters` reports the key each `SecureString` is encrypted under as `KeyId`.
+
+## Available functionality
+
+Sim SSM currently supports:
+
+- `PutParameterCommand`, creating a parameter or overwriting one
+- `GetParameterCommand`, by name, by `name:version` or by `name:label`
+- `GetParametersCommand`, reporting names it could not resolve in `InvalidParameters`
+- `GetParametersByPathCommand`, with and without `Recursive`
+- `DeleteParameterCommand` and `DeleteParametersCommand`
+- `DescribeParametersCommand`
+- `String`, `StringList` and `SecureString` parameter types
+- `SecureString` values encrypted through simulated KMS, decrypted only with `WithDecryption`
+- The `AWS::SSM::Parameter` CloudFormation resource, including `Ref` and `Fn::GetAtt`
+- Parameter name validation, including hierarchy depth and the reserved `aws` and `ssm` prefixes
+- Authorization of every operation by simulated IAM, against the real IAM action and ARN
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 ## Limitations
 

--- a/docs/services/sts/README.md
+++ b/docs/services/sts/README.md
@@ -7,24 +7,6 @@ It simulates assuming IAM Roles: it evaluates the request against [simulated IAM
 and issues temporary session credentials that the rest of the simulated environment authenticates
 like real AWS credentials.
 
-## Available functionality
-
-Sim STS currently supports:
-
-- `AssumeRoleCommand`
-- Trust-policy evaluation against the target Role's assume-role policy document
-- Identity-policy evaluation of the source caller, requiring `sts:AssumeRole` permission on the
-  target Role
-- Role-to-Role and cross-Account assumption
-- `ExternalId` matching through the `sts:ExternalId` trust-policy condition key
-- Session duration with `DurationSeconds`, defaulting to one hour
-- Temporary credentials registered with the target Account's sim IAM, including session-token and
-  expiry validation
-
-The simulator focuses on useful behaviour for tests and local development rather than full STS
-feature parity. Unsupported STS options may be ignored or may throw errors depending on whether the
-simulator needs them to model the requested behaviour.
-
 ## Basic usage
 
 Create a Role whose trust policy allows the Account to assume it, then assume it through STS. An
@@ -220,6 +202,23 @@ console.log(assumeRoleOutput.AssumedRoleUser?.Arn);
 
 An omitted or mismatched `ExternalId` leaves the trust-policy condition unmatched, so the assume
 request is denied.
+
+## Available functionality
+
+Sim STS currently supports:
+
+- `AssumeRoleCommand`
+- Trust-policy evaluation against the target Role's assume-role policy document
+- Identity-policy evaluation of the source caller, requiring `sts:AssumeRole` permission on the
+  target Role
+- Role-to-Role and cross-Account assumption
+- `ExternalId` matching through the `sts:ExternalId` trust-policy condition key
+- Session duration with `DurationSeconds`, defaulting to one hour
+- Temporary credentials registered with the target Account's sim IAM, including session-token and
+  expiry validation
+
+Unsupported STS options may be ignored or may throw errors depending on whether the simulator needs
+them to model the requested behaviour.
 
 ## Limitations
 

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -8,15 +8,6 @@ Nothing here replaces the clock for the whole process. Time belongs to a `SimAws
 it never disturbs another simulation running in the same test file, the real clock, or any other code
 in the process.
 
-## Available functionality
-
-- `simAws.now()` reads what the simulation currently calls the time.
-- `new SimAws({ clock })` starts a simulation at a given instant.
-- `simAws.clock()` returns the control: `freeze()`, `resume()`, `setTo(instant)`, `advanceBy(duration)`.
-- Advancing runs whatever falls due during the interval and returns once the simulation has
-  settled, so the next line can assert.
-- Served HTTP responses report simulated time in their `Date` header.
-
 ## Reading the time
 
 `simAws.now()` is what the simulation means by "now", which is not necessarily what the host clock


### PR DESCRIPTION
Each docs page now starts with its intro and the first thing a reader wants to do. The "Available functionality" list is reference material for someone checking whether a thing is simulated, so it sits at the end of the page next to "Limitations".

The simulated time list is dropped rather than moved, since every bullet restated the heading below it. The CloudFormation page's top list and its "Supported resources and limitations" section are merged into one functionality list and one limitations list at the end.

Also list Cognito and SSM as supporting SDK interception, which they do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the SDK interception guide to include Cognito and SSM.
  * Reorganized service documentation for clearer separation of usage guidance, available functionality, and limitations.
  * Added standalone CloudFormation usage guidance, examples, supported capabilities, and clarified limitations.
  * Added Lambda guidance for SDK interception and package imports.
  * Removed the detailed simulated-time API reference from the time documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->