### PR TITLE
feat: project attributes from simulated DynamoDB reads

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -367,6 +367,89 @@ reports nothing removed. Its `ReturnValues` takes `NONE` and `ALL_OLD`, as `PutI
 
 Both take the table's name or its ARN, as the table commands do.
 
+## Projecting attributes
+
+`GetItem` takes a `ProjectionExpression`, which is a comma-separated list of document paths. Only
+those paths come back. A path is an attribute name, then any number of `.attribute` dereferences and
+`[n]` list indexes: `address.city`, `lines[0].sku`.
+
+An attribute name that is a DynamoDB reserved word, or that has a character an expression cannot
+carry, is written as a `#name` placeholder and defined in `ExpressionAttributeNames`.
+
+```typescript sim-dynamodb-projection-expression
+/**
+ * Reading part of an item with a projection expression.
+ */
+
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: {
+      orderId: { S: "order-1" },
+      status: { S: "shipped" },
+      address: { M: { city: { S: "Leeds" }, postcode: { S: "LS1 1AA" } } },
+      lines: { L: [{ S: "widget" }, { S: "gasket" }] },
+    },
+  }),
+);
+
+const output = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    ProjectionExpression: "#s, address.city, lines[0]",
+    ExpressionAttributeNames: { "#s": "status" },
+  }),
+);
+
+console.log(Object.keys(output.Item ?? {}));
+// [ "status", "address", "lines" ]
+
+// The nested shape is kept: the address holds only the projected attribute.
+console.log(output.Item?.["address"]?.M);
+// { city: { S: "Leeds" } }
+
+// A projected list element comes back as a one element list.
+console.log(output.Item?.["lines"]?.L?.length);
+// 1
+```
+
+A projected path the item does not have is left out. It is not an error, and it does not come back
+as a `NULL`, so an item with none of the projected paths answers with an `Item` holding nothing.
+
+The placeholders and the expression have to agree exactly, in both directions. A `#name` the request
+does not define is a `ValidationException`, and so is an `ExpressionAttributeNames` entry no
+expression uses. The second is what a request hits after an expression is edited and the old
+placeholder is left behind.
+
+Two paths where one contains the other, such as `address, address.city`, are a `ValidationException`,
+as they are on real AWS: the pair does not say whether the whole map or one attribute of it was
+wanted. Naming one path twice counts the same way.
+
+A document path goes at most 32 levels deep, which is as far as an item nests. A negative index, a
+fractional index and a path past that depth are each a `ValidationException` naming the path.
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -596,8 +679,10 @@ authorizes against `*`.
 - `PutItem`, with the attribute value model behind it: numbers keep their digits, sets compare by
   value, and key attributes are checked against what the table declared. It takes a table name or
   ARN and authorizes before the lookup.
-- `GetItem`, answering with the whole item under a primary key, and with no `Item` at all when the
-  key holds nothing.
+- `GetItem`, answering with the item under a primary key, and with no `Item` at all when the key
+  holds nothing.
+- `ProjectionExpression` on `GetItem`, with document paths, list indexing and `ExpressionAttributeNames`
+  placeholders.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name and `Fn::GetAtt … Arn` the table ARN.
@@ -643,9 +728,14 @@ authorizes against `*`.
   stack deployed calls `simAws.backgroundTasksComplete()` first.
 - CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
   `DeletionPolicy` a template sets on a table.
-- Projection is not simulated. `ProjectionExpression` and `AttributesToGet` are refused rather than
-  ignored, since an item that came back whole where part of it was asked for would hide an
-  application reading an attribute it never requested.
+- `ProjectionExpression` is simulated on `GetItem` only. `BatchGetItem`, `Query` and `Scan` are not
+  implemented yet, so they have nothing to project from.
+- The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
+  where part of it was asked for would hide an application reading an attribute it never requested.
+  `ProjectionExpression` replaced it, and real DynamoDB has built nothing on it since.
+- The 4 KB limit on an expression and the 255 byte limit on a placeholder are not enforced. Nothing
+  here is slower for a long expression, so an expression real DynamoDB would refuse for its size is
+  evaluated.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
   so a test cannot observe a stale read here the way it might against a real table.
 - Condition expressions are not simulated. `ConditionExpression`, `ExpressionAttributeNames`,

--- a/docs/services/dynamodb/sim-dynamodb-projection-expression.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-projection-expression.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Reading part of an item with a projection expression.
+ */
+
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: {
+      orderId: { S: "order-1" },
+      status: { S: "shipped" },
+      address: { M: { city: { S: "Leeds" }, postcode: { S: "LS1 1AA" } } },
+      lines: { L: [{ S: "widget" }, { S: "gasket" }] },
+    },
+  }),
+);
+
+const output = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    ProjectionExpression: "#s, address.city, lines[0]",
+    ExpressionAttributeNames: { "#s": "status" },
+  }),
+);
+
+console.log(Object.keys(output.Item ?? {}));
+// [ "status", "address", "lines" ]
+
+// The nested shape is kept: the address holds only the projected attribute.
+console.log(output.Item?.["address"]?.M);
+// { city: { S: "Leeds" } }
+
+// A projected list element comes back as a one element list.
+console.log(output.Item?.["lines"]?.L?.length);
+// 1

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -282,21 +282,66 @@ the same checks PutItem applies on the way in.
 Important behavior:
 
 - GetItem leaves `Item` out altogether on a miss, rather than answering with an empty map. That
-  absence is how a caller tells a miss from an item carrying nothing but its key.
+  absence is how a caller tells a miss from an item carrying nothing but its key. A projection that
+  found none of what it asked for is the other case: the key was there, so `Item` is present and
+  empty.
+- GetItem reads its `ProjectionExpression` before it reaches the table, so an expression DynamoDB
+  would refuse is refused whether or not the key holds anything.
 - `ConsistentRead` is accepted either way and changes nothing. Nothing about a write is scheduled, so
   there is no window in which an eventually consistent read could answer with something older.
 - DeleteItem is idempotent. It names a key rather than an item, so deleting a key that is already
   free succeeds and reports nothing removed.
 - DeleteItem takes the same `ReturnValues` as PutItem, through `SimDynamoDbReturnValues`, which is
   where the two modes and the error text for a third live.
-- GetItem refuses `ProjectionExpression`, `AttributesToGet`, `ExpressionAttributeNames` and a
-  `ReturnConsumedCapacity` that asks for anything, in
-  `sim-dynamodb-unsimulated-item-read-input.ts`. DeleteItem refuses the same conditional write and
-  reporting inputs PutItem does.
+- GetItem refuses the legacy `AttributesToGet` and a `ReturnConsumedCapacity` that asks for anything,
+  in `sim-dynamodb-unsimulated-item-read-input.ts`. `ExpressionAttributeNames` with no expression to
+  use them in is a `ValidationException` rather than an unsupported operation, because real DynamoDB
+  refuses that too. DeleteItem refuses the same conditional write and reporting inputs PutItem does.
 
 Scans, queries, indexes, condition expressions and streams are not implemented. Billing mode and
 provisioned capacity are read and stored by CreateTable, but nothing enforces them: no write is ever
 throttled.
+
+## Expressions
+
+`expression/` holds the parts every DynamoDB expression parameter is made of. Projections,
+conditions, filters, key conditions and updates are all written in the same lexical shapes and all
+point at parts of an item the same way, so those parts are built once rather than once per
+expression kind. Writing them per feature is how the parsers drift apart and start disagreeing about
+what `a.b[0]` means.
+
+The shared parts:
+
+- `SimDynamoDbExpressionTokeniser` reads an expression into `name`, `namePlaceholder`,
+  `valuePlaceholder`, `number` and `symbol` tokens. The set of symbols it knows is deliberately
+  small, and grows as expression kinds arrive: a character outside it is refused rather than passed
+  through to a parser that would ignore it. A fraction is read as one number token, so an index of
+  `1.5` can be refused as a fraction rather than as a syntax error somewhere after it.
+- `SimDynamoDbExpressionTokens` is a parser's place in those tokens. Reading forwards, peeking, and
+  what happens at the end live there rather than in each parser.
+- `SimDynamoDbExpressionPlaceholders` holds one of `ExpressionAttributeNames` or
+  `ExpressionAttributeValues`. Both are a map of placeholders to what they stand for, so one generic
+  class holds either. It fails closed in both directions: a placeholder an expression uses and the
+  request does not define is refused, and so is an entry no expression used.
+- `SimDynamoDbDocumentPath` is where an expression is pointing, as attribute and index segments
+  rather than as text to split later. `SimDynamoDbDocumentPathParser` reads one, substituting name
+  placeholders as it goes, so everything downstream sees one kind of path. It stops at the first
+  token that cannot continue a path, leaving it for whatever is reading around it, such as the comma
+  between two projected paths.
+- `simDynamoDbExpressionError` builds every refusal, so they all read as
+  `Invalid <parameter>: <reason>`. A request can carry several expressions, so naming which one was
+  wrong matters.
+
+`expression/projection/` is the first consumer. `readSimDynamoDbProjection` reads a
+`ProjectionExpression` and its names into a `SimDynamoDbProjection`, and `SimDynamoDbProjectionNode`
+merges the paths into a tree before anything is read, so `address.city` and `address.postcode` become
+one `address` holding two attributes. Two paths where one contains the other are refused there, as
+real DynamoDB refuses them.
+
+Applying a projection is `undefined` for anything the item does not have, at every level: a missing
+attribute, an index past the end of a list, and a path reaching into the wrong kind of value all
+come back as nothing rather than as an error. A projected list is closed up, so `lines[2]` on its own
+answers with a one element list.
 
 ## CloudFormation
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-get-item-projection.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-get-item-projection.iso.test.ts
@@ -1,0 +1,256 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimGetItemCommandOutput } from "./item.command.js";
+
+/**
+ * A table holding one order, with a nested map and a list in it.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: {
+        orderId: { S: "order-1" },
+        status: { S: "shipped" },
+        address: {
+          M: {
+            city: { S: "Leeds" },
+            postcode: { S: "LS1 1AA" },
+            country: { S: "UK" },
+          },
+        },
+        lines: {
+          L: [
+            { M: { sku: { S: "a" }, quantity: { N: "1" } } },
+            { M: { sku: { S: "b" }, quantity: { N: "2" } } },
+            { M: { sku: { S: "c" }, quantity: { N: "3" } } },
+          ],
+        },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * Read the one order back with a projection over it.
+ */
+async function projected(
+  simDynamoDb: SimDynamoDb,
+  expression: string,
+  names?: Readonly<Record<string, string>>,
+): Promise<SimGetItemCommandOutput["Item"]> {
+  const output = await simDynamoDb.getItem({
+    input: {
+      TableName: "FooTable",
+      Key: { orderId: { S: "order-1" } },
+      ProjectionExpression: expression,
+      ExpressionAttributeNames: names,
+    },
+  });
+
+  return output.Item;
+}
+
+describe("DynamoDB GetItemCommand projection", () => {
+  it("answers with only the paths the expression names", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read with a projection naming a placeholder, a nested
+    // attribute and one list element.
+    const item = await projected(simDynamoDb, "#s, address.city, lines[0]", {
+      "#s": "status",
+    });
+
+    // Then only those come back, and everything else is left out.
+    assertNonNullable(item);
+    assertArrayLength(Object.keys(item), 3);
+    assertIdentical(item["status"]?.S, "shipped");
+    assertUndefined(item["orderId"]);
+  });
+
+  it("keeps the nested shape of a projected map", async () => {
+    // Given a table holding an order with a three attribute address.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When one attribute of the address is projected.
+    const item = await projected(simDynamoDb, "address.city");
+
+    // Then the address comes back as a map holding only that attribute,
+    // rather than as the attribute on its own.
+    const address = item?.["address"]?.M;
+    assertNonNullable(address);
+    assertArrayLength(Object.keys(address), 1);
+    assertIdentical(address["city"]?.S, "Leeds");
+  });
+
+  it("merges two paths into the same map", async () => {
+    // Given two projected paths reaching into one map.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When both are projected.
+    const item = await projected(simDynamoDb, "address.city, address.country");
+
+    // Then one map comes back holding both, rather than the second path
+    // replacing the first.
+    const address = item?.["address"]?.M;
+    assertNonNullable(address);
+    assertArrayLength(Object.keys(address), 2);
+    assertIdentical(address["country"]?.S, "UK");
+  });
+
+  it("closes up a projected list", async () => {
+    // Given a list of three elements with the first and last projected.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When both elements are projected.
+    const item = await projected(simDynamoDb, "lines[0].sku, lines[2].sku");
+
+    // Then a two element list comes back, in the order the list holds them,
+    // rather than a three element list with a gap in the middle.
+    const lines = item?.["lines"]?.L;
+    assertNonNullable(lines);
+    assertArrayLength(lines, 2);
+
+    const first = lines.at(0)?.M;
+    assertNonNullable(first);
+    assertIdentical(first["sku"]?.S, "a");
+    assertUndefined(first["quantity"]);
+    assertIdentical(lines.at(1)?.M?.["sku"]?.S, "c");
+  });
+
+  it("merges two paths into the same list element", async () => {
+    // Given two projected paths reaching into one element of a list.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When both are projected.
+    const item = await projected(
+      simDynamoDb,
+      "lines[1].sku, lines[1].quantity",
+    );
+
+    // Then one element comes back holding both, rather than the same element
+    // twice.
+    const lines = item?.["lines"]?.L;
+    assertNonNullable(lines);
+    assertArrayLength(lines, 1);
+    assertArrayLength(Object.keys(lines.at(0)?.M ?? {}), 2);
+  });
+
+  it("leaves out a list index past the end of the list", async () => {
+    // Given a projection naming an element the list is too short to have.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read.
+    const item = await projected(simDynamoDb, "lines[9]");
+
+    // Then the list is left out altogether, rather than coming back empty.
+    assertNonNullable(item);
+    assertUndefined(item["lines"]);
+  });
+
+  it("leaves out a path the item does not have", async () => {
+    // Given a projection naming an attribute the item never carried.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read.
+    const item = await projected(
+      simDynamoDb,
+      "status, discount, address.county",
+    );
+
+    // Then the missing paths are simply absent, rather than an error or a NULL
+    // standing in for them.
+    assertNonNullable(item);
+    assertArrayLength(Object.keys(item), 1);
+    assertUndefined(item["discount"]);
+    assertUndefined(item["address"]);
+  });
+
+  it("leaves out a path pointing into the wrong kind of value", async () => {
+    // Given a projection reaching into a string as though it were a map, and
+    // into a map as though it were a list.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read.
+    const item = await projected(simDynamoDb, "status.city, address[0]");
+
+    // Then neither comes back: the item does not have what was asked for.
+    assertNonNullable(item);
+    assertArrayLength(Object.keys(item), 0);
+  });
+
+  it("answers with an empty item when the projection finds nothing", async () => {
+    // Given a projection naming only attributes the item does not have.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        ProjectionExpression: "discount",
+      }),
+    );
+
+    // Then there is an Item with nothing in it, rather than no Item: the key
+    // was there, and nothing the request asked for was.
+    assertNonNullable(output.Item);
+    assertArrayLength(Object.keys(output.Item), 0);
+  });
+
+  it("answers with no item at all for a key holding nothing", async () => {
+    // Given a projection over a key the table does not hold.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is read.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-2" } },
+        ProjectionExpression: "status",
+      }),
+    );
+
+    // Then there is no Item, which is how a caller tells a miss from an item
+    // the projection found nothing in.
+    assertUndefined(output.Item);
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
@@ -6,6 +6,7 @@ import type {
 } from "./item.command.js";
 import { readSimDynamoDbKey } from "./sim-dynamodb-key-input.js";
 import { refuseUnsimulatedItemReadInput } from "./sim-dynamodb-unsimulated-item-read-input.js";
+import { readSimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection-expression.js";
 
 interface SimDynamoDbGetItemProperties {
   readonly access: SimDynamoDbTableAccess;
@@ -44,6 +45,9 @@ export class SimDynamoDbGetItem {
 
     refuseUnsimulatedItemReadInput(input);
 
+    // The projection is read before the table is reached, so an expression
+    // DynamoDB would refuse is refused whether or not the key holds anything.
+    const projection = readSimDynamoDbProjection(input);
     const table = this.access.required(
       "dynamodb:GetItem",
       input.TableName,
@@ -55,6 +59,11 @@ export class SimDynamoDbGetItem {
       return { $metadata: {} };
     }
 
-    return { Item: found.toAttributeValues(), $metadata: {} };
+    // A projection that found none of what it asked for leaves an item with no
+    // attributes, which is answered with as an empty Item rather than as a
+    // miss: the key was there, and nothing the request asked for was.
+    const projected = projection?.apply(found) ?? found;
+
+    return { Item: projected.toAttributeValues(), $metadata: {} };
   }
 }

--- a/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-read-input.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-read-input.iso.test.ts
@@ -11,7 +11,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimDynamoDbUnsupportedOperation } from "../../error/dynamodb.error.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
 import type { SimDynamoDb } from "../../sim-dynamodb.js";
 import type { SimGetItemCommandInput } from "./item.command.js";
 
@@ -48,14 +51,6 @@ async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
 
 describe("DynamoDB GetItemCommand unsimulated input", () => {
   it.each([
-    {
-      named: "ProjectionExpression",
-      input: { ProjectionExpression: "userId, note" },
-    },
-    {
-      named: "ExpressionAttributeNames",
-      input: { ExpressionAttributeNames: { "#u": "userId" } },
-    },
     {
       named: "AttributesToGet",
       input: { AttributesToGet: ["userId"] },
@@ -99,5 +94,26 @@ describe("DynamoDB GetItemCommand unsimulated input", () => {
 
     // Then nothing is refused, and the item comes back.
     assertIdentical(output.Item?.["note"]?.S, "first");
+  });
+
+  it("refuses ExpressionAttributeNames with no expression to use them in", async () => {
+    // Given a table holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a read defines names and carries no expression.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.getItem({
+        input: { ...keyInput, ExpressionAttributeNames: { "#n": "note" } },
+      }),
+    );
+
+    // Then it is a ValidationException rather than an unsupported operation:
+    // real DynamoDB refuses this too, since nothing would ever read them.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ExpressionAttributeNames can only be specified when using expressions",
+    );
   });
 });

--- a/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-read-input.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-read-input.ts
@@ -4,25 +4,17 @@ import { SimDynamoDbUnsimulatedInput } from "./sim-dynamodb-unsimulated-input.js
 /**
  * Refuse the GetItem inputs this simulation does not model.
  *
- * Every way of asking for part of an item is refused. An item that came back
- * whole where a projection was asked for would hide an application reading an
- * attribute it never requested.
+ * `AttributesToGet` is the way of asking for part of an item that
+ * `ProjectionExpression` replaced, and real DynamoDB has not built anything on
+ * it since. An item that came back whole where part of it was asked for would
+ * hide an application reading an attribute it never requested, so it is refused
+ * rather than ignored.
  */
 export function refuseUnsimulatedItemReadInput(
   input: SimGetItemCommandInput,
 ): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("GetItem");
 
-  unsimulated.refuse(
-    input.ProjectionExpression !== undefined,
-    "ProjectionExpression",
-    "answering with the whole item where part of it was asked for",
-  );
-  unsimulated.refuseNamed(
-    input.ExpressionAttributeNames,
-    "ExpressionAttributeNames",
-    "accepting names for an expression it cannot evaluate",
-  );
   unsimulated.refuse(
     (input.AttributesToGet ?? []).length > 0,
     "AttributesToGet",

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
@@ -32,6 +32,25 @@ describe("readSimDynamoDbProjection", () => {
     assertUndefined(readSimDynamoDbProjection({}));
   });
 
+  it("refuses names with no expression before it looks at their keys", () => {
+    // Given a request carrying names with no expression, keyed by the
+    // attribute name rather than by a placeholder.
+    // When the projection is read, then the refusal is that there is no
+    // expression to use them in, which is the one real DynamoDB gives and the
+    // one that says what to do about it.
+    const error = assertThrowsError(() =>
+      readSimDynamoDbProjection({
+        ExpressionAttributeNames: { status: "status" },
+      }),
+    );
+
+    assertIdentical(
+      error.message,
+      "ExpressionAttributeNames can only be specified when using " +
+        "expressions, and this request carries none",
+    );
+  });
+
   it("refuses a placeholder the request never defined", () => {
     // Given an expression using a placeholder with no entry for it.
     // When the projection is read, then it is refused naming the placeholder.

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
@@ -1,0 +1,150 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { readSimDynamoDbProjection } from "./sim-dynamodb-projection-expression.js";
+
+/**
+ * Read a projection, returning whatever it is refused with.
+ */
+function refusal(
+  expression: string,
+  names?: Readonly<Record<string, string>>,
+): Error {
+  return assertThrowsError(() =>
+    readSimDynamoDbProjection({
+      ProjectionExpression: expression,
+      ExpressionAttributeNames: names,
+    }),
+  );
+}
+
+describe("readSimDynamoDbProjection", () => {
+  it("reads nothing for a request with no expression", () => {
+    // Given a request asking for the whole item.
+    // When the projection is read, then there is none, so nothing cuts the
+    // item down.
+    assertUndefined(readSimDynamoDbProjection({}));
+  });
+
+  it("refuses a placeholder the request never defined", () => {
+    // Given an expression using a placeholder with no entry for it.
+    // When the projection is read, then it is refused naming the placeholder.
+    const error = refusal("#s, note");
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "ExpressionAttributeNames does not define #s, which an expression uses",
+    );
+  });
+
+  it("refuses a defined name the expression never uses", () => {
+    // Given an expression edited to drop a path, with the placeholder it used
+    // left behind.
+    // When the projection is read, then the leftover is refused.
+    const error = refusal("status", { "#c": "city" });
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "Value provided in ExpressionAttributeNames is unused in expressions: #c",
+    );
+  });
+
+  it("refuses an empty expression", () => {
+    // Given an expression naming nothing, which asks for no attributes at all.
+    // When the projection is read, then it is refused rather than read as
+    // asking for everything.
+    const error = refusal("  ");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: the expression names no attributes, and " +
+        "an expression cannot be empty",
+    );
+  });
+
+  it("refuses two paths where one contains the other", () => {
+    // Given a projection asking for a whole map and one attribute of it, which
+    // does not say which of the two was wanted.
+    // When the projection is read, then it is refused, as real DynamoDB
+    // refuses overlapping paths.
+    const error = refusal("address, address.city");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: two document paths overlap with each " +
+        "other, at 'address.city'",
+    );
+  });
+
+  it("refuses two paths where the second contains the first", () => {
+    // Given the same overlap written the other way round.
+    // When the projection is read, then it is refused as well, rather than the
+    // order of the paths deciding it.
+    const error = refusal("address.city, address");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: two document paths overlap with each " +
+        "other, at 'address'",
+    );
+  });
+
+  it("refuses one path named twice", () => {
+    // Given a projection naming the same path twice, which real DynamoDB
+    // counts as an overlap.
+    // When the projection is read, then it is refused.
+    const error = refusal("status, status");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: two document paths overlap with each " +
+        "other, at 'status'",
+    );
+  });
+
+  it("refuses something left over after the last path", () => {
+    // Given an expression with a stray bracket after its last path.
+    // When the projection is read, then it is refused rather than read up to
+    // the point it stopped making sense.
+    const error = refusal("status]");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; ']' follows a document " +
+        "path, where a comma or the end of the expression was expected",
+    );
+  });
+
+  it("refuses a trailing comma", () => {
+    // Given an expression ending in a comma, as one has after a path is
+    // deleted from the end of it.
+    // When the projection is read, then it is refused rather than read as the
+    // paths before it.
+    const error = refusal("status,");
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; an attribute name " +
+        "expected, but the expression ended",
+    );
+  });
+
+  it("takes a name placeholder used by two paths", () => {
+    // Given two paths reaching through the same placeholder, which uses the
+    // one entry twice.
+    // When the projection is read, then nothing is refused: an entry used
+    // anywhere is used.
+    readSimDynamoDbProjection({
+      ProjectionExpression: "#a.city, #a.country",
+      ExpressionAttributeNames: { "#a": "address" },
+    });
+  });
+});

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
@@ -27,11 +27,6 @@ export function readSimDynamoDbProjection(
   request: SimDynamoDbProjectionRequest,
 ): SimDynamoDbProjection | undefined {
   const expression = request.ProjectionExpression;
-  const names = new SimDynamoDbExpressionPlaceholders({
-    parameterName: "ExpressionAttributeNames",
-    marker: "#",
-    entries: request.ExpressionAttributeNames,
-  });
 
   if (expression === undefined) {
     assertNoNamesWithoutExpression(request.ExpressionAttributeNames);
@@ -39,6 +34,11 @@ export function readSimDynamoDbProjection(
     return undefined;
   }
 
+  const names = new SimDynamoDbExpressionPlaceholders({
+    parameterName: "ExpressionAttributeNames",
+    marker: "#",
+    entries: request.ExpressionAttributeNames,
+  });
   const paths = projectedPaths(expression, names);
   names.assertAllUsed();
 

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
@@ -1,0 +1,107 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
+import { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import { SimDynamoDbExpressionTokeniser } from "../sim-dynamodb-expression-tokeniser.js";
+import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { SimDynamoDbProjection } from "./sim-dynamodb-projection.js";
+
+const expressionName = "ProjectionExpression";
+
+interface SimDynamoDbProjectionRequest {
+  readonly ProjectionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Read the projection a request asks for, if it asks for one.
+ *
+ * A request with no ProjectionExpression asks for the whole item, so there is
+ * nothing to project. Names supplied without an expression to use them in are
+ * refused, as real DynamoDB refuses them: nothing would ever read them, and a
+ * request carrying them has almost always lost its expression somewhere.
+ */
+export function readSimDynamoDbProjection(
+  request: SimDynamoDbProjectionRequest,
+): SimDynamoDbProjection | undefined {
+  const expression = request.ProjectionExpression;
+  const names = new SimDynamoDbExpressionPlaceholders({
+    parameterName: "ExpressionAttributeNames",
+    marker: "#",
+    entries: request.ExpressionAttributeNames,
+  });
+
+  if (expression === undefined) {
+    assertNoNamesWithoutExpression(request.ExpressionAttributeNames);
+
+    return undefined;
+  }
+
+  const paths = projectedPaths(expression, names);
+  names.assertAllUsed();
+
+  return new SimDynamoDbProjection({ expressionName, paths });
+}
+
+/**
+ * Read the comma-separated document paths a ProjectionExpression names.
+ */
+function projectedPaths(
+  expression: string,
+  names: SimDynamoDbExpressionPlaceholders<string>,
+): readonly SimDynamoDbDocumentPath[] {
+  const tokens = new SimDynamoDbExpressionTokens({
+    expressionName,
+    tokens: new SimDynamoDbExpressionTokeniser({ expressionName }).tokenise(
+      expression,
+    ),
+  });
+
+  if (tokens.atEnd) {
+    throw simDynamoDbExpressionError(
+      expressionName,
+      "the expression names no attributes, and an expression cannot be empty",
+    );
+  }
+
+  const paths: SimDynamoDbDocumentPath[] = [];
+
+  do {
+    paths.push(new SimDynamoDbDocumentPathParser({ tokens, names }).parse());
+  } while (tokens.takeSymbol(","));
+
+  assertReadToEnd(tokens);
+
+  return paths;
+}
+
+/**
+ * Refuse an expression with something left over after its last path.
+ */
+function assertReadToEnd(tokens: SimDynamoDbExpressionTokens): void {
+  const remaining = tokens.peek();
+
+  if (remaining !== undefined) {
+    throw simDynamoDbExpressionError(
+      expressionName,
+      `syntax error; '${remaining.text}' follows a document path, where a ` +
+        `comma or the end of the expression was expected`,
+    );
+  }
+}
+
+/**
+ * Refuse names defined for an expression the request does not carry.
+ */
+function assertNoNamesWithoutExpression(
+  entries: Readonly<Record<string, string>> | undefined,
+): void {
+  if (Object.keys(entries ?? {}).length > 0) {
+    throw new SimDynamoDbValidationException(
+      "ExpressionAttributeNames can only be specified when using expressions, " +
+        "and this request carries none",
+    );
+  }
+}

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-node.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-node.ts
@@ -1,0 +1,198 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
+
+/**
+ * One point in a projection, and what was asked for below it.
+ *
+ * The paths a projection names are merged into a tree before anything is read,
+ * so `address.city` and `address.postcode` become one `address` holding two
+ * attributes rather than two separate reads that would then have to be put back
+ * together.
+ */
+export class SimDynamoDbProjectionNode {
+  private readonly expressionName: string;
+  private whole = false;
+  private readonly attributes = new Map<string, SimDynamoDbProjectionNode>();
+  private readonly indexes = new Map<number, SimDynamoDbProjectionNode>();
+
+  constructor(expressionName: string) {
+    this.expressionName = expressionName;
+  }
+
+  /**
+   * Add a path to the tree, from the segment at an offset onwards.
+   *
+   * Two paths where one contains the other are refused, as real DynamoDB
+   * refuses them: `address` and `address.city` together do not say whether the
+   * whole map or one attribute of it was wanted.
+   */
+  add(path: SimDynamoDbDocumentPath, offset = 0): void {
+    const segment = path.segments.at(offset);
+
+    if (segment === undefined) {
+      this.claimWhole(path);
+
+      return;
+    }
+
+    if (this.whole) {
+      throw this.overlapError(path);
+    }
+
+    if (segment.kind === "attribute") {
+      this.childAttribute(segment.name).add(path, offset + 1);
+
+      return;
+    }
+
+    this.childIndex(segment.index).add(path, offset + 1);
+  }
+
+  /**
+   * Read the part of a value this node asked for, or nothing when the value has
+   * no such part.
+   *
+   * A path the item does not have is left out rather than refused. The
+   * projection says where to look, and an item is free not to have it.
+   */
+  apply(value: SimDynamoDbValue): SimDynamoDbValue | undefined {
+    if (this.whole) {
+      return value;
+    }
+
+    if (value.kind === "M" && this.attributes.size > 0) {
+      return this.projectedMap(value.entries);
+    }
+
+    if (value.kind === "L" && this.indexes.size > 0) {
+      return this.projectedList(value.values);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Read the attributes this node asked for out of a map of them.
+   *
+   * The order the item holds them in is kept, rather than the order the
+   * expression named them in, so a projected item reads like the item it came
+   * from.
+   */
+  projectAttributes(
+    entries: ReadonlyMap<string, SimDynamoDbValue>,
+  ): ReadonlyMap<string, SimDynamoDbValue> {
+    const projected = new Map<string, SimDynamoDbValue>();
+
+    for (const [name, value] of entries) {
+      const node = this.attributes.get(name);
+      const part = node?.apply(value);
+
+      if (part !== undefined) {
+        projected.set(name, part);
+      }
+    }
+
+    return projected;
+  }
+
+  /**
+   * Take the whole of whatever is here, refusing a path already broken up.
+   */
+  private claimWhole(path: SimDynamoDbDocumentPath): void {
+    if (this.whole || this.attributes.size > 0 || this.indexes.size > 0) {
+      throw this.overlapError(path);
+    }
+
+    this.whole = true;
+  }
+
+  private childAttribute(name: string): SimDynamoDbProjectionNode {
+    const existing = this.attributes.get(name);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const added = new SimDynamoDbProjectionNode(this.expressionName);
+    this.attributes.set(name, added);
+
+    return added;
+  }
+
+  private childIndex(index: number): SimDynamoDbProjectionNode {
+    const existing = this.indexes.get(index);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const added = new SimDynamoDbProjectionNode(this.expressionName);
+    this.indexes.set(index, added);
+
+    return added;
+  }
+
+  /**
+   * The map this node asked for, or nothing when it holds none of it.
+   */
+  private projectedMap(
+    entries: ReadonlyMap<string, SimDynamoDbValue>,
+  ): SimDynamoDbValue | undefined {
+    const projected = this.projectAttributes(entries);
+
+    if (projected.size === 0) {
+      return undefined;
+    }
+
+    return { kind: "M", entries: projected };
+  }
+
+  /**
+   * The list elements this node asked for, closed up.
+   *
+   * Projecting `lines[2]` on its own answers with a one element list, as real
+   * DynamoDB does, rather than a list with two gaps before it. The elements
+   * stay in the order the list holds them.
+   */
+  private projectedList(
+    values: readonly SimDynamoDbValue[],
+  ): SimDynamoDbValue | undefined {
+    const projected = this.indexes
+      .entries()
+      .toArray()
+      .toSorted(([first], [second]) => first - second)
+      .map(([index, node]) => this.elementAt(values, index, node))
+      .filter((value) => value !== undefined);
+
+    if (projected.length === 0) {
+      return undefined;
+    }
+
+    return { kind: "L", values: projected };
+  }
+
+  /**
+   * The part of one list element a node asked for, if the list reaches it.
+   */
+  private elementAt(
+    values: readonly SimDynamoDbValue[],
+    index: number,
+    node: SimDynamoDbProjectionNode,
+  ): SimDynamoDbValue | undefined {
+    const value = values.at(index);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return node.apply(value);
+  }
+
+  private overlapError(path: SimDynamoDbDocumentPath): Error {
+    return simDynamoDbExpressionError(
+      this.expressionName,
+      `two document paths overlap with each other, at '${path.text}'`,
+    );
+  }
+}

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection.ts
@@ -1,0 +1,40 @@
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import { SimDynamoDbProjectionNode } from "./sim-dynamodb-projection-node.js";
+
+interface SimDynamoDbProjectionProperties {
+  readonly expressionName: string;
+  readonly paths: readonly SimDynamoDbDocumentPath[];
+}
+
+/**
+ * The parts of an item a ProjectionExpression asked for.
+ *
+ * A projection is built once from the paths and then applied to whatever items
+ * a read finds, so the same expression does not have to be parsed per item.
+ */
+export class SimDynamoDbProjection {
+  private readonly root: SimDynamoDbProjectionNode;
+
+  constructor(properties: SimDynamoDbProjectionProperties) {
+    this.root = new SimDynamoDbProjectionNode(properties.expressionName);
+
+    for (const path of properties.paths) {
+      this.root.add(path);
+    }
+  }
+
+  /**
+   * Cut an item down to what this projection asked for.
+   *
+   * A path the item does not have is left out. Real DynamoDB answers with the
+   * parts it found rather than with a NULL standing in for the parts it did
+   * not, so an item with none of the projected paths comes back with no
+   * attributes at all.
+   */
+  apply(item: SimDynamoDbItem): SimDynamoDbItem {
+    return SimDynamoDbItem.ofAttributes(
+      this.root.projectAttributes(item.entries()),
+    );
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
@@ -1,0 +1,181 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringStartsWith,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbDocumentPathParser } from "./sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbDocumentPath } from "./sim-dynamodb-document-path.js";
+import { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+import { SimDynamoDbExpressionTokeniser } from "./sim-dynamodb-expression-tokeniser.js";
+import { SimDynamoDbExpressionTokens } from "./sim-dynamodb-expression-tokens.js";
+
+const expressionName = "ProjectionExpression";
+
+/**
+ * Parse one document path, with whatever names it uses defined for it.
+ */
+function parsePath(
+  expression: string,
+  entries?: Readonly<Record<string, string>>,
+): SimDynamoDbDocumentPath {
+  const tokens = new SimDynamoDbExpressionTokens({
+    expressionName,
+    tokens: new SimDynamoDbExpressionTokeniser({ expressionName }).tokenise(
+      expression,
+    ),
+  });
+
+  return new SimDynamoDbDocumentPathParser({
+    tokens,
+    names: new SimDynamoDbExpressionPlaceholders({
+      parameterName: "ExpressionAttributeNames",
+      marker: "#",
+      entries,
+    }),
+  }).parse();
+}
+
+describe("SimDynamoDbDocumentPathParser", () => {
+  it("reads dot dereferencing and list indexing", () => {
+    // Given a path reaching into a map and then into a list inside it.
+    // When it is parsed.
+    const path = parsePath("order.lines[2].sku");
+
+    // Then each step is what it points at, rather than text to split later.
+    assertArrayLength(path.segments, 4);
+    assertIdentical(path.segments.at(0)?.kind, "attribute");
+    assertIdentical(path.segments.at(2)?.kind, "index");
+    assertIdentical(path.depth, 4);
+    assertIdentical(path.text, "order.lines[2].sku");
+  });
+
+  it("reads an index of zero", () => {
+    // Given the first element of a list, which is the index a boundary check
+    // written the wrong way round would refuse.
+    // When it is parsed, then it is an index of zero.
+    const path = parsePath("lines[0]");
+
+    assertIdentical(path.text, "lines[0]");
+  });
+
+  it("substitutes a name placeholder for the attribute it stands for", () => {
+    // Given a path written with placeholders, as a path naming a reserved word
+    // has to be.
+    // When it is parsed with those names defined.
+    const path = parsePath("#o.#s", { "#o": "order", "#s": "status" });
+
+    // Then the path names the attributes rather than the placeholders, so
+    // everything after it reads one kind of path.
+    assertIdentical(path.text, "order.status");
+  });
+
+  it("refuses a negative list index", () => {
+    // Given a path indexing backwards, which DynamoDB lists do not do.
+    // When it is parsed, then it is refused naming the path it was reading.
+    const error = assertThrowsError(() => parsePath("lines[-1]"));
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: a list index cannot be negative in the " +
+        "document path 'lines'",
+    );
+  });
+
+  it("refuses a fractional list index", () => {
+    // Given a path indexing at a fraction, which is between two elements.
+    // When it is parsed, then it is refused naming the path it was reading.
+    const error = assertThrowsError(() => parsePath("lines[1.5]"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: a list index is a whole number, and " +
+        "'1.5' is not in the document path 'lines'",
+    );
+  });
+
+  it("refuses a path deeper than an item nests", () => {
+    // Given a path of 33 attributes, one past where an item can go.
+    const tooDeep = Array.from(
+      { length: 33 },
+      (_, index) => `a${String(index)}`,
+    ).join(".");
+
+    // When it is parsed, then it is refused: nothing could ever be there.
+    const error = assertThrowsError(() => parsePath(tooDeep));
+
+    assertStringStartsWith(
+      error.message,
+      "Invalid ProjectionExpression: a document path goes at most 32 levels " +
+        "deep",
+    );
+  });
+
+  it("reads a path of exactly 32 levels", () => {
+    // Given a path at the deepest an item nests.
+    const deepest = Array.from(
+      { length: 32 },
+      (_, index) => `a${String(index)}`,
+    ).join(".");
+
+    // When it is parsed, then it is read rather than refused, so the cap is
+    // the limit rather than one short of it.
+    assertIdentical(parsePath(deepest).depth, 32);
+  });
+
+  it("refuses a list index with no closing bracket", () => {
+    // Given a path that opens an index and never closes it.
+    // When it is parsed, then it is refused rather than read to the end.
+    const error = assertThrowsError(() => parsePath("lines[0"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: a list index has no closing ']' in the " +
+        "document path 'lines'",
+    );
+  });
+
+  it("refuses a dot with nothing after it", () => {
+    // Given a path that dereferences into nothing.
+    // When it is parsed, then it is refused saying what was expected.
+    const error = assertThrowsError(() => parsePath("order."));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; an attribute name " +
+        "expected, but the expression ended",
+    );
+  });
+
+  it("refuses a path that does not start with an attribute name", () => {
+    // Given a path opening with a list index, which points at nothing: an item
+    // is a map of attributes rather than a list.
+    // When it is parsed, then it is refused with nothing read yet, so there is
+    // no path to name in the refusal.
+    const error = assertThrowsError(() => parsePath("[0]"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; an attribute name was " +
+        "expected, but '[' was given",
+    );
+  });
+
+  it("refuses something that is not an attribute name where one belongs", () => {
+    // Given a path dereferencing into a number, which is not an attribute
+    // name in an expression.
+    // When it is parsed, then it is refused naming what was given.
+    const error = assertThrowsError(() => parsePath("order.1"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; an attribute name was " +
+        "expected in the document path 'order', but '1' was given",
+    );
+  });
+});

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
@@ -99,6 +99,20 @@ describe("SimDynamoDbDocumentPathParser", () => {
     );
   });
 
+  it("refuses a whole number written as a fraction", () => {
+    // Given an index that works out to a whole number but is not written as
+    // one, which real DynamoDB reads as digits and refuses.
+    // When it is parsed, then it is refused rather than rounded to 2, so a
+    // path that works here is one that works on AWS.
+    const error = assertThrowsError(() => parsePath("lines[2.0]"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: a list index is a whole number, and " +
+        "'2.0' is not in the document path 'lines'",
+    );
+  });
+
   it("refuses a path deeper than an item nests", () => {
     // Given a path of 33 attributes, one past where an item can go.
     const tooDeep = Array.from(

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
@@ -98,7 +98,15 @@ export class SimDynamoDbDocumentPathParser {
     const token = this.tokens.next("a list index");
     const index = Number(token.text);
 
-    if (token.kind !== "number" || !Number.isSafeInteger(index)) {
+    // A fraction is refused on how it was written rather than on what it works
+    // out to, so `[2.0]` is refused along with `[2.5]`. Real DynamoDB reads an
+    // index as digits, and one written any other way is a syntax error there
+    // whether or not it lands on a whole number.
+    if (
+      token.kind !== "number" ||
+      token.text.includes(".") ||
+      !Number.isSafeInteger(index)
+    ) {
       throw this.pathError(
         `a list index is a whole number, and '${token.text}' is not`,
       );

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
@@ -1,0 +1,145 @@
+import {
+  SimDynamoDbDocumentPath,
+  type SimDynamoDbDocumentPathSegment,
+} from "./sim-dynamodb-document-path.js";
+import type { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "./sim-dynamodb-expression-tokens.js";
+
+/**
+ * Real DynamoDB stops at 32 levels of nesting inside one attribute, so a path
+ * reaching past that is pointing where an item cannot go.
+ */
+const greatestDepth = 32;
+
+interface SimDynamoDbDocumentPathParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+}
+
+/**
+ * Reads one document path out of an expression.
+ *
+ * Every expression kind DynamoDB has points at parts of an item the same way,
+ * so paths are read here once. The parser stops at the first token that cannot
+ * continue the path, leaving it for whatever is reading the expression around
+ * it, such as the comma between two projected paths.
+ */
+export class SimDynamoDbDocumentPathParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly segments: SimDynamoDbDocumentPathSegment[] = [];
+
+  constructor(properties: SimDynamoDbDocumentPathParserProperties) {
+    this.tokens = properties.tokens;
+    this.names = properties.names;
+  }
+
+  /**
+   * Read a path, from its first attribute to the last thing it dereferences.
+   */
+  parse(): SimDynamoDbDocumentPath {
+    this.segments.push(this.attribute());
+
+    while (this.continues()) {
+      this.assertWithinDepth();
+    }
+
+    return new SimDynamoDbDocumentPath(this.segments);
+  }
+
+  /**
+   * Read the next step of the path, answering whether there was one.
+   */
+  private continues(): boolean {
+    if (this.tokens.takeSymbol(".")) {
+      this.segments.push(this.attribute());
+
+      return true;
+    }
+
+    if (this.tokens.takeSymbol("[")) {
+      this.segments.push({ kind: "index", index: this.index() });
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Read an attribute name, which the request may have written as a
+   * placeholder.
+   */
+  private attribute(): SimDynamoDbDocumentPathSegment {
+    const token = this.tokens.next("an attribute name");
+
+    if (token.kind === "name") {
+      return { kind: "attribute", name: token.text };
+    }
+
+    if (token.kind === "namePlaceholder") {
+      return { kind: "attribute", name: this.names.required(token.text) };
+    }
+
+    throw this.tokens.error(
+      `syntax error; an attribute name was expected${this.after()}, but ` +
+        `'${token.text}' was given`,
+    );
+  }
+
+  /**
+   * Read a list index, and the bracket that closes it.
+   */
+  private index(): number {
+    if (this.tokens.takeSymbol("-")) {
+      throw this.pathError("a list index cannot be negative");
+    }
+
+    const token = this.tokens.next("a list index");
+    const index = Number(token.text);
+
+    if (token.kind !== "number" || !Number.isSafeInteger(index)) {
+      throw this.pathError(
+        `a list index is a whole number, and '${token.text}' is not`,
+      );
+    }
+
+    if (!this.tokens.takeSymbol("]")) {
+      throw this.pathError("a list index has no closing ']'");
+    }
+
+    return index;
+  }
+
+  /**
+   * Refuse a path pointing deeper than an item can nest.
+   */
+  private assertWithinDepth(): void {
+    if (this.segments.length > greatestDepth) {
+      throw this.pathError(
+        `a document path goes at most ${greatestDepth.toString()} levels ` +
+          `deep, which is as far as an item nests`,
+      );
+    }
+  }
+
+  /**
+   * Build an error naming the path as far as it was read.
+   */
+  private pathError(reason: string): Error {
+    return this.tokens.error(`${reason}${this.after()}`);
+  }
+
+  /**
+   * Where in the path something went wrong, for a refusal to name.
+   */
+  private after(): string {
+    const read = new SimDynamoDbDocumentPath(this.segments).text;
+
+    if (read === "") {
+      return "";
+    }
+
+    return ` in the document path '${read}'`;
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
@@ -1,0 +1,71 @@
+/**
+ * One step of a document path: an attribute of a map.
+ */
+export interface SimDynamoDbAttributeSegment {
+  readonly kind: "attribute";
+  readonly name: string;
+}
+
+/**
+ * One step of a document path: an element of a list.
+ */
+export interface SimDynamoDbIndexSegment {
+  readonly kind: "index";
+  readonly index: number;
+}
+
+/**
+ * One step of a document path.
+ */
+export type SimDynamoDbDocumentPathSegment =
+  SimDynamoDbAttributeSegment | SimDynamoDbIndexSegment;
+
+/**
+ * Where in an item one expression is pointing.
+ *
+ * A path is an attribute name, then any number of further attributes and list
+ * indexes: `address.city`, `lines[0].sku`. It says where to look rather than
+ * what is there, so the same path reads an item that has it and passes over an
+ * item that does not.
+ */
+export class SimDynamoDbDocumentPath {
+  public readonly segments: readonly SimDynamoDbDocumentPathSegment[];
+
+  constructor(segments: readonly SimDynamoDbDocumentPathSegment[]) {
+    this.segments = segments;
+  }
+
+  /**
+   * How many levels deep this path reaches.
+   */
+  get depth(): number {
+    return this.segments.length;
+  }
+
+  /**
+   * The path written back out, for a refusal to name.
+   *
+   * Placeholders are gone by this point, so this is the path the request meant
+   * rather than the path it wrote.
+   */
+  get text(): string {
+    return this.segments
+      .map((segment, index) => this.segmentText(segment, index))
+      .join("");
+  }
+
+  private segmentText(
+    segment: SimDynamoDbDocumentPathSegment,
+    index: number,
+  ): string {
+    if (segment.kind === "index") {
+      return `[${segment.index.toString()}]`;
+    }
+
+    if (index === 0) {
+      return segment.name;
+    }
+
+    return `.${segment.name}`;
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-error.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-error.ts
@@ -1,0 +1,17 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * Build the error one expression parameter is refused with.
+ *
+ * Real DynamoDB names the parameter that was wrong before saying what was wrong
+ * with it, because a request can carry several expressions at once. Every
+ * refusal here goes through this, so they all read the same way.
+ */
+export function simDynamoDbExpressionError(
+  expressionName: string,
+  reason: string,
+): SimDynamoDbValidationException {
+  return new SimDynamoDbValidationException(
+    `Invalid ${expressionName}: ${reason}`,
+  );
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-placeholders.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-placeholders.iso.test.ts
@@ -1,0 +1,111 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+
+function names(
+  entries?: Readonly<Record<string, string>>,
+): SimDynamoDbExpressionPlaceholders<string> {
+  return new SimDynamoDbExpressionPlaceholders({
+    parameterName: "ExpressionAttributeNames",
+    marker: "#",
+    entries,
+  });
+}
+
+describe("SimDynamoDbExpressionPlaceholders", () => {
+  it("answers with what a placeholder stands for", () => {
+    // Given names defining a placeholder for a reserved word.
+    const placeholders = names({ "#s": "status" });
+
+    // When an expression uses it, then it stands for the attribute name, and
+    // nothing is left over.
+    assertIdentical(placeholders.required("#s"), "status");
+    placeholders.assertAllUsed();
+  });
+
+  it("counts a placeholder used more than once as used once", () => {
+    // Given one placeholder used twice, as two paths into the same map would
+    // use it.
+    const placeholders = names({ "#s": "status" });
+
+    placeholders.required("#s");
+    placeholders.required("#s");
+
+    // When the entries are checked, then nothing is unused.
+    placeholders.assertAllUsed();
+  });
+
+  it("refuses a placeholder the request never defined", () => {
+    // Given names defining nothing.
+    const placeholders = names();
+
+    // When an expression uses a placeholder, then it is refused naming the
+    // placeholder, rather than read as an attribute called '#s'.
+    const error = assertThrowsError(() => placeholders.required("#s"));
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "ExpressionAttributeNames does not define #s, which an expression uses",
+    );
+  });
+
+  it("refuses an entry no expression used", () => {
+    // Given names defining two placeholders where an expression uses one, as a
+    // request has after an expression is edited and the old placeholder is
+    // left behind.
+    const placeholders = names({ "#s": "status", "#c": "city" });
+
+    placeholders.required("#s");
+
+    // When the entries are checked, then the leftover is refused by name.
+    const error = assertThrowsError(() => {
+      placeholders.assertAllUsed();
+    });
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "Value provided in ExpressionAttributeNames is unused in expressions: #c",
+    );
+  });
+
+  it("refuses a key that is not a placeholder", () => {
+    // Given names keyed by the attribute name rather than by a placeholder,
+    // which would leave every placeholder in the expression undefined.
+    // When the placeholders are built, then the key is refused by name.
+    const error = assertThrowsError(() => names({ status: "status" }));
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "ExpressionAttributeNames contains the invalid key status. A " +
+        "placeholder starts with '#'.",
+    );
+  });
+
+  it("holds the values parameter the same way", () => {
+    // Given the other placeholder parameter, which maps to attribute values
+    // rather than to names.
+    const values = new SimDynamoDbExpressionPlaceholders({
+      parameterName: "ExpressionAttributeValues",
+      marker: ":",
+      entries: { ":wanted": { S: "shipped" } },
+    });
+
+    // When one is read, then it comes back, and the same rules apply: both
+    // parameters work the same way, so they are held the same way.
+    assertIdentical(values.required(":wanted").S, "shipped");
+    assertIdentical(
+      assertThrowsError(() => values.required(":other")).message,
+      "ExpressionAttributeValues does not define :other, which an expression " +
+        "uses",
+    );
+  });
+});

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-placeholders.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-placeholders.ts
@@ -1,0 +1,93 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+interface SimDynamoDbExpressionPlaceholdersProperties<Value> {
+  /** The request parameter the entries came from, for a refusal to name. */
+  readonly parameterName: string;
+  /** The marker every key of that parameter starts with, `#` or `:`. */
+  readonly marker: string;
+  readonly entries?: Readonly<Record<string, Value>> | undefined;
+}
+
+/**
+ * The placeholders one request parameter defines for its expressions.
+ *
+ * `ExpressionAttributeNames` and `ExpressionAttributeValues` work the same way:
+ * a map of placeholders to what they stand for, where the expression and the
+ * map have to agree exactly. This holds either of them.
+ *
+ * It fails closed in both directions. A placeholder an expression uses and the
+ * request does not define is refused, and so is an entry the request defines
+ * and no expression uses. Real DynamoDB refuses both, and the unused one is
+ * what a request hits after an expression is edited and the old placeholder is
+ * left behind.
+ */
+export class SimDynamoDbExpressionPlaceholders<Value> {
+  private readonly parameterName: string;
+  private readonly marker: string;
+  private readonly entries: ReadonlyMap<string, Value>;
+  private readonly used = new Set<string>();
+
+  constructor(properties: SimDynamoDbExpressionPlaceholdersProperties<Value>) {
+    this.parameterName = properties.parameterName;
+    this.marker = properties.marker;
+    this.entries = new Map(Object.entries(properties.entries ?? {}));
+
+    this.assertKeysArePlaceholders();
+  }
+
+  /**
+   * What a placeholder stands for, refusing one the request never defined.
+   */
+  required(placeholder: string): Value {
+    const value = this.entries.get(placeholder);
+
+    if (value === undefined) {
+      throw new SimDynamoDbValidationException(
+        `${this.parameterName} does not define ${placeholder}, which an ` +
+          `expression uses`,
+      );
+    }
+
+    this.used.add(placeholder);
+
+    return value;
+  }
+
+  /**
+   * Refuse an entry no expression used.
+   *
+   * Called once every expression on the request has been read, so a placeholder
+   * used by any one of them counts as used.
+   */
+  assertAllUsed(): void {
+    const unused = this.entries
+      .keys()
+      .filter((placeholder) => !this.used.has(placeholder))
+      .toArray();
+
+    if (unused.length > 0) {
+      throw new SimDynamoDbValidationException(
+        `Value provided in ${this.parameterName} is unused in ` +
+          `expressions: ${unused.join(", ")}`,
+      );
+    }
+  }
+
+  /**
+   * Refuse a key that is not a placeholder at all.
+   *
+   * A map keyed by the bare attribute name rather than by `#name` would leave
+   * every placeholder in the expression undefined, which is a confusing way to
+   * find out the key was written wrong.
+   */
+  private assertKeysArePlaceholders(): void {
+    for (const key of this.entries.keys()) {
+      if (!key.startsWith(this.marker)) {
+        throw new SimDynamoDbValidationException(
+          `${this.parameterName} contains the invalid key ${key}. A ` +
+            `placeholder starts with '${this.marker}'.`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-token-reader.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-token-reader.ts
@@ -1,0 +1,155 @@
+import { simDynamoDbExpressionError } from "./sim-dynamodb-expression-error.js";
+import type {
+  SimDynamoDbExpressionToken,
+  SimDynamoDbExpressionTokenKind,
+} from "./sim-dynamodb-expression-token.js";
+
+/**
+ * An attribute name written into an expression: a letter or underscore, then
+ * letters, numbers and underscores. A name outside that has to be written as an
+ * ExpressionAttributeNames placeholder, on real DynamoDB as well as here.
+ */
+const namePattern = /^[A-Za-z_]\w*/;
+
+/**
+ * A placeholder, after its leading `#` or `:`.
+ */
+const placeholderPattern = /^\w+/;
+
+/**
+ * The whole part of a number, which is a list index in the expressions
+ * supported so far.
+ */
+const digitsPattern = /^\d+/;
+
+/**
+ * The fractional part of a number, read straight after the whole part.
+ *
+ * A fraction is read as one number rather than as a number, a dot and another
+ * number, so an index of `1.5` is refused as a fraction rather than as a
+ * syntax error somewhere after it.
+ */
+const fractionPattern = /^\.\d+/;
+
+/**
+ * The single characters that mean something in the expressions supported so
+ * far.
+ *
+ * This set grows as condition, filter and update expressions arrive. Until
+ * then, a character outside it is refused rather than passed through, so an
+ * expression this simulation cannot evaluate fails rather than half works.
+ */
+const symbols: ReadonlySet<string> = new Set([".", ",", "[", "]", "-"]);
+
+/**
+ * A token before it is told where in the expression it was found.
+ */
+export type SimDynamoDbUnplacedToken = Omit<
+  SimDynamoDbExpressionToken,
+  "position"
+>;
+
+/**
+ * Reads the one token an expression starts with.
+ *
+ * This knows what each kind of token looks like. Where the tokens are and what
+ * order they come in is not its business, so it takes whatever is left of an
+ * expression and answers with the first thing in it.
+ */
+export class SimDynamoDbExpressionTokenReader {
+  private readonly expressionName: string;
+
+  constructor(expressionName: string) {
+    this.expressionName = expressionName;
+  }
+
+  /**
+   * Read the token at the start of what is left of an expression.
+   */
+  read(remaining: string): SimDynamoDbUnplacedToken {
+    return (
+      this.name(remaining) ??
+      this.placeholder("namePlaceholder", "#", remaining) ??
+      this.placeholder("valuePlaceholder", ":", remaining) ??
+      this.number(remaining) ??
+      this.symbol(remaining)
+    );
+  }
+
+  /**
+   * Read an attribute name written into the expression itself.
+   */
+  private name(remaining: string): SimDynamoDbUnplacedToken | undefined {
+    const text = namePattern.exec(remaining)?.[0];
+
+    if (text === undefined) {
+      return undefined;
+    }
+
+    return { kind: "name", text };
+  }
+
+  /**
+   * Read a placeholder, which is its marker and the word after it.
+   *
+   * A marker with no word after it is refused here rather than read as a
+   * marker on its own, since a bare `#` names nothing.
+   */
+  private placeholder(
+    kind: SimDynamoDbExpressionTokenKind,
+    marker: string,
+    remaining: string,
+  ): SimDynamoDbUnplacedToken | undefined {
+    if (!remaining.startsWith(marker)) {
+      return undefined;
+    }
+
+    const named = remaining.slice(marker.length);
+    const word = placeholderPattern.exec(named)?.[0];
+
+    if (word === undefined) {
+      throw this.error(
+        `syntax error; the placeholder marker '${marker}' names nothing`,
+      );
+    }
+
+    return { kind, text: `${marker}${word}` };
+  }
+
+  /**
+   * Read a number, which is its digits and the fraction after them if it has
+   * one.
+   */
+  private number(remaining: string): SimDynamoDbUnplacedToken | undefined {
+    const digits = digitsPattern.exec(remaining)?.[0];
+
+    if (digits === undefined) {
+      return undefined;
+    }
+
+    const after = remaining.slice(digits.length);
+    const fraction = fractionPattern.exec(after)?.[0] ?? "";
+
+    return { kind: "number", text: `${digits}${fraction}` };
+  }
+
+  /**
+   * Read a single character that means something on its own.
+   */
+  private symbol(remaining: string): SimDynamoDbUnplacedToken {
+    const character = remaining.slice(0, 1);
+
+    if (!symbols.has(character)) {
+      throw this.error(`syntax error; unexpected character '${character}'`);
+    }
+
+    return { kind: "symbol", text: character };
+  }
+
+  /**
+   * Build the error the expression being read is refused with.
+   */
+  private error(reason: string): Error {
+    return simDynamoDbExpressionError(this.expressionName, reason);
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-token.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-token.ts
@@ -1,0 +1,20 @@
+/**
+ * What one piece of a DynamoDB expression is.
+ *
+ * A placeholder keeps its `#` or `:` in its text, so an error can name it the
+ * way the request wrote it.
+ */
+export type SimDynamoDbExpressionTokenKind =
+  "name" | "namePlaceholder" | "valuePlaceholder" | "number" | "symbol";
+
+/**
+ * One piece of a DynamoDB expression.
+ *
+ * The position is where the token starts in the expression text, so a refusal
+ * can say where it went wrong rather than only what was wrong.
+ */
+export interface SimDynamoDbExpressionToken {
+  readonly kind: SimDynamoDbExpressionTokenKind;
+  readonly text: string;
+  readonly position: number;
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbExpressionToken } from "./sim-dynamodb-expression-token.js";
+import { SimDynamoDbExpressionTokeniser } from "./sim-dynamodb-expression-tokeniser.js";
+
+function tokenise(expression: string): readonly SimDynamoDbExpressionToken[] {
+  return new SimDynamoDbExpressionTokeniser({
+    expressionName: "ProjectionExpression",
+  }).tokenise(expression);
+}
+
+describe("SimDynamoDbExpressionTokeniser", () => {
+  it("reads the pieces a document path is made of", () => {
+    // Given an expression naming an attribute, a nested attribute and an
+    // element of a list.
+    // When it is tokenised.
+    const tokens = tokenise("address.lines[10]");
+
+    // Then each piece comes back with what it is, so a parser reads meaning
+    // rather than characters.
+    assertArrayLength(tokens, 6);
+    assertIdentical(tokens.at(0)?.kind, "name");
+    assertIdentical(tokens.at(0)?.text, "address");
+    assertIdentical(tokens.at(1)?.kind, "symbol");
+    assertIdentical(tokens.at(2)?.text, "lines");
+    assertIdentical(tokens.at(3)?.text, "[");
+    assertIdentical(tokens.at(4)?.kind, "number");
+    assertIdentical(tokens.at(4)?.text, "10");
+    assertIdentical(tokens.at(5)?.text, "]");
+  });
+
+  it("reads a name placeholder and a value placeholder with their markers", () => {
+    // Given an expression using both kinds of placeholder.
+    // When it is tokenised.
+    const tokens = tokenise("#status, :wanted");
+
+    // Then each keeps its marker, so a refusal names it as the request wrote
+    // it.
+    assertIdentical(tokens.at(0)?.kind, "namePlaceholder");
+    assertIdentical(tokens.at(0)?.text, "#status");
+    assertIdentical(tokens.at(1)?.text, ",");
+    assertIdentical(tokens.at(2)?.kind, "valuePlaceholder");
+    assertIdentical(tokens.at(2)?.text, ":wanted");
+  });
+
+  it("reads a fraction as one number", () => {
+    // Given a list index written as a fraction, which is not an index.
+    // When it is tokenised.
+    const tokens = tokenise("[1.5]");
+
+    // Then the fraction is one token, so whatever reads it can say the index
+    // is not whole rather than fail somewhere after it.
+    assertArrayLength(tokens, 3);
+    assertIdentical(tokens.at(1)?.kind, "number");
+    assertIdentical(tokens.at(1)?.text, "1.5");
+  });
+
+  it("skips whitespace between tokens and reports where each starts", () => {
+    // Given an expression with spaces around its comma, as a request written
+    // by hand usually has.
+    // When it is tokenised.
+    const tokens = tokenise("  id ,  note");
+
+    // Then the spaces are gone, and each token knows where it came from.
+    assertArrayLength(tokens, 3);
+    assertIdentical(tokens.at(0)?.position, 2);
+    assertIdentical(tokens.at(1)?.position, 5);
+    assertIdentical(tokens.at(2)?.position, 8);
+  });
+
+  it("reads an empty expression as no tokens", () => {
+    // Given an expression with nothing in it.
+    // When it is tokenised, then there is nothing to read, which is left for
+    // the parser to refuse in its own terms.
+    assertArrayLength(tokenise(" ".repeat(3)), 0);
+  });
+
+  it("refuses a placeholder marker naming nothing", () => {
+    // Given a bare marker, which stands for no placeholder at all.
+    // When it is tokenised, then it is refused rather than read as a marker on
+    // its own.
+    const error = assertThrowsError(() => tokenise("#"));
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; the placeholder marker " +
+        "'#' names nothing",
+    );
+  });
+
+  it("refuses a character that means nothing in an expression", () => {
+    // Given an expression carrying a character no supported expression uses.
+    // When it is tokenised, then it is refused rather than passed through to a
+    // parser that would ignore it.
+    const error = assertThrowsError(() => tokenise("id = 3"));
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "Invalid ProjectionExpression: syntax error; unexpected character '='",
+    );
+  });
+
+  it("names the expression it was reading in a refusal", () => {
+    // Given a tokeniser reading some other expression parameter.
+    const tokeniser = new SimDynamoDbExpressionTokeniser({
+      expressionName: "ConditionExpression",
+    });
+
+    // When it refuses something, then the refusal names that parameter, since
+    // one request can carry several expressions.
+    const error = assertThrowsError(() => tokeniser.tokenise("%"));
+
+    assertIdentical(
+      error.message,
+      "Invalid ConditionExpression: syntax error; unexpected character '%'",
+    );
+  });
+});

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.ts
@@ -1,0 +1,56 @@
+import type { SimDynamoDbExpressionToken } from "./sim-dynamodb-expression-token.js";
+import { SimDynamoDbExpressionTokenReader } from "./sim-dynamodb-expression-token-reader.js";
+
+/**
+ * The gap between two tokens, which means nothing on its own.
+ */
+const whitespacePattern = /^\s+/;
+
+interface SimDynamoDbExpressionTokeniserProperties {
+  readonly expressionName: string;
+}
+
+/**
+ * Reads a DynamoDB expression into the pieces it is made of.
+ *
+ * Every expression parameter DynamoDB has is written in the same lexical
+ * shapes, so they are read here once rather than once per expression kind.
+ * What the pieces are allowed to say is left to whatever parses them.
+ *
+ * This walks the expression and records where each token was found. What each
+ * kind of token looks like belongs to
+ * {@link SimDynamoDbExpressionTokenReader}.
+ */
+export class SimDynamoDbExpressionTokeniser {
+  private readonly reader: SimDynamoDbExpressionTokenReader;
+
+  constructor(properties: SimDynamoDbExpressionTokeniserProperties) {
+    this.reader = new SimDynamoDbExpressionTokenReader(
+      properties.expressionName,
+    );
+  }
+
+  /**
+   * Read an expression into its tokens, skipping the whitespace between them.
+   */
+  tokenise(expression: string): readonly SimDynamoDbExpressionToken[] {
+    const tokens: SimDynamoDbExpressionToken[] = [];
+    let position = 0;
+
+    while (position < expression.length) {
+      const remaining = expression.slice(position);
+      const whitespace = whitespacePattern.exec(remaining)?.[0];
+
+      if (whitespace === undefined) {
+        const read = this.reader.read(remaining);
+
+        tokens.push({ ...read, position });
+        position += read.text.length;
+      } else {
+        position += whitespace.length;
+      }
+    }
+
+    return tokens;
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokens.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokens.ts
@@ -1,0 +1,78 @@
+import { simDynamoDbExpressionError } from "./sim-dynamodb-expression-error.js";
+import type { SimDynamoDbExpressionToken } from "./sim-dynamodb-expression-token.js";
+
+interface SimDynamoDbExpressionTokensProperties {
+  readonly expressionName: string;
+  readonly tokens: readonly SimDynamoDbExpressionToken[];
+}
+
+/**
+ * A parser's place in the tokens of one expression.
+ *
+ * Every expression kind is parsed by reading forwards through its tokens, so
+ * how far along it is, and what happens when it runs out, live here rather than
+ * in each parser.
+ */
+export class SimDynamoDbExpressionTokens {
+  private readonly expressionName: string;
+  private readonly tokens: readonly SimDynamoDbExpressionToken[];
+  private position = 0;
+
+  constructor(properties: SimDynamoDbExpressionTokensProperties) {
+    this.expressionName = properties.expressionName;
+    this.tokens = properties.tokens;
+  }
+
+  /**
+   * Whether every token has been read.
+   */
+  get atEnd(): boolean {
+    return this.position >= this.tokens.length;
+  }
+
+  /**
+   * The next token, without reading it.
+   */
+  peek(): SimDynamoDbExpressionToken | undefined {
+    return this.tokens[this.position];
+  }
+
+  /**
+   * Read the next token, refusing an expression that has run out.
+   */
+  next(expected: string): SimDynamoDbExpressionToken {
+    const upcoming = this.peek();
+
+    if (upcoming === undefined) {
+      throw this.error(
+        `syntax error; ${expected} expected, but the expression ended`,
+      );
+    }
+
+    this.position += 1;
+
+    return upcoming;
+  }
+
+  /**
+   * Read the next token when it is a symbol, and leave it otherwise.
+   */
+  takeSymbol(text: string): boolean {
+    const candidate = this.peek();
+
+    if (candidate?.kind !== "symbol" || candidate.text !== text) {
+      return false;
+    }
+
+    this.position += 1;
+
+    return true;
+  }
+
+  /**
+   * Build the error this expression is refused with.
+   */
+  error(reason: string): Error {
+    return simDynamoDbExpressionError(this.expressionName, reason);
+  }
+}

--- a/src/service/dynamodb/item/sim-dynamodb-item.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-item.ts
@@ -48,6 +48,20 @@ export class SimDynamoDbItem {
   }
 
   /**
+   * Hold attributes that have already been read and checked.
+   *
+   * Nothing is checked again here. It is for building an item out of another
+   * item's attributes, such as the part of one a projection asked for, where
+   * every value came from an item that was checked on the way in and the
+   * result is no bigger than that one.
+   */
+  static ofAttributes(
+    attributes: ReadonlyMap<string, SimDynamoDbValue>,
+  ): SimDynamoDbItem {
+    return new this(attributes);
+  }
+
+  /**
    * Get one of this item's attributes, if it has it.
    */
   attribute(name: string): SimDynamoDbValue | undefined {
@@ -59,6 +73,13 @@ export class SimDynamoDbItem {
    */
   attributeNames(): readonly string[] {
     return this.attributes.keys().toArray();
+  }
+
+  /**
+   * Every attribute this item carries, in the order they arrived.
+   */
+  entries(): ReadonlyMap<string, SimDynamoDbValue> {
+    return this.attributes;
   }
 
   /**


### PR DESCRIPTION
GetItem takes a ProjectionExpression, returning only the document paths it names with the nested map and list shape kept. A path the item does not have is left out rather than refused.

The tokenising, document path parsing and placeholder substitution behind it live under expression/, shared with the condition, filter and update expressions that follow, so the parsers cannot drift apart over what a.b[0] means. Placeholders fail closed in both directions, and two paths where one contains the other are refused as real DynamoDB refuses them.

Resolves https://github.com/KensioSoftware/yulin/issues/256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for DynamoDB `GetItem` projection expressions.
  * Supports nested attributes, list indexes, document paths, and expression-name placeholders.
  * Returns only requested attributes, omitting unavailable values and compacting projected lists.
  * Distinguishes existing items with no projected fields from missing items.
  * Added validation for malformed expressions, invalid paths, unused placeholders, and nesting limits.

* **Documentation**
  * Added usage examples and comprehensive projection-expression guidance.

* **Tests**
  * Added coverage for projection behavior, validation, nested paths, aliases, list indexing, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->