### PR TITLE
feat: redrive failed messages to a simulated SQS dead-letter queue

### DIFF
--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -185,6 +185,102 @@ A handle whose visibility timeout has lapsed with nobody else having received th
 still the most recent one, so deleting with it works. A handle the queue never issued fails with
 `ReceiptHandleIsInvalid`, and a repeated delete of a message already gone succeeds.
 
+## Dead-letter queues
+
+A `RedrivePolicy` says where a message goes once a consumer has had enough attempts at it. Once a
+message has been received `maxReceiveCount` times without being deleted, the next lapse of its
+visibility timeout moves it to the queue named by `deadLetterTargetArn` rather than making it
+receivable again. Advancing the clock is what drives the move, as it drives the timeout itself.
+
+```typescript sim-sqs-dead-letter-queue
+/**
+ * A message a consumer keeps failing on, ending up on the dead-letter queue.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+// The dead-letter queue has to exist before anything can point at it.
+const { QueueUrl: DeadLetterQueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders-dlq" }),
+);
+
+const deadLetter = await sqs.getQueueAttributes(
+  new GetQueueAttributesCommand({
+    QueueUrl: DeadLetterQueueUrl,
+    AttributeNames: ["QueueArn"],
+  }),
+);
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: {
+      VisibilityTimeout: "30",
+      RedrivePolicy: JSON.stringify({
+        deadLetterTargetArn: deadLetter.Attributes?.["QueueArn"],
+        maxReceiveCount: 3,
+      }),
+    },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+// A consumer takes the message and never gets as far as deleting it.
+async function failToHandleMessage(): Promise<void> {
+  await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+  await simAws.clock().advanceBy({ seconds: 31 });
+}
+
+await failToHandleMessage();
+await failToHandleMessage();
+await failToHandleMessage();
+
+// The source queue has given up on it.
+const empty = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(empty.Messages); // undefined
+
+const dead = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: DeadLetterQueueUrl }),
+);
+
+console.log(dead.Messages?.[0]?.Body); // "order-1"
+```
+
+The message arrives with its `MessageId`, body and message attributes unchanged, so a test can
+identify it. `ApproximateNumberOfMessages` on both queues reflects the move. A message deleted before
+its attempts run out never gets there, and a message still inside its visibility timeout has not moved
+yet, because the consumer holding it may still delete it.
+
+`SentTimestamp` is unchanged by the move, as it is on a real standard queue. The dead-letter queue's
+`MessageRetentionPeriod` therefore runs from when the message was first sent rather than restarting,
+which is why AWS suggests giving a dead-letter queue a longer retention period than the queue feeding
+it. `ApproximateReceiveCount` starts again from one, since a receive count counts receives from one
+queue and the message has not been received from this one yet. A moved message also reports
+`DeadLetterQueueSourceArn`, naming the queue it came from.
+
+The policy is validated when it is set, whether by `CreateQueue` or `SetQueueAttributes`. It has to be
+a JSON object with both a `deadLetterTargetArn` and a `maxReceiveCount` between 1 and 1000, carried as
+a JSON number or as a string holding one. The `deadLetterTargetArn` has to name a queue that already
+exists in the same account and region, as real SQS requires, so a policy pointing at nothing fails
+there and then rather than quietly losing messages later. Anything else fails with
+`InvalidParameterValue`.
+
+`GetQueueAttributes` reports `RedrivePolicy` back as the string it was set with.
+
 ## Delays
 
 `DelaySeconds` hides a new message until it lapses, either set on the queue for every message or on
@@ -344,10 +440,13 @@ console.log(read.Attributes?.["ApproximateNumberOfMessagesNotVisible"]); // "1"
 console.log(read.Attributes?.["QueueArn"]); // "arn:aws:sqs:us-east-1:888888888888:orders"
 ```
 
-An attribute real SQS reports and this simulation does not model, `RedrivePolicy` for one, is left out
-of a response rather than refused, since that is what real SQS does with an attribute a queue has no
-value for. Setting one is refused, because a queue that appeared to accept a redrive policy would
-behave differently here than on AWS.
+`RedrivePolicy` is the one other settable attribute, covered under
+[dead-letter queues](#dead-letter-queues) above.
+
+An attribute real SQS reports and this simulation does not model, `RedriveAllowPolicy` for one, is
+left out of a response rather than refused, since that is what real SQS does with an attribute a queue
+has no value for. Setting one is refused, because a queue that appeared to accept it would behave
+differently here than on AWS.
 
 `PurgeQueue` deletes everything on a queue, hidden messages included.
 
@@ -764,9 +863,10 @@ Sim SQS currently supports:
 - `ReceiveMessageCommand`, up to ten messages at a time, each under a fresh receipt handle
 - `DeleteMessageCommand`, `DeleteMessageBatchCommand` and `ChangeMessageVisibilityCommand`
 - Visibility timeouts, delays and message retention, all on the simulation's clock
+- `RedrivePolicy`, moving a message to its dead-letter queue once its receives run out
 - `MessageAttributes` round-tripping, with real `MD5OfMessageBody` and `MD5OfMessageAttributes` digests
-- The `SentTimestamp`, `ApproximateReceiveCount` and `ApproximateFirstReceiveTimestamp` system
-  attributes
+- The `SentTimestamp`, `ApproximateReceiveCount`, `ApproximateFirstReceiveTimestamp` and
+  `DeadLetterQueueSourceArn` system attributes
 - Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - `AWS::SQS::Queue` in a CloudFormation or CDK template, with `Ref` giving the queue URL and
@@ -789,8 +889,18 @@ Current documented limitations:
 - `DeleteQueue` and `PurgeQueue` take effect immediately, where real SQS may take up to 60 seconds
   over either. The 60 second hold on a deleted queue's name is simulated, so recreating a queue
   straight after deleting it fails with `QueueDeletedRecently` until the clock moves on.
-- Dead-letter queues are not simulated. `RedrivePolicy` and `RedriveAllowPolicy` are refused rather
-  than ignored, and a message that fails repeatedly stays on its queue.
+- Dead-letter queues are simulated for standard queues only, and only the `RedrivePolicy` half of
+  them. `RedriveAllowPolicy` is refused, so a dead-letter queue cannot restrict which queues may
+  redrive to it. `ListDeadLetterSourceQueues` and the `StartMessageMoveTask` family for draining a
+  dead-letter queue back to its source are not supported, so a redriven message is moved back by a
+  test sending it again.
+- `ApproximateReceiveCount` starting again from one on a dead-letter queue is this simulation's
+  reading of SQS rather than something AWS documents. A receive count counts receives from one queue,
+  and the moved message has not been received from the dead-letter queue yet. `SentTimestamp` being
+  unchanged by the move is documented AWS behaviour, and is simulated as such.
+- The `RedrivePolicy` property on `AWS::SQS::Queue` is not simulated, so a dead-letter queue is
+  configured by an SDK call rather than by a template. The property fails the resource rather than
+  being dropped.
 - Queue policies are not simulated (`AddPermission`, `RemovePermission` and the `Policy` attribute),
   so cross-account access to a queue cannot be granted. A request naming a
   `QueueOwnerAWSAccountId` other than the scope's own Account is refused.
@@ -805,8 +915,7 @@ Current documented limitations:
   for, and they are left out of the response.
 - SQS condition keys are not derived, so a policy relying on them will not match. Ordinary condition
   operators on values sim IAM does supply work as usual.
-- `ChangeMessageVisibilityBatch`, `ListDeadLetterSourceQueues`, the message move tasks and the batch
-  size limit (`BatchRequestTooLong`) are not supported.
+- `ChangeMessageVisibilityBatch` and the batch size limit (`BatchRequestTooLong`) are not supported.
 - Lambda event source mappings are not simulated, so a queue does not invoke a function on its own. A
   test invokes the consumer itself, as the Lambda example above does.
 - `AWS::SQS::Queue` is the only SQS resource type CloudFormation creates. `AWS::SQS::QueuePolicy` is

--- a/docs/services/sqs/sim-sqs-dead-letter-queue.example.ts
+++ b/docs/services/sqs/sim-sqs-dead-letter-queue.example.ts
@@ -1,0 +1,65 @@
+/**
+ * A message a consumer keeps failing on, ending up on the dead-letter queue.
+ */
+
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+
+// The dead-letter queue has to exist before anything can point at it.
+const { QueueUrl: DeadLetterQueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders-dlq" }),
+);
+
+const deadLetter = await sqs.getQueueAttributes(
+  new GetQueueAttributesCommand({
+    QueueUrl: DeadLetterQueueUrl,
+    AttributeNames: ["QueueArn"],
+  }),
+);
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({
+    QueueName: "orders",
+    Attributes: {
+      VisibilityTimeout: "30",
+      RedrivePolicy: JSON.stringify({
+        deadLetterTargetArn: deadLetter.Attributes?.["QueueArn"],
+        maxReceiveCount: 3,
+      }),
+    },
+  }),
+);
+
+await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+);
+
+// A consumer takes the message and never gets as far as deleting it.
+async function failToHandleMessage(): Promise<void> {
+  await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+  await simAws.clock().advanceBy({ seconds: 31 });
+}
+
+await failToHandleMessage();
+await failToHandleMessage();
+await failToHandleMessage();
+
+// The source queue has given up on it.
+const empty = await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(empty.Messages); // undefined
+
+const dead = await sqs.receiveMessage(
+  new ReceiveMessageCommand({ QueueUrl: DeadLetterQueueUrl }),
+);
+
+console.log(dead.Messages?.[0]?.Body); // "order-1"

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -41,6 +41,15 @@ splits reading an attribute from setting one: an attribute real SQS has and this
 is left out of a response, as real SQS leaves out an attribute a queue has no value for, but setting
 one is refused rather than ignored.
 
+`SimSqsRedrivePolicy` is held apart from the numeric attributes, because it is a JSON object and
+because a queue has none until one is set. It keeps the string it was parsed from, so
+`GetQueueAttributes` reports back what was set rather than a re-serialised version of it.
+`SimSqsDeadLetterTargets` resolves the queue a policy names, matching whole ARNs rather than reading
+the name out of one: that keeps the account and region in the comparison, which is what makes an ARN
+naming another scope find nothing. The target is checked when the policy is set, because a policy
+pointing at nothing would look like a working dead-letter queue and lose the messages it was supposed
+to keep.
+
 `SimSqsDeletedQueueNames` holds a deleted queue's name for 60 seconds, as real SQS holds it. The hold
 is measured on the simulation's clock, so advancing simulated time frees the name. That is the
 failure a redeployed stack actually hits.
@@ -71,7 +80,14 @@ has been issued can tell those two apart.
 
 Retention is applied whenever the messages are looked at rather than scheduled, so advancing
 simulated time past `MessageRetentionPeriod` loses the messages AWS would have dropped instead of
-keeping them indefinitely.
+keeping them indefinitely. Moving a message to a dead-letter queue works the same way, in
+`SimSqsQueue.applyLifecycle`: a message that has used up its receives moves the next time its
+visibility lapses, and nothing has to fire for that to happen.
+
+The one thing redrive needs that retention does not is that a queue other than the one being asked
+about can change. So `SimSqsQueueStore.applyLifecycle` brings every queue in the scope up to date,
+and `SimSqsQueueAccess` runs it before answering from any of them. A test reading only the dead-letter
+queue would otherwise find it empty, because the source queue is what notices the move.
 
 ## Command handling
 
@@ -153,7 +169,10 @@ refused rather than quietly answered with a local queue of the same name.
   The 60 second hold on a deleted queue's name is simulated.
 - A queue name ending in `.fifo` is refused, as are the FIFO-only request fields.
 - `SenderId` is not reported, because a simulated principal has no user or role id to report it as.
-- Tags, `RedrivePolicy`, queue policies and the encryption attributes are refused rather than ignored,
-  whether a request or a CloudFormation template asks for them.
+- Tags, `RedriveAllowPolicy`, queue policies and the encryption attributes are refused rather than
+  ignored, whether a request or a CloudFormation template asks for them. So is `RedrivePolicy` on a
+  CloudFormation resource, where it is not simulated, unlike the queue attribute of the same name.
+- A message moved to a dead-letter queue keeps its sent timestamp, which is documented AWS behaviour,
+  and starts its receive count again, which is not documented either way.
 
 The full list is in [docs/services/sqs](../../../docs/services/sqs/).

--- a/src/service/sqs/command/message/sim-sqs-dead-letter-queue.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-dead-letter-queue.iso.test.ts
@@ -272,6 +272,40 @@ describe("SQS dead-letter queues", () => {
     );
   });
 
+  it("accepts a late delete from the consumer whose message was moved", async () => {
+    // Given a consumer holding the handle from the receive that used up the
+    // message's last attempt, which has since moved to the dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // When that consumer finally finishes and deletes.
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: received.Messages?.[0]?.ReceiptHandle,
+      }),
+    );
+
+    // Then the delete succeeds and deletes nothing, as a delete under a
+    // superseded handle does, leaving the message on the dead-letter queue.
+    const dead = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: deadLetterQueueUrl }),
+      );
+
+    assertIdentical(dead.Messages?.[0]?.Body, "order-1");
+  });
+
   it("leaves messages where they are once the dead-letter queue is deleted", async () => {
     // Given a queue whose dead-letter queue has been deleted.
     const { simAws, queueUrl, deadLetterQueueUrl } =

--- a/src/service/sqs/command/message/sim-sqs-dead-letter-queue.iso.test.ts
+++ b/src/service/sqs/command/message/sim-sqs-dead-letter-queue.iso.test.ts
@@ -1,0 +1,296 @@
+import {
+  DeleteMessageCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  failToHandleMessage,
+  simAwsWithDeadLetterQueue,
+} from "../../../../../test/sqs/queue-fixture.js";
+
+describe("SQS dead-letter queues", () => {
+  it("moves a message to the dead-letter queue once its receives run out", async () => {
+    // Given a queue that gives up after three receives, holding a message.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(3);
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When a consumer receives it three times without ever deleting it.
+    await failToHandleMessage(simAws, queueUrl);
+    await failToHandleMessage(simAws, queueUrl);
+    await failToHandleMessage(simAws, queueUrl);
+
+    // Then it is on the dead-letter queue, with the same id and body.
+    const dead = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: deadLetterQueueUrl }),
+      );
+    const message = dead.Messages?.[0];
+
+    assertNonNullable(message);
+    assertIdentical(message.MessageId, sent.MessageId);
+    assertIdentical(message.Body, "order-1");
+  });
+
+  it("stops handing the message out on the queue it came from", async () => {
+    // Given a queue that gives up after two receives, holding a message.
+    const { simAws, queueUrl } = await simAwsWithDeadLetterQueue(2);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When a consumer fails to handle it twice.
+    await failToHandleMessage(simAws, queueUrl);
+    await failToHandleMessage(simAws, queueUrl);
+
+    // Then the source queue has nothing left to hand out.
+    const empty = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(empty.Messages);
+  });
+
+  it("keeps a message that is deleted before its receives run out", async () => {
+    // Given a queue that gives up after two receives, holding a message.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(2);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When a consumer fails once and then handles it on the second attempt.
+    await failToHandleMessage(simAws, queueUrl);
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    await simAws.sqs().deleteMessage(
+      new DeleteMessageCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: received.Messages?.[0]?.ReceiptHandle,
+      }),
+    );
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then nothing ever reaches the dead-letter queue.
+    const dead = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: deadLetterQueueUrl }),
+      );
+
+    assertUndefined(dead.Messages);
+  });
+
+  it("leaves a message in flight until its visibility timeout lapses", async () => {
+    // Given a queue that gives up after one receive, holding a message.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When it has been received and the timeout is still running.
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // Then it has not moved yet, because the consumer may still delete it.
+    const dead = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: deadLetterQueueUrl }),
+      );
+
+    assertUndefined(dead.Messages);
+  });
+
+  it("counts the moved message on the dead-letter queue and not the source", async () => {
+    // Given a queue that gives up after one receive, holding a message.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When the one receive it gets goes unhandled.
+    await failToHandleMessage(simAws, queueUrl);
+
+    // Then both queues report the move.
+    const source = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["ApproximateNumberOfMessages"],
+      }),
+    );
+    const dead = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: deadLetterQueueUrl,
+        AttributeNames: ["ApproximateNumberOfMessages"],
+      }),
+    );
+
+    assertIdentical(source.Attributes?.["ApproximateNumberOfMessages"], "0");
+    assertIdentical(dead.Attributes?.["ApproximateNumberOfMessages"], "1");
+  });
+
+  it("gives the moved message a fresh receive count on the dead-letter queue", async () => {
+    // Given a message that has been moved to the dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(2);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await failToHandleMessage(simAws, queueUrl);
+    await failToHandleMessage(simAws, queueUrl);
+
+    // When it is received from the dead-letter queue.
+    const dead = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: deadLetterQueueUrl,
+        MessageSystemAttributeNames: ["ApproximateReceiveCount"],
+      }),
+    );
+
+    // Then this is its first receive from that queue, because a receive count
+    // counts receives from one queue.
+    assertIdentical(
+      dead.Messages?.[0]?.Attributes?.["ApproximateReceiveCount"],
+      "1",
+    );
+  });
+
+  it("keeps the sent timestamp of the moved message", async () => {
+    // Given a queue that gives up after one receive, holding a message sent at
+    // an instant a test can name.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    simAws.clock().freeze();
+    const sentAt = simAws.clock().now().getTime();
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // When the message is moved half a minute later.
+    await failToHandleMessage(simAws, queueUrl);
+
+    const dead = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: deadLetterQueueUrl,
+        MessageSystemAttributeNames: ["SentTimestamp"],
+      }),
+    );
+
+    // Then it still reports when it was originally sent, as real SQS leaves the
+    // enqueue timestamp of a standard queue's message alone.
+    assertIdentical(
+      dead.Messages?.[0]?.Attributes?.["SentTimestamp"],
+      String(sentAt),
+    );
+  });
+
+  it("reports the queue a dead-lettered message came from", async () => {
+    // Given a message that has been moved to the dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await failToHandleMessage(simAws, queueUrl);
+
+    // When it is received asking for every system attribute.
+    const dead = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: deadLetterQueueUrl,
+        MessageSystemAttributeNames: ["All"],
+      }),
+    );
+
+    // Then it names its source queue, which only a moved message has.
+    assertIdentical(
+      dead.Messages?.[0]?.Attributes?.["DeadLetterQueueSourceArn"],
+      simAws.sqs().findQueue("orders")?.arn.value,
+    );
+  });
+
+  it("keeps the message attributes of the moved message", async () => {
+    // Given a queue that gives up after one receive, holding a message with an
+    // attribute on it.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          customer: { DataType: "String", StringValue: "acme" },
+        },
+      }),
+    );
+
+    // When the message is moved.
+    await failToHandleMessage(simAws, queueUrl);
+
+    const dead = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: deadLetterQueueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+
+    // Then the attribute is still on it.
+    assertIdentical(
+      dead.Messages?.[0]?.MessageAttributes?.["customer"]?.StringValue,
+      "acme",
+    );
+  });
+
+  it("leaves messages where they are once the dead-letter queue is deleted", async () => {
+    // Given a queue whose dead-letter queue has been deleted.
+    const { simAws, queueUrl, deadLetterQueueUrl } =
+      await simAwsWithDeadLetterQueue(1);
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.sqs().deleteQueue({ input: { QueueUrl: deadLetterQueueUrl } });
+
+    // When the message runs out of receives.
+    await failToHandleMessage(simAws, queueUrl);
+
+    // Then it stays on its own queue rather than being lost.
+    const again = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(again.Messages?.[0]?.Body, "order-1");
+  });
+});

--- a/src/service/sqs/command/queue/sim-sqs-create-queue.ts
+++ b/src/service/sqs/command/queue/sim-sqs-create-queue.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimSqsDeadLetterTargets } from "../../queue/sim-sqs-dead-letter-targets.js";
 import { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import {
   type SimSqsQueueAttributeInput,
@@ -20,6 +21,7 @@ interface SimSqsCreateQueueProperties {
   readonly access: SimSqsQueueAccess;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: BackgroundScheduler;
+  readonly deadLetterTargets: SimSqsDeadLetterTargets;
 }
 
 interface SimSqsCreateQueueOptions {
@@ -39,12 +41,14 @@ export class SimSqsCreateQueue {
   private readonly access: SimSqsQueueAccess;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clock: BackgroundScheduler;
+  private readonly deadLetterTargets: SimSqsDeadLetterTargets;
 
   constructor(properties: SimSqsCreateQueueProperties) {
     this.queues = properties.queues;
     this.access = properties.access;
     this.accountRegionScope = properties.accountRegionScope;
     this.clock = properties.clock;
+    this.deadLetterTargets = properties.deadLetterTargets;
   }
 
   /**
@@ -77,6 +81,11 @@ export class SimSqsCreateQueue {
 
   /**
    * Create the queue itself, once the name is known to be free.
+   *
+   * The requested attributes are applied to the new queue rather than folded
+   * into its defaults, so a queue created with a redrive policy has that policy
+   * checked the same way SetQueueAttributes checks one. The queue is only
+   * stored once the attributes have been accepted.
    */
   private created(
     name: SimSqsQueueName,
@@ -89,10 +98,12 @@ export class SimSqsCreateQueue {
     const queue = new SimSqsQueue({
       name,
       accountRegionScope: this.accountRegionScope,
-      attributes: SimSqsQueueAttributes.defaults().with(requested),
+      attributes: SimSqsQueueAttributes.defaults(),
       createdAt,
+      deadLetterTargets: this.deadLetterTargets,
     });
 
+    queue.applyAttributes(requested, createdAt);
     this.queues.add(queue);
 
     return queue;

--- a/src/service/sqs/command/queue/sim-sqs-queue-access.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-access.ts
@@ -1,3 +1,4 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
@@ -23,6 +24,7 @@ interface SimSqsQueueAccessProperties {
   readonly queues: SimSqsQueueStore;
   readonly authorizer: SimSqsAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: BackgroundScheduler;
 }
 
 /**
@@ -38,11 +40,13 @@ export class SimSqsQueueAccess {
   private readonly queues: SimSqsQueueStore;
   private readonly authorizer: SimSqsAuthorizer;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: BackgroundScheduler;
 
   constructor(properties: SimSqsQueueAccessProperties) {
     this.queues = properties.queues;
     this.authorizer = properties.authorizer;
     this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
   }
 
   /**
@@ -79,7 +83,7 @@ export class SimSqsQueueAccess {
 
     this.authorizeName(action, name, caller);
 
-    return this.queues.require(name);
+    return this.upToDate(name);
   }
 
   /**
@@ -93,6 +97,19 @@ export class SimSqsQueueAccess {
     const name = this.nameFromUrl(action, queueUrl);
 
     this.authorizeName(action, name, caller);
+
+    return this.upToDate(name);
+  }
+
+  /**
+   * The queue of a name, with every queue brought up to date first.
+   *
+   * Every queue and not just this one, because a message moves to a dead-letter
+   * queue when its source queue notices, and a request may be about the
+   * dead-letter queue rather than the source.
+   */
+  private upToDate(name: string): SimSqsQueue {
+    this.queues.applyLifecycle(this.clock.now());
 
     return this.queues.require(name);
   }

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
@@ -109,11 +109,11 @@ describe("SQS queue attribute commands", () => {
     // Given a queue.
     const { simAws, queueUrl } = await simAwsWithQueue();
 
-    // When a redrive policy is asked for.
+    // When a redrive allow policy is asked for.
     const read = await simAws.sqs().getQueueAttributes(
       new GetQueueAttributesCommand({
         QueueUrl: queueUrl,
-        AttributeNames: ["RedrivePolicy"],
+        AttributeNames: ["RedriveAllowPolicy"],
       }),
     );
 
@@ -264,12 +264,12 @@ describe("SQS queue attribute commands", () => {
     // Given a queue.
     const { simAws, queueUrl } = await simAwsWithQueue();
 
-    // When a redrive policy is set.
+    // When a queue policy is set.
     const error = await assertThrowsErrorAsync(async () => {
       await simAws.sqs().setQueueAttributes(
         new SetQueueAttributesCommand({
           QueueUrl: queueUrl,
-          Attributes: { RedrivePolicy: "{}" },
+          Attributes: { Policy: "{}" },
         }),
       );
     });

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -11,6 +11,7 @@ export {
   SimSqsQueueAttributes,
 } from "./queue/sim-sqs-queue-attributes.js";
 export { SimSqsQueueName } from "./queue/sim-sqs-queue-name.js";
+export { SimSqsRedrivePolicy } from "./queue/sim-sqs-redrive-policy.js";
 export {
   SimSqsQueueUrl,
   type SimSqsQueueUrlParts,

--- a/src/service/sqs/message/sim-sqs-message-store.ts
+++ b/src/service/sqs/message/sim-sqs-message-store.ts
@@ -51,6 +51,21 @@ export class SimSqsMessageStore {
   }
 
   /**
+   * The messages that have used up their receives and are receivable again.
+   *
+   * These are the ones a redrive policy moves to the dead-letter queue. Being
+   * visible again is the trigger: a message is only out of attempts once the
+   * visibility timeout of its last receive has lapsed, and until then the
+   * consumer holding it may still delete it.
+   */
+  exhausted(instant: Date, maxReceiveCount: number): readonly SimSqsMessage[] {
+    return this.messages.filter(
+      (message) =>
+        message.isVisibleAt(instant) && message.receiveCount >= maxReceiveCount,
+    );
+  }
+
+  /**
    * Record that a message was handed out under a receipt handle.
    */
   recordHandle(receiptHandle: string, message: SimSqsMessage): void {

--- a/src/service/sqs/message/sim-sqs-message.ts
+++ b/src/service/sqs/message/sim-sqs-message.ts
@@ -10,6 +10,7 @@ interface SimSqsMessageProperties {
   readonly attributes: SimSqsMessageAttributes;
   readonly sentAt: Date;
   readonly visibleFrom: Date;
+  readonly deadLetterSourceArn?: string | undefined;
 }
 
 /**
@@ -25,6 +26,7 @@ export class SimSqsMessage {
   public readonly sentAt: Date;
 
   private readonly visibility: SimSqsMessageVisibility;
+  private readonly deadLetterSourceArn: string | undefined;
   private receiptHandle: string | undefined;
 
   constructor(properties: SimSqsMessageProperties) {
@@ -33,6 +35,14 @@ export class SimSqsMessage {
     this.attributes = properties.attributes;
     this.sentAt = properties.sentAt;
     this.visibility = new SimSqsMessageVisibility(properties.visibleFrom);
+    this.deadLetterSourceArn = properties.deadLetterSourceArn;
+  }
+
+  /**
+   * How many times this message has been handed out without being deleted.
+   */
+  get receiveCount(): number {
+    return this.visibility.receiveCount;
   }
 
   /**
@@ -100,13 +110,38 @@ export class SimSqsMessage {
   }
 
   /**
+   * This message as it arrives on a dead-letter queue.
+   *
+   * What the message is carries over unchanged: the id, the body, the message
+   * attributes and the sent timestamp. Real SQS leaves the enqueue timestamp
+   * alone when it moves a message off a standard queue, so the dead-letter
+   * queue's retention period still runs from when the message was first sent
+   * rather than restarting.
+   *
+   * What does not carry over is the receive count, because a receive count
+   * counts receives from one queue and this message has not been received from
+   * this one. It is receivable straight away: the move is not a send, so the
+   * dead-letter queue's delay does not apply to it.
+   */
+  onDeadLetterQueue(instant: Date, sourceQueueArn: string): SimSqsMessage {
+    return new SimSqsMessage({
+      messageId: this.messageId,
+      body: this.body,
+      attributes: this.attributes,
+      sentAt: this.sentAt,
+      visibleFrom: instant,
+      deadLetterSourceArn: sourceQueueArn,
+    });
+  }
+
+  /**
    * The message system attributes SQS knows about this message.
    *
    * Only the attributes a receive request names are reported, so this is what is
    * available rather than what is returned.
    */
   systemAttributeValues(): ReadonlyMap<string, string> {
-    return new Map<string, string>([
+    const values = new Map<string, string>([
       ["SentTimestamp", String(this.sentAt.getTime())],
       ["ApproximateReceiveCount", String(this.visibility.receiveCount)],
       [
@@ -114,5 +149,11 @@ export class SimSqsMessage {
         String(this.visibility.firstReceived.getTime()),
       ],
     ]);
+
+    if (this.deadLetterSourceArn !== undefined) {
+      values.set("DeadLetterQueueSourceArn", this.deadLetterSourceArn);
+    }
+
+    return values;
   }
 }

--- a/src/service/sqs/queue/sim-sqs-dead-letter-targets.ts
+++ b/src/service/sqs/queue/sim-sqs-dead-letter-targets.ts
@@ -1,0 +1,95 @@
+import { SimSqsInvalidParameterValue } from "../error/sim-sqs.error.js";
+import type { SimSqsMessageStore } from "../message/sim-sqs-message-store.js";
+import type { SimSqsQueue } from "./sim-sqs-queue.js";
+import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
+import type { SimSqsQueueStore } from "./sim-sqs-queue-store.js";
+import {
+  type SimSqsRedrivePolicy,
+  simSqsRedrivePolicyIn,
+} from "./sim-sqs-redrive-policy.js";
+
+interface SimSqsDeadLetterTargetsProperties {
+  readonly queues: SimSqsQueueStore;
+}
+
+/**
+ * One queue's messages at an instant, as the thing a move works on.
+ */
+export interface SimSqsDeadLetterMove {
+  readonly policy: SimSqsRedrivePolicy | undefined;
+  readonly messages: SimSqsMessageStore;
+  readonly sourceQueueArn: string;
+  readonly instant: Date;
+}
+
+/**
+ * How a queue reaches the dead-letter queue its redrive policy names.
+ *
+ * The target is resolved by whole ARN rather than by the name inside one, so an
+ * ARN naming another Account or Region finds nothing. Real SQS requires a
+ * dead-letter queue to be in the same Account and Region as its source queue,
+ * and it has to exist before a policy can name it: a policy pointing at nothing
+ * would look like a working dead-letter queue and lose messages instead.
+ */
+export class SimSqsDeadLetterTargets {
+  private readonly queues: SimSqsQueueStore;
+
+  constructor(properties: SimSqsDeadLetterTargetsProperties) {
+    this.queues = properties.queues;
+  }
+
+  /**
+   * Refuse a request whose redrive policy names a queue that is not there.
+   *
+   * A request setting no redrive policy names no dead-letter queue, so there is
+   * nothing to check.
+   */
+  assertRequestedTarget(requested: SimSqsQueueAttributeInput): void {
+    const policy = simSqsRedrivePolicyIn(requested);
+
+    if (policy === undefined || this.find(policy) !== undefined) {
+      return;
+    }
+
+    throw new SimSqsInvalidParameterValue(
+      `Value ${policy.value} for parameter RedrivePolicy is invalid. Reason: ` +
+        `Dead letter target ${policy.deadLetterTargetArn} does not exist. A ` +
+        `dead-letter queue has to be an existing queue in the same Account ` +
+        `and Region as the queue redriving to it.`,
+    );
+  }
+
+  /**
+   * Move the messages a queue has given up on to its dead-letter queue.
+   *
+   * A queue with no redrive policy gives up on nothing. A dead-letter queue
+   * deleted since the policy was set leaves the messages where they are rather
+   * than losing them, which is the safer of the two ways to be wrong about a
+   * queue that is no longer there.
+   */
+  move(request: SimSqsDeadLetterMove): void {
+    const { policy, messages, sourceQueueArn, instant } = request;
+
+    if (policy === undefined) {
+      return;
+    }
+
+    const target = this.find(policy);
+
+    if (target === undefined) {
+      return;
+    }
+
+    for (const message of messages.exhausted(instant, policy.maxReceiveCount)) {
+      messages.remove(message);
+      target.add(message.onDeadLetterQueue(instant, sourceQueueArn));
+    }
+  }
+
+  /**
+   * The dead-letter queue a policy names, or undefined once it has been deleted.
+   */
+  private find(policy: SimSqsRedrivePolicy): SimSqsQueue | undefined {
+    return this.queues.findByArn(policy.deadLetterTargetArn);
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
@@ -3,6 +3,7 @@ import {
   SimSqsUnsupportedOperation,
 } from "../error/sim-sqs.error.js";
 import {
+  simSqsRedrivePolicyAttributeName,
   type SimSqsQueueAttributeSpec,
   simSqsSettableQueueAttributes,
 } from "./sim-sqs-queue-attribute-specs.js";
@@ -23,7 +24,7 @@ const readOnlyNames: ReadonlySet<string> = new Set([
 /**
  * Real SQS attributes this simulation does not model. A request setting one is
  * refused rather than quietly ignored, since a queue behaving as though it had
- * a redrive policy it does not have is worse than being told it cannot have one.
+ * a queue policy it does not have is worse than being told it cannot have one.
  */
 const unsimulatedNames: ReadonlySet<string> = new Set([
   "ContentBasedDeduplication",
@@ -34,7 +35,6 @@ const unsimulatedNames: ReadonlySet<string> = new Set([
   "KmsMasterKeyId",
   "Policy",
   "RedriveAllowPolicy",
-  "RedrivePolicy",
   "SqsManagedSseEnabled",
 ]);
 
@@ -42,6 +42,7 @@ const knownNames = new Set<string>([
   ...simSqsSettableQueueAttributes.map((spec) => spec.name),
   ...readOnlyNames,
   ...unsimulatedNames,
+  simSqsRedrivePolicyAttributeName,
 ]);
 
 const settableSpecsByName = new Map<string, SimSqsQueueAttributeSpec>(

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-numbers.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-numbers.ts
@@ -1,0 +1,132 @@
+import { SimSqsInvalidAttributeValue } from "../error/sim-sqs.error.js";
+import { SimSqsQueueAttributeNames } from "./sim-sqs-queue-attribute-names.js";
+import {
+  simSqsRedrivePolicyAttributeName,
+  type SimSqsQueueAttributeSpec,
+} from "./sim-sqs-queue-attribute-specs.js";
+import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
+
+const integerPattern = /^-?\d+$/;
+
+/**
+ * Read an attribute value, refusing anything outside the range real SQS
+ * accepts for it.
+ */
+function attributeNumber(
+  spec: SimSqsQueueAttributeSpec,
+  value: string,
+): number {
+  const invalid = new SimSqsInvalidAttributeValue(
+    `Value ${value} for parameter ${spec.name} is invalid. Reason: Must be ` +
+      `an integer from ${String(spec.minimum)} to ${String(spec.maximum)}.`,
+  );
+
+  if (!integerPattern.test(value)) {
+    throw invalid;
+  }
+
+  const parsed = Number(value);
+
+  if (parsed < spec.minimum || parsed > spec.maximum) {
+    throw invalid;
+  }
+
+  return parsed;
+}
+
+/**
+ * The numeric attribute entries a request actually carries.
+ *
+ * An SDK attribute map is a partial record, so an explicitly undefined value is
+ * the absence of an attribute rather than a request to set one. The redrive
+ * policy is left out because it is a JSON object with no numeric range to be
+ * checked against.
+ */
+function numberEntries(
+  requested: SimSqsQueueAttributeInput,
+): readonly [string, string][] {
+  return Object.entries(requested).filter(
+    (entry): entry is [string, string] =>
+      entry[1] !== undefined && entry[0] !== simSqsRedrivePolicyAttributeName,
+  );
+}
+
+/**
+ * The queue attributes that are amounts: a timeout, a size, a delay.
+ *
+ * They are held as numbers rather than as the strings a request carries,
+ * because that is what the queue's behaviour is expressed in. Strings are a
+ * wire format, applied on the way in and reported on the way out.
+ */
+export class SimSqsQueueAttributeNumbers {
+  private readonly values: ReadonlyMap<string, number>;
+
+  private constructor(values: ReadonlyMap<string, number>) {
+    this.values = values;
+  }
+
+  /**
+   * The values a queue created with no attributes has.
+   */
+  static defaults(): SimSqsQueueAttributeNumbers {
+    return new this(
+      new Map(
+        SimSqsQueueAttributeNames.settable.map((spec) => [
+          spec.name,
+          spec.defaultValue,
+        ]),
+      ),
+    );
+  }
+
+  /**
+   * The value of one attribute.
+   */
+  get(name: string): number {
+    const value = this.values.get(name);
+
+    /* v8 ignore next 3 -- unreachable: every settable attribute is present from
+       construction, and only settable names are ever read. */
+    if (value === undefined) {
+      throw new SimSqsInvalidAttributeValue(`No value for attribute ${name}`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Apply the values a request asks for, leaving the rest as they are.
+   */
+  with(requested: SimSqsQueueAttributeInput): SimSqsQueueAttributeNumbers {
+    const values = new Map(this.values);
+
+    for (const [name, value] of numberEntries(requested)) {
+      const spec = SimSqsQueueAttributeNames.specForSetting(name);
+
+      values.set(spec.name, attributeNumber(spec, value));
+    }
+
+    return new SimSqsQueueAttributeNumbers(values);
+  }
+
+  /**
+   * Whether every numeric attribute a request names already holds the value it
+   * asks for.
+   */
+  matches(requested: SimSqsQueueAttributeInput): boolean {
+    return numberEntries(requested).every(([name, value]) => {
+      const spec = SimSqsQueueAttributeNames.specForSetting(name);
+
+      return this.get(spec.name) === attributeNumber(spec, value);
+    });
+  }
+
+  /**
+   * The values as SQS reports them, back in their string form.
+   */
+  reported(): ReadonlyMap<string, string> {
+    return new Map<string, string>(
+      this.values.entries().map(([name, value]) => [name, String(value)]),
+    );
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
@@ -1,4 +1,10 @@
 /**
+ * The one settable attribute that is a JSON object rather than a number, so it
+ * has no numeric range to be checked against.
+ */
+export const simSqsRedrivePolicyAttributeName = "RedrivePolicy";
+
+/**
  * One queue attribute a request may set, and the range real SQS accepts for it.
  */
 export interface SimSqsQueueAttributeSpec {

--- a/src/service/sqs/queue/sim-sqs-queue-attributes.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attributes.ts
@@ -1,6 +1,6 @@
-import { SimSqsInvalidAttributeValue } from "../error/sim-sqs.error.js";
-import { SimSqsQueueAttributeNames } from "./sim-sqs-queue-attribute-names.js";
-import type { SimSqsQueueAttributeSpec } from "./sim-sqs-queue-attribute-specs.js";
+import { SimSqsQueueAttributeNumbers } from "./sim-sqs-queue-attribute-numbers.js";
+import { simSqsRedrivePolicyAttributeName } from "./sim-sqs-queue-attribute-specs.js";
+import { SimSqsRedrivePolicy } from "./sim-sqs-redrive-policy.js";
 
 /**
  * Queue attributes as a request carries them: SQS passes every attribute value
@@ -10,97 +10,66 @@ export type SimSqsQueueAttributeInput = Readonly<
   Record<string, string | undefined>
 >;
 
-const integerPattern = /^-?\d+$/;
-
-/**
- * Read an attribute value, refusing anything outside the range real SQS
- * accepts for it.
- */
-function attributeNumber(
-  spec: SimSqsQueueAttributeSpec,
-  value: string,
-): number {
-  const invalid = new SimSqsInvalidAttributeValue(
-    `Value ${value} for parameter ${spec.name} is invalid. Reason: Must be ` +
-      `an integer from ${String(spec.minimum)} to ${String(spec.maximum)}.`,
-  );
-
-  if (!integerPattern.test(value)) {
-    throw invalid;
-  }
-
-  const parsed = Number(value);
-
-  if (parsed < spec.minimum || parsed > spec.maximum) {
-    throw invalid;
-  }
-
-  return parsed;
-}
-
 /**
  * The attribute values held by one simulated queue.
  *
- * Attributes are held as numbers rather than as the strings a request carries,
- * because that is what the queue's behaviour is expressed in: a visibility
- * timeout is an amount of time, and a maximum message size is a number of
- * bytes. Strings are a wire format, applied on the way in and reported on the
- * way out.
+ * They come in two kinds. Most are amounts, held as numbers because that is
+ * what the queue's behaviour is expressed in. The redrive policy is a JSON
+ * object, and a queue has none until one is set, so it is held apart from the
+ * rest rather than squeezed into the same map.
  */
 export class SimSqsQueueAttributes {
-  private readonly values: ReadonlyMap<string, number>;
+  private readonly numbers: SimSqsQueueAttributeNumbers;
+  private readonly redrive: SimSqsRedrivePolicy | undefined;
 
-  private constructor(values: ReadonlyMap<string, number>) {
-    this.values = values;
+  private constructor(
+    numbers: SimSqsQueueAttributeNumbers,
+    redrive: SimSqsRedrivePolicy | undefined,
+  ) {
+    this.numbers = numbers;
+    this.redrive = redrive;
   }
 
   /**
    * The attribute values a queue created with no attributes has.
    */
   static defaults(): SimSqsQueueAttributes {
-    return new this(
-      new Map(
-        SimSqsQueueAttributeNames.settable.map((spec) => [
-          spec.name,
-          spec.defaultValue,
-        ]),
-      ),
-    );
+    return new this(SimSqsQueueAttributeNumbers.defaults(), undefined);
   }
 
   /** The delay a new message with no delay of its own waits out. */
   get delaySeconds(): number {
-    return this.numberFor("DelaySeconds");
+    return this.numbers.get("DelaySeconds");
   }
 
   /** The longest message body the queue accepts, in bytes. */
   get maximumMessageSizeBytes(): number {
-    return this.numberFor("MaximumMessageSize");
+    return this.numbers.get("MaximumMessageSize");
   }
 
   /** How long a message stays on the queue before SQS drops it. */
   get messageRetentionSeconds(): number {
-    return this.numberFor("MessageRetentionPeriod");
+    return this.numbers.get("MessageRetentionPeriod");
   }
 
   /** How long a received message is hidden from other consumers. */
   get visibilityTimeoutSeconds(): number {
-    return this.numberFor("VisibilityTimeout");
+    return this.numbers.get("VisibilityTimeout");
+  }
+
+  /** Where failed messages go, and after how many receives, if anywhere. */
+  get redrivePolicy(): SimSqsRedrivePolicy | undefined {
+    return this.redrive;
   }
 
   /**
    * Apply the attribute values a request asks for, leaving the rest as they are.
    */
   with(requested: SimSqsQueueAttributeInput): SimSqsQueueAttributes {
-    const values = new Map(this.values);
-
-    for (const [name, value] of definedEntries(requested)) {
-      const spec = SimSqsQueueAttributeNames.specForSetting(name);
-
-      values.set(spec.name, attributeNumber(spec, value));
-    }
-
-    return new SimSqsQueueAttributes(values);
+    return new SimSqsQueueAttributes(
+      this.numbers.with(requested),
+      this.redriveIn(requested),
+    );
   }
 
   /**
@@ -111,45 +80,51 @@ export class SimSqsQueueAttributes {
    * request carrying none matches any existing queue.
    */
   matches(requested: SimSqsQueueAttributeInput): boolean {
-    return definedEntries(requested).every(([name, value]) => {
-      const spec = SimSqsQueueAttributeNames.specForSetting(name);
-
-      return this.numberFor(spec.name) === attributeNumber(spec, value);
-    });
+    return this.redriveMatches(requested) && this.numbers.matches(requested);
   }
 
   /**
    * The attributes as SQS reports them, back in their string form.
+   *
+   * The redrive policy is reported as the string it was set with, since that is
+   * the string SQS holds the attribute as. A queue with no redrive policy
+   * reports none, as real SQS leaves out an attribute a queue has no value for.
    */
   reported(): ReadonlyMap<string, string> {
-    return new Map(
-      this.values.entries().map(([name, value]) => [name, String(value)]),
-    );
-  }
+    const reported = new Map(this.numbers.reported());
 
-  private numberFor(name: string): number {
-    const value = this.values.get(name);
-
-    /* v8 ignore next 3 -- unreachable: every settable attribute is present from
-       construction, and only settable names are ever read. */
-    if (value === undefined) {
-      throw new SimSqsInvalidAttributeValue(`No value for attribute ${name}`);
+    if (this.redrive !== undefined) {
+      reported.set(simSqsRedrivePolicyAttributeName, this.redrive.value);
     }
 
-    return value;
+    return reported;
   }
-}
 
-/**
- * The attribute entries a request actually carries.
- *
- * An SDK attribute map is a partial record, so an explicitly undefined value is
- * the absence of an attribute rather than a request to set one.
- */
-function definedEntries(
-  requested: SimSqsQueueAttributeInput,
-): readonly [string, string][] {
-  return Object.entries(requested).filter(
-    (entry): entry is [string, string] => entry[1] !== undefined,
-  );
+  /**
+   * The redrive policy after a request, which is the one it sets or the one
+   * already there.
+   */
+  private redriveIn(
+    requested: SimSqsQueueAttributeInput,
+  ): SimSqsRedrivePolicy | undefined {
+    // eslint-disable-next-line security/detect-object-injection -- a fixed key.
+    const value = requested[simSqsRedrivePolicyAttributeName];
+
+    if (value === undefined) {
+      return this.redrive;
+    }
+
+    return SimSqsRedrivePolicy.parse(value);
+  }
+
+  private redriveMatches(requested: SimSqsQueueAttributeInput): boolean {
+    // eslint-disable-next-line security/detect-object-injection -- a fixed key.
+    const value = requested[simSqsRedrivePolicyAttributeName];
+
+    if (value === undefined) {
+      return true;
+    }
+
+    return this.redrive?.matches(SimSqsRedrivePolicy.parse(value)) === true;
+  }
 }

--- a/src/service/sqs/queue/sim-sqs-queue-report.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-report.ts
@@ -1,0 +1,47 @@
+import type { SimSqsMessageCounts } from "../message/sim-sqs-message-store.js";
+import type { SimSqsQueueAttributes } from "./sim-sqs-queue-attributes.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * Real SQS reports the two queue timestamps in whole seconds since the epoch,
+ * unlike the message timestamps, which are in milliseconds.
+ */
+function epochSeconds(instant: Date): string {
+  return String(Math.floor(instant.getTime() / millisecondsPerSecond));
+}
+
+/**
+ * What one queue is at an instant, as the attributes are read off it.
+ */
+export interface SimSqsQueueReport {
+  readonly settings: SimSqsQueueAttributes;
+  readonly counts: SimSqsMessageCounts;
+  readonly createdAt: Date;
+  readonly lastModifiedAt: Date;
+  readonly queueArn: string;
+}
+
+/**
+ * The attributes SQS reports about a queue.
+ *
+ * This is the settable attributes together with the ones the queue itself
+ * decides: how many messages are in each state, when it was created and last
+ * changed, and its ARN. No request can set those, so they are built here rather
+ * than held with the settings.
+ */
+export function simSqsReportedQueueAttributes(
+  report: SimSqsQueueReport,
+): ReadonlyMap<string, string> {
+  const { settings, counts, createdAt, lastModifiedAt, queueArn } = report;
+
+  return new Map<string, string>([
+    ...settings.reported(),
+    ["ApproximateNumberOfMessages", String(counts.visible)],
+    ["ApproximateNumberOfMessagesDelayed", String(counts.delayed)],
+    ["ApproximateNumberOfMessagesNotVisible", String(counts.inFlight)],
+    ["CreatedTimestamp", epochSeconds(createdAt)],
+    ["LastModifiedTimestamp", epochSeconds(lastModifiedAt)],
+    ["QueueArn", queueArn],
+  ]);
+}

--- a/src/service/sqs/queue/sim-sqs-queue-store.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-store.ts
@@ -46,6 +46,31 @@ export class SimSqsQueueStore {
   }
 
   /**
+   * Find a queue by its ARN.
+   *
+   * Whole ARNs are compared rather than the name being read out of one, which
+   * keeps the Account and Region in the comparison: an ARN naming another scope
+   * finds no queue here, as it names no queue this simulated SQS holds.
+   */
+  findByArn(arn: string): SimSqsQueue | undefined {
+    return this.all.find((queue) => queue.arn.value === arn);
+  }
+
+  /**
+   * Bring every queue in this scope up to date at an instant.
+   *
+   * A message moves to its dead-letter queue when the source queue notices its
+   * visibility has lapsed, and nothing schedules that. A test that only reads
+   * the dead-letter queue would otherwise find it empty, so every queue is
+   * brought up to date before any one of them is answered from.
+   */
+  applyLifecycle(instant: Date): void {
+    for (const queue of this.all) {
+      queue.applyLifecycle(instant);
+    }
+  }
+
+  /**
    * Resolve a queue by name, or refuse.
    */
   require(name: string): SimSqsQueue {

--- a/src/service/sqs/queue/sim-sqs-queue.ts
+++ b/src/service/sqs/queue/sim-sqs-queue.ts
@@ -2,28 +2,21 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
 import { SimSqsQueueNameExists } from "../error/sim-sqs.error.js";
 import type { SimSqsMessage } from "../message/sim-sqs-message.js";
 import { SimSqsMessageStore } from "../message/sim-sqs-message-store.js";
+import type { SimSqsDeadLetterTargets } from "./sim-sqs-dead-letter-targets.js";
 import { SimSqsQueueArn } from "./sim-sqs-queue-arn.js";
 import type { SimSqsQueueName } from "./sim-sqs-queue-name.js";
 import type {
   SimSqsQueueAttributeInput,
   SimSqsQueueAttributes,
 } from "./sim-sqs-queue-attributes.js";
-
-const millisecondsPerSecond = 1000;
-
-/**
- * Real SQS reports the two queue timestamps in whole seconds since the epoch,
- * unlike the message timestamps, which are in milliseconds.
- */
-function epochSeconds(instant: Date): string {
-  return String(Math.floor(instant.getTime() / millisecondsPerSecond));
-}
+import { simSqsReportedQueueAttributes } from "./sim-sqs-queue-report.js";
 
 interface SimSqsQueueProperties {
   readonly name: SimSqsQueueName;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly attributes: SimSqsQueueAttributes;
   readonly createdAt: Date;
+  readonly deadLetterTargets: SimSqsDeadLetterTargets;
 }
 
 /**
@@ -32,9 +25,9 @@ interface SimSqsQueueProperties {
  * The queue owns its messages rather than a service-wide message table owning
  * them, because everything a message does depends on the queue's attributes: how
  * long it stays hidden once received, how long it is kept, and how big it is
- * allowed to be. Retention is applied whenever the messages are looked at, so
- * moving simulated time forward loses the messages AWS would have dropped
- * instead of holding them indefinitely.
+ * allowed to be. Retention and redrive are both applied whenever the messages
+ * are looked at, so moving simulated time forward loses the messages AWS would
+ * have dropped and moves the ones it would have given up on.
  */
 export class SimSqsQueue {
   public readonly name: SimSqsQueueName;
@@ -42,6 +35,7 @@ export class SimSqsQueue {
   public readonly createdAt: Date;
 
   private readonly messages = new SimSqsMessageStore();
+  private readonly deadLetterTargets: SimSqsDeadLetterTargets;
   private settings: SimSqsQueueAttributes;
   private lastModifiedAt: Date;
 
@@ -54,6 +48,7 @@ export class SimSqsQueue {
     this.createdAt = properties.createdAt;
     this.lastModifiedAt = properties.createdAt;
     this.settings = properties.attributes;
+    this.deadLetterTargets = properties.deadLetterTargets;
   }
 
   /**
@@ -90,12 +85,21 @@ export class SimSqsQueue {
 
   /**
    * Apply the attribute values a request asks for, as SetQueueAttributes does.
+   *
+   * A redrive policy is only accepted once its dead-letter queue is there to
+   * accept messages, as real SQS only accepts one then. A policy naming a queue
+   * that does not exist would look like a working dead-letter queue and lose
+   * the messages it was supposed to keep, so it fails here instead of later.
    */
   applyAttributes(
     requested: SimSqsQueueAttributeInput,
     modifiedAt: Date,
   ): void {
-    this.settings = this.settings.with(requested);
+    const updated = this.settings.with(requested);
+
+    this.deadLetterTargets.assertRequestedTarget(requested);
+
+    this.settings = updated;
     this.lastModifiedAt = modifiedAt;
   }
 
@@ -110,9 +114,27 @@ export class SimSqsQueue {
    * The messages that can be received at an instant, oldest first.
    */
   receivable(instant: Date, limit: number): readonly SimSqsMessage[] {
-    this.dropExpired(instant);
+    this.applyLifecycle(instant);
 
     return this.messages.receivable(instant, limit);
+  }
+
+  /**
+   * Bring this queue up to date at an instant.
+   *
+   * Nothing is scheduled to age a message out or to give up on one. Both happen
+   * on the simulation's clock: what the retention period has outlived is
+   * dropped, and what has run out of receives moves to the dead-letter queue.
+   * Running it twice at one instant does nothing the second time.
+   */
+  applyLifecycle(instant: Date): void {
+    this.dropExpired(instant);
+    this.deadLetterTargets.move({
+      policy: this.settings.redrivePolicy,
+      messages: this.messages,
+      sourceQueueArn: this.arn.value,
+      instant,
+    });
   }
 
   /**
@@ -130,7 +152,7 @@ export class SimSqsQueue {
     receiptHandle: string,
     instant: Date,
   ): SimSqsMessage | undefined {
-    this.dropExpired(instant);
+    this.applyLifecycle(instant);
 
     return this.messages.forHandle(receiptHandle);
   }
@@ -155,19 +177,15 @@ export class SimSqsQueue {
    * timestamps no request can set.
    */
   reportedAttributes(instant: Date): ReadonlyMap<string, string> {
-    this.dropExpired(instant);
+    this.applyLifecycle(instant);
 
-    const counts = this.messages.countsAt(instant);
-
-    return new Map<string, string>([
-      ...this.settings.reported(),
-      ["ApproximateNumberOfMessages", String(counts.visible)],
-      ["ApproximateNumberOfMessagesDelayed", String(counts.delayed)],
-      ["ApproximateNumberOfMessagesNotVisible", String(counts.inFlight)],
-      ["CreatedTimestamp", epochSeconds(this.createdAt)],
-      ["LastModifiedTimestamp", epochSeconds(this.lastModifiedAt)],
-      ["QueueArn", this.arn.value],
-    ]);
+    return simSqsReportedQueueAttributes({
+      settings: this.settings,
+      counts: this.messages.countsAt(instant),
+      createdAt: this.createdAt,
+      lastModifiedAt: this.lastModifiedAt,
+      queueArn: this.arn.value,
+    });
   }
 
   private dropExpired(instant: Date): void {

--- a/src/service/sqs/queue/sim-sqs-redrive-policy.iso.test.ts
+++ b/src/service/sqs/queue/sim-sqs-redrive-policy.iso.test.ts
@@ -1,0 +1,353 @@
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimSqsInvalidParameterValue,
+  SimSqsQueueNameExists,
+} from "../error/sim-sqs.error.js";
+import {
+  simAwsWithDeadLetterQueue,
+  simAwsWithQueue,
+} from "../../../../test/sqs/queue-fixture.js";
+
+/**
+ * Set a redrive policy on a queue, which is what a test asserting the policy is
+ * refused is actually doing.
+ */
+async function setRedrivePolicy(
+  simAws: SimAws,
+  queueUrl: string,
+  policy: string,
+): Promise<void> {
+  await simAws.sqs().setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: queueUrl,
+      Attributes: { RedrivePolicy: policy },
+    }),
+  );
+}
+
+describe("SQS redrive policy", () => {
+  it("reports back the redrive policy that was set", async () => {
+    // Given a queue and a dead-letter queue to point it at.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+    const policy = JSON.stringify({
+      deadLetterTargetArn: deadLetterQueueArn,
+      maxReceiveCount: 3,
+    });
+
+    // When the redrive policy is read back.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    // Then it is the string the queue was created with.
+    assertIdentical(read.Attributes?.["RedrivePolicy"], policy);
+  });
+
+  it("accepts a maxReceiveCount carried as a string, as AWS documents it", async () => {
+    // Given a queue and a dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When a policy carrying the count as a JSON string is set.
+    await setRedrivePolicy(
+      simAws,
+      queueUrl,
+      JSON.stringify({
+        deadLetterTargetArn: deadLetterQueueArn,
+        maxReceiveCount: "5",
+      }),
+    );
+
+    // Then it is accepted, as real SQS accepts either form.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes?.["RedrivePolicy"]);
+  });
+
+  it("refuses a redrive policy that is not JSON", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a redrive policy that is not JSON is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(simAws, queueUrl, "not json at all");
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a redrive policy that is not a JSON object", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a JSON array is set as the redrive policy.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(simAws, queueUrl, "[]");
+    });
+
+    // Then it is refused, since a redrive policy is a JSON map.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a redrive policy with no deadLetterTargetArn", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a policy naming no dead-letter queue is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({ maxReceiveCount: 3 }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a maxReceiveCount that is not an integer", async () => {
+    // Given a queue and a dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When a fractional receive count is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({
+          deadLetterTargetArn: deadLetterQueueArn,
+          maxReceiveCount: 2.5,
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a maxReceiveCount that is missing", async () => {
+    // Given a queue and a dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When a policy with no receive count is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({ deadLetterTargetArn: deadLetterQueueArn }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a maxReceiveCount below one", async () => {
+    // Given a queue and a dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When a receive count of zero is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({
+          deadLetterTargetArn: deadLetterQueueArn,
+          maxReceiveCount: 0,
+        }),
+      );
+    });
+
+    // Then it is refused, as real SQS accepts one to a thousand.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a maxReceiveCount above a thousand", async () => {
+    // Given a queue and a dead-letter queue.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When a receive count above the maximum is set as a string.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({
+          deadLetterTargetArn: deadLetterQueueArn,
+          maxReceiveCount: "1001",
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a dead-letter queue that does not exist", async () => {
+    // Given a queue and no dead-letter queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a policy naming a queue that is not there is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({
+          deadLetterTargetArn: "arn:aws:sqs:us-east-1:123456789012:missing",
+          maxReceiveCount: 3,
+        }),
+      );
+    });
+
+    // Then it is refused now, rather than losing messages later.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a dead-letter queue in another Account and Region", async () => {
+    // Given a queue, and a queue of the same name in another scope.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    await simAws
+      .account("222222222222")
+      .region("eu-west-2")
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders-dlq" }));
+
+    // When the queue is pointed at that other scope's queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setRedrivePolicy(
+        simAws,
+        queueUrl,
+        JSON.stringify({
+          deadLetterTargetArn: "arn:aws:sqs:eu-west-2:222222222222:orders-dlq",
+          maxReceiveCount: 3,
+        }),
+      );
+    });
+
+    // Then it is refused, as real SQS requires the two to share a scope.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+  });
+
+  it("refuses a redrive policy naming a queue that does not exist yet at CreateQueue", async () => {
+    // Given a simulated AWS with no queues on it.
+    const simAws = new SimAws();
+
+    // When a queue is created pointing at a dead-letter queue that is not there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          Attributes: {
+            RedrivePolicy: JSON.stringify({
+              deadLetterTargetArn: "arn:aws:sqs:us-east-1:123456789012:missing",
+              maxReceiveCount: 3,
+            }),
+          },
+        }),
+      );
+    });
+
+    // Then the queue is not created.
+    assertInstanceOf(error, SimSqsInvalidParameterValue);
+    assertUndefined(simAws.sqs().findQueue("orders"));
+  });
+
+  it("answers a repeated CreateQueue with the same redrive policy", async () => {
+    // Given a queue created with a redrive policy.
+    const { simAws, queueUrl, deadLetterQueueArn } =
+      await simAwsWithDeadLetterQueue(3);
+
+    // When the same queue is created again with the same policy.
+    const again = await simAws.sqs().createQueue(
+      new CreateQueueCommand({
+        QueueName: "orders",
+        Attributes: {
+          RedrivePolicy: JSON.stringify({
+            deadLetterTargetArn: deadLetterQueueArn,
+            maxReceiveCount: 3,
+          }),
+        },
+      }),
+    );
+
+    // Then it answers with the existing queue, as CreateQueue is idempotent.
+    assertIdentical(again.QueueUrl, queueUrl);
+  });
+
+  it("refuses a repeated CreateQueue with a different redrive policy", async () => {
+    // Given a queue created with a redrive policy.
+    const { simAws, deadLetterQueueArn } = await simAwsWithDeadLetterQueue(3);
+
+    // When the same queue is created again with a different receive count.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          Attributes: {
+            RedrivePolicy: JSON.stringify({
+              deadLetterTargetArn: deadLetterQueueArn,
+              maxReceiveCount: 9,
+            }),
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, as the attributes differ from the existing queue's.
+    assertInstanceOf(error, SimSqsQueueNameExists);
+  });
+
+  it("refuses a repeated CreateQueue asking for a policy the queue has not got", async () => {
+    // Given a queue with no redrive policy, and a dead-letter queue.
+    const { simAws } = await simAwsWithDeadLetterQueue(3);
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "invoices" }));
+
+    // When it is created again with a redrive policy.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "invoices",
+          Attributes: {
+            RedrivePolicy: JSON.stringify({
+              deadLetterTargetArn: "arn:aws:sqs:us-east-1:123456789012:missing",
+              maxReceiveCount: 3,
+            }),
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, since the existing queue has no policy to match.
+    assertInstanceOf(error, SimSqsQueueNameExists);
+  });
+});

--- a/src/service/sqs/queue/sim-sqs-redrive-policy.ts
+++ b/src/service/sqs/queue/sim-sqs-redrive-policy.ts
@@ -1,0 +1,164 @@
+import { SimSqsInvalidParameterValue } from "../error/sim-sqs.error.js";
+import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
+import { simSqsRedrivePolicyAttributeName } from "./sim-sqs-queue-attribute-specs.js";
+
+const minimumReceiveCount = 1;
+const maximumReceiveCount = 1000;
+const integerPattern = /^\d+$/;
+
+/**
+ * The error real SQS refuses a redrive policy with.
+ *
+ * Every reason is reported as one invalid parameter value carrying the policy
+ * that was sent, because that is the shape of the message AWS answers with and
+ * the whole policy is what has to be corrected.
+ */
+function invalidPolicy(value: string, reason: string): Error {
+  return new SimSqsInvalidParameterValue(
+    `Value ${value} for parameter RedrivePolicy is invalid. Reason: ${reason}.`,
+  );
+}
+
+/**
+ * Read a redrive policy string as the JSON map real SQS expects it to be.
+ */
+function parsedJsonMap(value: string): Readonly<Record<string, unknown>> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw invalidPolicy(value, "Redrive policy is not valid JSON");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw invalidPolicy(value, "Redrive policy is not a JSON object");
+  }
+
+  return parsed as Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Read the dead-letter queue ARN out of a parsed policy.
+ */
+function parsedTargetArn(
+  value: string,
+  parsed: Readonly<Record<string, unknown>>,
+): string {
+  const arn = parsed["deadLetterTargetArn"];
+
+  if (typeof arn !== "string" || arn === "") {
+    throw invalidPolicy(
+      value,
+      "Redrive policy requires a deadLetterTargetArn naming the dead-letter " +
+        "queue",
+    );
+  }
+
+  return arn;
+}
+
+/**
+ * Read the maximum receive count out of a parsed policy.
+ *
+ * SQS carries it as a JSON number or as a string holding one. AWS's own
+ * documented example sends a string, and CloudFormation sends a number, so both
+ * have to be read the same way.
+ */
+function parsedReceiveCount(
+  value: string,
+  parsed: Readonly<Record<string, unknown>>,
+): number {
+  const count = parsed["maxReceiveCount"];
+  const range = `${String(minimumReceiveCount)} to ${String(maximumReceiveCount)}`;
+  const outOfRange = invalidPolicy(
+    value,
+    `Value ${String(count)} for maxReceiveCount is invalid. It must be an ` +
+      `integer from ${range}`,
+  );
+
+  if (typeof count === "string" && integerPattern.test(count)) {
+    return inRange(Number(count), outOfRange);
+  }
+
+  if (typeof count === "number" && Number.isSafeInteger(count)) {
+    return inRange(count, outOfRange);
+  }
+
+  throw outOfRange;
+}
+
+function inRange(count: number, outOfRange: Error): number {
+  if (count < minimumReceiveCount || count > maximumReceiveCount) {
+    throw outOfRange;
+  }
+
+  return count;
+}
+
+interface SimSqsRedrivePolicyProperties {
+  readonly value: string;
+  readonly deadLetterTargetArn: string;
+  readonly maxReceiveCount: number;
+}
+
+/**
+ * The redrive policy of one simulated queue.
+ *
+ * It says two things: which queue failed messages go to, and how many receives
+ * a message gets before it is one of them. Both are read out of the JSON string
+ * SQS carries the attribute as, and the string itself is kept so
+ * `GetQueueAttributes` reports back what was set rather than a re-serialised
+ * version of it.
+ */
+export class SimSqsRedrivePolicy {
+  public readonly value: string;
+  public readonly deadLetterTargetArn: string;
+  public readonly maxReceiveCount: number;
+
+  private constructor(properties: SimSqsRedrivePolicyProperties) {
+    this.value = properties.value;
+    this.deadLetterTargetArn = properties.deadLetterTargetArn;
+    this.maxReceiveCount = properties.maxReceiveCount;
+  }
+
+  /**
+   * Read a redrive policy attribute value, refusing one real SQS would refuse.
+   */
+  static parse(value: string): SimSqsRedrivePolicy {
+    const parsed = parsedJsonMap(value);
+
+    return new this({
+      value,
+      deadLetterTargetArn: parsedTargetArn(value, parsed),
+      maxReceiveCount: parsedReceiveCount(value, parsed),
+    });
+  }
+
+  /**
+   * Whether another policy asks for the same dead-letter queue on the same
+   * terms, which is the question a repeated `CreateQueue` asks.
+   */
+  matches(other: SimSqsRedrivePolicy): boolean {
+    return (
+      this.deadLetterTargetArn === other.deadLetterTargetArn &&
+      this.maxReceiveCount === other.maxReceiveCount
+    );
+  }
+}
+
+/**
+ * The redrive policy a request is setting, if it is setting one.
+ */
+export function simSqsRedrivePolicyIn(
+  requested: SimSqsQueueAttributeInput,
+): SimSqsRedrivePolicy | undefined {
+  // eslint-disable-next-line security/detect-object-injection -- a fixed key.
+  const value = requested[simSqsRedrivePolicyAttributeName];
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return SimSqsRedrivePolicy.parse(value);
+}

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -22,6 +22,7 @@ import { SimSqsQueueCommands } from "./command/queue/sim-sqs-queue-commands.js";
 import type * as simSqsCommands from "./command/sim-sqs-command.types.js";
 import { SimSqsCfnResourceFactory } from "./cfn/sim-sqs-cfn-resource-factory.js";
 import { SimSqsMessageWriter } from "./message/sim-sqs-message-writer.js";
+import { SimSqsDeadLetterTargets } from "./queue/sim-sqs-dead-letter-targets.js";
 import type { SimSqsQueue } from "./queue/sim-sqs-queue.js";
 import { SimSqsQueueStore } from "./queue/sim-sqs-queue-store.js";
 import { SimSqsSdkCommandRouter } from "./sdk/sim-sqs-sdk-command-router.js";
@@ -69,6 +70,7 @@ export class SimSqs {
       queues: this.queues,
       authorizer: new SimSqsAuthorizer({ iam, accountRegionScope }),
       accountRegionScope,
+      clock: background,
     });
 
     this.background = background;
@@ -77,6 +79,7 @@ export class SimSqs {
       access,
       accountRegionScope,
       clock: background,
+      deadLetterTargets: new SimSqsDeadLetterTargets({ queues: this.queues }),
     });
     this.queueCommands = new SimSqsQueueCommands({
       queues: this.queues,

--- a/test/sqs/queue-fixture.ts
+++ b/test/sqs/queue-fixture.ts
@@ -38,8 +38,9 @@ export interface SimSqsReceivedMessageFixture extends SimSqsQueueFixture {
  */
 export async function simAwsWithQueue(
   attributes?: Record<string, string>,
+  existing?: SimAws,
 ): Promise<SimSqsQueueFixture> {
-  const simAws = new SimAws();
+  const simAws = existing ?? new SimAws();
   const created = await simAws.sqs().createQueue(
     new CreateQueueCommand({
       QueueName: "orders",
@@ -50,6 +51,65 @@ export async function simAwsWithQueue(
   assertNonNullable(created.QueueUrl, "CreateQueue answered with a queue URL");
 
   return { simAws, queueUrl: created.QueueUrl };
+}
+
+/**
+ * One simulated AWS holding a queue that redrives to a dead-letter queue.
+ */
+export interface SimSqsDeadLetterQueueFixture extends SimSqsQueueFixture {
+  readonly deadLetterQueueUrl: string;
+  readonly deadLetterQueueArn: string;
+}
+
+/**
+ * Make a simulated AWS holding a queue named `orders` that gives up on a message
+ * after `maxReceiveCount` receives and moves it to a queue named `orders-dlq`.
+ */
+export async function simAwsWithDeadLetterQueue(
+  maxReceiveCount: number,
+): Promise<SimSqsDeadLetterQueueFixture> {
+  const simAws = new SimAws();
+  const created = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "orders-dlq" }));
+
+  assertNonNullable(created.QueueUrl, "CreateQueue answered with a queue URL");
+
+  const deadLetterQueueArn = simAws.sqs().findQueue("orders-dlq")?.arn.value;
+
+  assertNonNullable(deadLetterQueueArn, "The dead-letter queue has an ARN");
+
+  const { queueUrl } = await simAwsWithQueue(
+    {
+      VisibilityTimeout: "30",
+      RedrivePolicy: JSON.stringify({
+        deadLetterTargetArn: deadLetterQueueArn,
+        maxReceiveCount,
+      }),
+    },
+    simAws,
+  );
+
+  return {
+    simAws,
+    queueUrl,
+    deadLetterQueueUrl: created.QueueUrl,
+    deadLetterQueueArn,
+  };
+}
+
+/**
+ * Receive a message and leave it undeleted until its visibility timeout lapses,
+ * which is how a consumer that cannot handle a message fails to handle it.
+ */
+export async function failToHandleMessage(
+  simAws: SimAws,
+  queueUrl: string,
+): Promise<void> {
+  await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+  await simAws.clock().advanceBy({ seconds: 31 });
 }
 
 /**


### PR DESCRIPTION
RedrivePolicy is accepted on CreateQueue and SetQueueAttributes. A message received maxReceiveCount times without being deleted moves to the queue named by deadLetterTargetArn on the next lapse of its visibility timeout, keeping its id, body, message attributes and sent timestamp.

The target has to be an existing queue in the same account and region, checked when the policy is set rather than when a message needs it.

Resolves https://github.com/KensioSoftware/yulin/issues/244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue support for simulated Amazon SQS standard queues.
  * Failed messages can be automatically moved after a configurable number of receive attempts.
  * Dead-letter deliveries preserve message content and metadata while reporting the source queue.
  * Added validation for redrive policies and dead-letter queue targets.

* **Documentation**
  * Added setup guidance and a complete dead-letter queue usage example.
  * Documented supported behavior, limitations, and unsupported policy features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->