### PR TITLE
feat: trigger a simulated Lambda from a simulated SQS queue

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -395,6 +395,182 @@ console.log(dryRunOutput.StatusCode);
 `Event` invocation handler errors are dropped, as sim Lambda does not simulate asynchronous
 retries or failure destinations yet.
 
+## Triggering a function from an SQS queue
+
+An event source mapping connects a [simulated queue](../sqs/ "Simulated SQS docs") to a function.
+Messages sent to the queue are delivered to the handler as an SQS event, with the `Records` shape
+real Lambda uses.
+
+Polling runs on the simulation's background scheduler, so a test awaits
+`simAws.backgroundTasksComplete()` and then asserts, rather than sleeping.
+
+`BatchSize` says how many messages one invocation may be given, and defaults to 10. The queue and
+the function have to be in the same account and region, as they do on real AWS.
+
+```typescript sim-lambda-sqs-event-source
+/**
+ * Delivering messages from a simulated queue to a simulated function.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+// The execution role needs the three SQS actions Lambda polls a queue with.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const consumed: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          consumed.push(record.body);
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer",
+    BatchSize: 5,
+  }),
+);
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(consumed); // ["order-1"]
+```
+
+Each record carries `messageId`, `receiptHandle`, `body`, `md5OfBody`, `messageAttributes`,
+`eventSource`, `eventSourceARN`, `awsRegion`, and the `attributes` map holding `SentTimestamp`,
+`ApproximateReceiveCount` and `ApproximateFirstReceiveTimestamp`. `SimLambdaSqsEvent` and
+`SimLambdaSqsEventRecord` are exported from `@kensio/yulin/lambda` for typing a handler, and are
+minimal structural equivalents of the `SQSEvent` and `SQSRecord` types from the `aws-lambda` typings
+package, so a handler already written against those can be passed in unchanged. `SenderId` is not
+reported, because a simulated caller has no user or role id to report it as.
+
+Creating the mapping checks two things real Lambda checks: that the queue exists, and that the
+function's execution role is allowed `sqs:ReceiveMessage`, `sqs:DeleteMessage` and
+`sqs:GetQueueAttributes` on it. A role missing one of them fails with
+`InvalidParameterValueException` naming the operation, rather than leaving a mapping that quietly
+delivers nothing.
+
+`GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
+`DeleteEventSourceMappingCommand` read and remove mappings. A mapping is `Creating` when the command
+returns and `Enabled` once the simulation has caught up, as on real Lambda. Deleting it stops the
+polling.
+
+### When the handler fails
+
+A handler that returns normally has handled the batch, and the messages are deleted from the queue.
+A handler that throws returns the whole batch: the messages stay on the queue, hidden until their
+visibility timeout lapses, and are delivered again after that. Advancing the simulation's clock is
+what brings them back:
+
+```typescript
+await simAws.clock().advanceBy({ seconds: 31 });
+```
+
+A queue with a `RedrivePolicy` eventually gives up on a message the handler keeps throwing on and
+moves it to the dead-letter queue, exactly as it would for any other failing consumer. See
+[dead-letter queues](../sqs/#dead-letter-queues "Simulated SQS dead-letter queue docs").
+
+The handler error itself is not reported to whoever sent the message, as it is not on real AWS. What
+the sender sees is the message coming back.
+
+### Reporting individual message failures
+
+A mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
+`batchItemFailures` list the handler returns: the message ids named in it go back to the queue, and
+the rest of the batch is deleted.
+
+```typescript
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer",
+    FunctionResponseTypes: ["ReportBatchItemFailures"],
+  }),
+);
+
+// The handler reports the message ids it could not handle.
+const handler = (event: SimLambdaSqsEvent) => ({
+  batchItemFailures: event.Records.filter((record) => !canHandle(record)).map(
+    (record) => ({ itemIdentifier: record.messageId }),
+  ),
+});
+```
+
+A report naming an id that was not in the batch returns the whole batch, as real Lambda does with a
+report it cannot trust. So does an entry with no `itemIdentifier`. A handler that returns nothing,
+or an empty `batchItemFailures` list, has handled the whole batch.
+
+### Event source mappings in templates
+
+`AWS::Lambda::EventSourceMapping` deploys the same thing, which is what CDK's
+`fn.addEventSource(new SqsEventSource(queue))` emits. `EventSourceArn` and `FunctionName` accept the
+`Fn::GetAtt` and `Ref` values a template gives them, `Ref` on the mapping returns its UUID, and
+`Fn::GetAtt` exposes `Id` and `EventSourceMappingArn`.
+
 ## Function URLs
 
 A Function URL is an HTTP endpoint for one function. Creating one with
@@ -1120,6 +1296,11 @@ Sim Lambda currently supports:
   resolved from the request
 - `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
   policies evaluated alongside identity policies
+- SQS event source mappings, created with `CreateEventSourceMappingCommand` and read with
+  `GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
+  `DeleteEventSourceMappingCommand`, delivering real-shaped SQS events and honouring `BatchSize`
+- `FunctionResponseTypes: ["ReportBatchItemFailures"]`, returning only the message ids the handler
+  reported
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
@@ -1132,17 +1313,18 @@ Sim Lambda currently supports:
 - IAM authorization of the Lambda commands themselves (`lambda:CreateFunction`,
   `lambda:GetFunction`, `lambda:InvokeFunction`, and the Function URL config actions)
 - AWS-like validation and errors, such as `ResourceConflictException` for a duplicate function name
-- The `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission` CloudFormation
-  resources, with `Ref`/`Fn::GetAtt` support and deploy-time executable bindings
+- The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission` and
+  `AWS::Lambda::EventSourceMapping` CloudFormation resources, with `Ref`/`Fn::GetAtt` support and
+  deploy-time executable bindings
 
 ## Limitations
 
 Current documented limitations:
 
 - Only `CreateFunctionCommand`, `GetFunctionCommand`, `InvokeCommand`, the permission commands
-  (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`) and the Function URL config
-  commands are supported. There is no `UpdateFunctionCode`, `DeleteFunction`, or function listing
-  yet.
+  (`AddPermissionCommand`, `RemovePermissionCommand`, `GetPolicyCommand`), the Function URL config
+  commands and the event source mapping commands are supported. There is no `UpdateFunctionCode`,
+  `DeleteFunction`, or function listing yet.
 - A cross-account grant is only half of what admits a call: the caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account the simulation knows nothing about is denied.
@@ -1175,9 +1357,20 @@ Current documented limitations:
   invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
 - `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
-- CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url` and
-  `AWS::Lambda::Permission` (`Version`, `Alias`, `EventSourceMapping`, ...) are skipped with an
-  "Unsupported" diagnostic.
+- SQS queues are the only event source. DynamoDB streams, Kinesis, Kafka and DocumentDB sources are
+  refused rather than accepted and never delivered from, and so are `FilterCriteria`, `ScalingConfig`,
+  `DestinationConfig`, `MaximumRetryAttempts` and the other mapping inputs this simulation has no
+  behaviour for.
+- `MaximumBatchingWindowInSeconds` is only simulated as 0: a partial batch is delivered as soon as
+  anything is on the queue, so a batching window would have nothing to wait for. A non-zero value is
+  refused, which also caps `BatchSize` at 10.
+- `UpdateEventSourceMapping` is not supported, so a mapping's batch size or enabled state is fixed
+  once it is created. `Enabled: false` at creation is simulated.
+- One poll delivers one batch. Real Lambda runs several pollers at once and scales them with the
+  queue, so nothing here shows what concurrency does to ordering or to a downstream service.
+- CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url`,
+  `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` (`Version`, `Alias`, ...) are
+  skipped with an "Unsupported" diagnostic.
 - The `vm` context is a namespacing convenience, not a security boundary: function code runs
   in-process with the same trust as the test suite itself. Do not run untrusted code through the
   simulator.

--- a/docs/services/lambda/sim-lambda-sqs-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-sqs-event-source.example.ts
@@ -1,0 +1,90 @@
+/**
+ * Delivering messages from a simulated queue to a simulated function.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+// The execution role needs the three SQS actions Lambda polls a queue with.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const consumed: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          consumed.push(record.body);
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer",
+    BatchSize: 5,
+  }),
+);
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(consumed); // ["order-1"]

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -768,6 +768,130 @@ work. The same applies to `SimSdk` interception: intercepting `SQSClient` routes
 the simulation with nothing touching the network. See
 [AWS SDK interception](../../sdk/ "Simulated AWS SDK docs").
 
+## Triggering a Lambda from a queue
+
+A Lambda event source mapping delivers messages from a queue to a function without anything calling
+`ReceiveMessage` itself. Messages sent to the queue arrive at the handler as an SQS event, in
+batches of up to `BatchSize`.
+
+Delivery runs on the simulation's background scheduler, so a test waits for it with
+`simAws.backgroundTasksComplete()`.
+
+```typescript sim-sqs-lambda-event-source
+/**
+ * A message sent to a queue reaching a Lambda through an event source mapping.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// Lambda polls the queue as the execution role, so the role has to allow it.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const consumed: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          consumed.push(record.body);
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer",
+  }),
+);
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+await simAws.backgroundTasksComplete();
+
+console.log(consumed); // ["order-1"]
+
+// The handler returned, so the message has been deleted from the queue.
+const remaining = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(remaining.Messages); // undefined
+```
+
+A handler that throws leaves the whole batch on the queue instead. The messages stay hidden until
+their visibility timeout lapses, come back after that, and eventually move to the dead-letter queue
+if the queue has a `RedrivePolicy`. That is the same path any other failing consumer takes, so
+advancing the clock is what drives it:
+
+```typescript
+await simAws.clock().advanceBy({ seconds: 31 });
+```
+
+See [simulated Lambda](../lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event
+source mapping docs") for the event shape, partial batch failures, and the
+`AWS::Lambda::EventSourceMapping` template resource.
+
 ## Deploying a queue from CloudFormation
 
 Simulated CloudFormation creates a queue from an `AWS::SQS::Queue` resource, in the stack's account
@@ -869,6 +993,8 @@ Sim SQS currently supports:
   `DeadLetterQueueSourceArn` system attributes
 - Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
+- Lambda event source mappings, delivering messages to a simulated function and deleting the batches
+  it handles
 - `AWS::SQS::Queue` in a CloudFormation or CDK template, with `Ref` giving the queue URL and
   `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`
 
@@ -916,8 +1042,10 @@ Current documented limitations:
 - SQS condition keys are not derived, so a policy relying on them will not match. Ordinary condition
   operators on values sim IAM does supply work as usual.
 - `ChangeMessageVisibilityBatch` and the batch size limit (`BatchRequestTooLong`) are not supported.
-- Lambda event source mappings are not simulated, so a queue does not invoke a function on its own. A
-  test invokes the consumer itself, as the Lambda example above does.
+- A Lambda event source mapping polls one batch at a time. Real Lambda runs several pollers at once
+  and scales them with the queue, so nothing here shows what that concurrency does to ordering. See
+  [simulated Lambda](../lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event
+source mapping docs") for the rest of the mapping limitations.
 - `AWS::SQS::Queue` is the only SQS resource type CloudFormation creates. `AWS::SQS::QueuePolicy` is
   skipped, and the queue properties this simulation has no behaviour for fail the resource rather
   than being dropped.

--- a/docs/services/sqs/sim-sqs-lambda-event-source.example.ts
+++ b/docs/services/sqs/sim-sqs-lambda-event-source.example.ts
@@ -1,0 +1,99 @@
+/**
+ * A message sent to a queue reaching a Lambda through an event source mapping.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+// Lambda polls the queue as the execution role, so the role has to allow it.
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderConsumerRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const consumed: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          consumed.push(record.body);
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "order-consumer",
+  }),
+);
+
+await simAws
+  .sqs()
+  .sendMessage(new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }));
+
+await simAws.backgroundTasksComplete();
+
+console.log(consumed); // ["order-1"]
+
+// The handler returned, so the message has been deleted from the queue.
+const remaining = await simAws
+  .sqs()
+  .receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+
+console.log(remaining.Messages); // undefined

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -229,6 +229,12 @@ because a retry or a delayed delivery runs later than the time the work was for.
 follows the same rule where it builds events: a Function URL request carries simulated time in
 `requestContext.time` and `requestContext.timeEpoch`.
 
+An SQS event source mapping does the same: the `SentTimestamp` and
+`ApproximateFirstReceiveTimestamp` attributes on a delivered record are simulated time, so a handler
+reading the event's time reads the clock the test controls. See
+[simulated Lambda](../services/lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda
+event source mapping docs").
+
 Handler code that takes a clock as a dependency stays the most testable option, on real AWS and
 here, and needs none of the machinery above.
 

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -13,6 +13,7 @@ import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import { SimKms } from "../../kms/index.js";
 import { SimLambda } from "../../lambda/index.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimS3 } from "../../s3/sim-s3.js";
@@ -145,6 +146,9 @@ export class SimAwsAccountRegionServiceBuilder {
    * code running in the vm runtime is provided host-installed AWS SDK
    * packages intercepted into this SimAws, as the real Lambda runtime
    * provides the SDK.
+   *
+   * Event source mappings poll the same scope's simulated SQS, as a queue can
+   * only be an event source for a function in its own Account and Region.
    */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return new SimLambda({
@@ -154,6 +158,7 @@ export class SimAwsAccountRegionServiceBuilder {
       runAsOwner: this.simAws,
       urlRegistry: this.lambdaUrlRegistry,
       codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
+      eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
       vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
         simAws: this.simAws,
         regionName: scope.accountRegionScope.regionName,

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-cfn-value-adapter.ts
@@ -1,3 +1,5 @@
+import { SimLambdaEventSourceMapping } from "../../../../lambda/event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaEventSourceMappingCfn } from "./sim-lambda-event-source-mapping-cfn.js";
 import { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
 import { SimLambdaFunctionUrl } from "../../../../lambda/function/url/sim-lambda-function-url.js";
 import { SimLambdaFunctionCfn } from "./sim-lambda-function-cfn.js";
@@ -25,6 +27,15 @@ export function lambdaValueAdapter(
     properties.simResource instanceof SimLambdaFunctionUrl
   ) {
     return new SimLambdaFunctionUrlCfn({ functionUrl: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Lambda::EventSourceMapping" &&
+    properties.simResource instanceof SimLambdaEventSourceMapping
+  ) {
+    return new SimLambdaEventSourceMappingCfn({
+      mapping: properties.simResource,
+    });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/lambda/sim-lambda-event-source-mapping-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/lambda/sim-lambda-event-source-mapping-cfn.ts
@@ -1,0 +1,47 @@
+import type { SimLambdaEventSourceMapping } from "../../../../lambda/event-source/sim-lambda-event-source-mapping.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLambdaEventSourceMappingCfnProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+}
+
+/**
+ * CloudFormation-facing behaviour for an AWS::Lambda::EventSourceMapping
+ * Resource.
+ */
+export class SimLambdaEventSourceMappingCfn implements SimCfnResourceValueAdapter {
+  private readonly mapping: SimLambdaEventSourceMapping;
+
+  constructor(properties: SimLambdaEventSourceMappingCfnProperties) {
+    this.mapping = properties.mapping;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::Lambda::EventSourceMapping returns the
+   * mapping's identifier, which is its UUID.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.mapping.uuid;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::Lambda::EventSourceMapping.
+   *
+   * `Id` is the mapping identifier, and `EventSourceMappingArn` names the
+   * mapping the way a policy would.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Id") {
+      return this.mapping.uuid;
+    }
+
+    if (attributeName === "EventSourceMappingArn") {
+      return this.mapping.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::Lambda::EventSourceMapping attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -268,6 +268,11 @@ clock, so advancing simulated time is what redelivers it. Scheduling a failed ba
 clock even for a zero visibility timeout is deliberate: a poll that ran straight back round would
 spin on a batch the function keeps failing.
 
+An announcement only reaches a mapping that was already watching, so a poll that finds nothing asks
+the queue when its earliest hidden message comes back and schedules itself for then. That is what
+delivers the messages a mapping was created alongside, rather than stranding a queue whose messages
+were all in flight when the mapping was made.
+
 `queue/` is the port onto SQS. `SimLambdaEventSourceQueues` is what polling needs from a queue, and
 `SimSqsEventSourceQueues` implements it over the ordinary SQS commands, as the function's execution
 role, so simulated IAM authorizes each poll the way real IAM does. A standalone `SimLambda` has no

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -53,14 +53,16 @@ Current command areas include:
   `update-function-url-config/`, `delete-function-url-config/`,
   `list-function-url-configs/`
 - `add-permission/`, `remove-permission/`, `get-policy/`
+- `event-source-mapping/`
 
 Commands sharing a set of collaborators are grouped behind one class per area — `command/function/`,
-`command/function-url/`, `command/permission/` — so the `SimLambda` facade stays a delegation
-rather than repeating the same wiring block per command. `command/sim-lambda-command.types.ts`
-gathers the command types for the same reason.
+`command/function-url/`, `command/permission/`, `command/event-source-mapping/` — so the `SimLambda`
+facade stays a delegation rather than repeating the same wiring block per command.
+`command/sim-lambda-command.types.ts` gathers the command types for the same reason.
 
 The main `SimLambda` class delegates command execution to handlers rather than keeping command
-handling logic inline.
+handling logic inline. `sim-lambda-commands.ts` holds the wiring of those command areas, so the
+facade itself is state and delegation and nothing else.
 
 ## Function model
 
@@ -249,6 +251,43 @@ execution roles.
 A standalone `SimLambda` (constructed directly rather than through `SimAws`) is its own run-as
 owner, keeping its ambient callers isolated.
 
+## Event source mappings
+
+`event-source/` owns delivery from a simulated SQS queue to a function.
+
+Real Lambda polls a queue continuously, and nothing in this simulation runs continuously, so the
+queue says when there is something to poll for. `SimSqsQueueActivity` (in sim SQS) holds the
+watchers on a queue, `SimSqsQueue.add` tells them a message has arrived, and
+`SimLambdaEventSourcePoller` schedules a poll in response. A message moved to a dead-letter queue
+arrives the same way, so a mapping on a dead-letter queue is polled too.
+
+`SimLambdaEventSourcePollSchedule` decides when that poll happens. A message that is receivable now
+schedules a background task; one sent with a delay is scheduled for the instant it becomes
+receivable; and a batch that came back is scheduled for the end of its visibility timeout, on the
+clock, so advancing simulated time is what redelivers it. Scheduling a failed batch's retry on the
+clock even for a zero visibility timeout is deliberate: a poll that ran straight back round would
+spin on a batch the function keeps failing.
+
+`queue/` is the port onto SQS. `SimLambdaEventSourceQueues` is what polling needs from a queue, and
+`SimSqsEventSourceQueues` implements it over the ordinary SQS commands, as the function's execution
+role, so simulated IAM authorizes each poll the way real IAM does. A standalone `SimLambda` has no
+sim SQS, and `SimLambdaNoEventSourceQueues` refuses with guidance rather than silently delivering
+nothing. `SimLambdaSqsEventSourceArn` reads a queue ARN into the URL requests name it by and the
+Region event records report.
+
+Creating a mapping checks what real Lambda checks before it will make one: that the queue exists,
+and that the execution role may call `ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes` on
+it (`SimLambdaEventSourceRolePermissions`). Both failures are the mapping's, not the poller's: a
+mapping that cannot poll looks like a working subscription and delivers nothing.
+
+`poll/` holds what one poll does. `SimLambdaEventSourceDelivery` invokes the function directly
+rather than through the Invoke command, because the handler error has to be seen: the asynchronous
+invoke path drops it, and this is what decides whether the batch goes back on the queue.
+`SimLambdaSqsBatchResponse` reads what the function said about the batch, including a
+`batchItemFailures` report when the mapping was told to expect one, and returns the whole batch for
+a report it cannot trust. `SimLambdaSqsEventBuilder` turns a batch into the event's own shape,
+which is the lower-case record naming and the base64 binary attribute values real AWS uses.
+
 ## Function URLs
 
 `function/url/` owns Function URLs: `SimLambdaFunctionUrl` is the stored resource and
@@ -373,13 +412,21 @@ omit template `Code` and `Handler`. Unbound functions keep their template code o
 `src/service/cloudformation/resource/cfn/lambda/`, keeping the function model free of
 CloudFormation concerns.
 
-Other `AWS::Lambda::*` resource types (`Version`, `Alias`, `Permission`, `EventSourceMapping`, ...)
-are not supported and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
+`cfn/event-source-mapping/` creates `AWS::Lambda::EventSourceMapping`, which is what CDK's
+`fn.addEventSource(new SqsEventSource(queue))` emits. The properties this simulation has no
+behaviour for fail the resource rather than being dropped, worded as an invalid resource so the
+engine does not skip it: a stack that deployed the queue and the function and nothing between them
+would look like a working subscription.
+
+Other `AWS::Lambda::*` resource types (`Version`, `Alias`, ...) are not supported and are skipped by
+the CloudFormation engine with an "Unsupported" diagnostic.
 
 ## Not simulated yet
 
-- `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function` and
-  `AWS::Lambda::Url`
+- `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`,
+  `AWS::Lambda::Url`, `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping`
+- event sources other than SQS queues, `FilterCriteria`, `UpdateEventSourceMapping`, and polling
+  concurrency
 - Function URL `Cors` configuration and OPTIONS preflight handling
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.ts
@@ -1,0 +1,52 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { SimCfnLambdaEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-properties.js";
+
+interface SimCfnLambdaEventSourceMappingCreatorProperties {
+  readonly lambda: SimLambda;
+}
+
+/**
+ * Creates simulated event source mappings from CloudFormation Resources.
+ *
+ * This is what CDK's `fn.addEventSource(new SqsEventSource(queue))` emits, so a
+ * synthesized template is the usual way a mapping comes into existence outside
+ * a direct SDK call. The mapping is created through the ordinary
+ * CreateEventSourceMapping command, so a template deploying one gets the same
+ * execution-role check an SDK caller would.
+ */
+export class SimCfnLambdaEventSourceMappingCreator {
+  private readonly lambda: SimLambda;
+
+  constructor(properties: SimCfnLambdaEventSourceMappingCreatorProperties) {
+    this.lambda = properties.lambda;
+  }
+
+  /**
+   * Create a mapping from an AWS::Lambda::EventSourceMapping Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLambdaEventSourceMapping> {
+    const created = await this.lambda.createEventSourceMapping({
+      input: new SimCfnLambdaEventSourceMappingProperties({
+        resource,
+        properties,
+      }).createInput(),
+    });
+
+    const mapping = this.lambda.getSimEventSourceMapping(created.UUID);
+
+    assertDefined(
+      mapping,
+      `Sim Lambda event source mapping ${resource.logicalId} after ` +
+        "CloudFormation creation",
+    );
+
+    return mapping;
+  }
+}

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -1,0 +1,81 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateEventSourceMappingCommandInput } from "../../command/event-source-mapping/event-source-mapping.command.js";
+import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { assertSimulatedEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-property-rules.js";
+import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+
+interface SimCfnLambdaEventSourceMappingPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads an AWS::Lambda::EventSourceMapping Resource into the input
+ * CreateEventSourceMapping takes.
+ *
+ * Nothing about batch sizes or event source ARNs is decided here: the command
+ * validates those, so a mapping a template deployed is the same thing an SDK
+ * caller would have got.
+ */
+export class SimCfnLambdaEventSourceMappingProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly parser = new SimCfnLambdaPropertyParser();
+
+  constructor(properties: SimCfnLambdaEventSourceMappingPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The create input this Resource asks for, refusing what is not simulated.
+   */
+  createInput(): SimCreateEventSourceMappingCommandInput {
+    assertSimulatedEventSourceMappingProperties(
+      this.resource.logicalId,
+      this.properties,
+    );
+
+    return {
+      EventSourceArn: this.parser.requiredString(
+        this.resource,
+        this.properties["EventSourceArn"],
+        "EventSourceArn",
+      ),
+      FunctionName: simCfnLambdaTargetFunctionName(
+        this.parser.requiredString(
+          this.resource,
+          this.properties["FunctionName"],
+          "FunctionName",
+        ),
+      ),
+      BatchSize: this.parser.optionalNumber(
+        this.resource,
+        this.properties["BatchSize"],
+        "BatchSize",
+      ),
+      Enabled: this.parser.optionalBoolean(
+        this.resource,
+        this.properties["Enabled"],
+        "Enabled",
+      ),
+      MaximumBatchingWindowInSeconds: this.parser.optionalNumber(
+        this.resource,
+        this.properties["MaximumBatchingWindowInSeconds"],
+        "MaximumBatchingWindowInSeconds",
+      ),
+      FunctionResponseTypes: this.functionResponseTypes(),
+    };
+  }
+
+  private functionResponseTypes():
+    readonly SimLambdaFunctionResponseType[] | undefined {
+    return this.parser.optionalStringList(
+      this.resource,
+      this.properties["FunctionResponseTypes"],
+      "FunctionResponseTypes",
+    ) as readonly SimLambdaFunctionResponseType[] | undefined;
+  }
+}

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -1,0 +1,90 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The AWS::Lambda::EventSourceMapping properties this simulation acts on.
+ */
+const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "BatchSize",
+  "Enabled",
+  "EventSourceArn",
+  "FunctionName",
+  "FunctionResponseTypes",
+  "MaximumBatchingWindowInSeconds",
+]);
+
+/**
+ * Real AWS::Lambda::EventSourceMapping properties this simulation does not
+ * model.
+ *
+ * Every one of them changes what the function sees or when it sees it, so a
+ * template asking for one fails the Resource rather than deploying a mapping
+ * that quietly ignores it.
+ */
+const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
+  "AmazonManagedKafkaEventSourceConfig",
+  "BisectBatchOnFunctionError",
+  "DestinationConfig",
+  "DocumentDBEventSourceConfig",
+  "FilterCriteria",
+  "KmsKeyArn",
+  "MaximumRecordAgeInSeconds",
+  "MaximumRetryAttempts",
+  "MetricsConfig",
+  "ParallelizationFactor",
+  "ProvisionedPollerConfig",
+  "Queues",
+  "ScalingConfig",
+  "SelfManagedEventSource",
+  "SelfManagedKafkaEventSourceConfig",
+  "SourceAccessConfigurations",
+  "StartingPosition",
+  "StartingPositionTimestamp",
+  "Tags",
+  "Topics",
+  "TumblingWindowInSeconds",
+]);
+
+/**
+ * Build the error a property of an AWS::Lambda::EventSourceMapping Resource is
+ * refused with.
+ *
+ * The wording matters: sim CloudFormation skips a Resource whose error reads as
+ * an unsupported Resource type, and skipping is the wrong answer for a mapping
+ * that cannot be created as the template asks. The stack would deploy with the
+ * queue and the function and nothing between them.
+ */
+export function eventSourceMappingPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid AWS::Lambda::EventSourceMapping Resource ${logicalId}: ${reason}`,
+  );
+}
+
+/**
+ * Refuse everything about an AWS::Lambda::EventSourceMapping Resource that is
+ * not simulated.
+ */
+export function assertSimulatedEventSourceMappingProperties(
+  logicalId: string,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  for (const name of Object.keys(properties)) {
+    if (unsimulatedPropertyNames.has(name)) {
+      throw eventSourceMappingPropertyError(
+        logicalId,
+        `${name} is a real AWS::Lambda::EventSourceMapping property that ` +
+          "this simulation does not simulate, so it is refused rather than " +
+          "ignored",
+      );
+    }
+
+    if (!simulatedPropertyNames.has(name)) {
+      throw eventSourceMappingPropertyError(
+        logicalId,
+        `${name} is not an AWS::Lambda::EventSourceMapping property`,
+      );
+    }
+  }
+}

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -1,0 +1,289 @@
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLambdaEventSourceMappingCfn } from "../../../cloudformation/resource/cfn/lambda/sim-lambda-event-source-mapping-cfn.js";
+import { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaSqsEvent } from "../../event-source/poll/sim-lambda-sqs-event.js";
+import { SimLambdaCloudFormationResourceFactory } from "../sim-cfn-lambda-resource-factory.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+const mappingProperties: SimCfnTemplateValueRecord = {
+  EventSourceArn: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+  FunctionName: { Ref: "ConsumerFunction" },
+  BatchSize: 5,
+  FunctionResponseTypes: ["ReportBatchItemFailures"],
+};
+
+/**
+ * A template with a queue, a consumer function whose role may poll it, and a
+ * mapping between them, as CDK's `fn.addEventSource(new SqsEventSource(queue))`
+ * synthesises one.
+ */
+function consumerTemplate(
+  properties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrderQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders" },
+      },
+      ConsumerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrderConsumerRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+          Policies: [
+            {
+              PolicyName: "ConsumeOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "sqs:ReceiveMessage",
+                      "sqs:DeleteMessage",
+                      "sqs:GetQueueAttributes",
+                    ],
+                    Resource: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      ConsumerFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "order-consumer",
+          Role: { "Fn::GetAtt": ["ConsumerRole", "Arn"] },
+        },
+      },
+      OrderConsumerMapping: {
+        Type: "AWS::Lambda::EventSourceMapping",
+        Properties: properties,
+      },
+    },
+    Outputs: {
+      MappingRef: { Value: { Ref: "OrderConsumerMapping" } },
+      MappingArn: {
+        Value: {
+          "Fn::GetAtt": ["OrderConsumerMapping", "EventSourceMappingArn"],
+        },
+      },
+      MappingId: { Value: { "Fn::GetAtt": ["OrderConsumerMapping", "Id"] } },
+    },
+  };
+}
+
+/**
+ * Attempt a mapping creation with the given properties and answer with the
+ * error it is refused with.
+ */
+async function mappingCreationError(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const resource = new SimCfnResource({
+    accountRegionScope: {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadMapping",
+    template: {
+      Type: "AWS::Lambda::EventSourceMapping",
+      Properties: properties,
+    },
+  });
+  const factory = new SimLambdaCloudFormationResourceFactory(simAws.lambda());
+
+  try {
+    await factory.create("EventSourceMapping", resource, {
+      simAws,
+      resources: new Map(),
+    });
+  } catch (error) {
+    assertInstanceOf(error, Error);
+
+    return error;
+  }
+
+  throw new Error("Expected event source mapping creation to reject");
+}
+
+describe("Lambda CloudFormation event source mapping deployment", () => {
+  it("creates a mapping that delivers from AWS::Lambda::EventSourceMapping", async () => {
+    // Given a template with a queue, a function and a mapping between them.
+    const simAws = new SimAws();
+    const events: SimLambdaSqsEvent[] = [];
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: consumerTemplate(mappingProperties),
+      bindings: [
+        {
+          logicalId: "ConsumerFunction",
+          handler: (event: SimLambdaSqsEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Resource is backed by a simulated mapping.
+    const resource = stack.getResource("OrderConsumerMapping");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimLambdaEventSourceMapping);
+    assertIdentical(resource.simResource.batchSize, 5);
+    assertTrue(resource.simResource.reportsBatchItemFailures);
+
+    // And Ref resolves to the mapping's UUID, Fn::GetAtt to its ARN.
+    assertIdentical(
+      stack.outputs.get("MappingRef")?.value,
+      resource.simResource.uuid,
+    );
+    assertIdentical(
+      stack.outputs.get("MappingArn")?.value,
+      resource.simResource.arn,
+    );
+    assertIdentical(
+      stack.outputs.get("MappingId")?.value,
+      resource.simResource.uuid,
+    );
+
+    // And a message sent to the deployed queue reaches the deployed function.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders")?.url,
+        MessageBody: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+
+  it("refuses an attribute AWS::Lambda::EventSourceMapping does not have", () => {
+    // Given the CloudFormation-facing adapter for a mapping.
+    const adapter = new SimLambdaEventSourceMappingCfn({
+      mapping: new SimLambdaEventSourceMapping({
+        accountRegionScope: {
+          accountId: "111111111111" as SimAwsAccountId,
+          regionName: "eu-west-2",
+        },
+        eventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+        functionName: "order-consumer",
+        functionArn:
+          "arn:aws:lambda:eu-west-2:111111111111:function:order-consumer",
+        createdAt: new Date(0),
+      }),
+    });
+
+    // When a template asks for an attribute the Resource does not have.
+    const error = assertThrowsError(() => adapter.attributeValue("Nonsense"));
+
+    // Then it fails rather than resolving to something made up.
+    assertStringIncludes(error.message, "Nonsense");
+  });
+
+  it("refuses a property this simulation does not model", async () => {
+    // Given a template asking a mapping to filter events.
+    const error = await mappingCreationError({
+      ...mappingProperties,
+      FilterCriteria: { Filters: [{ Pattern: "{}" }] },
+    });
+
+    // Then the Resource fails rather than deploying a mapping ignoring it.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::EventSourceMapping Resource BadMapping: " +
+        "FilterCriteria is a real AWS::Lambda::EventSourceMapping property",
+    );
+  });
+
+  it("refuses a property AWS::Lambda::EventSourceMapping does not have", async () => {
+    // Given a template with a made-up property.
+    const error = await mappingCreationError({
+      ...mappingProperties,
+      Nonsense: "true",
+    });
+
+    // Then the Resource fails rather than dropping it.
+    assertStringIncludes(
+      error.message,
+      "Nonsense is not an AWS::Lambda::EventSourceMapping property",
+    );
+  });
+
+  it("refuses a list property that is not a list", async () => {
+    // Given a template whose response types are a bare string.
+    const error = await mappingCreationError({
+      EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+      FunctionName: "order-consumer",
+      FunctionResponseTypes: "ReportBatchItemFailures",
+    });
+
+    // Then the Resource fails with a diagnostic naming the property.
+    assertStringIncludes(error.message, "FunctionResponseTypes must be a list");
+  });
+
+  it("refuses a list entry that is not a string", async () => {
+    // Given a template whose response types hold a number.
+    const error = await mappingCreationError({
+      EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+      FunctionName: "order-consumer",
+      FunctionResponseTypes: [7],
+    });
+
+    // Then the Resource fails with a diagnostic naming the entry.
+    assertStringIncludes(
+      error.message,
+      "FunctionResponseTypes[0] must be a string",
+    );
+  });
+
+  it("refuses a malformed property value", async () => {
+    // Given a template whose batch size is a string.
+    const error = await mappingCreationError({
+      EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+      FunctionName: "order-consumer",
+      BatchSize: "five",
+    });
+
+    // Then the Resource fails with a diagnostic naming the property.
+    assertInstanceOf(error, TypeError);
+    assertStringIncludes(error.message, "BatchSize must be a number");
+  });
+});

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-property-parser.ts
@@ -76,6 +76,27 @@ export class SimCfnLambdaPropertyParser {
   }
 
   /**
+   * Parse a property value that must be a list of strings when present.
+   */
+  optionalStringList(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): readonly string[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "a list");
+    }
+
+    return value.map((entry: SimCfnTemplateValue, index: number) =>
+      this.requiredString(resource, entry, `${label}[${String(index)}]`),
+    );
+  }
+
+  /**
    * Parse a property value that must be a record of strings when present.
    *
    * CloudFormation has no typed map, so every value has to be checked: a

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-target-function.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-target-function.ts
@@ -1,27 +1,16 @@
-const functionArnSeparator = ":function:";
+import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
 
 /**
  * Get the function name a template property pointing at a function names.
  *
- * `AWS::Lambda::Url` reaches this through `TargetFunctionArn` and
- * `AWS::Lambda::Permission` through `FunctionName`, and templates reach either
- * in two ways: `Fn::GetAtt` on the function, giving a full ARN, or `Ref`,
- * giving the function name. Both are accepted, as both are valid template ways
- * to point at the same function. A version or alias qualifier on the ARN is
- * dropped, as qualified functions are not simulated.
+ * `AWS::Lambda::Url` reaches this through `TargetFunctionArn`, and
+ * `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` through
+ * `FunctionName`. Templates reach either in two ways: `Fn::GetAtt` on the
+ * function, giving a full ARN, or `Ref`, giving the function name. Both are
+ * accepted, as both are valid template ways to point at the same function.
  */
 export function simCfnLambdaTargetFunctionName(
   targetFunctionArn: string,
 ): string {
-  const separatorIndex = targetFunctionArn.indexOf(functionArnSeparator);
-
-  if (separatorIndex === -1) {
-    return targetFunctionArn;
-  }
-
-  const nameAndQualifier = targetFunctionArn.slice(
-    separatorIndex + functionArnSeparator.length,
-  );
-
-  return nameAndQualifier.split(":", 1)[0] ?? nameAndQualifier;
+  return simLambdaFunctionNameOf(targetFunctionArn);
 }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimLambda } from "../sim-lambda.js";
+import { SimCfnLambdaEventSourceMappingCreator } from "./event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.js";
 import { SimCfnLambdaFunctionCreator } from "./function/sim-cfn-lambda-function-creator.js";
 import { SimCfnLambdaPermissionCreator } from "./permission/sim-cfn-lambda-permission-creator.js";
 import { SimCfnLambdaUrlCreator } from "./url/sim-cfn-lambda-url-creator.js";
@@ -15,11 +16,15 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
   private readonly functionCreator: SimCfnLambdaFunctionCreator;
   private readonly urlCreator: SimCfnLambdaUrlCreator;
   private readonly permissionCreator: SimCfnLambdaPermissionCreator;
+  private readonly eventSourceMappingCreator: SimCfnLambdaEventSourceMappingCreator;
 
   constructor(lambda: SimLambda) {
     this.functionCreator = new SimCfnLambdaFunctionCreator({ lambda });
     this.urlCreator = new SimCfnLambdaUrlCreator({ lambda });
     this.permissionCreator = new SimCfnLambdaPermissionCreator({ lambda });
+    this.eventSourceMappingCreator = new SimCfnLambdaEventSourceMappingCreator({
+      lambda,
+    });
   }
 
   /**
@@ -40,6 +45,12 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
       }
       case "Url": {
         return await this.urlCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "EventSourceMapping": {
+        return await this.eventSourceMappingCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -1,0 +1,88 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
+import {
+  batchSizeIn,
+  functionResponseTypesIn,
+  requiredString,
+} from "./create-event-source-mapping-values.js";
+import { refuseUnsimulatedInput } from "./create-event-source-mapping-refusals.js";
+import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
+
+interface SimLambdaEventSourceMappingInputProperties {
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly functionName: string;
+  readonly batchSize: number;
+  readonly enabled: boolean;
+  readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
+}
+
+/**
+ * One checked CreateEventSourceMapping request.
+ *
+ * Everything the request is refused for is decided here, before a mapping
+ * exists: a mapping that cannot poll the way it was asked to would look like a
+ * working subscription and deliver nothing.
+ */
+export class SimLambdaEventSourceMappingInput {
+  public readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  public readonly functionName: string;
+  public readonly batchSize: number;
+  public readonly enabled: boolean;
+  public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
+
+  private constructor(properties: SimLambdaEventSourceMappingInputProperties) {
+    this.eventSourceArn = properties.eventSourceArn;
+    this.functionName = properties.functionName;
+    this.batchSize = properties.batchSize;
+    this.enabled = properties.enabled;
+    this.functionResponseTypes = properties.functionResponseTypes;
+  }
+
+  /**
+   * Read a CreateEventSourceMapping request, refusing what this simulation
+   * cannot deliver as asked.
+   */
+  static of(
+    input: SimCreateEventSourceMappingCommandInput,
+    scope: SimAwsAccountRegionScope,
+  ): SimLambdaEventSourceMappingInput {
+    refuseUnsimulatedInput(input);
+
+    return new this({
+      eventSourceArn: eventSourceArnIn(input, scope),
+      functionName: simLambdaFunctionNameOf(
+        requiredString(input.FunctionName, "functionName"),
+      ),
+      batchSize: batchSizeIn(input),
+      enabled: input.Enabled ?? true,
+      functionResponseTypes: functionResponseTypesIn(input),
+    });
+  }
+}
+
+/**
+ * The queue an event source ARN names, refusing one this simulated Lambda
+ * cannot poll.
+ */
+function eventSourceArnIn(
+  input: SimCreateEventSourceMappingCommandInput,
+  scope: SimAwsAccountRegionScope,
+): SimLambdaSqsEventSourceArn {
+  const eventSourceArn = SimLambdaSqsEventSourceArn.of(
+    requiredString(input.EventSourceArn, "eventSourceArn"),
+  );
+
+  if (!eventSourceArn.isIn(scope.accountId, scope.regionName)) {
+    throw new SimLambdaInvalidParameterValueException(
+      `EventSourceArn ${eventSourceArn.value} names Account ` +
+        `${eventSourceArn.accountId} in ${eventSourceArn.regionName}, and a ` +
+        `function in Account ${scope.accountId} in ${scope.regionName} can ` +
+        "only be mapped to a queue in its own Account and Region",
+    );
+  }
+
+  return eventSourceArn;
+}

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -1,0 +1,76 @@
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
+
+/**
+ * The inputs a mapping cannot be created with here, and why each is refused.
+ *
+ * Every one of them changes what a function sees or when it sees it, so
+ * accepting and ignoring one would let a test pass on behaviour the deployment
+ * would not have.
+ */
+const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
+  ["FilterCriteria", "event filtering is not simulated"],
+  ["ScalingConfig", "polling concurrency is not simulated"],
+  ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
+  ["DestinationConfig", "failure destinations are not simulated"],
+  ["MaximumRetryAttempts", "retry limits are not simulated"],
+  ["MaximumRecordAgeInSeconds", "record ages are not simulated"],
+  ["BisectBatchOnFunctionError", "batch bisection is not simulated"],
+  ["ParallelizationFactor", "polling concurrency is not simulated"],
+  ["TumblingWindowInSeconds", "tumbling windows are not simulated"],
+  ["StartingPosition", "SQS queues are the only simulated event source"],
+  [
+    "StartingPositionTimestamp",
+    "SQS queues are the only simulated event source",
+  ],
+  ["Topics", "SQS queues are the only simulated event source"],
+  ["Queues", "SQS queues are the only simulated event source"],
+  ["SelfManagedEventSource", "SQS queues are the only simulated event source"],
+  [
+    "SelfManagedKafkaEventSourceConfig",
+    "SQS queues are the only simulated event source",
+  ],
+  [
+    "AmazonManagedKafkaEventSourceConfig",
+    "SQS queues are the only simulated event source",
+  ],
+  [
+    "DocumentDBEventSourceConfig",
+    "SQS queues are the only simulated event source",
+  ],
+  [
+    "SourceAccessConfigurations",
+    "event source authentication is not simulated",
+  ],
+  ["MetricsConfig", "event source metrics are not simulated"],
+  ["KMSKeyArn", "filter criteria encryption is not simulated"],
+  ["Tags", "tags are not simulated"],
+]);
+
+/**
+ * Refuse an input this simulation has no behaviour for.
+ */
+export function refuseUnsimulatedInput(
+  input: SimCreateEventSourceMappingCommandInput,
+): void {
+  for (const [name, value] of Object.entries(input)) {
+    const reason = unsimulatedInputs.get(name);
+
+    if (value !== undefined && reason !== undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `${name} on an event source mapping is not simulated: ${reason}`,
+      );
+    }
+  }
+
+  if (
+    input.MaximumBatchingWindowInSeconds !== undefined &&
+    input.MaximumBatchingWindowInSeconds !== 0
+  ) {
+    throw new SimLambdaInvalidParameterValueException(
+      "MaximumBatchingWindowInSeconds on an event source mapping is only " +
+        "simulated as 0: a partial batch is delivered as soon as anything is " +
+        "on the queue, so a batching window would have nothing to wait for",
+    );
+  }
+}

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -1,0 +1,194 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeConsumerFunction,
+  makePollingRole,
+  makeSourceQueue,
+  recordingHandler,
+} from "../../../../../test/lambda/event-source-fixture.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../../sim-lambda.js";
+import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
+
+interface MappableSimAws {
+  readonly simAws: SimAws;
+  readonly queueArn: string;
+  readonly functionName: string;
+}
+
+async function simAwsReadyToMap(): Promise<MappableSimAws> {
+  const simAws = new SimAws();
+  const { queueArn } = await makeSourceQueue(simAws);
+  const roleArn = await makePollingRole(simAws, queueArn);
+  const functionName = await makeConsumerFunction(
+    simAws,
+    roleArn,
+    recordingHandler().handler,
+  );
+
+  return { simAws, queueArn, functionName };
+}
+
+/**
+ * Try to create a mapping with an input, and answer with what it was refused
+ * with.
+ */
+async function refusedMapping(
+  ready: MappableSimAws,
+  input: Partial<SimCreateEventSourceMappingCommandInput>,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await ready.simAws.lambda().createEventSourceMapping({
+      input: {
+        EventSourceArn: ready.queueArn,
+        FunctionName: ready.functionName,
+        ...input,
+      },
+    });
+  });
+}
+
+describe("sim Lambda CreateEventSourceMapping validation", () => {
+  it("requires an event source ARN", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping names no event source.
+    const error = await refusedMapping(ready, { EventSourceArn: undefined });
+
+    // Then the request is refused as invalid.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "eventSourceArn");
+  });
+
+  it("requires a function name", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping names no function.
+    const error = await refusedMapping(ready, { FunctionName: undefined });
+
+    // Then the request is refused as invalid.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "functionName");
+  });
+
+  it("refuses an event source that is not an SQS queue", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping names a DynamoDB stream.
+    const error = await refusedMapping(ready, {
+      EventSourceArn:
+        "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-07-30T00:00:00.000",
+    });
+
+    // Then it is refused rather than accepted and never delivered from.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "is not an SQS queue ARN");
+  });
+
+  it("refuses a queue in another Account or Region", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping names a queue belonging to another Account.
+    const error = await refusedMapping(ready, {
+      EventSourceArn: "arn:aws:sqs:eu-west-2:222222222222:orders",
+    });
+
+    // Then it is refused, as a queue can only feed a function beside it.
+    assertStringIncludes(error.message, "its own Account and Region");
+  });
+
+  it("refuses a batch size larger than a queue with no batching window gives", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for a batch of fifty.
+    const error = await refusedMapping(ready, { BatchSize: 50 });
+
+    // Then it is refused rather than delivering ten.
+    assertStringIncludes(error.message, "BatchSize 50 is out of range");
+  });
+
+  it("refuses a batching window, which nothing here would wait out", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks to batch for five seconds.
+    const error = await refusedMapping(ready, {
+      MaximumBatchingWindowInSeconds: 5,
+    });
+
+    // Then it is refused rather than silently ignored.
+    assertStringIncludes(error.message, "MaximumBatchingWindowInSeconds");
+  });
+
+  it("refuses a function response type Lambda does not have", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping names a response type that is not a Lambda one.
+    const error = await refusedMapping(ready, {
+      FunctionResponseTypes: ["ReportEverything"],
+    });
+
+    // Then it is refused.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "ReportEverything");
+  });
+
+  it("refuses filter criteria, which would change what the function sees", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for event filtering.
+    const error = await refusedMapping(ready, {
+      FilterCriteria: { Filters: [{ Pattern: "{}" }] },
+    });
+
+    // Then it is refused rather than delivering everything.
+    assertStringIncludes(error.message, "FilterCriteria");
+    assertStringIncludes(error.message, "not simulated");
+  });
+
+  it("refuses a mapping on a standalone simulated Lambda with no queues", async () => {
+    // Given a simulated Lambda constructed outside SimAws.
+    const lambda = new SimLambda({
+      accountRegionScope: {
+        accountId: "111111111111" as SimAwsAccountId,
+        regionName: "eu-west-2",
+      },
+    });
+
+    await lambda.createFunction({
+      input: {
+        FunctionName: "order-consumer",
+        Role: "arn:aws:iam::111111111111:role/OrderConsumerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(recordingHandler().handler) },
+      },
+    });
+
+    // When a mapping is created on it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await lambda.createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+          FunctionName: "order-consumer",
+        }),
+      );
+    });
+
+    // Then it says there is no simulated SQS to poll.
+    assertStringIncludes(error.message, "no simulated SQS to poll");
+  });
+});

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -120,6 +120,17 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "BatchSize 50 is out of range");
   });
 
+  it("refuses a batch size that is not a whole number", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for two and a half messages at a time.
+    const error = await refusedMapping(ready, { BatchSize: 2.5 });
+
+    // Then it is refused here rather than failing later inside a poll.
+    assertStringIncludes(error.message, "BatchSize 2.5 is out of range");
+  });
+
   it("refuses a batching window, which nothing here would wait out", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -1,0 +1,74 @@
+import {
+  DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE,
+  type SimLambdaFunctionResponseType,
+} from "../../event-source/sim-lambda-event-source-mapping.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
+import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
+
+/**
+ * The largest batch real Lambda delivers from a standard queue without a
+ * batching window to fill it.
+ */
+const maximumBatchSize = 10;
+
+/**
+ * The batch size a mapping delivers with, refusing one a queue with no
+ * batching window would never fill.
+ */
+export function batchSizeIn(
+  input: SimCreateEventSourceMappingCommandInput,
+): number {
+  const batchSize =
+    input.BatchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
+
+  if (batchSize < 1 || batchSize > maximumBatchSize) {
+    throw new SimLambdaInvalidParameterValueException(
+      `BatchSize ${String(batchSize)} is out of range: a queue with no ` +
+        `batching window delivers between 1 and ` +
+        `${String(maximumBatchSize)} messages at a time`,
+    );
+  }
+
+  return batchSize;
+}
+
+/**
+ * The response types the function reports, refusing one Lambda does not have.
+ */
+export function functionResponseTypesIn(
+  input: SimCreateEventSourceMappingCommandInput,
+): readonly SimLambdaFunctionResponseType[] {
+  const responseTypes = input.FunctionResponseTypes ?? [];
+
+  for (const responseType of responseTypes) {
+    if (responseType !== "ReportBatchItemFailures") {
+      throw new SimLambdaValidationException(
+        `FunctionResponseTypes value ${responseType} is not a Lambda ` +
+          "function response type. ReportBatchItemFailures is the only one",
+      );
+    }
+  }
+
+  return responseTypes as readonly SimLambdaFunctionResponseType[];
+}
+
+/**
+ * A field a request has to carry, reported the way real Lambda reports a
+ * missing one.
+ */
+export function requiredString(
+  value: string | undefined,
+  field: string,
+): string {
+  if (value === undefined || value === "") {
+    throw new SimLambdaValidationException(
+      `1 validation error detected: Value null at '${field}' failed to ` +
+        "satisfy constraint: Member must not be null",
+    );
+  }
+
+  return value;
+}

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -24,11 +24,15 @@ export function batchSizeIn(
   const batchSize =
     input.BatchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
 
-  if (batchSize < 1 || batchSize > maximumBatchSize) {
+  if (
+    !Number.isSafeInteger(batchSize) ||
+    batchSize < 1 ||
+    batchSize > maximumBatchSize
+  ) {
     throw new SimLambdaInvalidParameterValueException(
       `BatchSize ${String(batchSize)} is out of range: a queue with no ` +
-        `batching window delivers between 1 and ` +
-        `${String(maximumBatchSize)} messages at a time`,
+        `batching window delivers a whole number of messages between 1 and ` +
+        `${String(maximumBatchSize)} at a time`,
     );
   }
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -1,0 +1,140 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaEventSourceQueues } from "../../event-source/queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
+import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
+import { SimLambdaEventSourceRolePermissions } from "../../event-source/sim-lambda-event-source-role-permissions.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+import { SimLambdaEventSourceMappingInput } from "./create-event-source-mapping-input.js";
+import type {
+  SimCreateEventSourceMappingCommand,
+  SimCreateEventSourceMappingCommandOutput,
+} from "./event-source-mapping.command.js";
+
+interface CreateEventSourceMappingCommandHandlerProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly mappings: SimLambdaEventSourceMappingStore;
+  readonly pollers: SimLambdaEventSourcePollers;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface CreateEventSourceMappingCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated Lambda CreateEventSourceMappingCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateEventSourceMappingCommand/
+ *
+ * Two things are checked here that only look like polling concerns: that the
+ * queue exists, and that the function's execution role may poll it. Real Lambda
+ * checks both when the mapping is created, because a mapping that cannot poll
+ * looks like a working subscription and delivers nothing.
+ */
+export class CreateEventSourceMappingCommandHandler implements CommandHandler<
+  SimCreateEventSourceMappingCommand,
+  SimCreateEventSourceMappingCommandOutput
+> {
+  private readonly properties: CreateEventSourceMappingCommandHandlerProperties;
+  private readonly authorizer: FunctionUrlAuthorizer;
+  private readonly rolePermissions: SimLambdaEventSourceRolePermissions;
+
+  constructor(properties: CreateEventSourceMappingCommandHandlerProperties) {
+    this.properties = properties;
+    this.authorizer = new FunctionUrlAuthorizer({
+      iam: properties.iam,
+      action: "lambda:CreateEventSourceMapping",
+    });
+    this.rolePermissions = new SimLambdaEventSourceRolePermissions({
+      iam: properties.iam,
+    });
+  }
+
+  /**
+   * Create an event source mapping, and start it polling.
+   */
+  async handle(
+    command: SimCreateEventSourceMappingCommand,
+    options?: CreateEventSourceMappingCommandHandlerOptions,
+  ): Promise<SimCreateEventSourceMappingCommandOutput> {
+    const input = SimLambdaEventSourceMappingInput.of(
+      command.input,
+      this.properties.accountRegionScope,
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.properties.background.sequence();
+
+    const { functions } = this.properties;
+
+    this.authorizer.authorize(
+      functions.functionArn(input.functionName),
+      options?.caller,
+    );
+
+    const simFunction = functions.require(input.functionName);
+
+    await this.assertPollable(simFunction, input.eventSourceArn);
+
+    return {
+      $metadata: {},
+      ...this.created(input, simFunction).configuration(),
+    };
+  }
+
+  /**
+   * Refuse a mapping whose queue cannot be polled as the execution role.
+   *
+   * The role's permission is checked before the queue is read, so a role with
+   * no access is told what it is missing rather than being told the queue does
+   * not exist.
+   */
+  private async assertPollable(
+    simFunction: SimLambdaFunction,
+    eventSourceArn: SimLambdaSqsEventSourceArn,
+  ): Promise<void> {
+    this.rolePermissions.assertMayPoll(
+      simFunction.roleArn,
+      eventSourceArn.value,
+    );
+
+    // Reading the queue's attributes as the role is how the mapping finds out
+    // the queue is there at all, exactly as the poller will.
+    await this.properties.queues.visibilityTimeoutSeconds({
+      queueArn: eventSourceArn.value,
+      caller: { kind: "arn", arn: simFunction.roleArn },
+    });
+  }
+
+  private created(
+    input: SimLambdaEventSourceMappingInput,
+    simFunction: SimLambdaFunction,
+  ): SimLambdaEventSourceMapping {
+    const mapping = new SimLambdaEventSourceMapping({
+      accountRegionScope: this.properties.accountRegionScope,
+      eventSourceArn: input.eventSourceArn.value,
+      functionName: input.functionName,
+      functionArn: simFunction.arn,
+      batchSize: input.batchSize,
+      enabled: input.enabled,
+      functionResponseTypes: input.functionResponseTypes,
+      createdAt: this.properties.background.now(),
+    });
+
+    this.properties.mappings.add(mapping);
+    this.properties.pollers.start(mapping, input.eventSourceArn);
+
+    return mapping;
+  }
+}

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.iso.test.ts
@@ -1,0 +1,191 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeConsumerFunction,
+  makePollingRole,
+  makeSourceQueue,
+  recordingHandler,
+  simAwsWithSqsEventSource,
+} from "../../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * A simulated AWS with a queue and a function, and no mapping between them.
+ */
+async function simAwsReadyToMap(
+  roleActions?: readonly string[],
+): Promise<{ simAws: SimAws; queueArn: string; functionName: string }> {
+  const simAws = new SimAws();
+  const { queueArn } = await makeSourceQueue(simAws);
+  const roleArn = await makePollingRole(simAws, queueArn, roleActions);
+  const functionName = await makeConsumerFunction(
+    simAws,
+    roleArn,
+    recordingHandler().handler,
+  );
+
+  return { simAws, queueArn, functionName };
+}
+
+describe("sim Lambda CreateEventSourceMapping", () => {
+  it("reports the created mapping", async () => {
+    // Given a queue and a function.
+    const { simAws, queueArn, functionName } = await simAwsReadyToMap();
+
+    // When a mapping is created between them.
+    const created = await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: queueArn,
+        FunctionName: functionName,
+        BatchSize: 5,
+      }),
+    );
+
+    // Then it is reported the way real Lambda reports one.
+    assertIdentical(created.EventSourceArn, queueArn);
+    assertIdentical(created.BatchSize, 5);
+    assertIdentical(created.State, "Creating");
+    assertIdentical(created.MaximumBatchingWindowInSeconds, 0);
+    assertStringIncludes(created.EventSourceMappingArn, "event-source-mapping");
+  });
+
+  it("becomes Enabled once the simulation has caught up", async () => {
+    // Given a newly created mapping.
+    const { simAws, uuid } = await simAwsWithSqsEventSource();
+
+    // When the simulation settles.
+    await simAws.backgroundTasksComplete();
+
+    // Then the mapping is enabled, as it is on real Lambda.
+    const mapping = await simAws
+      .lambda()
+      .getEventSourceMapping({ input: { UUID: uuid } });
+
+    assertIdentical(mapping.State, "Enabled");
+  });
+
+  it("refuses an event source ARN naming a queue that does not exist", async () => {
+    // Given a function whose role may poll a queue that was never created.
+    const simAws = new SimAws();
+    const missingQueueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:missing`;
+    const roleArn = await makePollingRole(simAws, missingQueueArn);
+    const functionName = await makeConsumerFunction(
+      simAws,
+      roleArn,
+      recordingHandler().handler,
+    );
+
+    // When a mapping is created for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: missingQueueArn,
+          FunctionName: functionName,
+        }),
+      );
+    });
+
+    // Then the mapping is refused rather than made and never delivered from.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses an execution role that may not receive from the queue", async () => {
+    // Given a function whose role may delete but not receive.
+    const { simAws, queueArn, functionName } = await simAwsReadyToMap([
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]);
+
+    // When a mapping is created for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: queueArn,
+          FunctionName: functionName,
+        }),
+      );
+    });
+
+    // Then it is refused the way real Lambda refuses one.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(
+      error.message,
+      "The provided execution role does not have permissions to call " +
+        "ReceiveMessage on SQS",
+    );
+  });
+
+  it("refuses an execution role that may not delete from the queue", async () => {
+    // Given a function whose role may receive but not delete.
+    const { simAws, queueArn, functionName } = await simAwsReadyToMap([
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueAttributes",
+    ]);
+
+    // When a mapping is created for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: queueArn,
+          FunctionName: functionName,
+        }),
+      );
+    });
+
+    // Then it is refused, because it could only ever deliver twice.
+    assertStringIncludes(
+      error.message,
+      "does not have permissions to call DeleteMessage on SQS",
+    );
+  });
+
+  it("refuses an execution role that may not read the queue's attributes", async () => {
+    // Given a function whose role may receive and delete only.
+    const { simAws, queueArn, functionName } = await simAwsReadyToMap([
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+    ]);
+
+    // When a mapping is created for it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: queueArn,
+          FunctionName: functionName,
+        }),
+      );
+    });
+
+    // Then it is refused, as real Lambda refuses one.
+    assertStringIncludes(
+      error.message,
+      "does not have permissions to call GetQueueAttributes on SQS",
+    );
+  });
+
+  it("refuses a mapping for a function that does not exist", async () => {
+    // Given a queue and no function of that name.
+    const simAws = new SimAws();
+    const { queueArn } = await makeSourceQueue(simAws);
+
+    // When a mapping names one anyway.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: queueArn,
+          FunctionName: "no-such-function",
+        }),
+      );
+    });
+
+    // Then it is refused as a missing function.
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+});

--- a/src/service/lambda/command/event-source-mapping/event-source-mapping-access.ts
+++ b/src/service/lambda/command/event-source-mapping/event-source-mapping-access.ts
@@ -1,0 +1,88 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
+
+/**
+ * The function name a request naming none authorizes against: every function
+ * in the Account and Region.
+ */
+export const anyFunctionName = "*";
+
+interface SimLambdaEventSourceMappingAccessProperties {
+  readonly mappings: SimLambdaEventSourceMappingStore;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * How a request reaches the event source mapping it names.
+ *
+ * Real Lambda gives these actions the function the mapping delivers to as
+ * their resource, so that is what they authorize against. The mapping is
+ * resolved first, because its UUID is the only thing a request carries and the
+ * function it belongs to is not knowable without it.
+ */
+export class SimLambdaEventSourceMappingAccess {
+  private readonly mappings: SimLambdaEventSourceMappingStore;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimLambdaEventSourceMappingAccessProperties) {
+    this.mappings = properties.mappings;
+    this.functions = properties.functions;
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Resolve the mapping a request names by UUID, authorizing the action on the
+   * function it delivers to.
+   */
+  require(
+    action: string,
+    uuid: string | undefined,
+    caller?: SimAwsCaller,
+  ): SimLambdaEventSourceMapping {
+    const mapping = this.mappings.require(requiredUuid(uuid));
+
+    this.authorize(action, mapping.functionArn, caller);
+
+    return mapping;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a function by name.
+   */
+  authorizeFunction(
+    action: string,
+    functionName: string,
+    caller?: SimAwsCaller,
+  ): void {
+    this.authorize(action, this.functions.functionArn(functionName), caller);
+  }
+
+  private authorize(
+    action: string,
+    functionArn: string,
+    caller: SimAwsCaller | undefined,
+  ): void {
+    new FunctionUrlAuthorizer({ iam: this.iam, action }).authorize(
+      functionArn,
+      caller,
+    );
+  }
+}
+
+function requiredUuid(uuid: string | undefined): string {
+  if (uuid === undefined || uuid === "") {
+    throw new SimLambdaValidationException(
+      "1 validation error detected: Value null at 'uuid' failed to satisfy " +
+        "constraint: Member must not be null",
+    );
+  }
+
+  return uuid;
+}

--- a/src/service/lambda/command/event-source-mapping/event-source-mapping.command.ts
+++ b/src/service/lambda/command/event-source-mapping/event-source-mapping.command.ts
@@ -1,0 +1,107 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateEventSourceMappingCommand/
+ *
+ * The event source mapping commands share their output shape, because every one
+ * of them reports the mapping it acted on, so they share one module.
+ */
+
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaEventSourceMappingConfiguration } from "../../event-source/sim-lambda-event-source-mapping.js";
+
+/**
+ * Minimal structural sim Lambda event source mapping output.
+ */
+export interface SimEventSourceMappingCommandOutput extends SimLambdaEventSourceMappingConfiguration {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Lambda CreateEventSourceMapping command.
+ */
+export interface SimCreateEventSourceMappingCommand {
+  readonly input: SimCreateEventSourceMappingCommandInput;
+}
+
+/**
+ * Minimal structural sim Lambda CreateEventSourceMapping input.
+ *
+ * The inputs this simulation has no behaviour for are declared so a request
+ * carrying one can be refused rather than silently ignored.
+ */
+export interface SimCreateEventSourceMappingCommandInput {
+  readonly EventSourceArn?: string | undefined;
+  readonly FunctionName?: string | undefined;
+  readonly Enabled?: boolean | undefined;
+  readonly BatchSize?: number | undefined;
+  readonly MaximumBatchingWindowInSeconds?: number | undefined;
+  readonly FunctionResponseTypes?: readonly string[] | undefined;
+  readonly FilterCriteria?: object | undefined;
+  readonly ScalingConfig?: object | undefined;
+  readonly DestinationConfig?: object | undefined;
+  readonly SelfManagedEventSource?: object | undefined;
+  readonly SelfManagedKafkaEventSourceConfig?: object | undefined;
+  readonly AmazonManagedKafkaEventSourceConfig?: object | undefined;
+  readonly DocumentDBEventSourceConfig?: object | undefined;
+  readonly SourceAccessConfigurations?: readonly object[] | undefined;
+  readonly ProvisionedPollerConfig?: object | undefined;
+  readonly MetricsConfig?: object | undefined;
+  readonly StartingPosition?: string | undefined;
+  readonly StartingPositionTimestamp?: Date | undefined;
+  readonly Topics?: readonly string[] | undefined;
+  readonly Queues?: readonly string[] | undefined;
+  readonly MaximumRecordAgeInSeconds?: number | undefined;
+  readonly MaximumRetryAttempts?: number | undefined;
+  readonly ParallelizationFactor?: number | undefined;
+  readonly TumblingWindowInSeconds?: number | undefined;
+  readonly BisectBatchOnFunctionError?: boolean | undefined;
+  readonly KMSKeyArn?: string | undefined;
+  readonly Tags?: Record<string, string> | undefined;
+}
+
+export type SimCreateEventSourceMappingCommandOutput =
+  SimEventSourceMappingCommandOutput;
+
+/**
+ * Minimal structural sim Lambda GetEventSourceMapping command.
+ */
+export interface SimGetEventSourceMappingCommand {
+  readonly input: SimGetEventSourceMappingCommandInput;
+}
+
+export interface SimGetEventSourceMappingCommandInput {
+  readonly UUID?: string | undefined;
+}
+
+export type SimGetEventSourceMappingCommandOutput =
+  SimEventSourceMappingCommandOutput;
+
+/**
+ * Minimal structural sim Lambda DeleteEventSourceMapping command.
+ */
+export interface SimDeleteEventSourceMappingCommand {
+  readonly input: SimDeleteEventSourceMappingCommandInput;
+}
+
+export interface SimDeleteEventSourceMappingCommandInput {
+  readonly UUID?: string | undefined;
+}
+
+export type SimDeleteEventSourceMappingCommandOutput =
+  SimEventSourceMappingCommandOutput;
+
+/**
+ * Minimal structural sim Lambda ListEventSourceMappings command.
+ */
+export interface SimListEventSourceMappingsCommand {
+  readonly input: SimListEventSourceMappingsCommandInput;
+}
+
+export interface SimListEventSourceMappingsCommandInput {
+  readonly EventSourceArn?: string | undefined;
+  readonly FunctionName?: string | undefined;
+}
+
+export interface SimListEventSourceMappingsCommandOutput {
+  readonly EventSourceMappings: readonly SimLambdaEventSourceMappingConfiguration[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.iso.test.ts
@@ -47,6 +47,19 @@ describe("sim Lambda event source mapping commands", () => {
     assertIdentical(error.name, "ResourceNotFoundException");
   });
 
+  it("refuses a request naming no mapping at all", async () => {
+    // Given a simulated AWS with one mapping on it.
+    const { simAws } = await simAwsWithSqsEventSource();
+
+    // When a mapping is read with no UUID.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().getEventSourceMapping({ input: {} });
+    });
+
+    // Then the request is refused as invalid.
+    assertIdentical(error.name, "ValidationException");
+  });
+
   it("lists the mappings of a queue", async () => {
     // Given a mapping between a queue and a function.
     const { simAws, queueArn, uuid } = await simAwsWithSqsEventSource();

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.iso.test.ts
@@ -1,0 +1,171 @@
+import {
+  DeleteEventSourceMappingCommand,
+  GetEventSourceMappingCommand,
+  ListEventSourceMappingsCommand,
+} from "@aws-sdk/client-lambda";
+import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithSqsEventSource } from "../../../../../test/lambda/event-source-fixture.js";
+
+describe("sim Lambda event source mapping commands", () => {
+  it("reads one mapping back by its UUID", async () => {
+    // Given a mapping between a queue and a function.
+    const { simAws, uuid, queueArn } = await simAwsWithSqsEventSource();
+
+    // When it is read back.
+    const mapping = await simAws
+      .lambda()
+      .getEventSourceMapping(new GetEventSourceMappingCommand({ UUID: uuid }));
+
+    // Then it reports what it was created with.
+    assertIdentical(mapping.UUID, uuid);
+    assertIdentical(mapping.EventSourceArn, queueArn);
+    assertIdentical(mapping.BatchSize, 10);
+  });
+
+  it("refuses a UUID belonging to no mapping", async () => {
+    // Given a simulated AWS with one mapping on it.
+    const { simAws } = await simAwsWithSqsEventSource();
+
+    // When another UUID is read.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().getEventSourceMapping(
+        new GetEventSourceMappingCommand({
+          UUID: "1a4b6c8d-0000-0000-0000-000000000000",
+        }),
+      );
+    });
+
+    // Then it is reported as missing.
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("lists the mappings of a queue", async () => {
+    // Given a mapping between a queue and a function.
+    const { simAws, queueArn, uuid } = await simAwsWithSqsEventSource();
+
+    // When the mappings of that queue are listed.
+    const listed = await simAws
+      .lambda()
+      .listEventSourceMappings(
+        new ListEventSourceMappingsCommand({ EventSourceArn: queueArn }),
+      );
+
+    // Then the mapping is in the listing.
+    assertArrayLength(listed.EventSourceMappings, 1);
+    assertIdentical(listed.EventSourceMappings[0].UUID, uuid);
+  });
+
+  it("leaves out the mappings of another queue", async () => {
+    // Given a mapping between a queue and a function.
+    const { simAws } = await simAwsWithSqsEventSource();
+
+    // When the mappings of a different queue are listed.
+    const listed = await simAws.lambda().listEventSourceMappings(
+      new ListEventSourceMappingsCommand({
+        EventSourceArn: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:invoices`,
+      }),
+    );
+
+    // Then nothing is listed.
+    assertArrayLength(listed.EventSourceMappings, 0);
+  });
+
+  it("stops delivering once the mapping is deleted", async () => {
+    // Given a mapping that has delivered a message.
+    const { simAws, uuid, queueUrl, events } = await simAwsWithSqsEventSource();
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(events, 1);
+
+    // When the mapping is deleted and another message is sent.
+    await simAws
+      .lambda()
+      .deleteEventSourceMapping(
+        new DeleteEventSourceMappingCommand({ UUID: uuid }),
+      );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-2" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function was not given it.
+    assertArrayLength(events, 1);
+  });
+
+  it("forgets a deleted mapping", async () => {
+    // Given a deleted mapping.
+    const { simAws, uuid } = await simAwsWithSqsEventSource();
+
+    await simAws
+      .lambda()
+      .deleteEventSourceMapping(
+        new DeleteEventSourceMappingCommand({ UUID: uuid }),
+      );
+
+    // When it is read back.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .lambda()
+        .getEventSourceMapping(
+          new GetEventSourceMappingCommand({ UUID: uuid }),
+        );
+    });
+
+    // Then it is gone.
+    assertIdentical(error.name, "ResourceNotFoundException");
+  });
+
+  it("authorizes reading a mapping against the function", async () => {
+    // Given a caller allowed nothing on the function.
+    const { simAws, uuid } = await simAwsWithSqsEventSource();
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrderConsumerRole",
+        PolicyName: "NoLambdaActions",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Deny",
+            Action: "lambda:GetEventSourceMapping",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When that caller reads the mapping.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .lambda()
+        .getEventSourceMapping(
+          new GetEventSourceMappingCommand({ UUID: uuid }),
+          {
+            caller: {
+              kind: "arn",
+              arn: `arn:aws:iam::${simAws.defaultAccountId}:role/OrderConsumerRole`,
+            },
+          },
+        );
+    });
+
+    // Then simulated IAM refuses it.
+    assertIdentical(error.name, "AccessDenied");
+  });
+});

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
@@ -1,0 +1,164 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimLambdaEventSourceQueues } from "../../event-source/queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
+import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
+import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import { CreateEventSourceMappingCommandHandler } from "./create-event-source-mapping.handler.js";
+import {
+  anyFunctionName,
+  SimLambdaEventSourceMappingAccess,
+} from "./event-source-mapping-access.js";
+import type {
+  SimCreateEventSourceMappingCommand,
+  SimCreateEventSourceMappingCommandOutput,
+  SimDeleteEventSourceMappingCommand,
+  SimDeleteEventSourceMappingCommandOutput,
+  SimGetEventSourceMappingCommand,
+  SimGetEventSourceMappingCommandOutput,
+  SimListEventSourceMappingsCommand,
+  SimListEventSourceMappingsCommandOutput,
+} from "./event-source-mapping.command.js";
+
+interface SimLambdaEventSourceMappingCommandsProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly pollers: SimLambdaEventSourcePollers;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface SimLambdaEventSourceMappingCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The event source mapping commands of one simulated Lambda scope.
+ *
+ * All four act on the same store and authorize against the function the mapping
+ * delivers to, so they share one class rather than repeating that wiring.
+ * Creating a mapping is the only one with anything else to do, so it is the
+ * only one with a handler of its own.
+ */
+export class SimLambdaEventSourceMappingCommands {
+  private readonly mappings = new SimLambdaEventSourceMappingStore();
+  private readonly access: SimLambdaEventSourceMappingAccess;
+  private readonly properties: SimLambdaEventSourceMappingCommandsProperties;
+
+  constructor(properties: SimLambdaEventSourceMappingCommandsProperties) {
+    this.properties = properties;
+    this.access = new SimLambdaEventSourceMappingAccess({
+      mappings: this.mappings,
+      functions: properties.functions,
+      iam: properties.iam,
+    });
+  }
+
+  /**
+   * Create an event source mapping from a queue to a function.
+   */
+  async create(
+    command: SimCreateEventSourceMappingCommand,
+    options?: SimLambdaEventSourceMappingCommandOptions,
+  ): Promise<SimCreateEventSourceMappingCommandOutput> {
+    return await new CreateEventSourceMappingCommandHandler({
+      ...this.properties,
+      mappings: this.mappings,
+    }).handle(command, options);
+  }
+
+  /**
+   * Read one event source mapping.
+   */
+  async get(
+    command: SimGetEventSourceMappingCommand,
+    options?: SimLambdaEventSourceMappingCommandOptions,
+  ): Promise<SimGetEventSourceMappingCommandOutput> {
+    await this.properties.background.sequence();
+
+    const mapping = this.access.require(
+      "lambda:GetEventSourceMapping",
+      command.input.UUID,
+      options?.caller,
+    );
+
+    return { $metadata: {}, ...mapping.configuration() };
+  }
+
+  /**
+   * List the event source mappings, narrowed by queue or function.
+   *
+   * A listing naming no function authorizes against every function in the
+   * Account and Region, because that is what it can report on. A policy naming
+   * one function ARN therefore allows only the listing that names it.
+   */
+  async list(
+    command: SimListEventSourceMappingsCommand,
+    options?: SimLambdaEventSourceMappingCommandOptions,
+  ): Promise<SimListEventSourceMappingsCommandOutput> {
+    await this.properties.background.sequence();
+
+    const functionName = listedFunctionName(command.input.FunctionName);
+
+    this.access.authorizeFunction(
+      "lambda:ListEventSourceMappings",
+      functionName ?? anyFunctionName,
+      options?.caller,
+    );
+
+    const matching = this.mappings.matching({
+      eventSourceArn: command.input.EventSourceArn,
+      functionName,
+    });
+
+    return {
+      $metadata: {},
+      EventSourceMappings: matching.map((mapping) => mapping.configuration()),
+    };
+  }
+
+  /**
+   * Delete an event source mapping, which stops it polling.
+   */
+  async delete(
+    command: SimDeleteEventSourceMappingCommand,
+    options?: SimLambdaEventSourceMappingCommandOptions,
+  ): Promise<SimDeleteEventSourceMappingCommandOutput> {
+    await this.properties.background.sequence();
+
+    const mapping = this.access.require(
+      "lambda:DeleteEventSourceMapping",
+      command.input.UUID,
+      options?.caller,
+    );
+
+    this.properties.pollers.stop(mapping);
+    this.mappings.remove(mapping);
+
+    return { $metadata: {}, ...mapping.configuration() };
+  }
+
+  /**
+   * Find a mapping by UUID, for tests inspecting mapping state directly.
+   */
+  find(uuid: string): SimLambdaEventSourceMapping | undefined {
+    return this.mappings.find(uuid);
+  }
+}
+
+/**
+ * The function name a listing is narrowed by, which is any of them when the
+ * request names none.
+ */
+function listedFunctionName(requested: string | undefined): string | undefined {
+  if (requested === undefined) {
+    return undefined;
+  }
+
+  return simLambdaFunctionNameOf(requested);
+}

--- a/src/service/lambda/command/sim-lambda-command.types.ts
+++ b/src/service/lambda/command/sim-lambda-command.types.ts
@@ -11,6 +11,21 @@ export type {
   SimAddPermissionCommandOutput,
 } from "./add-permission/add-permission.command.js";
 export type {
+  SimCreateEventSourceMappingCommand,
+  SimCreateEventSourceMappingCommandInput,
+  SimCreateEventSourceMappingCommandOutput,
+  SimDeleteEventSourceMappingCommand,
+  SimDeleteEventSourceMappingCommandInput,
+  SimDeleteEventSourceMappingCommandOutput,
+  SimEventSourceMappingCommandOutput,
+  SimGetEventSourceMappingCommand,
+  SimGetEventSourceMappingCommandInput,
+  SimGetEventSourceMappingCommandOutput,
+  SimListEventSourceMappingsCommand,
+  SimListEventSourceMappingsCommandInput,
+  SimListEventSourceMappingsCommandOutput,
+} from "./event-source-mapping/event-source-mapping.command.js";
+export type {
   SimCreateFunctionCommand,
   SimCreateFunctionCommandOutput,
 } from "./create-function/create-function.command.js";

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
@@ -1,0 +1,53 @@
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import {
+  type SimLambdaSqsBatchOutcome,
+  SimLambdaSqsBatchResponse,
+} from "./sim-lambda-sqs-batch-response.js";
+import { SimLambdaSqsEventBuilder } from "./sim-lambda-sqs-event.js";
+
+interface SimLambdaEventSourceDeliveryProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+}
+
+/**
+ * Hands one batch to a function and reads what became of it.
+ *
+ * The batch is invoked directly rather than through the Invoke command because
+ * the handler's error has to be seen: an asynchronous invocation drops it, and
+ * this is what decides whether the messages go back on the queue.
+ */
+export class SimLambdaEventSourceDelivery {
+  private readonly eventBuilder: SimLambdaSqsEventBuilder;
+  private readonly batchResponse: SimLambdaSqsBatchResponse;
+
+  constructor(properties: SimLambdaEventSourceDeliveryProperties) {
+    this.eventBuilder = new SimLambdaSqsEventBuilder(properties.eventSourceArn);
+    this.batchResponse = new SimLambdaSqsBatchResponse(
+      properties.mapping.reportsBatchItemFailures,
+    );
+  }
+
+  /**
+   * Deliver a batch, answering with what to delete and what to leave.
+   */
+  async to(
+    simFunction: SimLambdaFunction,
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): Promise<SimLambdaSqsBatchOutcome> {
+    try {
+      return this.batchResponse.handled(
+        messages,
+        await simFunction.invoke(this.eventBuilder.of(messages)),
+      );
+    } catch {
+      // As on real Lambda, the handler error goes to the function's logs and
+      // not to whoever sent the message. What the sender sees is the batch
+      // coming back to the queue.
+      return this.batchResponse.failed(messages);
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-schedule.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-schedule.ts
@@ -1,0 +1,79 @@
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../../util/background/background.js";
+
+const millisecondsPerSecond = 1000;
+
+interface SimLambdaEventSourcePollScheduleProperties {
+  readonly background: BackgroundScheduler;
+  readonly poll: BackgroundTask;
+}
+
+/**
+ * When one event source mapping polls next.
+ *
+ * Real Lambda polls its queue continuously, and nothing in this simulation runs
+ * continuously, so every poll is scheduled in response to something: a message
+ * arriving, a batch coming back, or a batch that filled the request suggesting
+ * there is more waiting.
+ */
+export class SimLambdaEventSourcePollSchedule {
+  private readonly background: BackgroundScheduler;
+  private readonly poll: BackgroundTask;
+
+  private scheduled = false;
+
+  constructor(properties: SimLambdaEventSourcePollScheduleProperties) {
+    this.background = properties.background;
+    this.poll = properties.poll;
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, unless a poll is already
+   * waiting to happen.
+   */
+  now(): void {
+    if (this.scheduled) {
+      return;
+    }
+
+    this.scheduled = true;
+    this.background.schedule(async () => {
+      this.scheduled = false;
+
+      await this.poll();
+    });
+  }
+
+  /**
+   * Poll when a message becomes receivable, which is now for an ordinary send
+   * and later for one sent with a delay.
+   */
+  at(instant: Date): void {
+    if (instant.getTime() <= this.background.now().getTime()) {
+      this.now();
+
+      return;
+    }
+
+    this.background.scheduleAt(instant, this.poll);
+  }
+
+  /**
+   * Poll again once a visibility timeout has run, which is an instant on the
+   * simulation's clock rather than something that fires.
+   *
+   * Advancing time is what brings a returned batch back, so this is scheduled
+   * on the clock even for a timeout of zero. A poll that ran straight back
+   * round would spin on a batch the function keeps failing.
+   */
+  afterSeconds(seconds: number): void {
+    this.background.scheduleAt(
+      new Date(
+        this.background.now().getTime() + seconds * millisecondsPerSecond,
+      ),
+      this.poll,
+    );
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
@@ -113,6 +113,8 @@ export class SimLambdaEventSourcePoller implements SimLambdaEventSourceQueueWatc
     });
 
     if (messages.length === 0) {
+      this.pollWhenSomethingComesBack();
+
       return;
     }
 
@@ -139,6 +141,23 @@ export class SimLambdaEventSourcePoller implements SimLambdaEventSourceQueueWatc
     }
 
     return this.properties.functions.find(this.properties.mapping.functionName);
+  }
+
+  /**
+   * Look again when a message the queue could not hand out becomes
+   * receivable.
+   *
+   * A mapping created while every message on its queue is in flight, or one
+   * whose queue holds only delayed messages, has nothing to wake it otherwise.
+   */
+  private pollWhenSomethingComesBack(): void {
+    const availableFrom = this.properties.queues.nextAvailability(
+      this.properties.eventSourceArn.value,
+    );
+
+    if (availableFrom !== undefined) {
+      this.schedule.at(availableFrom);
+    }
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
@@ -1,0 +1,164 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type {
+  SimLambdaEventSourceQueueRequest,
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+} from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
+import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
+import type { SimLambdaSqsBatchOutcome } from "./sim-lambda-sqs-batch-response.js";
+
+interface SimLambdaEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one event source mapping's queue and invokes its function.
+ *
+ * Real Lambda polls a queue continuously. Nothing in this simulation runs
+ * continuously, so the queue says when a message has arrived and a poll is
+ * scheduled in response. A test that awaits the simulation settling has
+ * therefore watched the whole delivery happen, rather than having waited a
+ * while and hoped.
+ *
+ * A batch the function returns from is deleted from the queue. A batch it
+ * throws on is left there, which hides it for the visibility timeout and hands
+ * it back afterwards, so a redrive policy eventually gives up on it exactly as
+ * it would for any other failing consumer. That is why the poller invokes the
+ * function directly rather than through the Invoke command: an asynchronous
+ * invocation drops its handler error, and this one has to be seen.
+ */
+export class SimLambdaEventSourcePoller implements SimLambdaEventSourceQueueWatcher {
+  private readonly properties: SimLambdaEventSourcePollerProperties;
+  private readonly delivery: SimLambdaEventSourceDelivery;
+  private readonly schedule: SimLambdaEventSourcePollSchedule;
+
+  private stopped = false;
+
+  constructor(properties: SimLambdaEventSourcePollerProperties) {
+    this.properties = properties;
+    this.delivery = new SimLambdaEventSourceDelivery(properties);
+    this.schedule = new SimLambdaEventSourcePollSchedule({
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.run();
+      },
+    });
+  }
+
+  /**
+   * Watch the queue this mapping polls.
+   *
+   * Watching starts as soon as the mapping is created, before it has finished
+   * creating, so a message sent in between is not missed. The poll it wakes
+   * finds a mapping that is not polling yet and does nothing, and the poll that
+   * follows activation picks the message up.
+   */
+  watch(): void {
+    this.properties.queues.watch(this.properties.eventSourceArn.value, this);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, which is what a newly enabled
+   * mapping does with whatever is already on its queue.
+   */
+  pollNow(): void {
+    this.schedule.now();
+  }
+
+  /**
+   * Stop polling, as deleting the mapping does.
+   */
+  stop(): void {
+    this.stopped = true;
+    this.properties.queues.unwatch(this.properties.eventSourceArn.value, this);
+  }
+
+  /**
+   * Take a message arriving on the queue as something to poll for.
+   */
+  messageAvailable(availableFrom: Date): void {
+    this.schedule.at(availableFrom);
+  }
+
+  /**
+   * Poll once: one batch, delivered and then deleted or left behind.
+   */
+  private async run(): Promise<void> {
+    const simFunction = this.pollingFunction();
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    // Polling is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its queue.
+    const request = {
+      queueArn: this.properties.eventSourceArn.value,
+      caller: { kind: "arn", arn: simFunction.roleArn },
+    } as const satisfies SimLambdaEventSourceQueueRequest;
+    const visibilityTimeoutSeconds =
+      await this.properties.queues.visibilityTimeoutSeconds(request);
+    const messages = await this.properties.queues.receive({
+      ...request,
+      batchSize: this.properties.mapping.batchSize,
+    });
+
+    if (messages.length === 0) {
+      return;
+    }
+
+    const outcome = await this.delivery.to(simFunction, messages);
+
+    await this.properties.queues.deleteMessages({
+      ...request,
+      receiptHandles: outcome.handledReceiptHandles,
+    });
+
+    this.pollAgainAfter(outcome, messages.length, visibilityTimeoutSeconds);
+  }
+
+  /**
+   * The function this mapping delivers to, while it should be delivering.
+   *
+   * A mapping still being created is not polling yet, and a disabled one never
+   * is. A function that is not there is not an error here: the mapping simply
+   * has nothing to deliver to.
+   */
+  private pollingFunction(): SimLambdaFunction | undefined {
+    if (this.stopped || !this.properties.mapping.isPolling) {
+      return undefined;
+    }
+
+    return this.properties.functions.find(this.properties.mapping.functionName);
+  }
+
+  /**
+   * Decide when this mapping polls again: when a returned batch becomes
+   * visible again, or straight away when a batch filled the request and there
+   * may be more waiting.
+   */
+  private pollAgainAfter(
+    outcome: SimLambdaSqsBatchOutcome,
+    receivedCount: number,
+    visibilityTimeoutSeconds: number,
+  ): void {
+    if (outcome.hasReturnedMessages) {
+      this.schedule.afterSeconds(visibilityTimeoutSeconds);
+
+      return;
+    }
+
+    if (receivedCount >= this.properties.mapping.batchSize) {
+      this.schedule.now();
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.iso.test.ts
@@ -1,0 +1,75 @@
+import { assertArrayLength, assertFalse } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+import { SimLambdaSqsBatchResponse } from "./sim-lambda-sqs-batch-response.js";
+
+const messages: readonly SimLambdaEventSourceMessage[] = [
+  {
+    MessageId: "message-1",
+    ReceiptHandle: "handle-1",
+    MD5OfBody: "digest-1",
+    Body: "order-1",
+  },
+  {
+    MessageId: "message-2",
+    ReceiptHandle: "handle-2",
+    MD5OfBody: "digest-2",
+    Body: "order-2",
+  },
+];
+
+describe("sim Lambda SQS batch responses", () => {
+  it("keeps the whole batch when the mapping expects no failure report", () => {
+    // Given a mapping the function does not report batch item failures to.
+    const response = new SimLambdaSqsBatchResponse(false);
+
+    // When the function returns a report anyway.
+    const outcome = response.handled(messages, {
+      batchItemFailures: [{ itemIdentifier: "message-2" }],
+    });
+
+    // Then it is ignored, as real Lambda ignores one it was not told to
+    // expect.
+    assertArrayLength(outcome.handled, 2);
+    assertFalse(outcome.hasReturnedMessages);
+  });
+
+  it("returns the whole batch for a report entry that is not an object", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaSqsBatchResponse(true);
+
+    // When the function reports a bare string.
+    const outcome = response.handled(messages, {
+      batchItemFailures: ["message-2"],
+    });
+
+    // Then the whole batch goes back rather than guessing what was meant.
+    assertArrayLength(outcome.returned, 2);
+  });
+
+  it("returns the whole batch for an entry with no message id", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaSqsBatchResponse(true);
+
+    // When the function reports an entry whose identifier is not a string.
+    const outcome = response.handled(messages, {
+      batchItemFailures: [{ itemIdentifier: 7 }],
+    });
+
+    // Then the whole batch goes back.
+    assertArrayLength(outcome.returned, 2);
+  });
+
+  it("keeps the whole batch when the function returns nothing", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaSqsBatchResponse(true);
+
+    // When the function returns undefined, as a handler with no return does.
+    const outcome = response.handled(messages, undefined);
+
+    // Then the whole batch is handled.
+    assertArrayLength(outcome.handled, 2);
+    assertArrayLength(outcome.handledReceiptHandles, 2);
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
@@ -1,0 +1,133 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+
+/**
+ * What became of one batch handed to a function.
+ *
+ * A batch is either deleted from the queue or left on it to become visible
+ * again. Partial batch responses split it, which is the only reason this is a
+ * pair of lists rather than a yes or no.
+ */
+export class SimLambdaSqsBatchOutcome {
+  public readonly handled: readonly SimLambdaEventSourceMessage[];
+  public readonly returned: readonly SimLambdaEventSourceMessage[];
+
+  constructor(
+    handled: readonly SimLambdaEventSourceMessage[],
+    returned: readonly SimLambdaEventSourceMessage[],
+  ) {
+    this.handled = handled;
+    this.returned = returned;
+  }
+
+  /**
+   * The receipt handles of the messages to delete from the queue.
+   */
+  get handledReceiptHandles(): readonly string[] {
+    return this.handled.map((message) => message.ReceiptHandle);
+  }
+
+  /**
+   * Whether anything was left on the queue to be delivered again.
+   */
+  get hasReturnedMessages(): boolean {
+    return this.returned.length > 0;
+  }
+}
+
+/**
+ * Reads what a function said about the batch it was given.
+ *
+ * A function that returns normally has handled the whole batch, unless the
+ * mapping was told to expect a batch item failure report and the function sent
+ * one. A report naming an id that was not in the batch returns the whole batch,
+ * as on real Lambda: the alternative is to guess which messages the function
+ * meant, and guessing wrong loses a message.
+ */
+export class SimLambdaSqsBatchResponse {
+  private readonly reportsBatchItemFailures: boolean;
+
+  constructor(reportsBatchItemFailures: boolean) {
+    this.reportsBatchItemFailures = reportsBatchItemFailures;
+  }
+
+  /**
+   * What became of a batch the function returned from.
+   */
+  handled(
+    messages: readonly SimLambdaEventSourceMessage[],
+    result: unknown,
+  ): SimLambdaSqsBatchOutcome {
+    const failedIds = this.reportedFailureIds(result);
+
+    if (failedIds === undefined) {
+      return new SimLambdaSqsBatchOutcome(messages, []);
+    }
+
+    if (!this.namesBatchMessages(failedIds, messages)) {
+      return this.failed(messages);
+    }
+
+    return new SimLambdaSqsBatchOutcome(
+      messages.filter((message) => !failedIds.includes(message.MessageId)),
+      messages.filter((message) => failedIds.includes(message.MessageId)),
+    );
+  }
+
+  /**
+   * What becomes of a batch the function threw on: the whole of it goes back.
+   */
+  failed(
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): SimLambdaSqsBatchOutcome {
+    return new SimLambdaSqsBatchOutcome([], messages);
+  }
+
+  /**
+   * The message ids a batch item failure report names, or undefined when the
+   * function reported none.
+   */
+  private reportedFailureIds(result: unknown): readonly string[] | undefined {
+    if (!this.reportsBatchItemFailures || !isRecord(result)) {
+      return undefined;
+    }
+
+    const reported = result["batchItemFailures"];
+
+    if (!Array.isArray(reported) || reported.length === 0) {
+      return undefined;
+    }
+
+    return reported.map((failure: unknown) => itemIdentifier(failure));
+  }
+
+  private namesBatchMessages(
+    failedIds: readonly string[],
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): boolean {
+    return failedIds.every((failedId) =>
+      messages.some((message) => message.MessageId === failedId),
+    );
+  }
+}
+
+/**
+ * The message id one reported failure names.
+ *
+ * An entry naming nothing is reported as an empty id, which no message has, so
+ * the whole batch goes back. That is what real Lambda does with a malformed
+ * report rather than dropping the entry.
+ */
+function itemIdentifier(failure: unknown): string {
+  if (!isRecord(failure)) {
+    return "";
+  }
+
+  const identifier = failure["itemIdentifier"];
+
+  if (typeof identifier !== "string") {
+    return "";
+  }
+
+  return identifier;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-event.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-event.ts
@@ -1,0 +1,113 @@
+import type {
+  SimLambdaEventSourceMessage,
+  SimLambdaEventSourceMessageAttribute,
+} from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+
+/**
+ * One message attribute as an SQS event record carries it.
+ *
+ * The list values are always there and always empty, as they are on real AWS:
+ * SQS accepts the list data types in a request and reports nothing for them.
+ */
+export interface SimLambdaSqsEventMessageAttribute {
+  readonly stringValue?: string | undefined;
+  readonly binaryValue?: string | undefined;
+  readonly stringListValues: readonly string[];
+  readonly binaryListValues: readonly string[];
+  readonly dataType: string;
+}
+
+/**
+ * One message as an SQS event record.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+ */
+export interface SimLambdaSqsEventRecord {
+  readonly messageId: string;
+  readonly receiptHandle: string;
+  readonly body: string;
+  readonly attributes: Record<string, string>;
+  readonly messageAttributes: Record<string, SimLambdaSqsEventMessageAttribute>;
+  readonly md5OfBody: string;
+  readonly eventSource: "aws:sqs";
+  readonly eventSourceARN: string;
+  readonly awsRegion: string;
+}
+
+/**
+ * The event an SQS event source mapping invokes a function with.
+ */
+export interface SimLambdaSqsEvent {
+  readonly Records: readonly SimLambdaSqsEventRecord[];
+}
+
+/**
+ * Builds the SQS event for one batch of polled messages.
+ *
+ * The event is what the function code sees, so it is built in the event's own
+ * naming rather than the queue's: lower-case record fields, the message system
+ * attributes flattened into `attributes`, and binary attribute values base64
+ * encoded as they cross into JSON.
+ */
+export class SimLambdaSqsEventBuilder {
+  private readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+
+  constructor(eventSourceArn: SimLambdaSqsEventSourceArn) {
+    this.eventSourceArn = eventSourceArn;
+  }
+
+  /**
+   * The event for a batch of messages.
+   */
+  of(messages: readonly SimLambdaEventSourceMessage[]): SimLambdaSqsEvent {
+    return { Records: messages.map((message) => this.record(message)) };
+  }
+
+  private record(
+    message: SimLambdaEventSourceMessage,
+  ): SimLambdaSqsEventRecord {
+    return {
+      messageId: message.MessageId,
+      receiptHandle: message.ReceiptHandle,
+      body: message.Body,
+      attributes: { ...message.Attributes },
+      messageAttributes: this.messageAttributes(message),
+      md5OfBody: message.MD5OfBody,
+      eventSource: "aws:sqs",
+      eventSourceARN: this.eventSourceArn.value,
+      awsRegion: this.eventSourceArn.regionName,
+    };
+  }
+
+  private messageAttributes(
+    message: SimLambdaEventSourceMessage,
+  ): Record<string, SimLambdaSqsEventMessageAttribute> {
+    return Object.fromEntries(
+      Object.entries(message.MessageAttributes ?? {}).map(([name, value]) => [
+        name,
+        eventMessageAttribute(value),
+      ]),
+    );
+  }
+}
+
+function eventMessageAttribute(
+  attribute: SimLambdaEventSourceMessageAttribute,
+): SimLambdaSqsEventMessageAttribute {
+  return {
+    stringValue: attribute.StringValue,
+    binaryValue: base64Of(attribute.BinaryValue),
+    stringListValues: [],
+    binaryListValues: [],
+    dataType: attribute.DataType ?? "String",
+  };
+}
+
+function base64Of(value: Uint8Array | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Buffer.from(value).toString("base64");
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-event-source-queue-service.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-event-source-queue-service.ts
@@ -1,0 +1,54 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimLambdaEventSourceMessage,
+  SimLambdaEventSourceQueueWatcher,
+} from "./sim-lambda-event-source-queues.js";
+
+interface QueueCommandOptions {
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * The narrow slice of simulated SQS that event source polling needs.
+ * SimSqs structurally implements this interface.
+ */
+export interface SimLambdaEventSourceQueueService {
+  getQueueAttributes(
+    command: {
+      input: { QueueUrl: string; AttributeNames: readonly string[] };
+    },
+    options?: QueueCommandOptions,
+  ): Promise<{ Attributes?: Record<string, string> | undefined }>;
+
+  receiveMessage(
+    command: {
+      input: {
+        QueueUrl: string;
+        MaxNumberOfMessages: number;
+        MessageSystemAttributeNames: readonly string[];
+        MessageAttributeNames: readonly string[];
+      };
+    },
+    options?: QueueCommandOptions,
+  ): Promise<{ Messages?: readonly SimLambdaEventSourceMessage[] | undefined }>;
+
+  deleteMessageBatch(
+    command: {
+      input: {
+        QueueUrl: string;
+        Entries: readonly { Id: string; ReceiptHandle: string }[];
+      };
+    },
+    options?: QueueCommandOptions,
+  ): Promise<unknown>;
+
+  queueActivity(): SimLambdaEventSourceQueueActivity;
+}
+
+/**
+ * The part of simulated SQS that says when a message has arrived on a queue.
+ */
+export interface SimLambdaEventSourceQueueActivity {
+  watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
+  unwatch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-event-source-queue-service.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-event-source-queue-service.ts
@@ -49,6 +49,7 @@ export interface SimLambdaEventSourceQueueService {
  * The part of simulated SQS that says when a message has arrived on a queue.
  */
 export interface SimLambdaEventSourceQueueActivity {
+  nextAvailability(queueArn: string): Date | undefined;
   watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
   unwatch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
 }

--- a/src/service/lambda/event-source/queue/sim-lambda-event-source-queues.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-event-source-queues.ts
@@ -1,0 +1,148 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+
+/**
+ * One message attribute as a queue reports it.
+ */
+export interface SimLambdaEventSourceMessageAttribute {
+  readonly DataType?: string | undefined;
+  readonly StringValue?: string | undefined;
+  readonly BinaryValue?: Uint8Array | undefined;
+  readonly StringListValues?: readonly string[] | undefined;
+  readonly BinaryListValues?: readonly Uint8Array[] | undefined;
+}
+
+/**
+ * One message as a queue hands it to a poller.
+ *
+ * These are the queue's own field names rather than the event's: what the
+ * poller receives is a message, and turning it into an SQS event record is the
+ * event builder's job.
+ */
+export interface SimLambdaEventSourceMessage {
+  readonly MessageId: string;
+  readonly ReceiptHandle: string;
+  readonly MD5OfBody: string;
+  readonly Body: string;
+  readonly Attributes?: Record<string, string> | undefined;
+  readonly MessageAttributes?:
+    Record<string, SimLambdaEventSourceMessageAttribute> | undefined;
+}
+
+/**
+ * A poller's request to the queue it polls, made as the function's execution
+ * role so simulated IAM applies to it as it does on real Lambda.
+ */
+export interface SimLambdaEventSourceQueueRequest {
+  readonly queueArn: string;
+  readonly caller: SimAwsCaller;
+}
+
+export interface SimLambdaEventSourceReceiveRequest extends SimLambdaEventSourceQueueRequest {
+  readonly batchSize: number;
+}
+
+export interface SimLambdaEventSourceDeleteRequest extends SimLambdaEventSourceQueueRequest {
+  readonly receiptHandles: readonly string[];
+}
+
+/**
+ * Something watching a queue on a poller's behalf.
+ */
+export interface SimLambdaEventSourceQueueWatcher {
+  messageAvailable(availableFrom: Date): void;
+}
+
+/**
+ * The queues a simulated Lambda event source mapping polls.
+ *
+ * This is the narrow slice of simulated SQS that polling needs, kept as an
+ * interface so Lambda depends on what it does with a queue rather than on the
+ * SQS service object. Every operation carries the caller, because polling on
+ * real Lambda is done with the function's execution role and is refused when
+ * that role has no permission for it.
+ */
+export interface SimLambdaEventSourceQueues {
+  /**
+   * How long a received message stays hidden, and by asking, whether the queue
+   * is there to be polled at all.
+   */
+  visibilityTimeoutSeconds(
+    request: SimLambdaEventSourceQueueRequest,
+  ): Promise<number>;
+
+  /**
+   * Take up to a batch of messages off the queue.
+   */
+  receive(
+    request: SimLambdaEventSourceReceiveRequest,
+  ): Promise<readonly SimLambdaEventSourceMessage[]>;
+
+  /**
+   * Delete the messages a batch has been handled successfully.
+   */
+  deleteMessages(request: SimLambdaEventSourceDeleteRequest): Promise<void>;
+
+  /**
+   * Watch a queue for messages arriving on it.
+   */
+  watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
+
+  /**
+   * Stop watching a queue.
+   */
+  unwatch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
+}
+
+/**
+ * Event source queues used when no simulated SQS is wired up, such as for a
+ * standalone SimLambda constructed outside SimAws.
+ */
+export class SimLambdaNoEventSourceQueues implements SimLambdaEventSourceQueues {
+  /**
+   * Refuse to look at a queue, explaining how to reach one.
+   */
+  visibilityTimeoutSeconds(
+    request: SimLambdaEventSourceQueueRequest,
+  ): Promise<number> {
+    return Promise.reject(this.noQueues(request.queueArn));
+  }
+
+  /**
+   * Refuse to poll, explaining how to reach a queue.
+   */
+  receive(
+    request: SimLambdaEventSourceReceiveRequest,
+  ): Promise<readonly SimLambdaEventSourceMessage[]> {
+    return Promise.reject(this.noQueues(request.queueArn));
+  }
+
+  /**
+   * Refuse to delete, explaining how to reach a queue.
+   */
+  deleteMessages(request: SimLambdaEventSourceDeleteRequest): Promise<void> {
+    return Promise.reject(this.noQueues(request.queueArn));
+  }
+
+  /**
+   * Watch nothing: there is no queue to watch.
+   */
+  watch(): void {
+    //
+  }
+
+  /**
+   * Stop watching nothing.
+   */
+  unwatch(): void {
+    //
+  }
+
+  private noQueues(queueArn: string): SimLambdaError {
+    return new SimLambdaError(
+      `Cannot poll ${queueArn}: this SimLambda has no simulated SQS to poll. ` +
+        "Create the event source mapping through SimAws, or construct " +
+        "SimLambda with eventSourceQueues.",
+    );
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-event-source-queues.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-event-source-queues.ts
@@ -84,6 +84,15 @@ export interface SimLambdaEventSourceQueues {
   deleteMessages(request: SimLambdaEventSourceDeleteRequest): Promise<void>;
 
   /**
+   * When the earliest message the queue cannot hand out yet becomes
+   * receivable, or nothing when it holds no such message.
+   *
+   * A poll that found nothing asks this, because a queue whose messages are all
+   * in flight or delayed has nothing to announce when they come back.
+   */
+  nextAvailability(queueArn: string): Date | undefined;
+
+  /**
    * Watch a queue for messages arriving on it.
    */
   watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void;
@@ -122,6 +131,13 @@ export class SimLambdaNoEventSourceQueues implements SimLambdaEventSourceQueues 
    */
   deleteMessages(request: SimLambdaEventSourceDeleteRequest): Promise<void> {
     return Promise.reject(this.noQueues(request.queueArn));
+  }
+
+  /**
+   * Answer with nothing: there is no queue to look at.
+   */
+  nextAvailability(): Date | undefined {
+    return;
   }
 
   /**

--- a/src/service/lambda/event-source/queue/sim-lambda-no-event-source-queues.iso.test.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-no-event-source-queues.iso.test.ts
@@ -1,4 +1,8 @@
-import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimLambdaNoEventSourceQueues } from "./sim-lambda-event-source-queues.js";
@@ -38,11 +42,14 @@ describe("sim Lambda event source queues with no simulated SQS", () => {
     // Given a simulated Lambda with no simulated SQS behind it.
     const queues = new SimLambdaNoEventSourceQueues();
 
-    // When a poller watches and stops watching a queue.
+    // When a poller watches a queue, asks when to look again, and stops.
     queues.watch();
+
+    const availability = queues.nextAvailability();
+
     queues.unwatch();
 
-    // Then nothing happens, which is all there is to check: a mapping on one
-    // of these was refused when it was created.
+    // Then it never has anything to come back for.
+    assertUndefined(availability);
   });
 });

--- a/src/service/lambda/event-source/queue/sim-lambda-no-event-source-queues.iso.test.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-no-event-source-queues.iso.test.ts
@@ -1,0 +1,48 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaNoEventSourceQueues } from "./sim-lambda-event-source-queues.js";
+
+const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+const request = {
+  queueArn,
+  caller: { kind: "arn", arn: "arn:aws:iam::111111111111:role/Consumer" },
+} as const;
+
+describe("sim Lambda event source queues with no simulated SQS", () => {
+  it("refuses every poll operation, saying how to reach a queue", async () => {
+    // Given a simulated Lambda with no simulated SQS behind it.
+    const queues = new SimLambdaNoEventSourceQueues();
+
+    // When each polling operation is attempted.
+    const errors = await Promise.all([
+      assertThrowsErrorAsync(async () => {
+        await queues.visibilityTimeoutSeconds(request);
+      }),
+      assertThrowsErrorAsync(async () => {
+        await queues.receive({ ...request, batchSize: 10 });
+      }),
+      assertThrowsErrorAsync(async () => {
+        await queues.deleteMessages({ ...request, receiptHandles: ["one"] });
+      }),
+    ]);
+
+    // Then each says there is nothing to poll, and how to fix it.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "no simulated SQS to poll");
+      assertStringIncludes(error.message, queueArn);
+    }
+  });
+
+  it("watches nothing, because there is no queue to watch", () => {
+    // Given a simulated Lambda with no simulated SQS behind it.
+    const queues = new SimLambdaNoEventSourceQueues();
+
+    // When a poller watches and stops watching a queue.
+    queues.watch();
+    queues.unwatch();
+
+    // Then nothing happens, which is all there is to check: a mapping on one
+    // of these was refused when it was created.
+  });
+});

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,0 +1,64 @@
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+
+const queueArnPattern =
+  /^arn:aws:sqs:(?<region>[a-z0-9-]+):(?<account>\d{12}):(?<name>[\w-]{1,80})$/u;
+
+/**
+ * The queue ARN an event source mapping is created for.
+ *
+ * A queue ARN has no resource type separator in it, so it is parsed here rather
+ * than by the shared ARN reader. Both halves of what a poller needs come out of
+ * it: the URL requests name the queue by, and the Region the event records
+ * report.
+ */
+export class SimLambdaSqsEventSourceArn {
+  public readonly value: string;
+  public readonly regionName: string;
+  public readonly accountId: string;
+  public readonly queueName: string;
+
+  private constructor(value: string, parts: Record<string, string>) {
+    this.value = value;
+    this.regionName = parts["region"] ?? "";
+    this.accountId = parts["account"] ?? "";
+    this.queueName = parts["name"] ?? "";
+  }
+
+  /**
+   * Read an event source ARN, refusing one that names no simulated event
+   * source.
+   *
+   * SQS queues are the only event source this simulation polls, so an ARN for
+   * any other one is refused rather than accepted and never delivered from.
+   */
+  static of(eventSourceArn: string): SimLambdaSqsEventSourceArn {
+    const parts = queueArnPattern.exec(eventSourceArn)?.groups;
+
+    if (parts === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `EventSourceArn ${eventSourceArn} is not an SQS queue ARN. SQS queues ` +
+          "are the only simulated Lambda event source, and a queue ARN is " +
+          "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+      );
+    }
+
+    return new this(eventSourceArn, parts);
+  }
+
+  /**
+   * The URL SQS requests name this queue by.
+   */
+  get queueUrl(): string {
+    return (
+      `https://sqs.${this.regionName}.amazonaws.com/` +
+      `${this.accountId}/${this.queueName}`
+    );
+  }
+
+  /**
+   * Whether this queue is in an Account and Region.
+   */
+  isIn(accountId: string, regionName: string): boolean {
+    return this.accountId === accountId && this.regionName === regionName;
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-sqs-event-source-queue-attributes.ts
+++ b/src/service/lambda/event-source/queue/sim-sqs-event-source-queue-attributes.ts
@@ -1,0 +1,74 @@
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceQueueRequest } from "./sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceQueueService } from "./sim-lambda-event-source-queue-service.js";
+import { SimLambdaSqsEventSourceArn } from "./sim-lambda-sqs-event-source-arn.js";
+
+const defaultVisibilityTimeoutSeconds = 30;
+
+interface SimSqsEventSourceQueueAttributesProperties {
+  readonly sqs: SimLambdaEventSourceQueueService;
+}
+
+/**
+ * What a poller reads about the queue it polls.
+ *
+ * Only the visibility timeout, which is how long a returned batch stays hidden
+ * before it is delivered again. Asking for it is also how a mapping finds out
+ * the queue is there at all, which is why real Lambda wants
+ * `sqs:GetQueueAttributes` on a queue it is asked to poll.
+ */
+export class SimSqsEventSourceQueueAttributes {
+  private readonly sqs: SimLambdaEventSourceQueueService;
+
+  constructor(properties: SimSqsEventSourceQueueAttributesProperties) {
+    this.sqs = properties.sqs;
+  }
+
+  /**
+   * How long a received message stays hidden, as the queue reports it.
+   */
+  async visibilityTimeoutSeconds(
+    request: SimLambdaEventSourceQueueRequest,
+  ): Promise<number> {
+    const attributes = await this.read(request);
+
+    return Number(
+      attributes["VisibilityTimeout"] ?? defaultVisibilityTimeoutSeconds,
+    );
+  }
+
+  /**
+   * Read a queue's attributes as the execution role, reporting a queue that is
+   * not there the way real Lambda reports an event source it cannot reach.
+   */
+  private async read(
+    request: SimLambdaEventSourceQueueRequest,
+  ): Promise<Record<string, string>> {
+    try {
+      const output = await this.sqs.getQueueAttributes(
+        {
+          input: {
+            QueueUrl: SimLambdaSqsEventSourceArn.of(request.queueArn).queueUrl,
+            AttributeNames: ["VisibilityTimeout"],
+          },
+        },
+        { caller: request.caller },
+      );
+
+      return output.Attributes ?? {};
+    } catch (error) {
+      throw this.queueLookupError(error, request.queueArn);
+    }
+  }
+
+  private queueLookupError(error: unknown, queueArn: string): unknown {
+    if (error instanceof Error && error.name === "QueueDoesNotExist") {
+      return new SimLambdaInvalidParameterValueException(
+        `The event source ${queueArn} does not exist`,
+        { cause: error },
+      );
+    }
+
+    return error;
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-sqs-event-source-queues.ts
+++ b/src/service/lambda/event-source/queue/sim-sqs-event-source-queues.ts
@@ -97,6 +97,14 @@ export class SimSqsEventSourceQueues implements SimLambdaEventSourceQueues {
   }
 
   /**
+   * When the earliest message the queue cannot hand out yet becomes
+   * receivable.
+   */
+  nextAvailability(queueArn: string): Date | undefined {
+    return this.sqs.queueActivity().nextAvailability(queueArn);
+  }
+
+  /**
    * Watch a queue for messages arriving on it.
    */
   watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void {

--- a/src/service/lambda/event-source/queue/sim-sqs-event-source-queues.ts
+++ b/src/service/lambda/event-source/queue/sim-sqs-event-source-queues.ts
@@ -1,0 +1,116 @@
+import type {
+  SimLambdaEventSourceDeleteRequest,
+  SimLambdaEventSourceMessage,
+  SimLambdaEventSourceQueueRequest,
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+  SimLambdaEventSourceReceiveRequest,
+} from "./sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceQueueService } from "./sim-lambda-event-source-queue-service.js";
+import { SimSqsEventSourceQueueAttributes } from "./sim-sqs-event-source-queue-attributes.js";
+import { SimLambdaSqsEventSourceArn } from "./sim-lambda-sqs-event-source-arn.js";
+
+interface SimSqsEventSourceQueuesProperties {
+  readonly sqs: SimLambdaEventSourceQueueService;
+}
+
+/**
+ * Simulated SQS as the queues a Lambda event source mapping polls.
+ *
+ * Every call goes through the SQS command it would go through on real AWS, as
+ * the function's execution role, so a role without `sqs:ReceiveMessage`,
+ * `sqs:DeleteMessage` or `sqs:GetQueueAttributes` on the queue is refused here
+ * rather than quietly polling anyway.
+ */
+export class SimSqsEventSourceQueues implements SimLambdaEventSourceQueues {
+  private readonly sqs: SimLambdaEventSourceQueueService;
+  private readonly attributes: SimSqsEventSourceQueueAttributes;
+
+  constructor(properties: SimSqsEventSourceQueuesProperties) {
+    this.sqs = properties.sqs;
+    this.attributes = new SimSqsEventSourceQueueAttributes(properties);
+  }
+
+  /**
+   * How long a received message stays hidden.
+   *
+   * This is a GetQueueAttributes call, which is also how a mapping finds out
+   * whether the queue it names is there at all: real Lambda needs the same
+   * permission for the same reason.
+   */
+  async visibilityTimeoutSeconds(
+    request: SimLambdaEventSourceQueueRequest,
+  ): Promise<number> {
+    return await this.attributes.visibilityTimeoutSeconds(request);
+  }
+
+  /**
+   * Take up to a batch of messages off the queue.
+   *
+   * Every system attribute and message attribute is asked for, because a real
+   * SQS event record carries them whether or not the function reads them.
+   */
+  async receive(
+    request: SimLambdaEventSourceReceiveRequest,
+  ): Promise<readonly SimLambdaEventSourceMessage[]> {
+    const output = await this.sqs.receiveMessage(
+      {
+        input: {
+          QueueUrl: this.queueUrl(request),
+          MaxNumberOfMessages: request.batchSize,
+          MessageSystemAttributeNames: ["All"],
+          MessageAttributeNames: ["All"],
+        },
+      },
+      { caller: request.caller },
+    );
+
+    return output.Messages ?? [];
+  }
+
+  /**
+   * Delete the messages of a batch the function handled.
+   *
+   * Batched because that is what real Lambda does with a handled batch, and
+   * because simulated SQS authorizes a batch delete as `sqs:DeleteMessage`, the
+   * action real IAM has.
+   */
+  async deleteMessages(
+    request: SimLambdaEventSourceDeleteRequest,
+  ): Promise<void> {
+    if (request.receiptHandles.length === 0) {
+      return;
+    }
+
+    await this.sqs.deleteMessageBatch(
+      {
+        input: {
+          QueueUrl: this.queueUrl(request),
+          Entries: request.receiptHandles.map((receiptHandle, index) => ({
+            Id: String(index),
+            ReceiptHandle: receiptHandle,
+          })),
+        },
+      },
+      { caller: request.caller },
+    );
+  }
+
+  /**
+   * Watch a queue for messages arriving on it.
+   */
+  watch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.sqs.queueActivity().watch(queueArn, watcher);
+  }
+
+  /**
+   * Stop watching a queue.
+   */
+  unwatch(queueArn: string, watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.sqs.queueActivity().unwatch(queueArn, watcher);
+  }
+
+  private queueUrl(request: SimLambdaEventSourceQueueRequest): string {
+    return SimLambdaSqsEventSourceArn.of(request.queueArn).queueUrl;
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping-store.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping-store.ts
@@ -1,0 +1,85 @@
+import { SimLambdaResourceNotFoundException } from "../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
+
+/**
+ * What a listing of event source mappings is narrowed by.
+ *
+ * Both are optional and both apply, as they do on real Lambda: a request naming
+ * neither lists every mapping in the Account and Region.
+ */
+export interface SimLambdaEventSourceMappingFilter {
+  readonly eventSourceArn?: string | undefined;
+  readonly functionName?: string | undefined;
+}
+
+/**
+ * The event source mappings of one simulated Lambda scope.
+ *
+ * Mappings are keyed by their UUID because that is what addresses them: Get and
+ * Delete name a mapping by UUID and nothing else, and a queue and a function can
+ * have more than one mapping between them.
+ */
+export class SimLambdaEventSourceMappingStore {
+  private readonly mappings = new Map<string, SimLambdaEventSourceMapping>();
+
+  /**
+   * Every mapping in this scope, in creation order.
+   */
+  get all(): readonly SimLambdaEventSourceMapping[] {
+    return this.mappings.values().toArray();
+  }
+
+  /**
+   * Store a newly created mapping.
+   */
+  add(mapping: SimLambdaEventSourceMapping): void {
+    this.mappings.set(mapping.uuid, mapping);
+  }
+
+  /**
+   * Find a mapping by UUID.
+   */
+  find(uuid: string): SimLambdaEventSourceMapping | undefined {
+    return this.mappings.get(uuid);
+  }
+
+  /**
+   * Resolve a mapping by UUID, or fail as real Lambda does.
+   */
+  require(uuid: string): SimLambdaEventSourceMapping {
+    const found = this.find(uuid);
+
+    if (found === undefined) {
+      throw new SimLambdaResourceNotFoundException(
+        `The resource you requested does not exist: no event source mapping ` +
+          `with UUID ${uuid}`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * The mappings matching a listing request.
+   */
+  matching(
+    filter: SimLambdaEventSourceMappingFilter,
+  ): readonly SimLambdaEventSourceMapping[] {
+    return this.all.filter(
+      (mapping) =>
+        matches(filter.eventSourceArn, mapping.eventSourceArn) &&
+        matches(filter.functionName, mapping.functionName),
+    );
+  }
+
+  /**
+   * Forget a deleted mapping.
+   */
+  remove(mapping: SimLambdaEventSourceMapping): void {
+    this.mappings.delete(mapping.uuid);
+  }
+}
+
+function matches(wanted: string | undefined, held: string): boolean {
+  return wanted === undefined || wanted === held;
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimLambdaFunctionArn } from "../function/sim-lambda-function.js";
+
+/**
+ * Event source mapping ARNs address the mapping by its UUID.
+ */
+export type SimLambdaEventSourceMappingArn =
+  `arn:aws:lambda:${string}:${string}:event-source-mapping:${string}`;
+
+/**
+ * The batch size real Lambda uses for an SQS event source when the mapping
+ * does not name one.
+ */
+export const DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE = 10;
+
+/**
+ * The response types a mapping can be told the function reports.
+ *
+ * Only the batch item failure one exists on real Lambda.
+ */
+export type SimLambdaFunctionResponseType = "ReportBatchItemFailures";
+
+/**
+ * The lifecycle states an event source mapping reports.
+ *
+ * A mapping is Creating until the simulation has caught up with it, then either
+ * Enabled or Disabled, as on real Lambda. The states in between, such as
+ * Updating and Deleting, belong to operations this simulation does not have.
+ */
+export type SimLambdaEventSourceMappingState =
+  "Creating" | "Enabled" | "Disabled";
+
+interface SimLambdaEventSourceMappingProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly eventSourceArn: string;
+  readonly functionName: string;
+  readonly functionArn: SimLambdaFunctionArn;
+  readonly batchSize?: number | undefined;
+  readonly enabled?: boolean | undefined;
+  readonly functionResponseTypes?:
+    readonly SimLambdaFunctionResponseType[] | undefined;
+  readonly createdAt: Date;
+}
+
+/**
+ * The AWS-shaped configuration of an event source mapping, as the
+ * CreateEventSourceMapping, GetEventSourceMapping, ListEventSourceMappings and
+ * DeleteEventSourceMapping responses all report it.
+ */
+export interface SimLambdaEventSourceMappingConfiguration {
+  readonly UUID: string;
+  readonly EventSourceMappingArn: SimLambdaEventSourceMappingArn;
+  readonly EventSourceArn: string;
+  readonly FunctionArn: SimLambdaFunctionArn;
+  readonly BatchSize: number;
+  readonly MaximumBatchingWindowInSeconds: number;
+  readonly FunctionResponseTypes: readonly SimLambdaFunctionResponseType[];
+  readonly State: SimLambdaEventSourceMappingState;
+  readonly StateTransitionReason: string;
+  readonly LastModified: Date;
+}
+
+/**
+ * One simulated Lambda event source mapping, from an SQS queue to a function.
+ *
+ * The mapping holds what polling is done with rather than doing the polling: a
+ * poller reads the batch size and the response types from here, and the mapping
+ * stays the piece of state a Get or List reports.
+ */
+export class SimLambdaEventSourceMapping {
+  public readonly uuid: string = randomUUID();
+  public readonly eventSourceArn: string;
+  public readonly functionName: string;
+  public readonly functionArn: SimLambdaFunctionArn;
+  public readonly batchSize: number;
+  public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
+
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly enabled: boolean;
+  private readonly lastModified: Date;
+  #state: SimLambdaEventSourceMappingState = "Creating";
+
+  constructor(properties: SimLambdaEventSourceMappingProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.eventSourceArn = properties.eventSourceArn;
+    this.functionName = properties.functionName;
+    this.functionArn = properties.functionArn;
+    this.batchSize =
+      properties.batchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
+    this.functionResponseTypes = properties.functionResponseTypes ?? [];
+    this.enabled = properties.enabled ?? true;
+    this.lastModified = properties.createdAt;
+  }
+
+  /**
+   * The ARN naming this mapping.
+   */
+  get arn(): SimLambdaEventSourceMappingArn {
+    const { regionName, accountId } = this.accountRegionScope;
+
+    return `arn:aws:lambda:${regionName}:${accountId}:event-source-mapping:${this.uuid}`;
+  }
+
+  /**
+   * The state this mapping is in.
+   */
+  get state(): SimLambdaEventSourceMappingState {
+    return this.#state;
+  }
+
+  /**
+   * Whether this mapping is polling its event source.
+   *
+   * A mapping still being created is not, as on real Lambda, where a mapping
+   * starts delivering once it reaches the Enabled state.
+   */
+  get isPolling(): boolean {
+    return this.#state === "Enabled";
+  }
+
+  /**
+   * Whether the function reports its own batch item failures.
+   */
+  get reportsBatchItemFailures(): boolean {
+    return this.functionResponseTypes.includes("ReportBatchItemFailures");
+  }
+
+  /**
+   * Finish creating this mapping, as real Lambda does asynchronously.
+   */
+  activate(): Promise<void> {
+    this.#state = this.enabled ? "Enabled" : "Disabled";
+
+    return Promise.resolve();
+  }
+
+  /**
+   * The AWS-like configuration for this mapping.
+   */
+  configuration(): SimLambdaEventSourceMappingConfiguration {
+    return {
+      UUID: this.uuid,
+      EventSourceMappingArn: this.arn,
+      EventSourceArn: this.eventSourceArn,
+      FunctionArn: this.functionArn,
+      BatchSize: this.batchSize,
+      // Partial batches are delivered as soon as anything is available, so the
+      // batching window is always zero. Anything else is refused at creation.
+      MaximumBatchingWindowInSeconds: 0,
+      FunctionResponseTypes: this.functionResponseTypes,
+      State: this.#state,
+      StateTransitionReason: "USER_INITIATED",
+      LastModified: this.lastModified,
+    };
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -89,7 +89,9 @@ export class SimLambdaEventSourceMapping {
     this.functionArn = properties.functionArn;
     this.batchSize =
       properties.batchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
-    this.functionResponseTypes = properties.functionResponseTypes ?? [];
+    // Copied rather than held, so a caller keeping the list it passed in
+    // cannot change what this mapping does with a batch afterwards.
+    this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];
     this.enabled = properties.enabled ?? true;
     this.lastModified = properties.createdAt;
   }

--- a/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
@@ -1,0 +1,63 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimLambdaFunctionLookup } from "../function/url/sim-lambda-function-lookup.js";
+import { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller.js";
+import type { SimLambdaEventSourceQueues } from "./queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
+
+interface SimLambdaEventSourcePollersProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The pollers of one simulated Lambda scope, one for each event source mapping.
+ *
+ * A mapping is state a request can read; a poller is the running thing behind
+ * it. They are kept apart so the mapping stays what Get and List report, and so
+ * deleting a mapping has somewhere to stop the polling.
+ */
+export class SimLambdaEventSourcePollers {
+  private readonly pollers = new Map<string, SimLambdaEventSourcePoller>();
+  private readonly properties: SimLambdaEventSourcePollersProperties;
+
+  constructor(properties: SimLambdaEventSourcePollersProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Start polling for a newly created mapping.
+   *
+   * The mapping finishes creating in the background, as it does on real Lambda,
+   * and starts polling once it does. Whatever is already on the queue is polled
+   * for then, because real Lambda does not only deliver what arrives after the
+   * mapping was made.
+   */
+  start(
+    mapping: SimLambdaEventSourceMapping,
+    eventSourceArn: SimLambdaSqsEventSourceArn,
+  ): void {
+    const poller = new SimLambdaEventSourcePoller({
+      ...this.properties,
+      mapping,
+      eventSourceArn,
+    });
+
+    this.pollers.set(mapping.uuid, poller);
+    poller.watch();
+
+    this.properties.background.schedule(async () => {
+      await mapping.activate();
+      poller.pollNow();
+    });
+  }
+
+  /**
+   * Stop polling for a deleted mapping.
+   */
+  stop(mapping: SimLambdaEventSourceMapping): void {
+    this.pollers.get(mapping.uuid)?.stop();
+    this.pollers.delete(mapping.uuid);
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
@@ -1,0 +1,57 @@
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+/**
+ * What a function's execution role has to be allowed to do on a queue for
+ * Lambda to poll it.
+ *
+ * These are the three operations real Lambda checks when an SQS event source
+ * mapping is created, and the three its poller performs afterwards.
+ */
+const requiredQueueOperations = [
+  "ReceiveMessage",
+  "DeleteMessage",
+  "GetQueueAttributes",
+] as const;
+
+interface SimLambdaEventSourceRolePermissionsProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Checks that a function's execution role may poll the queue a mapping names.
+ *
+ * Real Lambda refuses to create the mapping at all when the role cannot poll,
+ * rather than creating one that silently delivers nothing, so this is checked
+ * up front here too. The poller's own calls go through simulated IAM again
+ * afterwards, as they do on AWS: this check is about failing early, not about
+ * standing in for authorization.
+ */
+export class SimLambdaEventSourceRolePermissions {
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimLambdaEventSourceRolePermissionsProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Refuse a mapping whose execution role cannot poll the queue.
+   */
+  assertMayPoll(roleArn: string, queueArn: string): void {
+    for (const operation of requiredQueueOperations) {
+      const decision = this.iam.authorize({
+        action: `sqs:${operation}`,
+        resource: queueArn,
+        caller: { kind: "arn", arn: roleArn },
+      });
+
+      if (decision.isDenied) {
+        throw new SimLambdaInvalidParameterValueException(
+          `The provided execution role does not have permissions to call ` +
+            `${operation} on SQS. Role ${roleArn} has no policy allowing ` +
+            `sqs:${operation} on ${queueArn}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-sqs-event-source-event.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-sqs-event-source-event.iso.test.ts
@@ -1,0 +1,145 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeConsumerFunction,
+  makePollingRole,
+  makeSourceQueue,
+  recordingHandler,
+  simAwsWithSqsEventSource,
+} from "../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("sim Lambda SQS event source event records", () => {
+  it("carries the message attributes the sender set", async () => {
+    // Given a queue mapped to a function.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource();
+
+    // When a message with a text and a binary attribute is sent.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        MessageAttributes: {
+          source: { DataType: "String", StringValue: "checkout" },
+          signature: {
+            DataType: "Binary",
+            BinaryValue: new TextEncoder().encode("sig"),
+          },
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the record carries them in the event's own shape, with the binary
+    // value base64 encoded as it is on real AWS.
+    assertArrayLength(events, 1);
+
+    const attributes = events[0].Records[0]?.messageAttributes;
+
+    assertNonNullable(attributes);
+    assertIdentical(attributes["source"]?.stringValue, "checkout");
+    assertIdentical(attributes["source"].dataType, "String");
+    assertIdentical(
+      attributes["signature"]?.binaryValue,
+      Buffer.from("sig").toString("base64"),
+    );
+    assertArrayLength(attributes["signature"].stringListValues, 0);
+  });
+
+  it("waits for a delayed message to become receivable", async () => {
+    // Given a queue mapped to a function.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource();
+
+    // When a message is sent with a delay.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: "order-1",
+        DelaySeconds: 10,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const beforeDelay = events.length;
+
+    // Then it arrives once simulated time reaches the end of the delay.
+    await simAws.clock().advanceBy({ seconds: 11 });
+
+    assertIdentical(beforeDelay, 0);
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+
+  it("delivers nothing while the mapping is disabled", async () => {
+    // Given a mapping created disabled.
+    const simAws = new SimAws();
+    const { queueUrl, queueArn } = await makeSourceQueue(simAws);
+    const roleArn = await makePollingRole(simAws, queueArn);
+    const { handler, events } = recordingHandler();
+    const functionName = await makeConsumerFunction(simAws, roleArn, handler);
+    const mapping = await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: queueArn,
+        FunctionName: functionName,
+        Enabled: false,
+      }),
+    );
+
+    // When a message is sent to the queue.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing was delivered, and the mapping says why.
+    assertArrayLength(events, 0);
+    assertIdentical(
+      simAws.lambda().getSimEventSourceMapping(mapping.UUID)?.state,
+      "Disabled",
+    );
+  });
+
+  it("surfaces a polling failure when the role loses its access", async () => {
+    // Given a mapping whose execution role is denied the queue after it was
+    // created.
+    const { simAws, queueUrl, queueArn } = await simAwsWithSqsEventSource();
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrderConsumerRole",
+        PolicyName: "NoMoreOrders",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Deny", Action: "sqs:*", Resource: queueArn },
+        }),
+      }),
+    );
+
+    // When a message is sent for it to poll.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    // Then the simulation reports the failure rather than quietly delivering
+    // nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.backgroundTasksComplete();
+    });
+
+    assertStringIncludes(error.message, "sqs:GetQueueAttributes");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-sqs-event-source-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-sqs-event-source-failures.iso.test.ts
@@ -1,0 +1,203 @@
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+function throwing(): never {
+  throw new Error("Consumer could not handle the batch");
+}
+
+describe("sim Lambda SQS event source mapping failures", () => {
+  it("leaves a batch the handler threw on for its visibility timeout", async () => {
+    // Given a queue mapped to a function that cannot handle what it is given.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      queueAttributes: { VisibilityTimeout: "30" },
+      handlerResult: throwing,
+    });
+
+    // When a message is sent and the handler throws on it.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(events, 1);
+
+    // Then the message is still on the queue, hidden while the timeout runs.
+    const hidden = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(hidden.Messages);
+  });
+
+  it("delivers the batch again once the visibility timeout lapses", async () => {
+    // Given a queue whose mapped function threw on a message.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      queueAttributes: { VisibilityTimeout: "30" },
+      handlerResult: throwing,
+    });
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // When simulated time reaches the end of the visibility timeout.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then the same message was handed to the function again.
+    assertArrayLength(events, 2);
+    assertIdentical(events[1].Records[0]?.body, "order-1");
+    assertIdentical(
+      events[1].Records[0].attributes["ApproximateReceiveCount"],
+      "2",
+    );
+  });
+
+  it("redrives a message the handler keeps throwing on", async () => {
+    // Given a queue that gives up after two receives, mapped to a function
+    // that cannot handle anything.
+    const simAws = new SimAws();
+
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders-dlq" }));
+
+    const deadLetterQueueArn = simAws.sqs().findQueue("orders-dlq")?.arn.value;
+
+    assertNonNullable(deadLetterQueueArn);
+
+    const { queueUrl } = await simAwsWithSqsEventSource({
+      simAws,
+      queueAttributes: {
+        VisibilityTimeout: "30",
+        RedrivePolicy: JSON.stringify({
+          deadLetterTargetArn: deadLetterQueueArn,
+          maxReceiveCount: 2,
+        }),
+      },
+      handlerResult: throwing,
+    });
+
+    // When the message has been delivered and thrown on twice.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ seconds: 31 });
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then it is on the dead-letter queue rather than the source queue.
+    const dead = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders-dlq")?.url,
+      }),
+    );
+
+    assertIdentical(dead.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("deletes the rest of a batch a function reports item failures for", async () => {
+    // Given a mapping told the function reports its own batch item failures.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      queueAttributes: { VisibilityTimeout: "30" },
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: (event) => ({
+        batchItemFailures: event.Records.filter(
+          (record) => record.body === "order-2",
+        ).map((record) => ({ itemIdentifier: record.messageId })),
+      }),
+    });
+
+    // When a batch of two arrives and the function fails one of them.
+    await simAws.sqs().sendMessageBatch({
+      input: {
+        QueueUrl: queueUrl,
+        Entries: [
+          { Id: "1", MessageBody: "order-1" },
+          { Id: "2", MessageBody: "order-2" },
+        ],
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    const firstDelivery = events.length;
+
+    // Then only the reported one comes back once its visibility lapses.
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    assertIdentical(firstDelivery, 1);
+    assertArrayLength(events, 2);
+
+    const redelivered = events[1].Records;
+
+    assertArrayLength(redelivered, 1);
+    assertIdentical(redelivered[0].body, "order-2");
+  });
+
+  it("returns the whole batch when the report names a message it was not given", async () => {
+    // Given a function reporting a failure for a message id from nowhere.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      queueAttributes: { VisibilityTimeout: "30" },
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: () => ({
+        batchItemFailures: [{ itemIdentifier: "not-a-message-in-this-batch" }],
+      }),
+    });
+
+    // When a message is delivered to it.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then the message it was given comes back rather than being deleted on a
+    // report that cannot be trusted.
+    assertArrayLength(events, 2);
+    assertIdentical(events[1].Records[0]?.body, "order-1");
+  });
+
+  it("deletes the batch when the function reports no item failures", async () => {
+    // Given a function reporting an empty list of batch item failures.
+    const { simAws, queueUrl } = await simAwsWithSqsEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: () => ({ batchItemFailures: [] }),
+    });
+
+    // When a message is delivered to it.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the message is gone from the queue.
+    const remaining = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(remaining.Messages);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-sqs-event-source-in-flight.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-sqs-event-source-in-flight.iso.test.ts
@@ -1,0 +1,97 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import {
+  ChangeMessageVisibilityCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeConsumerFunction,
+  makePollingRole,
+  makeSourceQueue,
+  recordingHandler,
+  simAwsWithSqsEventSource,
+} from "../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("sim Lambda SQS event source mappings and in-flight messages", () => {
+  it("delivers a message that was in flight when the mapping was made", async () => {
+    // Given a queue whose only message another consumer is holding.
+    const simAws = new SimAws();
+    const { queueUrl, queueArn } = await makeSourceQueue(simAws, {
+      VisibilityTimeout: "30",
+    });
+    const roleArn = await makePollingRole(simAws, queueArn);
+    const { handler, events } = recordingHandler();
+    const functionName = await makeConsumerFunction(simAws, roleArn, handler);
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    // When a mapping is created while that message is hidden, and nothing else
+    // is ever sent.
+    await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: queueArn,
+        FunctionName: functionName,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const beforeTimeout = events.length;
+
+    await simAws.clock().advanceBy({ seconds: 31 });
+
+    // Then the message reaches the function once it is receivable again,
+    // rather than being stranded on the queue.
+    assertIdentical(beforeTimeout, 0);
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+
+  it("delivers a message another consumer took and gave back", async () => {
+    // Given a mapped queue whose message another consumer has received.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      queueAttributes: { VisibilityTimeout: "30" },
+    });
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+    const receiptHandle = received.Messages?.[0]?.ReceiptHandle;
+
+    assertNonNullable(receiptHandle);
+
+    // When that consumer gives it straight back.
+    await simAws.sqs().changeMessageVisibility(
+      new ChangeMessageVisibilityCommand({
+        QueueUrl: queueUrl,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: 0,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the mapping is given it.
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-sqs-event-source-polling.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-sqs-event-source-polling.iso.test.ts
@@ -1,0 +1,79 @@
+import { CreateEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeConsumerFunction,
+  makePollingRole,
+  makeSourceQueue,
+  recordingHandler,
+  simAwsWithSqsEventSource,
+} from "../../../../test/lambda/event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("sim Lambda SQS event source polling", () => {
+  it("honours the batch size, never delivering more than it at once", async () => {
+    // Given a queue mapped to a function two messages at a time.
+    const { simAws, queueUrl, events } = await simAwsWithSqsEventSource({
+      batchSize: 2,
+    });
+
+    // When five messages are sent.
+    for (const body of ["1", "2", "3", "4", "5"]) {
+      // eslint-disable-next-line no-await-in-loop
+      await simAws
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: body }),
+        );
+    }
+
+    await simAws.backgroundTasksComplete();
+
+    // Then every message arrived, in batches of no more than two.
+    const delivered = events.flatMap((event) => event.Records);
+
+    assertArrayLength(delivered, 5);
+
+    for (const event of events) {
+      assertTrue(event.Records.length <= 2);
+    }
+  });
+
+  it("delivers the messages already on a queue when the mapping is made", async () => {
+    // Given a queue holding a message, and a function with nothing mapped to it.
+    const simAws = new SimAws();
+    const { queueUrl, queueArn } = await makeSourceQueue(simAws);
+    const roleArn = await makePollingRole(simAws, queueArn);
+    const { handler, events } = recordingHandler();
+    const functionName = await makeConsumerFunction(simAws, roleArn, handler);
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const beforeMapping = events.length;
+
+    // When a mapping is created for the queue that already holds it.
+    await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: queueArn,
+        FunctionName: functionName,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the message that was already there is delivered.
+    assertIdentical(beforeMapping, 0);
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-sqs-event-source.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-sqs-event-source.iso.test.ts
@@ -1,0 +1,68 @@
+import { ReceiveMessageCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+
+describe("sim Lambda SQS event source mappings", () => {
+  it("delivers a sent message to the function as an SQS event", async () => {
+    // Given a queue mapped to a function.
+    const { simAws, queueUrl, queueArn, events } =
+      await simAwsWithSqsEventSource();
+
+    simAws.clock().freeze();
+
+    // When a message is sent to the queue.
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler was given one real-shaped SQS record.
+    assertArrayLength(events, 1);
+
+    const record = events[0].Records[0];
+
+    assertNonNullable(record);
+    assertIdentical(record.messageId, sent.MessageId);
+    assertIdentical(record.body, "order-1");
+    assertIdentical(record.eventSource, "aws:sqs");
+    assertIdentical(record.eventSourceARN, queueArn);
+    assertIdentical(record.awsRegion, simAws.defaultRegionName);
+    assertIdentical(record.md5OfBody, sent.MD5OfMessageBody);
+    assertIdentical(record.attributes["ApproximateReceiveCount"], "1");
+    assertIdentical(
+      record.attributes["SentTimestamp"],
+      String(simAws.now().getTime()),
+    );
+    assertNonNullable(record.receiptHandle);
+  });
+
+  it("deletes the batch a handler returns from", async () => {
+    // Given a queue mapped to a function that handles what it is given.
+    const { simAws, queueUrl } = await simAwsWithSqsEventSource();
+
+    // When a message is sent and delivered.
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the message is gone from the queue.
+    const remaining = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertUndefined(remaining.Messages);
+  });
+});

--- a/src/service/lambda/function/sim-lambda-function-name.ts
+++ b/src/service/lambda/function/sim-lambda-function-name.ts
@@ -1,0 +1,23 @@
+const functionArnSeparator = ":function:";
+
+/**
+ * Get the function name out of whatever names a function.
+ *
+ * Real Lambda accepts a name or a function ARN wherever it takes a
+ * `FunctionName`, and CloudFormation templates point at a function either way
+ * too: `Ref` gives the name and `Fn::GetAtt` gives the ARN. A version or alias
+ * qualifier on the ARN is dropped, as qualified functions are not simulated.
+ */
+export function simLambdaFunctionNameOf(functionNameOrArn: string): string {
+  const separatorIndex = functionNameOrArn.indexOf(functionArnSeparator);
+
+  if (separatorIndex === -1) {
+    return functionNameOrArn;
+  }
+
+  const nameAndQualifier = functionNameOrArn.slice(
+    separatorIndex + functionArnSeparator.length,
+  );
+
+  return nameAndQualifier.split(":", 1)[0] ?? nameAndQualifier;
+}

--- a/src/service/lambda/function/url/sim-lambda-function-lookup.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-lookup.ts
@@ -38,6 +38,13 @@ export class SimLambdaFunctionLookup {
   }
 
   /**
+   * Get a function by name, or nothing when the name belongs to no function.
+   */
+  find(functionName: string): SimLambdaFunction | undefined {
+    return this.functions.get(functionName as SimLambdaFunctionName);
+  }
+
+  /**
    * Get a function by name, or fail as AWS does when there is no such
    * function.
    */

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -18,3 +18,8 @@ export type {
   SimLambdaFunctionUrlEvent,
   SimLambdaFunctionUrlResult,
 } from "./serve/event/sim-lambda-url-event.type.js";
+export type {
+  SimLambdaSqsEvent,
+  SimLambdaSqsEventMessageAttribute,
+  SimLambdaSqsEventRecord,
+} from "./event-source/poll/sim-lambda-sqs-event.js";

--- a/src/service/lambda/sdk/sim-lambda-event-source-sdk-routing.iso.test.ts
+++ b/src/service/lambda/sdk/sim-lambda-event-source-sdk-routing.iso.test.ts
@@ -1,0 +1,113 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  DeleteEventSourceMappingCommand,
+  GetEventSourceMappingCommand,
+  LambdaClient,
+  ListEventSourceMappingsCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SQSClient } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+describe("simulated Lambda event source mapping SDK routing", () => {
+  it("round-trips the mapping Commands through an intercepted client", async () => {
+    // Given an intercepted Lambda client, with a queue and a function to map.
+    using simSdk = new SimSdk();
+    const lambda = new LambdaClient({ region: "eu-west-2" });
+    const sqs = new SQSClient({ region: "eu-west-2" });
+
+    simSdk.intercept(lambda);
+    simSdk.intercept(sqs);
+
+    await sqs.send(new CreateQueueCommand({ QueueName: "orders" }));
+
+    const simSqs = simSdk.simAws
+      .accountRegionScope(simSdk.simAws.defaultAccountId, "eu-west-2")
+      .sqs();
+    const queueArn = simSqs.findQueue("orders")?.arn.value;
+
+    assertNonNullable(queueArn);
+
+    const role = await simSdk.simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "OrderConsumerRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    await simSdk.simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrderConsumerRole",
+        PolicyName: "ConsumeOrders",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: [
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+            ],
+            Resource: queueArn,
+          },
+        }),
+      }),
+    );
+
+    await lambda.send(
+      new CreateFunctionCommand({
+        FunctionName: "order-consumer",
+        Role: role.Role.Arn,
+        Code: { ZipFile: makeLambdaZipFileInput(() => undefined) },
+      }),
+    );
+
+    // When the mapping is created, read, listed and deleted through the SDK.
+    const created = await lambda.send(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: queueArn,
+        FunctionName: "order-consumer",
+      }),
+    );
+
+    assertNonNullable(created.UUID);
+
+    const read = await lambda.send(
+      new GetEventSourceMappingCommand({ UUID: created.UUID }),
+    );
+    const listed = await lambda.send(
+      new ListEventSourceMappingsCommand({ FunctionName: "order-consumer" }),
+    );
+    const deleted = await lambda.send(
+      new DeleteEventSourceMappingCommand({ UUID: created.UUID }),
+    );
+
+    // Then each Command reached the simulated Lambda of the client's Region.
+    assertIdentical(read.EventSourceArn, queueArn);
+    assertArrayLength(listed.EventSourceMappings ?? [], 1);
+    assertIdentical(deleted.UUID, created.UUID);
+    assertUndefined(
+      simSdk.simAws
+        .accountRegionScope(simSdk.simAws.defaultAccountId, "eu-west-2")
+        .lambda()
+        .getSimEventSourceMapping(created.UUID),
+    );
+  });
+});

--- a/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
+++ b/src/service/lambda/sdk/sim-lambda-sdk-command-router.ts
@@ -5,6 +5,12 @@ import {
 } from "../../../sdk/index.js";
 import type { SimAddPermissionCommand } from "../command/add-permission/add-permission.command.js";
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
+import type {
+  SimCreateEventSourceMappingCommand,
+  SimDeleteEventSourceMappingCommand,
+  SimGetEventSourceMappingCommand,
+  SimListEventSourceMappingsCommand,
+} from "../command/event-source-mapping/event-source-mapping.command.js";
 import type { SimCreateFunctionUrlConfigCommand } from "../command/create-function-url-config/create-function-url-config.command.js";
 import type { SimDeleteFunctionUrlConfigCommand } from "../command/delete-function-url-config/delete-function-url-config.command.js";
 import type { SimGetFunctionCommand } from "../command/get-function/get-function.command.js";
@@ -77,6 +83,38 @@ export class SimLambdaSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLambda.deleteFunctionUrlConfig(
             command as SimDeleteFunctionUrlConfigCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateEventSourceMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.createEventSourceMapping(
+            command as SimCreateEventSourceMappingCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetEventSourceMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.getEventSourceMapping(
+            command as SimGetEventSourceMappingCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListEventSourceMappingsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.listEventSourceMappings(
+            command as SimListEventSourceMappingsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteEventSourceMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simLambda.deleteEventSourceMapping(
+            command as SimDeleteEventSourceMappingCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -1,0 +1,125 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimLambdaEventSourceMappingCommands } from "./command/event-source-mapping/sim-lambda-event-source-mapping-commands.js";
+import { SimLambdaFunctionCommands } from "./command/function/sim-lambda-function-commands.js";
+import { SimLambdaFunctionUrlCommands } from "./command/function-url/sim-lambda-function-url-commands.js";
+import { SimLambdaPermissionCommands } from "./command/permission/sim-lambda-permission-commands.js";
+import { SimLambdaEventSourcePollers } from "./event-source/sim-lambda-event-source-pollers.js";
+import {
+  type SimLambdaEventSourceQueues,
+  SimLambdaNoEventSourceQueues,
+} from "./event-source/queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
+import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
+import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
+import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
+import { SimLambdaFunctionUrlStore } from "./function/url/sim-lambda-function-url-store.js";
+import { SimLambdaUrlRegistry } from "./registry/sim-lambda-url-registry.js";
+
+/**
+ * How one simulated Lambda is put together.
+ */
+export interface SimLambdaProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly runAsOwner?: SimAwsRunAsOwner;
+  readonly codeStore?: SimLambdaCodeStore;
+  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
+  readonly urlRegistry?: SimLambdaUrlRegistry;
+  readonly eventSourceQueues?: SimLambdaEventSourceQueues;
+}
+
+interface SimLambdaCommandsProperties extends SimLambdaProperties {
+  readonly functions: SimLambdaFunctionMap;
+  readonly runAsOwner: SimAwsRunAsOwner;
+}
+
+/**
+ * The command areas of one simulated Lambda, and the state they share.
+ *
+ * The wiring lives here rather than in the SimLambda constructor so the service
+ * facade stays what it is meant to be: state and delegation. Each area is
+ * grouped by the collaborators it shares, so a command's own handler is reached
+ * through the area it belongs to.
+ */
+export class SimLambdaCommands {
+  public readonly functionUrlStore: SimLambdaFunctionUrlStore;
+  public readonly functionLookup: SimLambdaFunctionLookup;
+  public readonly functions: SimLambdaFunctionCommands;
+  public readonly functionUrls: SimLambdaFunctionUrlCommands;
+  public readonly permissions: SimLambdaPermissionCommands;
+  public readonly eventSourceMappings: SimLambdaEventSourceMappingCommands;
+
+  constructor(properties: SimLambdaCommandsProperties) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      codeStore,
+      vmSdkModuleProvider,
+      // A standalone SimLambda is not reachable over HTTP, so its own registry
+      // is enough; a SimAws-created one shares the environment-wide registry
+      // the serving layer routes with.
+      urlRegistry = new SimLambdaUrlRegistry(),
+      // A standalone SimLambda has no simulated SQS to poll, so an event source
+      // mapping made on one is refused rather than never delivering.
+      eventSourceQueues = new SimLambdaNoEventSourceQueues(),
+    } = properties;
+
+    this.functionLookup = new SimLambdaFunctionLookup({
+      accountRegionScope,
+      functions: properties.functions,
+    });
+    this.functionUrlStore = new SimLambdaFunctionUrlStore({
+      accountRegionScope,
+      urlRegistry,
+      clock: background,
+    });
+    this.functionUrls = new SimLambdaFunctionUrlCommands({
+      functionUrls: this.functionUrlStore,
+      functions: this.functionLookup,
+      iam,
+      background,
+    });
+    this.permissions = new SimLambdaPermissionCommands({
+      functions: this.functionLookup,
+      iam,
+      background,
+    });
+    this.eventSourceMappings = new SimLambdaEventSourceMappingCommands({
+      accountRegionScope,
+      pollers: new SimLambdaEventSourcePollers({
+        functions: this.functionLookup,
+        queues: eventSourceQueues,
+        background,
+      }),
+      queues: eventSourceQueues,
+      functions: this.functionLookup,
+      iam,
+      background,
+    });
+    this.functions = new SimLambdaFunctionCommands({
+      accountRegionScope,
+      functions: properties.functions,
+      iam,
+      background,
+      runAsOwner: properties.runAsOwner,
+      // Shared across function creations so a conflicting environment variable
+      // is only reported once for this simulated Lambda.
+      environmentConflicts: new SimLambdaEnvironmentConflicts(),
+      codeStore,
+      vmSdkModuleProvider,
+    });
+  }
+}

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -1,74 +1,26 @@
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
-import {
-  type BackgroundScheduler,
-  BackgroundTasks,
-} from "../../util/background/background.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
-import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
-import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
-import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
-import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
-import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
-import { SimLambdaFunctionCommands } from "./command/function/sim-lambda-function-commands.js";
+import type { SimLambdaEventSourceMapping } from "./event-source/sim-lambda-event-source-mapping.js";
 import type {
   SimLambdaFunction,
   SimLambdaFunctionMap,
   SimLambdaFunctionName,
 } from "./function/sim-lambda-function.js";
-import { SimLambdaFunctionUrlCommands } from "./command/function-url/sim-lambda-function-url-commands.js";
-import { SimLambdaPermissionCommands } from "./command/permission/sim-lambda-permission-commands.js";
-import type {
-  SimAddPermissionCommand,
-  SimAddPermissionCommandOutput,
-  SimCreateFunctionCommand,
-  SimCreateFunctionCommandOutput,
-  SimCreateFunctionUrlConfigCommand,
-  SimCreateFunctionUrlConfigCommandOutput,
-  SimDeleteFunctionUrlConfigCommand,
-  SimDeleteFunctionUrlConfigCommandOutput,
-  SimGetFunctionCommand,
-  SimGetFunctionCommandOutput,
-  SimGetFunctionUrlConfigCommand,
-  SimGetFunctionUrlConfigCommandOutput,
-  SimGetPolicyCommand,
-  SimGetPolicyCommandOutput,
-  SimInvokeCommand,
-  SimInvokeCommandOutput,
-  SimListFunctionUrlConfigsCommand,
-  SimListFunctionUrlConfigsCommandOutput,
-  SimRemovePermissionCommand,
-  SimRemovePermissionCommandOutput,
-  SimUpdateFunctionUrlConfigCommand,
-  SimUpdateFunctionUrlConfigCommandOutput,
-} from "./command/sim-lambda-command.types.js";
-import { SimLambdaFunctionLookup } from "./function/url/sim-lambda-function-lookup.js";
-import { SimLambdaFunctionUrlStore } from "./function/url/sim-lambda-function-url-store.js";
 import type {
   SimLambdaFunctionUrl,
   SimLambdaFunctionUrlId,
 } from "./function/url/sim-lambda-function-url.js";
-import { SimLambdaUrlRegistry } from "./registry/sim-lambda-url-registry.js";
+import type * as simLambdaCommands from "./command/sim-lambda-command.types.js";
+import {
+  SimLambdaCommands,
+  type SimLambdaProperties,
+} from "./sim-lambda-commands.js";
 import { SimLambdaSdkCommandRouter } from "./sdk/sim-lambda-sdk-command-router.js";
 
 export interface SimLambdaRequestOptions {
   readonly caller?: SimAwsCaller;
-}
-
-interface SimLambdaProperties {
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly iam?: SimIamInterServiceAuthZ;
-  readonly background?: BackgroundScheduler;
-  readonly runAsOwner?: SimAwsRunAsOwner;
-  readonly codeStore?: SimLambdaCodeStore;
-  readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
-  readonly urlRegistry?: SimLambdaUrlRegistry;
 }
 
 /**
@@ -76,17 +28,7 @@ interface SimLambdaProperties {
  */
 export class SimLambda {
   private readonly functions: SimLambdaFunctionMap = new Map();
-  private readonly functionUrls: SimLambdaFunctionUrlStore;
-  private readonly functionLookup: SimLambdaFunctionLookup;
-  private readonly functionCommands: SimLambdaFunctionCommands;
-  private readonly functionUrlCommands: SimLambdaFunctionUrlCommands;
-  private readonly permissionCommands: SimLambdaPermissionCommands;
-
-  /**
-   * Shared across function creations so a conflicting environment variable is
-   * only reported once for this simulated Lambda.
-   */
-  private readonly environmentConflicts = new SimLambdaEnvironmentConflicts();
+  private readonly commands: SimLambdaCommands;
 
   private readonly cfnFactory = new SimLambdaCloudFormationResourceFactory(
     this,
@@ -94,50 +36,13 @@ export class SimLambda {
   private readonly sdkRouter = new SimLambdaSdkCommandRouter(this);
 
   constructor(properties: SimLambdaProperties = {}) {
-    const {
-      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
-      background = new BackgroundTasks(),
-      codeStore,
-      vmSdkModuleProvider,
-      // A standalone SimLambda is not reachable over HTTP, so its own
-      // registry is enough; a SimAws-created one shares the environment-wide
-      // registry the serving layer routes with.
-      urlRegistry = new SimLambdaUrlRegistry(),
-    } = properties;
-
-    this.functionLookup = new SimLambdaFunctionLookup({
-      accountRegionScope,
+    this.commands = new SimLambdaCommands({
+      ...properties,
       functions: this.functions,
-    });
-    this.functionUrls = new SimLambdaFunctionUrlStore({
-      accountRegionScope,
-      urlRegistry,
-      clock: background,
-    });
-    this.functionUrlCommands = new SimLambdaFunctionUrlCommands({
-      functionUrls: this.functionUrls,
-      functions: this.functionLookup,
-      iam,
-      background,
-    });
-    this.permissionCommands = new SimLambdaPermissionCommands({
-      functions: this.functionLookup,
-      iam,
-      background,
-    });
-    this.functionCommands = new SimLambdaFunctionCommands({
-      accountRegionScope,
-      functions: this.functions,
-      iam,
-      background,
       // Ambient execution-role callers are tracked per owning SimAws instance.
       // A standalone SimLambda is its own little universe, so it owns its own
       // ambient callers.
       runAsOwner: properties.runAsOwner ?? this,
-      environmentConflicts: this.environmentConflicts,
-      codeStore,
-      vmSdkModuleProvider,
     });
   }
 
@@ -145,110 +50,159 @@ export class SimLambda {
    * Handle a Create Function Command from the SDK.
    */
   async createFunction(
-    command: SimCreateFunctionCommand,
+    command: simLambdaCommands.SimCreateFunctionCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimCreateFunctionCommandOutput> {
-    return await this.functionCommands.create(command, options);
+  ): Promise<simLambdaCommands.SimCreateFunctionCommandOutput> {
+    return await this.commands.functions.create(command, options);
   }
 
   /**
    * Handle a Get Function Command from the SDK.
    */
   async getFunction(
-    command: SimGetFunctionCommand,
+    command: simLambdaCommands.SimGetFunctionCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimGetFunctionCommandOutput> {
-    return await this.functionCommands.get(command, options);
+  ): Promise<simLambdaCommands.SimGetFunctionCommandOutput> {
+    return await this.commands.functions.get(command, options);
   }
 
   /**
    * Handle an Invoke Command from the SDK.
    */
   async invoke(
-    command: SimInvokeCommand,
+    command: simLambdaCommands.SimInvokeCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimInvokeCommandOutput> {
-    return await this.functionCommands.invoke(command, options);
+  ): Promise<simLambdaCommands.SimInvokeCommandOutput> {
+    return await this.commands.functions.invoke(command, options);
   }
 
   /**
    * Handle a Create Function Url Config Command from the SDK.
    */
   async createFunctionUrlConfig(
-    command: SimCreateFunctionUrlConfigCommand,
+    command: simLambdaCommands.SimCreateFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimCreateFunctionUrlConfigCommandOutput> {
-    return await this.functionUrlCommands.create(command, options);
+  ): Promise<simLambdaCommands.SimCreateFunctionUrlConfigCommandOutput> {
+    return await this.commands.functionUrls.create(command, options);
   }
 
   /**
    * Handle a Get Function Url Config Command from the SDK.
    */
   async getFunctionUrlConfig(
-    command: SimGetFunctionUrlConfigCommand,
+    command: simLambdaCommands.SimGetFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimGetFunctionUrlConfigCommandOutput> {
-    return await this.functionUrlCommands.get(command, options);
+  ): Promise<simLambdaCommands.SimGetFunctionUrlConfigCommandOutput> {
+    return await this.commands.functionUrls.get(command, options);
   }
 
   /**
    * Handle an Update Function Url Config Command from the SDK.
    */
   async updateFunctionUrlConfig(
-    command: SimUpdateFunctionUrlConfigCommand,
+    command: simLambdaCommands.SimUpdateFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimUpdateFunctionUrlConfigCommandOutput> {
-    return await this.functionUrlCommands.update(command, options);
+  ): Promise<simLambdaCommands.SimUpdateFunctionUrlConfigCommandOutput> {
+    return await this.commands.functionUrls.update(command, options);
   }
 
   /**
    * Handle a Delete Function Url Config Command from the SDK.
    */
   async deleteFunctionUrlConfig(
-    command: SimDeleteFunctionUrlConfigCommand,
+    command: simLambdaCommands.SimDeleteFunctionUrlConfigCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimDeleteFunctionUrlConfigCommandOutput> {
-    return await this.functionUrlCommands.delete(command, options);
+  ): Promise<simLambdaCommands.SimDeleteFunctionUrlConfigCommandOutput> {
+    return await this.commands.functionUrls.delete(command, options);
   }
 
   /**
    * Handle a List Function Url Configs Command from the SDK.
    */
   async listFunctionUrlConfigs(
-    command: SimListFunctionUrlConfigsCommand,
+    command: simLambdaCommands.SimListFunctionUrlConfigsCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimListFunctionUrlConfigsCommandOutput> {
-    return await this.functionUrlCommands.list(command, options);
+  ): Promise<simLambdaCommands.SimListFunctionUrlConfigsCommandOutput> {
+    return await this.commands.functionUrls.list(command, options);
+  }
+
+  /**
+   * Handle a Create Event Source Mapping Command from the SDK.
+   */
+  async createEventSourceMapping(
+    command: simLambdaCommands.SimCreateEventSourceMappingCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimCreateEventSourceMappingCommandOutput> {
+    return await this.commands.eventSourceMappings.create(command, options);
+  }
+
+  /**
+   * Handle a Get Event Source Mapping Command from the SDK.
+   */
+  async getEventSourceMapping(
+    command: simLambdaCommands.SimGetEventSourceMappingCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimGetEventSourceMappingCommandOutput> {
+    return await this.commands.eventSourceMappings.get(command, options);
+  }
+
+  /**
+   * Handle a List Event Source Mappings Command from the SDK.
+   */
+  async listEventSourceMappings(
+    command: simLambdaCommands.SimListEventSourceMappingsCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimListEventSourceMappingsCommandOutput> {
+    return await this.commands.eventSourceMappings.list(command, options);
+  }
+
+  /**
+   * Handle a Delete Event Source Mapping Command from the SDK.
+   */
+  async deleteEventSourceMapping(
+    command: simLambdaCommands.SimDeleteEventSourceMappingCommand,
+    options?: SimLambdaRequestOptions,
+  ): Promise<simLambdaCommands.SimDeleteEventSourceMappingCommandOutput> {
+    return await this.commands.eventSourceMappings.delete(command, options);
   }
 
   /**
    * Handle an Add Permission Command from the SDK.
    */
   async addPermission(
-    command: SimAddPermissionCommand,
+    command: simLambdaCommands.SimAddPermissionCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimAddPermissionCommandOutput> {
-    return await this.permissionCommands.add(command, options);
+  ): Promise<simLambdaCommands.SimAddPermissionCommandOutput> {
+    return await this.commands.permissions.add(command, options);
   }
 
   /**
    * Handle a Remove Permission Command from the SDK.
    */
   async removePermission(
-    command: SimRemovePermissionCommand,
+    command: simLambdaCommands.SimRemovePermissionCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimRemovePermissionCommandOutput> {
-    return await this.permissionCommands.remove(command, options);
+  ): Promise<simLambdaCommands.SimRemovePermissionCommandOutput> {
+    return await this.commands.permissions.remove(command, options);
   }
 
   /**
    * Handle a Get Policy Command from the SDK.
    */
   async getPolicy(
-    command: SimGetPolicyCommand,
+    command: simLambdaCommands.SimGetPolicyCommand,
     options?: SimLambdaRequestOptions,
-  ): Promise<SimGetPolicyCommandOutput> {
-    return await this.permissionCommands.getPolicy(command, options);
+  ): Promise<simLambdaCommands.SimGetPolicyCommandOutput> {
+    return await this.commands.permissions.getPolicy(command, options);
+  }
+
+  /**
+   * Get a simulated event source mapping by its UUID.
+   */
+  getSimEventSourceMapping(
+    uuid: string,
+  ): SimLambdaEventSourceMapping | undefined {
+    return this.commands.eventSourceMappings.find(uuid);
   }
 
   /**
@@ -266,7 +220,7 @@ export class SimLambda {
   getSimFunctionUrl(
     functionName: SimLambdaFunctionName | string,
   ): SimLambdaFunctionUrl | undefined {
-    return this.functionUrls.get(functionName);
+    return this.commands.functionUrlStore.get(functionName);
   }
 
   /**
@@ -278,7 +232,7 @@ export class SimLambda {
   getSimFunctionUrlById(
     urlId: SimLambdaFunctionUrlId,
   ): SimLambdaFunctionUrl | undefined {
-    return this.functionUrls.byUrlId(urlId);
+    return this.commands.functionUrlStore.byUrlId(urlId);
   }
 
   /**

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -89,13 +89,21 @@ about can change. So `SimSqsQueueStore.applyLifecycle` brings every queue in the
 and `SimSqsQueueAccess` runs it before answering from any of them. A test reading only the dead-letter
 queue would otherwise find it empty, because the source queue is what notices the move.
 
-`SimSqsQueueActivity` is how something outside SQS learns a message has arrived. Real SQS is polled
-continuously by whatever consumes it, and nothing in this simulation runs continuously, so a
-simulated consumer that would poll is told instead. `SimSqsQueue.add` tells the queue's watchers,
-which covers a message moved to a dead-letter queue as well as a send, and carries the instant the
-message becomes receivable rather than now, because a delayed message is not receivable yet. A
-Lambda event source mapping is the one thing using it (see
-[the Lambda service README](../lambda/README.md)).
+`SimSqsQueueActivity` is how a consumer that cannot poll continuously keeps up with a queue. Real SQS
+is polled continuously by whatever consumes it, and nothing in this simulation runs continuously, so
+a simulated consumer that would poll is told instead.
+
+The queue announces every transition it makes: a message arriving (`add`, which covers a move to a
+dead-letter queue as well as a send), a message being handed out and hidden (`recordHandle`), and a
+message having its visibility changed (`hideMessage`). Each carries the instant the message becomes
+receivable rather than now, because a delayed or in-flight message is not receivable yet. Without the
+last two, a message another consumer took would come back to the queue with nothing watching for it.
+
+An announcement only reaches whoever was watching at the time, so `nextAvailability` answers the
+other half: when the earliest message a queue cannot hand out yet becomes receivable. A consumer that
+started watching a queue whose messages were all in flight asks that rather than waiting for an
+announcement that has already been made. A Lambda event source mapping is the one thing using either
+(see [the Lambda service README](../lambda/README.md)).
 
 ## Command handling
 

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -89,6 +89,14 @@ about can change. So `SimSqsQueueStore.applyLifecycle` brings every queue in the
 and `SimSqsQueueAccess` runs it before answering from any of them. A test reading only the dead-letter
 queue would otherwise find it empty, because the source queue is what notices the move.
 
+`SimSqsQueueActivity` is how something outside SQS learns a message has arrived. Real SQS is polled
+continuously by whatever consumes it, and nothing in this simulation runs continuously, so a
+simulated consumer that would poll is told instead. `SimSqsQueue.add` tells the queue's watchers,
+which covers a message moved to a dead-letter queue as well as a send, and carries the instant the
+message becomes receivable rather than now, because a delayed message is not receivable yet. A
+Lambda event source mapping is the one thing using it (see
+[the Lambda service README](../lambda/README.md)).
+
 ## Command handling
 
 AWS SDK-style operations are implemented under `command/`, grouped by the collaborators they share
@@ -174,5 +182,7 @@ refused rather than quietly answered with a local queue of the same name.
   CloudFormation resource, where it is not simulated, unlike the queue attribute of the same name.
 - A message moved to a dead-letter queue keeps its sent timestamp, which is documented AWS behaviour,
   and starts its receive count again, which is not documented either way.
+- A Lambda event source mapping polls one batch at a time, where real Lambda runs several pollers and
+  scales them with the queue.
 
 The full list is in [docs/services/sqs](../../../docs/services/sqs/).

--- a/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
+++ b/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
@@ -67,7 +67,7 @@ export class SimSqsChangeMessageVisibility {
       );
     }
 
-    message.hideFor(changedAt, timeout);
+    queue.hideMessage(message, changedAt, timeout);
 
     return { $metadata: {} };
   }

--- a/src/service/sqs/command/queue/sim-sqs-create-queue.ts
+++ b/src/service/sqs/command/queue/sim-sqs-create-queue.ts
@@ -7,6 +7,7 @@ import {
   type SimSqsQueueAttributeInput,
   SimSqsQueueAttributes,
 } from "../../queue/sim-sqs-queue-attributes.js";
+import type { SimSqsQueueActivity } from "../../queue/sim-sqs-queue-activity.js";
 import { SimSqsQueueName } from "../../queue/sim-sqs-queue-name.js";
 import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
 import type { SimSqsQueueAccess } from "./sim-sqs-queue-access.js";
@@ -22,6 +23,7 @@ interface SimSqsCreateQueueProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: BackgroundScheduler;
   readonly deadLetterTargets: SimSqsDeadLetterTargets;
+  readonly activity: SimSqsQueueActivity;
 }
 
 interface SimSqsCreateQueueOptions {
@@ -42,6 +44,7 @@ export class SimSqsCreateQueue {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly clock: BackgroundScheduler;
   private readonly deadLetterTargets: SimSqsDeadLetterTargets;
+  private readonly activity: SimSqsQueueActivity;
 
   constructor(properties: SimSqsCreateQueueProperties) {
     this.queues = properties.queues;
@@ -49,6 +52,7 @@ export class SimSqsCreateQueue {
     this.accountRegionScope = properties.accountRegionScope;
     this.clock = properties.clock;
     this.deadLetterTargets = properties.deadLetterTargets;
+    this.activity = properties.activity;
   }
 
   /**
@@ -101,6 +105,7 @@ export class SimSqsCreateQueue {
       attributes: SimSqsQueueAttributes.defaults(),
       createdAt,
       deadLetterTargets: this.deadLetterTargets,
+      activity: this.activity,
     });
 
     queue.applyAttributes(requested, createdAt);

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -1,6 +1,10 @@
 export { SimSqs, type SimSqsRequestOptions } from "./sim-sqs.js";
 export { SimSqsQueue } from "./queue/sim-sqs-queue.js";
 export {
+  SimSqsQueueActivity,
+  type SimSqsQueueWatcher,
+} from "./queue/sim-sqs-queue-activity.js";
+export {
   sqsAnyQueueArn,
   SimSqsQueueArn,
   sqsQueueArnPrefix,

--- a/src/service/sqs/message/sim-sqs-message-store.ts
+++ b/src/service/sqs/message/sim-sqs-message-store.ts
@@ -51,6 +51,22 @@ export class SimSqsMessageStore {
   }
 
   /**
+   * When the earliest message that cannot be received yet becomes receivable,
+   * or nothing when every message here is receivable already.
+   */
+  nextAvailability(instant: Date): Date | undefined {
+    const pending = this.messages
+      .filter((message) => !message.isVisibleAt(instant))
+      .map((message) => message.availableFrom.getTime());
+
+    if (pending.length === 0) {
+      return undefined;
+    }
+
+    return new Date(Math.min(...pending));
+  }
+
+  /**
    * The messages that have used up their receives and are receivable again.
    *
    * These are the ones a redrive policy moves to the dead-letter queue. Being

--- a/src/service/sqs/message/sim-sqs-message-visibility.ts
+++ b/src/service/sqs/message/sim-sqs-message-visibility.ts
@@ -32,6 +32,13 @@ export class SimSqsMessageVisibility {
   }
 
   /**
+   * The instant from which the message can be received.
+   */
+  get availableFrom(): Date {
+    return this.visibleFrom;
+  }
+
+  /**
    * When the message was first handed out.
    *
    * Only a message being handed out reports its attributes, and handing one out

--- a/src/service/sqs/message/sim-sqs-message.ts
+++ b/src/service/sqs/message/sim-sqs-message.ts
@@ -46,6 +46,16 @@ export class SimSqsMessage {
   }
 
   /**
+   * The instant from which this message can be received.
+   *
+   * A message sent with a delay is not receivable when it arrives, so anything
+   * waiting for it has to wait for this rather than for the send.
+   */
+  get availableFrom(): Date {
+    return this.visibility.availableFrom;
+  }
+
+  /**
    * Whether this message can be received at an instant.
    */
   isVisibleAt(instant: Date): boolean {

--- a/src/service/sqs/queue/sim-sqs-queue-activity.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-activity.ts
@@ -1,3 +1,6 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimSqsQueueStore } from "./sim-sqs-queue-store.js";
+
 /**
  * Something outside SQS waiting for messages to arrive on a queue.
  *
@@ -15,8 +18,15 @@ export interface SimSqsQueueWatcher {
   messageAvailable(availableFrom: Date): void;
 }
 
+interface SimSqsQueueActivityProperties {
+  readonly queues: SimSqsQueueStore;
+  readonly clock: SimClock;
+}
+
 /**
- * The watchers on the queues of one simulated SQS scope.
+ * What a consumer that cannot poll continuously needs from the queues of one
+ * simulated SQS scope: to be told when a message can next be received, and to
+ * be able to ask when none has been announced.
  *
  * Watchers are held by queue ARN rather than on the queue itself, so a watcher
  * survives whatever the queue does, and so the queue model stays a queue rather
@@ -24,6 +34,25 @@ export interface SimSqsQueueWatcher {
  */
 export class SimSqsQueueActivity {
   private readonly watchers = new Map<string, SimSqsQueueWatcher[]>();
+  private readonly queues: SimSqsQueueStore;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimSqsQueueActivityProperties) {
+    this.queues = properties.queues;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * When the earliest message a queue cannot hand out yet becomes receivable,
+   * or nothing when it holds no such message.
+   *
+   * A consumer that started watching a queue whose messages were all in flight
+   * or delayed has nothing to wake it, because their arrival was announced
+   * before it was watching. Asking is how it finds out when to look.
+   */
+  nextAvailability(queueArn: string): Date | undefined {
+    return this.queues.findByArn(queueArn)?.nextAvailability(this.clock.now());
+  }
 
   /**
    * Watch a queue for messages arriving on it.
@@ -43,9 +72,13 @@ export class SimSqsQueueActivity {
   }
 
   /**
-   * Tell a queue's watchers a message has arrived on it.
+   * Tell a queue's watchers when a message on it can next be received.
+   *
+   * A message arriving, a message being handed out and hidden, and a message
+   * having its visibility changed are all the same thing to a watcher: there is
+   * something to poll for at an instant.
    */
-  messageAdded(queueArn: string, availableFrom: Date): void {
+  messageAvailableAt(queueArn: string, availableFrom: Date): void {
     for (const watcher of this.watchersOf(queueArn)) {
       watcher.messageAvailable(availableFrom);
     }

--- a/src/service/sqs/queue/sim-sqs-queue-activity.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-activity.ts
@@ -1,0 +1,57 @@
+/**
+ * Something outside SQS waiting for messages to arrive on a queue.
+ *
+ * A Lambda event source mapping is the one this exists for: real Lambda polls a
+ * queue continuously, and nothing in this simulation runs continuously, so the
+ * queue says when there is something to poll for instead.
+ */
+export interface SimSqsQueueWatcher {
+  /**
+   * A message has arrived, and can be received from the given instant.
+   *
+   * The instant is when the message becomes visible rather than now, because a
+   * message sent with a delay is not receivable yet.
+   */
+  messageAvailable(availableFrom: Date): void;
+}
+
+/**
+ * The watchers on the queues of one simulated SQS scope.
+ *
+ * Watchers are held by queue ARN rather than on the queue itself, so a watcher
+ * survives whatever the queue does, and so the queue model stays a queue rather
+ * than a subscription list.
+ */
+export class SimSqsQueueActivity {
+  private readonly watchers = new Map<string, SimSqsQueueWatcher[]>();
+
+  /**
+   * Watch a queue for messages arriving on it.
+   */
+  watch(queueArn: string, watcher: SimSqsQueueWatcher): void {
+    this.watchers.set(queueArn, [...this.watchersOf(queueArn), watcher]);
+  }
+
+  /**
+   * Stop watching a queue.
+   */
+  unwatch(queueArn: string, watcher: SimSqsQueueWatcher): void {
+    this.watchers.set(
+      queueArn,
+      this.watchersOf(queueArn).filter((held) => held !== watcher),
+    );
+  }
+
+  /**
+   * Tell a queue's watchers a message has arrived on it.
+   */
+  messageAdded(queueArn: string, availableFrom: Date): void {
+    for (const watcher of this.watchersOf(queueArn)) {
+      watcher.messageAvailable(availableFrom);
+    }
+  }
+
+  private watchersOf(queueArn: string): readonly SimSqsQueueWatcher[] {
+    return this.watchers.get(queueArn) ?? [];
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue.ts
+++ b/src/service/sqs/queue/sim-sqs-queue.ts
@@ -117,7 +117,7 @@ export class SimSqsQueue {
    */
   add(message: SimSqsMessage): void {
     this.messages.add(message);
-    this.activity.messageAdded(this.arn.value, message.availableFrom);
+    this.announceAvailability(message);
   }
 
   /**
@@ -127,6 +127,20 @@ export class SimSqsQueue {
     this.applyLifecycle(instant);
 
     return this.messages.receivable(instant, limit);
+  }
+
+  /**
+   * When the earliest message this queue cannot hand out yet becomes
+   * receivable, or nothing when it holds no such message.
+   *
+   * This is not something SQS reports. It is how a consumer that cannot poll
+   * continuously, such as a Lambda event source mapping, knows when to look
+   * again at a queue whose messages are all in flight or delayed.
+   */
+  nextAvailability(instant: Date): Date | undefined {
+    this.applyLifecycle(instant);
+
+    return this.messages.nextAvailability(instant);
   }
 
   /**
@@ -149,9 +163,27 @@ export class SimSqsQueue {
 
   /**
    * Record that a message was handed out under a receipt handle.
+   *
+   * A message handed out is hidden until its visibility timeout lapses, and
+   * watchers are told when that is. Without it, a message another consumer
+   * received would come back to the queue with nothing watching for it.
    */
   recordHandle(receiptHandle: string, message: SimSqsMessage): void {
     this.messages.recordHandle(receiptHandle, message);
+    this.announceAvailability(message);
+  }
+
+  /**
+   * Hide a message for a visibility timeout starting now, as
+   * ChangeMessageVisibility does, telling watchers when it comes back.
+   */
+  hideMessage(
+    message: SimSqsMessage,
+    instant: Date,
+    visibilityTimeoutSeconds: number,
+  ): void {
+    message.hideFor(instant, visibilityTimeoutSeconds);
+    this.announceAvailability(message);
   }
 
   /**
@@ -196,6 +228,13 @@ export class SimSqsQueue {
       lastModifiedAt: this.lastModifiedAt,
       queueArn: this.arn.value,
     });
+  }
+
+  /**
+   * Tell this queue's watchers when a message can next be received.
+   */
+  private announceAvailability(message: SimSqsMessage): void {
+    this.activity.messageAvailableAt(this.arn.value, message.availableFrom);
   }
 
   private dropExpired(instant: Date): void {

--- a/src/service/sqs/queue/sim-sqs-queue.ts
+++ b/src/service/sqs/queue/sim-sqs-queue.ts
@@ -3,6 +3,7 @@ import { SimSqsQueueNameExists } from "../error/sim-sqs.error.js";
 import type { SimSqsMessage } from "../message/sim-sqs-message.js";
 import { SimSqsMessageStore } from "../message/sim-sqs-message-store.js";
 import type { SimSqsDeadLetterTargets } from "./sim-sqs-dead-letter-targets.js";
+import type { SimSqsQueueActivity } from "./sim-sqs-queue-activity.js";
 import { SimSqsQueueArn } from "./sim-sqs-queue-arn.js";
 import type { SimSqsQueueName } from "./sim-sqs-queue-name.js";
 import type {
@@ -17,6 +18,7 @@ interface SimSqsQueueProperties {
   readonly attributes: SimSqsQueueAttributes;
   readonly createdAt: Date;
   readonly deadLetterTargets: SimSqsDeadLetterTargets;
+  readonly activity: SimSqsQueueActivity;
 }
 
 /**
@@ -36,6 +38,7 @@ export class SimSqsQueue {
 
   private readonly messages = new SimSqsMessageStore();
   private readonly deadLetterTargets: SimSqsDeadLetterTargets;
+  private readonly activity: SimSqsQueueActivity;
   private settings: SimSqsQueueAttributes;
   private lastModifiedAt: Date;
 
@@ -49,6 +52,7 @@ export class SimSqsQueue {
     this.lastModifiedAt = properties.createdAt;
     this.settings = properties.attributes;
     this.deadLetterTargets = properties.deadLetterTargets;
+    this.activity = properties.activity;
   }
 
   /**
@@ -105,9 +109,15 @@ export class SimSqsQueue {
 
   /**
    * Take a newly sent message.
+   *
+   * Anything watching the queue is told, which is how a Lambda event source
+   * mapping learns there is something to poll for. A message moved here from
+   * another queue arrives the same way, so a dead-letter queue with a mapping on
+   * it is polled too.
    */
   add(message: SimSqsMessage): void {
     this.messages.add(message);
+    this.activity.messageAdded(this.arn.value, message.availableFrom);
   }
 
   /**

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -24,6 +24,7 @@ import { SimSqsCfnResourceFactory } from "./cfn/sim-sqs-cfn-resource-factory.js"
 import { SimSqsMessageWriter } from "./message/sim-sqs-message-writer.js";
 import { SimSqsDeadLetterTargets } from "./queue/sim-sqs-dead-letter-targets.js";
 import type { SimSqsQueue } from "./queue/sim-sqs-queue.js";
+import { SimSqsQueueActivity } from "./queue/sim-sqs-queue-activity.js";
 import { SimSqsQueueStore } from "./queue/sim-sqs-queue-store.js";
 import { SimSqsSdkCommandRouter } from "./sdk/sim-sqs-sdk-command-router.js";
 
@@ -56,6 +57,7 @@ export class SimSqs {
   private readonly deletionCommands: SimSqsDeleteMessageCommands;
   private readonly visibilityCommand: SimSqsChangeMessageVisibility;
   private readonly background: BackgroundScheduler;
+  private readonly activity = new SimSqsQueueActivity();
   private readonly sdkRouter = new SimSqsSdkCommandRouter(this);
   private readonly cfnFactory = new SimSqsCfnResourceFactory({ sqs: this });
 
@@ -80,6 +82,7 @@ export class SimSqs {
       accountRegionScope,
       clock: background,
       deadLetterTargets: new SimSqsDeadLetterTargets({ queues: this.queues }),
+      activity: this.activity,
     });
     this.queueCommands = new SimSqsQueueCommands({
       queues: this.queues,
@@ -117,6 +120,18 @@ export class SimSqs {
    */
   findQueue(name: string): SimSqsQueue | undefined {
     return this.queues.find(name);
+  }
+
+  /**
+   * Watch the queues in this scope for messages arriving on them.
+   *
+   * This is not an SQS API operation. Real SQS is polled continuously by
+   * whatever consumes it, and nothing in this simulation runs continuously, so a
+   * simulated consumer that would poll is told when there is something to poll
+   * for instead. A Lambda event source mapping is what uses it.
+   */
+  queueActivity(): SimSqsQueueActivity {
+    return this.activity;
   }
 
   /**

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -57,7 +57,7 @@ export class SimSqs {
   private readonly deletionCommands: SimSqsDeleteMessageCommands;
   private readonly visibilityCommand: SimSqsChangeMessageVisibility;
   private readonly background: BackgroundScheduler;
-  private readonly activity = new SimSqsQueueActivity();
+  private readonly activity: SimSqsQueueActivity;
   private readonly sdkRouter = new SimSqsSdkCommandRouter(this);
   private readonly cfnFactory = new SimSqsCfnResourceFactory({ sqs: this });
 
@@ -76,6 +76,10 @@ export class SimSqs {
     });
 
     this.background = background;
+    this.activity = new SimSqsQueueActivity({
+      queues: this.queues,
+      clock: background,
+    });
     this.queueCreation = new SimSqsCreateQueue({
       queues: this.queues,
       access,
@@ -123,12 +127,12 @@ export class SimSqs {
   }
 
   /**
-   * Watch the queues in this scope for messages arriving on them.
+   * Keep up with the queues in this scope without polling them.
    *
-   * This is not an SQS API operation. Real SQS is polled continuously by
-   * whatever consumes it, and nothing in this simulation runs continuously, so a
+   * Not an SQS API operation. Real SQS is polled continuously by whatever
+   * consumes it, and nothing in this simulation runs continuously, so a
    * simulated consumer that would poll is told when there is something to poll
-   * for instead. A Lambda event source mapping is what uses it.
+   * for. A Lambda event source mapping is what uses it.
    */
   queueActivity(): SimSqsQueueActivity {
     return this.activity;

--- a/test/lambda/event-source-fixture.ts
+++ b/test/lambda/event-source-fixture.ts
@@ -1,0 +1,200 @@
+/**
+ * The parts an event source mapping test needs before it can say anything about
+ * delivery: a queue, a role that may poll it, a function to deliver to, and the
+ * mapping between them.
+ *
+ * These live under `test/` for the same reason as the SQS queue fixture: eslint
+ * rejects a test file exporting helpers alongside its own `describe` calls.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand } from "@aws-sdk/client-sqs";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLambdaSqsEvent } from "../../src/service/lambda/event-source/poll/sim-lambda-sqs-event.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * The SQS operations real Lambda requires an execution role to be allowed
+ * before it will create an event source mapping.
+ */
+export const sqsPollingActions: readonly string[] = [
+  "sqs:ReceiveMessage",
+  "sqs:DeleteMessage",
+  "sqs:GetQueueAttributes",
+];
+
+/**
+ * One simulated AWS with a queue on it.
+ */
+export interface SimSqsSourceQueue {
+  readonly simAws: SimAws;
+  readonly queueUrl: string;
+  readonly queueArn: string;
+}
+
+/**
+ * Make a queue named `orders` for an event source mapping to poll.
+ */
+export async function makeSourceQueue(
+  simAws: SimAws,
+  attributes?: Record<string, string>,
+): Promise<SimSqsSourceQueue> {
+  const created = await simAws.sqs().createQueue(
+    new CreateQueueCommand({
+      QueueName: "orders",
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+  const queueArn = simAws.sqs().findQueue("orders")?.arn.value;
+
+  assertNonNullable(created.QueueUrl, "CreateQueue answered with a queue URL");
+  assertNonNullable(queueArn, "The queue has an ARN");
+
+  return { simAws, queueUrl: created.QueueUrl, queueArn };
+}
+
+/**
+ * Make an execution role allowed to poll a queue.
+ */
+export async function makePollingRole(
+  simAws: SimAws,
+  queueArn: string,
+  actions: readonly string[] = sqsPollingActions,
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderConsumerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderConsumerRole",
+      PolicyName: "ConsumeOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: actions, Resource: queueArn },
+      }),
+    }),
+  );
+
+  const roleArn = role.Role.Arn;
+  assertNonNullable(roleArn, "CreateRole answered with a role ARN");
+
+  return roleArn;
+}
+
+/**
+ * Make a function backed by a real in-process handler, so a test can watch what
+ * the handler was given.
+ */
+export async function makeConsumerFunction(
+  simAws: SimAws,
+  roleArn: string,
+  handler: SimLambdaHandler,
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "order-consumer",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  return "order-consumer";
+}
+
+/**
+ * A handler that records the events it is given.
+ */
+export interface RecordingHandler {
+  readonly handler: SimLambdaHandler;
+  readonly events: SimLambdaSqsEvent[];
+}
+
+/**
+ * Make a handler recording every event it receives, and returning a result.
+ */
+export function recordingHandler(
+  result: (event: SimLambdaSqsEvent) => unknown = (): undefined => undefined,
+): RecordingHandler {
+  const events: SimLambdaSqsEvent[] = [];
+
+  return {
+    events,
+    handler: (event: unknown): unknown => {
+      const sqsEvent = event as SimLambdaSqsEvent;
+
+      events.push(sqsEvent);
+
+      return result(sqsEvent);
+    },
+  };
+}
+
+/**
+ * One simulated AWS with a queue delivering to a function.
+ */
+export interface SimSqsEventSourceFixture extends SimSqsSourceQueue {
+  readonly functionName: string;
+  readonly roleArn: string;
+  readonly events: SimLambdaSqsEvent[];
+  readonly uuid: string;
+}
+
+interface SqsEventSourceOptions {
+  readonly simAws?: SimAws;
+  readonly queueAttributes?: Record<string, string>;
+  readonly roleActions?: readonly string[];
+  readonly handlerResult?: (event: SimLambdaSqsEvent) => unknown;
+  readonly batchSize?: number;
+  readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+}
+
+/**
+ * Make a simulated AWS with a queue, a consumer function, and a mapping from
+ * one to the other.
+ */
+export async function simAwsWithSqsEventSource(
+  options: SqsEventSourceOptions = {},
+): Promise<SimSqsEventSourceFixture> {
+  const simAws = options.simAws ?? new SimAws();
+  const queue = await makeSourceQueue(simAws, options.queueAttributes);
+  const roleArn = await makePollingRole(
+    simAws,
+    queue.queueArn,
+    options.roleActions,
+  );
+  const { handler, events } = recordingHandler(options.handlerResult);
+  const functionName = await makeConsumerFunction(simAws, roleArn, handler);
+
+  const mapping = await simAws.lambda().createEventSourceMapping(
+    new CreateEventSourceMappingCommand({
+      EventSourceArn: queue.queueArn,
+      FunctionName: functionName,
+      ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
+      ...(options.functionResponseTypes !== undefined && {
+        FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
+    }),
+  );
+
+  assertNonNullable(mapping.UUID, "The mapping has a UUID");
+
+  return { ...queue, functionName, roleArn, events, uuid: mapping.UUID };
+}


### PR DESCRIPTION
An event source mapping delivers messages from a simulated queue to a simulated function as a real-shaped SQS event. Polling runs as the function's execution role on the shared background scheduler, a handled batch is deleted, and a batch the handler throws on goes back to the queue to be redelivered and eventually redriven.

Resolves https://github.com/KensioSoftware/yulin/issues/245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Lambda event source mappings for SQS queues, including create/get/list/delete via the SDK and region-scoped operation.
  * Deliver SQS messages to Lambda handlers in batches, delete successfully processed messages, and support dead-letter behavior and retries.
  * Added CloudFormation support for `AWS::Lambda::EventSourceMapping`, including `Ref` mapping IDs and `EventSourceMappingArn`.
  * Added support for partial batch failure reporting with `FunctionResponseTypes: ["ReportBatchItemFailures"]`.
* **Documentation**
  * Expanded guidance and examples, including SQS-specific polling/availability timing and event timestamp semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->