### PR TITLE
feat: send and receive messages on simulated SQS queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm i -D @kensio/yulin
 - [Route53](./docs/services/route53 "Simulated Route53 docs")
 - [S3](./docs/services/s3 "Simulated S3 docs")
 - [Secrets Manager](./docs/services/secretsmanager "Simulated Secrets Manager docs")
+- [SQS](./docs/services/sqs "Simulated SQS docs")
 - [SSM Parameter Store](./docs/services/ssm "Simulated SSM Parameter Store docs")
 - [STS](./docs/services/sts "Simulated STS docs")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [Route53](./services/route53/ "Simulated Route53 usage docs")
 - [S3](./services/s3/ "Simulated S3 usage docs")
 - [Secrets Manager](./services/secretsmanager/ "Simulated Secrets Manager usage docs")
+- [SQS](./services/sqs/ "Simulated SQS usage docs")
 - [SSM Parameter Store](./services/ssm/ "Simulated SSM Parameter Store usage docs")
 - [STS](./services/sts/ "Simulated STS usage docs")
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -173,7 +173,7 @@ throw a diagnostic error.
 ## Supported services and Commands
 
 All simulated services support SDK interception: ACM, CloudFormation, CloudFront, Cognito, DynamoDB,
-IAM, KMS, Lambda, Route53, S3, Secrets Manager, SSM and STS. Each service's own docs under
+IAM, KMS, Lambda, Route53, S3, Secrets Manager, SQS, SSM and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1,0 +1,726 @@
+# Simulated SQS
+
+Yulin includes a simulated Amazon SQS for tests and local development. Messages are held in memory,
+hidden and released on the simulation's own clock, and every operation is authorized by simulated IAM.
+
+Standard queues only. SQS-specific types are imported from the `@kensio/yulin/sqs` subpath.
+
+## Creating a queue and sending a message
+
+```typescript sim-sqs-send-and-receive
+/**
+ * Sending a message to a simulated queue and receiving it.
+ */
+
+import {
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+);
+const message = received.Messages?.[0];
+
+console.log(message?.Body); // "order-1"
+
+await sqs.deleteMessage(
+  new DeleteMessageCommand({
+    QueueUrl,
+    ReceiptHandle: message?.ReceiptHandle,
+  }),
+);
+```
+
+A queue URL is `https://sqs.<region>.amazonaws.com/<account-id>/<name>`, and the ARN is
+`arn:aws:sqs:<region>:<account-id>:<name>`. An SQS ARN has no resource type in it, so the queue name
+follows the account id directly.
+
+`CreateQueue` is idempotent, as it is on real AWS. A second request for the same name returns the
+existing queue's URL when the attributes it names match, and fails with `QueueNameExists` when they
+differ. A request naming no attributes always matches.
+
+## Visibility timeouts
+
+A received message is hidden from other consumers for the queue's visibility timeout, 30 seconds by
+default. Nothing is scheduled to release it: the message records the instant it is hidden until, and it
+becomes receivable again once simulated time reaches that instant. Advancing the clock is therefore all
+a test needs to watch an undeleted message come back.
+
+```typescript sim-sqs-visibility-timeout
+/**
+ * A message that was received but never deleted, coming back once its
+ * visibility timeout lapses.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { VisibilityTimeout: "30" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const first = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(first.Messages?.length); // 1
+
+// The message is invisible to everyone else while the timeout runs.
+const empty = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(empty.Messages); // undefined
+
+await simAws.clock().advanceBy({ seconds: 31 });
+
+const again = await sqs.receiveMessage(
+  new ReceiveMessageCommand({
+    QueueUrl,
+    MessageSystemAttributeNames: ["ApproximateReceiveCount"],
+  }),
+);
+
+console.log(again.Messages?.[0]?.Attributes?.["ApproximateReceiveCount"]); // "2"
+```
+
+A receive request can override the timeout for the messages it takes with `VisibilityTimeout`, and a
+consumer part way through a slow handler can ask for more time with `ChangeMessageVisibility`. The new
+timeout runs from the moment of the change rather than from the receive, as it does on real AWS, and
+a timeout of zero gives the message straight back to the queue.
+
+`ChangeMessageVisibility` on a message whose timeout has already lapsed fails with `MessageNotInflight`,
+which is what real SQS answers: there is no timeout left to change.
+
+See [simulated time](../../time/ "Simulated time docs") for what else the clock can do.
+
+## Receipt handles
+
+Every receive issues a fresh receipt handle, and a delete has to use the handle from the most recent
+receive of that message. A handle from an earlier receive is accepted and deletes nothing, which is
+exactly what real SQS does with one.
+
+That is the failure a consumer slower than its visibility timeout hits. Its message went back on the
+queue, someone else took it, and its own delete quietly does nothing.
+
+```typescript sim-sqs-stale-receipt-handle
+/**
+ * A slow consumer deleting with a receipt handle another receive has
+ * superseded.
+ */
+
+import {
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { VisibilityTimeout: "30" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const slow = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// The slow consumer takes longer than the visibility timeout, and another
+// consumer receives the message in the meantime.
+await simAws.clock().advanceBy({ seconds: 31 });
+await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// The delete succeeds and deletes nothing.
+await sqs.deleteMessage(
+  new DeleteMessageCommand({
+    QueueUrl,
+    ReceiptHandle: slow.Messages?.[0]?.ReceiptHandle,
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 31 });
+
+const still = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(still.Messages?.[0]?.Body); // "order-1"
+```
+
+A handle whose visibility timeout has lapsed with nobody else having received the message since is
+still the most recent one, so deleting with it works. A handle the queue never issued fails with
+`ReceiptHandleIsInvalid`, and a repeated delete of a message already gone succeeds.
+
+## Delays
+
+`DelaySeconds` hides a new message until it lapses, either set on the queue for every message or on
+one message as it is sent.
+
+```typescript sim-sqs-delayed-message
+/**
+ * A message that cannot be received until the delay it was sent with lapses.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({
+    QueueUrl,
+    MessageBody: "order-1",
+    DelaySeconds: 60,
+  }),
+);
+
+const early = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(early.Messages); // undefined
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const late = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(late.Messages?.[0]?.Body); // "order-1"
+```
+
+`MessageRetentionPeriod` works on the same clock. A message on the queue longer than the retention
+period, four days by default, is gone rather than kept indefinitely.
+
+## Message attributes
+
+Message attributes round-trip, and both digests are real: `MD5OfMessageBody` is an MD5 of the body, and
+`MD5OfMessageAttributes` uses the length-prefixed encoding real SQS digests attributes with. A consumer
+checking either against its own digest is checking something real.
+
+A receive returns no attributes unless it names them, as on real AWS. `All` or `.*` selects every
+attribute, a bare name selects one, and a name ending in `.*` selects a prefix.
+
+```typescript sim-sqs-message-attributes
+/**
+ * Message attributes on a simulated queue, and asking for them back.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+const sent = await sqs.sendMessage(
+  new SendMessageCommand({
+    QueueUrl,
+    MessageBody: "order-1",
+    MessageAttributes: {
+      tenant: { DataType: "String", StringValue: "acme" },
+      attempt: { DataType: "Number", StringValue: "1" },
+    },
+  }),
+);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl, MessageAttributeNames: ["All"] }),
+);
+const message = received.Messages?.[0];
+
+console.log(message?.MessageAttributes?.["tenant"]?.StringValue); // "acme"
+console.log(message?.MD5OfMessageAttributes === sent.MD5OfMessageAttributes); // true
+console.log(message?.MD5OfBody === sent.MD5OfMessageBody); // true
+```
+
+The name and data type rules are the real ones. A name using a reserved `AWS.` or `Amazon.` prefix, a
+data type that is not `String`, `Number` or `Binary`, or a value that does not match its data type is
+refused here rather than on AWS.
+
+The message system attributes are asked for separately, with `MessageSystemAttributeNames`, or with
+the discontinued `AttributeNames` that means the same thing. `SentTimestamp`,
+`ApproximateReceiveCount` and `ApproximateFirstReceiveTimestamp` are reported.
+
+## Queue attributes
+
+`GetQueueAttributes` returns only the attributes a request names, as real SQS does, and `All` names
+every attribute this simulation holds. The defaults are the AWS ones: `VisibilityTimeout` 30,
+`DelaySeconds` 0, `MessageRetentionPeriod` 345600, `MaximumMessageSize` 262144 and
+`ReceiveMessageWaitTimeSeconds` 0.
+
+```typescript sim-sqs-queue-attributes
+/**
+ * Reading the counts and settings of a simulated queue.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: { VisibilityTimeout: "120" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-2" }),
+);
+await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+const read = await sqs.getQueueAttributes(
+  new GetQueueAttributesCommand({ QueueUrl, AttributeNames: ["All"] }),
+);
+
+console.log(read.Attributes?.["VisibilityTimeout"]); // "120"
+console.log(read.Attributes?.["ApproximateNumberOfMessages"]); // "1"
+console.log(read.Attributes?.["ApproximateNumberOfMessagesNotVisible"]); // "1"
+console.log(read.Attributes?.["QueueArn"]); // "arn:aws:sqs:us-east-1:888888888888:orders"
+```
+
+An attribute real SQS reports and this simulation does not model, `RedrivePolicy` for one, is left out
+of a response rather than refused, since that is what real SQS does with an attribute a queue has no
+value for. Setting one is refused, because a queue that appeared to accept a redrive policy would
+behave differently here than on AWS.
+
+`PurgeQueue` deletes everything on a queue, hidden messages included.
+
+## IAM permissions
+
+Every operation is authorized against the queue's ARN, which carries the queue name with no resource
+type in front of it. Two details are worth knowing, because both are real SQS behaviour that a policy
+can get wrong:
+
+- `ListQueues` has no queue-level permission, so a policy allowing it names
+  `arn:aws:sqs:<region>:<account-id>:*`. A policy naming one queue grants no listing.
+- The batch operations are authorized as their singular action. There is no `sqs:SendMessageBatch`,
+  `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action for a policy to name.
+
+```typescript sim-sqs-iam-policy
+/**
+ * A Role allowed to consume from one simulated queue and nothing else.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumer",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+        // A queue ARN has no resource type: not "...:queue/orders".
+        Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+  { caller },
+);
+
+console.log(received.Messages?.[0]?.Body); // "order-1"
+
+try {
+  await sqs.sendMessage(
+    new SendMessageCommand({ QueueUrl, MessageBody: "order-2" }),
+    { caller },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}
+```
+
+## Batches
+
+`SendMessageBatch` and `DeleteMessageBatch` take up to ten entries. An entry that fails on its own is
+reported in `Failed` while the rest of the batch goes through, as real SQS reports it. An empty batch,
+more than ten entries, a malformed entry id or two entries sharing an id fail the whole request.
+
+```typescript sim-sqs-send-message-batch
+/**
+ * A batch send where one entry fails on its own.
+ */
+
+import {
+  CreateQueueCommand,
+  SendMessageBatchCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { MaximumMessageSize: "1024" },
+  }),
+);
+
+const sent = await sqs.sendMessageBatch(
+  new SendMessageBatchCommand({
+    QueueUrl,
+    Entries: [
+      { Id: "one", MessageBody: "order-1" },
+      { Id: "two", MessageBody: "x".repeat(2048) },
+    ],
+  }),
+);
+
+console.log(sent.Successful?.map((entry) => entry.Id)); // ["one"]
+console.log(sent.Failed?.[0]?.Code); // "InvalidParameterValue"
+```
+
+## Deleting a queue
+
+`DeleteQueue` removes the queue and everything on it. The name is not free straight away: real SQS
+holds a deleted queue's name for 60 seconds, and so does this. Advancing simulated time past it frees
+the name, which is what a redeployed stack depends on.
+
+```typescript sim-sqs-delete-queue
+/**
+ * A deleted queue holding its name for a minute, as real SQS holds it.
+ */
+
+import { CreateQueueCommand, DeleteQueueCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSqsQueueDeletedRecently } from "@kensio/yulin/sqs";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.deleteQueue(new DeleteQueueCommand({ QueueUrl }));
+
+try {
+  await sqs.createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDeletedRecently); // true
+}
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const recreated = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+console.log(recreated.QueueUrl === QueueUrl); // true
+```
+
+## Scoping
+
+Queues belong to an account and a region, as they do on real AWS. A queue name is unique within one
+account and region and nowhere wider, so the same name can be used in two regions for two different
+queues.
+
+```typescript sim-sqs-scoping
+/**
+ * Simulated queues are scoped to an account and region.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueUrlCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSqsQueueDoesNotExist } from "@kensio/yulin/sqs";
+
+const simAws = new SimAws();
+
+const { QueueUrl } = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .sqs()
+    .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDoesNotExist); // true
+}
+
+// A queue URL naming another Region reaches nothing either.
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .sqs()
+    .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDoesNotExist); // true
+}
+```
+
+## Inside a simulated Lambda handler
+
+Function code requiring `@aws-sdk/client-sqs` is routed into the same simulated AWS environment, with
+the function's execution role as the caller. A handler consuming a queue therefore has to be allowed
+to, by that role's policy, the same as on real AWS.
+
+```typescript sim-sqs-lambda-consumer
+/**
+ * A simulated Lambda handler consuming a message from a simulated queue.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+        Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+      },
+    }),
+  }),
+);
+
+const handlerCode = [
+  'const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require("@aws-sdk/client-sqs");',
+  "exports.handler = async () => {",
+  "  const client = new SQSClient({});",
+  "  const received = await client.send(new ReceiveMessageCommand({",
+  "    QueueUrl: process.env.QUEUE_URL,",
+  "  }));",
+  "  const message = received.Messages[0];",
+  "  await client.send(new DeleteMessageCommand({",
+  "    QueueUrl: process.env.QUEUE_URL,",
+  "    ReceiptHandle: message.ReceiptHandle,",
+  "  }));",
+  "  return message.Body;",
+  "};",
+].join("\n");
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: { ZipFile: makeLambdaCodeZip({ "index.js": handlerCode }) },
+    Environment: { Variables: { QUEUE_URL: QueueUrl! } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "order-consumer" }));
+
+console.log(Buffer.from(invoked.Payload ?? []).toString("utf8")); // "\"order-1\""
+```
+
+See [simulated Lambda](../lambda/ "Simulated Lambda docs") for how function code and execution roles
+work. The same applies to `SimSdk` interception: intercepting `SQSClient` routes ordinary SDK code into
+the simulation with nothing touching the network. See
+[AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
+
+## Available functionality
+
+Sim SQS currently supports:
+
+- `CreateQueueCommand`, idempotent for a matching name and attributes, and `DeleteQueueCommand`
+- `GetQueueUrlCommand` and `ListQueuesCommand`, with a name prefix and paging
+- `GetQueueAttributesCommand`, `SetQueueAttributesCommand` and `PurgeQueueCommand`
+- `SendMessageCommand` and `SendMessageBatchCommand`, with per-message or per-queue delays
+- `ReceiveMessageCommand`, up to ten messages at a time, each under a fresh receipt handle
+- `DeleteMessageCommand`, `DeleteMessageBatchCommand` and `ChangeMessageVisibilityCommand`
+- Visibility timeouts, delays and message retention, all on the simulation's clock
+- `MessageAttributes` round-tripping, with real `MD5OfMessageBody` and `MD5OfMessageAttributes` digests
+- The `SentTimestamp`, `ApproximateReceiveCount` and `ApproximateFirstReceiveTimestamp` system
+  attributes
+- Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
+- Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+
+## Limitations
+
+Current documented limitations:
+
+- Standard queues only. A queue name ending in `.fifo` is refused, as are `MessageGroupId`,
+  `MessageDeduplicationId` and `ReceiveRequestAttemptId`.
+- Delivery is exactly once and in order. Real standard queues guarantee at-least-once delivery and
+  make no ordering promise, so a test relying on the order messages come back in, or on a message
+  arriving only once, is relying on something AWS does not promise.
+- Long polling does not wait. `WaitTimeSeconds` and `ReceiveMessageWaitTimeSeconds` are accepted and
+  validated, and a receive returns at once. Nothing else is running in process that could send a
+  message during the wait, so waiting could only ever time out.
+- `DeleteQueue` and `PurgeQueue` take effect immediately, where real SQS may take up to 60 seconds
+  over either. The 60 second hold on a deleted queue's name is simulated, so recreating a queue
+  straight after deleting it fails with `QueueDeletedRecently` until the clock moves on.
+- Dead-letter queues are not simulated. `RedrivePolicy` and `RedriveAllowPolicy` are refused rather
+  than ignored, and a message that fails repeatedly stays on its queue.
+- Queue policies are not simulated (`AddPermission`, `RemovePermission` and the `Policy` attribute),
+  so cross-account access to a queue cannot be granted. A request naming a
+  `QueueOwnerAWSAccountId` other than the scope's own Account is refused.
+- Encryption is not simulated. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
+  `SqsManagedSseEnabled` are refused, and message bodies are held in process memory as they were
+  sent. That is not a security boundary: anything sharing the process can reach them.
+- Tags are not simulated. `TagQueue`, `UntagQueue` and `ListQueueTags` are not supported, and
+  `CreateQueue` refuses a `tags` parameter rather than dropping it.
+- `SenderId` is not reported, because a simulated caller has no user or role id to report it as.
+  `AWSTraceHeader` is not reported either, and `MessageSystemAttributes` on a send are refused. Asking
+  for any of them is accepted, as real SQS accepts a request for an attribute a message has no value
+  for, and they are left out of the response.
+- SQS condition keys are not derived, so a policy relying on them will not match. Ordinary condition
+  operators on values sim IAM does supply work as usual.
+- `ChangeMessageVisibilityBatch`, `ListDeadLetterSourceQueues`, the message move tasks and the batch
+  size limit (`BatchRequestTooLong`) are not supported.
+- Lambda event source mappings are not simulated, so a queue does not invoke a function on its own. A
+  test invokes the consumer itself, as the Lambda example above does.
+- There is no `AWS::SQS::Queue` CloudFormation resource yet, so a queue is created through the SDK
+  rather than deployed from a template.
+- SQS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -692,9 +692,11 @@ Current documented limitations:
 
 - Standard queues only. A queue name ending in `.fifo` is refused, as are `MessageGroupId`,
   `MessageDeduplicationId` and `ReceiveRequestAttemptId`.
-- Delivery is exactly once and in order. Real standard queues guarantee at-least-once delivery and
-  make no ordering promise, so a test relying on the order messages come back in, or on a message
-  arriving only once, is relying on something AWS does not promise.
+- Ordering and duplicates are stricter here than AWS promises. Messages come back oldest first, and a
+  message is handed out to one consumer at a time. Real standard queues make no ordering promise and
+  guarantee at-least-once delivery, so there a copy of a message can arrive twice and messages can
+  arrive out of order. Redelivery after a visibility timeout lapses is simulated, since that follows
+  from the timeout; a duplicate arriving on its own is not.
 - Long polling does not wait. `WaitTimeSeconds` and `ReceiveMessageWaitTimeSeconds` are accepted and
   validated, and a receive returns at once. Nothing else is running in process that could send a
   message during the wait, so waiting could only ever time out.

--- a/docs/services/sqs/sim-sqs-delayed-message.example.ts
+++ b/docs/services/sqs/sim-sqs-delayed-message.example.ts
@@ -1,0 +1,36 @@
+/**
+ * A message that cannot be received until the delay it was sent with lapses.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({
+    QueueUrl,
+    MessageBody: "order-1",
+    DelaySeconds: 60,
+  }),
+);
+
+const early = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(early.Messages); // undefined
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const late = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(late.Messages?.[0]?.Body); // "order-1"

--- a/docs/services/sqs/sim-sqs-delete-queue.example.ts
+++ b/docs/services/sqs/sim-sqs-delete-queue.example.ts
@@ -1,0 +1,31 @@
+/**
+ * A deleted queue holding its name for a minute, as real SQS holds it.
+ */
+
+import { CreateQueueCommand, DeleteQueueCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSqsQueueDeletedRecently } from "@kensio/yulin/sqs";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.deleteQueue(new DeleteQueueCommand({ QueueUrl }));
+
+try {
+  await sqs.createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDeletedRecently); // true
+}
+
+await simAws.clock().advanceBy({ seconds: 61 });
+
+const recreated = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+console.log(recreated.QueueUrl === QueueUrl); // true

--- a/docs/services/sqs/sim-sqs-iam-policy.example.ts
+++ b/docs/services/sqs/sim-sqs-iam-policy.example.ts
@@ -1,0 +1,73 @@
+/**
+ * A Role allowed to consume from one simulated queue and nothing else.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumer",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+        // A queue ARN has no resource type: not "...:queue/orders".
+        Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: role.Role.Arn } as const;
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+  { caller },
+);
+
+console.log(received.Messages?.[0]?.Body); // "order-1"
+
+try {
+  await sqs.sendMessage(
+    new SendMessageCommand({ QueueUrl, MessageBody: "order-2" }),
+    { caller },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}

--- a/docs/services/sqs/sim-sqs-lambda-consumer.example.ts
+++ b/docs/services/sqs/sim-sqs-lambda-consumer.example.ts
@@ -1,0 +1,85 @@
+/**
+ * A simulated Lambda handler consuming a message from a simulated queue.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const regionName = simAws.defaultRegionName;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+        Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+      },
+    }),
+  }),
+);
+
+const handlerCode = [
+  'const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require("@aws-sdk/client-sqs");',
+  "exports.handler = async () => {",
+  "  const client = new SQSClient({});",
+  "  const received = await client.send(new ReceiveMessageCommand({",
+  "    QueueUrl: process.env.QUEUE_URL,",
+  "  }));",
+  "  const message = received.Messages[0];",
+  "  await client.send(new DeleteMessageCommand({",
+  "    QueueUrl: process.env.QUEUE_URL,",
+  "    ReceiptHandle: message.ReceiptHandle,",
+  "  }));",
+  "  return message.Body;",
+  "};",
+].join("\n");
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: { ZipFile: makeLambdaCodeZip({ "index.js": handlerCode }) },
+    Environment: { Variables: { QUEUE_URL: QueueUrl! } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const invoked = await simAws
+  .lambda()
+  .invoke(new InvokeCommand({ FunctionName: "order-consumer" }));
+
+console.log(Buffer.from(invoked.Payload ?? []).toString("utf8")); // "\"order-1\""

--- a/docs/services/sqs/sim-sqs-message-attributes.example.ts
+++ b/docs/services/sqs/sim-sqs-message-attributes.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Message attributes on a simulated queue, and asking for them back.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+const sent = await sqs.sendMessage(
+  new SendMessageCommand({
+    QueueUrl,
+    MessageBody: "order-1",
+    MessageAttributes: {
+      tenant: { DataType: "String", StringValue: "acme" },
+      attempt: { DataType: "Number", StringValue: "1" },
+    },
+  }),
+);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl, MessageAttributeNames: ["All"] }),
+);
+const message = received.Messages?.[0];
+
+console.log(message?.MessageAttributes?.["tenant"]?.StringValue); // "acme"
+console.log(message?.MD5OfMessageAttributes === sent.MD5OfMessageAttributes); // true
+console.log(message?.MD5OfBody === sent.MD5OfMessageBody); // true

--- a/docs/services/sqs/sim-sqs-queue-attributes.example.ts
+++ b/docs/services/sqs/sim-sqs-queue-attributes.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Reading the counts and settings of a simulated queue.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: { VisibilityTimeout: "120" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-2" }),
+);
+await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+const read = await sqs.getQueueAttributes(
+  new GetQueueAttributesCommand({ QueueUrl, AttributeNames: ["All"] }),
+);
+
+console.log(read.Attributes?.["VisibilityTimeout"]); // "120"
+console.log(read.Attributes?.["ApproximateNumberOfMessages"]); // "1"
+console.log(read.Attributes?.["ApproximateNumberOfMessagesNotVisible"]); // "1"
+console.log(read.Attributes?.["QueueArn"]); // "arn:aws:sqs:us-east-1:888888888888:orders"

--- a/docs/services/sqs/sim-sqs-scoping.example.ts
+++ b/docs/services/sqs/sim-sqs-scoping.example.ts
@@ -1,0 +1,41 @@
+/**
+ * Simulated queues are scoped to an account and region.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueUrlCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import { SimSqsQueueDoesNotExist } from "@kensio/yulin/sqs";
+
+const simAws = new SimAws();
+
+const { QueueUrl } = await simAws
+  .account("222222222222")
+  .region("eu-west-2")
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .sqs()
+    .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDoesNotExist); // true
+}
+
+// A queue URL naming another Region reaches nothing either.
+try {
+  await simAws
+    .account("222222222222")
+    .region("us-east-1")
+    .sqs()
+    .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+} catch (error) {
+  console.log(error instanceof SimSqsQueueDoesNotExist); // true
+}

--- a/docs/services/sqs/sim-sqs-send-and-receive.example.ts
+++ b/docs/services/sqs/sim-sqs-send-and-receive.example.ts
@@ -1,0 +1,37 @@
+/**
+ * Sending a message to a simulated queue and receiving it.
+ */
+
+import {
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const received = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl }),
+);
+const message = received.Messages?.[0];
+
+console.log(message?.Body); // "order-1"
+
+await sqs.deleteMessage(
+  new DeleteMessageCommand({
+    QueueUrl,
+    ReceiptHandle: message?.ReceiptHandle,
+  }),
+);

--- a/docs/services/sqs/sim-sqs-send-message-batch.example.ts
+++ b/docs/services/sqs/sim-sqs-send-message-batch.example.ts
@@ -1,0 +1,33 @@
+/**
+ * A batch send where one entry fails on its own.
+ */
+
+import {
+  CreateQueueCommand,
+  SendMessageBatchCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { MaximumMessageSize: "1024" },
+  }),
+);
+
+const sent = await sqs.sendMessageBatch(
+  new SendMessageBatchCommand({
+    QueueUrl,
+    Entries: [
+      { Id: "one", MessageBody: "order-1" },
+      { Id: "two", MessageBody: "x".repeat(2048) },
+    ],
+  }),
+);
+
+console.log(sent.Successful?.map((entry) => entry.Id)); // ["one"]
+console.log(sent.Failed?.[0]?.Code); // "InvalidParameterValue"

--- a/docs/services/sqs/sim-sqs-stale-receipt-handle.example.ts
+++ b/docs/services/sqs/sim-sqs-stale-receipt-handle.example.ts
@@ -1,0 +1,48 @@
+/**
+ * A slow consumer deleting with a receipt handle another receive has
+ * superseded.
+ */
+
+import {
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { VisibilityTimeout: "30" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const slow = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// The slow consumer takes longer than the visibility timeout, and another
+// consumer receives the message in the meantime.
+await simAws.clock().advanceBy({ seconds: 31 });
+await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+// The delete succeeds and deletes nothing.
+await sqs.deleteMessage(
+  new DeleteMessageCommand({
+    QueueUrl,
+    ReceiptHandle: slow.Messages?.[0]?.ReceiptHandle,
+  }),
+);
+
+await simAws.clock().advanceBy({ seconds: 31 });
+
+const still = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(still.Messages?.[0]?.Body); // "order-1"

--- a/docs/services/sqs/sim-sqs-visibility-timeout.example.ts
+++ b/docs/services/sqs/sim-sqs-visibility-timeout.example.ts
@@ -1,0 +1,46 @@
+/**
+ * A message that was received but never deleted, coming back once its
+ * visibility timeout lapses.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: { VisibilityTimeout: "30" },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+const first = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(first.Messages?.length); // 1
+
+// The message is invisible to everyone else while the timeout runs.
+const empty = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(empty.Messages); // undefined
+
+await simAws.clock().advanceBy({ seconds: 31 });
+
+const again = await sqs.receiveMessage(
+  new ReceiveMessageCommand({
+    QueueUrl,
+    MessageSystemAttributeNames: ["ApproximateReceiveCount"],
+  }),
+);
+
+console.log(again.Messages?.[0]?.Attributes?.["ApproximateReceiveCount"]); // "2"

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -24,7 +24,8 @@
       "@kensio/yulin/secretsmanager": [
         "../src/service/secretsmanager/index.ts"
       ],
-      "@kensio/yulin/serve": ["../src/serve/index.ts"]
+      "@kensio/yulin/serve": ["../src/serve/index.ts"],
+      "@kensio/yulin/sqs": ["../src/service/sqs/index.ts"]
     }
   },
   "include": ["**/*.example.ts", "**/*.examples.ts"]

--- a/package.json
+++ b/package.json
@@ -95,6 +95,10 @@
       "import": "./dist/service/secretsmanager/index.js",
       "types": "./dist/service/secretsmanager/index.d.ts"
     },
+    "./sqs": {
+      "import": "./dist/service/sqs/index.js",
+      "types": "./dist/service/sqs/index.d.ts"
+    },
     "./ssm": {
       "import": "./dist/service/ssm/index.js",
       "types": "./dist/service/ssm/index.d.ts"
@@ -125,6 +129,7 @@
     "@aws-sdk/client-route-53": "^3.1095.0",
     "@aws-sdk/client-s3": "^3.1095.0",
     "@aws-sdk/client-secrets-manager": "^3.1095.0",
+    "@aws-sdk/client-sqs": "^3.1097.0",
     "@aws-sdk/client-ssm": "^3.1095.0",
     "@aws-sdk/client-sts": "^3.1095.0",
     "@aws-sdk/s3-request-presigner": "^3.1095.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1097.0
+        version: 3.1097.0
       '@aws-sdk/client-ssm':
         specifier: ^3.1095.0
         version: 3.1095.0
@@ -227,6 +230,10 @@ packages:
     resolution: {integrity: sha512-CiBryu8nC+8PVx72ybrxIPLOMoGLW0hGMWMvgqBWm8ZYOeE+w+c7HcLsuLhEiPzKMON8Xng0lPKCIm1ANWsv+Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1097.0':
+    resolution: {integrity: sha512-2YjZPl8ml3jP7pQXJEC2LMdVJ7oPIchlR+byEWCG6mclzUPy2OcLTvXqW4QMlXeB0JWjdqXcsWw1dBn+SuMvKQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-ssm@3.1095.0':
     resolution: {integrity: sha512-0A88Y+mFdsHGHInTC0xLiKkrIrVz7uzDImOv50zIFb189oo4oTStOd9Ht1gw4Il5nXnLd2qokfVxePnZwaIoFg==}
     engines: {node: '>=20.0.0'}
@@ -239,12 +246,20 @@ packages:
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.2':
+    resolution: {integrity: sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.62':
     resolution: {integrity: sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.63':
+    resolution: {integrity: sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.63':
@@ -255,12 +270,20 @@ packages:
     resolution: {integrity: sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.65':
+    resolution: {integrity: sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.6':
     resolution: {integrity: sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.7':
     resolution: {integrity: sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.8':
+    resolution: {integrity: sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.68':
@@ -271,12 +294,20 @@ packages:
     resolution: {integrity: sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.70':
+    resolution: {integrity: sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.72':
     resolution: {integrity: sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.73':
     resolution: {integrity: sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.74':
+    resolution: {integrity: sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.61':
@@ -287,6 +318,10 @@ packages:
     resolution: {integrity: sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.63':
+    resolution: {integrity: sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.5':
     resolution: {integrity: sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==}
     engines: {node: '>=20.0.0'}
@@ -295,12 +330,20 @@ packages:
     resolution: {integrity: sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.7':
+    resolution: {integrity: sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.68':
     resolution: {integrity: sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.69':
+    resolution: {integrity: sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.35':
@@ -323,12 +366,20 @@ packages:
     resolution: {integrity: sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.38':
+    resolution: {integrity: sha512-izM6iWpd/s50WMcYOjLJfWm7McNiJKeit/NNUQ4JQIU0rBmNPMvf7AsJN7tk28N+afPYbpPIUSE3BNWZwtwf8w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.35':
     resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.36':
     resolution: {integrity: sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.37':
+    resolution: {integrity: sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1095.0':
@@ -345,6 +396,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1096.0':
     resolution: {integrity: sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1097.0':
+    resolution: {integrity: sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -2106,6 +2161,18 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-sqs@3.1097.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/credential-provider-node': 3.972.74
+      '@aws-sdk/middleware-sdk-sqs': 3.972.38
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-ssm@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2140,6 +2207,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.2':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.0
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.61':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2151,6 +2229,14 @@ snapshots:
   '@aws-sdk/credential-provider-env@3.972.62':
     dependencies:
       '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2176,15 +2262,25 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-ini@3.973.6':
     dependencies:
       '@aws-sdk/core': 3.977.1
-      '@aws-sdk/credential-provider-env': 3.972.61
-      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
       '@aws-sdk/credential-provider-login': 3.972.68
-      '@aws-sdk/credential-provider-process': 3.972.61
-      '@aws-sdk/credential-provider-sso': 3.973.5
-      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2208,10 +2304,26 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.8':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/credential-provider-env': 3.972.63
+      '@aws-sdk/credential-provider-http': 3.972.65
+      '@aws-sdk/credential-provider-login': 3.972.70
+      '@aws-sdk/credential-provider-process': 3.972.63
+      '@aws-sdk/credential-provider-sso': 3.973.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.69
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.1
-      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2221,6 +2333,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2254,6 +2375,20 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.74':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.63
+      '@aws-sdk/credential-provider-http': 3.972.65
+      '@aws-sdk/credential-provider-ini': 3.973.8
+      '@aws-sdk/credential-provider-process': 3.972.63
+      '@aws-sdk/credential-provider-sso': 3.973.7
+      '@aws-sdk/credential-provider-web-identity': 3.972.69
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.61':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2265,6 +2400,14 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.62':
     dependencies:
       '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2290,6 +2433,16 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.7':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
+      '@aws-sdk/token-providers': 3.1097.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2303,6 +2456,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2343,6 +2505,13 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.38':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.35':
     dependencies:
       '@aws-sdk/core': 3.977.1
@@ -2357,6 +2526,17 @@ snapshots:
   '@aws-sdk/nested-clients@3.997.36':
     dependencies:
       '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.37':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/signature-v4-multi-region': 3.996.42
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2384,7 +2564,7 @@ snapshots:
   '@aws-sdk/token-providers@3.1095.0':
     dependencies:
       '@aws-sdk/core': 3.977.1
-      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2394,6 +2574,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1097.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.2
+      '@aws-sdk/nested-clients': 3.997.37
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -56,6 +56,9 @@ export function resolveSimSdkCommandRouter(
     case "Secrets Manager": {
       return scoped.secretsManager().sdkCommandRouter();
     }
+    case "SQS": {
+      return scoped.sqs().sdkCommandRouter();
+    }
     case "SSM": {
       return scoped.ssm().sdkCommandRouter();
     }

--- a/src/sdk/sim-sdk.iso.test.ts
+++ b/src/sdk/sim-sdk.iso.test.ts
@@ -295,7 +295,7 @@ describe("simulated AWS SDK", () => {
     using simSdk = new SimSdk();
     // A structurally valid SDK client for a service Yulin does not simulate.
     const client: SdkClientLike = {
-      config: { serviceId: "SQS", region: "us-east-1" },
+      config: { serviceId: "SNS", region: "us-east-1" },
       send: () => Promise.resolve("real send"),
     };
     simSdk.intercept(client);
@@ -304,7 +304,7 @@ describe("simulated AWS SDK", () => {
       await client.send({ input: {} });
     });
 
-    assertStringIncludes(error.message, "SQS");
+    assertStringIncludes(error.message, "SNS");
   });
 
   it("rejects intercepting a client that is already intercepted", () => {

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -17,6 +17,7 @@ import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-la
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimS3 } from "../../s3/sim-s3.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
+import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
 import { SimSts } from "../../sts/sim-sts.js";
 import type { SimAwsAccountServiceCache } from "./sim-aws-account-service-cache.js";
@@ -180,6 +181,20 @@ export class SimAwsAccountRegionServiceBuilder {
       iam: this.accountServices.createIam(scope),
       background: this.background,
       kms: scope.kms(),
+    });
+  }
+
+  /**
+   * Create simulated SQS for an Account Region scope.
+   *
+   * Queues are Region-scoped on real AWS: a queue URL and ARN both name the
+   * Region, and a queue cannot be reached from another one.
+   */
+  createSqs(scope: SimAwsAccountRegionContainer): SimSqs {
+    return new SimSqs({
+      accountRegionScope: scope.accountRegionScope,
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
     });
   }
 

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -18,6 +18,7 @@ import type { SimKms } from "../../kms/index.js";
 import type { SimLambda } from "../../lambda/index.js";
 import { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import type { SimSecretsManager } from "../../secretsmanager/index.js";
+import type { SimSqs } from "../../sqs/index.js";
 import type { SimSsm } from "../../ssm/index.js";
 import type { SimSts } from "../../sts/sim-sts.js";
 import { SimAwsAccountRegionServiceBuilder } from "./sim-aws-account-region-service-builder.js";
@@ -165,6 +166,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Secrets Manager for an Account Region scope. */
   createSecretsManager(scope: SimAwsAccountRegionContainer): SimSecretsManager {
     return this.accountRegionServices.createSecretsManager(scope);
+  }
+
+  /** Create simulated SQS for an Account Region scope. */
+  createSqs(scope: SimAwsAccountRegionContainer): SimSqs {
+    return this.accountRegionServices.createSqs(scope);
   }
 
   /** Create simulated SSM for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -13,6 +13,7 @@ import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 
@@ -149,6 +150,15 @@ export class SimAwsAccountRegionContainer {
   secretsManager(): SimSecretsManager {
     return this.memo.getOrCreate("secretsManager", () =>
       this.simAws.serviceFactory.createSecretsManager(this),
+    );
+  }
+
+  /**
+   * Get simulated SQS for this account and region.
+   */
+  sqs(): SimSqs {
+    return this.memo.getOrCreate("sqs", () =>
+      this.simAws.serviceFactory.createSqs(this),
     );
   }
 

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -27,6 +27,7 @@ import type { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
+import type { SimSqs } from "../sqs/index.js";
 import type { SimSsm } from "../ssm/index.js";
 import type { SimSts } from "../sts/sim-sts.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
@@ -243,6 +244,11 @@ export class SimAws {
   /** Get simulated Secrets Manager in the default Account Region scope. */
   secretsManager(): SimSecretsManager {
     return this.accountRegionScope().secretsManager();
+  }
+
+  /** Get simulated SQS in the default Account Region scope. */
+  sqs(): SimSqs {
+    return this.accountRegionScope().sqs();
   }
 
   /** Get simulated SSM in the default Account Region scope. */

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -123,8 +123,10 @@ refused rather than quietly answered with a local queue of the same name.
 
 ## Divergences worth knowing
 
-- Delivery is exactly once and in order. Real standard queues promise at-least-once and no ordering,
-  so a test relying on the order here is relying on something AWS does not promise.
+- Ordering and duplicates are stricter than AWS promises: messages come back oldest first, and a
+  message is handed out to one consumer at a time. Real standard queues make no ordering promise and
+  deliver at least once. Redelivery once a visibility timeout lapses is simulated, since that follows
+  from the timeout; a duplicate arriving on its own is not.
 - `ReceiveMessageWaitTimeSeconds` and `WaitTimeSeconds` are accepted and not waited out. Nothing else
   is running that could send a message during the wait, so waiting could only ever time out.
 - `DeleteQueue` and `PurgeQueue` happen at once, where real SQS may take up to a minute over either.

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -1,0 +1,136 @@
+# Simulated SQS implementation
+
+This directory contains the simulated SQS service implementation. Standard queues only.
+
+The guiding decision here is that visibility is a timestamp rather than a timer. A received message
+records the instant it is hidden until, and it becomes receivable again when the simulation's clock
+reaches that instant. Nothing has to fire, so a test advances simulated time instead of waiting out a
+real thirty seconds, and the behaviour a consumer slower than its visibility timeout actually hits is
+testable in a millisecond.
+
+## Entry points
+
+- `sim-sqs.ts` is the main in-memory service object for one account/region scope.
+- `index.ts` exports the public SQS simulator API for `@kensio/yulin/sqs`.
+
+A `SimSqs` instance owns a `SimSqsQueueStore` holding its queues. The simulator is scoped to an
+account and region because real queues are: both the queue URL and the ARN name the region, and a
+queue name is unique within one account and region rather than globally.
+
+## Queue model
+
+Queue state lives under `queue/`.
+
+`SimSqsQueue` is the stored resource: its name, its ARN and URL, its attributes, its timestamps and
+its messages. The queue owns its messages rather than a service-wide message table owning them,
+because everything a message does depends on the queue's attributes: how long it stays hidden once
+received, how long it is kept, and how large it is allowed to be.
+
+`SimSqsQueueArn` builds both the ARN and the URL, since they carry the same three facts in two
+formats. A queue ARN has no resource type separator, so it is `arn:aws:sqs:region:account:name`
+rather than anything with a `queue/` in it. That is also why `parseSimArn` returns undefined for one,
+and why `SimSqsQueueUrl` does the URL parsing this service needs.
+
+`SimSqsQueueUrl` reads a queue URL into its region, account and name. All three matter: a URL naming
+another account or region reaches nothing here rather than having its name read out and looked up
+locally.
+
+`SimSqsQueueAttributes` holds the settable attributes as numbers rather than as the strings a request
+carries, because that is what the queue's behaviour is expressed in. `SimSqsQueueAttributeNames`
+splits reading an attribute from setting one: an attribute real SQS has and this simulation does not
+is left out of a response, as real SQS leaves out an attribute a queue has no value for, but setting
+one is refused rather than ignored.
+
+`SimSqsDeletedQueueNames` holds a deleted queue's name for 60 seconds, as real SQS holds it. The hold
+is measured on the simulation's clock, so advancing simulated time frees the name. That is the
+failure a redeployed stack actually hits.
+
+## Message model
+
+Message state lives under `message/`.
+
+`SimSqsMessage` is what is on the queue: its id, its body, its attributes and when it was sent.
+`SimSqsMessageVisibility` is the part that changes as it is handed out and given back, and it is the
+reason the two are separate: a delay and a visibility timeout are the same idea seen from either side
+of a first receive, so both are one instant the message is invisible until.
+
+`SimSqsMessageBody` validates the size and characters real SQS validates, and holds a real MD5 of the
+body. The digest is real because that is the whole point of it: a sender comparing `MD5OfMessageBody`
+against its own digest either finds the body it sent or finds a bug.
+
+`SimSqsMessageAttributes` is the set of attributes on one message, with the length-prefixed digest
+encoding real SQS uses for `MD5OfMessageAttributes`. It is a set rather than a list of separate values
+because both the digest and a receive request's selection are properties of the set.
+`SimSqsMessageAttributePayload` splits a text value from a binary one, so nothing downstream has to
+ask which kind it is holding.
+
+`SimSqsMessageStore` holds a queue's messages and every receipt handle it has issued. Handles live
+here rather than on the messages because a handle outlives the message it names: real SQS accepts a
+delete for a message already deleted and refuses a handle it never issued, and only a store of what
+has been issued can tell those two apart.
+
+Retention is applied whenever the messages are looked at rather than scheduled, so advancing
+simulated time past `MessageRetentionPeriod` loses the messages AWS would have dropped instead of
+keeping them indefinitely.
+
+## Command handling
+
+AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
+rather than one class per command, so the `SimSqs` facade stays a delegation:
+
+- `command/queue/` — `CreateQueue`, `GetQueueUrl`, `ListQueues`, `DeleteQueue`, the attribute
+  commands and `PurgeQueue`
+- `command/message/` — the send, receive, delete and visibility commands
+- `command/authorize/` — the shared IAM authorizer
+- `command/sim-sqs-command.types.ts` — the command types gathered for the facade
+
+`SimSqsQueueAccess` is how every operation but `ListQueues` reaches its queue: read the queue URL,
+authorize the action against the ARN that URL implies, then look the queue up. Authorization comes
+first because real IAM decides before the service does anything, so a caller with no permission is
+refused whether or not the queue exists.
+
+`SimSqsMessageWriter` is shared by `SendMessage` and every entry of `SendMessageBatch`, so the two
+cannot drift apart on what a delay means or how large a body may be. `SimSqsReceiveRequest` is the
+same idea for receiving: the whole request is checked before the first message is touched, so an
+invalid request never half-receives one.
+
+`sim-sqs-batch-entries.ts` holds the two halves of batch behaviour real SQS distinguishes. An empty
+batch, too many entries, a malformed id or two entries sharing one take the whole request down;
+anything else is one entry's own failure, reported in `Failed` while the rest of the batch goes
+through.
+
+As elsewhere, implementation code under `src/` does not import real AWS SDK packages. The structural
+command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
+command instances.
+
+## Authorization
+
+`SimSqsAuthorizer` authorizes each operation against the queue's ARN, which carries the queue name
+with no resource type in front of it. A policy written with a `queue/` in the resource matches nothing
+here, as it matches nothing on real AWS.
+
+Two details are real SQS behaviour worth keeping:
+
+- `ListQueues` authorizes against `arn:aws:sqs:region:account:*`, because real SQS gives it no
+  queue-level permission. A policy naming one queue ARN therefore allows no listing.
+- The batch operations authorize as their singular action. Real SQS has no `sqs:SendMessageBatch`,
+  `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action, so a policy naming one grants
+  nothing.
+
+There is no queue policy support, so this service passes no resource policies into the IAM decision.
+Cross-account access to a queue therefore cannot be granted, and a request naming another owner is
+refused rather than quietly answered with a local queue of the same name.
+
+## Divergences worth knowing
+
+- Delivery is exactly once and in order. Real standard queues promise at-least-once and no ordering,
+  so a test relying on the order here is relying on something AWS does not promise.
+- `ReceiveMessageWaitTimeSeconds` and `WaitTimeSeconds` are accepted and not waited out. Nothing else
+  is running that could send a message during the wait, so waiting could only ever time out.
+- `DeleteQueue` and `PurgeQueue` happen at once, where real SQS may take up to a minute over either.
+  The 60 second hold on a deleted queue's name is simulated.
+- A queue name ending in `.fifo` is refused, as are the FIFO-only request fields.
+- `SenderId` is not reported, because a simulated principal has no user or role id to report it as.
+- Tags, `RedrivePolicy`, queue policies and the encryption attributes are refused rather than ignored.
+
+The full list is in [docs/services/sqs](../../../docs/services/sqs/).

--- a/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
@@ -1,0 +1,81 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { sqsAnyQueueArn } from "../../queue/sim-sqs-queue-arn.js";
+
+interface SimSqsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to SQS requests.
+ *
+ * A queue ARN has no resource type in it, so the resource an operation
+ * authorizes against is `arn:aws:sqs:region:account:queue-name`. A policy
+ * written with a `queue/` in the resource matches nothing here, as it matches
+ * nothing on real AWS.
+ *
+ * ListQueues is the exception: real SQS gives it no queue-level permission, so
+ * it authorizes against every queue in the account and region rather than one of
+ * them. A policy naming a single queue ARN therefore allows no listing.
+ */
+export class SimSqsAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSqsAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a queue, named by its ARN.
+   *
+   * The queue need not exist. Real IAM evaluates a request before the service
+   * handles it, so a caller with no permission is refused whether or not the
+   * queue is there, and CreateQueue authorizes against the ARN the queue is
+   * about to have.
+   */
+  authorizeQueue(
+    action: string,
+    queueArn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, queueArn, caller);
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular queue.
+   */
+  authorizeAnyQueue(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      action,
+      sqsAnyQueueArn(this.accountRegionScope),
+      caller,
+    );
+  }
+
+  private authorizeResource(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
@@ -1,0 +1,289 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateQueueCommand,
+  DeleteMessageBatchCommand,
+  ListQueuesCommand,
+  ReceiveMessageCommand,
+  SendMessageBatchCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+const accountId = "111111111111" as SimAwsAccountId;
+const regionName = "eu-west-2";
+
+/**
+ * A simulated AWS with a queue and a Role whose only permissions are the ones
+ * the given policy statement grants.
+ */
+async function simAwsWithRole(statement: object): Promise<{
+  simAws: SimAws;
+  queueUrl: string;
+  caller: SimAwsCaller;
+}> {
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+  const created = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "QueueUser",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "QueueUser",
+      PolicyName: "UseQueue",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return {
+    simAws,
+    queueUrl: created.QueueUrl ?? "",
+    caller: { kind: "arn", arn: role.Role.Arn },
+  };
+}
+
+describe("SQS IAM authorization", () => {
+  it("allows a queue operation named by the queue ARN", async () => {
+    // Given a Role allowed to send to one queue by its ARN, which carries no
+    // resource type before the queue name.
+    const { simAws, queueUrl, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    // When it sends a message.
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller },
+      );
+
+    // Then the policy allowed it.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("denies a queue operation the Role has no permission for", async () => {
+    // Given a Role allowed to send but not to receive.
+    const { simAws, queueUrl, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    // When it tries to receive.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }), {
+          caller,
+        });
+    });
+
+    // Then it is denied.
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "sqs:ReceiveMessage");
+  });
+
+  it("denies a policy naming the queue ARN with a resource type in it", async () => {
+    // Given a Role whose policy names the queue as though SQS ARNs had a
+    // resource type, which they do not.
+    const { simAws, queueUrl, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:queue/orders`,
+    });
+
+    // When it sends a message.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+        }),
+        { caller },
+      );
+    });
+
+    // Then the policy reaches nothing, as it reaches nothing on real AWS.
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("authorizes a batch send as sqs:SendMessage", async () => {
+    // Given a Role allowed only to send, since real SQS has no
+    // sqs:SendMessageBatch action for a policy to name.
+    const { simAws, queueUrl, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    // When it sends a batch.
+    const sent = await simAws.sqs().sendMessageBatch(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [{ Id: "one", MessageBody: "order-1" }],
+      }),
+      { caller },
+    );
+
+    // Then the singular action allowed it.
+    assertArrayEquals(
+      sent.Successful?.map((entry) => entry.Id),
+      ["one"],
+    );
+  });
+
+  it("authorizes a batch delete as sqs:DeleteMessage", async () => {
+    // Given a Role allowed to send, receive and delete.
+    const { simAws, queueUrl, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: ["sqs:SendMessage", "sqs:ReceiveMessage", "sqs:DeleteMessage"],
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller },
+      );
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }), {
+        caller,
+      });
+
+    // When it deletes as a batch.
+    const deleted = await simAws.sqs().deleteMessageBatch(
+      new DeleteMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [
+          {
+            Id: "one",
+            ReceiptHandle: received.Messages?.[0]?.ReceiptHandle,
+          },
+        ],
+      }),
+      { caller },
+    );
+
+    // Then the singular action allowed it.
+    assertArrayEquals(
+      deleted.Successful?.map((entry) => entry.Id),
+      ["one"],
+    );
+  });
+
+  it("authorizes listing against every queue in the Account and Region", async () => {
+    // Given a Role allowed to list with the resource real SQS documents for it.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:ListQueues",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:*`,
+    });
+
+    // When it lists the queues.
+    const listed = await simAws
+      .sqs()
+      .listQueues(new ListQueuesCommand({}), { caller });
+
+    // Then the listing is allowed.
+    assertIdentical(listed.QueueUrls?.length, 1);
+  });
+
+  it("denies listing to a policy naming one queue ARN", async () => {
+    // Given a Role allowed to list only the one queue by name, which real SQS
+    // gives no queue-level permission for.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:ListQueues",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    // When it lists the queues.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().listQueues(new ListQueuesCommand({}), { caller });
+    });
+
+    // Then it is denied, as it would be on real AWS.
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("denies a create the Role has no permission for", async () => {
+    // Given a Role allowed to send but not to create queues.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:*`,
+    });
+
+    // When it creates a queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .createQueue(new CreateQueueCommand({ QueueName: "invoices" }), {
+          caller,
+        });
+    });
+
+    // Then it is denied against the ARN the queue would have had.
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "invoices");
+  });
+
+  it("denies an operation on a queue that does not exist", async () => {
+    // Given a Role allowed to send to one queue only.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+      Resource: `arn:aws:sqs:${regionName}:${accountId}:orders`,
+    });
+
+    // When it sends to a queue that is not there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: `https://sqs.${regionName}.amazonaws.com/${accountId}/invoices`,
+          MessageBody: "order-1",
+        }),
+        { caller },
+      );
+    });
+
+    // Then IAM decides first, as real IAM decides before the service looks
+    // anything up.
+    assertIdentical(error.name, "AccessDenied");
+  });
+});

--- a/src/service/sqs/command/message/consume.command.ts
+++ b/src/service/sqs/command/message/consume.command.ts
@@ -1,0 +1,72 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimSqsBatchResultErrorEntry } from "./send.command.js";
+
+/**
+ * Minimal structural sim SQS DeleteMessage command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/DeleteMessageCommand/
+ */
+export interface SimDeleteMessageCommand {
+  readonly input: SimDeleteMessageCommandInput;
+}
+
+export interface SimDeleteMessageCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly ReceiptHandle?: string | undefined;
+}
+
+export interface SimDeleteMessageCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One entry of a DeleteMessageBatch request.
+ */
+export interface SimSqsDeleteMessageBatchEntry {
+  readonly Id?: string | undefined;
+  readonly ReceiptHandle?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SQS DeleteMessageBatch command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/DeleteMessageBatchCommand/
+ */
+export interface SimDeleteMessageBatchCommand {
+  readonly input: SimDeleteMessageBatchCommandInput;
+}
+
+export interface SimDeleteMessageBatchCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly Entries?: readonly SimSqsDeleteMessageBatchEntry[] | undefined;
+}
+
+export interface SimSqsDeleteMessageBatchResultEntry {
+  readonly Id: string;
+}
+
+export interface SimDeleteMessageBatchCommandOutput {
+  readonly Successful?:
+    readonly SimSqsDeleteMessageBatchResultEntry[] | undefined;
+  readonly Failed?: readonly SimSqsBatchResultErrorEntry[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS ChangeMessageVisibility command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/ChangeMessageVisibilityCommand/
+ */
+export interface SimChangeMessageVisibilityCommand {
+  readonly input: SimChangeMessageVisibilityCommandInput;
+}
+
+export interface SimChangeMessageVisibilityCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly ReceiptHandle?: string | undefined;
+  readonly VisibilityTimeout?: number | undefined;
+}
+
+export interface SimChangeMessageVisibilityCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sqs/command/message/receive.command.ts
+++ b/src/service/sqs/command/message/receive.command.ts
@@ -1,0 +1,44 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimSqsMessageAttributeValue } from "../../message/sim-sqs-message-attribute-value.js";
+
+/**
+ * One message as sim SQS reports it in a receive response.
+ *
+ * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html
+ */
+export interface SimSqsReceivedMessage {
+  readonly MessageId: string;
+  readonly ReceiptHandle: string;
+  readonly MD5OfBody: string;
+  readonly Body: string;
+  readonly Attributes?: Record<string, string> | undefined;
+  readonly MessageAttributes?:
+    Record<string, SimSqsMessageAttributeValue> | undefined;
+  readonly MD5OfMessageAttributes?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SQS ReceiveMessage command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/ReceiveMessageCommand/
+ */
+export interface SimReceiveMessageCommand {
+  readonly input: SimReceiveMessageCommandInput;
+}
+
+export interface SimReceiveMessageCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly MaxNumberOfMessages?: number | undefined;
+  readonly VisibilityTimeout?: number | undefined;
+  readonly WaitTimeSeconds?: number | undefined;
+  readonly MessageAttributeNames?: readonly string[] | undefined;
+  readonly MessageSystemAttributeNames?: readonly string[] | undefined;
+  /** Discontinued by real SQS, and the same thing as the name above. */
+  readonly AttributeNames?: readonly string[] | undefined;
+  readonly ReceiveRequestAttemptId?: string | undefined;
+}
+
+export interface SimReceiveMessageCommandOutput {
+  readonly Messages?: readonly SimSqsReceivedMessage[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sqs/command/message/send.command.ts
+++ b/src/service/sqs/command/message/send.command.ts
@@ -1,0 +1,93 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimSqsMessageAttributeInput } from "../../message/sim-sqs-message-attribute-value.js";
+
+/**
+ * A message system attribute as a send request carries it.
+ *
+ * Real SQS accepts only `AWSTraceHeader` here. Simulated SQS models no message
+ * system attributes on send, so a request carrying one is refused.
+ */
+export interface SimSqsMessageSystemAttributeInput {
+  readonly DataType?: string | undefined;
+  readonly StringValue?: string | undefined;
+}
+
+/**
+ * The message fields shared by SendMessage and one SendMessageBatch entry.
+ */
+export interface SimSqsSentMessage {
+  readonly MessageBody?: string | undefined;
+  readonly DelaySeconds?: number | undefined;
+  readonly MessageAttributes?: SimSqsMessageAttributeInput | undefined;
+  readonly MessageSystemAttributes?:
+    | Readonly<Record<string, SimSqsMessageSystemAttributeInput | undefined>>
+    | undefined;
+  readonly MessageDeduplicationId?: string | undefined;
+  readonly MessageGroupId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SQS SendMessage command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/SendMessageCommand/
+ */
+export interface SimSendMessageCommand {
+  readonly input: SimSendMessageCommandInput;
+}
+
+export interface SimSendMessageCommandInput extends SimSqsSentMessage {
+  readonly QueueUrl?: string | undefined;
+}
+
+export interface SimSendMessageCommandOutput {
+  readonly MessageId?: string | undefined;
+  readonly MD5OfMessageBody?: string | undefined;
+  readonly MD5OfMessageAttributes?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One entry of a SendMessageBatch request.
+ */
+export interface SimSqsSendMessageBatchEntry extends SimSqsSentMessage {
+  readonly Id?: string | undefined;
+}
+
+/**
+ * Minimal structural sim SQS SendMessageBatch command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/SendMessageBatchCommand/
+ */
+export interface SimSendMessageBatchCommand {
+  readonly input: SimSendMessageBatchCommandInput;
+}
+
+export interface SimSendMessageBatchCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly Entries?: readonly SimSqsSendMessageBatchEntry[] | undefined;
+}
+
+export interface SimSqsSendMessageBatchResultEntry {
+  readonly Id: string;
+  readonly MessageId: string;
+  readonly MD5OfMessageBody: string;
+  readonly MD5OfMessageAttributes?: string | undefined;
+}
+
+/**
+ * One entry of a batch request that failed on its own, while the rest of the
+ * batch went through.
+ */
+export interface SimSqsBatchResultErrorEntry {
+  readonly Id: string;
+  readonly SenderFault: boolean;
+  readonly Code: string;
+  readonly Message?: string | undefined;
+}
+
+export interface SimSendMessageBatchCommandOutput {
+  readonly Successful?:
+    readonly SimSqsSendMessageBatchResultEntry[] | undefined;
+  readonly Failed?: readonly SimSqsBatchResultErrorEntry[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sqs/command/message/sim-sqs-batch-entries.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-batch-entries.iso.test.ts
@@ -1,0 +1,57 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSqsInvalidParameterValue } from "../../error/sim-sqs.error.js";
+import { requireBatchEntries, runBatch } from "./sim-sqs-batch-entries.js";
+
+describe("SQS batch entries", () => {
+  it("keeps every entry under the id it was given", () => {
+    // Given two entries.
+    const entries = requireBatchEntries(
+      [{ Id: "one" }, { Id: "two" }],
+      "SendMessage",
+    );
+
+    // When each is run.
+    const outcome = runBatch(entries, (_entry, id) => id);
+
+    // Then each result is reported under its own entry id.
+    assertArrayEquals(outcome.successful, ["one", "two"]);
+    assertArrayEquals(outcome.failed, []);
+  });
+
+  it("reports an SQS failure as one entry's own", () => {
+    // Given one entry whose work fails the way SQS fails.
+    const entries = requireBatchEntries([{ Id: "one" }], "SendMessage");
+
+    // When it is run.
+    const outcome = runBatch(entries, () => {
+      throw new SimSqsInvalidParameterValue("no good");
+    });
+
+    // Then the failure belongs to the entry rather than the request.
+    assertIdentical(outcome.failed.at(0)?.Code, "InvalidParameterValue");
+    assertIdentical(outcome.failed.at(0)?.Message, "no good");
+  });
+
+  it("lets a failure that is not an SQS failure take the request down", () => {
+    // Given one entry whose work fails for a reason that is not about the entry,
+    // as an IAM denial would.
+    const entries = requireBatchEntries([{ Id: "one" }], "SendMessage");
+
+    // When it is run.
+    const error = assertThrowsError(() => {
+      runBatch(entries, () => {
+        throw new Error("not authorized to perform sqs:SendMessage");
+      });
+    });
+
+    // Then it is not reported as an entry failure: the whole request fails.
+    assertInstanceOf(error, Error);
+    assertIdentical(error.message, "not authorized to perform sqs:SendMessage");
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-batch-entries.ts
+++ b/src/service/sqs/command/message/sim-sqs-batch-entries.ts
@@ -1,0 +1,122 @@
+import {
+  SimSqsBatchEntryIdsNotDistinct,
+  SimSqsEmptyBatchRequest,
+  SimSqsError,
+  SimSqsInvalidBatchEntryId,
+  SimSqsTooManyEntriesInBatchRequest,
+} from "../../error/sim-sqs.error.js";
+import type { SimSqsBatchResultErrorEntry } from "./send.command.js";
+
+const maximumEntries = 10;
+
+const entryIdPattern = /^[\w-]{1,80}$/;
+
+/**
+ * What every batch request entry carries: an id the response reports it under.
+ */
+export interface SimSqsIdentifiedEntry {
+  readonly Id?: string | undefined;
+}
+
+/**
+ * One entry of a batch request whose id has been checked.
+ */
+export interface SimSqsBatchEntry<T> {
+  readonly id: string;
+  readonly entry: T;
+}
+
+/**
+ * The outcome of running a batch: what went through, and what failed on its own.
+ */
+export interface SimSqsBatchOutcome<T> {
+  readonly successful: readonly T[];
+  readonly failed: readonly SimSqsBatchResultErrorEntry[];
+}
+
+/**
+ * Check the entries of a batch request the way real SQS checks them.
+ *
+ * These are the failures that take the whole request down rather than one entry:
+ * an empty batch, too many entries, a malformed id, or two entries sharing one.
+ * Everything else is a per-entry failure, reported in `Failed` while the rest of
+ * the batch goes through.
+ */
+export function requireBatchEntries<T extends SimSqsIdentifiedEntry>(
+  entries: readonly T[] | undefined,
+  operation: string,
+): readonly SimSqsBatchEntry<T>[] {
+  if (entries === undefined || entries.length === 0) {
+    throw new SimSqsEmptyBatchRequest(
+      `There should be at least one ${operation}BatchRequestEntry in the request`,
+    );
+  }
+
+  if (entries.length > maximumEntries) {
+    throw new SimSqsTooManyEntriesInBatchRequest(
+      `Maximum number of entries per request is ${String(maximumEntries)}. ` +
+        `You have sent ${String(entries.length)}.`,
+    );
+  }
+
+  const checked = entries.map((entry) => ({
+    id: requireEntryId(entry.Id),
+    entry,
+  }));
+  const ids = new Set(checked.map(({ id }) => id));
+
+  if (ids.size !== checked.length) {
+    throw new SimSqsBatchEntryIdsNotDistinct(
+      "Two or more batch entries in the request have the same Id",
+    );
+  }
+
+  return checked;
+}
+
+/**
+ * Run every entry of a batch, keeping one entry's failure out of the way of the
+ * others.
+ *
+ * Real SQS answers a batch request with two lists rather than failing it, so a
+ * message too large for the queue does not stop the nine beside it being sent.
+ */
+export function runBatch<T, R>(
+  entries: readonly SimSqsBatchEntry<T>[],
+  run: (entry: T, id: string) => R,
+): SimSqsBatchOutcome<R> {
+  const successful: R[] = [];
+  const failed: SimSqsBatchResultErrorEntry[] = [];
+
+  for (const { id, entry } of entries) {
+    try {
+      successful.push(run(entry, id));
+    } catch (error) {
+      // Only an SQS failure belongs to one entry. Anything else, an IAM denial
+      // above all, is about the request as a whole.
+      if (!(error instanceof SimSqsError)) {
+        throw error;
+      }
+
+      failed.push({
+        Id: id,
+        SenderFault: true,
+        Code: error.name,
+        Message: error.message,
+      });
+    }
+  }
+
+  return { successful, failed };
+}
+
+function requireEntryId(id: string | undefined): string {
+  if (id === undefined || !entryIdPattern.test(id)) {
+    throw new SimSqsInvalidBatchEntryId(
+      `A batch entry id is required, and may contain up to 80 alphanumeric ` +
+        `characters, hyphens and underscores. Got '${String(id)}'.`,
+    );
+  }
+
+  return id;
+}

--- a/src/service/sqs/command/message/sim-sqs-change-message-visibility.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-change-message-visibility.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  ChangeMessageVisibilityCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsMessageNotInflight,
+  SimSqsReceiptHandleIsInvalid,
+} from "../../error/sim-sqs.error.js";
+import {
+  simAwsWithQueue,
+  simAwsWithReceivedMessage,
+} from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS ChangeMessageVisibility", () => {
+  it("keeps a message hidden for longer", async () => {
+    // Given a received message with a short visibility timeout.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "30",
+      },
+    );
+
+    // When the consumer asks for ten minutes more.
+    await simAws.sqs().changeMessageVisibility(
+      new ChangeMessageVisibilityCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: 600,
+      }),
+    );
+
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the message is still hidden past the queue's own timeout.
+    assertUndefined(empty.Messages);
+  });
+
+  it("releases a message back to the queue at once", async () => {
+    // Given a received message hidden for five minutes.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "300",
+      },
+    );
+
+    // When the consumer gives it up rather than handling it.
+    await simAws.sqs().changeMessageVisibility(
+      new ChangeMessageVisibilityCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: 0,
+      }),
+    );
+
+    // Then it is receivable again straight away.
+    const again = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(again.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("refuses to change the visibility of a message that is not in flight", async () => {
+    // Given a received message whose visibility timeout has lapsed.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "30",
+      },
+    );
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // When the consumer asks for longer.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().changeMessageVisibility(
+        new ChangeMessageVisibilityCommand({
+          QueueUrl: queueUrl,
+          ReceiptHandle: receiptHandle,
+          VisibilityTimeout: 600,
+        }),
+      );
+    });
+
+    // Then it is refused the way real SQS refuses it.
+    assertInstanceOf(error, SimSqsMessageNotInflight);
+  });
+
+  it("refuses a visibility timeout beyond twelve hours", async () => {
+    // Given a received message.
+    const { simAws, queueUrl, receiptHandle } =
+      await simAwsWithReceivedMessage();
+
+    // When a longer timeout is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().changeMessageVisibility(
+        new ChangeMessageVisibilityCommand({
+          QueueUrl: queueUrl,
+          ReceiptHandle: receiptHandle,
+          VisibilityTimeout: 43_201,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a change with no timeout", async () => {
+    // Given a received message.
+    const { simAws, queueUrl, receiptHandle } =
+      await simAwsWithReceivedMessage();
+
+    // When no timeout is given.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().changeMessageVisibility({
+        input: { QueueUrl: queueUrl, ReceiptHandle: receiptHandle },
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a handle the queue never issued", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a made-up handle is used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().changeMessageVisibility(
+        new ChangeMessageVisibilityCommand({
+          QueueUrl: queueUrl,
+          ReceiptHandle: "not-a-handle",
+          VisibilityTimeout: 60,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsReceiptHandleIsInvalid);
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
+++ b/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
@@ -1,0 +1,94 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsMessageNotInflight,
+} from "../../error/sim-sqs.error.js";
+import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
+import { SimSqsMessageHandles } from "./sim-sqs-message-handles.js";
+import type {
+  SimChangeMessageVisibilityCommand,
+  SimChangeMessageVisibilityCommandOutput,
+} from "./consume.command.js";
+
+const maximumVisibilityTimeoutSeconds = 43_200;
+
+interface SimSqsChangeMessageVisibilityProperties {
+  readonly access: SimSqsQueueAccess;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsChangeMessageVisibilityOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The ChangeMessageVisibility command.
+ *
+ * The new timeout runs from now rather than from when the message was received,
+ * as it does on real SQS, so a consumer part way through a slow handler asks for
+ * the time it still needs. A timeout of zero gives the message straight back to
+ * the queue.
+ */
+export class SimSqsChangeMessageVisibility {
+  private readonly access: SimSqsQueueAccess;
+  private readonly clock: BackgroundScheduler;
+  private readonly handles: SimSqsMessageHandles;
+
+  constructor(properties: SimSqsChangeMessageVisibilityProperties) {
+    this.access = properties.access;
+    this.clock = properties.clock;
+    this.handles = new SimSqsMessageHandles({ clock: properties.clock });
+  }
+
+  /**
+   * Change how much longer a received message stays hidden.
+   */
+  handle(
+    command: SimChangeMessageVisibilityCommand,
+    options?: SimSqsChangeMessageVisibilityOptions,
+  ): SimChangeMessageVisibilityCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:ChangeMessageVisibility",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const timeout = visibilityTimeout(command.input.VisibilityTimeout);
+    const changedAt = this.clock.now();
+    const message = this.handles.message(
+      queue,
+      SimSqsMessageHandles.required(command.input.ReceiptHandle),
+    );
+
+    if (!message.isInFlightAt(changedAt)) {
+      throw new SimSqsMessageNotInflight(
+        "The message referred to isn't in flight: its visibility timeout has " +
+          "already lapsed, so there is none left to change",
+      );
+    }
+
+    message.hideFor(changedAt, timeout);
+
+    return { $metadata: {} };
+  }
+}
+
+/**
+ * How long a message is hidden for by a visibility change.
+ */
+function visibilityTimeout(requested: number | undefined): number {
+  if (
+    requested === undefined ||
+    !Number.isSafeInteger(requested) ||
+    requested < 0 ||
+    requested > maximumVisibilityTimeoutSeconds
+  ) {
+    throw new SimSqsInvalidParameterValue(
+      `Value ${String(requested)} for parameter VisibilityTimeout is ` +
+        `invalid. Reason: Must be an integer from 0 to ` +
+        `${String(maximumVisibilityTimeoutSeconds)}.`,
+    );
+  }
+
+  return requested;
+}

--- a/src/service/sqs/command/message/sim-sqs-consume-message-commands.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-consume-message-commands.iso.test.ts
@@ -1,0 +1,231 @@
+import {
+  DeleteMessageBatchCommand,
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimSqsReceiptHandleIsInvalid,
+  SimSqsValidationException,
+} from "../../error/sim-sqs.error.js";
+import {
+  simAwsWithQueue,
+  simAwsWithReceivedMessage,
+} from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS DeleteMessage", () => {
+  it("deletes the message a receipt handle names", async () => {
+    // Given a received message that was immediately visible again.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "0",
+      },
+    );
+
+    // When it is deleted.
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+      }),
+    );
+
+    // Then it is gone.
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(empty.Messages);
+  });
+
+  it("deletes a message whose visibility timeout has already lapsed", async () => {
+    // Given a received message whose timeout has run out, with nobody else
+    // having received it since.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "30",
+      },
+    );
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // When the slow consumer finally deletes it.
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+      }),
+    );
+
+    // Then the delete works, as it does on real AWS: the handle is still the one
+    // from the most recent receive.
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(empty.Messages);
+  });
+
+  it("deletes nothing when the handle is from an earlier receive", async () => {
+    // Given a message received twice, because the first consumer was slower than
+    // the visibility timeout.
+    const { simAws, queueUrl, receiptHandle } = await simAwsWithReceivedMessage(
+      {
+        VisibilityTimeout: "30",
+      },
+    );
+    await simAws.clock().advanceBy({ seconds: 31 });
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // When the first consumer deletes with the handle it was given.
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+      }),
+    );
+
+    // Then the request succeeds and the message stays where it is, as real SQS
+    // leaves it: the receive that handle belongs to has been superseded.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    const again = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(again.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("accepts a second delete of the same message", async () => {
+    // Given a message that has been deleted.
+    const { simAws, queueUrl, receiptHandle } =
+      await simAwsWithReceivedMessage();
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+      }),
+    );
+
+    // When the same handle is used again, as a retry would.
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+      }),
+    );
+
+    // Then nothing is left on the queue and nothing failed.
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(empty.Messages);
+  });
+
+  it("refuses a receipt handle the queue never issued", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a made-up handle is used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().deleteMessage(
+        new DeleteMessageCommand({
+          QueueUrl: queueUrl,
+          ReceiptHandle: "not-a-handle",
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsReceiptHandleIsInvalid);
+  });
+
+  it("refuses a delete with no receipt handle", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a delete carries no handle.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().deleteMessage({ input: { QueueUrl: queueUrl } });
+    });
+
+    // Then the missing input is reported.
+    assertInstanceOf(error, SimSqsValidationException);
+  });
+});
+
+describe("SQS DeleteMessageBatch", () => {
+  it("deletes every entry and reports each under its own id", async () => {
+    // Given a queue holding two received messages.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-2" }),
+      );
+
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 2,
+      }),
+    );
+
+    // When both are deleted at once.
+    const deleted = await simAws.sqs().deleteMessageBatch(
+      new DeleteMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: (received.Messages ?? []).map((message, index) => ({
+          Id: `entry-${String(index)}`,
+          ReceiptHandle: message.ReceiptHandle,
+        })),
+      }),
+    );
+
+    // Then both went through.
+    assertArrayEquals(
+      deleted.Successful?.map((entry) => entry.Id),
+      ["entry-0", "entry-1"],
+    );
+    assertArrayEquals(deleted.Failed ?? [], []);
+  });
+
+  it("reports one failed entry while the rest of the batch goes through", async () => {
+    // Given a received message, and a made-up handle beside it.
+    const { simAws, queueUrl, receiptHandle } =
+      await simAwsWithReceivedMessage();
+
+    // When both are deleted at once.
+    const deleted = await simAws.sqs().deleteMessageBatch(
+      new DeleteMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [
+          { Id: "good", ReceiptHandle: receiptHandle },
+          { Id: "bad", ReceiptHandle: "not-a-handle" },
+        ],
+      }),
+    );
+
+    // Then the good one is deleted and the bad one is reported on its own.
+    assertArrayEquals(
+      deleted.Successful?.map((entry) => entry.Id),
+      ["good"],
+    );
+    assertIdentical(deleted.Failed?.[0]?.Code, "ReceiptHandleIsInvalid");
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-delete-message-commands.ts
+++ b/src/service/sqs/command/message/sim-sqs-delete-message-commands.ts
@@ -1,0 +1,110 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
+import { requireBatchEntries, runBatch } from "./sim-sqs-batch-entries.js";
+import { SimSqsMessageHandles } from "./sim-sqs-message-handles.js";
+import type {
+  SimDeleteMessageBatchCommand,
+  SimDeleteMessageBatchCommandOutput,
+  SimDeleteMessageCommand,
+  SimDeleteMessageCommandOutput,
+  SimSqsDeleteMessageBatchEntry,
+  SimSqsDeleteMessageBatchResultEntry,
+} from "./consume.command.js";
+
+/**
+ * Real SQS authorizes a batch delete as `sqs:DeleteMessage`. There is no
+ * `sqs:DeleteMessageBatch` action, so a policy naming one grants nothing.
+ */
+const messageDeletionAction = "sqs:DeleteMessage";
+
+interface SimSqsDeleteMessageCommandsProperties {
+  readonly access: SimSqsQueueAccess;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsDeleteMessageCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands a consumer finishes a message with.
+ */
+export class SimSqsDeleteMessageCommands {
+  private readonly access: SimSqsQueueAccess;
+  private readonly handles: SimSqsMessageHandles;
+
+  constructor(properties: SimSqsDeleteMessageCommandsProperties) {
+    this.access = properties.access;
+    this.handles = new SimSqsMessageHandles({ clock: properties.clock });
+  }
+
+  /**
+   * Delete one message by the receipt handle it was received with.
+   */
+  deleteMessage(
+    command: SimDeleteMessageCommand,
+    options?: SimSqsDeleteMessageCommandsOptions,
+  ): SimDeleteMessageCommandOutput {
+    const queue = this.access.requireByUrl(
+      messageDeletionAction,
+      command.input.QueueUrl,
+      options?.caller,
+    );
+
+    this.delete(queue, command.input.ReceiptHandle);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Delete up to ten messages at once.
+   */
+  deleteMessageBatch(
+    command: SimDeleteMessageBatchCommand,
+    options?: SimSqsDeleteMessageCommandsOptions,
+  ): SimDeleteMessageBatchCommandOutput {
+    const queue = this.access.requireByUrl(
+      messageDeletionAction,
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const entries = requireBatchEntries(command.input.Entries, "DeleteMessage");
+
+    const outcome = runBatch(
+      entries,
+      (
+        entry: SimSqsDeleteMessageBatchEntry,
+        id,
+      ): SimSqsDeleteMessageBatchResultEntry => {
+        this.delete(queue, entry.ReceiptHandle);
+
+        return { Id: id };
+      },
+    );
+
+    return {
+      $metadata: {},
+      Successful: outcome.successful,
+      Failed: outcome.failed,
+    };
+  }
+
+  /**
+   * Delete the message a receipt handle names.
+   *
+   * A handle from an earlier receive is accepted and deletes nothing, which is
+   * what real SQS does with one: the receive it belongs to has been superseded,
+   * so the message another consumer now holds is left where it is. That is the
+   * failure a consumer slower than the visibility timeout actually hits.
+   */
+  private delete(queue: SimSqsQueue, requested: string | undefined): void {
+    const receiptHandle = SimSqsMessageHandles.required(requested);
+    const message = this.handles.message(queue, receiptHandle);
+
+    if (message.holdsReceiptHandle(receiptHandle)) {
+      queue.removeMessage(message);
+    }
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-message-handles.ts
+++ b/src/service/sqs/command/message/sim-sqs-message-handles.ts
@@ -1,0 +1,56 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import {
+  SimSqsReceiptHandleIsInvalid,
+  SimSqsValidationException,
+} from "../../error/sim-sqs.error.js";
+import type { SimSqsMessage } from "../../message/sim-sqs-message.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+
+interface SimSqsMessageHandlesProperties {
+  readonly clock: BackgroundScheduler;
+}
+
+/**
+ * How a request reaches the message a receipt handle names.
+ *
+ * Deleting a message and changing its visibility both start here, and both have
+ * to tell three cases apart: a handle the queue never issued, a handle it did
+ * issue for a message that has since been received again, and the handle from the
+ * most recent receive. Only the first is a failure.
+ */
+export class SimSqsMessageHandles {
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsMessageHandlesProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * The receipt handle a request has to carry.
+   */
+  static required(receiptHandle: string | undefined): string {
+    if (receiptHandle === undefined || receiptHandle === "") {
+      throw new SimSqsValidationException(
+        "The request must contain the parameter ReceiptHandle",
+      );
+    }
+
+    return receiptHandle;
+  }
+
+  /**
+   * The message a receipt handle names, refusing a handle the queue never issued.
+   */
+  message(queue: SimSqsQueue, receiptHandle: string): SimSqsMessage {
+    const message = queue.messageForHandle(receiptHandle, this.clock.now());
+
+    if (message === undefined) {
+      throw new SimSqsReceiptHandleIsInvalid(
+        `The receipt handle '${receiptHandle}' is not a receipt handle this ` +
+          `queue issued`,
+      );
+    }
+
+    return message;
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-receive-limits.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-limits.ts
@@ -1,0 +1,104 @@
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+} from "../../error/sim-sqs.error.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import type { SimReceiveMessageCommandInput } from "./receive.command.js";
+
+const maximumMessages = 10;
+const maximumVisibilityTimeoutSeconds = 43_200;
+const maximumWaitTimeSeconds = 20;
+
+/**
+ * How many messages a request may be answered with.
+ */
+export function requestedMessageCount(requested: number | undefined): number {
+  if (requested === undefined) {
+    return 1;
+  }
+
+  if (
+    !Number.isSafeInteger(requested) ||
+    requested < 1 ||
+    requested > maximumMessages
+  ) {
+    throw new SimSqsInvalidParameterValue(
+      `Value ${String(requested)} for parameter MaxNumberOfMessages is ` +
+        `invalid. Reason: Must be between 1 and ${String(maximumMessages)}, ` +
+        `if provided.`,
+    );
+  }
+
+  return requested;
+}
+
+/**
+ * How long the messages this request hands out stay hidden.
+ *
+ * A request may override the queue's visibility timeout for the messages it
+ * receives, which is how a consumer with a slow handler asks for longer.
+ */
+export function visibilityTimeoutFor(
+  queue: SimSqsQueue,
+  input: SimReceiveMessageCommandInput,
+): number {
+  const requested = input.VisibilityTimeout;
+
+  if (requested === undefined) {
+    return queue.attributes.visibilityTimeoutSeconds;
+  }
+
+  if (
+    !Number.isSafeInteger(requested) ||
+    requested < 0 ||
+    requested > maximumVisibilityTimeoutSeconds
+  ) {
+    throw new SimSqsInvalidParameterValue(
+      `Value ${String(requested)} for parameter VisibilityTimeout is ` +
+        `invalid. Reason: Must be an integer from 0 to ` +
+        `${String(maximumVisibilityTimeoutSeconds)}.`,
+    );
+  }
+
+  return requested;
+}
+
+/**
+ * Check a long polling wait time, which this simulation accepts and does not
+ * wait out.
+ *
+ * There is nothing to wait for in process: a receive answers from state that is
+ * already there, so waiting could only ever time out. Returning at once is the
+ * honest behaviour, and it is documented as a divergence rather than hidden.
+ */
+export function assertWaitTime(requested: number | undefined): void {
+  if (requested === undefined) {
+    return;
+  }
+
+  if (
+    !Number.isSafeInteger(requested) ||
+    requested < 0 ||
+    requested > maximumWaitTimeSeconds
+  ) {
+    throw new SimSqsInvalidParameterValue(
+      `Value ${String(requested)} for parameter WaitTimeSeconds is invalid. ` +
+        `Reason: Must be an integer from 0 to ` +
+        `${String(maximumWaitTimeSeconds)}.`,
+    );
+  }
+}
+
+/**
+ * Refuse the receive inputs this simulation does not model.
+ */
+export function refuseUnsimulatedReceiveInput(
+  input: SimReceiveMessageCommandInput,
+): void {
+  if (input.ReceiveRequestAttemptId !== undefined) {
+    throw new SimSqsUnsupportedOperation(
+      "ReceiveRequestAttemptId applies to FIFO queues, which simulated SQS " +
+        "does not support",
+    );
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-receive-message-attributes.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-message-attributes.iso.test.ts
@@ -1,0 +1,218 @@
+import { ReceiveMessageCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimSqsInvalidAttributeName,
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+} from "../../error/sim-sqs.error.js";
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS ReceiveMessage attributes and validation", () => {
+  it("reports the system attributes a request asks for", async () => {
+    // Given a queue holding a message, sent at a known instant.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    simAws.clock().freeze();
+
+    const sentAt = simAws.now();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When every system attribute is asked for.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageSystemAttributeNames: ["All"],
+      }),
+    );
+
+    // Then the ones this simulation knows are reported, in milliseconds.
+    const attributes = received.Messages?.[0]?.Attributes;
+
+    assertNonNullable(attributes);
+    assertIdentical(attributes["ApproximateReceiveCount"], "1");
+    assertIdentical(attributes["SentTimestamp"], String(sentAt.getTime()));
+    assertIdentical(
+      attributes["ApproximateFirstReceiveTimestamp"],
+      String(sentAt.getTime()),
+    );
+  });
+
+  it("reports system attributes named the discontinued way too", async () => {
+    // Given a queue holding a message.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When they are asked for as AttributeNames, as older code does.
+    const received = await simAws.sqs().receiveMessage({
+      input: {
+        QueueUrl: queueUrl,
+        AttributeNames: ["ApproximateReceiveCount"],
+      },
+    });
+
+    // Then they come back the same way.
+    assertIdentical(
+      received.Messages?.[0]?.Attributes?.["ApproximateReceiveCount"],
+      "1",
+    );
+  });
+
+  it("reports no system attributes when a request asks for none", async () => {
+    // Given a queue holding a message.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When it is received without naming any attribute.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then none come back, as real SQS returns none.
+    assertUndefined(received.Messages?.[0]?.Attributes);
+  });
+
+  it("leaves out a system attribute a standard queue has no value for", async () => {
+    // Given a queue holding a message.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When a FIFO-only attribute is asked for.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageSystemAttributeNames: ["MessageGroupId"],
+      }),
+    );
+
+    // Then it is left out rather than refused, as real SQS leaves it out.
+    assertUndefined(received.Messages?.[0]?.Attributes);
+  });
+
+  it("refuses a system attribute name that is not an SQS attribute", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an invented attribute is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().receiveMessage({
+        input: {
+          QueueUrl: queueUrl,
+          MessageSystemAttributeNames: ["ReceiveCount"],
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeName);
+  });
+
+  it("returns at once when long polling has nothing to wait for", async () => {
+    // Given an empty queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a receive asks to wait for a message.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: queueUrl, WaitTimeSeconds: 20 }),
+      );
+
+    // Then it comes back empty rather than waiting: nothing else is running that
+    // could send a message while it waited.
+    assertUndefined(received.Messages);
+  });
+
+  it("refuses a wait time beyond twenty seconds", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a longer wait is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().receiveMessage(
+        new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          WaitTimeSeconds: 21,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a request for more than ten messages", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When eleven messages are asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().receiveMessage(
+        new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          MaxNumberOfMessages: 11,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a visibility timeout beyond twelve hours", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a longer timeout is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().receiveMessage(
+        new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          VisibilityTimeout: 43_201,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a FIFO receive attempt id", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a receive request carries one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().receiveMessage(
+        new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          ReceiveRequestAttemptId: "attempt-1",
+        }),
+      );
+    });
+
+    // Then it is refused, since FIFO queues are not simulated.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-receive-message.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-message.iso.test.ts
@@ -1,0 +1,292 @@
+import {
+  DeleteMessageCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS ReceiveMessage", () => {
+  it("hands out a message with a receipt handle and the digest of its body", async () => {
+    // Given a queue holding one message.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When it is received.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the message is the one that was sent, under a fresh receipt handle.
+    const message = received.Messages?.[0];
+
+    assertNonNullable(message);
+    assertIdentical(message.MessageId, sent.MessageId);
+    assertIdentical(message.Body, "order-1");
+    assertIdentical(message.MD5OfBody, sent.MD5OfMessageBody);
+    assertNonNullable(message.ReceiptHandle);
+  });
+
+  it("hides a received message for the queue's visibility timeout", async () => {
+    // Given a queue with a thirty second visibility timeout holding a message.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      VisibilityTimeout: "30",
+    });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When it is received, and another consumer tries to receive it.
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then there is nothing to receive while the timeout is running.
+    assertUndefined(empty.Messages);
+  });
+
+  it("gives an undeleted message back once the visibility timeout lapses", async () => {
+    // Given a received message that was never deleted.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      VisibilityTimeout: "30",
+    });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // When simulated time moves past the timeout.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    const again = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageSystemAttributeNames: ["ApproximateReceiveCount"],
+      }),
+    );
+
+    // Then the message is receivable again, and says it has been received twice.
+    const message = again.Messages?.[0];
+
+    assertNonNullable(message);
+    assertIdentical(message.Body, "order-1");
+    assertIdentical(message.Attributes?.["ApproximateReceiveCount"], "2");
+  });
+
+  it("keeps a deleted message from coming back when the timeout lapses", async () => {
+    // Given a message that was received and deleted.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      VisibilityTimeout: "30",
+    });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: received.Messages?.[0]?.ReceiptHandle,
+      }),
+    );
+
+    // When simulated time moves past the timeout.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then there is nothing left on the queue.
+    assertUndefined(empty.Messages);
+  });
+
+  it("hides a new message until the delay it was sent with lapses", async () => {
+    // Given a queue holding a message sent with a delay.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        DelaySeconds: 60,
+      }),
+    );
+
+    // When a consumer receives before the delay lapses, and again after.
+    const early = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    await simAws.clock().advanceBy({ seconds: 61 });
+
+    const late = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the message only arrives once the delay is over.
+    assertUndefined(early.Messages);
+    assertIdentical(late.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("delays every message on a queue with a delay of its own", async () => {
+    // Given a queue with a delay and a message sent with none.
+    const { simAws, queueUrl } = await simAwsWithQueue({ DelaySeconds: "45" });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When a consumer receives before the queue's delay lapses, and again after.
+    const early = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    await simAws.clock().advanceBy({ seconds: 46 });
+
+    const late = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the queue's delay applied to the message.
+    assertUndefined(early.Messages);
+    assertIdentical(late.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("returns one message at a time unless asked for more", async () => {
+    // Given a queue holding three messages.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    for (const body of ["order-1", "order-2", "order-3"]) {
+      // eslint-disable-next-line no-await-in-loop
+      await simAws
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: body }),
+        );
+    }
+
+    // When one receive takes the default and the next asks for two.
+    const one = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    const two = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 2,
+      }),
+    );
+
+    // Then each receive hands out what it asked for, oldest first.
+    assertArrayEquals(
+      one.Messages?.map((message) => message.Body),
+      ["order-1"],
+    );
+    assertArrayEquals(
+      two.Messages?.map((message) => message.Body),
+      ["order-2", "order-3"],
+    );
+  });
+
+  it("hides received messages for the timeout a request asks for", async () => {
+    // Given a queue with a short visibility timeout holding a message.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      VisibilityTimeout: "5",
+    });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When the consumer asks for longer than the queue's own timeout.
+    await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        VisibilityTimeout: 600,
+      }),
+    );
+
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the message stays hidden past the queue's timeout.
+    assertUndefined(empty.Messages);
+  });
+
+  it("drops a message whose retention period has run out", async () => {
+    // Given a queue holding a message, with the shortest retention SQS allows.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      MessageRetentionPeriod: "60",
+    });
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When simulated time moves past the retention period.
+    await simAws.clock().advanceBy({ seconds: 61 });
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then the message is gone, as real SQS drops it.
+    assertUndefined(received.Messages);
+  });
+
+  it("takes only the messages that are visible", async () => {
+    // Given a queue holding a delayed message and a visible one.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "later",
+        DelaySeconds: 60,
+      }),
+    );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "now" }),
+      );
+
+    // When several messages are asked for.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: 10,
+      }),
+    );
+
+    // Then only the visible one is handed out.
+    assertArrayLength(received.Messages ?? [], 1);
+    assertIdentical(received.Messages?.[0]?.Body, "now");
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-receive-message.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-message.ts
@@ -1,0 +1,59 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
+import type {
+  SimReceiveMessageCommand,
+  SimReceiveMessageCommandOutput,
+} from "./receive.command.js";
+import { SimSqsReceiveRequest } from "./sim-sqs-receive-request.js";
+
+interface SimSqsReceiveMessageProperties {
+  readonly access: SimSqsQueueAccess;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsReceiveMessageOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The ReceiveMessage command.
+ *
+ * Receiving hides each message it hands out for the visibility timeout, so the
+ * same message does not come back to a second consumer while the first is still
+ * working on it. Nothing is scheduled to release it: the message records the
+ * instant it is hidden until, and it becomes receivable again when simulated
+ * time reaches it. Advancing the clock is therefore all a test has to do to
+ * watch an undeleted message come back.
+ */
+export class SimSqsReceiveMessage {
+  private readonly access: SimSqsQueueAccess;
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsReceiveMessageProperties) {
+    this.access = properties.access;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Receive up to `MaxNumberOfMessages` messages, hiding each of them.
+   */
+  handle(
+    command: SimReceiveMessageCommand,
+    options?: SimSqsReceiveMessageOptions,
+  ): SimReceiveMessageCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:ReceiveMessage",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const request = SimSqsReceiveRequest.of(command.input, queue);
+    const receivedAt = this.clock.now();
+    const received = queue.receivable(receivedAt, request.messageCount);
+
+    return {
+      $metadata: {},
+      Messages: request.taken(queue, received, receivedAt),
+    };
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-receive-request.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-request.ts
@@ -1,0 +1,92 @@
+import type { SimSqsMessage } from "../../message/sim-sqs-message.js";
+import { SimSqsRequestedSystemAttributes } from "../../message/sim-sqs-message-system-attributes.js";
+import { makeSimSqsReceiptHandle } from "../../message/sim-sqs-receipt-handle.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import type {
+  SimReceiveMessageCommandInput,
+  SimSqsReceivedMessage,
+} from "./receive.command.js";
+import {
+  assertWaitTime,
+  refuseUnsimulatedReceiveInput,
+  requestedMessageCount,
+  visibilityTimeoutFor,
+} from "./sim-sqs-receive-limits.js";
+import { SimSqsReceivedMessageView } from "./sim-sqs-received-message-view.js";
+
+/**
+ * One checked receive request.
+ *
+ * Everything a receive decides before it hands anything out lives here: how many
+ * messages it may take, how long they stay hidden, and how they are reported. The
+ * whole request is checked before the first message is touched, so an invalid
+ * request never half-receives one.
+ */
+export class SimSqsReceiveRequest {
+  public readonly messageCount: number;
+
+  private readonly visibilityTimeoutSeconds: number;
+  private readonly view: SimSqsReceivedMessageView;
+
+  private constructor(
+    input: SimReceiveMessageCommandInput,
+    queue: SimSqsQueue,
+  ) {
+    this.messageCount = requestedMessageCount(input.MaxNumberOfMessages);
+    this.visibilityTimeoutSeconds = visibilityTimeoutFor(queue, input);
+    this.view = new SimSqsReceivedMessageView({
+      systemAttributes: SimSqsRequestedSystemAttributes.of(
+        input.MessageSystemAttributeNames,
+        input.AttributeNames,
+      ),
+      messageAttributeNames: input.MessageAttributeNames,
+    });
+  }
+
+  /**
+   * Read a receive request, refusing one real SQS would refuse.
+   */
+  static of(
+    input: SimReceiveMessageCommandInput,
+    queue: SimSqsQueue,
+  ): SimSqsReceiveRequest {
+    refuseUnsimulatedReceiveInput(input);
+    assertWaitTime(input.WaitTimeSeconds);
+
+    return new this(input, queue);
+  }
+
+  /**
+   * Take the messages this request found, or nothing at all.
+   *
+   * Real SQS sends no `Messages` field rather than an empty list when there is
+   * nothing to hand out, so an empty receive is reported as absence.
+   */
+  taken(
+    queue: SimSqsQueue,
+    found: readonly SimSqsMessage[],
+    receivedAt: Date,
+  ): readonly SimSqsReceivedMessage[] | undefined {
+    if (found.length === 0) {
+      return undefined;
+    }
+
+    return found.map((message) => this.take(queue, message, receivedAt));
+  }
+
+  /**
+   * Take one message: hide it, record the handle it went out under, and report it.
+   */
+  private take(
+    queue: SimSqsQueue,
+    message: SimSqsMessage,
+    receivedAt: Date,
+  ): SimSqsReceivedMessage {
+    const receiptHandle = makeSimSqsReceiptHandle();
+
+    message.receiveAt(receivedAt, this.visibilityTimeoutSeconds, receiptHandle);
+    queue.recordHandle(receiptHandle, message);
+
+    return this.view.of(message, receiptHandle);
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-received-message-view.ts
+++ b/src/service/sqs/command/message/sim-sqs-received-message-view.ts
@@ -1,0 +1,55 @@
+import type { SimSqsMessage } from "../../message/sim-sqs-message.js";
+import type { SimSqsMessageAttributes } from "../../message/sim-sqs-message-attributes.js";
+import type { SimSqsRequestedSystemAttributes } from "../../message/sim-sqs-message-system-attributes.js";
+import type { SimSqsReceivedMessage } from "./receive.command.js";
+
+interface SimSqsReceivedMessageViewProperties {
+  readonly systemAttributes: SimSqsRequestedSystemAttributes;
+  readonly messageAttributeNames: readonly string[] | undefined;
+}
+
+/**
+ * How one receive request reports the messages it takes.
+ *
+ * Both attribute kinds are reported only when the request named them, which is
+ * what real SQS does. A consumer that never named an attribute gets a message
+ * without it here, rather than one that would lose the attribute on AWS.
+ */
+export class SimSqsReceivedMessageView {
+  private readonly systemAttributes: SimSqsRequestedSystemAttributes;
+  private readonly messageAttributeNames: readonly string[] | undefined;
+
+  constructor(properties: SimSqsReceivedMessageViewProperties) {
+    this.systemAttributes = properties.systemAttributes;
+    this.messageAttributeNames = properties.messageAttributeNames;
+  }
+
+  /**
+   * One received message as SQS reports it.
+   */
+  of(message: SimSqsMessage, receiptHandle: string): SimSqsReceivedMessage {
+    return {
+      MessageId: message.messageId,
+      ReceiptHandle: receiptHandle,
+      MD5OfBody: message.body.digest,
+      Body: message.body.value,
+      Attributes: this.systemAttributes.from(message.systemAttributeValues()),
+      ...reportedMessageAttributes(
+        message.attributes.selected(this.messageAttributeNames),
+      ),
+    };
+  }
+}
+
+function reportedMessageAttributes(
+  selected: SimSqsMessageAttributes,
+): Partial<SimSqsReceivedMessage> {
+  if (selected.isEmpty) {
+    return {};
+  }
+
+  return {
+    MessageAttributes: selected.reported(),
+    MD5OfMessageAttributes: selected.digest(),
+  };
+}

--- a/src/service/sqs/command/message/sim-sqs-send-message-batch.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-send-message-batch.iso.test.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import { SendMessageBatchCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimSqsBatchEntryIdsNotDistinct,
+  SimSqsEmptyBatchRequest,
+  SimSqsInvalidBatchEntryId,
+  SimSqsTooManyEntriesInBatchRequest,
+} from "../../error/sim-sqs.error.js";
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS SendMessageBatch", () => {
+  it("sends every entry and reports each under its own id", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When two messages are sent as a batch.
+    const sent = await simAws.sqs().sendMessageBatch(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [
+          { Id: "one", MessageBody: "order-1" },
+          { Id: "two", MessageBody: "order-2" },
+        ],
+      }),
+    );
+
+    // Then both went through, each carrying its own digest.
+    const first = sent.Successful?.[0];
+
+    assertArrayEquals(
+      sent.Successful?.map((entry) => entry.Id),
+      ["one", "two"],
+    );
+    assertNonNullable(first);
+    assertIdentical(
+      first.MD5OfMessageBody,
+      createHash("md5").update("order-1", "utf8").digest("hex"),
+    );
+    assertArrayLength(sent.Failed ?? [], 0);
+  });
+
+  it("reports one failed entry while the rest of the batch goes through", async () => {
+    // Given a queue with a small maximum message size.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      MaximumMessageSize: "1024",
+    });
+
+    // When a batch carrying one oversized message is sent.
+    const sent = await simAws.sqs().sendMessageBatch(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [
+          { Id: "one", MessageBody: "order-1" },
+          { Id: "two", MessageBody: "x".repeat(1025) },
+        ],
+      }),
+    );
+
+    // Then the good one is sent and the bad one is reported on its own.
+    const failed = sent.Failed?.[0];
+
+    assertArrayEquals(
+      sent.Successful?.map((entry) => entry.Id),
+      ["one"],
+    );
+    assertNonNullable(failed);
+    assertIdentical(failed.Id, "two");
+    assertIdentical(failed.Code, "InvalidParameterValue");
+    assertTrue(failed.SenderFault);
+  });
+
+  it("refuses a batch with no entries", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an empty batch is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .sendMessageBatch(
+          new SendMessageBatchCommand({ QueueUrl: queueUrl, Entries: [] }),
+        );
+    });
+
+    // Then the whole request is refused.
+    assertInstanceOf(error, SimSqsEmptyBatchRequest);
+  });
+
+  it("refuses a batch of more than ten entries", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When eleven messages are sent at once.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessageBatch(
+        new SendMessageBatchCommand({
+          QueueUrl: queueUrl,
+          Entries: Array.from({ length: 11 }, (_, index) => ({
+            Id: `entry-${String(index)}`,
+            MessageBody: "order",
+          })),
+        }),
+      );
+    });
+
+    // Then the whole request is refused.
+    assertInstanceOf(error, SimSqsTooManyEntriesInBatchRequest);
+  });
+
+  it("refuses two entries sharing an id", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When two entries carry the same id.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessageBatch(
+        new SendMessageBatchCommand({
+          QueueUrl: queueUrl,
+          Entries: [
+            { Id: "one", MessageBody: "order-1" },
+            { Id: "one", MessageBody: "order-2" },
+          ],
+        }),
+      );
+    });
+
+    // Then the whole request is refused.
+    assertInstanceOf(error, SimSqsBatchEntryIdsNotDistinct);
+  });
+
+  it("refuses an entry id real SQS would refuse", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an entry id carries a disallowed character.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessageBatch(
+        new SendMessageBatchCommand({
+          QueueUrl: queueUrl,
+          Entries: [{ Id: "one two", MessageBody: "order-1" }],
+        }),
+      );
+    });
+
+    // Then the whole request is refused.
+    assertInstanceOf(error, SimSqsInvalidBatchEntryId);
+  });
+
+  it("refuses an entry with no id", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an entry carries no id at all.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessageBatch({
+        input: { QueueUrl: queueUrl, Entries: [{ MessageBody: "order-1" }] },
+      });
+    });
+
+    // Then the whole request is refused.
+    assertInstanceOf(error, SimSqsInvalidBatchEntryId);
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-send-message-commands.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-send-message-commands.iso.test.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import {
+  SimSqsInvalidMessageContents,
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+} from "../../error/sim-sqs.error.js";
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS SendMessage", () => {
+  it("reports a message id and a real MD5 of the body", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message is sent.
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // Then the digest is one the sender can check its own body against.
+    assertNonNullable(sent.MessageId);
+    assertUuidV4(sent.MessageId);
+    assertIdentical(
+      sent.MD5OfMessageBody,
+      createHash("md5").update("order-1", "utf8").digest("hex"),
+    );
+    assertUndefined(sent.MD5OfMessageAttributes);
+  });
+
+  it("refuses a body larger than the queue accepts", async () => {
+    // Given a queue with a small maximum message size.
+    const { simAws, queueUrl } = await simAwsWithQueue({
+      MaximumMessageSize: "1024",
+    });
+
+    // When a larger body is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "x".repeat(1025),
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses an empty body", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message with no body is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage({ input: { QueueUrl: queueUrl } });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a body carrying characters SQS does not allow", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a body with a control character is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: `order${String.fromCodePoint(0)}one`,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidMessageContents);
+  });
+
+  it("accepts a body of emoji and other supplementary characters", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a body outside the basic multilingual plane is sent.
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order 🧾" }),
+      );
+
+    // Then it is accepted, as real SQS accepts it.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("accepts a body with newlines and other allowed characters", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a body with a newline, a tab and a replacement character is sent.
+    const sent = await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: `line one\n\tline two ${String.fromCodePoint(0xff_fd)}`,
+      }),
+    );
+
+    // Then it is accepted, as real SQS accepts all of them.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("refuses a per-message delay outside the range real SQS accepts", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a delay beyond fifteen minutes is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          DelaySeconds: 901,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses the FIFO fields, since there are no FIFO queues here", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message group is named.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageGroupId: "tenant-acme",
+        }),
+      );
+    });
+
+    // Then it is refused rather than accepted as an ordering that is not there.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+
+  it("refuses message system attributes", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an X-Ray trace header is sent with the message.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageSystemAttributes: {
+            AWSTraceHeader: { DataType: "String", StringValue: "Root=1-2-3" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, since they are not modelled.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+
+  it("refuses a send with no queue URL", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a message is sent with no queue named.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage({ input: { MessageBody: "order-1" } });
+    });
+
+    // Then the missing input is reported.
+    assertIdentical(error.name, "ValidationException");
+  });
+
+  it("refuses a queue URL that is not a queue URL", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a message is sent to something that is not a queue URL.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: "https://example.com/orders",
+          MessageBody: "order-1",
+        }),
+      );
+    });
+
+    // Then it is refused as an invalid address.
+    assertIdentical(error.name, "InvalidAddress");
+  });
+
+  it("reaches no queue through a URL naming another Region", async () => {
+    // Given a queue in one Region.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // When a message is sent to a same-named queue in another Region.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: "https://sqs.us-east-1.amazonaws.com/111111111111/orders",
+          MessageBody: "order-1",
+        }),
+      );
+    });
+
+    // Then the queue does not exist as far as this scope is concerned.
+    assertIdentical(error.name, "QueueDoesNotExist");
+  });
+});

--- a/src/service/sqs/command/message/sim-sqs-send-message-commands.ts
+++ b/src/service/sqs/command/message/sim-sqs-send-message-commands.ts
@@ -1,0 +1,103 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsMessageWriter } from "../../message/sim-sqs-message-writer.js";
+import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
+import { requireBatchEntries, runBatch } from "./sim-sqs-batch-entries.js";
+import {
+  sentMessageAttributesDigest,
+  sentMessageWrite,
+} from "./sim-sqs-sent-message.js";
+import type {
+  SimSendMessageBatchCommand,
+  SimSendMessageBatchCommandOutput,
+  SimSendMessageCommand,
+  SimSendMessageCommandOutput,
+  SimSqsSendMessageBatchResultEntry,
+} from "./send.command.js";
+
+/**
+ * Real SQS authorizes a batch send as `sqs:SendMessage`. There is no
+ * `sqs:SendMessageBatch` action, so a policy naming one grants nothing.
+ */
+const messageSendAction = "sqs:SendMessage";
+
+interface SimSqsSendMessageCommandsProperties {
+  readonly access: SimSqsQueueAccess;
+  readonly writer: SimSqsMessageWriter;
+}
+
+interface SimSqsSendMessageCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that put messages on a queue.
+ */
+export class SimSqsSendMessageCommands {
+  private readonly access: SimSqsQueueAccess;
+  private readonly writer: SimSqsMessageWriter;
+
+  constructor(properties: SimSqsSendMessageCommandsProperties) {
+    this.access = properties.access;
+    this.writer = properties.writer;
+  }
+
+  /**
+   * Send one message.
+   */
+  send(
+    command: SimSendMessageCommand,
+    options?: SimSqsSendMessageCommandsOptions,
+  ): SimSendMessageCommandOutput {
+    const queue = this.access.requireByUrl(
+      messageSendAction,
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const message = this.writer.write(queue, sentMessageWrite(command.input));
+
+    return {
+      $metadata: {},
+      MessageId: message.messageId,
+      MD5OfMessageBody: message.body.digest,
+      MD5OfMessageAttributes: sentMessageAttributesDigest(message),
+    };
+  }
+
+  /**
+   * Send up to ten messages at once.
+   *
+   * A message one entry cannot send is reported in `Failed` while the rest of the
+   * batch goes through, as real SQS reports it.
+   */
+  sendBatch(
+    command: SimSendMessageBatchCommand,
+    options?: SimSqsSendMessageCommandsOptions,
+  ): SimSendMessageBatchCommandOutput {
+    const queue = this.access.requireByUrl(
+      messageSendAction,
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const entries = requireBatchEntries(command.input.Entries, "SendMessage");
+
+    const outcome = runBatch(
+      entries,
+      (entry, id): SimSqsSendMessageBatchResultEntry => {
+        const message = this.writer.write(queue, sentMessageWrite(entry));
+
+        return {
+          Id: id,
+          MessageId: message.messageId,
+          MD5OfMessageBody: message.body.digest,
+          MD5OfMessageAttributes: sentMessageAttributesDigest(message),
+        };
+      },
+    );
+
+    return {
+      $metadata: {},
+      Successful: outcome.successful,
+      Failed: outcome.failed,
+    };
+  }
+}

--- a/src/service/sqs/command/message/sim-sqs-sent-message.ts
+++ b/src/service/sqs/command/message/sim-sqs-sent-message.ts
@@ -1,0 +1,52 @@
+import { SimSqsUnsupportedOperation } from "../../error/sim-sqs.error.js";
+import type { SimSqsMessage } from "../../message/sim-sqs-message.js";
+import { SimSqsMessageAttributes } from "../../message/sim-sqs-message-attributes.js";
+import type { SimSqsMessageWrite } from "../../message/sim-sqs-message-writer.js";
+import type { SimSqsSentMessage } from "./send.command.js";
+
+/**
+ * Read the message a send request describes, refusing the fields this simulation
+ * does not model.
+ *
+ * The FIFO fields are refused because there are no FIFO queues here to give them
+ * meaning, and a message accepted with a `MessageGroupId` that ordered nothing
+ * would be a message a test believed was ordered.
+ */
+export function sentMessageWrite(sent: SimSqsSentMessage): SimSqsMessageWrite {
+  if (
+    sent.MessageDeduplicationId !== undefined ||
+    sent.MessageGroupId !== undefined
+  ) {
+    throw new SimSqsUnsupportedOperation(
+      "MessageDeduplicationId and MessageGroupId apply to FIFO queues, which " +
+        "simulated SQS does not support",
+    );
+  }
+
+  if (sent.MessageSystemAttributes !== undefined) {
+    throw new SimSqsUnsupportedOperation(
+      "MessageSystemAttributes carry the X-Ray trace header, which simulated " +
+        "SQS does not model",
+    );
+  }
+
+  return {
+    body: sent.MessageBody,
+    attributes: SimSqsMessageAttributes.of(sent.MessageAttributes),
+    delaySeconds: sent.DelaySeconds,
+  };
+}
+
+/**
+ * The digest of a message's attributes, which SQS reports only when there are
+ * some.
+ */
+export function sentMessageAttributesDigest(
+  message: SimSqsMessage,
+): string | undefined {
+  if (message.attributes.isEmpty) {
+    return undefined;
+  }
+
+  return message.attributes.digest();
+}

--- a/src/service/sqs/command/queue/queue.command.ts
+++ b/src/service/sqs/command/queue/queue.command.ts
@@ -1,0 +1,134 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimSqsQueueAttributeInput } from "../../queue/sim-sqs-queue-attributes.js";
+
+/**
+ * Minimal structural sim SQS CreateQueue command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/CreateQueueCommand/
+ */
+export interface SimCreateQueueCommand {
+  readonly input: SimCreateQueueCommandInput;
+}
+
+export interface SimCreateQueueCommandInput {
+  readonly QueueName?: string | undefined;
+  readonly Attributes?: SimSqsQueueAttributeInput | undefined;
+  /** The SQS API names this parameter in lower case, unlike every other one. */
+  readonly tags?: Readonly<Record<string, string>> | undefined;
+}
+
+export interface SimCreateQueueCommandOutput {
+  readonly QueueUrl?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS GetQueueUrl command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/GetQueueUrlCommand/
+ */
+export interface SimGetQueueUrlCommand {
+  readonly input: SimGetQueueUrlCommandInput;
+}
+
+export interface SimGetQueueUrlCommandInput {
+  readonly QueueName?: string | undefined;
+  readonly QueueOwnerAWSAccountId?: string | undefined;
+}
+
+export interface SimGetQueueUrlCommandOutput {
+  readonly QueueUrl?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS ListQueues command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/ListQueuesCommand/
+ */
+export interface SimListQueuesCommand {
+  readonly input: SimListQueuesCommandInput;
+}
+
+export interface SimListQueuesCommandInput {
+  readonly QueueNamePrefix?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListQueuesCommandOutput {
+  readonly QueueUrls?: readonly string[] | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS DeleteQueue command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/DeleteQueueCommand/
+ */
+export interface SimDeleteQueueCommand {
+  readonly input: SimDeleteQueueCommandInput;
+}
+
+export interface SimDeleteQueueCommandInput {
+  readonly QueueUrl?: string | undefined;
+}
+
+export interface SimDeleteQueueCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS GetQueueAttributes command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/GetQueueAttributesCommand/
+ */
+export interface SimGetQueueAttributesCommand {
+  readonly input: SimGetQueueAttributesCommandInput;
+}
+
+export interface SimGetQueueAttributesCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly AttributeNames?: readonly string[] | undefined;
+}
+
+export interface SimGetQueueAttributesCommandOutput {
+  readonly Attributes?: Record<string, string> | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS SetQueueAttributes command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/SetQueueAttributesCommand/
+ */
+export interface SimSetQueueAttributesCommand {
+  readonly input: SimSetQueueAttributesCommandInput;
+}
+
+export interface SimSetQueueAttributesCommandInput {
+  readonly QueueUrl?: string | undefined;
+  readonly Attributes?: SimSqsQueueAttributeInput | undefined;
+}
+
+export interface SimSetQueueAttributesCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim SQS PurgeQueue command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/command/PurgeQueueCommand/
+ */
+export interface SimPurgeQueueCommand {
+  readonly input: SimPurgeQueueCommandInput;
+}
+
+export interface SimPurgeQueueCommandInput {
+  readonly QueueUrl?: string | undefined;
+}
+
+export interface SimPurgeQueueCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/sqs/command/queue/sim-sqs-create-queue.ts
+++ b/src/service/sqs/command/queue/sim-sqs-create-queue.ts
@@ -1,0 +1,100 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import {
+  type SimSqsQueueAttributeInput,
+  SimSqsQueueAttributes,
+} from "../../queue/sim-sqs-queue-attributes.js";
+import { SimSqsQueueName } from "../../queue/sim-sqs-queue-name.js";
+import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
+import type { SimSqsQueueAccess } from "./sim-sqs-queue-access.js";
+import { refuseUnsimulatedQueueInput } from "./sim-sqs-unsimulated-queue-input.js";
+import type {
+  SimCreateQueueCommand,
+  SimCreateQueueCommandOutput,
+} from "./queue.command.js";
+
+interface SimSqsCreateQueueProperties {
+  readonly queues: SimSqsQueueStore;
+  readonly access: SimSqsQueueAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsCreateQueueOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The CreateQueue command.
+ *
+ * Real SQS treats it as idempotent: a request for a name that is already taken
+ * returns the existing queue's URL when the attributes it names match, and fails
+ * when they differ. That is what makes a deployment which creates its own queue
+ * safe to run twice.
+ */
+export class SimSqsCreateQueue {
+  private readonly queues: SimSqsQueueStore;
+  private readonly access: SimSqsQueueAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsCreateQueueProperties) {
+    this.queues = properties.queues;
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Create a queue, or answer with the existing one of that name.
+   */
+  handle(
+    command: SimCreateQueueCommand,
+    options?: SimSqsCreateQueueOptions,
+  ): SimCreateQueueCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedQueueInput(input);
+
+    const name = SimSqsQueueName.required(input.QueueName);
+    const requested = input.Attributes ?? {};
+
+    this.access.authorizeName("sqs:CreateQueue", name.value, options?.caller);
+
+    const existing = this.queues.find(name.value);
+
+    if (existing !== undefined) {
+      return {
+        $metadata: {},
+        QueueUrl: existing.urlWhenAttributesMatch(requested),
+      };
+    }
+
+    return { $metadata: {}, QueueUrl: this.created(name, requested).url };
+  }
+
+  /**
+   * Create the queue itself, once the name is known to be free.
+   */
+  private created(
+    name: SimSqsQueueName,
+    requested: SimSqsQueueAttributeInput,
+  ): SimSqsQueue {
+    const createdAt = this.clock.now();
+
+    this.queues.assertNameAvailable(name.value, createdAt);
+
+    const queue = new SimSqsQueue({
+      name,
+      accountRegionScope: this.accountRegionScope,
+      attributes: SimSqsQueueAttributes.defaults().with(requested),
+      createdAt,
+    });
+
+    this.queues.add(queue);
+
+    return queue;
+  }
+}

--- a/src/service/sqs/command/queue/sim-sqs-queue-access.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-access.ts
@@ -1,0 +1,136 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimSqsInvalidAddress,
+  SimSqsQueueDoesNotExist,
+  SimSqsValidationException,
+} from "../../error/sim-sqs.error.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import { sqsQueueArnPrefix } from "../../queue/sim-sqs-queue-arn.js";
+import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
+import { SimSqsQueueUrl } from "../../queue/sim-sqs-queue-url.js";
+import type { SimSqsAuthorizer } from "../authorize/sim-sqs-authorizer.js";
+
+/**
+ * The operation an IAM action names, for a message about a missing request
+ * input.
+ */
+function operationName(action: string): string {
+  return action.replace("sqs:", "");
+}
+
+interface SimSqsQueueAccessProperties {
+  readonly queues: SimSqsQueueStore;
+  readonly authorizer: SimSqsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a request reaches the queue it names.
+ *
+ * Every operation but ListQueues and CreateQueue starts the same way: read the
+ * queue URL, authorize the action against the ARN that URL implies, then look the
+ * queue up. Authorization comes first because real IAM decides before the
+ * service does anything, so a caller with no permission is refused whether or not
+ * the queue exists.
+ */
+export class SimSqsQueueAccess {
+  private readonly queues: SimSqsQueueStore;
+  private readonly authorizer: SimSqsAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSqsQueueAccessProperties) {
+    this.queues = properties.queues;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on the queue of a given name.
+   */
+  authorizeName(action: string, name: string, caller?: SimAwsCaller): void {
+    this.authorizer.authorizeQueue(
+      action,
+      sqsQueueArnPrefix(this.accountRegionScope) + name,
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular queue.
+   */
+  authorizeAnyQueue(action: string, caller?: SimAwsCaller): void {
+    this.authorizer.authorizeAnyQueue(action, caller);
+  }
+
+  /**
+   * Resolve the queue a request names by name, authorizing the action first.
+   */
+  requireByName(
+    action: string,
+    name: string | undefined,
+    caller?: SimAwsCaller,
+  ): SimSqsQueue {
+    if (name === undefined || name === "") {
+      throw new SimSqsValidationException(
+        `${operationName(action)} requires a QueueName`,
+      );
+    }
+
+    this.authorizeName(action, name, caller);
+
+    return this.queues.require(name);
+  }
+
+  /**
+   * Resolve the queue a request names by URL, authorizing the action first.
+   */
+  requireByUrl(
+    action: string,
+    queueUrl: string | undefined,
+    caller?: SimAwsCaller,
+  ): SimSqsQueue {
+    const name = this.nameFromUrl(action, queueUrl);
+
+    this.authorizeName(action, name, caller);
+
+    return this.queues.require(name);
+  }
+
+  /**
+   * Read the queue name out of the URL a request carries.
+   *
+   * A URL naming another account or region reaches nothing, rather than having
+   * its name read out and looked up locally. A queue URL is scoped, and treating
+   * a foreign one as local would let a test pass while the real call crossed an
+   * account boundary it has no permission for.
+   */
+  private nameFromUrl(action: string, queueUrl: string | undefined): string {
+    if (queueUrl === undefined || queueUrl === "") {
+      throw new SimSqsValidationException(
+        `${operationName(action)} requires a QueueUrl`,
+      );
+    }
+
+    const parts = SimSqsQueueUrl.parse(queueUrl);
+
+    if (parts === undefined) {
+      throw new SimSqsInvalidAddress(
+        `The address ${queueUrl} is not valid for this endpoint: a queue URL ` +
+          `is https://sqs.<region>.amazonaws.com/<account-id>/<queue-name>`,
+      );
+    }
+
+    const { accountId, regionName } = this.accountRegionScope;
+
+    if (parts.accountId !== accountId || parts.regionName !== regionName) {
+      throw new SimSqsQueueDoesNotExist(
+        `The specified queue does not exist: ${queueUrl} names Account ` +
+          `${parts.accountId} in ${parts.regionName}, and this simulated SQS ` +
+          `is Account ${accountId} in ${regionName}`,
+      );
+    }
+
+    return parts.name;
+  }
+}

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
@@ -1,0 +1,362 @@
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  PurgeQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSqsInvalidAttributeName,
+  SimSqsInvalidAttributeValue,
+  SimSqsUnsupportedOperation,
+  SimSqsValidationException,
+} from "../../error/sim-sqs.error.js";
+
+/**
+ * A simulated AWS with one queue, and that queue's URL.
+ */
+async function simAwsWithQueue(
+  attributes?: Record<string, string>,
+): Promise<{ simAws: SimAws; queueUrl: string }> {
+  const simAws = new SimAws();
+  const created = await simAws.sqs().createQueue(
+    new CreateQueueCommand({
+      QueueName: "orders",
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+
+  return { simAws, queueUrl: created.QueueUrl ?? "" };
+}
+
+describe("SQS queue attribute commands", () => {
+  it("gives a new queue the attribute defaults real SQS gives it", async () => {
+    // Given a queue created with no attributes.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When every attribute is asked for.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    // Then the defaults are the ones AWS documents.
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["VisibilityTimeout"], "30");
+    assertIdentical(read.Attributes["DelaySeconds"], "0");
+    assertIdentical(read.Attributes["MessageRetentionPeriod"], "345600");
+    assertIdentical(read.Attributes["MaximumMessageSize"], "262144");
+    assertIdentical(read.Attributes["ReceiveMessageWaitTimeSeconds"], "0");
+  });
+
+  it("reports the queue ARN and its timestamps", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When the read-only attributes are asked for.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["QueueArn", "CreatedTimestamp"],
+      }),
+    );
+
+    // Then the ARN names the queue, and the timestamp is in whole seconds.
+    const createdSeconds = Math.floor(simAws.now().getTime() / 1000);
+
+    assertNonNullable(read.Attributes);
+    assertIdentical(
+      read.Attributes["QueueArn"],
+      `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`,
+    );
+    assertIdentical(
+      read.Attributes["CreatedTimestamp"],
+      String(createdSeconds),
+    );
+  });
+
+  it("returns only the attributes a request names", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When one attribute is asked for.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["VisibilityTimeout"],
+      }),
+    );
+
+    // Then that is all that comes back.
+    assertNonNullable(read.Attributes);
+    assertArrayLength(Object.keys(read.Attributes), 1);
+    assertIdentical(read.Attributes["VisibilityTimeout"], "30");
+  });
+
+  it("returns no attributes when a request names none", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When the attributes are asked for without naming any.
+    const read = await simAws
+      .sqs()
+      .getQueueAttributes(
+        new GetQueueAttributesCommand({ QueueUrl: queueUrl }),
+      );
+
+    // Then none come back, as real SQS returns none.
+    assertUndefined(read.Attributes);
+  });
+
+  it("leaves out an attribute real SQS has and this simulation does not", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a redrive policy is asked for.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    // Then it is left out rather than refused, as real SQS leaves out an
+    // attribute the queue has no value for.
+    assertUndefined(read.Attributes);
+  });
+
+  it("refuses an attribute name that is not an SQS attribute", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an invented attribute is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().getQueueAttributes({
+        input: {
+          QueueUrl: queueUrl,
+          AttributeNames: ["VisibilityTimeoutSeconds"],
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeName);
+  });
+
+  it("counts visible, hidden and delayed messages separately", async () => {
+    // Given a queue holding a visible message, a received one and a delayed one.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "a" }),
+      );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "b" }),
+      );
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "c",
+        DelaySeconds: 60,
+      }),
+    );
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // When the counts are asked for.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    // Then each message is counted in the state it is in.
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["ApproximateNumberOfMessages"], "1");
+    assertIdentical(
+      read.Attributes["ApproximateNumberOfMessagesNotVisible"],
+      "1",
+    );
+    assertIdentical(read.Attributes["ApproximateNumberOfMessagesDelayed"], "1");
+  });
+
+  it("changes an attribute of an existing queue", async () => {
+    // Given a queue with the default visibility timeout.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When the timeout is changed.
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: { VisibilityTimeout: "120" },
+      }),
+    );
+
+    // Then the new value is what the queue reports.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["VisibilityTimeout"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["VisibilityTimeout"], "120");
+  });
+
+  it("refuses an attribute value outside the range real SQS accepts", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a visibility timeout beyond twelve hours is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes(
+        new SetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          Attributes: { VisibilityTimeout: "43201" },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeValue);
+  });
+
+  it("refuses an attribute value that is not a whole number", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a queue is created with a fractional delay.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          Attributes: { DelaySeconds: "1.5" },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeValue);
+  });
+
+  it("refuses to set an attribute SQS reports rather than accepts", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a read-only attribute is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes(
+        new SetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          Attributes: { QueueArn: "arn:aws:sqs:us-east-1:111111111111:other" },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeName);
+  });
+
+  it("refuses to set a real SQS attribute this simulation does not model", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a redrive policy is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes(
+        new SetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          Attributes: { RedrivePolicy: "{}" },
+        }),
+      );
+    });
+
+    // Then it is refused rather than ignored.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+
+  it("refuses to set an attribute that is not an SQS attribute", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an invented attribute is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes({
+        input: { QueueUrl: queueUrl, Attributes: { Timeout: "10" } },
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidAttributeName);
+  });
+
+  it("refuses a set with no attributes", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When attributes are set without any being given.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes({ input: { QueueUrl: queueUrl } });
+    });
+
+    // Then the missing input is reported.
+    assertInstanceOf(error, SimSqsValidationException);
+  });
+
+  it("purges every message on a queue", async () => {
+    // Given a queue holding two messages, one of them in flight.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "a" }),
+      );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "b" }),
+      );
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // When the queue is purged.
+    await simAws
+      .sqs()
+      .purgeQueue(new PurgeQueueCommand({ QueueUrl: queueUrl }));
+
+    // Then nothing is left on it, hidden or otherwise.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["ApproximateNumberOfMessages"], "0");
+    assertIdentical(
+      read.Attributes["ApproximateNumberOfMessagesNotVisible"],
+      "0",
+    );
+  });
+});

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
@@ -22,23 +22,7 @@ import {
   SimSqsUnsupportedOperation,
   SimSqsValidationException,
 } from "../../error/sim-sqs.error.js";
-
-/**
- * A simulated AWS with one queue, and that queue's URL.
- */
-async function simAwsWithQueue(
-  attributes?: Record<string, string>,
-): Promise<{ simAws: SimAws; queueUrl: string }> {
-  const simAws = new SimAws();
-  const created = await simAws.sqs().createQueue(
-    new CreateQueueCommand({
-      QueueName: "orders",
-      ...(attributes !== undefined && { Attributes: attributes }),
-    }),
-  );
-
-  return { simAws, queueUrl: created.QueueUrl ?? "" };
-}
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
 
 describe("SQS queue attribute commands", () => {
   it("gives a new queue the attribute defaults real SQS gives it", async () => {

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.ts
@@ -1,0 +1,138 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimSqsValidationException } from "../../error/sim-sqs.error.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import { SimSqsQueueAttributeNames } from "../../queue/sim-sqs-queue-attribute-names.js";
+import type { SimSqsQueueAccess } from "./sim-sqs-queue-access.js";
+import type {
+  SimGetQueueAttributesCommand,
+  SimGetQueueAttributesCommandOutput,
+  SimPurgeQueueCommand,
+  SimPurgeQueueCommandOutput,
+  SimSetQueueAttributesCommand,
+  SimSetQueueAttributesCommandOutput,
+} from "./queue.command.js";
+
+interface SimSqsQueueAttributeCommandsProperties {
+  readonly access: SimSqsQueueAccess;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsQueueAttributeCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that read and change what a queue does, rather than what is on it.
+ */
+export class SimSqsQueueAttributeCommands {
+  private readonly access: SimSqsQueueAccess;
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsQueueAttributeCommandsProperties) {
+    this.access = properties.access;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Read the attributes a request asks for.
+   *
+   * Only the named attributes come back, as on real SQS, so a request naming
+   * none gets none. `All` names every attribute this simulation holds; an
+   * attribute real SQS has and this simulation does not is left out rather than
+   * refused, because that is what real SQS does with an attribute a queue has no
+   * value for.
+   */
+  getQueueAttributes(
+    command: SimGetQueueAttributesCommand,
+    options?: SimSqsQueueAttributeCommandsOptions,
+  ): SimGetQueueAttributesCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:GetQueueAttributes",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const requested = command.input.AttributeNames ?? [];
+
+    for (const name of requested) {
+      SimSqsQueueAttributeNames.assertReadable(name);
+    }
+
+    const reported = this.reportedAttributes(queue, requested);
+
+    if (reported === undefined) {
+      return { $metadata: {} };
+    }
+
+    return { $metadata: {}, Attributes: reported };
+  }
+
+  /**
+   * Change the attributes of a queue.
+   */
+  setQueueAttributes(
+    command: SimSetQueueAttributesCommand,
+    options?: SimSqsQueueAttributeCommandsOptions,
+  ): SimSetQueueAttributesCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:SetQueueAttributes",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+    const requested = command.input.Attributes;
+
+    if (requested === undefined) {
+      throw new SimSqsValidationException(
+        "SetQueueAttributes requires Attributes",
+      );
+    }
+
+    queue.applyAttributes(requested, this.clock.now());
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Delete every message on a queue.
+   *
+   * Real SQS takes up to 60 seconds over a purge, during which messages sent
+   * before it may still be deleted and messages sent during it may still be
+   * purged. This purge happens at once, which is a deliberate simplification: a
+   * test can then assert on an empty queue immediately.
+   */
+  purgeQueue(
+    command: SimPurgeQueueCommand,
+    options?: SimSqsQueueAttributeCommandsOptions,
+  ): SimPurgeQueueCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:PurgeQueue",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+
+    queue.purge(this.clock.now());
+
+    return { $metadata: {} };
+  }
+
+  private reportedAttributes(
+    queue: SimSqsQueue,
+    requested: readonly string[],
+  ): Record<string, string> | undefined {
+    if (requested.length === 0) {
+      return undefined;
+    }
+
+    const available = queue.reportedAttributes(this.clock.now());
+    const selected = available
+      .entries()
+      .filter(([name]) => requested.includes("All") || requested.includes(name))
+      .toArray();
+
+    if (selected.length === 0) {
+      return undefined;
+    }
+
+    return Object.fromEntries(selected);
+  }
+}

--- a/src/service/sqs/command/queue/sim-sqs-queue-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-commands.iso.test.ts
@@ -1,0 +1,378 @@
+import {
+  CreateQueueCommand,
+  DeleteQueueCommand,
+  GetQueueUrlCommand,
+  ListQueuesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsQueueDeletedRecently,
+  SimSqsQueueDoesNotExist,
+  SimSqsQueueNameExists,
+  SimSqsUnsupportedOperation,
+  SimSqsValidationException,
+} from "../../error/sim-sqs.error.js";
+
+describe("SQS queue commands", () => {
+  it("creates a queue with a URL and ARN naming its Account and Region", async () => {
+    // Given a simulated AWS in one Account and Region.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When a queue is created.
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // Then the URL is the one real SQS would give it.
+    assertIdentical(
+      created.QueueUrl,
+      "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+    );
+
+    // And the ARN carries the name with no resource type in front of it.
+    const queue = simAws.sqs().findQueue("orders");
+
+    assertNonNullable(queue);
+    assertIdentical(
+      queue.arn.value,
+      "arn:aws:sqs:eu-west-2:111111111111:orders",
+    );
+  });
+
+  it("answers a repeated create with the existing queue URL", async () => {
+    // Given an existing queue with a visibility timeout.
+    const simAws = new SimAws();
+    const created = await simAws.sqs().createQueue(
+      new CreateQueueCommand({
+        QueueName: "orders",
+        Attributes: { VisibilityTimeout: "60" },
+      }),
+    );
+
+    // When it is created again with the same attributes, and with none.
+    const again = await simAws.sqs().createQueue(
+      new CreateQueueCommand({
+        QueueName: "orders",
+        Attributes: { VisibilityTimeout: "60" },
+      }),
+    );
+    const withoutAttributes = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // Then both answer with the queue that is already there.
+    assertIdentical(again.QueueUrl, created.QueueUrl);
+    assertIdentical(withoutAttributes.QueueUrl, created.QueueUrl);
+  });
+
+  it("refuses a repeated create whose attributes differ", async () => {
+    // Given an existing queue with a visibility timeout.
+    const simAws = new SimAws();
+    await simAws.sqs().createQueue(
+      new CreateQueueCommand({
+        QueueName: "orders",
+        Attributes: { VisibilityTimeout: "60" },
+      }),
+    );
+
+    // When it is created again with a different one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          Attributes: { VisibilityTimeout: "30" },
+        }),
+      );
+    });
+
+    // Then the name is reported as taken, as real SQS reports it.
+    assertInstanceOf(error, SimSqsQueueNameExists);
+  });
+
+  it("holds a deleted queue name until simulated time moves on", async () => {
+    // Given a queue that has just been deleted.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+    await simAws
+      .sqs()
+      .deleteQueue(new DeleteQueueCommand({ QueueUrl: created.QueueUrl }));
+
+    // When the name is used again straight away.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+    });
+
+    // Then it is still held, as real SQS holds it for a minute.
+    assertInstanceOf(error, SimSqsQueueDeletedRecently);
+
+    // And advancing the clock past the minute frees it.
+    await simAws.clock().advanceBy({ seconds: 61 });
+
+    const recreated = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    assertIdentical(recreated.QueueUrl, created.QueueUrl);
+  });
+
+  it("gets the URL of a queue by name", async () => {
+    // Given an existing queue.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // When its URL is asked for by name.
+    const found = await simAws
+      .sqs()
+      .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+
+    // Then it is the URL the queue was created with.
+    assertIdentical(found.QueueUrl, created.QueueUrl);
+  });
+
+  it("refuses to find a queue that does not exist", async () => {
+    // Given a simulated AWS with no queues.
+    const simAws = new SimAws();
+
+    // When an unknown name is looked up.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .getQueueUrl(new GetQueueUrlCommand({ QueueName: "orders" }));
+    });
+
+    // Then it is reported the way real SQS reports it.
+    assertInstanceOf(error, SimSqsQueueDoesNotExist);
+  });
+
+  it("refuses a request for a queue owned by another Account", async () => {
+    // Given an existing queue.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111" as SimAwsAccountId,
+    });
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // When it is asked for as another Account's queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().getQueueUrl(
+        new GetQueueUrlCommand({
+          QueueName: "orders",
+          QueueOwnerAWSAccountId: "222222222222",
+        }),
+      );
+    });
+
+    // Then it is refused, since cross-account access is not simulated.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+
+  it("lists queues by name prefix, a page at a time", async () => {
+    // Given three queues, two of them sharing a prefix.
+    const simAws = new SimAws();
+    for (const name of ["orders-new", "orders-done", "invoices"]) {
+      // eslint-disable-next-line no-await-in-loop
+      await simAws
+        .sqs()
+        .createQueue(new CreateQueueCommand({ QueueName: name }));
+    }
+
+    // When they are listed by prefix, one at a time.
+    const first = await simAws
+      .sqs()
+      .listQueues(
+        new ListQueuesCommand({ QueueNamePrefix: "orders", MaxResults: 1 }),
+      );
+    const second = await simAws.sqs().listQueues(
+      new ListQueuesCommand({
+        QueueNamePrefix: "orders",
+        MaxResults: 1,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then each page carries one matching queue, in creation order.
+    assertArrayEquals(
+      first.QueueUrls?.map((url) => queueName(url)),
+      ["orders-new"],
+    );
+    assertArrayEquals(
+      second.QueueUrls?.map((url) => queueName(url)),
+      ["orders-done"],
+    );
+    assertUndefined(second.NextToken);
+  });
+
+  it("lists every queue when no prefix is given", async () => {
+    // Given two queues.
+    const simAws = new SimAws();
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "invoices" }));
+
+    // When they are listed.
+    const listed = await simAws.sqs().listQueues(new ListQueuesCommand({}));
+
+    // Then both are there.
+    assertArrayEquals(
+      listed.QueueUrls?.map((url) => queueName(url)),
+      ["orders", "invoices"],
+    );
+    assertUndefined(listed.NextToken);
+  });
+
+  it("refuses a listing page size outside the range real SQS accepts", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a listing asks for more results than SQS allows.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .listQueues(new ListQueuesCommand({ MaxResults: 1001 }));
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a continuation token it did not issue", async () => {
+    // Given a queue to list.
+    const simAws = new SimAws();
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // When a made-up token is passed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .listQueues(new ListQueuesCommand({ NextToken: "not-a-token" }));
+    });
+
+    // Then it is refused rather than answered from the beginning.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("deletes a queue", async () => {
+    // Given an existing queue.
+    const simAws = new SimAws();
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+    // When it is deleted.
+    await simAws
+      .sqs()
+      .deleteQueue(new DeleteQueueCommand({ QueueUrl: created.QueueUrl }));
+
+    // Then it is gone.
+    assertUndefined(simAws.sqs().findQueue("orders"));
+  });
+
+  it("refuses a FIFO queue name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a FIFO queue is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .createQueue(new CreateQueueCommand({ QueueName: "orders.fifo" }));
+    });
+
+    // Then it is refused rather than created as a standard queue.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+    assertStringIncludes(error.message, "FIFO");
+  });
+
+  it("refuses a queue name real SQS would refuse", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a name with a disallowed character is used.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .sqs()
+        .createQueue(new CreateQueueCommand({ QueueName: "orders queue" }));
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a create with no queue name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a queue is created with no name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue({ input: {} });
+    });
+
+    // Then the missing input is reported.
+    assertInstanceOf(error, SimSqsValidationException);
+  });
+
+  it("refuses queue tags rather than dropping them", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a queue is created with tags.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          tags: { Team: "payments" },
+        }),
+      );
+    });
+
+    // Then it is refused, since tags are not simulated.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+
+  it("refuses a get with no queue name", async () => {
+    // Given a simulated AWS.
+    const simAws = new SimAws();
+
+    // When a URL is asked for with no name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().getQueueUrl({ input: {} });
+    });
+
+    // Then the missing input is reported.
+    assertInstanceOf(error, SimSqsValidationException);
+  });
+});
+
+/**
+ * The queue name at the end of a queue URL.
+ */
+function queueName(queueUrl: string): string {
+  return queueUrl.split("/").pop() ?? "";
+}

--- a/src/service/sqs/command/queue/sim-sqs-queue-commands.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-commands.ts
@@ -1,0 +1,113 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
+import type { SimSqsQueueAccess } from "./sim-sqs-queue-access.js";
+import { SimSqsQueuePage } from "./sim-sqs-queue-page.js";
+import { refuseForeignQueueOwner } from "./sim-sqs-unsimulated-queue-input.js";
+import type {
+  SimDeleteQueueCommand,
+  SimDeleteQueueCommandOutput,
+  SimGetQueueUrlCommand,
+  SimGetQueueUrlCommandOutput,
+  SimListQueuesCommand,
+  SimListQueuesCommandOutput,
+} from "./queue.command.js";
+
+interface SimSqsQueueCommandsProperties {
+  readonly queues: SimSqsQueueStore;
+  readonly access: SimSqsQueueAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: BackgroundScheduler;
+}
+
+interface SimSqsQueueCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that find and delete queues.
+ */
+export class SimSqsQueueCommands {
+  private readonly queues: SimSqsQueueStore;
+  private readonly access: SimSqsQueueAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsQueueCommandsProperties) {
+    this.queues = properties.queues;
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Get the URL of a queue by name.
+   */
+  getQueueUrl(
+    command: SimGetQueueUrlCommand,
+    options?: SimSqsQueueCommandsOptions,
+  ): SimGetQueueUrlCommandOutput {
+    refuseForeignQueueOwner(
+      command.input.QueueOwnerAWSAccountId,
+      this.accountRegionScope.accountId,
+    );
+
+    const queue = this.access.requireByName(
+      "sqs:GetQueueUrl",
+      command.input.QueueName,
+      options?.caller,
+    );
+
+    return { $metadata: {}, QueueUrl: queue.url };
+  }
+
+  /**
+   * List the queues in this scope, oldest first.
+   *
+   * Real SQS gives this action no queue-level permission, so it authorizes
+   * against every queue in the account and region and does not filter the list
+   * by what the caller can reach.
+   */
+  listQueues(
+    command: SimListQueuesCommand,
+    options?: SimSqsQueueCommandsOptions,
+  ): SimListQueuesCommandOutput {
+    const input = command.input;
+
+    this.access.authorizeAnyQueue("sqs:ListQueues", options?.caller);
+
+    const page = new SimSqsQueuePage(
+      this.queues.withNamePrefix(input.QueueNamePrefix),
+      input,
+    );
+
+    return {
+      $metadata: {},
+      QueueUrls: page.queues.map((queue) => queue.url),
+      NextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Delete a queue and everything on it.
+   *
+   * The queue goes at once here, where real SQS may take up to a minute over it.
+   * The name it held is not free straight away either way: real SQS refuses to
+   * reuse it for 60 seconds, and so does this.
+   */
+  deleteQueue(
+    command: SimDeleteQueueCommand,
+    options?: SimSqsQueueCommandsOptions,
+  ): SimDeleteQueueCommandOutput {
+    const queue = this.access.requireByUrl(
+      "sqs:DeleteQueue",
+      command.input.QueueUrl,
+      options?.caller,
+    );
+
+    this.queues.remove(queue, this.clock.now());
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/sqs/command/queue/sim-sqs-queue-page.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-page.ts
@@ -1,0 +1,92 @@
+import { SimSqsInvalidParameterValue } from "../../error/sim-sqs.error.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+
+const defaultMaxResults = 1000;
+const maxMaxResults = 1000;
+
+/**
+ * The paging fields a ListQueues request carries.
+ */
+export interface SimSqsQueuePageInput {
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * One page of listed queues, and the token that reaches the next one.
+ */
+export class SimSqsQueuePage {
+  public readonly queues: readonly SimSqsQueue[];
+  public readonly nextToken: string | undefined;
+
+  constructor(listed: readonly SimSqsQueue[], input: SimSqsQueuePageInput) {
+    const maxResults = SimSqsQueuePage.maxResults(input.MaxResults);
+    const startIndex = SimSqsQueuePage.startIndex(
+      input.NextToken,
+      listed.length,
+    );
+    const nextIndex = startIndex + maxResults;
+
+    this.queues = listed.slice(startIndex, nextIndex);
+    this.nextToken = SimSqsQueuePage.tokenFor(nextIndex, listed.length);
+  }
+
+  private static maxResults(requested: number | undefined): number {
+    const maxResults = requested ?? defaultMaxResults;
+
+    if (
+      !Number.isSafeInteger(maxResults) ||
+      maxResults < 1 ||
+      maxResults > maxMaxResults
+    ) {
+      throw new SimSqsInvalidParameterValue(
+        `Value ${String(requested)} for parameter MaxResults is invalid. ` +
+          `Reason: Must be an integer from 1 to ${String(maxMaxResults)}.`,
+      );
+    }
+
+    return maxResults;
+  }
+
+  /**
+   * Read a continuation token as its offset into the listed queues.
+   *
+   * Tokens are the canonical non-negative integer representation this command
+   * emits, so anything else is refused rather than silently starting again from
+   * the beginning.
+   */
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+
+    const startIndex = Number(nextToken);
+
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex < 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimSqsInvalidParameterValue(
+        "NextToken is not a token this simulation issued",
+      );
+    }
+
+    return startIndex;
+  }
+
+  private static tokenFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+
+    return String(nextIndex);
+  }
+}

--- a/src/service/sqs/command/queue/sim-sqs-unsimulated-queue-input.ts
+++ b/src/service/sqs/command/queue/sim-sqs-unsimulated-queue-input.ts
@@ -1,0 +1,39 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimSqsUnsupportedOperation } from "../../error/sim-sqs.error.js";
+import type { SimCreateQueueCommandInput } from "./queue.command.js";
+
+/**
+ * Refuse the queue request inputs this simulation does not model.
+ *
+ * Dropping a tag would leave a queue looking tagged to the request that sent it
+ * and untagged to everything else, and answering a request for another Account's
+ * queue with a local one of the same name would let a test pass while the real
+ * call crossed a boundary it has no permission for. Both are refused instead.
+ */
+export function refuseUnsimulatedQueueInput(
+  input: SimCreateQueueCommandInput,
+): void {
+  if (input.tags !== undefined) {
+    throw new SimSqsUnsupportedOperation(
+      "Queue tags are not simulated, so CreateQueue refuses them rather than " +
+        "dropping them",
+    );
+  }
+}
+
+/**
+ * Refuse a request for a queue owned by another Account.
+ *
+ * Cross-account access needs a queue policy, which is not simulated.
+ */
+export function refuseForeignQueueOwner(
+  owner: string | undefined,
+  accountId: SimAwsAccountId,
+): void {
+  if (owner !== undefined && owner !== accountId) {
+    throw new SimSqsUnsupportedOperation(
+      `QueueOwnerAWSAccountId ${owner} names another Account, and ` +
+        `cross-account queue access is not simulated`,
+    );
+  }
+}

--- a/src/service/sqs/command/sim-sqs-command.types.ts
+++ b/src/service/sqs/command/sim-sqs-command.types.ts
@@ -1,0 +1,58 @@
+/**
+ * The sim SQS Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateQueueCommand,
+  SimCreateQueueCommandInput,
+  SimCreateQueueCommandOutput,
+  SimDeleteQueueCommand,
+  SimDeleteQueueCommandInput,
+  SimDeleteQueueCommandOutput,
+  SimGetQueueAttributesCommand,
+  SimGetQueueAttributesCommandInput,
+  SimGetQueueAttributesCommandOutput,
+  SimGetQueueUrlCommand,
+  SimGetQueueUrlCommandInput,
+  SimGetQueueUrlCommandOutput,
+  SimListQueuesCommand,
+  SimListQueuesCommandInput,
+  SimListQueuesCommandOutput,
+  SimPurgeQueueCommand,
+  SimPurgeQueueCommandInput,
+  SimPurgeQueueCommandOutput,
+  SimSetQueueAttributesCommand,
+  SimSetQueueAttributesCommandInput,
+  SimSetQueueAttributesCommandOutput,
+} from "./queue/queue.command.js";
+export type {
+  SimSendMessageBatchCommand,
+  SimSendMessageBatchCommandInput,
+  SimSendMessageBatchCommandOutput,
+  SimSendMessageCommand,
+  SimSendMessageCommandInput,
+  SimSendMessageCommandOutput,
+  SimSqsBatchResultErrorEntry,
+  SimSqsMessageSystemAttributeInput,
+  SimSqsSendMessageBatchEntry,
+  SimSqsSendMessageBatchResultEntry,
+  SimSqsSentMessage,
+} from "./message/send.command.js";
+export type {
+  SimReceiveMessageCommand,
+  SimReceiveMessageCommandInput,
+  SimReceiveMessageCommandOutput,
+  SimSqsReceivedMessage,
+} from "./message/receive.command.js";
+export type {
+  SimChangeMessageVisibilityCommand,
+  SimChangeMessageVisibilityCommandInput,
+  SimChangeMessageVisibilityCommandOutput,
+  SimDeleteMessageBatchCommand,
+  SimDeleteMessageBatchCommandInput,
+  SimDeleteMessageBatchCommandOutput,
+  SimDeleteMessageCommand,
+  SimDeleteMessageCommandInput,
+  SimDeleteMessageCommandOutput,
+  SimSqsDeleteMessageBatchEntry,
+  SimSqsDeleteMessageBatchResultEntry,
+} from "./message/consume.command.js";

--- a/src/service/sqs/error/sim-sqs.error.ts
+++ b/src/service/sqs/error/sim-sqs.error.ts
@@ -1,0 +1,230 @@
+/**
+ * Minimal metadata shape for simulated SQS errors.
+ */
+export interface SimSqsErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated SQS errors.
+ */
+export class SimSqsError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimSqsErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated SQS QueueDoesNotExist error.
+ *
+ * The name is the one the SDK gives the exception. Real SQS sends it on the
+ * wire as `AWS.SimpleQueueService.NonExistentQueue`.
+ */
+export class SimSqsQueueDoesNotExist extends SimSqsError {
+  public override readonly name = "QueueDoesNotExist";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS QueueNameExists error.
+ *
+ * CreateQueue answers this when the name is taken and the request carries
+ * attributes differing from the existing queue's. Real SQS sends it on the wire
+ * as `QueueAlreadyExists`.
+ */
+export class SimSqsQueueNameExists extends SimSqsError {
+  public override readonly name = "QueueNameExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS QueueDeletedRecently error.
+ *
+ * Real SQS holds a deleted queue's name for 60 seconds, so a name cannot be
+ * reused immediately after DeleteQueue.
+ */
+export class SimSqsQueueDeletedRecently extends SimSqsError {
+  public override readonly name = "QueueDeletedRecently";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidAddress error.
+ *
+ * This is what a QueueUrl that is not a queue URL at all produces.
+ */
+export class SimSqsInvalidAddress extends SimSqsError {
+  public override readonly name = "InvalidAddress";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidAttributeName error.
+ *
+ * Real SQS reports an attribute name it has no such attribute for this way,
+ * including a read-only attribute a SetQueueAttributes request tries to set.
+ */
+export class SimSqsInvalidAttributeName extends SimSqsError {
+  public override readonly name = "InvalidAttributeName";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidAttributeValue error.
+ *
+ * This is an attribute value outside the range real SQS accepts for it.
+ */
+export class SimSqsInvalidAttributeValue extends SimSqsError {
+  public override readonly name = "InvalidAttributeValue";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidParameterValue error.
+ *
+ * Real SQS reports a request input outside the range it accepts this way, such
+ * as a MaxNumberOfMessages above ten or a malformed queue name.
+ */
+export class SimSqsInvalidParameterValue extends SimSqsError {
+  public override readonly name = "InvalidParameterValue";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidMessageContents error.
+ *
+ * A message body may only carry the characters real SQS allows, which is a
+ * subset of Unicode rather than any string.
+ */
+export class SimSqsInvalidMessageContents extends SimSqsError {
+  public override readonly name = "InvalidMessageContents";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS ReceiptHandleIsInvalid error.
+ *
+ * This is a receipt handle the queue never issued. A handle it did issue for a
+ * message received again since is valid but stale, which is a different thing.
+ */
+export class SimSqsReceiptHandleIsInvalid extends SimSqsError {
+  public override readonly name = "ReceiptHandleIsInvalid";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS MessageNotInflight error.
+ *
+ * ChangeMessageVisibility answers this for a message that is not currently
+ * hidden, since there is no visibility timeout left to change.
+ */
+export class SimSqsMessageNotInflight extends SimSqsError {
+  public override readonly name = "MessageNotInflight";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS EmptyBatchRequest error.
+ */
+export class SimSqsEmptyBatchRequest extends SimSqsError {
+  public override readonly name = "EmptyBatchRequest";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS TooManyEntriesInBatchRequest error.
+ */
+export class SimSqsTooManyEntriesInBatchRequest extends SimSqsError {
+  public override readonly name = "TooManyEntriesInBatchRequest";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS BatchEntryIdsNotDistinct error.
+ */
+export class SimSqsBatchEntryIdsNotDistinct extends SimSqsError {
+  public override readonly name = "BatchEntryIdsNotDistinct";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS InvalidBatchEntryId error.
+ */
+export class SimSqsInvalidBatchEntryId extends SimSqsError {
+  public override readonly name = "InvalidBatchEntryId";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS UnsupportedOperation error.
+ *
+ * This is what simulated SQS refuses a real SQS feature it does not simulate
+ * with, such as a FIFO queue or a redrive policy. Refusing is deliberate: a
+ * request that quietly did something else would pass here and behave
+ * differently on AWS.
+ */
+export class SimSqsUnsupportedOperation extends SimSqsError {
+  public override readonly name = "UnsupportedOperation";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated SQS ValidationException error.
+ *
+ * Real SQS reports a missing required request input this way.
+ */
+export class SimSqsValidationException extends SimSqsError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -1,0 +1,43 @@
+export { SimSqs, type SimSqsRequestOptions } from "./sim-sqs.js";
+export { SimSqsQueue } from "./queue/sim-sqs-queue.js";
+export {
+  sqsAnyQueueArn,
+  SimSqsQueueArn,
+  sqsQueueArnPrefix,
+  sqsQueueUrlPrefix,
+} from "./queue/sim-sqs-queue-arn.js";
+export {
+  type SimSqsQueueAttributeInput,
+  SimSqsQueueAttributes,
+} from "./queue/sim-sqs-queue-attributes.js";
+export { SimSqsQueueName } from "./queue/sim-sqs-queue-name.js";
+export {
+  SimSqsQueueUrl,
+  type SimSqsQueueUrlParts,
+} from "./queue/sim-sqs-queue-url.js";
+export { SimSqsMessage } from "./message/sim-sqs-message.js";
+export { SimSqsMessageAttributes } from "./message/sim-sqs-message-attributes.js";
+export type {
+  SimSqsMessageAttributeInput,
+  SimSqsMessageAttributeValue,
+} from "./message/sim-sqs-message-attribute-value.js";
+export { SimSqsMessageBody } from "./message/sim-sqs-message-body.js";
+export {
+  SimSqsBatchEntryIdsNotDistinct,
+  SimSqsEmptyBatchRequest,
+  SimSqsError,
+  SimSqsInvalidAddress,
+  SimSqsInvalidAttributeName,
+  SimSqsInvalidAttributeValue,
+  SimSqsInvalidBatchEntryId,
+  SimSqsInvalidMessageContents,
+  SimSqsInvalidParameterValue,
+  SimSqsMessageNotInflight,
+  SimSqsQueueDeletedRecently,
+  SimSqsQueueDoesNotExist,
+  SimSqsQueueNameExists,
+  SimSqsReceiptHandleIsInvalid,
+  SimSqsTooManyEntriesInBatchRequest,
+  SimSqsUnsupportedOperation,
+  SimSqsValidationException,
+} from "./error/sim-sqs.error.js";

--- a/src/service/sqs/message/sim-sqs-message-attribute-digest.iso.test.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute-digest.iso.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simAwsWithQueue } from "../../../../test/sqs/queue-fixture.js";
+
+describe("SQS message attribute digests", () => {
+  it("digests attributes the way real SQS digests them", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message with one string attribute is sent.
+    const sent = await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    // Then the digest is the documented length-prefixed encoding: the name, the
+    // data type, the transport type byte, then the value.
+    const encoded = Buffer.concat([
+      lengthPrefixed("tenant"),
+      lengthPrefixed("String"),
+      Buffer.of(1),
+      lengthPrefixed("acme"),
+    ]);
+
+    assertIdentical(
+      sent.MD5OfMessageAttributes,
+      createHash("md5").update(encoded).digest("hex"),
+    );
+  });
+
+  it("digests a binary attribute under its own transport type", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message with one binary attribute is sent.
+    const sent = await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          payload: { DataType: "Binary", BinaryValue: new Uint8Array([7, 8]) },
+        },
+      }),
+    );
+
+    // Then the value's bytes are digested behind a transport type of two.
+    const encoded = Buffer.concat([
+      lengthPrefixed("payload"),
+      lengthPrefixed("Binary"),
+      Buffer.of(2),
+      lengthPrefixed(Buffer.from([7, 8])),
+    ]);
+
+    assertIdentical(
+      sent.MD5OfMessageAttributes,
+      createHash("md5").update(encoded).digest("hex"),
+    );
+  });
+});
+
+/**
+ * One digest field, as SQS encodes message attributes.
+ */
+function lengthPrefixed(value: string | Buffer): Buffer {
+  const bytes = Buffer.from(value);
+  const length = Buffer.alloc(4);
+
+  length.writeUInt32BE(bytes.length);
+
+  return Buffer.concat([length, bytes]);
+}

--- a/src/service/sqs/message/sim-sqs-message-attribute-payload.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute-payload.ts
@@ -1,0 +1,71 @@
+import type { SimSqsMessageAttributeValue } from "./sim-sqs-message-attribute-value.js";
+
+/**
+ * The value of one message attribute.
+ *
+ * An attribute carries text or bytes and never both, so the two are separate
+ * implementations rather than one shape with two optional fields. That is what
+ * lets the digest and the reported form be stated without either of them asking
+ * which kind it is holding.
+ */
+export interface SimSqsMessageAttributePayload {
+  /**
+   * The byte real SQS digests this kind of value under.
+   */
+  readonly transportType: number;
+
+  /**
+   * The value's bytes, as they go into a message attribute digest.
+   */
+  readonly bytes: Buffer;
+
+  /**
+   * This value as SQS reports it, alongside its data type.
+   */
+  reported(dataType: string): SimSqsMessageAttributeValue;
+}
+
+/**
+ * A message attribute value travelling as text, which is what a String or
+ * Number data type means.
+ */
+export class SimSqsStringPayload implements SimSqsMessageAttributePayload {
+  public readonly transportType = 1;
+  public readonly bytes: Buffer;
+
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = value;
+    this.bytes = Buffer.from(value, "utf8");
+  }
+
+  /**
+   * This value as SQS reports it, alongside its data type.
+   */
+  reported(dataType: string): SimSqsMessageAttributeValue {
+    return { DataType: dataType, StringValue: this.value };
+  }
+}
+
+/**
+ * A message attribute value travelling as bytes.
+ */
+export class SimSqsBinaryPayload implements SimSqsMessageAttributePayload {
+  public readonly transportType = 2;
+  public readonly bytes: Buffer;
+
+  private readonly value: Uint8Array;
+
+  constructor(value: Uint8Array) {
+    this.value = value;
+    this.bytes = Buffer.from(value);
+  }
+
+  /**
+   * This value as SQS reports it, alongside its data type.
+   */
+  reported(dataType: string): SimSqsMessageAttributeValue {
+    return { DataType: dataType, BinaryValue: this.value };
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-attribute-payload.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute-payload.ts
@@ -55,10 +55,13 @@ export class SimSqsBinaryPayload implements SimSqsMessageAttributePayload {
   public readonly transportType = 2;
   public readonly bytes: Buffer;
 
-  private readonly value: Uint8Array;
-
+  /**
+   * The bytes are copied on the way in and again on the way out, so a sent
+   * message does not share an array with the sender or with a consumer. Real SQS
+   * holds bytes a caller cannot reach afterwards, and a simulation that handed
+   * the same array back would let a mutation reach across a send.
+   */
   constructor(value: Uint8Array) {
-    this.value = value;
     this.bytes = Buffer.from(value);
   }
 
@@ -66,6 +69,6 @@ export class SimSqsBinaryPayload implements SimSqsMessageAttributePayload {
    * This value as SQS reports it, alongside its data type.
    */
   reported(dataType: string): SimSqsMessageAttributeValue {
-    return { DataType: dataType, BinaryValue: this.value };
+    return { DataType: dataType, BinaryValue: Uint8Array.from(this.bytes) };
   }
 }

--- a/src/service/sqs/message/sim-sqs-message-attribute-rules.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute-rules.ts
@@ -1,0 +1,111 @@
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+} from "../error/sim-sqs.error.js";
+import {
+  SimSqsBinaryPayload,
+  type SimSqsMessageAttributePayload,
+  SimSqsStringPayload,
+} from "./sim-sqs-message-attribute-payload.js";
+import type { SimSqsMessageAttributeValue } from "./sim-sqs-message-attribute-value.js";
+
+const attributeNamePattern = /^[\w\-.]{1,256}$/;
+
+const reservedNamePrefixes = ["aws.", "amazon."];
+
+const baseDataTypes = ["String", "Number", "Binary"];
+
+/**
+ * What real SQS accepts as a message attribute.
+ *
+ * These are real SQS rules rather than conveniences, so an attribute they accept
+ * is one AWS would accept.
+ */
+export function assertUsableAttributeName(name: string): void {
+  const invalid = new SimSqsInvalidParameterValue(
+    `The message attribute name '${name}' is invalid. Attribute names may ` +
+      `contain alphanumeric characters, underscores, hyphens and periods, may ` +
+      `not begin or end with a period, may not contain two periods in ` +
+      `succession, and may not begin with a reserved AWS prefix.`,
+  );
+
+  if (!attributeNamePattern.test(name)) {
+    throw invalid;
+  }
+
+  if (name.startsWith(".") || name.endsWith(".") || name.includes("..")) {
+    throw invalid;
+  }
+
+  const lowerCased = name.toLowerCase();
+
+  if (reservedNamePrefixes.some((prefix) => lowerCased.startsWith(prefix))) {
+    throw invalid;
+  }
+}
+
+/**
+ * Check the data type an attribute declares, which is one of three, optionally
+ * followed by a custom label.
+ */
+export function assertUsableDataType(name: string, dataType: string): void {
+  const isKnown = baseDataTypes.some(
+    (baseType) => dataType === baseType || dataType.startsWith(`${baseType}.`),
+  );
+
+  if (!isKnown) {
+    throw new SimSqsInvalidParameterValue(
+      `The message attribute '${name}' has an invalid message attribute type: ` +
+        `the type must be String, Number or Binary, optionally followed by a ` +
+        `custom label`,
+    );
+  }
+}
+
+/**
+ * Read the value of an attribute, which has to match the data type it declares.
+ *
+ * List-valued attributes are reserved for future use by real SQS, which refuses
+ * them, so this simulation refuses them too rather than storing something AWS
+ * would not accept.
+ */
+export function attributePayload(
+  name: string,
+  dataType: string,
+  value: SimSqsMessageAttributeValue,
+): SimSqsMessageAttributePayload {
+  if (
+    value.StringListValues !== undefined ||
+    value.BinaryListValues !== undefined
+  ) {
+    throw new SimSqsUnsupportedOperation(
+      `The message attribute '${name}' carries list values, which real SQS ` +
+        `reserves for future use and does not accept`,
+    );
+  }
+
+  if (dataType.startsWith("Binary")) {
+    if (value.BinaryValue === undefined || value.StringValue !== undefined) {
+      throw invalidPayload(name, dataType, "BinaryValue");
+    }
+
+    return new SimSqsBinaryPayload(value.BinaryValue);
+  }
+
+  if (value.StringValue === undefined || value.BinaryValue !== undefined) {
+    throw invalidPayload(name, dataType, "StringValue");
+  }
+
+  return new SimSqsStringPayload(value.StringValue);
+}
+
+function invalidPayload(
+  name: string,
+  dataType: string,
+  expected: string,
+): SimSqsInvalidParameterValue {
+  return new SimSqsInvalidParameterValue(
+    `The message attribute '${name}' must carry exactly one ${expected} for ` +
+      `its ${dataType} data type`,
+  );
+}

--- a/src/service/sqs/message/sim-sqs-message-attribute-value.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute-value.ts
@@ -1,0 +1,19 @@
+/**
+ * One message attribute as a request carries it and a response reports it.
+ *
+ * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html
+ */
+export interface SimSqsMessageAttributeValue {
+  readonly DataType?: string | undefined;
+  readonly StringValue?: string | undefined;
+  readonly BinaryValue?: Uint8Array | undefined;
+  readonly StringListValues?: readonly string[] | undefined;
+  readonly BinaryListValues?: readonly Uint8Array[] | undefined;
+}
+
+/**
+ * Message attributes as a request carries them.
+ */
+export type SimSqsMessageAttributeInput = Readonly<
+  Record<string, SimSqsMessageAttributeValue | undefined>
+>;

--- a/src/service/sqs/message/sim-sqs-message-attribute.ts
+++ b/src/service/sqs/message/sim-sqs-message-attribute.ts
@@ -1,0 +1,81 @@
+import type { SimSqsMessageAttributePayload } from "./sim-sqs-message-attribute-payload.js";
+import {
+  assertUsableAttributeName,
+  assertUsableDataType,
+  attributePayload,
+} from "./sim-sqs-message-attribute-rules.js";
+import type { SimSqsMessageAttributeValue } from "./sim-sqs-message-attribute-value.js";
+
+const lengthPrefixBytes = 4;
+
+/**
+ * One digest field: a four byte big-endian length, then the bytes themselves.
+ */
+function lengthPrefixed(bytes: Buffer): Buffer {
+  const length = Buffer.alloc(lengthPrefixBytes);
+
+  length.writeUInt32BE(bytes.length);
+
+  return Buffer.concat([length, bytes]);
+}
+
+/**
+ * One validated message attribute.
+ */
+export class SimSqsMessageAttribute {
+  public readonly name: string;
+  public readonly dataType: string;
+
+  private readonly payload: SimSqsMessageAttributePayload;
+
+  private constructor(
+    name: string,
+    dataType: string,
+    payload: SimSqsMessageAttributePayload,
+  ) {
+    this.name = name;
+    this.dataType = dataType;
+    this.payload = payload;
+  }
+
+  /**
+   * Read one message attribute, refusing one real SQS would refuse.
+   */
+  static of(
+    name: string,
+    value: SimSqsMessageAttributeValue,
+  ): SimSqsMessageAttribute {
+    assertUsableAttributeName(name);
+
+    const dataType = value.DataType ?? "";
+
+    assertUsableDataType(name, dataType);
+
+    return new this(name, dataType, attributePayload(name, dataType, value));
+  }
+
+  /**
+   * This attribute as SQS reports it in a response.
+   */
+  reported(): SimSqsMessageAttributeValue {
+    return this.payload.reported(this.dataType);
+  }
+
+  /**
+   * The bytes this attribute contributes to a message attribute digest.
+   *
+   * Real SQS digests message attributes in a defined encoding: the name, then the
+   * data type, each as a big-endian length followed by its UTF-8 bytes, then a
+   * byte saying whether the value travels as text or as bytes, then the value in
+   * the same length-prefixed form. Reproducing it is what makes
+   * `MD5OfMessageAttributes` a digest a caller can check rather than a token.
+   */
+  digestBytes(): Buffer {
+    return Buffer.concat([
+      lengthPrefixed(Buffer.from(this.name, "utf8")),
+      lengthPrefixed(Buffer.from(this.dataType, "utf8")),
+      Buffer.of(this.payload.transportType),
+      lengthPrefixed(this.payload.bytes),
+    ]);
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-attributes.iso.test.ts
+++ b/src/service/sqs/message/sim-sqs-message-attributes.iso.test.ts
@@ -144,6 +144,54 @@ describe("SQS message attributes", () => {
     assertUndefined(received.Messages?.[0]?.MD5OfMessageAttributes);
   });
 
+  it("keeps a binary attribute clear of the arrays either side of it", async () => {
+    // Given a queue and a binary attribute value the sender still holds.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    const payload = new Uint8Array([1, 2, 3]);
+
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          payload: { DataType: "Binary", BinaryValue: payload },
+        },
+      }),
+    );
+
+    // When the sender mutates its own array afterwards, and a consumer mutates
+    // the one it is given.
+    payload[0] = 9;
+
+    const first = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["All"],
+        VisibilityTimeout: 0,
+      }),
+    );
+    const received = first.Messages?.[0]?.MessageAttributes?.["payload"];
+
+    assertNonNullable(received?.BinaryValue);
+    received.BinaryValue[1] = 9;
+
+    // Then the message still carries the bytes it was sent with.
+    const again = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+
+    assertArrayEquals(
+      [
+        ...(again.Messages?.[0]?.MessageAttributes?.["payload"]?.BinaryValue ??
+          []),
+      ],
+      [1, 2, 3],
+    );
+  });
+
   it("refuses an attribute name real SQS would refuse", async () => {
     // Given a queue.
     const { simAws, queueUrl } = await simAwsWithQueue();

--- a/src/service/sqs/message/sim-sqs-message-attributes.iso.test.ts
+++ b/src/service/sqs/message/sim-sqs-message-attributes.iso.test.ts
@@ -1,0 +1,329 @@
+import { ReceiveMessageCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+} from "../error/sim-sqs.error.js";
+import { simAwsWithQueue } from "../../../../test/sqs/queue-fixture.js";
+
+describe("SQS message attributes", () => {
+  it("round-trips string, number and binary attributes with their digest", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a message carrying one attribute of each kind is sent and received.
+    const sent = await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+          attempt: { DataType: "Number", StringValue: "2" },
+          payload: {
+            DataType: "Binary",
+            BinaryValue: new Uint8Array([1, 2, 3]),
+          },
+        },
+      }),
+    );
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+
+    // Then every attribute comes back as it was sent, under the same digest.
+    const message = received.Messages?.[0];
+
+    assertNonNullable(message?.MessageAttributes);
+    assertIdentical(message.MessageAttributes["tenant"]?.StringValue, "acme");
+    assertIdentical(message.MessageAttributes["attempt"]?.DataType, "Number");
+    assertArrayEquals(
+      [...(message.MessageAttributes["payload"]?.BinaryValue ?? [])],
+      [1, 2, 3],
+    );
+    assertIdentical(
+      message.MD5OfMessageAttributes,
+      sent.MD5OfMessageAttributes,
+    );
+  });
+
+  it("selects the attributes a receive request asks for by prefix", async () => {
+    // Given a queue holding a message with two prefixed attributes and one other.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          "app.tenant": { DataType: "String", StringValue: "acme" },
+          "app.attempt": { DataType: "Number", StringValue: "2" },
+          other: { DataType: "String", StringValue: "no" },
+        },
+      }),
+    );
+
+    // When the prefix is asked for.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["app.*"],
+      }),
+    );
+
+    // Then only the matching attributes come back.
+    const attributes = received.Messages?.[0]?.MessageAttributes;
+
+    assertNonNullable(attributes);
+    assertArrayEquals(
+      Object.keys(attributes).toSorted((one, other) =>
+        one.localeCompare(other),
+      ),
+      ["app.attempt", "app.tenant"],
+    );
+  });
+
+  it("selects one attribute by name", async () => {
+    // Given a queue holding a message with two attributes.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+          attempt: { DataType: "Number", StringValue: "2" },
+        },
+      }),
+    );
+
+    // When one of them is asked for by name.
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MessageAttributeNames: ["tenant"],
+      }),
+    );
+
+    // Then that is the only one that comes back.
+    const attributes = received.Messages?.[0]?.MessageAttributes;
+
+    assertNonNullable(attributes);
+    assertArrayEquals(Object.keys(attributes), ["tenant"]);
+  });
+
+  it("returns none when a receive request asks for none", async () => {
+    // Given a queue holding a message with an attribute.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    // When it is received without naming any attribute.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then none come back, as real SQS returns none.
+    assertUndefined(received.Messages?.[0]?.MessageAttributes);
+    assertUndefined(received.Messages?.[0]?.MD5OfMessageAttributes);
+  });
+
+  it("refuses an attribute name real SQS would refuse", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute name uses a reserved prefix.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            "AWS.tenant": { DataType: "String", StringValue: "acme" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses an attribute name with a disallowed character", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute name has a space in it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            "tenant name": { DataType: "String", StringValue: "acme" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses an attribute name with two periods in succession", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute name has a double period in it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            "app..tenant": { DataType: "String", StringValue: "acme" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a data type that is not one of the three SQS has", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute declares its own data type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            tenant: { DataType: "Text", StringValue: "acme" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses an attribute with no data type at all", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute declares no data type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage({
+        input: {
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: { tenant: { StringValue: "acme" } },
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("accepts a custom label on one of the three data types", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute labels its string type.
+    const sent = await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          tenant: { DataType: "String.tenantId", StringValue: "acme" },
+        },
+      }),
+    );
+
+    // Then it is accepted, as real SQS accepts it.
+    assertNonNullable(sent.MD5OfMessageAttributes);
+  });
+
+  it("refuses a value that does not match its data type", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a binary attribute carries a string value.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            payload: { DataType: "Binary", StringValue: "acme" },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a string attribute with no value", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a string attribute carries nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: { tenant: { DataType: "String" } },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses list values, which real SQS refuses too", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When an attribute carries a list of values.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+          MessageAttributes: {
+            tenants: { DataType: "String", StringListValues: ["acme"] },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsUnsupportedOperation);
+  });
+});

--- a/src/service/sqs/message/sim-sqs-message-attributes.ts
+++ b/src/service/sqs/message/sim-sqs-message-attributes.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+import { SimSqsMessageAttribute } from "./sim-sqs-message-attribute.js";
+import type {
+  SimSqsMessageAttributeInput,
+  SimSqsMessageAttributeValue,
+} from "./sim-sqs-message-attribute-value.js";
+
+const everyAttributeSelectors = new Set(["All", ".*"]);
+
+const prefixSelectorSuffix = ".*";
+
+/**
+ * The message attributes of one message.
+ *
+ * Attributes are digested and reported as a set rather than one at a time,
+ * because both are properties of the set: the digest covers the attributes in
+ * name order, and a receive request selects a subset of them.
+ */
+export class SimSqsMessageAttributes {
+  private readonly attributes: readonly SimSqsMessageAttribute[];
+
+  private constructor(attributes: readonly SimSqsMessageAttribute[]) {
+    this.attributes = attributes;
+  }
+
+  /**
+   * Read the message attributes of a request, refusing any real SQS would
+   * refuse.
+   */
+  static of(
+    input: SimSqsMessageAttributeInput | undefined,
+  ): SimSqsMessageAttributes {
+    const attributes = Object.entries(input ?? {})
+      .filter(
+        (entry): entry is [string, SimSqsMessageAttributeValue] =>
+          entry[1] !== undefined,
+      )
+      .map(([name, value]) => SimSqsMessageAttribute.of(name, value));
+
+    return new this(attributes);
+  }
+
+  /**
+   * Whether there are no attributes here, in which case SQS reports neither the
+   * attributes nor their digest.
+   */
+  get isEmpty(): boolean {
+    return this.attributes.length === 0;
+  }
+
+  /**
+   * The MD5 digest of these attributes, as SQS reports it.
+   */
+  digest(): string {
+    const digested = Buffer.concat(
+      this.attributes
+        .toSorted((one, other) => one.name.localeCompare(other.name))
+        .map((attribute) => attribute.digestBytes()),
+    );
+
+    return createHash("md5").update(digested).digest("hex");
+  }
+
+  /**
+   * These attributes as SQS reports them in a response.
+   */
+  reported(): Record<string, SimSqsMessageAttributeValue> {
+    return Object.fromEntries(
+      this.attributes.map((attribute) => [
+        attribute.name,
+        attribute.reported(),
+      ]),
+    );
+  }
+
+  /**
+   * The attributes a receive request asked for.
+   *
+   * Real SQS returns no message attributes unless they are named, so a consumer
+   * that forgot to ask for them gets none here too. `All` and `.*` select every
+   * attribute, a bare name selects that one, and a name ending in `.*` selects
+   * every attribute with that prefix.
+   */
+  selected(names: readonly string[] | undefined): SimSqsMessageAttributes {
+    if (names === undefined || names.length === 0) {
+      return new SimSqsMessageAttributes([]);
+    }
+
+    if (names.some((name) => everyAttributeSelectors.has(name))) {
+      return this;
+    }
+
+    return new SimSqsMessageAttributes(
+      this.attributes.filter((attribute) =>
+        names.some((name) => selects(name, attribute.name)),
+      ),
+    );
+  }
+}
+
+/**
+ * Whether one requested attribute name selects an attribute.
+ */
+function selects(requested: string, attributeName: string): boolean {
+  if (requested.endsWith(prefixSelectorSuffix)) {
+    return attributeName.startsWith(
+      requested.slice(0, -prefixSelectorSuffix.length),
+    );
+  }
+
+  return requested === attributeName;
+}

--- a/src/service/sqs/message/sim-sqs-message-attributes.ts
+++ b/src/service/sqs/message/sim-sqs-message-attributes.ts
@@ -50,11 +50,15 @@ export class SimSqsMessageAttributes {
 
   /**
    * The MD5 digest of these attributes, as SQS reports it.
+   *
+   * The names are ordered by their code units rather than by a locale, because
+   * the order decides the digest. A locale-aware comparison sorts mixed-case
+   * names differently from AWS, and differently on different machines.
    */
   digest(): string {
     const digested = Buffer.concat(
       this.attributes
-        .toSorted((one, other) => one.name.localeCompare(other.name))
+        .toSorted(byName)
         .map((attribute) => attribute.digestBytes()),
     );
 
@@ -96,6 +100,21 @@ export class SimSqsMessageAttributes {
       ),
     );
   }
+}
+
+/**
+ * Order two attributes by name, comparing code units rather than by locale.
+ */
+function byName(
+  one: SimSqsMessageAttribute,
+  other: SimSqsMessageAttribute,
+): number {
+  // Attribute names within one message are unique, so there is no equal case.
+  if (one.name < other.name) {
+    return -1;
+  }
+
+  return 1;
 }
 
 /**

--- a/src/service/sqs/message/sim-sqs-message-body.ts
+++ b/src/service/sqs/message/sim-sqs-message-body.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import {
+  SimSqsInvalidMessageContents,
+  SimSqsInvalidParameterValue,
+} from "../error/sim-sqs.error.js";
+
+const allowedControlCharacters = new Set([0x9, 0xa, 0xd]);
+const space = 0x20;
+const beforeSurrogates = 0xd7_ff;
+const afterSurrogates = 0xe0_00;
+const lastAllowedBmp = 0xff_fd;
+const firstSupplementary = 0x1_00_00;
+const lastSupplementary = 0x10_ff_ff;
+
+/**
+ * Whether a code point is one real SQS allows in a message body.
+ *
+ * The allowed set is tab, newline, carriage return, and the Unicode ranges
+ * either side of the surrogate block. Anything else, a control character or a
+ * lone surrogate, is refused rather than sent.
+ */
+function isAllowedInBody(codePoint: number): boolean {
+  if (allowedControlCharacters.has(codePoint)) {
+    return true;
+  }
+
+  return (
+    (codePoint >= space && codePoint <= beforeSurrogates) ||
+    (codePoint >= afterSurrogates && codePoint <= lastAllowedBmp) ||
+    (codePoint >= firstSupplementary && codePoint <= lastSupplementary)
+  );
+}
+
+/**
+ * One message body, with the digest a sender checks it by.
+ *
+ * The digest is a real MD5 of the body, as real SQS reports, because that is the
+ * whole point of it: a sender comparing `MD5OfMessageBody` against its own
+ * digest either finds the body it sent or finds a bug, and a made-up value would
+ * tell it nothing.
+ */
+export class SimSqsMessageBody {
+  public readonly value: string;
+  public readonly digest: string;
+
+  private constructor(value: string) {
+    this.value = value;
+    this.digest = createHash("md5").update(value, "utf8").digest("hex");
+  }
+
+  /**
+   * Read a message body, refusing one real SQS would refuse.
+   */
+  static of(value: string, maximumBytes: number): SimSqsMessageBody {
+    if (value === "") {
+      throw new SimSqsInvalidParameterValue(
+        "The request must contain the parameter MessageBody",
+      );
+    }
+
+    const byteLength = Buffer.byteLength(value, "utf8");
+
+    if (byteLength > maximumBytes) {
+      throw new SimSqsInvalidParameterValue(
+        `One or more parameters are invalid. Reason: Message must be shorter ` +
+          `than ${String(maximumBytes)} bytes, and this one is ` +
+          `${String(byteLength)} bytes.`,
+      );
+    }
+
+    // Iterating a string yields whole code points, so a surrogate pair is one
+    // character here rather than two unpaired halves.
+    for (const character of value) {
+      const codePoint = character.codePointAt(0);
+
+      assertDefined(codePoint, "Every character has a first code point");
+
+      if (!isAllowedInBody(codePoint)) {
+        throw new SimSqsInvalidMessageContents(
+          "The message contains characters outside the allowed set",
+        );
+      }
+    }
+
+    return new this(value);
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-store.ts
+++ b/src/service/sqs/message/sim-sqs-message-store.ts
@@ -1,0 +1,96 @@
+import type { SimSqsMessage } from "./sim-sqs-message.js";
+
+/**
+ * How many messages a queue holds in each of the states SQS counts separately.
+ */
+export interface SimSqsMessageCounts {
+  readonly visible: number;
+  readonly inFlight: number;
+  readonly delayed: number;
+}
+
+/**
+ * The messages of one simulated queue, and the receipt handles it has issued.
+ *
+ * Handles are kept here rather than on the messages because a handle outlives
+ * the message it names: a consumer deleting an already deleted message is
+ * accepted by real SQS, and a handle the queue never issued is not. Only a store
+ * of what has been issued can tell those two apart.
+ */
+export class SimSqsMessageStore {
+  private messages: readonly SimSqsMessage[] = [];
+  private readonly handles = new Map<string, SimSqsMessage>();
+
+  /**
+   * Take a newly sent message.
+   */
+  add(message: SimSqsMessage): void {
+    this.messages = [...this.messages, message];
+  }
+
+  /**
+   * Forget the messages whose retention period has run out.
+   *
+   * Real SQS drops a message once it has been on the queue longer than the
+   * retention period, so advancing simulated time past it loses the message here
+   * too rather than keeping it forever.
+   */
+  dropExpired(instant: Date, retentionSeconds: number): void {
+    this.messages = this.messages.filter(
+      (message) => !message.hasExpiredBy(instant, retentionSeconds),
+    );
+  }
+
+  /**
+   * The messages that can be received at an instant, oldest first.
+   */
+  receivable(instant: Date, limit: number): readonly SimSqsMessage[] {
+    return this.messages
+      .filter((message) => message.isVisibleAt(instant))
+      .slice(0, limit);
+  }
+
+  /**
+   * Record that a message was handed out under a receipt handle.
+   */
+  recordHandle(receiptHandle: string, message: SimSqsMessage): void {
+    this.handles.set(receiptHandle, message);
+  }
+
+  /**
+   * The message a receipt handle names, or undefined for a handle this queue
+   * never issued.
+   */
+  forHandle(receiptHandle: string): SimSqsMessage | undefined {
+    return this.handles.get(receiptHandle);
+  }
+
+  /**
+   * Forget a deleted message.
+   */
+  remove(message: SimSqsMessage): void {
+    this.messages = this.messages.filter((held) => held !== message);
+  }
+
+  /**
+   * Forget every message, as PurgeQueue does.
+   */
+  purge(): void {
+    this.messages = [];
+  }
+
+  /**
+   * How many messages are in each state at an instant.
+   */
+  countsAt(instant: Date): SimSqsMessageCounts {
+    return {
+      visible: this.countWhere((message) => message.isVisibleAt(instant)),
+      inFlight: this.countWhere((message) => message.isInFlightAt(instant)),
+      delayed: this.countWhere((message) => message.isDelayedAt(instant)),
+    };
+  }
+
+  private countWhere(matches: (message: SimSqsMessage) => boolean): number {
+    return this.messages.filter((message) => matches(message)).length;
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-system-attributes.ts
+++ b/src/service/sqs/message/sim-sqs-message-system-attributes.ts
@@ -20,6 +20,7 @@ const knownNames = new Set<string>([
   "SenderId",
   "SentTimestamp",
   "SequenceNumber",
+  "SqsManagedSseEnabled",
 ]);
 
 /**

--- a/src/service/sqs/message/sim-sqs-message-system-attributes.ts
+++ b/src/service/sqs/message/sim-sqs-message-system-attributes.ts
@@ -1,0 +1,91 @@
+import { SimSqsInvalidAttributeName } from "../error/sim-sqs.error.js";
+
+const everySelector = "All";
+
+/**
+ * The message system attribute names real SQS accepts on a receive request.
+ *
+ * The FIFO ones and the tracing one are here because asking for them is valid:
+ * real SQS leaves an attribute out when the message has no value for it, so a
+ * request naming `MessageGroupId` on a standard queue gets silence rather than a
+ * failure. A name that is not an SQS attribute at all is refused.
+ */
+const knownNames = new Set<string>([
+  "ApproximateFirstReceiveTimestamp",
+  "ApproximateReceiveCount",
+  "AWSTraceHeader",
+  "DeadLetterQueueSourceArn",
+  "MessageDeduplicationId",
+  "MessageGroupId",
+  "SenderId",
+  "SentTimestamp",
+  "SequenceNumber",
+]);
+
+/**
+ * The message system attributes one receive request asked for.
+ *
+ * Real SQS returns none of them unless they are named, so a consumer relying on
+ * `ApproximateReceiveCount` has to ask for it. Reporting them unasked would let
+ * a test read a value that would be missing on AWS.
+ */
+export class SimSqsRequestedSystemAttributes {
+  private readonly names: readonly string[];
+
+  private constructor(names: readonly string[]) {
+    this.names = names;
+  }
+
+  /**
+   * Read the attribute names a receive request asked for, refusing a name real
+   * SQS has no such attribute for.
+   *
+   * `MessageSystemAttributeNames` and the deprecated `AttributeNames` mean the
+   * same thing, so both are gathered here.
+   */
+  static of(
+    ...requested: readonly (readonly string[] | undefined)[]
+  ): SimSqsRequestedSystemAttributes {
+    const names = requested.flatMap((group) => group ?? []);
+
+    for (const name of names) {
+      if (name !== everySelector && !knownNames.has(name)) {
+        throw new SimSqsInvalidAttributeName(
+          `Unknown Attribute ${name}: it is not an SQS message system ` +
+            `attribute name`,
+        );
+      }
+    }
+
+    return new this(names);
+  }
+
+  /**
+   * Pick the requested attributes out of the ones a message has.
+   *
+   * Undefined means the response carries no `Attributes` at all, which is what
+   * real SQS sends when nothing was asked for.
+   */
+  from(
+    available: ReadonlyMap<string, string>,
+  ): Record<string, string> | undefined {
+    if (this.names.length === 0) {
+      return undefined;
+    }
+
+    const selected = available
+      .entries()
+      .filter(([name]) => this.selects(name))
+      .toArray();
+
+    if (selected.length === 0) {
+      return undefined;
+    }
+
+    return Object.fromEntries(selected);
+  }
+
+  private selects(name: string): boolean {
+    return this.names.includes(everySelector) || this.names.includes(name);
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-visibility.ts
+++ b/src/service/sqs/message/sim-sqs-message-visibility.ts
@@ -1,0 +1,88 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * Whether one message can be received, and when it next can be.
+ *
+ * This is held as the instant the message becomes receivable rather than as a
+ * timer. That is what makes a visibility timeout something a test can advance the
+ * simulation clock past: nothing has to fire for a message to come back, it
+ * simply becomes visible again once simulated time reaches the instant it was
+ * hidden until.
+ *
+ * A delay works the same way. A message sent with a delay is invisible from the
+ * moment it arrives, and the only difference from an in-flight message is that it
+ * has never been received.
+ */
+export class SimSqsMessageVisibility {
+  private visibleFrom: Date;
+  private receives = 0;
+  private firstReceivedAt: Date | undefined;
+
+  constructor(visibleFrom: Date) {
+    this.visibleFrom = visibleFrom;
+  }
+
+  /**
+   * How many times the message has been handed out and not deleted.
+   */
+  get receiveCount(): number {
+    return this.receives;
+  }
+
+  /**
+   * When the message was first handed out.
+   *
+   * Only a message being handed out reports its attributes, and handing one out
+   * is what sets the first receive, so there is always one to report by then.
+   */
+  get firstReceived(): Date {
+    assertDefined(
+      this.firstReceivedAt,
+      "A message reports its first receive once it has been received",
+    );
+
+    return this.firstReceivedAt;
+  }
+
+  /**
+   * Whether the message can be received at an instant.
+   */
+  isVisibleAt(instant: Date): boolean {
+    return this.visibleFrom.getTime() <= instant.getTime();
+  }
+
+  /**
+   * Whether the message is still waiting out the delay it was sent with.
+   */
+  isDelayedAt(instant: Date): boolean {
+    return this.receives === 0 && !this.isVisibleAt(instant);
+  }
+
+  /**
+   * Whether the message is hidden by a visibility timeout, which SQS counts as
+   * in flight.
+   */
+  isInFlightAt(instant: Date): boolean {
+    return this.receives > 0 && !this.isVisibleAt(instant);
+  }
+
+  /**
+   * Record a receive, and hide the message for its visibility timeout.
+   */
+  receiveAt(instant: Date, visibilityTimeoutSeconds: number): void {
+    this.receives += 1;
+    this.firstReceivedAt ??= instant;
+    this.hideFor(instant, visibilityTimeoutSeconds);
+  }
+
+  /**
+   * Hide the message for a visibility timeout starting at an instant.
+   */
+  hideFor(instant: Date, visibilityTimeoutSeconds: number): void {
+    this.visibleFrom = new Date(
+      instant.getTime() + visibilityTimeoutSeconds * millisecondsPerSecond,
+    );
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message-writer.ts
+++ b/src/service/sqs/message/sim-sqs-message-writer.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimSqsInvalidParameterValue } from "../error/sim-sqs.error.js";
+import type { SimSqsQueue } from "../queue/sim-sqs-queue.js";
+import { SimSqsMessage } from "./sim-sqs-message.js";
+import type { SimSqsMessageAttributes } from "./sim-sqs-message-attributes.js";
+import { SimSqsMessageBody } from "./sim-sqs-message-body.js";
+
+const maximumDelaySeconds = 900;
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * One message as a sender describes it, with the request's own wrapping removed.
+ */
+export interface SimSqsMessageWrite {
+  readonly body: string | undefined;
+  readonly attributes: SimSqsMessageAttributes;
+  readonly delaySeconds: number | undefined;
+}
+
+interface SimSqsMessageWriterProperties {
+  readonly clock: BackgroundScheduler;
+}
+
+/**
+ * Puts a message on a queue.
+ *
+ * SendMessage and each entry of SendMessageBatch end up here, so the two cannot
+ * drift apart on what a delay means, on how large a body may be, or on what a
+ * message id looks like. The queue's own attributes decide all three, which is
+ * why the queue comes in with the write rather than being consulted by the
+ * caller.
+ */
+export class SimSqsMessageWriter {
+  private readonly clock: BackgroundScheduler;
+
+  constructor(properties: SimSqsMessageWriterProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Write one message to a queue, and hand back what was written.
+   */
+  write(queue: SimSqsQueue, requested: SimSqsMessageWrite): SimSqsMessage {
+    const sentAt = this.clock.now();
+    const delaySeconds = this.delayFor(queue, requested.delaySeconds);
+    const message = new SimSqsMessage({
+      messageId: randomUUID(),
+      body: SimSqsMessageBody.of(
+        requested.body ?? "",
+        queue.attributes.maximumMessageSizeBytes,
+      ),
+      attributes: requested.attributes,
+      sentAt,
+      visibleFrom: new Date(
+        sentAt.getTime() + delaySeconds * millisecondsPerSecond,
+      ),
+    });
+
+    queue.add(message);
+
+    return message;
+  }
+
+  /**
+   * The delay a message waits out before it can be received.
+   *
+   * A message with no delay of its own takes the queue's, which is what makes
+   * `DelaySeconds` on the queue a delay every message inherits.
+   */
+  private delayFor(queue: SimSqsQueue, requested: number | undefined): number {
+    if (requested === undefined) {
+      return queue.attributes.delaySeconds;
+    }
+
+    if (
+      !Number.isSafeInteger(requested) ||
+      requested < 0 ||
+      requested > maximumDelaySeconds
+    ) {
+      throw new SimSqsInvalidParameterValue(
+        `Value ${String(requested)} for parameter DelaySeconds is invalid. ` +
+          `Reason: Must be an integer from 0 to ${String(maximumDelaySeconds)}.`,
+      );
+    }
+
+    return requested;
+  }
+}

--- a/src/service/sqs/message/sim-sqs-message.ts
+++ b/src/service/sqs/message/sim-sqs-message.ts
@@ -1,0 +1,118 @@
+import type { SimSqsMessageAttributes } from "./sim-sqs-message-attributes.js";
+import type { SimSqsMessageBody } from "./sim-sqs-message-body.js";
+import { SimSqsMessageVisibility } from "./sim-sqs-message-visibility.js";
+
+const millisecondsPerSecond = 1000;
+
+interface SimSqsMessageProperties {
+  readonly messageId: string;
+  readonly body: SimSqsMessageBody;
+  readonly attributes: SimSqsMessageAttributes;
+  readonly sentAt: Date;
+  readonly visibleFrom: Date;
+}
+
+/**
+ * One message on a simulated queue.
+ *
+ * What the message is stays here; whether it can be received belongs to its
+ * visibility, which is the part that changes as it is handed out and given back.
+ */
+export class SimSqsMessage {
+  public readonly messageId: string;
+  public readonly body: SimSqsMessageBody;
+  public readonly attributes: SimSqsMessageAttributes;
+  public readonly sentAt: Date;
+
+  private readonly visibility: SimSqsMessageVisibility;
+  private receiptHandle: string | undefined;
+
+  constructor(properties: SimSqsMessageProperties) {
+    this.messageId = properties.messageId;
+    this.body = properties.body;
+    this.attributes = properties.attributes;
+    this.sentAt = properties.sentAt;
+    this.visibility = new SimSqsMessageVisibility(properties.visibleFrom);
+  }
+
+  /**
+   * Whether this message can be received at an instant.
+   */
+  isVisibleAt(instant: Date): boolean {
+    return this.visibility.isVisibleAt(instant);
+  }
+
+  /**
+   * Whether this message is still waiting out the delay it was sent with.
+   */
+  isDelayedAt(instant: Date): boolean {
+    return this.visibility.isDelayedAt(instant);
+  }
+
+  /**
+   * Whether this message is hidden by a visibility timeout, which SQS counts as
+   * in flight.
+   */
+  isInFlightAt(instant: Date): boolean {
+    return this.visibility.isInFlightAt(instant);
+  }
+
+  /**
+   * Whether the queue's retention period has run out for this message.
+   *
+   * Retention runs from when the message was sent, however many times it has been
+   * received since.
+   */
+  hasExpiredBy(instant: Date, retentionSeconds: number): boolean {
+    return (
+      this.sentAt.getTime() + retentionSeconds * millisecondsPerSecond <=
+      instant.getTime()
+    );
+  }
+
+  /**
+   * Hand this message out, hiding it for its visibility timeout.
+   */
+  receiveAt(
+    instant: Date,
+    visibilityTimeoutSeconds: number,
+    receiptHandle: string,
+  ): void {
+    this.receiptHandle = receiptHandle;
+    this.visibility.receiveAt(instant, visibilityTimeoutSeconds);
+  }
+
+  /**
+   * Hide this message for a visibility timeout starting now.
+   */
+  hideFor(instant: Date, visibilityTimeoutSeconds: number): void {
+    this.visibility.hideFor(instant, visibilityTimeoutSeconds);
+  }
+
+  /**
+   * Whether a receipt handle is the one this message was last received with.
+   *
+   * An older handle is not. Real SQS accepts a request carrying one and does
+   * nothing, because the receive it belongs to has been superseded.
+   */
+  holdsReceiptHandle(receiptHandle: string): boolean {
+    return this.receiptHandle === receiptHandle;
+  }
+
+  /**
+   * The message system attributes SQS knows about this message.
+   *
+   * Only the attributes a receive request names are reported, so this is what is
+   * available rather than what is returned.
+   */
+  systemAttributeValues(): ReadonlyMap<string, string> {
+    return new Map<string, string>([
+      ["SentTimestamp", String(this.sentAt.getTime())],
+      ["ApproximateReceiveCount", String(this.visibility.receiveCount)],
+      [
+        "ApproximateFirstReceiveTimestamp",
+        String(this.visibility.firstReceived.getTime()),
+      ],
+    ]);
+  }
+}

--- a/src/service/sqs/message/sim-sqs-receipt-handle.ts
+++ b/src/service/sqs/message/sim-sqs-receipt-handle.ts
@@ -1,0 +1,15 @@
+import { randomBytes } from "node:crypto";
+
+const handleBytes = 72;
+
+/**
+ * Issue a receipt handle for one receive of one message.
+ *
+ * Real receipt handles are long opaque strings, and a fresh one is issued every
+ * time a message is handed out. Generating something equally opaque here means
+ * nothing can quietly depend on a handle's shape, or on it being the message id,
+ * the way a consumer written against a simpler fake might.
+ */
+export function makeSimSqsReceiptHandle(): string {
+  return randomBytes(handleBytes).toString("base64");
+}

--- a/src/service/sqs/queue/sim-sqs-deleted-queue-names.ts
+++ b/src/service/sqs/queue/sim-sqs-deleted-queue-names.ts
@@ -1,0 +1,54 @@
+import { SimSqsQueueDeletedRecently } from "../error/sim-sqs.error.js";
+
+/**
+ * Real SQS holds a deleted queue's name for 60 seconds before it can be used
+ * again.
+ */
+const nameHoldSeconds = 60;
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * The queue names a deletion is still holding.
+ *
+ * This is the SQS version of a behaviour that bites a redeployed stack: a queue
+ * deleted a moment ago still owns its name, so recreating it fails. The hold is
+ * measured on the simulation's clock, so advancing simulated time past it frees
+ * the name, rather than a test having to wait a real minute.
+ */
+export class SimSqsDeletedQueueNames {
+  private readonly deletedAt = new Map<string, Date>();
+
+  /**
+   * Record that a queue with this name has just been deleted.
+   */
+  record(name: string, instant: Date): void {
+    this.deletedAt.set(name, instant);
+  }
+
+  /**
+   * Refuse a name a recent deletion is still holding.
+   */
+  assertAvailable(name: string, instant: Date): void {
+    const deletion = this.deletedAt.get(name);
+
+    if (deletion === undefined) {
+      return;
+    }
+
+    const heldUntil =
+      deletion.getTime() + nameHoldSeconds * millisecondsPerSecond;
+
+    if (instant.getTime() >= heldUntil) {
+      this.deletedAt.delete(name);
+
+      return;
+    }
+
+    throw new SimSqsQueueDeletedRecently(
+      `You must wait ${String(nameHoldSeconds)} seconds after deleting a ` +
+        `queue before you can create another with the same name. Queue ` +
+        `'${name}' was deleted at ${deletion.toISOString()}.`,
+    );
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-arn.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-arn.ts
@@ -1,0 +1,67 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimSqsQueueName } from "./sim-sqs-queue-name.js";
+
+/**
+ * The part of a queue ARN that comes before the queue's own name.
+ *
+ * A queue ARN has no resource type separator, so the name follows the account
+ * id directly. That is why `parseSimArn` cannot read one, and why an IAM policy
+ * resource for a queue is `arn:aws:sqs:region:account:name` rather than
+ * anything with a `queue/` in it.
+ */
+export function sqsQueueArnPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `arn:aws:sqs:${regionName}:${accountId}:`;
+}
+
+/**
+ * The resource an operation naming no particular queue authorizes against.
+ *
+ * Real SQS gives ListQueues no queue-level permission, so a policy allowing it
+ * names every queue in the account and region rather than one of them.
+ */
+export function sqsAnyQueueArn(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  return `${sqsQueueArnPrefix(accountRegionScope)}*`;
+}
+
+/**
+ * The part of a queue URL that comes before the queue's own name.
+ */
+export function sqsQueueUrlPrefix(
+  accountRegionScope: SimAwsAccountRegionScope,
+): string {
+  const { regionName, accountId } = accountRegionScope;
+
+  return `https://sqs.${regionName}.amazonaws.com/${accountId}/`;
+}
+
+interface SimSqsQueueArnProperties {
+  readonly name: SimSqsQueueName;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The ARN and URL of one simulated queue.
+ *
+ * The two travel together because they carry the same three facts, the region,
+ * the account and the name, in two formats: SDK requests name a queue by URL
+ * and IAM policies name it by ARN. Building both here keeps them in step.
+ */
+export class SimSqsQueueArn {
+  public readonly name: string;
+  public readonly value: string;
+  public readonly url: string;
+
+  constructor(properties: SimSqsQueueArnProperties) {
+    const { name, accountRegionScope } = properties;
+
+    this.name = name.value;
+    this.value = sqsQueueArnPrefix(accountRegionScope) + name.value;
+    this.url = sqsQueueUrlPrefix(accountRegionScope) + name.value;
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
@@ -1,0 +1,110 @@
+import {
+  SimSqsInvalidAttributeName,
+  SimSqsUnsupportedOperation,
+} from "../error/sim-sqs.error.js";
+import {
+  type SimSqsQueueAttributeSpec,
+  simSqsSettableQueueAttributes,
+} from "./sim-sqs-queue-attribute-specs.js";
+
+/**
+ * The attributes SQS reports and no request sets, because the queue itself
+ * decides them.
+ */
+const readOnlyNames: ReadonlySet<string> = new Set([
+  "ApproximateNumberOfMessages",
+  "ApproximateNumberOfMessagesDelayed",
+  "ApproximateNumberOfMessagesNotVisible",
+  "CreatedTimestamp",
+  "LastModifiedTimestamp",
+  "QueueArn",
+]);
+
+/**
+ * Real SQS attributes this simulation does not model. A request setting one is
+ * refused rather than quietly ignored, since a queue behaving as though it had
+ * a redrive policy it does not have is worse than being told it cannot have one.
+ */
+const unsimulatedNames: ReadonlySet<string> = new Set([
+  "ContentBasedDeduplication",
+  "DeduplicationScope",
+  "FifoQueue",
+  "FifoThroughputLimit",
+  "KmsDataKeyReusePeriodSeconds",
+  "KmsMasterKeyId",
+  "Policy",
+  "RedriveAllowPolicy",
+  "RedrivePolicy",
+  "SqsManagedSseEnabled",
+]);
+
+const knownNames = new Set<string>([
+  ...simSqsSettableQueueAttributes.map((spec) => spec.name),
+  ...readOnlyNames,
+  ...unsimulatedNames,
+]);
+
+const settableSpecsByName = new Map<string, SimSqsQueueAttributeSpec>(
+  simSqsSettableQueueAttributes.map((spec) => [spec.name, spec]),
+);
+
+/**
+ * The queue attribute names, and what each of them may be used for.
+ *
+ * Reading and setting are separate questions. Real SQS leaves an attribute out
+ * of a GetQueueAttributes response when the queue has no value for it, so
+ * asking for an attribute this simulation does not model is answered with
+ * silence rather than a failure. Setting one is refused, because a request that
+ * appeared to succeed would leave the queue behaving differently here than on
+ * AWS.
+ */
+export const SimSqsQueueAttributeNames = {
+  /**
+   * The attributes a CreateQueue or SetQueueAttributes request may set.
+   */
+  get settable(): readonly SimSqsQueueAttributeSpec[] {
+    return simSqsSettableQueueAttributes;
+  },
+
+  /**
+   * Ensure an attribute name is one real SQS reports.
+   */
+  assertReadable(name: string): void {
+    if (name === "All" || knownNames.has(name)) {
+      return;
+    }
+
+    throw new SimSqsInvalidAttributeName(
+      `Unknown Attribute ${name}: it is not an SQS queue attribute name`,
+    );
+  },
+
+  /**
+   * Get the spec for an attribute a request is setting, refusing one that
+   * cannot be set.
+   */
+  specForSetting(name: string): SimSqsQueueAttributeSpec {
+    const spec = settableSpecsByName.get(name);
+
+    if (spec !== undefined) {
+      return spec;
+    }
+
+    if (unsimulatedNames.has(name)) {
+      throw new SimSqsUnsupportedOperation(
+        `Queue attribute ${name} is a real SQS attribute that simulated SQS ` +
+          `does not simulate, so setting it is refused rather than ignored`,
+      );
+    }
+
+    if (readOnlyNames.has(name)) {
+      throw new SimSqsInvalidAttributeName(
+        `Unknown Attribute ${name}: it is reported by SQS rather than set`,
+      );
+    }
+
+    throw new SimSqsInvalidAttributeName(
+      `Unknown Attribute ${name}: it is not an SQS queue attribute name`,
+    );
+  },
+};

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
@@ -1,0 +1,42 @@
+/**
+ * One queue attribute a request may set, and the range real SQS accepts for it.
+ */
+export interface SimSqsQueueAttributeSpec {
+  readonly name: string;
+  readonly defaultValue: number;
+  readonly minimum: number;
+  readonly maximum: number;
+}
+
+/**
+ * The queue attributes simulated SQS holds, with the defaults and ranges real SQS
+ * applies to them.
+ */
+export const simSqsSettableQueueAttributes: readonly SimSqsQueueAttributeSpec[] =
+  [
+    { name: "DelaySeconds", defaultValue: 0, minimum: 0, maximum: 900 },
+    {
+      name: "MaximumMessageSize",
+      defaultValue: 262_144,
+      minimum: 1024,
+      maximum: 262_144,
+    },
+    {
+      name: "MessageRetentionPeriod",
+      defaultValue: 345_600,
+      minimum: 60,
+      maximum: 1_209_600,
+    },
+    {
+      name: "ReceiveMessageWaitTimeSeconds",
+      defaultValue: 0,
+      minimum: 0,
+      maximum: 20,
+    },
+    {
+      name: "VisibilityTimeout",
+      defaultValue: 30,
+      minimum: 0,
+      maximum: 43_200,
+    },
+  ];

--- a/src/service/sqs/queue/sim-sqs-queue-attributes.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attributes.ts
@@ -1,0 +1,155 @@
+import { SimSqsInvalidAttributeValue } from "../error/sim-sqs.error.js";
+import { SimSqsQueueAttributeNames } from "./sim-sqs-queue-attribute-names.js";
+import type { SimSqsQueueAttributeSpec } from "./sim-sqs-queue-attribute-specs.js";
+
+/**
+ * Queue attributes as a request carries them: SQS passes every attribute value
+ * as a string, whatever the attribute means.
+ */
+export type SimSqsQueueAttributeInput = Readonly<
+  Record<string, string | undefined>
+>;
+
+const integerPattern = /^-?\d+$/;
+
+/**
+ * Read an attribute value, refusing anything outside the range real SQS
+ * accepts for it.
+ */
+function attributeNumber(
+  spec: SimSqsQueueAttributeSpec,
+  value: string,
+): number {
+  const invalid = new SimSqsInvalidAttributeValue(
+    `Value ${value} for parameter ${spec.name} is invalid. Reason: Must be ` +
+      `an integer from ${String(spec.minimum)} to ${String(spec.maximum)}.`,
+  );
+
+  if (!integerPattern.test(value)) {
+    throw invalid;
+  }
+
+  const parsed = Number(value);
+
+  if (parsed < spec.minimum || parsed > spec.maximum) {
+    throw invalid;
+  }
+
+  return parsed;
+}
+
+/**
+ * The attribute values held by one simulated queue.
+ *
+ * Attributes are held as numbers rather than as the strings a request carries,
+ * because that is what the queue's behaviour is expressed in: a visibility
+ * timeout is an amount of time, and a maximum message size is a number of
+ * bytes. Strings are a wire format, applied on the way in and reported on the
+ * way out.
+ */
+export class SimSqsQueueAttributes {
+  private readonly values: ReadonlyMap<string, number>;
+
+  private constructor(values: ReadonlyMap<string, number>) {
+    this.values = values;
+  }
+
+  /**
+   * The attribute values a queue created with no attributes has.
+   */
+  static defaults(): SimSqsQueueAttributes {
+    return new this(
+      new Map(
+        SimSqsQueueAttributeNames.settable.map((spec) => [
+          spec.name,
+          spec.defaultValue,
+        ]),
+      ),
+    );
+  }
+
+  /** The delay a new message with no delay of its own waits out. */
+  get delaySeconds(): number {
+    return this.numberFor("DelaySeconds");
+  }
+
+  /** The longest message body the queue accepts, in bytes. */
+  get maximumMessageSizeBytes(): number {
+    return this.numberFor("MaximumMessageSize");
+  }
+
+  /** How long a message stays on the queue before SQS drops it. */
+  get messageRetentionSeconds(): number {
+    return this.numberFor("MessageRetentionPeriod");
+  }
+
+  /** How long a received message is hidden from other consumers. */
+  get visibilityTimeoutSeconds(): number {
+    return this.numberFor("VisibilityTimeout");
+  }
+
+  /**
+   * Apply the attribute values a request asks for, leaving the rest as they are.
+   */
+  with(requested: SimSqsQueueAttributeInput): SimSqsQueueAttributes {
+    const values = new Map(this.values);
+
+    for (const [name, value] of definedEntries(requested)) {
+      const spec = SimSqsQueueAttributeNames.specForSetting(name);
+
+      values.set(spec.name, attributeNumber(spec, value));
+    }
+
+    return new SimSqsQueueAttributes(values);
+  }
+
+  /**
+   * Whether every attribute a request names already holds the value it asks for.
+   *
+   * This is the question CreateQueue asks about a name already taken. Only the
+   * attributes in the request are compared, as real SQS compares them, so a
+   * request carrying none matches any existing queue.
+   */
+  matches(requested: SimSqsQueueAttributeInput): boolean {
+    return definedEntries(requested).every(([name, value]) => {
+      const spec = SimSqsQueueAttributeNames.specForSetting(name);
+
+      return this.numberFor(spec.name) === attributeNumber(spec, value);
+    });
+  }
+
+  /**
+   * The attributes as SQS reports them, back in their string form.
+   */
+  reported(): ReadonlyMap<string, string> {
+    return new Map(
+      this.values.entries().map(([name, value]) => [name, String(value)]),
+    );
+  }
+
+  private numberFor(name: string): number {
+    const value = this.values.get(name);
+
+    /* v8 ignore next 3 -- unreachable: every settable attribute is present from
+       construction, and only settable names are ever read. */
+    if (value === undefined) {
+      throw new SimSqsInvalidAttributeValue(`No value for attribute ${name}`);
+    }
+
+    return value;
+  }
+}
+
+/**
+ * The attribute entries a request actually carries.
+ *
+ * An SDK attribute map is a partial record, so an explicitly undefined value is
+ * the absence of an attribute rather than a request to set one.
+ */
+function definedEntries(
+  requested: SimSqsQueueAttributeInput,
+): readonly [string, string][] {
+  return Object.entries(requested).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined,
+  );
+}

--- a/src/service/sqs/queue/sim-sqs-queue-name.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-name.ts
@@ -1,0 +1,63 @@
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsUnsupportedOperation,
+  SimSqsValidationException,
+} from "../error/sim-sqs.error.js";
+
+/**
+ * Real SQS allows alphanumeric characters, hyphens and underscores, up to 80
+ * characters. A FIFO queue name additionally ends in `.fifo`, which is the only
+ * way a period gets into a name.
+ */
+const queueNamePattern = /^[\w-]{1,80}$/;
+
+const fifoSuffix = ".fifo";
+
+/**
+ * The name of one simulated queue.
+ *
+ * The name is the whole identity of a queue: it is the resource part of the
+ * ARN with no type separator in front of it, and the last segment of the queue
+ * URL. Validating it in one place is what keeps a name that works here one
+ * that would work on real AWS.
+ */
+export class SimSqsQueueName {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  /**
+   * Read the queue name a request has to carry.
+   */
+  static required(name: string | undefined): SimSqsQueueName {
+    if (name === undefined || name === "") {
+      throw new SimSqsValidationException("A QueueName is required");
+    }
+
+    return this.of(name);
+  }
+
+  /**
+   * Read a queue name from request input, refusing one real SQS would refuse.
+   */
+  static of(value: string): SimSqsQueueName {
+    if (value.endsWith(fifoSuffix)) {
+      throw new SimSqsUnsupportedOperation(
+        `Queue name '${value}' names a FIFO queue, which simulated SQS does ` +
+          `not support. Only standard queues are simulated.`,
+      );
+    }
+
+    if (!queueNamePattern.test(value)) {
+      throw new SimSqsInvalidParameterValue(
+        `Value '${value}' for parameter QueueName is invalid. Reason: Can ` +
+          `only include alphanumeric characters, hyphens, or underscores. 1 ` +
+          `to 80 in length.`,
+      );
+    }
+
+    return new this(value);
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-store.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-store.ts
@@ -1,0 +1,78 @@
+import { SimSqsQueueDoesNotExist } from "../error/sim-sqs.error.js";
+import { SimSqsDeletedQueueNames } from "./sim-sqs-deleted-queue-names.js";
+import type { SimSqsQueue } from "./sim-sqs-queue.js";
+
+/**
+ * The queues of one simulated SQS scope.
+ *
+ * Queues are keyed by name, which is the whole of their identity: the name is
+ * the resource part of the ARN and the last segment of the URL, and it is unique
+ * within one account and region.
+ */
+export class SimSqsQueueStore {
+  private readonly queues = new Map<string, SimSqsQueue>();
+  private readonly deletedNames = new SimSqsDeletedQueueNames();
+
+  /**
+   * Every queue in this scope, in creation order.
+   */
+  get all(): readonly SimSqsQueue[] {
+    return this.queues.values().toArray();
+  }
+
+  /**
+   * The queues whose names start with a prefix, in creation order.
+   *
+   * No prefix means every queue, as an SQS listing with no prefix lists them all.
+   */
+  withNamePrefix(prefix: string | undefined): readonly SimSqsQueue[] {
+    return this.all.filter((queue) =>
+      queue.name.value.startsWith(prefix ?? ""),
+    );
+  }
+
+  /**
+   * Store a newly created queue.
+   */
+  add(queue: SimSqsQueue): void {
+    this.queues.set(queue.name.value, queue);
+  }
+
+  /**
+   * Find a queue by name.
+   */
+  find(name: string): SimSqsQueue | undefined {
+    return this.queues.get(name);
+  }
+
+  /**
+   * Resolve a queue by name, or refuse.
+   */
+  require(name: string): SimSqsQueue {
+    const found = this.find(name);
+
+    if (found === undefined) {
+      throw new SimSqsQueueDoesNotExist(
+        `The specified queue does not exist: no queue named '${name}' in ` +
+          `this Account and Region`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted queue, holding its name as real SQS holds it.
+   */
+  remove(queue: SimSqsQueue, deletedAt: Date): void {
+    this.queues.delete(queue.name.value);
+    this.deletedNames.record(queue.name.value, deletedAt);
+  }
+
+  /**
+   * Refuse a name a recent deletion is still holding.
+   */
+  assertNameAvailable(name: string, instant: Date): void {
+    this.deletedNames.assertAvailable(name, instant);
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-url.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-url.ts
@@ -1,0 +1,53 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+
+/**
+ * A queue URL is the only way an SDK request names a queue, and it carries the
+ * region and account as well as the name. Real SQS accepts it with or without a
+ * trailing slash; its own documented examples show both.
+ */
+const queueUrlPattern =
+  /^https:\/\/sqs\.(?<region>[a-z\d-]+)\.amazonaws\.com\/(?<accountId>\d{12})\/(?<name>[^/]+)\/?$/;
+
+/**
+ * The three facts a queue URL carries.
+ */
+export interface SimSqsQueueUrlParts {
+  readonly regionName: AwsRegionName;
+  readonly accountId: SimAwsAccountId;
+  readonly name: string;
+}
+
+/**
+ * Reads a queue URL.
+ *
+ * The region and account matter as much as the name. A queue URL naming
+ * another account or region does not reach a local queue that happens to share
+ * a name, so the parts are kept rather than the name alone.
+ */
+export const SimSqsQueueUrl = {
+  /**
+   * Read the parts of a queue URL, or undefined for a value that is not one.
+   */
+  parse(value: string): SimSqsQueueUrlParts | undefined {
+    const groups = queueUrlPattern.exec(value)?.groups;
+
+    if (groups === undefined) {
+      return undefined;
+    }
+
+    const { region, accountId, name } = groups;
+
+    /* v8 ignore next 3 -- unreachable: a match always fills every named group,
+       but the index signature the regex groups come back as cannot say so. */
+    if (region === undefined || accountId === undefined || name === undefined) {
+      return undefined;
+    }
+
+    return {
+      regionName: region as AwsRegionName,
+      accountId: accountId as SimAwsAccountId,
+      name,
+    };
+  },
+};

--- a/src/service/sqs/queue/sim-sqs-queue.ts
+++ b/src/service/sqs/queue/sim-sqs-queue.ts
@@ -1,0 +1,176 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSqsQueueNameExists } from "../error/sim-sqs.error.js";
+import type { SimSqsMessage } from "../message/sim-sqs-message.js";
+import { SimSqsMessageStore } from "../message/sim-sqs-message-store.js";
+import { SimSqsQueueArn } from "./sim-sqs-queue-arn.js";
+import type { SimSqsQueueName } from "./sim-sqs-queue-name.js";
+import type {
+  SimSqsQueueAttributeInput,
+  SimSqsQueueAttributes,
+} from "./sim-sqs-queue-attributes.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * Real SQS reports the two queue timestamps in whole seconds since the epoch,
+ * unlike the message timestamps, which are in milliseconds.
+ */
+function epochSeconds(instant: Date): string {
+  return String(Math.floor(instant.getTime() / millisecondsPerSecond));
+}
+
+interface SimSqsQueueProperties {
+  readonly name: SimSqsQueueName;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly attributes: SimSqsQueueAttributes;
+  readonly createdAt: Date;
+}
+
+/**
+ * One simulated standard queue.
+ *
+ * The queue owns its messages rather than a service-wide message table owning
+ * them, because everything a message does depends on the queue's attributes: how
+ * long it stays hidden once received, how long it is kept, and how big it is
+ * allowed to be. Retention is applied whenever the messages are looked at, so
+ * moving simulated time forward loses the messages AWS would have dropped
+ * instead of holding them indefinitely.
+ */
+export class SimSqsQueue {
+  public readonly name: SimSqsQueueName;
+  public readonly arn: SimSqsQueueArn;
+  public readonly createdAt: Date;
+
+  private readonly messages = new SimSqsMessageStore();
+  private settings: SimSqsQueueAttributes;
+  private lastModifiedAt: Date;
+
+  constructor(properties: SimSqsQueueProperties) {
+    this.name = properties.name;
+    this.arn = new SimSqsQueueArn({
+      name: properties.name,
+      accountRegionScope: properties.accountRegionScope,
+    });
+    this.createdAt = properties.createdAt;
+    this.lastModifiedAt = properties.createdAt;
+    this.settings = properties.attributes;
+  }
+
+  /**
+   * The URL requests name this queue by.
+   */
+  get url(): string {
+    return this.arn.url;
+  }
+
+  /**
+   * This queue's URL, for a request that asked to create it again.
+   *
+   * Real SQS answers a repeated CreateQueue with the URL of the queue already
+   * there when the attributes match, and refuses it when they differ. Only the
+   * attributes the request named are compared.
+   */
+  urlWhenAttributesMatch(requested: SimSqsQueueAttributeInput): string {
+    if (!this.settings.matches(requested)) {
+      throw new SimSqsQueueNameExists(
+        `A queue already exists with the name ${this.name.value} and ` +
+          `different attributes to the ones requested`,
+      );
+    }
+
+    return this.url;
+  }
+
+  /**
+   * The attribute values this queue behaves by.
+   */
+  get attributes(): SimSqsQueueAttributes {
+    return this.settings;
+  }
+
+  /**
+   * Apply the attribute values a request asks for, as SetQueueAttributes does.
+   */
+  applyAttributes(
+    requested: SimSqsQueueAttributeInput,
+    modifiedAt: Date,
+  ): void {
+    this.settings = this.settings.with(requested);
+    this.lastModifiedAt = modifiedAt;
+  }
+
+  /**
+   * Take a newly sent message.
+   */
+  add(message: SimSqsMessage): void {
+    this.messages.add(message);
+  }
+
+  /**
+   * The messages that can be received at an instant, oldest first.
+   */
+  receivable(instant: Date, limit: number): readonly SimSqsMessage[] {
+    this.dropExpired(instant);
+
+    return this.messages.receivable(instant, limit);
+  }
+
+  /**
+   * Record that a message was handed out under a receipt handle.
+   */
+  recordHandle(receiptHandle: string, message: SimSqsMessage): void {
+    this.messages.recordHandle(receiptHandle, message);
+  }
+
+  /**
+   * The message a receipt handle names, or undefined for a handle this queue
+   * never issued.
+   */
+  messageForHandle(
+    receiptHandle: string,
+    instant: Date,
+  ): SimSqsMessage | undefined {
+    this.dropExpired(instant);
+
+    return this.messages.forHandle(receiptHandle);
+  }
+
+  /**
+   * Forget a deleted message.
+   */
+  removeMessage(message: SimSqsMessage): void {
+    this.messages.remove(message);
+  }
+
+  /**
+   * Forget every message on this queue, as PurgeQueue does.
+   */
+  purge(purgedAt: Date): void {
+    this.messages.purge();
+    this.lastModifiedAt = purgedAt;
+  }
+
+  /**
+   * The attributes SQS reports about this queue, including the counts and
+   * timestamps no request can set.
+   */
+  reportedAttributes(instant: Date): ReadonlyMap<string, string> {
+    this.dropExpired(instant);
+
+    const counts = this.messages.countsAt(instant);
+
+    return new Map<string, string>([
+      ...this.settings.reported(),
+      ["ApproximateNumberOfMessages", String(counts.visible)],
+      ["ApproximateNumberOfMessagesDelayed", String(counts.delayed)],
+      ["ApproximateNumberOfMessagesNotVisible", String(counts.inFlight)],
+      ["CreatedTimestamp", epochSeconds(this.createdAt)],
+      ["LastModifiedTimestamp", epochSeconds(this.lastModifiedAt)],
+      ["QueueArn", this.arn.value],
+    ]);
+  }
+
+  private dropExpired(instant: Date): void {
+    this.messages.dropExpired(instant, this.settings.messageRetentionSeconds);
+  }
+}

--- a/src/service/sqs/sdk/sim-sqs-sdk-command-router.iso.test.ts
+++ b/src/service/sqs/sdk/sim-sqs-sdk-command-router.iso.test.ts
@@ -1,0 +1,44 @@
+import { assertArrayIncludesAll, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimSqsSdkCommandRouter", () => {
+  it("names every Command simulated SQS handles", () => {
+    // Given a scoped simulated SQS.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.sqs().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateQueueCommand",
+      "GetQueueUrlCommand",
+      "ListQueuesCommand",
+      "DeleteQueueCommand",
+      "GetQueueAttributesCommand",
+      "SetQueueAttributesCommand",
+      "PurgeQueueCommand",
+      "SendMessageCommand",
+      "SendMessageBatchCommand",
+      "ReceiveMessageCommand",
+      "DeleteMessageCommand",
+      "DeleteMessageBatchCommand",
+      "ChangeMessageVisibilityCommand",
+    ]);
+  });
+
+  it("has no route for a Command it does not handle", () => {
+    // Given a scoped simulated SQS.
+    const simAws = new SimAws();
+
+    // When a Command outside the simulated operations is looked up.
+    const route = simAws
+      .sqs()
+      .sdkCommandRouter()
+      .route("ChangeMessageVisibilityBatchCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});

--- a/src/service/sqs/sdk/sim-sqs-sdk-command-router.ts
+++ b/src/service/sqs/sdk/sim-sqs-sdk-command-router.ts
@@ -1,0 +1,155 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimChangeMessageVisibilityCommand,
+  SimDeleteMessageBatchCommand,
+  SimDeleteMessageCommand,
+} from "../command/message/consume.command.js";
+import type { SimReceiveMessageCommand } from "../command/message/receive.command.js";
+import type {
+  SimSendMessageBatchCommand,
+  SimSendMessageCommand,
+} from "../command/message/send.command.js";
+import type {
+  SimCreateQueueCommand,
+  SimDeleteQueueCommand,
+  SimGetQueueAttributesCommand,
+  SimGetQueueUrlCommand,
+  SimListQueuesCommand,
+  SimPurgeQueueCommand,
+  SimSetQueueAttributesCommand,
+} from "../command/queue/queue.command.js";
+import type { SimSqs } from "../sim-sqs.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated SQS.
+ */
+export class SimSqsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simSqs: SimSqs) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateQueueCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.createQueue(
+            command as SimCreateQueueCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetQueueUrlCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.getQueueUrl(
+            command as SimGetQueueUrlCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListQueuesCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.listQueues(
+            command as SimListQueuesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteQueueCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.deleteQueue(
+            command as SimDeleteQueueCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetQueueAttributesCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.getQueueAttributes(
+            command as SimGetQueueAttributesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SetQueueAttributesCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.setQueueAttributes(
+            command as SimSetQueueAttributesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PurgeQueueCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.purgeQueue(
+            command as SimPurgeQueueCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SendMessageCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.sendMessage(
+            command as SimSendMessageCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "SendMessageBatchCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.sendMessageBatch(
+            command as SimSendMessageBatchCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ReceiveMessageCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.receiveMessage(
+            command as SimReceiveMessageCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteMessageCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.deleteMessage(
+            command as SimDeleteMessageCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteMessageBatchCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.deleteMessageBatch(
+            command as SimDeleteMessageBatchCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ChangeMessageVisibilityCommand",
+        async (command, context): Promise<unknown> =>
+          await simSqs.changeMessageVisibility(
+            command as SimChangeMessageVisibilityCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated SQS can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated SQS supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/sqs/sdk/sim-sqs-sdk-routing.iso.test.ts
+++ b/src/service/sqs/sdk/sim-sqs-sdk-routing.iso.test.ts
@@ -1,0 +1,278 @@
+/* eslint-disable @typescript-eslint/naming-convention -- environment
+   variable names are AWS-shaped rather than code identifiers. */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  ChangeMessageVisibilityCommand,
+  CreateQueueCommand,
+  DeleteMessageBatchCommand,
+  DeleteQueueCommand,
+  GetQueueAttributesCommand,
+  GetQueueUrlCommand,
+  ListQueuesCommand,
+  PurgeQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageBatchCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  makeSimAwsAccountId,
+  type SimAwsAccountId,
+} from "../../aws/sim-aws-account.js";
+import { makeLambdaCodeZip } from "../../lambda/function/code/make-lambda-code-zip.js";
+
+const emptyBytes = new Uint8Array();
+
+const consumerCode =
+  'const { SQSClient, ReceiveMessageCommand, DeleteMessageCommand } = require("@aws-sdk/client-sqs");\n' +
+  "exports.handler = async () => {\n" +
+  "  const client = new SQSClient({});\n" +
+  "  const received = await client.send(new ReceiveMessageCommand({\n" +
+  "    QueueUrl: process.env.QUEUE_URL,\n" +
+  "  }));\n" +
+  "  const message = received.Messages[0];\n" +
+  "  await client.send(new DeleteMessageCommand({\n" +
+  "    QueueUrl: process.env.QUEUE_URL,\n" +
+  "    ReceiptHandle: message.ReceiptHandle,\n" +
+  "  }));\n" +
+  "  return message.Body;\n" +
+  "};\n";
+
+/**
+ * A simulated AWS holding a queue with one message on it, and a Lambda function
+ * whose code consumes that message as its execution Role.
+ */
+async function simAwsWithConsumer(
+  accountId: SimAwsAccountId,
+  policyStatement?: object,
+): Promise<{ simAws: SimAws; queueUrl: string }> {
+  const simAws = new SimAws({ defaultAccountId: accountId });
+  const created = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+  const queueUrl = created.QueueUrl ?? "";
+
+  await simAws
+    .sqs()
+    .sendMessage(
+      new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+    );
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "QueueConsumerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (policyStatement !== undefined) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "QueueConsumerRole",
+        PolicyName: "ConsumeQueue",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: policyStatement,
+        }),
+      }),
+    );
+  }
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "order-consumer",
+      Role: role.Role.Arn,
+      Handler: "index.handler",
+      Code: { ZipFile: makeLambdaCodeZip({ "index.js": consumerCode }) },
+      Environment: { Variables: { QUEUE_URL: queueUrl } },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return { simAws, queueUrl };
+}
+
+describe("SQS SDK interception", () => {
+  it("routes an intercepted SQSClient to simulated SQS", async () => {
+    // Given an intercepted SQS SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SQSClient);
+
+    const client = new SQSClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a queue, sends a message and reads it back.
+    const created = await client.send(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+    await client.send(
+      new SendMessageCommand({
+        QueueUrl: created.QueueUrl,
+        MessageBody: "order-1",
+      }),
+    );
+    const received = await client.send(
+      new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+    );
+
+    // Then it works with nothing touching the network, and the URL names the
+    // Region the client was configured for.
+    assertStringIncludes(String(created.QueueUrl), "https://sqs.eu-west-2.");
+    assertIdentical(received.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("routes every supported Command through the intercepted client", async () => {
+    // Given an intercepted SQS SDK client with a queue.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SQSClient);
+
+    const client = new SQSClient({ region: "eu-west-2" });
+    const created = await client.send(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+    const queueUrl = created.QueueUrl;
+
+    // When each of the remaining operations is used.
+    const found = await client.send(
+      new GetQueueUrlCommand({ QueueName: "orders" }),
+    );
+    const listed = await client.send(new ListQueuesCommand({}));
+
+    await client.send(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: { VisibilityTimeout: "60" },
+      }),
+    );
+
+    const attributes = await client.send(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["VisibilityTimeout"],
+      }),
+    );
+
+    await client.send(
+      new SendMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [{ Id: "one", MessageBody: "order-1" }],
+      }),
+    );
+
+    const received = await client.send(
+      new ReceiveMessageCommand({ QueueUrl: queueUrl }),
+    );
+    const receiptHandle = received.Messages?.[0]?.ReceiptHandle;
+
+    await client.send(
+      new ChangeMessageVisibilityCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: 120,
+      }),
+    );
+
+    const deleted = await client.send(
+      new DeleteMessageBatchCommand({
+        QueueUrl: queueUrl,
+        Entries: [{ Id: "one", ReceiptHandle: receiptHandle }],
+      }),
+    );
+
+    await client.send(new PurgeQueueCommand({ QueueUrl: queueUrl }));
+    await client.send(new DeleteQueueCommand({ QueueUrl: queueUrl }));
+
+    // Then each one reached simulated SQS.
+    assertIdentical(found.QueueUrl, queueUrl);
+    assertIdentical(listed.QueueUrls?.length, 1);
+    assertIdentical(attributes.Attributes?.VisibilityTimeout, "60");
+    assertIdentical(deleted.Successful?.[0]?.Id, "one");
+  });
+
+  it("consumes a message inside a Lambda handler as the execution Role", async () => {
+    // Given a function whose code receives and deletes a message, running as a
+    // Role allowed to do both.
+    const accountId = makeSimAwsAccountId();
+    const { simAws } = await simAwsWithConsumer(accountId, {
+      Effect: "Allow",
+      Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage"],
+      // A queue ARN carries the name with no resource type in front of it.
+      Resource: `arn:aws:sqs:us-east-1:${accountId}:orders`,
+    });
+
+    // When the function is invoked.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "order-consumer" }));
+
+    // Then the handler's own SDK calls reached simulated SQS as the execution
+    // Role, and that Role's policy allowed them.
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "order-1");
+  });
+
+  it("denies a Lambda handler whose Role may not read the queue", async () => {
+    // Given the same function, running as a Role with no SQS permissions.
+    const { simAws } = await simAwsWithConsumer(makeSimAwsAccountId());
+
+    // When the function is invoked.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "order-consumer" }));
+
+    // Then the handler fails the way it would on real AWS, rather than consuming
+    // the message anyway.
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes);
+
+    assertStringIncludes(payload.toString("utf8"), "not authorized");
+  });
+
+  it("leaves a message on the queue when the handler fails", async () => {
+    // Given a function whose Role may receive but not delete.
+    const accountId = makeSimAwsAccountId();
+    const { simAws, queueUrl } = await simAwsWithConsumer(accountId, {
+      Effect: "Allow",
+      Action: "sqs:ReceiveMessage",
+      Resource: `arn:aws:sqs:us-east-1:${accountId}:orders`,
+    });
+
+    // When it is invoked and fails part way through.
+    const invoked = await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "order-consumer" }));
+
+    assertIdentical(invoked.FunctionError, "Unhandled");
+
+    // Then the message comes back once its visibility timeout lapses, as it
+    // would on real AWS.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertNonNullable(received.Messages);
+    assertIdentical(received.Messages[0]?.Body, "order-1");
+  });
+});

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -1,0 +1,266 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimSqsAuthorizer } from "./command/authorize/sim-sqs-authorizer.js";
+import { SimSqsChangeMessageVisibility } from "./command/message/sim-sqs-change-message-visibility.js";
+import { SimSqsDeleteMessageCommands } from "./command/message/sim-sqs-delete-message-commands.js";
+import { SimSqsReceiveMessage } from "./command/message/sim-sqs-receive-message.js";
+import { SimSqsSendMessageCommands } from "./command/message/sim-sqs-send-message-commands.js";
+import { SimSqsQueueAccess } from "./command/queue/sim-sqs-queue-access.js";
+import { SimSqsCreateQueue } from "./command/queue/sim-sqs-create-queue.js";
+import { SimSqsQueueAttributeCommands } from "./command/queue/sim-sqs-queue-attribute-commands.js";
+import { SimSqsQueueCommands } from "./command/queue/sim-sqs-queue-commands.js";
+import type * as simSqsCommands from "./command/sim-sqs-command.types.js";
+import { SimSqsMessageWriter } from "./message/sim-sqs-message-writer.js";
+import type { SimSqsQueue } from "./queue/sim-sqs-queue.js";
+import { SimSqsQueueStore } from "./queue/sim-sqs-queue-store.js";
+import { SimSqsSdkCommandRouter } from "./sdk/sim-sqs-sdk-command-router.js";
+
+export interface SimSqsRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+interface SimSqsProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated SQS. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * Queues are scoped to an account and region, as they are on real AWS: a queue
+ * name is unique within one of those scopes, and both the queue URL and the ARN
+ * name the region.
+ *
+ * Only standard queues are simulated. FIFO queues are not.
+ */
+export class SimSqs {
+  private readonly queues = new SimSqsQueueStore();
+  private readonly queueCreation: SimSqsCreateQueue;
+  private readonly queueCommands: SimSqsQueueCommands;
+  private readonly attributeCommands: SimSqsQueueAttributeCommands;
+  private readonly sendCommands: SimSqsSendMessageCommands;
+  private readonly receiveCommand: SimSqsReceiveMessage;
+  private readonly deletionCommands: SimSqsDeleteMessageCommands;
+  private readonly visibilityCommand: SimSqsChangeMessageVisibility;
+  private readonly background: BackgroundScheduler;
+  private readonly sdkRouter = new SimSqsSdkCommandRouter(this);
+
+  constructor(properties: SimSqsProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const access = new SimSqsQueueAccess({
+      queues: this.queues,
+      authorizer: new SimSqsAuthorizer({ iam, accountRegionScope }),
+      accountRegionScope,
+    });
+
+    this.background = background;
+    this.queueCreation = new SimSqsCreateQueue({
+      queues: this.queues,
+      access,
+      accountRegionScope,
+      clock: background,
+    });
+    this.queueCommands = new SimSqsQueueCommands({
+      queues: this.queues,
+      access,
+      accountRegionScope,
+      clock: background,
+    });
+    this.attributeCommands = new SimSqsQueueAttributeCommands({
+      access,
+      clock: background,
+    });
+    this.sendCommands = new SimSqsSendMessageCommands({
+      access,
+      writer: new SimSqsMessageWriter({ clock: background }),
+    });
+    this.receiveCommand = new SimSqsReceiveMessage({
+      access,
+      clock: background,
+    });
+    this.deletionCommands = new SimSqsDeleteMessageCommands({
+      access,
+      clock: background,
+    });
+    this.visibilityCommand = new SimSqsChangeMessageVisibility({
+      access,
+      clock: background,
+    });
+  }
+
+  /**
+   * Find a queue by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting queue
+   * state without going through a Command and its authorization.
+   */
+  findQueue(name: string): SimSqsQueue | undefined {
+    return this.queues.find(name);
+  }
+
+  /**
+   * Handle a CreateQueue Command from the SDK.
+   */
+  async createQueue(
+    command: simSqsCommands.SimCreateQueueCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimCreateQueueCommandOutput> {
+    await this.background.sequence();
+    return this.queueCreation.handle(command, options);
+  }
+
+  /**
+   * Handle a GetQueueUrl Command from the SDK.
+   */
+  async getQueueUrl(
+    command: simSqsCommands.SimGetQueueUrlCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimGetQueueUrlCommandOutput> {
+    await this.background.sequence();
+    return this.queueCommands.getQueueUrl(command, options);
+  }
+
+  /**
+   * Handle a ListQueues Command from the SDK.
+   */
+  async listQueues(
+    command: simSqsCommands.SimListQueuesCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimListQueuesCommandOutput> {
+    await this.background.sequence();
+    return this.queueCommands.listQueues(command, options);
+  }
+
+  /**
+   * Handle a DeleteQueue Command from the SDK.
+   */
+  async deleteQueue(
+    command: simSqsCommands.SimDeleteQueueCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimDeleteQueueCommandOutput> {
+    await this.background.sequence();
+    return this.queueCommands.deleteQueue(command, options);
+  }
+
+  /**
+   * Handle a GetQueueAttributes Command from the SDK.
+   */
+  async getQueueAttributes(
+    command: simSqsCommands.SimGetQueueAttributesCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimGetQueueAttributesCommandOutput> {
+    await this.background.sequence();
+    return this.attributeCommands.getQueueAttributes(command, options);
+  }
+
+  /**
+   * Handle a SetQueueAttributes Command from the SDK.
+   */
+  async setQueueAttributes(
+    command: simSqsCommands.SimSetQueueAttributesCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimSetQueueAttributesCommandOutput> {
+    await this.background.sequence();
+    return this.attributeCommands.setQueueAttributes(command, options);
+  }
+
+  /**
+   * Handle a PurgeQueue Command from the SDK.
+   */
+  async purgeQueue(
+    command: simSqsCommands.SimPurgeQueueCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimPurgeQueueCommandOutput> {
+    await this.background.sequence();
+    return this.attributeCommands.purgeQueue(command, options);
+  }
+
+  /**
+   * Handle a SendMessage Command from the SDK.
+   */
+  async sendMessage(
+    command: simSqsCommands.SimSendMessageCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimSendMessageCommandOutput> {
+    await this.background.sequence();
+    return this.sendCommands.send(command, options);
+  }
+
+  /**
+   * Handle a SendMessageBatch Command from the SDK.
+   */
+  async sendMessageBatch(
+    command: simSqsCommands.SimSendMessageBatchCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimSendMessageBatchCommandOutput> {
+    await this.background.sequence();
+    return this.sendCommands.sendBatch(command, options);
+  }
+
+  /**
+   * Handle a ReceiveMessage Command from the SDK.
+   */
+  async receiveMessage(
+    command: simSqsCommands.SimReceiveMessageCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimReceiveMessageCommandOutput> {
+    await this.background.sequence();
+    return this.receiveCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DeleteMessage Command from the SDK.
+   */
+  async deleteMessage(
+    command: simSqsCommands.SimDeleteMessageCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimDeleteMessageCommandOutput> {
+    await this.background.sequence();
+    return this.deletionCommands.deleteMessage(command, options);
+  }
+
+  /**
+   * Handle a DeleteMessageBatch Command from the SDK.
+   */
+  async deleteMessageBatch(
+    command: simSqsCommands.SimDeleteMessageBatchCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimDeleteMessageBatchCommandOutput> {
+    await this.background.sequence();
+    return this.deletionCommands.deleteMessageBatch(command, options);
+  }
+
+  /**
+   * Handle a ChangeMessageVisibility Command from the SDK.
+   */
+  async changeMessageVisibility(
+    command: simSqsCommands.SimChangeMessageVisibilityCommand,
+    options?: SimSqsRequestOptions,
+  ): Promise<simSqsCommands.SimChangeMessageVisibilityCommandOutput> {
+    await this.background.sequence();
+    return this.visibilityCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/test/sqs/queue-fixture.ts
+++ b/test/sqs/queue-fixture.ts
@@ -13,6 +13,7 @@ import {
   ReceiveMessageCommand,
   SendMessageCommand,
 } from "@aws-sdk/client-sqs";
+import { assertNonNullable } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
 
@@ -46,7 +47,9 @@ export async function simAwsWithQueue(
     }),
   );
 
-  return { simAws, queueUrl: created.QueueUrl ?? "" };
+  assertNonNullable(created.QueueUrl, "CreateQueue answered with a queue URL");
+
+  return { simAws, queueUrl: created.QueueUrl };
 }
 
 /**
@@ -67,9 +70,12 @@ export async function simAwsWithReceivedMessage(
     .sqs()
     .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
 
-  return {
-    simAws,
-    queueUrl,
-    receiptHandle: received.Messages?.[0]?.ReceiptHandle ?? "",
-  };
+  const receiptHandle = received.Messages?.[0]?.ReceiptHandle;
+
+  assertNonNullable(
+    receiptHandle,
+    "ReceiveMessage answered with a receipt handle",
+  );
+
+  return { simAws, queueUrl, receiptHandle };
 }

--- a/test/sqs/queue-fixture.ts
+++ b/test/sqs/queue-fixture.ts
@@ -1,0 +1,75 @@
+/**
+ * A simulated AWS with one queue on it, which nearly every SQS test needs
+ * before it can say anything about messages.
+ *
+ * This lives under `test/` for the same reasons as `test/kms/`: eslint rejects a
+ * test file that exports helpers alongside its own `describe` calls, and
+ * `test/**` is type-checked with everything else, excluded from the published
+ * build, not collected as a suite, and not counted in coverage.
+ */
+
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+
+/**
+ * One simulated AWS and the URL of the one queue on it.
+ */
+export interface SimSqsQueueFixture {
+  readonly simAws: SimAws;
+  readonly queueUrl: string;
+}
+
+/**
+ * One simulated AWS holding a message that has been received once, and the
+ * receipt handle that receive was answered with.
+ */
+export interface SimSqsReceivedMessageFixture extends SimSqsQueueFixture {
+  readonly receiptHandle: string;
+}
+
+/**
+ * Make a simulated AWS holding one queue named `orders`.
+ */
+export async function simAwsWithQueue(
+  attributes?: Record<string, string>,
+): Promise<SimSqsQueueFixture> {
+  const simAws = new SimAws();
+  const created = await simAws.sqs().createQueue(
+    new CreateQueueCommand({
+      QueueName: "orders",
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+
+  return { simAws, queueUrl: created.QueueUrl ?? "" };
+}
+
+/**
+ * Make a simulated AWS holding one queue with one already received message on it.
+ */
+export async function simAwsWithReceivedMessage(
+  attributes?: Record<string, string>,
+): Promise<SimSqsReceivedMessageFixture> {
+  const { simAws, queueUrl } = await simAwsWithQueue(attributes);
+
+  await simAws
+    .sqs()
+    .sendMessage(
+      new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+    );
+
+  const received = await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+  return {
+    simAws,
+    queueUrl,
+    receiptHandle: received.Messages?.[0]?.ReceiptHandle ?? "",
+  };
+}


### PR DESCRIPTION
Adds a simulated standard-queue SQS reachable as simAws.sqs(), handling the queue, message and visibility commands and authorizing each one through simulated IAM. Visibility timeouts, delays and retention run on the simulation clock, so a test advances time instead of waiting.

Resolves https://github.com/KensioSoftware/yulin/issues/242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon SQS support for local development and testing.
  * Supports queue management, message sending/receiving, deletion, batching, visibility timeouts, delays, retention, attributes, pagination, and simulated time.
  * Added account/region scoping, IAM authorization, and routing for SQS SDK calls, including calls from simulated Lambda functions.
  * Added a public SQS package entry point.

* **Documentation**
  * Added comprehensive SQS behavior documentation and runnable examples covering common workflows, IAM, batching, message attributes, scoping, and queue lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->