### PR TITLE
feat: create simulated DynamoDB tables from AWS::DynamoDB::Table reso…

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -972,6 +972,7 @@ The resource types it creates are:
 - `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`
+- `AWS::DynamoDB::Table`
 - `AWS::IAM::Role`, `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy`
 - `AWS::KMS::Key` and `AWS::KMS::Alias`
 - `AWS::Lambda::Function`, `AWS::Lambda::Url` and `AWS::Lambda::Permission`

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -486,6 +486,95 @@ await simAws.backgroundTasksComplete();
 
 Creating a name that is already taken in the same scope fails with `ResourceInUseException`.
 
+## Deploying a table from CloudFormation
+
+Simulated CloudFormation creates a table from an `AWS::DynamoDB::Table` resource, in the stack's
+account and region. The table is created through `CreateTable`, so a template-created table is the
+same thing an SDK caller would get: the same name validation, the same key schema and attribute
+definition rules, the same ARN.
+
+`Ref` on the resource gives the table name, as it does on real AWS, so it can be handed straight to
+`PutItem`. `Fn::GetAtt … Arn` gives the table ARN, which is what an IAM policy names it by.
+
+```typescript sim-dynamodb-cloudformation-table
+/**
+ * Deploying a table from a CloudFormation template and writing to it.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+          AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+          BillingMode: "PAY_PER_REQUEST",
+        },
+      },
+    },
+    Outputs: {
+      OrdersTableName: { Value: { Ref: "OrdersTable" } },
+      OrdersTableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// Ref resolves to the table name, so it works as a PutItem TableName.
+const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+
+console.log(tableName);
+// "orders-stack-OrdersTable"
+
+await simAws
+  .dynamoDb()
+  .putItem(
+    new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
+  );
+
+console.log(stack.outputs.get("OrdersTableArn")?.value);
+// "arn:aws:dynamodb:us-east-1:888888888888:table/orders-stack-OrdersTable"
+```
+
+The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
+`ProvisionedThroughput`, `TableClass` and `DeletionProtectionEnabled`. Each one is passed to
+`CreateTable` rather than applied here, so a value the template gets wrong fails the same way it
+would for an SDK caller.
+
+A table with no `TableName` is named after the stack and its logical ID, so the table above with its
+name left out would be `orders-stack-OrdersTable`. Real CloudFormation adds random characters to
+that, which a template cannot predict either way. Two stacks deploying the same template get two
+differently named tables. The generated name is trimmed to the 255 characters a table name allows,
+ending in a hash of the untrimmed name so two long names that start the same stay apart.
+
+`Fn::GetAtt … StreamArn` is refused by name. Streams are not simulated, and an invented stream ARN
+would read as a working stream to whatever the template handed it to.
+
+A property with behaviour that is not simulated skips the resource, with a reason naming the
+property, and the rest of the stack still deploys: `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`,
+`TimeToLiveSpecification`, `Tags`, `StreamSpecification`, `KinesisStreamSpecification`,
+`SSESpecification`, `PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`,
+`ImportSourceSpecification`, `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property
+`AWS::DynamoDB::Table` does not have fails the resource instead, since that is a template real
+CloudFormation would refuse too.
+
+`AWS::DynamoDB::GlobalTable` is skipped rather than deployed, since replication across regions is
+not simulated.
+
+CDK works without hand-editing. A `dynamodb.Table` synthesises a template that deploys here, with
+the table name reaching a function through its environment and a grant policy naming the table by
+the ARN `Fn::GetAtt` gives.
+
 ## IAM authorization
 
 `CreateTable` authorizes `dynamodb:CreateTable` against the ARN the table is about to have, before
@@ -510,6 +599,8 @@ authorizes against `*`.
 - `GetItem`, answering with the whole item under a primary key, and with no `Item` at all when the
   key holds nothing.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
+- `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
+  table name and `Fn::GetAtt … Arn` the table ARN.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
 
 ## Limitations
@@ -546,8 +637,12 @@ authorizes against `*`.
   refuses that status anyway, for when it can.
 - Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
   is ever throttled with `ProvisionedThroughputExceededException`.
-- `UpdateTable`, `UpdateItem`, `Query`, `Scan` and the batch item commands are not implemented yet,
-  and neither is `AWS::DynamoDB::Table` in CloudFormation.
+- `UpdateTable`, `UpdateItem`, `Query`, `Scan` and the batch item commands are not implemented yet.
+- A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
+  Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
+  stack deployed calls `simAws.backgroundTasksComplete()` first.
+- CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
+  `DeletionPolicy` a template sets on a table.
 - Projection is not simulated. `ProjectionExpression` and `AttributesToGet` are refused rather than
   ignored, since an item that came back whole where part of it was asked for would hide an
   application reading an attribute it never requested.

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-table.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-table.example.ts
@@ -1,0 +1,47 @@
+/**
+ * Deploying a table from a CloudFormation template and writing to it.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+          AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+          BillingMode: "PAY_PER_REQUEST",
+        },
+      },
+    },
+    Outputs: {
+      OrdersTableName: { Value: { Ref: "OrdersTable" } },
+      OrdersTableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// Ref resolves to the table name, so it works as a PutItem TableName.
+const tableName = stack.outputs.get("OrdersTableName")?.value as string;
+
+console.log(tableName);
+// "orders-stack-OrdersTable"
+
+await simAws
+  .dynamoDb()
+  .putItem(
+    new PutItemCommand({ TableName: tableName, Item: { id: { S: "1" } } }),
+  );
+
+console.log(stack.outputs.get("OrdersTableArn")?.value);
+// "arn:aws:dynamodb:us-east-1:888888888888:table/orders-stack-OrdersTable"

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
@@ -1,0 +1,124 @@
+import {
+  DescribeTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+describe("Sim CDK DynamoDB Table deployment local integration", () => {
+  it("deploys a CDK table an SDK caller then writes to and reads from", async () => {
+    // Given a CDK stack with an unnamed on-demand table with a partition and a
+    // sort key.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersTable = new dynamodb.Table(stack, "OrdersTable", {
+  partitionKey: { name: "customerId", type: dynamodb.AttributeType.STRING },
+  sortKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+});
+
+new cdk.CfnOutput(stack, "OrdersTableName", {
+  value: ordersTable.tableName,
+});
+
+new cdk.CfnOutput(stack, "OrdersTableArn", {
+  value: ordersTable.tableArn,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the AWS::DynamoDB::Table
+    // Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the table name the CDK output carries is the deployed table, named
+    // after the stack and the logical ID because the template did not name it.
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+    assertStringStartsWith(tableName, "TestStack-OrdersTable");
+
+    const described = await scoped
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: tableName }));
+
+    assertNonNullable(described.Table);
+    assertNonNullable(described.Table.KeySchema);
+    assertIdentical(described.Table.TableStatus, "ACTIVE");
+    assertIdentical(
+      described.Table.BillingModeSummary?.BillingMode,
+      "PAY_PER_REQUEST",
+    );
+    assertIdentical(
+      described.Table.KeySchema.at(0)?.AttributeName,
+      "customerId",
+    );
+    assertIdentical(described.Table.KeySchema.at(1)?.AttributeName, "orderId");
+    assertIdentical(
+      stack.outputs.get("OrdersTableArn")?.value,
+      described.Table.TableArn,
+    );
+
+    // And an item written to it reads back off it.
+    await scoped.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-1" },
+          total: { N: "42.5" },
+        },
+      }),
+    );
+
+    const read = await scoped.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: { customerId: { S: "customer-1" }, orderId: { S: "order-1" } },
+      }),
+    );
+
+    assertIdentical(read.Item?.["total"]?.N, "42.5");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-cfn-value-adapter.ts
@@ -1,0 +1,22 @@
+import { SimDynamoDbTable } from "../../../../dynamodb/table/sim-dynamodb-table.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimDynamoDbTableCfn } from "./sim-dynamodb-table-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated DynamoDB Resource.
+ */
+export function dynamoDbValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::DynamoDB::Table" &&
+    properties.simResource instanceof SimDynamoDbTable
+  ) {
+    return new SimDynamoDbTableCfn({ table: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
@@ -1,0 +1,128 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+/**
+ * A template referencing its table by one attribute, so a test only has to say
+ * which one.
+ */
+function tableAttributeTemplate(attributeName: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+          AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+          BillingMode: "PAY_PER_REQUEST",
+        },
+      },
+    },
+    Outputs: {
+      TableAttribute: {
+        Value: { "Fn::GetAtt": ["OrdersTable", attributeName] },
+      },
+    },
+  };
+}
+
+describe("AWS::DynamoDB::Table CloudFormation values", () => {
+  it("refuses Fn::GetAtt StreamArn by name", async () => {
+    // Given a template asking for the table's stream ARN, which is not
+    // simulated because streams are not.
+    const simAws = new SimAws({
+      defaultAccountId: accountIdOneOnes,
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When the template is deployed, then it fails rather than inventing an
+    // ARN that would read as a working stream.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: tableAttributeTemplate("StreamArn"),
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::DynamoDB::Table attribute StreamArn",
+    );
+  });
+
+  it("refuses an attribute AWS::DynamoDB::Table does not have", async () => {
+    // Given a template asking for an attribute the Resource type has no such
+    // thing as.
+    const simAws = new SimAws({
+      defaultAccountId: accountIdOneOnes,
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When the template is deployed, then the refusal names the attribute.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: tableAttributeTemplate("TableSizeBytes"),
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::DynamoDB::Table attribute TableSizeBytes",
+    );
+  });
+
+  it("answers a Ref for a table another Resource depends on", async () => {
+    // Given a template handing the table name to a Lambda function through its
+    // environment, which is what a Ref is for.
+    const simAws = new SimAws({
+      defaultAccountId: accountIdOneOnes,
+      defaultRegionName: "eu-west-2",
+    });
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              BillingMode: "PAY_PER_REQUEST",
+            },
+          },
+        },
+        Outputs: {
+          TableRef: {
+            Value: {
+              "Fn::Join": ["", ["table:", { Ref: "OrdersTable" }]],
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Ref resolved to the table name where it was used.
+    assertIdentical(stack.outputs.get("TableRef")?.value, "table:orders");
+  });
+});

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
@@ -1,0 +1,54 @@
+import type { SimDynamoDbTable } from "../../../../dynamodb/table/sim-dynamodb-table.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimDynamoDbTableCfnProperties {
+  readonly table: SimDynamoDbTable;
+}
+
+/**
+ * CloudFormation-facing values for a simulated DynamoDB table.
+ */
+export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
+  private readonly table: SimDynamoDbTable;
+
+  constructor(properties: SimDynamoDbTableCfnProperties) {
+    this.table = properties.table;
+  }
+
+  /**
+   * AWS::DynamoDB::Table Ref returns the table name rather than its ARN, which
+   * is what makes a Ref usable as a PutItem TableName. It is also what a
+   * template hands a function through its environment.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.table.tableName;
+  }
+
+  /**
+   * AWS::DynamoDB::Table attributes.
+   *
+   * `Arn` is what an IAM policy names the table by. `StreamArn` is refused by
+   * name: DynamoDB streams are not simulated, and an invented stream ARN would
+   * read as a working stream to whatever the template handed it to.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.table.arn;
+      }
+      case "StreamArn": {
+        throw new Error(
+          `Unsupported AWS::DynamoDB::Table attribute StreamArn: DynamoDB ` +
+            `streams are not simulated, so there is no stream ARN to give ` +
+            `rather than one nothing is publishing to`,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::DynamoDB::Table attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -2,6 +2,7 @@ import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
+import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
@@ -49,6 +50,7 @@ export function simCfnResourceValueAdapter(
     acmValueAdapter(properties) ??
     cloudFrontValueAdapter(properties) ??
     cognitoValueAdapter(properties) ??
+    dynamoDbValueAdapter(properties) ??
     iamValueAdapter(properties) ??
     kmsValueAdapter(properties) ??
     lambdaValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
+++ b/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+
+/**
+ * How many characters of the hash of the untrimmed name a trimmed one ends
+ * with, so two long names that start the same do not become one name.
+ */
+const distinguisherLength = 8;
+
+interface SimCfnGeneratedResourceNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+  readonly maximumLength: number;
+}
+
+/**
+ * The name CloudFormation gives a Resource whose template does not name it.
+ *
+ * Real CloudFormation generates `<stack name>-<logical ID>-<random>`. The
+ * random part is left out here so a test can predict the name, which is the one
+ * thing a template cannot rely on for real. Everything else follows AWS: two
+ * stacks deploying the same template get different names, because the stack
+ * name is part of it.
+ *
+ * Each service has its own limit on how long a name can be, so a long stack
+ * name and logical ID together are trimmed to fit. The start is kept, since
+ * that is where the stack name is, and the trimmed name ends in a hash of the
+ * untrimmed one. CDK puts its own disambiguating hash at the end of a logical
+ * ID, which is exactly what trimming cuts off, so without that two Resources in
+ * one stack could end up asking for the same name.
+ */
+export class SimCfnGeneratedResourceName {
+  private readonly stackName: string | undefined;
+  private readonly logicalId: string;
+  private readonly maximumLength: number;
+
+  constructor(properties: SimCfnGeneratedResourceNameProperties) {
+    this.stackName = properties.stackName;
+    this.logicalId = properties.logicalId;
+    this.maximumLength = properties.maximumLength;
+  }
+
+  /**
+   * The generated name.
+   */
+  get value(): string {
+    const composed = this.composed();
+
+    if (composed.length <= this.maximumLength) {
+      return composed;
+    }
+
+    const kept = composed.slice(
+      0,
+      this.maximumLength - distinguisherLength - 1,
+    );
+
+    return `${kept}-${this.distinguisher(composed)}`;
+  }
+
+  /**
+   * The tail a trimmed name ends with, derived from the whole untrimmed name.
+   *
+   * It is a hash rather than the random characters real CloudFormation uses, so
+   * the name stays the same between deployments of the same template.
+   */
+  private distinguisher(composed: string): string {
+    return createHash("sha1")
+      .update(composed)
+      .digest("hex")
+      .slice(0, distinguisherLength);
+  }
+
+  /**
+   * The name before it is trimmed to the length the service allows.
+   *
+   * A Resource created outside a stack has no stack name to derive one from, so
+   * it falls back to the logical ID on its own.
+   */
+  private composed(): string {
+    if (this.stackName === undefined || this.stackName === "") {
+      return this.logicalId;
+    }
+
+    return `${this.stackName}-${this.logicalId}`;
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.iso.test.ts
@@ -105,8 +105,8 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
         accountRegionScope,
         {
           providerName: "AWS",
-          serviceName: "DynamoDB",
-          resourceTypeName: "Table",
+          serviceName: "SNS",
+          resourceTypeName: "Topic",
         },
       ),
     );
@@ -114,8 +114,35 @@ describe("resolveSimCloudFormationServiceResourceFactory", () => {
     // Then the unsupported service name is included for diagnosis.
     assertIdentical(
       error.message,
-      "Unsupported sim CloudFormation Resource service DynamoDB",
+      "Unsupported sim CloudFormation Resource service SNS",
     );
+  });
+
+  it("resolves the DynamoDB Resource factory in the requested Account and Region scope", () => {
+    // Given a parsed AWS::DynamoDB Resource type and an explicit scope.
+    const simAws = new SimAws();
+    const accountRegionScope: SimAwsAccountRegionScope = {
+      accountId: "111111111111" as SimAwsAccountId,
+      regionName: "eu-west-2",
+    };
+    const scopedAws = simAws.accountRegionScope(
+      accountRegionScope.accountId,
+      accountRegionScope.regionName,
+    );
+
+    // When the service Resource factory is resolved.
+    const factory = resolveSimCloudFormationServiceResourceFactory(
+      simAws,
+      accountRegionScope,
+      {
+        providerName: "AWS",
+        serviceName: "DynamoDB",
+        resourceTypeName: "Table",
+      },
+    );
+
+    // Then the factory comes from the DynamoDB service for that exact scope.
+    assertIdentical(factory, scopedAws.dynamoDb().cfnResourceFactory());
   });
 
   it("rejects non-AWS and non-Custom Resource providers", () => {

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -54,6 +54,9 @@ export function resolveSimCloudFormationServiceResourceFactory(
     case "Cognito": {
       return scopedAws.cognitoIdentityProvider().cfnResourceFactory();
     }
+    case "DynamoDB": {
+      return scopedAws.dynamoDb().cfnResourceFactory();
+    }
     case "IAM": {
       return scopedAws.iam().cfnResourceFactory();
     }

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -298,6 +298,39 @@ Scans, queries, indexes, condition expressions and streams are not implemented. 
 provisioned capacity are read and stored by CreateTable, but nothing enforces them: no write is ever
 throttled.
 
+## CloudFormation
+
+`cfn/` owns the `AWS::DynamoDB::*` resource types, following the rule that CloudFormation
+orchestrates and services create.
+
+`SimDynamoDbCfnResourceFactory` is the entry point, resolved into the CloudFormation engine by
+`sim-cfn-service-resolver.ts`. `Table` is the only resource type it creates. Anything else, including
+`GlobalTable`, throws an `Unsupported sim DynamoDB CloudFormation Resource` error, which is the
+wording that marks a resource as skipped rather than failing the stack.
+
+The parts under `cfn/table/` split by responsibility:
+
+- `SimCfnDynamoDbTablePropertyRules` decides what a property means. A simulated property is passed
+  on, a real property that is not simulated skips the resource with a reason naming it, and anything
+  that is not an `AWS::DynamoDB::Table` property at all fails the resource, because that is a
+  template real CloudFormation would refuse too.
+- `SimCfnDynamoDbTableValues` reads the plain shapes a property can hold, naming the property path in
+  each refusal. It takes a number from the string a template Parameter carries one as.
+- `SimCfnDynamoDbTableProperties` turns the template properties into `CreateTable` input, and
+  generates a name for a table the template did not name, through the shared
+  `SimCfnGeneratedResourceName`.
+- `SimCfnDynamoDbTableCreator` calls `SimDynamoDb.createTable()` with that input and finds the
+  created table through `SimDynamoDb.findTable()`.
+
+Nothing here decides what a key schema, a billing mode or a table class is allowed to be. Creating
+the table through the ordinary command is what keeps a template-created table the same thing an SDK
+caller would have got.
+
+`Ref` and `Fn::GetAtt` behaviour lives with the CloudFormation engine rather than on the table, in
+`SimDynamoDbTableCfn` under `cloudformation/resource/cfn/dynamodb/`. `Ref` answers with the table
+name and `Fn::GetAtt Arn` with the table ARN. `StreamArn` is refused by name, since an invented
+stream ARN would read as a working stream.
+
 ## Error model
 
 DynamoDB-specific errors live under `error/`.

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
@@ -1,0 +1,52 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimDynamoDb } from "../sim-dynamodb.js";
+import { SimCfnDynamoDbTableCreator } from "./table/sim-cfn-dynamodb-table-creator.js";
+
+interface SimDynamoDbCfnResourceFactoryProperties {
+  readonly dynamoDb: SimDynamoDb;
+}
+
+/**
+ * CloudFormation Resource factory for simulated DynamoDB resources.
+ */
+export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly tableCreator: SimCfnDynamoDbTableCreator;
+
+  constructor(properties: SimDynamoDbCfnResourceFactoryProperties) {
+    this.tableCreator = new SimCfnDynamoDbTableCreator({
+      dynamoDb: properties.dynamoDb,
+    });
+  }
+
+  /**
+   * Create a simulated DynamoDB resource from a CloudFormation Resource.
+   *
+   * The table is the only AWS::DynamoDB::* Resource type this simulation
+   * models. A global table replicates across regions, which is not simulated,
+   * so AWS::DynamoDB::GlobalTable is reported as unsupported and skipped rather
+   * than quietly created as an ordinary table in one region.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    switch (resourceTypeName) {
+      case "Table": {
+        return await this.tableCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim DynamoDB CloudFormation Resource ${resourceTypeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
@@ -1,0 +1,198 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * The key schema and definitions a valid table carries, so a test can change
+ * one property without restating the rest.
+ */
+const validKeyProperties = {
+  KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+};
+
+describe("DynamoDB CloudFormation Table validation", () => {
+  it("fails a table the CreateTable rules refuse", async () => {
+    // Given a template naming a key attribute it never defines, which
+    // CreateTable refuses for an SDK caller too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: {
+              Type: "AWS::DynamoDB::Table",
+              Properties: {
+                TableName: "orders",
+                KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+                AttributeDefinitions: [
+                  { AttributeName: "customerId", AttributeType: "S" },
+                ],
+                BillingMode: "PAY_PER_REQUEST",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // And the failure is the one CreateTable gives, because the Resource is
+    // created by calling it.
+    assertStringIncludes(
+      error.message,
+      "The KeySchema names the attribute id, which has no AttributeDefinition",
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    assertNonNullable(stack);
+    assertIdentical(stack.getResource("OrdersTable")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("skips a table with a property that is not simulated", async () => {
+    // Given a template asking for a time to live, which is not simulated, in a
+    // stack with another Resource in it.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              ...validKeyProperties,
+              TimeToLiveSpecification: {
+                AttributeName: "expiresAt",
+                Enabled: true,
+              },
+            },
+          },
+          OrdersBucket: { Type: "AWS::S3::Bucket" },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is skipped, with a reason naming the property, rather
+    // than created without the behaviour the template asked for.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "TimeToLiveSpecification is a real AWS::DynamoDB::Table property that " +
+        "simulated DynamoDB does not simulate",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+
+    // And the rest of the stack still deploys.
+    assertTrue(stack.getResource("OrdersBucket")?.deployed);
+  });
+
+  it("skips a global table rather than creating an ordinary one", async () => {
+    // Given a template with an AWS::DynamoDB::GlobalTable in it, which
+    // replicates across regions.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::GlobalTable",
+            Properties: { TableName: "orders", ...validKeyProperties },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then it is skipped, naming the Resource type, and no table is created.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "Unsupported sim DynamoDB CloudFormation Resource GlobalTable",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("leaves a table unprotected when a Parameter says so", async () => {
+    // Given a template taking its deletion protection from a Parameter, which
+    // resolves to a string rather than the boolean a literal property carries.
+    const simAws = new SimAws();
+
+    // When the template is deployed with a value for it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { TableProtected: "false" },
+      template: {
+        Parameters: { TableProtected: { Type: "String" } },
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              ...validKeyProperties,
+              DeletionProtectionEnabled: { Ref: "TableProtected" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table carries the value the Parameter named.
+    assertFalse(
+      simAws.dynamoDb().findTable("orders")?.deletionProtectionEnabled,
+    );
+  });
+
+  it("protects a table a Parameter asks to protect", async () => {
+    // Given the same template with the Parameter set the other way.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { TableProtected: "true" },
+      template: {
+        Parameters: { TableProtected: { Type: "String" } },
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              ...validKeyProperties,
+              DeletionProtectionEnabled: { Ref: "TableProtected" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is protected from deletion.
+    assertTrue(
+      simAws.dynamoDb().findTable("orders")?.deletionProtectionEnabled,
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
@@ -1,0 +1,366 @@
+import {
+  DescribeTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * A template holding one on-demand table with a partition and a sort key.
+ */
+const ordersTableTemplate = {
+  Resources: {
+    OrdersTable: {
+      Type: "AWS::DynamoDB::Table",
+      Properties: {
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "orderId", KeyType: "RANGE" },
+        ],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      },
+    },
+  },
+  Outputs: {
+    OrdersTableName: { Value: { Ref: "OrdersTable" } },
+  },
+};
+
+describe("DynamoDB CloudFormation Table deployment", () => {
+  it("creates a table carrying the key schema and attribute definitions", async () => {
+    // Given a template declaring a named table.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [
+                { AttributeName: "customerId", KeyType: "HASH" },
+                { AttributeName: "orderId", KeyType: "RANGE" },
+              ],
+              AttributeDefinitions: [
+                { AttributeName: "customerId", AttributeType: "S" },
+                { AttributeName: "orderId", AttributeType: "S" },
+              ],
+              BillingMode: "PAY_PER_REQUEST",
+              TableClass: "STANDARD_INFREQUENT_ACCESS",
+              DeletionProtectionEnabled: true,
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    // The table becomes ACTIVE in the background, as it does for an SDK
+    // caller's CreateTable.
+    await simAws.backgroundTasksComplete();
+
+    // Then DescribeTable finds it, described as an SDK caller's table is, so a
+    // wrong value in the template is a wrong value in the test.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table);
+    assertNonNullable(described.Table.KeySchema);
+    assertIdentical(described.Table.TableStatus, "ACTIVE");
+    assertIdentical(
+      described.Table.TableArn,
+      "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+    );
+    assertIdentical(
+      described.Table.KeySchema.at(0)?.AttributeName,
+      "customerId",
+    );
+    assertIdentical(described.Table.KeySchema.at(1)?.AttributeName, "orderId");
+    assertIdentical(
+      described.Table.AttributeDefinitions?.at(0)?.AttributeType,
+      "S",
+    );
+    assertIdentical(
+      described.Table.BillingModeSummary?.BillingMode,
+      "PAY_PER_REQUEST",
+    );
+    assertIdentical(
+      described.Table.TableClassSummary?.TableClass,
+      "STANDARD_INFREQUENT_ACCESS",
+    );
+    assertTrue(described.Table.DeletionProtectionEnabled);
+  });
+
+  it("provisions a table with the throughput the template sets", async () => {
+    // Given a template asking for provisioned capacity, as CDK emits for a
+    // table with no billing mode of its own.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              BillingMode: "PROVISIONED",
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 3,
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the capacity is reported back off the table.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table?.ProvisionedThroughput);
+    assertIdentical(described.Table.ProvisionedThroughput.ReadCapacityUnits, 5);
+    assertIdentical(
+      described.Table.ProvisionedThroughput.WriteCapacityUnits,
+      3,
+    );
+  });
+
+  it("provisions capacity a template Parameter supplies as a string", async () => {
+    // Given a template taking its read capacity from a Parameter, which
+    // resolves to a string rather than the number a literal property carries.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed with a value for it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { TableReadCapacity: "7" },
+      template: {
+        Parameters: { TableReadCapacity: { Type: "Number" } },
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              ProvisionedThroughput: {
+                ReadCapacityUnits: { Ref: "TableReadCapacity" },
+                WriteCapacityUnits: 1,
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table has the capacity the Parameter carried.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertIdentical(
+      described.Table?.ProvisionedThroughput?.ReadCapacityUnits,
+      7,
+    );
+  });
+
+  it("resolves Ref to the table name and Fn::GetAtt Arn to the table ARN", async () => {
+    // Given a template referencing its table both ways.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              BillingMode: "PAY_PER_REQUEST",
+            },
+          },
+        },
+        Outputs: {
+          TableRef: { Value: { Ref: "OrdersTable" } },
+          TableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then Ref is the table name, as AWS::DynamoDB::Table Ref is, so it can be
+    // handed straight to PutItem.
+    assertIdentical(stack.outputs.get("TableRef")?.value, "orders");
+    assertIdentical(
+      stack.outputs.get("TableArn")?.value,
+      "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+    );
+  });
+
+  it("writes and reads an item through the table a Ref names", async () => {
+    // Given a deployed table whose name the stack outputs.
+    const simAws = simAwsInEuWest2();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTableTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+
+    // When an item is written to the table the Ref named.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-1" },
+          total: { N: "42.5" },
+        },
+      }),
+    );
+
+    // Then it reads back off the deployed table.
+    const read = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: tableName,
+        Key: { customerId: { S: "customer-1" }, orderId: { S: "order-1" } },
+      }),
+    );
+
+    assertIdentical(read.Item?.["total"]?.N, "42.5");
+  });
+
+  it("names an unnamed table after the stack and its logical ID", async () => {
+    // Given a template leaving TableName out, as CDK does for a table with no
+    // explicit name.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTableTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the name carries the stack name and the logical ID, so a Lambda
+    // environment variable built from the Ref reaches the deployed table.
+    assertIdentical(
+      stack.outputs.get("OrdersTableName")?.value,
+      "orders-stack-OrdersTable",
+    );
+    assertNonNullable(simAws.dynamoDb().findTable("orders-stack-OrdersTable"));
+  });
+
+  it("gives two stacks deploying one template two differently named tables", async () => {
+    // Given one template with no TableName in it, deployed twice.
+    const simAws = simAwsInEuWest2();
+
+    // When both stacks are deployed.
+    const first = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTableTemplate,
+    });
+    const second = await simAws.cloudFormation().deployTemplate({
+      stackName: "returns-stack",
+      template: ordersTableTemplate,
+    });
+    await first.waitForDeployComplete();
+    await second.waitForDeployComplete();
+
+    // Then the two tables have different names, because the stack name is part
+    // of a generated one, so neither stack collides with the other.
+    const firstName = first.outputs.get("OrdersTableName")?.value;
+    const secondName = second.outputs.get("OrdersTableName")?.value;
+
+    assertTypeString(firstName);
+    assertTypeString(secondName);
+    assertStringStartsWith(firstName, "orders-stack-");
+    assertStringStartsWith(secondName, "returns-stack-");
+    assertNonNullable(simAws.dynamoDb().findTable(firstName));
+    assertNonNullable(simAws.dynamoDb().findTable(secondName));
+  });
+
+  it("creates the table in the Account and Region the stack deploys into", async () => {
+    // Given a template deployed through a scoped simulated CloudFormation.
+    const simAws = new SimAws();
+    const scoped = simAws.account("222222222222").region("us-east-1");
+
+    // When the template is deployed.
+    const stack = await scoped.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: {
+              TableName: "orders",
+              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+              AttributeDefinitions: [
+                { AttributeName: "id", AttributeType: "S" },
+              ],
+              BillingMode: "PAY_PER_REQUEST",
+            },
+          },
+        },
+        Outputs: {
+          TableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the table is in that scope, and the default scope has none.
+    assertIdentical(
+      stack.outputs.get("TableArn")?.value,
+      "arn:aws:dynamodb:us-east-1:222222222222:table/orders",
+    );
+    assertNonNullable(scoped.dynamoDb().findTable("orders"));
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+});

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -1,0 +1,63 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { SimCfnDynamoDbTableProperties } from "./sim-cfn-dynamodb-table-properties.js";
+
+interface SimCfnDynamoDbTableCreatorProperties {
+  readonly dynamoDb: SimDynamoDb;
+}
+
+/**
+ * Creates simulated tables from AWS::DynamoDB::Table Resources.
+ *
+ * The table is created through the ordinary CreateTable command rather than
+ * constructed directly, so a table a template deployed is the same thing an SDK
+ * caller would have got: the same name validation, the same key schema and
+ * attribute definition rules, the same refusals for what this simulation does
+ * not model.
+ */
+export class SimCfnDynamoDbTableCreator {
+  private readonly dynamoDb: SimDynamoDb;
+
+  constructor(properties: SimCfnDynamoDbTableCreatorProperties) {
+    this.dynamoDb = properties.dynamoDb;
+  }
+
+  /**
+   * Create a table from an AWS::DynamoDB::Table Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimDynamoDbTable> {
+    const tableProperties = new SimCfnDynamoDbTableProperties({
+      resource,
+      properties,
+    });
+    tableProperties.assertSimulated();
+
+    const name = tableProperties.name();
+
+    await this.dynamoDb.createTable({
+      input: {
+        TableName: name,
+        KeySchema: tableProperties.keySchema(),
+        AttributeDefinitions: tableProperties.attributeDefinitions(),
+        BillingMode: tableProperties.billingMode(),
+        ProvisionedThroughput: tableProperties.provisionedThroughput(),
+        TableClass: tableProperties.tableClass(),
+        DeletionProtectionEnabled: tableProperties.deletionProtectionEnabled(),
+      },
+    });
+
+    const table = this.dynamoDb.findTable(name);
+    assertDefined(
+      table,
+      `sim DynamoDB table ${name} after CloudFormation creation`,
+    );
+
+    return table;
+  }
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
@@ -1,0 +1,292 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimDynamoDbCfnResourceFactory } from "../sim-cfn-dynamodb-resource-factory.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+/**
+ * The key schema and definitions a valid table carries, so a test can change
+ * one property without restating the rest.
+ */
+const validKeyProperties = {
+  KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+};
+
+function tableResource(properties: SimCfnTemplateValueRecord): SimCfnResource {
+  return new SimCfnResource({
+    accountRegionScope: {
+      accountId: accountIdOneOnes,
+      regionName: "eu-west-2",
+    },
+    logicalId: "BadTable",
+    template: { Type: "AWS::DynamoDB::Table", Properties: properties },
+  });
+}
+
+/**
+ * Create a table straight through the Resource factory, returning whatever it
+ * rejects with. Keeps the property reading under test without a whole stack.
+ */
+async function createTableResource(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const factory = new SimDynamoDbCfnResourceFactory({
+    dynamoDb: simAws.dynamoDb(),
+  });
+
+  return await assertThrowsErrorAsync(async () => {
+    return await factory.create("Table", tableResource(properties), {
+      simAws,
+      resources: new Map(),
+    });
+  });
+}
+
+describe("AWS::DynamoDB::Table property reading", () => {
+  it("refuses a TableName that is not a string", async () => {
+    // Given a template carrying something other than a name as TableName.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: 42,
+      ...validKeyProperties,
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: TableName must be a " +
+        "string",
+    );
+  });
+
+  it("refuses a KeySchema that is not a list", async () => {
+    // Given a template carrying an object where the key schema list belongs.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: { AttributeName: "id", KeyType: "HASH" },
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: KeySchema must be a " +
+        "list",
+    );
+  });
+
+  it("refuses a KeySchema element that is not an object", async () => {
+    // Given a template carrying a plain string where a key schema element
+    // belongs.
+    // When the Resource is created, then the refusal names the position.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: ["id"],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: KeySchema.0 must be " +
+        "an object",
+    );
+  });
+
+  it("refuses a key schema attribute name that is not a string", async () => {
+    // Given a template carrying a number where an attribute name belongs.
+    // When the Resource is created, then the refusal names the property path.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: 1, KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "KeySchema.0.AttributeName must be a string",
+    );
+  });
+
+  it("refuses an attribute definition type that is not a string", async () => {
+    // Given a template carrying a number where an attribute type belongs.
+    // When the Resource is created, then the refusal names the property path.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: 3 }],
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "AttributeDefinitions.0.AttributeType must be a string",
+    );
+  });
+
+  it("refuses a BillingMode that is not a string", async () => {
+    // Given a template carrying a number where the billing mode belongs.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: 1,
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: BillingMode must be a " +
+        "string",
+    );
+  });
+
+  it("refuses a TableClass that is not a string", async () => {
+    // Given a template carrying a list where the table class belongs.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: "orders",
+      ...validKeyProperties,
+      TableClass: ["STANDARD"],
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: TableClass must be a " +
+        "string",
+    );
+  });
+
+  it("refuses a ProvisionedThroughput that is not an object", async () => {
+    // Given a template carrying a number where the throughput object belongs.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      ProvisionedThroughput: 5,
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "ProvisionedThroughput must be an object",
+    );
+  });
+
+  it("refuses a capacity that is neither a number nor a number in a string", async () => {
+    // Given a template carrying a word where a capacity belongs.
+    // When the Resource is created, then it is refused rather than read as
+    // nothing, which would look like a missing capacity instead.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: "plenty",
+        WriteCapacityUnits: 1,
+      },
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "ProvisionedThroughput.ReadCapacityUnits must be a number",
+    );
+  });
+
+  it("refuses a blank capacity string", async () => {
+    // Given a template carrying whitespace where a capacity belongs, which
+    // Number() would otherwise read as zero.
+    // When the Resource is created, then it is refused.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: "  ",
+      },
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "ProvisionedThroughput.WriteCapacityUnits must be a number",
+    );
+  });
+
+  it("refuses a DeletionProtectionEnabled value that is neither true nor false", async () => {
+    // Given a template carrying something else as DeletionProtectionEnabled.
+    // When the Resource is created, then it is refused rather than read as
+    // false, since a table left unprotected is the wrong way to fail.
+    const error = await createTableResource({
+      TableName: "orders",
+      ...validKeyProperties,
+      DeletionProtectionEnabled: "yes",
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: " +
+        "DeletionProtectionEnabled must be true or false",
+    );
+  });
+
+  it("leaves a missing KeySchema for CreateTable to refuse", async () => {
+    // Given a template with no KeySchema in it at all.
+    // When the Resource is created, then the refusal is the one CreateTable
+    // gives, rather than a second wording for the same missing property.
+    const error = await createTableResource({ TableName: "orders" });
+
+    assertStringIncludes(
+      error.message,
+      "A KeySchema with a HASH key element is required",
+    );
+  });
+
+  it("leaves a half-filled ProvisionedThroughput for CreateTable to refuse", async () => {
+    // Given a template naming a read capacity and no write capacity.
+    // When the Resource is created, then CreateTable refuses the missing one.
+    const error = await createTableResource({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      ProvisionedThroughput: { ReadCapacityUnits: 5 },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "WriteCapacityUnits must be at least 1 when BillingMode is PROVISIONED",
+    );
+  });
+
+  it("refuses a property AWS::DynamoDB::Table does not have", async () => {
+    // Given a template carrying a property that is not on the Resource type,
+    // which real CloudFormation refuses too.
+    // When the Resource is created, then it is refused rather than skipped:
+    // nothing is missing from the simulation, the template is wrong.
+    const error = await createTableResource({
+      TableName: "orders",
+      ...validKeyProperties,
+      ReadCapacityUnits: 5,
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid AWS::DynamoDB::Table Resource BadTable: ReadCapacityUnits is " +
+        "not an AWS::DynamoDB::Table property",
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -1,0 +1,138 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimDynamoDbAttributeDefinitionInput,
+  SimDynamoDbKeySchemaElementInput,
+  SimDynamoDbProvisionedThroughput,
+} from "../../command/table/table.types.js";
+import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
+import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * A table name is at most 255 characters, so a generated one is trimmed to fit.
+ */
+const maximumNameLength = 255;
+
+interface SimCfnDynamoDbTablePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::DynamoDB::Table CloudFormation properties into the shape
+ * CreateTable takes.
+ *
+ * Nothing here decides what a key schema, a billing mode or a table class is
+ * allowed to be. Each value is passed through to CreateTable in the shape it
+ * takes, so the table a template deployed had to pass the same validation an
+ * SDK caller's table does.
+ */
+export class SimCfnDynamoDbTableProperties {
+  private readonly resource: SimCfnResource;
+  private readonly rules: SimCfnDynamoDbTablePropertyRules;
+  private readonly values: SimCfnDynamoDbTableValues;
+
+  constructor(properties: SimCfnDynamoDbTablePropertiesProperties) {
+    this.resource = properties.resource;
+    this.rules = new SimCfnDynamoDbTablePropertyRules({
+      logicalId: properties.resource.logicalId,
+      properties: properties.properties,
+    });
+    this.values = new SimCfnDynamoDbTableValues({
+      logicalId: properties.resource.logicalId,
+      properties: properties.properties,
+    });
+  }
+
+  /**
+   * Refuse everything about this Resource that is not simulated, before
+   * anything is read off it.
+   */
+  assertSimulated(): void {
+    this.rules.assertSimulated();
+  }
+
+  /**
+   * The table name.
+   *
+   * An unnamed table is named after the stack and the logical ID, as real
+   * CloudFormation names one, so one template deployed under two stack names
+   * makes two tables.
+   */
+  name(): string {
+    return this.values.string("TableName") ?? this.generatedName();
+  }
+
+  /**
+   * The table's primary key elements, in the order the template lists them.
+   */
+  keySchema(): readonly SimDynamoDbKeySchemaElementInput[] {
+    return this.values.list("KeySchema").map((element) => {
+      return {
+        AttributeName: element.string("AttributeName"),
+        KeyType: element.string("KeyType"),
+      };
+    });
+  }
+
+  /**
+   * The definitions of the attributes the table's keys are made of.
+   */
+  attributeDefinitions(): readonly SimDynamoDbAttributeDefinitionInput[] {
+    return this.values.list("AttributeDefinitions").map((definition) => {
+      return {
+        AttributeName: definition.string("AttributeName"),
+        AttributeType: definition.string("AttributeType"),
+      };
+    });
+  }
+
+  /**
+   * The billing mode, which CreateTable checks and defaults.
+   */
+  billingMode(): string | undefined {
+    return this.values.string("BillingMode");
+  }
+
+  /**
+   * The capacity a provisioned table is created with.
+   */
+  provisionedThroughput(): SimDynamoDbProvisionedThroughput | undefined {
+    const throughput = this.values.object("ProvisionedThroughput");
+
+    if (throughput === undefined) {
+      return undefined;
+    }
+
+    return {
+      ReadCapacityUnits: throughput.number("ReadCapacityUnits"),
+      WriteCapacityUnits: throughput.number("WriteCapacityUnits"),
+    };
+  }
+
+  /**
+   * The table class, which CreateTable checks.
+   */
+  tableClass(): string | undefined {
+    return this.values.string("TableClass");
+  }
+
+  /**
+   * Whether the table is protected from deletion.
+   */
+  deletionProtectionEnabled(): boolean | undefined {
+    return this.values.boolean("DeletionProtectionEnabled");
+  }
+
+  /**
+   * The name for a table the template did not name.
+   */
+  private generatedName(): string {
+    return new SimCfnGeneratedResourceName({
+      stackName: this.resource.stackName,
+      logicalId: this.resource.logicalId,
+      maximumLength: maximumNameLength,
+    }).value;
+  }
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -1,0 +1,125 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The AWS::DynamoDB::Table properties this simulation acts on.
+ *
+ * Each one is handed to CreateTable rather than applied here, so what a value
+ * is allowed to be stays in one place: the rules simulated DynamoDB already
+ * applies to a CreateTable request.
+ */
+const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "AttributeDefinitions",
+  "BillingMode",
+  "DeletionProtectionEnabled",
+  "KeySchema",
+  "ProvisionedThroughput",
+  "TableClass",
+  "TableName",
+]);
+
+/**
+ * Real AWS::DynamoDB::Table properties this simulation does not model.
+ *
+ * Each one changes what the table does. A table deployed without its secondary
+ * indexes would answer queries differently, and one deployed without its time
+ * to live would hold items that should have expired, so the Resource is
+ * skipped rather than deployed as something else.
+ */
+const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
+  "ContributorInsightsSpecification",
+  "GlobalSecondaryIndexes",
+  "ImportSourceSpecification",
+  "KinesisStreamSpecification",
+  "LocalSecondaryIndexes",
+  "OnDemandThroughput",
+  "PointInTimeRecoverySpecification",
+  "ResourcePolicy",
+  "SSESpecification",
+  "StreamSpecification",
+  "Tags",
+  "TimeToLiveSpecification",
+  "WarmThroughput",
+]);
+
+/**
+ * Build the error a property of an AWS::DynamoDB::Table Resource is refused
+ * with.
+ *
+ * The wording matters. Sim CloudFormation skips a Resource whose error reads as
+ * an unsupported Resource type, and skipping is the wrong answer for a table
+ * the template described in a way it cannot be created: nothing is missing from
+ * the simulation, the template is wrong, and the same template would fail on
+ * real CloudFormation.
+ */
+export function dynamoDbTablePropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid AWS::DynamoDB::Table Resource ${logicalId}: ${reason}`,
+  );
+}
+
+interface SimCfnDynamoDbTablePropertyRulesProperties {
+  readonly logicalId: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Which AWS::DynamoDB::Table properties simulated DynamoDB can act on.
+ *
+ * A real property that is not simulated skips the Resource, with a reason
+ * naming it, so the rest of the stack still deploys and the report says what
+ * was left out. Anything that is not an AWS::DynamoDB::Table property at all
+ * fails the Resource instead, because that is a template real CloudFormation
+ * would refuse too.
+ */
+export class SimCfnDynamoDbTablePropertyRules {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: SimCfnDynamoDbTablePropertyRulesProperties) {
+    this.logicalId = properties.logicalId;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Refuse everything about this Resource that is not simulated.
+   */
+  assertSimulated(): void {
+    for (const name of Object.keys(this.properties)) {
+      this.assertSimulatedProperty(name);
+    }
+  }
+
+  private assertSimulatedProperty(name: string): void {
+    if (simulatedPropertyNames.has(name)) {
+      return;
+    }
+
+    if (unsimulatedPropertyNames.has(name)) {
+      throw this.skipError(name);
+    }
+
+    throw dynamoDbTablePropertyError(
+      this.logicalId,
+      `${name} is not an AWS::DynamoDB::Table property`,
+    );
+  }
+
+  /**
+   * The error that skips this Resource over a property that is not simulated.
+   *
+   * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
+   * as skipped rather than failing the stack, so the rest of the template still
+   * deploys and the skip reason names the property.
+   */
+  private skipError(name: string): Error {
+    return new Error(
+      `Unsupported sim DynamoDB CloudFormation Resource ${this.logicalId}: ` +
+        `${name} is a real AWS::DynamoDB::Table property that simulated ` +
+        `DynamoDB does not simulate, so the table is skipped rather than ` +
+        `created without it`,
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-values.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-values.ts
@@ -1,0 +1,175 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { dynamoDbTablePropertyError } from "./sim-cfn-dynamodb-table-property-rules.js";
+
+interface SimCfnDynamoDbTableValuesProperties {
+  readonly logicalId: string;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly path?: string;
+}
+
+/**
+ * Reads the plain shapes an AWS::DynamoDB::Table property can hold.
+ *
+ * Only the template's own shape is checked here: a list where a list belongs, a
+ * number where a number belongs. What a value is allowed to mean is left to
+ * CreateTable.
+ *
+ * A nested object or list entry is read through a reader of its own, carrying
+ * the path it sits at, so a refusal names the whole property path it came from
+ * rather than just the field.
+ */
+export class SimCfnDynamoDbTableValues {
+  private readonly logicalId: string;
+  private readonly entries: ReadonlyMap<string, SimCfnTemplateValue>;
+  private readonly path: string;
+
+  constructor(properties: SimCfnDynamoDbTableValuesProperties) {
+    this.logicalId = properties.logicalId;
+    this.entries = new Map(Object.entries(properties.properties));
+    this.path = properties.path ?? "";
+  }
+
+  /**
+   * Read a property holding a list of objects, such as a key schema.
+   *
+   * A property the template leaves out reads as no entries, which is what
+   * CreateTable then refuses in its own words.
+   */
+  list(name: string): readonly SimCfnDynamoDbTableValues[] {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return [];
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.error(`${this.at(name)} must be a list`);
+    }
+
+    return value.map((element, index) => {
+      return this.reader(element, `${this.at(name)}.${index.toString()}`);
+    });
+  }
+
+  /**
+   * Read a property holding an object, where the template may leave it out.
+   */
+  object(name: string): SimCfnDynamoDbTableValues | undefined {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return this.reader(value, this.at(name));
+  }
+
+  /**
+   * Read a property holding a string, where the template may leave it out.
+   */
+  string(name: string): string | undefined {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.error(`${this.at(name)} must be a string`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Read a property holding a number.
+   *
+   * CloudFormation carries a number as a string when it came from a template
+   * Parameter, so both are read.
+   */
+  number(name: string): number | undefined {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    throw this.error(`${this.at(name)} must be a number`);
+  }
+
+  /**
+   * Read a property holding a boolean.
+   *
+   * CloudFormation carries a boolean as a string when it came from a template
+   * Parameter, so both are read. Anything else is refused rather than read as
+   * false, since what the template asked for is not knowable.
+   */
+  boolean(name: string): boolean | undefined {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === true || value === "true") {
+      return true;
+    }
+
+    if (value === false || value === "false") {
+      return false;
+    }
+
+    throw this.error(`${this.at(name)} must be true or false`);
+  }
+
+  /**
+   * Build the error this Resource is refused with.
+   */
+  error(reason: string): Error {
+    return dynamoDbTablePropertyError(this.logicalId, reason);
+  }
+
+  /**
+   * A reader over a nested value, refusing one that is not an object.
+   */
+  private reader(
+    value: SimCfnTemplateValue,
+    path: string,
+  ): SimCfnDynamoDbTableValues {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.error(`${path} must be an object`);
+    }
+
+    return new SimCfnDynamoDbTableValues({
+      logicalId: this.logicalId,
+      properties: value,
+      path,
+    });
+  }
+
+  /**
+   * The whole path a property sits at, for a refusal to name.
+   */
+  private at(name: string): string {
+    if (this.path === "") {
+      return name;
+    }
+
+    return `${this.path}.${name}`;
+  }
+}

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -37,6 +37,8 @@ import {
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimDynamoDatabaseSdkCommandRouter } from "./sdk/sim-dynamodb-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
+import { SimDynamoDbCfnResourceFactory } from "./cfn/sim-cfn-dynamodb-resource-factory.js";
+import type { SimDynamoDbTable } from "./table/sim-dynamodb-table.js";
 
 export interface SimDynamoDbRequestOptions {
   readonly caller?: SimAwsCaller;
@@ -62,6 +64,9 @@ export class SimDynamoDb {
   private readonly itemReads: SimDynamoDbGetItem;
   private readonly itemDeletions: SimDynamoDbDeleteItem;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
+  private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
+    dynamoDb: this,
+  });
 
   constructor(properties: SimDynamoDatabaseProperties = {}) {
     const {
@@ -170,6 +175,25 @@ export class SimDynamoDb {
   ): Promise<SimDeleteItemCommandOutput> {
     await this.background.sequence();
     return this.itemDeletions.handle(command, options);
+  }
+
+  /**
+   * Find a table by name, if there is one here.
+   *
+   * Not a DynamoDB API operation. It reads the simulated state directly, for
+   * the parts of the simulator that hold a table rather than describe one, such
+   * as CloudFormation after it has created one. A name real DynamoDB would
+   * refuse belongs to no table, so it is not found rather than an error.
+   */
+  findTable(name: string): SimDynamoDbTable | undefined {
+    return this.tables.findByName(name);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimDynamoDbCfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-store.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-store.ts
@@ -37,6 +37,17 @@ export class SimDynamoDbTableStore {
   }
 
   /**
+   * Find a table by a plain name, without reading it as a table name first.
+   *
+   * A name real DynamoDB would refuse belongs to no table, so it is simply not
+   * found. That is what lets a caller holding a name rather than a request look
+   * a table up.
+   */
+  findByName(name: string): SimDynamoDbTable | undefined {
+    return this.tables.get(name as DynamoDbTableName);
+  }
+
+  /**
    * Forget a table, and the items it was holding with it.
    */
   remove(name: SimDynamoDbTableName): void {

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.ts
@@ -1,12 +1,6 @@
-import { createHash } from "node:crypto";
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
 
 const maximumNameLength = 80;
-
-/**
- * How many characters of the hash of the untrimmed name a trimmed one ends
- * with, so two long names that start the same do not become one name.
- */
-const distinguisherLength = 8;
 
 interface SimCfnSqsQueueNameProperties {
   readonly stackName: string | undefined;
@@ -16,67 +10,26 @@ interface SimCfnSqsQueueNameProperties {
 /**
  * The name CloudFormation gives a queue whose template does not name it.
  *
- * Real CloudFormation generates `<stack name>-<logical ID>-<random>`. The
- * random part is left out here so a test can predict the name, which is the one
- * thing a template cannot rely on for real. Everything else follows AWS: two
- * stacks deploying the same template get different queue names, because the
- * stack name is part of it.
- *
  * A queue name is at most 80 characters, so a long stack name and logical ID
- * together are trimmed to fit. The start is kept, since that is where the stack
- * name is, and the trimmed name ends in a hash of the untrimmed one. CDK puts
- * its own disambiguating hash at the end of a logical ID, which is exactly what
- * trimming cuts off, so without that two queues in one stack could end up
- * asking for the same name.
+ * together are trimmed to fit. How a generated name is put together and
+ * trimmed is the same for every service, and lives in
+ * {@link SimCfnGeneratedResourceName}.
  */
 export class SimCfnSqsQueueName {
-  private readonly stackName: string | undefined;
-  private readonly logicalId: string;
+  private readonly generated: SimCfnGeneratedResourceName;
 
   constructor(properties: SimCfnSqsQueueNameProperties) {
-    this.stackName = properties.stackName;
-    this.logicalId = properties.logicalId;
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
   }
 
   /**
    * The generated queue name.
    */
   get value(): string {
-    const composed = this.composed();
-
-    if (composed.length <= maximumNameLength) {
-      return composed;
-    }
-
-    const kept = composed.slice(0, maximumNameLength - distinguisherLength - 1);
-
-    return `${kept}-${this.distinguisher(composed)}`;
-  }
-
-  /**
-   * The tail a trimmed name ends with, derived from the whole untrimmed name.
-   *
-   * It is a hash rather than the random characters real CloudFormation uses, so
-   * the name stays the same between deployments of the same template.
-   */
-  private distinguisher(composed: string): string {
-    return createHash("sha1")
-      .update(composed)
-      .digest("hex")
-      .slice(0, distinguisherLength);
-  }
-
-  /**
-   * The name before it is trimmed to the length SQS allows.
-   *
-   * A Resource created outside a stack has no stack name to derive one from, so
-   * it falls back to the logical ID on its own.
-   */
-  private composed(): string {
-    if (this.stackName === undefined || this.stackName === "") {
-      return this.logicalId;
-    }
-
-    return `${this.stackName}-${this.logicalId}`;
+    return this.generated.value;
   }
 }


### PR DESCRIPTION
…urces

AWS::DynamoDB::Table deploys through the ordinary CreateTable path, so a table a template deployed is the same thing an SDK caller would have got. Ref gives the table name and Fn::GetAtt Arn the table ARN. StreamArn is refused by name, since streams are not simulated. A property this simulation does not model skips the resource with a reason naming it, and the rest of the stack still deploys.

The generated name for an unnamed resource moves out of SimCfnSqsQueueName into a shared SimCfnGeneratedResourceName, parameterised by the length limit each service applies.

Resolves https://github.com/KensioSoftware/yulin/issues/255