### PR TITLE
feat: create simulated SQS queues from AWS::SQS::Queue

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -978,6 +978,7 @@ The resource types it creates are:
 - `AWS::Route53::HostedZone` and `AWS::Route53::RecordSet`
 - `AWS::S3::Bucket` and `AWS::S3::BucketPolicy`
 - `AWS::SecretsManager::Secret`
+- `AWS::SQS::Queue`
 - `AWS::SSM::Parameter`
 - selected CDK custom resources, including CDK S3 BucketDeployment
 

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -736,7 +736,8 @@ The properties applied to the queue are `VisibilityTimeout`, `DelaySeconds`,
 A queue with no `QueueName` is named from the stack name and the logical ID, so the queue above with
 its name left out would be `orders-stack-OrdersQueue`. Real CloudFormation adds random characters to
 that, which a template cannot predict either way. The generated name is trimmed to the 80 characters
-a queue name allows.
+a queue name allows, ending in a hash of the untrimmed name so two long names that start the same
+stay apart.
 
 `FifoQueue: true` fails the resource, because only standard queues are simulated and a FIFO queue
 created as a standard one would take messages in an order the deployment does not promise. The

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -669,6 +669,89 @@ work. The same applies to `SimSdk` interception: intercepting `SQSClient` routes
 the simulation with nothing touching the network. See
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
+## Deploying a queue from CloudFormation
+
+Simulated CloudFormation creates a queue from an `AWS::SQS::Queue` resource, in the stack's account
+and region. The queue is created through `CreateQueue`, so a template-created queue is the same thing
+an SDK caller would get: the same name validation, the same attribute ranges, the same ARN and URL.
+
+`Ref` on the resource gives the queue URL rather than its name or ARN, as it does on real AWS, so it
+can be handed straight to `SendMessage`. `Fn::GetAtt … Arn`, `Fn::GetAtt … QueueName` and
+`Fn::GetAtt … QueueUrl` give those.
+
+```typescript sim-sqs-cloudformation-queue
+/**
+ * Deploying a queue from a CloudFormation template and sending to it.
+ */
+
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: {
+          QueueName: "orders",
+          VisibilityTimeout: 120,
+          MessageRetentionPeriod: 3600,
+        },
+      },
+    },
+    Outputs: {
+      OrdersQueueUrl: {
+        Value: { Ref: "OrdersQueue" },
+      },
+      OrdersQueueArn: {
+        Value: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the queue URL, so it works as a SendMessage QueueUrl.
+const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+
+await simAws
+  .sqs()
+  .sendMessage(
+    new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+  );
+
+console.log(stack.outputs.get("OrdersQueueArn")?.value);
+// "arn:aws:sqs:us-east-1:888888888888:orders"
+```
+
+The properties applied to the queue are `VisibilityTimeout`, `DelaySeconds`,
+`MessageRetentionPeriod`, `MaximumMessageSize` and `ReceiveMessageWaitTimeSeconds`. Each is passed to
+`CreateQueue`, so a value outside the range real SQS accepts fails the resource.
+
+A queue with no `QueueName` is named from the stack name and the logical ID, so the queue above with
+its name left out would be `orders-stack-OrdersQueue`. Real CloudFormation adds random characters to
+that, which a template cannot predict either way. The generated name is trimmed to the 80 characters
+a queue name allows.
+
+`FifoQueue: true` fails the resource, because only standard queues are simulated and a FIFO queue
+created as a standard one would take messages in an order the deployment does not promise. The
+properties with behaviour that is not simulated fail the resource in the same way rather than being
+dropped: `RedrivePolicy`, `RedriveAllowPolicy`, `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`,
+`SqsManagedSseEnabled`, `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and
+`Tags`. So does a property `AWS::SQS::Queue` does not have.
+
+`AWS::SQS::QueuePolicy` is skipped rather than deployed, since queue policies are not simulated. The
+rest of the stack still deploys.
+
+CDK works without hand-editing. An `sqs.Queue` with `grantSendMessages(fn)` synthesises a template
+that deploys here, with the queue URL reaching the function through its environment and the grant
+policy naming the queue by the ARN `Fn::GetAtt` gives.
+
 ## Available functionality
 
 Sim SQS currently supports:
@@ -685,6 +768,8 @@ Sim SQS currently supports:
   attributes
 - Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+- `AWS::SQS::Queue` in a CloudFormation or CDK template, with `Ref` giving the queue URL and
+  `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`
 
 ## Limitations
 
@@ -723,6 +808,7 @@ Current documented limitations:
   size limit (`BatchRequestTooLong`) are not supported.
 - Lambda event source mappings are not simulated, so a queue does not invoke a function on its own. A
   test invokes the consumer itself, as the Lambda example above does.
-- There is no `AWS::SQS::Queue` CloudFormation resource yet, so a queue is created through the SDK
-  rather than deployed from a template.
+- `AWS::SQS::Queue` is the only SQS resource type CloudFormation creates. `AWS::SQS::QueuePolicy` is
+  skipped, and the queue properties this simulation has no behaviour for fail the resource rather
+  than being dropped.
 - SQS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sqs/sim-sqs-cloudformation-queue.example.ts
+++ b/docs/services/sqs/sim-sqs-cloudformation-queue.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Deploying a queue from a CloudFormation template and sending to it.
+ */
+
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: {
+          QueueName: "orders",
+          VisibilityTimeout: 120,
+          MessageRetentionPeriod: 3600,
+        },
+      },
+    },
+    Outputs: {
+      OrdersQueueUrl: {
+        Value: { Ref: "OrdersQueue" },
+      },
+      OrdersQueueArn: {
+        Value: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// Ref resolves to the queue URL, so it works as a SendMessage QueueUrl.
+const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+
+await simAws
+  .sqs()
+  .sendMessage(
+    new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+  );
+
+console.log(stack.outputs.get("OrdersQueueArn")?.value);
+// "arn:aws:sqs:us-east-1:888888888888:orders"

--- a/src/service/cloudformation/cdk/sqs/sim-cdk-sqs-queue.loc.test.ts
+++ b/src/service/cloudformation/cdk/sqs/sim-cdk-sqs-queue.loc.test.ts
@@ -1,0 +1,152 @@
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimSqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-url.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const emptyBytes = new Uint8Array();
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+/**
+ * A handler sending to the queue whose URL CDK put in its environment.
+ */
+const sendMessageHandlerSource = `
+const { SQSClient, SendMessageCommand } = require("@aws-sdk/client-sqs");
+const client = new SQSClient({});
+exports.handler = async () => {
+  await client.send(
+    new SendMessageCommand({
+      QueueUrl: process.env.ORDERS_QUEUE_URL,
+      MessageBody: "order-1",
+    }),
+  );
+  return { sent: true };
+};
+`;
+
+describe("Sim CDK SQS Queue deployment local integration", () => {
+  it("deploys a CDK queue a granted Lambda sends to", async () => {
+    // Given a CDK stack with an unnamed queue and a Lambda granted send
+    // access to it, handed the queue URL through its environment.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersQueue = new sqs.Queue(stack, "OrdersQueue", {
+  visibilityTimeout: cdk.Duration.seconds(120),
+  retentionPeriod: cdk.Duration.hours(2),
+  deliveryDelay: cdk.Duration.seconds(5),
+});
+
+const producerFunction = new lambda.Function(stack, "ProducerFunction", {
+  functionName: "cdk-order-producer",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(sendMessageHandlerSource)}),
+  environment: {
+    ORDERS_QUEUE_URL: ordersQueue.queueUrl,
+  },
+});
+
+ordersQueue.grantSendMessages(producerFunction);
+
+new cdk.CfnOutput(stack, "OrdersQueueUrl", {
+  value: ordersQueue.queueUrl,
+});
+
+new cdk.CfnOutput(stack, "OrdersQueueArn", {
+  value: ordersQueue.queueArn,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the AWS::SQS::Queue Resource
+    // CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the queue URL CDK output carries is the deployed queue, named after
+    // the stack and the logical ID because the template did not name it.
+    const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value;
+    assertTypeString(queueUrl);
+
+    const queueName = SimSqsQueueUrl.parse(queueUrl)?.name;
+    assertTypeString(queueName);
+    assertStringStartsWith(queueName, "TestStack-OrdersQueue");
+
+    // And the attributes the CDK construct set are on it.
+    const attributes = await scoped.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+    assertNonNullable(attributes.Attributes);
+    assertIdentical(attributes.Attributes["VisibilityTimeout"], "120");
+    assertIdentical(attributes.Attributes["MessageRetentionPeriod"], "7200");
+    assertIdentical(attributes.Attributes["DelaySeconds"], "5");
+    assertIdentical(
+      stack.outputs.get("OrdersQueueArn")?.value,
+      attributes.Attributes["QueueArn"],
+    );
+
+    // And the deployed function sends to it as its granted execution role,
+    // against the queue ARN the CDK grant produced.
+    const invoked = await scoped
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "cdk-order-producer" }));
+
+    assertUndefined(invoked.FunctionError);
+    const payload = Buffer.from(invoked.Payload ?? emptyBytes).toString("utf8");
+    assertIdentical(payload, JSON.stringify({ sent: true }));
+
+    // And the message is on the queue once its delivery delay has passed.
+    await simAws.clock().advanceBy({ seconds: 5 });
+    const received = await scoped
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.at(0)?.Body, "order-1");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -8,6 +8,7 @@ import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
 import { secretsManagerValueAdapter } from "./secretsmanager/sim-secrets-manager-cfn-value-adapter.js";
+import { sqsValueAdapter } from "./sqs/sim-sqs-cfn-value-adapter.js";
 import { ssmValueAdapter } from "./ssm/sim-ssm-cfn-value-adapter.js";
 import { SimCfnDefaultResourceValueAdapter } from "./sim-cfn-default-resource-value-adapter.js";
 
@@ -54,6 +55,7 @@ export function simCfnResourceValueAdapter(
     route53ValueAdapter(properties) ??
     s3ValueAdapter(properties) ??
     secretsManagerValueAdapter(properties) ??
+    sqsValueAdapter(properties) ??
     ssmValueAdapter(properties) ??
     new SimCfnDefaultResourceValueAdapter({
       logicalId: properties.logicalId,

--- a/src/service/cloudformation/resource/cfn/sqs/sim-sqs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sqs/sim-sqs-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimSqsQueue } from "../../../../sqs/queue/sim-sqs-queue.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimSqsQueueCfn } from "./sim-sqs-queue-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated SQS Resource.
+ */
+export function sqsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::SQS::Queue" &&
+    properties.simResource instanceof SimSqsQueue
+  ) {
+    return new SimSqsQueueCfn({ queue: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sqs/sim-sqs-queue-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/sqs/sim-sqs-queue-cfn.ts
@@ -1,0 +1,52 @@
+import type { SimSqsQueue } from "../../../../sqs/queue/sim-sqs-queue.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimSqsQueueCfnProperties {
+  readonly queue: SimSqsQueue;
+}
+
+/**
+ * CloudFormation-facing values for a simulated SQS queue.
+ */
+export class SimSqsQueueCfn implements SimCfnResourceValueAdapter {
+  private readonly queue: SimSqsQueue;
+
+  constructor(properties: SimSqsQueueCfnProperties) {
+    this.queue = properties.queue;
+  }
+
+  /**
+   * AWS::SQS::Queue Ref returns the queue URL rather than its name or ARN,
+   * which is what makes a Ref usable as a SendMessage QueueUrl.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.queue.url;
+  }
+
+  /**
+   * AWS::SQS::Queue attributes.
+   *
+   * The ARN is what an IAM policy names the queue by, and the name is what
+   * GetQueueUrl takes, so a template can reach the queue whichever of the three
+   * the thing using it needs.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.queue.arn.value;
+      }
+      case "QueueName": {
+        return this.queue.name.value;
+      }
+      case "QueueUrl": {
+        return this.queue.url;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::SQS::Queue attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -72,6 +72,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "SecretsManager": {
       return scopedAws.secretsManager().cfnResourceFactory();
     }
+    case "SQS": {
+      return scopedAws.sqs().cfnResourceFactory();
+    }
     case "SSM": {
       return scopedAws.ssm().cfnResourceFactory();
     }

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -26,6 +26,7 @@ export interface SimCloudFormationResourceProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly background?: BackgroundScheduler;
   readonly logicalId?: string;
+  readonly stackName?: string | undefined;
   readonly template?: SimCfnTemplateValueRecord;
   readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
   readonly parameters?: SimCfnParameters | undefined;
@@ -69,6 +70,8 @@ export interface SimCloudFormationResourceCreateContext {
 export class SimCfnResource<T extends object = object> {
   public readonly accountRegionScope: SimAwsAccountRegionScope;
   public readonly logicalId: string;
+  /** The Stack this Resource belongs to, where a generated name comes from. */
+  public readonly stackName: string | undefined;
   public readonly template: SimCfnTemplateValueRecord;
   private readonly creationState = new SimCfnResourceCreationState<T>();
   private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
@@ -82,6 +85,7 @@ export class SimCfnResource<T extends object = object> {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       background = new BackgroundTasks(),
       logicalId = "Resource",
+      stackName,
       template = {},
       cfnResourceFactory,
       parameters,
@@ -91,6 +95,7 @@ export class SimCfnResource<T extends object = object> {
     this.accountRegionScope = accountRegionScope;
     this.background = background;
     this.logicalId = logicalId;
+    this.stackName = stackName;
     this.template = template;
     this.resourceTemplateReader = new SimCfnResourceTemplateReader(template);
     this.propertyResolver = new SimCfnResourcePropertyResolver({ parameters });

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
@@ -30,6 +30,7 @@ export function makeSimCfnStackResourceMap(
         accountRegionScope,
         background,
         logicalId: resourceTemplate.logicalId,
+        stackName: template.stackName,
         template: resourceTemplate.template,
         parameters: template.parameters,
         resourceLogicalIds,

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -103,6 +103,26 @@ As elsewhere, implementation code under `src/` does not import real AWS SDK pack
 command types in `*.command.ts` match the SDK shapes closely enough for callers to pass real SDK
 command instances.
 
+## CloudFormation
+
+`cfn/` holds the `AWS::SQS::Queue` resource factory. `SimCfnSqsQueueProperties` reads the template
+properties into the shape `CreateQueue` takes, and `SimCfnSqsQueueCreator` sends that command, so a
+queue a template deployed is the same thing an SDK caller would have got. Nothing about the attribute
+ranges or the name rules is repeated here.
+
+The properties this simulation has no behaviour for fail the resource rather than being dropped,
+including `FifoQueue: true`. A queue deployed without its redrive policy would look to the template
+like a queue with a dead-letter queue and have none. The failures are worded as an invalid resource
+rather than an unsupported one, because sim CloudFormation skips a resource whose error reads as
+unsupported, and skipping is the wrong answer for a queue that cannot be created as asked.
+
+`SimCfnSqsQueueName` generates the name for a queue the template does not name, from the stack name
+and the logical ID. The random characters real CloudFormation adds are left out so a test can predict
+the name.
+
+`Ref` and `Fn::GetAtt` behaviour lives with the other CloudFormation value adapters, in
+`cloudformation/resource/cfn/sqs/`. `Ref` gives the queue URL, as real CloudFormation does.
+
 ## Authorization
 
 `SimSqsAuthorizer` authorizes each operation against the queue's ARN, which carries the queue name
@@ -133,6 +153,7 @@ refused rather than quietly answered with a local queue of the same name.
   The 60 second hold on a deleted queue's name is simulated.
 - A queue name ending in `.fifo` is refused, as are the FIFO-only request fields.
 - `SenderId` is not reported, because a simulated principal has no user or role id to report it as.
-- Tags, `RedrivePolicy`, queue policies and the encryption attributes are refused rather than ignored.
+- Tags, `RedrivePolicy`, queue policies and the encryption attributes are refused rather than ignored,
+  whether a request or a CloudFormation template asks for them.
 
 The full list is in [docs/services/sqs](../../../docs/services/sqs/).

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-creator.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-creator.ts
@@ -1,0 +1,49 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSqs } from "../../sim-sqs.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import { SimCfnSqsQueueProperties } from "./sim-cfn-sqs-queue-properties.js";
+
+interface SimCfnSqsQueueCreatorProperties {
+  readonly sqs: SimSqs;
+}
+
+/**
+ * Creates simulated queues from AWS::SQS::Queue Resources.
+ *
+ * The queue is created through the ordinary CreateQueue command rather than
+ * constructed directly, so a queue a template deployed is the same thing an SDK
+ * caller would have got: the same name validation, the same attribute ranges,
+ * the same refusals for what this simulation does not model.
+ */
+export class SimCfnSqsQueueCreator {
+  private readonly sqs: SimSqs;
+
+  constructor(properties: SimCfnSqsQueueCreatorProperties) {
+    this.sqs = properties.sqs;
+  }
+
+  /**
+   * Create a queue from an AWS::SQS::Queue Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSqsQueue> {
+    const queueProperties = new SimCfnSqsQueueProperties({
+      resource,
+      properties,
+    });
+    const name = queueProperties.name();
+
+    await this.sqs.createQueue({
+      input: { QueueName: name, Attributes: queueProperties.attributes() },
+    });
+
+    const queue = this.sqs.findQueue(name);
+    assertDefined(queue, `sim SQS queue ${name} after CloudFormation creation`);
+
+    return queue;
+  }
+}

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
@@ -1,4 +1,9 @@
-import { assertIdentical, assertStringLength } from "@kensio/smartass";
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringLength,
+  assertStringStartsWith,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimCfnSqsQueueName } from "./sim-cfn-sqs-queue-name.js";
@@ -45,6 +50,38 @@ describe("SimCfnSqsQueueName", () => {
     // When the generated name is read, then it is trimmed to fit, keeping the
     // start, so the stack name is still in it.
     assertStringLength(name.value, 80);
-    assertIdentical(name.value, `${"a".repeat(60)}-OrdersQueueWithARat`);
+    assertStringStartsWith(name.value, `${"a".repeat(60)}-OrdersQu`);
+
+    // And the same template generates the same name again, rather than a new
+    // one each deployment.
+    assertIdentical(
+      name.value,
+      new SimCfnSqsQueueName({
+        stackName: "a".repeat(60),
+        logicalId: "OrdersQueueWithARatherLongLogicalId",
+      }).value,
+    );
+  });
+
+  it("keeps two trimmed names apart where only the trimmed-off part differs", () => {
+    // Given two logical IDs that are the same up to the point a generated name
+    // is trimmed at. CDK puts its disambiguating hash at the end of a logical
+    // ID, which is the part trimming takes off.
+    const stackName = "a".repeat(40);
+    const sharedPrefix = "OrdersQueue".repeat(4);
+    const first = new SimCfnSqsQueueName({
+      stackName,
+      logicalId: `${sharedPrefix}E6CA6235`,
+    });
+    const second = new SimCfnSqsQueueName({
+      stackName,
+      logicalId: `${sharedPrefix}1B3D8A07`,
+    });
+
+    // When both names are read, then they are different names, so the two
+    // queues do not collide on one name.
+    assertStringLength(first.value, 80);
+    assertStringLength(second.value, 80);
+    assertFalse(first.value === second.value);
   });
 });

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
@@ -1,0 +1,50 @@
+import { assertIdentical, assertStringLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnSqsQueueName } from "./sim-cfn-sqs-queue-name.js";
+
+describe("SimCfnSqsQueueName", () => {
+  it("names a queue after the stack and the logical ID", () => {
+    // Given a Resource in a stack.
+    const name = new SimCfnSqsQueueName({
+      stackName: "orders-stack",
+      logicalId: "OrdersQueue",
+    });
+
+    // When the generated name is read, then it carries both, as a real
+    // CloudFormation generated name does.
+    assertIdentical(name.value, "orders-stack-OrdersQueue");
+  });
+
+  it("falls back to the logical ID with no stack name", () => {
+    // Given a Resource created outside a stack, which has no stack name to
+    // derive a name from.
+    const noStack = new SimCfnSqsQueueName({
+      stackName: undefined,
+      logicalId: "OrdersQueue",
+    });
+    const emptyStackName = new SimCfnSqsQueueName({
+      stackName: "",
+      logicalId: "OrdersQueue",
+    });
+
+    // When the generated name is read, then it is the logical ID on its own
+    // rather than a name with an empty part in it.
+    assertIdentical(noStack.value, "OrdersQueue");
+    assertIdentical(emptyStackName.value, "OrdersQueue");
+  });
+
+  it("trims a generated name to the 80 characters SQS allows", () => {
+    // Given a stack name and logical ID that are too long together for a queue
+    // name, which real SQS refuses at 81 characters.
+    const name = new SimCfnSqsQueueName({
+      stackName: "a".repeat(60),
+      logicalId: "OrdersQueueWithARatherLongLogicalId",
+    });
+
+    // When the generated name is read, then it is trimmed to fit, keeping the
+    // start, so the stack name is still in it.
+    assertStringLength(name.value, 80);
+    assertIdentical(name.value, `${"a".repeat(60)}-OrdersQueueWithARat`);
+  });
+});

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
@@ -1,0 +1,50 @@
+const maximumNameLength = 80;
+
+interface SimCfnSqsQueueNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a queue whose template does not name it.
+ *
+ * Real CloudFormation generates `<stack name>-<logical ID>-<random>`. The
+ * random part is left out here so a test can predict the name, which is the one
+ * thing a template cannot rely on for real. Everything else follows AWS: two
+ * stacks deploying the same template get different queue names, because the
+ * stack name is part of it.
+ *
+ * A queue name is at most 80 characters, so a long stack name and logical ID
+ * together are trimmed to fit. The start is kept, since that is where the stack
+ * name is.
+ */
+export class SimCfnSqsQueueName {
+  private readonly stackName: string | undefined;
+  private readonly logicalId: string;
+
+  constructor(properties: SimCfnSqsQueueNameProperties) {
+    this.stackName = properties.stackName;
+    this.logicalId = properties.logicalId;
+  }
+
+  /**
+   * The generated queue name.
+   */
+  get value(): string {
+    return this.composed().slice(0, maximumNameLength);
+  }
+
+  /**
+   * The name before it is trimmed to the length SQS allows.
+   *
+   * A Resource created outside a stack has no stack name to derive one from, so
+   * it falls back to the logical ID on its own.
+   */
+  private composed(): string {
+    if (this.stackName === undefined || this.stackName === "") {
+      return this.logicalId;
+    }
+
+    return `${this.stackName}-${this.logicalId}`;
+  }
+}

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
@@ -1,4 +1,12 @@
+import { createHash } from "node:crypto";
+
 const maximumNameLength = 80;
+
+/**
+ * How many characters of the hash of the untrimmed name a trimmed one ends
+ * with, so two long names that start the same do not become one name.
+ */
+const distinguisherLength = 8;
 
 interface SimCfnSqsQueueNameProperties {
   readonly stackName: string | undefined;
@@ -16,7 +24,10 @@ interface SimCfnSqsQueueNameProperties {
  *
  * A queue name is at most 80 characters, so a long stack name and logical ID
  * together are trimmed to fit. The start is kept, since that is where the stack
- * name is.
+ * name is, and the trimmed name ends in a hash of the untrimmed one. CDK puts
+ * its own disambiguating hash at the end of a logical ID, which is exactly what
+ * trimming cuts off, so without that two queues in one stack could end up
+ * asking for the same name.
  */
 export class SimCfnSqsQueueName {
   private readonly stackName: string | undefined;
@@ -31,7 +42,28 @@ export class SimCfnSqsQueueName {
    * The generated queue name.
    */
   get value(): string {
-    return this.composed().slice(0, maximumNameLength);
+    const composed = this.composed();
+
+    if (composed.length <= maximumNameLength) {
+      return composed;
+    }
+
+    const kept = composed.slice(0, maximumNameLength - distinguisherLength - 1);
+
+    return `${kept}-${this.distinguisher(composed)}`;
+  }
+
+  /**
+   * The tail a trimmed name ends with, derived from the whole untrimmed name.
+   *
+   * It is a hash rather than the random characters real CloudFormation uses, so
+   * the name stays the same between deployments of the same template.
+   */
+  private distinguisher(composed: string): string {
+    return createHash("sha1")
+      .update(composed)
+      .digest("hex")
+      .slice(0, distinguisherLength);
   }
 
   /**

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
@@ -1,0 +1,99 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSqsQueueAttributeInput } from "../../queue/sim-sqs-queue-attributes.js";
+import { SimCfnSqsQueueName } from "./sim-cfn-sqs-queue-name.js";
+import {
+  SimCfnSqsQueuePropertyRules,
+  sqsQueuePropertyError,
+} from "./sim-cfn-sqs-queue-property-rules.js";
+
+interface SimCfnSqsQueuePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::SQS::Queue CloudFormation properties into the shape CreateQueue
+ * takes.
+ *
+ * The queue attributes are passed through as the strings SQS carries them as,
+ * so the range each one is checked against is the range simulated SQS already
+ * applies to a CreateQueue request.
+ */
+export class SimCfnSqsQueueProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly rules: SimCfnSqsQueuePropertyRules;
+
+  constructor(properties: SimCfnSqsQueuePropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.rules = new SimCfnSqsQueuePropertyRules({
+      logicalId: properties.resource.logicalId,
+      properties: properties.properties,
+    });
+  }
+
+  /**
+   * The queue name.
+   *
+   * An unnamed queue is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties["QueueName"];
+
+    if (name === undefined) {
+      return new SimCfnSqsQueueName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw this.propertyError("QueueName must be a string");
+    }
+
+    return name;
+  }
+
+  /**
+   * The queue attributes the template sets, in the string form CreateQueue
+   * takes them in.
+   */
+  attributes(): SimSqsQueueAttributeInput {
+    this.rules.assertSimulated();
+
+    return Object.fromEntries(
+      Object.entries(this.properties)
+        .filter(([name]) => this.rules.isAttributeProperty(name))
+        .map(([name, value]) => [name, this.numberValue(value, name)]),
+    );
+  }
+
+  /**
+   * Read a numeric property as the string an SQS attribute carries.
+   *
+   * CloudFormation carries these as numbers, and as strings when they came from
+   * a template Parameter, so both are accepted. What each number has to be is
+   * left to SQS.
+   */
+  private numberValue(value: SimCfnTemplateValue, name: string): string {
+    if (typeof value === "number") {
+      return String(value);
+    }
+
+    if (typeof value === "string") {
+      return value;
+    }
+
+    throw this.propertyError(`${name} must be a number`);
+  }
+
+  private propertyError(reason: string): Error {
+    return sqsQueuePropertyError(this.resource.logicalId, reason);
+  }
+}

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
@@ -1,0 +1,143 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The AWS::SQS::Queue properties carrying a queue attribute of the same name.
+ *
+ * CloudFormation names these exactly as the SQS API names the attributes, so
+ * they are handed to CreateQueue rather than applied here. That leaves the
+ * ranges and defaults in one place: the ones simulated SQS already validates.
+ */
+const attributePropertyNames: ReadonlySet<string> = new Set([
+  "DelaySeconds",
+  "MaximumMessageSize",
+  "MessageRetentionPeriod",
+  "ReceiveMessageWaitTimeSeconds",
+  "VisibilityTimeout",
+]);
+
+/**
+ * Real AWS::SQS::Queue properties this simulation does not model.
+ *
+ * A queue deployed without its redrive policy would look like a queue with a
+ * dead-letter queue to the template and have none, so these fail the Resource
+ * rather than being dropped on the way through.
+ */
+const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
+  "ContentBasedDeduplication",
+  "DeduplicationScope",
+  "FifoThroughputLimit",
+  "KmsDataKeyReusePeriodSeconds",
+  "KmsMasterKeyId",
+  "RedriveAllowPolicy",
+  "RedrivePolicy",
+  "SqsManagedSseEnabled",
+  "Tags",
+]);
+
+/**
+ * The FifoQueue values that ask for a FIFO queue. CloudFormation carries a
+ * boolean property as either, depending on where the value came from.
+ */
+const fifoQueueValues: ReadonlySet<SimCfnTemplateValue | undefined> = new Set([
+  true,
+  "true",
+]);
+
+/**
+ * Build the error a property of an AWS::SQS::Queue Resource is refused with.
+ *
+ * The wording matters. Sim CloudFormation skips a Resource whose error reads as
+ * an unsupported Resource type, and skipping is the wrong answer for a queue
+ * that cannot be created as the template asks: the stack would deploy without
+ * it.
+ */
+export function sqsQueuePropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(`Invalid AWS::SQS::Queue Resource ${logicalId}: ${reason}`);
+}
+
+interface SimCfnSqsQueuePropertyRulesProperties {
+  readonly logicalId: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Which AWS::SQS::Queue properties simulated SQS can act on.
+ *
+ * Anything else fails the Resource. Being stricter than CloudFormation shows up
+ * as a puzzling deployment failure here; being looser shows up as a queue
+ * behaving one way in a test and another way on AWS.
+ */
+export class SimCfnSqsQueuePropertyRules {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: SimCfnSqsQueuePropertyRulesProperties) {
+    this.logicalId = properties.logicalId;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Whether a property carries a queue attribute of the same name.
+   */
+  isAttributeProperty(name: string): boolean {
+    return attributePropertyNames.has(name);
+  }
+
+  /**
+   * Refuse everything about this Resource that is not simulated.
+   */
+  assertSimulated(): void {
+    this.refuseFifoQueue();
+
+    for (const name of Object.keys(this.properties)) {
+      this.assertSimulatedProperty(name);
+    }
+  }
+
+  /**
+   * Refuse a FIFO queue.
+   *
+   * Only standard queues are simulated, and a FIFO queue quietly created as a
+   * standard one would take messages in an order the deployment does not
+   * promise, so the Resource fails instead.
+   */
+  private refuseFifoQueue(): void {
+    if (!fifoQueueValues.has(this.properties["FifoQueue"])) {
+      return;
+    }
+
+    throw sqsQueuePropertyError(
+      this.logicalId,
+      "FifoQueue names a FIFO queue, which simulated SQS does not simulate. " +
+        "Only standard queues are simulated, so the queue is not created " +
+        "rather than created as a standard queue",
+    );
+  }
+
+  private assertSimulatedProperty(name: string): void {
+    if (unsimulatedPropertyNames.has(name)) {
+      throw sqsQueuePropertyError(
+        this.logicalId,
+        `${name} is a real AWS::SQS::Queue property that simulated SQS does ` +
+          `not simulate, so it is refused rather than ignored`,
+      );
+    }
+
+    if (
+      name !== "QueueName" &&
+      name !== "FifoQueue" &&
+      !this.isAttributeProperty(name)
+    ) {
+      throw sqsQueuePropertyError(
+        this.logicalId,
+        `${name} is not an AWS::SQS::Queue property`,
+      );
+    }
+  }
+}

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
@@ -41,9 +41,18 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
  * The FifoQueue values that ask for a FIFO queue. CloudFormation carries a
  * boolean property as either, depending on where the value came from.
  */
-const fifoQueueValues: ReadonlySet<SimCfnTemplateValue | undefined> = new Set([
+const fifoQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
   true,
   "true",
+]);
+
+/**
+ * The FifoQueue values that ask for a standard queue, which is the only kind
+ * this simulation creates.
+ */
+const standardQueueValues: ReadonlySet<SimCfnTemplateValue> = new Set([
+  false,
+  "false",
 ]);
 
 /**
@@ -105,18 +114,29 @@ export class SimCfnSqsQueuePropertyRules {
    *
    * Only standard queues are simulated, and a FIFO queue quietly created as a
    * standard one would take messages in an order the deployment does not
-   * promise, so the Resource fails instead.
+   * promise, so the Resource fails instead. A value that is neither true nor
+   * false is refused as well, rather than read as false: CloudFormation would
+   * refuse it too, and the queue it asked for is not knowable.
    */
   private refuseFifoQueue(): void {
-    if (!fifoQueueValues.has(this.properties["FifoQueue"])) {
+    const fifo = this.properties["FifoQueue"];
+
+    if (fifo === undefined || standardQueueValues.has(fifo)) {
       return;
+    }
+
+    if (fifoQueueValues.has(fifo)) {
+      throw sqsQueuePropertyError(
+        this.logicalId,
+        "FifoQueue names a FIFO queue, which simulated SQS does not " +
+          "simulate. Only standard queues are simulated, so the queue is not " +
+          "created rather than created as a standard queue",
+      );
     }
 
     throw sqsQueuePropertyError(
       this.logicalId,
-      "FifoQueue names a FIFO queue, which simulated SQS does not simulate. " +
-        "Only standard queues are simulated, so the queue is not created " +
-        "rather than created as a standard queue",
+      "FifoQueue must be true or false",
     );
   }
 

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
@@ -1,0 +1,283 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimSqsCfnResourceFactory } from "./sim-sqs-cfn-resource-factory.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function queueResource(properties: SimCfnTemplateValueRecord): SimCfnResource {
+  return new SimCfnResource({
+    accountRegionScope: {
+      accountId: accountIdOneOnes,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadQueue",
+    template: { Type: "AWS::SQS::Queue", Properties: properties },
+  });
+}
+
+/**
+ * Create a queue straight through the Resource factory, returning whatever it
+ * rejects with. Keeps the property rules under test without a whole stack.
+ */
+async function createQueueResource(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const factory = new SimSqsCfnResourceFactory({ sqs: simAws.sqs() });
+
+  return await assertThrowsErrorAsync(async () => {
+    return await factory.create("Queue", queueResource(properties), {
+      simAws,
+      resources: new Map(),
+    });
+  });
+}
+
+describe("SQS CloudFormation Queue validation", () => {
+  it("fails a FIFO queue rather than creating a standard one", async () => {
+    // Given a template asking for a FIFO queue, which is not simulated.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: { QueueName: "orders.fifo", FifoQueue: true },
+            },
+          },
+        },
+      });
+    });
+
+    // And the failure names FIFO, rather than the Resource being skipped or
+    // quietly deployed as a standard queue.
+    assertStringIncludes(
+      error.message,
+      "FifoQueue names a FIFO queue, which simulated SQS does not simulate",
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    assertNonNullable(stack);
+    assertIdentical(stack.getResource("OrdersQueue")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.sqs().findQueue("orders.fifo"));
+  });
+
+  it("creates a standard queue for FifoQueue false", async () => {
+    // Given a template setting FifoQueue false, which is a standard queue.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders", FifoQueue: false },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue is created, since nothing about it is FIFO.
+    assertNonNullable(simAws.sqs().findQueue("orders"));
+  });
+
+  it("refuses the properties this simulation does not model", async () => {
+    // Given templates declaring properties with behaviour that is not
+    // simulated.
+    // When each Resource is created, then each is refused by name rather than
+    // deploying a queue that behaves differently here than on AWS.
+    const redrive = await createQueueResource({
+      QueueName: "orders",
+      RedrivePolicy: { maxReceiveCount: 3 },
+    });
+    assertIdentical(
+      redrive.message,
+      "Invalid AWS::SQS::Queue Resource BadQueue: RedrivePolicy is a real " +
+        "AWS::SQS::Queue property that simulated SQS does not simulate, so " +
+        "it is refused rather than ignored",
+    );
+
+    const encryption = await createQueueResource({
+      QueueName: "orders",
+      KmsMasterKeyId: "alias/aws/sqs",
+    });
+    assertStringIncludes(
+      encryption.message,
+      "KmsMasterKeyId is a real AWS::SQS::Queue property",
+    );
+
+    const tags = await createQueueResource({
+      QueueName: "orders",
+      Tags: [{ Key: "component", Value: "orders" }],
+    });
+    assertStringIncludes(
+      tags.message,
+      "Tags is a real AWS::SQS::Queue property",
+    );
+  });
+
+  it("refuses a property AWS::SQS::Queue does not have", async () => {
+    // Given a template naming a property that is not on this Resource type.
+    // When the Resource is created, then it is refused rather than ignored, so
+    // a misspelled property does not pass here and fail the deployment.
+    const error = await createQueueResource({
+      QueueName: "orders",
+      VisibilityTimeoutSeconds: 30,
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::SQS::Queue Resource BadQueue: VisibilityTimeoutSeconds " +
+        "is not an AWS::SQS::Queue property",
+    );
+  });
+
+  it("refuses malformed property values", async () => {
+    // Given properties of the wrong shape.
+    // When each Resource is created, then each is refused by name.
+    const name = await createQueueResource({ QueueName: 42 });
+    assertIdentical(
+      name.message,
+      "Invalid AWS::SQS::Queue Resource BadQueue: QueueName must be a string",
+    );
+
+    const timeout = await createQueueResource({
+      QueueName: "orders",
+      VisibilityTimeout: true,
+    });
+    assertIdentical(
+      timeout.message,
+      "Invalid AWS::SQS::Queue Resource BadQueue: VisibilityTimeout must be " +
+        "a number",
+    );
+  });
+
+  it("passes the attribute ranges SQS applies through to CreateQueue", async () => {
+    // Given a template setting an attribute outside the range real SQS
+    // accepts for it.
+    // When the Resource is created, then CreateQueue refuses it, so the
+    // refusal reads the same whether a template or an SDK caller asked.
+    const error = await createQueueResource({
+      QueueName: "orders",
+      VisibilityTimeout: 50_000,
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Value 50000 for parameter VisibilityTimeout is invalid",
+    );
+  });
+
+  it("refuses a queue name another stack already used", async () => {
+    // Given a queue a stack already deployed. Sim CloudFormation has no
+    // UpdateStack, so every deployment is a create.
+    const simAws = new SimAws();
+    const factory = new SimSqsCfnResourceFactory({ sqs: simAws.sqs() });
+    await factory.create(
+      "Queue",
+      queueResource({ QueueName: "orders", VisibilityTimeout: 60 }),
+      { simAws, resources: new Map() },
+    );
+
+    // When a second stack claims the same name with different attributes, then
+    // it is refused, as real SQS refuses it.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await factory.create(
+        "Queue",
+        queueResource({ QueueName: "orders", VisibilityTimeout: 120 }),
+        { simAws, resources: new Map() },
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "A queue already exists with the name orders and different attributes",
+    );
+  });
+
+  it("refuses an attribute AWS::SQS::Queue does not have", async () => {
+    // Given a deployed queue.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("OrdersQueue");
+    assertNonNullable(resource);
+
+    // When an attribute the Resource type does not have is read, then it is
+    // refused rather than resolving to nothing.
+    const error = assertThrowsError(() => {
+      resource.attributeValue("QueueArn");
+    });
+    assertIdentical(
+      error.message,
+      "Unsupported AWS::SQS::Queue attribute QueueArn",
+    );
+  });
+
+  it("records a queue policy as skipped", async () => {
+    // Given a template declaring an SQS Resource type that is not a queue.
+    // Queue policies grant cross-account access, which is not simulated.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+          OrdersQueuePolicy: {
+            Type: "AWS::SQS::QueuePolicy",
+            Properties: { Queues: [{ Ref: "OrdersQueue" }] },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the stack completes with that Resource skipped rather than failing
+    // the deployment.
+    assertArrayLength(stack.skippedResources, 1);
+    const skipped = stack.skippedResources[0];
+    assertNonNullable(skipped);
+    assertTrue(skipped.skipped);
+    assertIdentical(
+      skipped.skippedReason,
+      "Unsupported sim SQS CloudFormation Resource QueuePolicy",
+    );
+  });
+});

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
@@ -102,6 +102,23 @@ describe("SQS CloudFormation Queue validation", () => {
     assertNonNullable(simAws.sqs().findQueue("orders"));
   });
 
+  it("refuses a FifoQueue value that is neither true nor false", async () => {
+    // Given a template carrying something else as FifoQueue, which real
+    // CloudFormation refuses as well.
+    // When the Resource is created, then it is refused rather than read as
+    // false, since the queue it asked for is not knowable.
+    const error = await createQueueResource({
+      QueueName: "orders",
+      FifoQueue: "yes",
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::SQS::Queue Resource BadQueue: FifoQueue must be true or " +
+        "false",
+    );
+  });
+
   it("refuses the properties this simulation does not model", async () => {
     // Given templates declaring properties with behaviour that is not
     // simulated.

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
@@ -1,0 +1,278 @@
+import {
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimSqsQueue } from "../queue/sim-sqs-queue.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+describe("SQS CloudFormation Queue deployment", () => {
+  it("creates a queue with the attributes the template sets", async () => {
+    // Given a template declaring a queue with every attribute it can set.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: {
+              QueueName: "orders",
+              VisibilityTimeout: 120,
+              DelaySeconds: 5,
+              MessageRetentionPeriod: 3600,
+              MaximumMessageSize: 2048,
+              ReceiveMessageWaitTimeSeconds: 10,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the attributes read back as an SDK caller would read them, so a
+    // wrong value in the template is a wrong value in the test.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+        AttributeNames: ["All"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes);
+    assertIdentical(read.Attributes["VisibilityTimeout"], "120");
+    assertIdentical(read.Attributes["DelaySeconds"], "5");
+    assertIdentical(read.Attributes["MessageRetentionPeriod"], "3600");
+    assertIdentical(read.Attributes["MaximumMessageSize"], "2048");
+    assertIdentical(read.Attributes["ReceiveMessageWaitTimeSeconds"], "10");
+    assertIdentical(
+      read.Attributes["QueueArn"],
+      "arn:aws:sqs:eu-west-2:111111111111:orders",
+    );
+  });
+
+  it("applies an attribute a template Parameter supplies", async () => {
+    // Given a template taking its visibility timeout from a Parameter, which
+    // resolves to a string rather than the number a literal property carries.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed with a value for it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { QueueVisibilityTimeout: "90" },
+      template: {
+        Parameters: { QueueVisibilityTimeout: { Type: "Number" } },
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: {
+              QueueName: "orders",
+              VisibilityTimeout: { Ref: "QueueVisibilityTimeout" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue has the value the Parameter carried.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+        AttributeNames: ["VisibilityTimeout"],
+      }),
+    );
+
+    assertIdentical(read.Attributes?.["VisibilityTimeout"], "90");
+  });
+
+  it("resolves Ref to the queue URL and Fn::GetAtt to its ARN, name and URL", async () => {
+    // Given a template referencing its queue every way it can.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+        },
+        Outputs: {
+          QueueRef: { Value: { Ref: "OrdersQueue" } },
+          QueueArn: { Value: { "Fn::GetAtt": ["OrdersQueue", "Arn"] } },
+          QueueName: { Value: { "Fn::GetAtt": ["OrdersQueue", "QueueName"] } },
+          QueueUrl: { Value: { "Fn::GetAtt": ["OrdersQueue", "QueueUrl"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then Ref is the queue URL, as AWS::SQS::Queue Ref is, so it can be
+    // handed straight to SendMessage.
+    assertIdentical(
+      stack.outputs.get("QueueRef")?.value,
+      "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+    );
+    assertIdentical(
+      stack.outputs.get("QueueArn")?.value,
+      "arn:aws:sqs:eu-west-2:111111111111:orders",
+    );
+    assertIdentical(stack.outputs.get("QueueName")?.value, "orders");
+    assertIdentical(
+      stack.outputs.get("QueueUrl")?.value,
+      "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+    );
+  });
+
+  it("sends and receives on the queue a Ref names", async () => {
+    // Given a deployed queue whose URL the stack outputs.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+        },
+        Outputs: { QueueUrl: { Value: { Ref: "OrdersQueue" } } },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const queueUrl = stack.outputs.get("QueueUrl")?.value;
+    assertTypeString(queueUrl);
+
+    // When a message is sent to the URL the Ref gave.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // Then it is receivable from the queue the template created.
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.at(0)?.Body, "order-1");
+  });
+
+  it("names an unnamed queue after the stack and its logical ID", async () => {
+    // Given a template leaving QueueName out, as CDK does for a queue with no
+    // explicit name.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: { Type: "AWS::SQS::Queue" },
+        },
+        Outputs: {
+          QueueName: { Value: { "Fn::GetAtt": ["OrdersQueue", "QueueName"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue is named from the stack name and the logical ID, as real
+    // CloudFormation names one, without the random characters a template could
+    // not predict anyway.
+    assertIdentical(
+      stack.outputs.get("QueueName")?.value,
+      "orders-stack-OrdersQueue",
+    );
+    assertNonNullable(simAws.sqs().findQueue("orders-stack-OrdersQueue"));
+  });
+
+  it("backs the CloudFormation Resource with the simulated queue", async () => {
+    // Given a deployed queue.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders" },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Resource is inspected.
+    const resource = stack.getResource("OrdersQueue");
+    assertNonNullable(resource);
+
+    // Then it is backed by the same simulated queue the service holds, rather
+    // than some other simulated resource that happens to have an ARN.
+    const queue = resource.simResource;
+    assertInstanceOf(queue, SimSqsQueue);
+    assertIdentical(simAws.sqs().findQueue("orders"), queue);
+  });
+
+  it("creates the queue in the stack's account and region", async () => {
+    // Given a simulated AWS whose default scope is not the stack's.
+    const simAws = new SimAws();
+
+    // When a template is deployed into another account and region.
+    const stack = await simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: { QueueName: "orders" },
+            },
+          },
+        },
+      });
+    await stack.waitForDeployComplete();
+
+    // Then the queue exists in that account and region, and nowhere else.
+    const scoped = simAws
+      .account(accountIdOneOnes)
+      .region("us-east-1")
+      .sqs()
+      .findQueue("orders");
+
+    assertNonNullable(scoped);
+    assertIdentical(
+      scoped.arn.value,
+      "arn:aws:sqs:us-east-1:111111111111:orders",
+    );
+    assertUndefined(simAws.sqs().findQueue("orders"));
+  });
+});

--- a/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
+++ b/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
@@ -1,0 +1,50 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimSqs } from "../sim-sqs.js";
+import { SimCfnSqsQueueCreator } from "./queue/sim-cfn-sqs-queue-creator.js";
+
+interface SimSqsCfnResourceFactoryProperties {
+  readonly sqs: SimSqs;
+}
+
+/**
+ * CloudFormation Resource factory for simulated SQS resources.
+ */
+export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly queueCreator: SimCfnSqsQueueCreator;
+
+  constructor(properties: SimSqsCfnResourceFactoryProperties) {
+    this.queueCreator = new SimCfnSqsQueueCreator({ sqs: properties.sqs });
+  }
+
+  /**
+   * Create a simulated SQS resource from a CloudFormation Resource.
+   *
+   * The queue is the only AWS::SQS::* Resource type this simulation models. A
+   * queue policy grants cross-account access, which is not simulated, so
+   * AWS::SQS::QueuePolicy is reported as unsupported and skipped rather than
+   * quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Queue": {
+        return await this.queueCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim SQS CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -20,6 +20,7 @@ import { SimSqsCreateQueue } from "./command/queue/sim-sqs-create-queue.js";
 import { SimSqsQueueAttributeCommands } from "./command/queue/sim-sqs-queue-attribute-commands.js";
 import { SimSqsQueueCommands } from "./command/queue/sim-sqs-queue-commands.js";
 import type * as simSqsCommands from "./command/sim-sqs-command.types.js";
+import { SimSqsCfnResourceFactory } from "./cfn/sim-sqs-cfn-resource-factory.js";
 import { SimSqsMessageWriter } from "./message/sim-sqs-message-writer.js";
 import type { SimSqsQueue } from "./queue/sim-sqs-queue.js";
 import { SimSqsQueueStore } from "./queue/sim-sqs-queue-store.js";
@@ -55,6 +56,7 @@ export class SimSqs {
   private readonly visibilityCommand: SimSqsChangeMessageVisibility;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSqsSdkCommandRouter(this);
+  private readonly cfnFactory = new SimSqsCfnResourceFactory({ sqs: this });
 
   constructor(properties: SimSqsProperties = {}) {
     const {
@@ -255,6 +257,13 @@ export class SimSqs {
   ): Promise<simSqsCommands.SimChangeMessageVisibilityCommandOutput> {
     await this.background.sequence();
     return this.visibilityCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimSqsCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**


### PR DESCRIPTION
Deploys AWS::SQS::Queue from CloudFormation and CDK templates into the stack's account and region, through the ordinary CreateQueue command. Ref gives the queue URL, and Fn::GetAtt gives Arn, QueueName and QueueUrl. An unnamed queue is named from the stack name and logical ID.

FifoQueue and the properties this simulation has no behaviour for fail the resource rather than deploying a queue that behaves differently here than on AWS.

Resolves https://github.com/KensioSoftware/yulin/issues/243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation support for `AWS::SQS::Queue`.
  * Queue properties, generated names, `Ref`, and supported `Fn::GetAtt` values are now available during deployments.
  * Added support for deploying queues from CDK-generated templates.
  * Added an example demonstrating queue deployment and messaging.

* **Documentation**
  * Expanded CloudFormation and SQS documentation with supported properties, limitations, validation behavior, and deployment examples.

* **Bug Fixes**
  * Unsupported queue configurations and properties now fail clearly, while unsupported queue policies are skipped without blocking the rest of the stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->