### PR TITLE
feat: guard simulated DynamoDB writes with condition expressions

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -459,13 +459,18 @@ works as well as `AND`.
 The functions are `attribute_exists`, `attribute_not_exists`, `attribute_type`, `begins_with`,
 `contains` and `size`. Function names are read in lower case only, as they are on real AWS.
 `attribute_exists` is true for an attribute stored as `NULL`, since `NULL` is a value rather than an
-absent one. `size` is a number rather than a condition, so it goes beside a comparator: a string and
+absent one. The first operand of every one of them names a path in the item, so a supplied value
+there is refused rather than compared. `size` is a number rather than a condition, so it goes beside a comparator: a string and
 binary measure in bytes, and a set, a list or a map in how many things it holds.
 
 Strings compare by UTF-8 byte order, numbers compare by their digits rather than by what they round
-to, and binary compares as unsigned bytes. A comparison between two different types is false rather
-than an error, and so is one naming a path the item does not have. That is what real DynamoDB does,
-and it is what lets one condition guard items that do not all carry the same attributes.
+to, and binary compares as unsigned bytes.
+
+A comparison between two different types is never an error. Equality works across types, so a string
+and a number are not equal: `=` is false and `<>` is true. Ordering does not, so `<`, `<=`, `>` and
+`>=` are all false between them, as they are for a path the item does not have. That is what real
+DynamoDB does, and it is what lets one condition guard items that do not all carry the same
+attributes.
 
 `ExpressionAttributeNames` and `ExpressionAttributeValues` have to agree exactly with the expression,
 in both directions: a placeholder the request does not define is a `ValidationException`, and so is

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -367,6 +367,110 @@ reports nothing removed. Its `ReturnValues` takes `NONE` and `ALL_OLD`, as `PutI
 
 Both take the table's name or its ARN, as the table commands do.
 
+## Conditional writes
+
+`PutItem` and `DeleteItem` take a `ConditionExpression`, which is checked against whatever is stored
+under the key before anything changes. A condition that does not hold leaves the item exactly as it
+was and throws `ConditionalCheckFailedException`, with the name and message real DynamoDB uses.
+
+That is how a write becomes an insert if absent, and how a version attribute becomes optimistic
+locking.
+
+```typescript sim-dynamodb-conditional-write
+/**
+ * Inserting only if absent, and writing only against the version last read.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const order = {
+  TableName: "FoobarTable",
+  Item: { orderId: { S: "order-1" }, version: { N: "1" } },
+  ConditionExpression: "attribute_not_exists(orderId)",
+};
+
+// The key is free, so the insert goes through.
+await dynamoDb.putItem(new PutItemCommand(order));
+
+// The key is taken now, so the same insert is turned away.
+try {
+  await dynamoDb.putItem(new PutItemCommand(order));
+} catch (error) {
+  console.log((error as Error).name); // "ConditionalCheckFailedException"
+}
+
+// Optimistic locking: write only if the version is still the one last read.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+    ConditionExpression: "version = :was",
+    ExpressionAttributeValues: { ":was": { N: "1" } },
+  }),
+);
+
+// A second writer holding the same stale version now loses the race.
+try {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FoobarTable",
+      Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+      ConditionExpression: "version = :was",
+      ExpressionAttributeValues: { ":was": { N: "1" } },
+      ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+    }),
+  );
+} catch (error) {
+  // ALL_OLD puts the item it lost to on the exception, so a retry needs no
+  // second read.
+  console.log((error as { Item?: Record<string, { N?: string }> }).Item);
+  // { orderId: { S: "order-1" }, version: { N: "2" } }
+}
+```
+
+`ReturnValuesOnConditionCheckFailure` takes `NONE` and `ALL_OLD`. `ALL_OLD` puts the stored item on
+the exception as `Item`, and there is no `Item` when the key held nothing.
+
+The expression is read before the table is reached, so an expression DynamoDB would refuse is
+refused whether or not the key holds anything.
+
+### What a condition can say
+
+The comparators are `=`, `<>`, `<`, `<=`, `>` and `>=`. `BETWEEN` takes two bounds and counts both as
+inside. `IN` takes up to 100 operands. `AND`, `OR`, `NOT` and brackets combine them, with `NOT`
+binding tighter than `AND` and `AND` tighter than `OR`. Keywords are read in any case, so `and`
+works as well as `AND`.
+
+The functions are `attribute_exists`, `attribute_not_exists`, `attribute_type`, `begins_with`,
+`contains` and `size`. Function names are read in lower case only, as they are on real AWS.
+`attribute_exists` is true for an attribute stored as `NULL`, since `NULL` is a value rather than an
+absent one. `size` is a number rather than a condition, so it goes beside a comparator: a string and
+binary measure in bytes, and a set, a list or a map in how many things it holds.
+
+Strings compare by UTF-8 byte order, numbers compare by their digits rather than by what they round
+to, and binary compares as unsigned bytes. A comparison between two different types is false rather
+than an error, and so is one naming a path the item does not have. That is what real DynamoDB does,
+and it is what lets one condition guard items that do not all carry the same attributes.
+
+`ExpressionAttributeNames` and `ExpressionAttributeValues` have to agree exactly with the expression,
+in both directions: a placeholder the request does not define is a `ValidationException`, and so is
+an entry no expression uses.
+
 ## Projecting attributes
 
 `GetItem` takes a `ProjectionExpression`, which is a comma-separated list of document paths. Only
@@ -684,6 +788,9 @@ authorizes against `*`.
 - `ProjectionExpression` on `GetItem`, with document paths, list indexing and `ExpressionAttributeNames`
   placeholders.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
+- `ConditionExpression` on `PutItem` and `DeleteItem`, with the six comparators, `BETWEEN`, `IN`,
+  `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
+  `begins_with`, `contains` and `size` functions.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name and `Fn::GetAtt … Arn` the table ARN.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
@@ -738,10 +845,15 @@ authorizes against `*`.
   evaluated.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
   so a test cannot observe a stale read here the way it might against a real table.
-- Condition expressions are not simulated. `ConditionExpression`, `ExpressionAttributeNames`,
-  `ExpressionAttributeValues`, `Expected` and `ConditionalOperator` are refused rather than ignored,
-  since a condition that is never evaluated would let a write or a delete through that DynamoDB would
-  have turned away.
+- Condition expressions are simulated on `PutItem` and `DeleteItem` only. `UpdateItem`, the
+  transactional condition checks and the key condition and filter expressions of `Query` and `Scan`
+  are not implemented yet, so there is nothing else to guard.
+- The legacy `Expected` and `ConditionalOperator` are refused rather than ignored, since an
+  expectation that is never evaluated would let a write or a delete through that DynamoDB would have
+  turned away. `ConditionExpression` replaced them, and real DynamoDB has built nothing on them
+  since.
+- The 4 KB limit on an expression and the 300 operator limit are not enforced. Nothing here is slower
+  for a long expression, so an expression real DynamoDB would refuse for its size is evaluated.
 - Capacity and item collection reporting are not simulated. `ReturnConsumedCapacity` and
   `ReturnItemCollectionMetrics` are refused unless they name `NONE`.
 - A `Key` that does not match the table's key schema is refused with the attribute named. Real

--- a/docs/services/dynamodb/sim-dynamodb-conditional-write.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-conditional-write.example.ts
@@ -1,0 +1,64 @@
+/**
+ * Inserting only if absent, and writing only against the version last read.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const order = {
+  TableName: "FoobarTable",
+  Item: { orderId: { S: "order-1" }, version: { N: "1" } },
+  ConditionExpression: "attribute_not_exists(orderId)",
+};
+
+// The key is free, so the insert goes through.
+await dynamoDb.putItem(new PutItemCommand(order));
+
+// The key is taken now, so the same insert is turned away.
+try {
+  await dynamoDb.putItem(new PutItemCommand(order));
+} catch (error) {
+  console.log((error as Error).name); // "ConditionalCheckFailedException"
+}
+
+// Optimistic locking: write only if the version is still the one last read.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+    ConditionExpression: "version = :was",
+    ExpressionAttributeValues: { ":was": { N: "1" } },
+  }),
+);
+
+// A second writer holding the same stale version now loses the race.
+try {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FoobarTable",
+      Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+      ConditionExpression: "version = :was",
+      ExpressionAttributeValues: { ":was": { N: "1" } },
+      ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+    }),
+  );
+} catch (error) {
+  // ALL_OLD puts the item it lost to on the exception, so a retry needs no
+  // second read.
+  console.log((error as { Item?: Record<string, { N?: string }> }).Item);
+  // { orderId: { S: "order-1" }, version: { N: "2" } }
+}

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -293,6 +293,10 @@ Important behavior:
   free succeeds and reports nothing removed.
 - DeleteItem takes the same `ReturnValues` as PutItem, through `SimDynamoDbReturnValues`, which is
   where the two modes and the error text for a third live.
+- Both take a `ConditionExpression`, through the shared `SimDynamoDbConditionCheck`. The condition is
+  checked against what is stored before anything changes, so a write it turns away leaves the item
+  exactly as it was. PutItem finds what is stored through `SimDynamoDbTable.itemUnder`, which reads
+  the key out of the item being written rather than out of a Key of its own.
 - GetItem refuses the legacy `AttributesToGet` and a `ReturnConsumedCapacity` that asks for anything,
   in `sim-dynamodb-unsimulated-item-read-input.ts`. `ExpressionAttributeNames` with no expression to
   use them in is a `ValidationException` rather than an unsupported operation, because real DynamoDB
@@ -332,7 +336,29 @@ The shared parts:
   `Invalid <parameter>: <reason>`. A request can carry several expressions, so naming which one was
   wrong matters.
 
-`expression/projection/` is the first consumer. `readSimDynamoDbProjection` reads a
+`expression/condition/` reads a ConditionExpression into a `SimDynamoDbCondition`, which answers yes
+or no for a `SimDynamoDbConditionSubject`: the item stored under the key, which may be nothing at
+all. That is what makes `attribute_not_exists(id)` an insert if absent, since every path resolves to
+nothing when there is no item.
+
+`SimDynamoDbConditionParser` is recursive descent with one method per precedence level, so the
+precedence DynamoDB documents is the shape of the class rather than a table somewhere. The operands
+and the function calls have parsers of their own, because deciding whether `size` is a call or an
+attribute named `size` is a different job from deciding whether an OR binds looser than an AND.
+
+The comparison rules live in `item/sim-dynamodb-value-comparison.ts` rather than inside the
+evaluator, because sort key conditions and filter expressions compare the same way when `Query` and
+`Scan` arrive. Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare
+through `SimDynamoDbNumber.compareTo` so digits past what a JavaScript number holds still order
+correctly, and binary compares as unsigned bytes. Two values of different types have no order at all,
+which is what makes a comparison between them false rather than an error.
+
+`SimDynamoDbConditionCheck` under `command/item/` is what PutItem and DeleteItem both use. It reads
+the expression before the table is reached, so an expression DynamoDB would refuse is refused
+whether or not the key holds anything, and it throws
+`SimDynamoDbConditionalCheckFailedException` before anything is written.
+
+`expression/projection/` is the other consumer. `readSimDynamoDbProjection` reads a
 `ProjectionExpression` and its names into a `SimDynamoDbProjection`, and `SimDynamoDbProjectionNode`
 merges the paths into a tree before anything is read, so `address.city` and `address.postcode` become
 one `address` holding two attributes. Two paths where one contains the other are refused there, as
@@ -396,6 +422,12 @@ Current specialized errors:
   - name: `ValidationException`
   - HTTP status: `400`
   - used for request input real DynamoDB would refuse
+- `SimDynamoDbConditionalCheckFailedException`
+  - name: `ConditionalCheckFailedException`
+  - HTTP status: `400`
+  - used when a ConditionExpression did not hold, with the message real DynamoDB uses so SDK error
+    handling matches. It carries the stored item when the request asked for it with
+    `ReturnValuesOnConditionCheckFailure`.
 - `SimDynamoDbUnsupportedOperation`
   - name: `UnsupportedOperation`
   - HTTP status: `400`

--- a/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
@@ -1,0 +1,118 @@
+import {
+  SimDynamoDbConditionalCheckFailedException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import { readSimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition-expression.js";
+import type { SimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition.js";
+import { SimDynamoDbConditionSubject } from "../../expression/condition/sim-dynamodb-condition-subject.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeValue } from "./item.types.js";
+
+/**
+ * What a request can ask to be given back when its condition turns it away.
+ */
+const failureModes: ReadonlySet<string> = new Set(["NONE", "ALL_OLD"]);
+
+interface SimDynamoDbConditionCheckInput {
+  readonly ConditionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ReturnValuesOnConditionCheckFailure?: string | undefined;
+}
+
+interface SimDynamoDbConditionCheckProperties {
+  readonly condition: SimDynamoDbCondition | undefined;
+  readonly reportsItem: boolean;
+}
+
+/**
+ * The condition a write is guarded by, and what happens when it does not hold.
+ *
+ * PutItem and DeleteItem guard a write the same way, so they check it the same
+ * way. The check is against whatever is stored under the key already, which may
+ * be nothing: that is what makes `attribute_not_exists` an insert if absent.
+ */
+export class SimDynamoDbConditionCheck {
+  private readonly condition: SimDynamoDbCondition | undefined;
+  private readonly reportsItem: boolean;
+
+  private constructor(properties: SimDynamoDbConditionCheckProperties) {
+    this.condition = properties.condition;
+    this.reportsItem = properties.reportsItem;
+  }
+
+  /**
+   * Read the condition a request carries, before anything is looked up.
+   *
+   * An expression DynamoDB would refuse is refused whether or not the key holds
+   * anything, so a bad expression fails the same way every time.
+   */
+  static read(
+    input: SimDynamoDbConditionCheckInput,
+    operation: string,
+  ): SimDynamoDbConditionCheck {
+    return new this({
+      condition: readSimDynamoDbCondition(input),
+      reportsItem: this.reportsItemFor(input, operation),
+    });
+  }
+
+  /**
+   * Whether the request asked for the item that turned it away.
+   */
+  private static reportsItemFor(
+    input: SimDynamoDbConditionCheckInput,
+    operation: string,
+  ): boolean {
+    const asked = input.ReturnValuesOnConditionCheckFailure;
+
+    if (asked === undefined) {
+      return false;
+    }
+
+    if (!failureModes.has(asked)) {
+      throw new SimDynamoDbValidationException(
+        `ReturnValuesOnConditionCheckFailure set to invalid value: ${asked}. ` +
+          `${operation} takes NONE or ALL_OLD.`,
+      );
+    }
+
+    return asked === "ALL_OLD";
+  }
+
+  /**
+   * Refuse the write when the condition does not hold for what is stored.
+   *
+   * Nothing has changed by the time this throws, so the item is left exactly as
+   * it was.
+   */
+  assertHoldsFor(existing: SimDynamoDbItem | undefined): void {
+    if (this.condition === undefined) {
+      return;
+    }
+
+    if (this.condition.holdsFor(new SimDynamoDbConditionSubject(existing))) {
+      return;
+    }
+
+    throw new SimDynamoDbConditionalCheckFailedException(
+      this.reportedItem(existing),
+    );
+  }
+
+  /**
+   * The item the failure carries, when the request asked for it and there was
+   * one.
+   */
+  private reportedItem(
+    existing: SimDynamoDbItem | undefined,
+  ): Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined {
+    if (!this.reportsItem) {
+      return undefined;
+    }
+
+    return existing?.toAttributeValues();
+  }
+}

--- a/src/service/dynamodb/command/item/sim-dynamodb-conditional-write.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-conditional-write.iso.test.ts
@@ -1,0 +1,311 @@
+import {
+  CreateTableCommand,
+  DeleteItemCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbConditionalCheckFailedException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table holding one order at version 2.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: {
+        orderId: { S: "order-1" },
+        status: { S: "shipped" },
+        version: { N: "2" },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The version the stored order is at.
+ */
+async function storedVersion(
+  simDynamoDb: SimDynamoDb,
+): Promise<string | undefined> {
+  const output = await simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "FooTable",
+      Key: { orderId: { S: "order-1" } },
+    }),
+  );
+
+  return output.Item?.["version"]?.N;
+}
+
+describe("DynamoDB conditional writes", () => {
+  it("writes an item only where the key is free", async () => {
+    // Given a table already holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a write insists the key is free.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FooTable",
+          Item: { orderId: { S: "order-1" }, version: { N: "1" } },
+          ConditionExpression: "attribute_not_exists(orderId)",
+        }),
+      ),
+    );
+
+    // Then it fails with the name and message real DynamoDB uses, so code
+    // catching it by either works here unchanged.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    assertIdentical(error.name, "ConditionalCheckFailedException");
+    assertIdentical(error.message, "The conditional request failed.");
+
+    // And the stored order is exactly as it was.
+    assertIdentical(await storedVersion(simDynamoDb), "2");
+  });
+
+  it("writes into a key that is free", async () => {
+    // Given a table holding one order under a different key.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an insert if absent names a key nothing holds.
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-2" }, version: { N: "1" } },
+        ConditionExpression: "attribute_not_exists(orderId)",
+      }),
+    );
+
+    // Then the write goes through.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-2" } },
+      }),
+    );
+    assertIdentical(output.Item?.["version"]?.N, "1");
+  });
+
+  it("writes only where the version is the one it expected", async () => {
+    // Given an order at version 2.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a write expects version 1, as a stale reader would.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FooTable",
+          Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+          ConditionExpression: "attribute_exists(orderId) AND version = :was",
+          ExpressionAttributeValues: { ":was": { N: "1" } },
+        }),
+      ),
+    );
+
+    // Then it is turned away, and the order is untouched.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    assertIdentical(await storedVersion(simDynamoDb), "2");
+
+    // And the same write with the version it is actually at goes through.
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, version: { N: "3" } },
+        ConditionExpression: "attribute_exists(orderId) AND version = :was",
+        ExpressionAttributeValues: { ":was": { N: "2" } },
+      }),
+    );
+    assertIdentical(await storedVersion(simDynamoDb), "3");
+  });
+
+  it("deletes only where the condition holds", async () => {
+    // Given an order that has shipped.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a delete insists it has not.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.deleteItem(
+        new DeleteItemCommand({
+          TableName: "FooTable",
+          Key: { orderId: { S: "order-1" } },
+          ConditionExpression: "status = :packed",
+          ExpressionAttributeValues: { ":packed": { S: "packed" } },
+        }),
+      ),
+    );
+
+    // Then it is turned away, and the order is still there.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    assertIdentical(await storedVersion(simDynamoDb), "2");
+
+    // And a delete naming the status it actually has removes it.
+    const removed = await simDynamoDb.deleteItem(
+      new DeleteItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        ConditionExpression: "status = :shipped",
+        ExpressionAttributeValues: { ":shipped": { S: "shipped" } },
+        ReturnValues: "ALL_OLD",
+      }),
+    );
+    assertIdentical(removed.Attributes?.["status"]?.S, "shipped");
+    assertUndefined(await storedVersion(simDynamoDb));
+  });
+
+  it("puts the item that turned a write away on the failure when asked", async () => {
+    // Given an order at version 2 and a write expecting version 1.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the write asks for the item on failure.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FooTable",
+          Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+          ConditionExpression: "version = :was",
+          ExpressionAttributeValues: { ":was": { N: "1" } },
+          ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+        }),
+      ),
+    );
+
+    // Then the item it lost to is on the exception, which is how a caller
+    // retries without a second read.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    assertIdentical(error.Item?.["version"]?.N, "2");
+  });
+
+  it("leaves the item off the failure when the request did not ask", async () => {
+    // Given the same write asking for nothing back, and one asking for NONE.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    for (const asked of [undefined, "NONE"]) {
+      // When the condition turns it away.
+      // eslint-disable-next-line no-await-in-loop
+      const error = await assertThrowsErrorAsync(async () =>
+        simDynamoDb.putItem({
+          input: {
+            TableName: "FooTable",
+            Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+            ConditionExpression: "version = :was",
+            ExpressionAttributeValues: { ":was": { N: "1" } },
+            ReturnValuesOnConditionCheckFailure: asked,
+          },
+        }),
+      );
+
+      // Then nothing about the stored item is reported back.
+      assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+      assertUndefined(error.Item);
+    }
+  });
+
+  it("reports no item where the condition failed against a free key", async () => {
+    // Given a write into a free key that insists something is there.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the condition turns it away.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FooTable",
+          Item: { orderId: { S: "order-9" } },
+          ConditionExpression: "attribute_exists(orderId)",
+          ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+        }),
+      ),
+    );
+
+    // Then there is no item to report, since the key held nothing.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    assertUndefined(error.Item);
+  });
+
+  it("refuses a ReturnValuesOnConditionCheckFailure it does not have", async () => {
+    // Given a mode neither PutItem nor DeleteItem takes.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a write names it, then it is refused naming the command.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.deleteItem({
+        input: {
+          TableName: "FooTable",
+          Key: { orderId: { S: "order-1" } },
+          ReturnValuesOnConditionCheckFailure: "ALL_NEW",
+        },
+      }),
+    );
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "ReturnValuesOnConditionCheckFailure set to invalid value: ALL_NEW. " +
+        "DeleteItem takes NONE or ALL_OLD.",
+    );
+  });
+
+  it("refuses a bad expression whether or not the key holds anything", async () => {
+    // Given a write into a key that holds nothing, with an expression
+    // DynamoDB would refuse.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When it is made, then the expression is refused rather than the write
+    // quietly going through because there was nothing to check it against.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FooTable",
+          Item: { orderId: { S: "order-9" } },
+          ConditionExpression: "version = :missing",
+        }),
+      ),
+    );
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+
+    const read = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-9" } },
+      }),
+    );
+    assertUndefined(read.Item);
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
@@ -5,6 +5,7 @@ import type {
   SimDeleteItemCommandOutput,
 } from "./item.command.js";
 import { readSimDynamoDbKey } from "./sim-dynamodb-key-input.js";
+import { SimDynamoDbConditionCheck } from "./sim-dynamodb-condition-check.js";
 import { SimDynamoDbReturnValues } from "./sim-dynamodb-return-values.js";
 import { refuseUnsimulatedItemWriteInput } from "./sim-dynamodb-unsimulated-item-write-input.js";
 
@@ -22,6 +23,9 @@ interface SimDynamoDbDeleteItemOptions {
  * DeleteItem names a key rather than an item, so deleting a key that holds
  * nothing succeeds and reports nothing removed. The item is gone by the time
  * the call returns, so a read that follows it misses.
+ *
+ * A ConditionExpression is checked against whatever is stored under the key. A
+ * condition that does not hold leaves the item exactly as it was.
  */
 export class SimDynamoDbDeleteItem {
   private readonly access: SimDynamoDbTableAccess;
@@ -41,6 +45,9 @@ export class SimDynamoDbDeleteItem {
 
     refuseUnsimulatedItemWriteInput(input, "DeleteItem");
 
+    // The condition is read before the table is reached, so an expression
+    // DynamoDB would refuse is refused whether or not the key holds anything.
+    const check = SimDynamoDbConditionCheck.read(input, "DeleteItem");
     const table = this.access.required(
       "dynamodb:DeleteItem",
       input.TableName,
@@ -50,7 +57,11 @@ export class SimDynamoDbDeleteItem {
       input.ReturnValues,
       "DeleteItem",
     );
-    const removed = table.deleteItem(readSimDynamoDbKey(input.Key));
+    const key = readSimDynamoDbKey(input.Key);
+
+    check.assertHoldsFor(table.getItem(key));
+
+    const removed = table.deleteItem(key);
 
     if (!asked.wantsOldItem() || removed === undefined) {
       return { $metadata: {} };

--- a/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
@@ -7,6 +7,7 @@ import type {
   SimPutItemCommandInput,
   SimPutItemCommandOutput,
 } from "./item.command.js";
+import { SimDynamoDbConditionCheck } from "./sim-dynamodb-condition-check.js";
 import { SimDynamoDbReturnValues } from "./sim-dynamodb-return-values.js";
 import { refuseUnsimulatedItemWriteInput } from "./sim-dynamodb-unsimulated-item-write-input.js";
 
@@ -35,6 +36,9 @@ function readItem(input: SimPutItemCommandInput): SimDynamoDbItem {
  * A put replaces the whole item under its primary key rather than merging into
  * it, which is what makes PutItem different from UpdateItem. The item is
  * written before the call returns, so a read that follows finds it.
+ *
+ * A ConditionExpression is checked against whatever is stored under the key
+ * already. A condition that does not hold leaves the table exactly as it was.
  */
 export class SimDynamoDbPutItem {
   private readonly access: SimDynamoDbTableAccess;
@@ -54,13 +58,20 @@ export class SimDynamoDbPutItem {
 
     refuseUnsimulatedItemWriteInput(input, "PutItem");
 
+    // The condition is read before the table is reached, so an expression
+    // DynamoDB would refuse is refused whether or not the key holds anything.
+    const check = SimDynamoDbConditionCheck.read(input, "PutItem");
     const table = this.access.required(
       "dynamodb:PutItem",
       input.TableName,
       options?.caller,
     );
     const asked = SimDynamoDbReturnValues.read(input.ReturnValues, "PutItem");
-    const replaced = table.putItem(readItem(input));
+    const item = readItem(input);
+
+    check.assertHoldsFor(table.itemUnder(item));
+
+    const replaced = table.putItem(item);
 
     if (!asked.wantsOldItem() || replaced === undefined) {
       return { $metadata: {} };

--- a/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-write-input.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-write-input.iso.test.ts
@@ -30,21 +30,9 @@ const keyInput = {
 } as const satisfies SimDeleteItemCommandInput;
 
 /**
- * The conditional write and reporting inputs PutItem and DeleteItem share.
+ * The reporting and legacy conditional inputs PutItem and DeleteItem share.
  */
 const writeInputs = [
-  {
-    named: "ConditionExpression",
-    input: { ConditionExpression: "attribute_not_exists(userId)" },
-  },
-  {
-    named: "ExpressionAttributeNames",
-    input: { ExpressionAttributeNames: { "#u": "userId" } },
-  },
-  {
-    named: "ExpressionAttributeValues",
-    input: { ExpressionAttributeValues: { ":u": { S: "user-1" } } },
-  },
   {
     named: "ReturnConsumedCapacity",
     input: { ReturnConsumedCapacity: "TOTAL" },
@@ -52,10 +40,6 @@ const writeInputs = [
   {
     named: "ReturnItemCollectionMetrics",
     input: { ReturnItemCollectionMetrics: "SIZE" },
-  },
-  {
-    named: "ReturnValuesOnConditionCheckFailure",
-    input: { ReturnValuesOnConditionCheckFailure: "ALL_OLD" },
   },
   {
     named: "Expected",

--- a/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-write-input.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-write-input.ts
@@ -1,7 +1,4 @@
-import type {
-  SimDynamoDbAttributeValue,
-  SimDynamoDbExpectedAttributeValue,
-} from "./item.types.js";
+import type { SimDynamoDbExpectedAttributeValue } from "./item.types.js";
 import { SimDynamoDbUnsimulatedInput } from "./sim-dynamodb-unsimulated-input.js";
 
 /**
@@ -10,14 +7,8 @@ import { SimDynamoDbUnsimulatedInput } from "./sim-dynamodb-unsimulated-input.js
  * other, so they refuse the same ones.
  */
 interface SimDynamoDbItemWriteInput {
-  readonly ConditionExpression?: string | undefined;
-  readonly ExpressionAttributeNames?:
-    Readonly<Record<string, string>> | undefined;
-  readonly ExpressionAttributeValues?:
-    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
   readonly ReturnConsumedCapacity?: string | undefined;
   readonly ReturnItemCollectionMetrics?: string | undefined;
-  readonly ReturnValuesOnConditionCheckFailure?: string | undefined;
   readonly Expected?:
     Readonly<Record<string, SimDynamoDbExpectedAttributeValue>> | undefined;
   readonly ConditionalOperator?: string | undefined;
@@ -27,9 +18,12 @@ interface SimDynamoDbItemWriteInput {
  * Refuse the inputs this simulation does not model on a command that changes an
  * item.
  *
- * A condition that is never evaluated would let a change through that DynamoDB
- * would have turned away, and capacity figures that are never measured would
- * report a cost nothing here incurs. Both are refused rather than ignored.
+ * `Expected` and `ConditionalOperator` are the conditional write that
+ * `ConditionExpression` replaced, and real DynamoDB has built nothing on them
+ * since. An expectation that is never evaluated would let a change through that
+ * DynamoDB would have turned away, and capacity figures that are never measured
+ * would report a cost nothing here incurs. Both are refused rather than
+ * ignored.
  */
 export function refuseUnsimulatedItemWriteInput(
   input: SimDynamoDbItemWriteInput,
@@ -37,21 +31,6 @@ export function refuseUnsimulatedItemWriteInput(
 ): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput(operation);
 
-  unsimulated.refuse(
-    input.ConditionExpression !== undefined,
-    "ConditionExpression",
-    "applying a change the condition may have ruled out",
-  );
-  unsimulated.refuseNamed(
-    input.ExpressionAttributeNames,
-    "ExpressionAttributeNames",
-    "accepting names for an expression it cannot evaluate",
-  );
-  unsimulated.refuseNamed(
-    input.ExpressionAttributeValues,
-    "ExpressionAttributeValues",
-    "accepting values for an expression it cannot evaluate",
-  );
   unsimulated.refuseReporting(
     input.ReturnConsumedCapacity,
     "ReturnConsumedCapacity",
@@ -61,11 +40,6 @@ export function refuseUnsimulatedItemWriteInput(
     input.ReturnItemCollectionMetrics,
     "ReturnItemCollectionMetrics",
     "reporting item collection sizes nothing here tracks",
-  );
-  unsimulated.refuseReporting(
-    input.ReturnValuesOnConditionCheckFailure,
-    "ReturnValuesOnConditionCheckFailure",
-    "answering for a condition check that never happens",
   );
   unsimulated.refuseNamed(
     input.Expected,

--- a/src/service/dynamodb/error/dynamodb.error.ts
+++ b/src/service/dynamodb/error/dynamodb.error.ts
@@ -1,3 +1,5 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+
 /**
  * Minimal metadata shape for simulated DynamoDB errors.
  */
@@ -51,6 +53,28 @@ export class SimDynamoDbValidationException extends SimDynamoDbError {
 
   constructor(message: string) {
     super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated DynamoDB ConditionalCheckFailedException error.
+ *
+ * This is what a write guarded by a ConditionExpression fails with when the
+ * condition did not hold. The name and the message are the ones real DynamoDB
+ * uses, so code that catches it by either works here unchanged.
+ *
+ * `Item` carries the item that was there, and only when the request asked for
+ * it with ReturnValuesOnConditionCheckFailure.
+ */
+export class SimDynamoDbConditionalCheckFailedException extends SimDynamoDbError {
+  public override readonly name = "ConditionalCheckFailedException";
+
+  public readonly Item:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+
+  constructor(item?: Readonly<Record<string, SimDynamoDbAttributeValue>>) {
+    super("The conditional request failed.", { httpStatusCode: 400 });
+    this.Item = item;
   }
 }
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison-parser.ts
@@ -1,0 +1,129 @@
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
+import {
+  SimDynamoDbBetweenCondition,
+  SimDynamoDbComparisonCondition,
+  SimDynamoDbInCondition,
+  simDynamoDbComparators,
+} from "./sim-dynamodb-condition-comparison.js";
+import type { SimDynamoDbConditionOperand } from "./sim-dynamodb-condition-operand.js";
+import type { SimDynamoDbConditionOperandParser } from "./sim-dynamodb-condition-operand-parser.js";
+
+/**
+ * Real DynamoDB takes at most 100 operands in an IN list.
+ */
+const greatestInOperands = 100;
+
+interface SimDynamoDbConditionComparisonParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly operands: SimDynamoDbConditionOperandParser;
+}
+
+/**
+ * Reads the three ways a condition expression puts one operand against others:
+ * a comparator, a range, and a list.
+ *
+ * All three start with an operand and are told apart by what follows it, so
+ * they are read together rather than tried one after another.
+ */
+export class SimDynamoDbConditionComparisonParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly operands: SimDynamoDbConditionOperandParser;
+
+  constructor(properties: SimDynamoDbConditionComparisonParserProperties) {
+    this.tokens = properties.tokens;
+    this.operands = properties.operands;
+  }
+
+  /**
+   * Read an operand and whatever it is put against.
+   */
+  parse(): SimDynamoDbCondition {
+    const operand = this.operands.parse();
+
+    if (this.tokens.takeKeyword("BETWEEN")) {
+      return this.between(operand);
+    }
+
+    if (this.tokens.takeKeyword("IN")) {
+      return this.within(operand);
+    }
+
+    return new SimDynamoDbComparisonCondition(
+      operand,
+      this.comparator(),
+      this.operands.parse(),
+    );
+  }
+
+  /**
+   * `operand BETWEEN lower AND upper`, where both bounds count as inside.
+   *
+   * The AND here belongs to BETWEEN rather than joining two conditions, which
+   * is why the range is read at this level rather than above AND.
+   */
+  private between(operand: SimDynamoDbConditionOperand): SimDynamoDbCondition {
+    const lower = this.operands.parse();
+    this.tokens.expectKeyword("AND");
+
+    return new SimDynamoDbBetweenCondition(
+      operand,
+      lower,
+      this.operands.parse(),
+    );
+  }
+
+  /**
+   * `operand IN (first, second, ...)`.
+   */
+  private within(operand: SimDynamoDbConditionOperand): SimDynamoDbCondition {
+    this.tokens.expectSymbol("(", "syntax error; IN takes a bracketed list");
+
+    const candidates = this.candidates();
+    this.tokens.expectSymbol(")", "syntax error; the IN list is not closed");
+
+    this.assertWithinInLimit(candidates.length);
+
+    return new SimDynamoDbInCondition(operand, candidates);
+  }
+
+  /**
+   * The operands of an IN list, up to its closing bracket.
+   */
+  private candidates(): readonly SimDynamoDbConditionOperand[] {
+    const candidates: SimDynamoDbConditionOperand[] = [this.operands.parse()];
+
+    while (this.tokens.takeSymbol(",")) {
+      candidates.push(this.operands.parse());
+    }
+
+    return candidates;
+  }
+
+  /**
+   * Read the comparator between two operands.
+   */
+  private comparator(): string {
+    const token = this.tokens.next("a comparator");
+
+    if (token.kind !== "symbol" || !simDynamoDbComparators.has(token.text)) {
+      throw this.tokens.error(
+        `syntax error; a comparator was expected, but '${token.text}' was given`,
+      );
+    }
+
+    return token.text;
+  }
+
+  /**
+   * Refuse an IN list longer than DynamoDB takes.
+   */
+  private assertWithinInLimit(count: number): void {
+    if (count > greatestInOperands) {
+      throw this.tokens.error(
+        `IN takes at most ${greatestInOperands.toString()} operands, and ` +
+          `${count.toString()} were given`,
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
@@ -19,6 +19,9 @@ export const simDynamoDbComparators: ReadonlySet<string> = new Set([
 
 /**
  * Whether an ordering satisfies a comparator.
+ *
+ * Only the four ordering comparators reach here, so the last of them is the
+ * remaining case. `=` and `<>` are answered by equality before this is asked.
  */
 function ordered(comparator: string, order: number): boolean {
   switch (comparator) {
@@ -40,10 +43,11 @@ function ordered(comparator: string, order: number): boolean {
 /**
  * Two operands compared against each other.
  *
- * A comparison between two types DynamoDB does not order, such as a string and
- * a number, is false rather than an error. That is what real DynamoDB does, and
- * it is what lets one condition guard items that do not all carry the same
- * attributes.
+ * A comparison between two types is never an error, which is what lets one
+ * condition guard items that do not all carry the same attributes. What it
+ * answers depends on the comparator. Equality works across types, so a string
+ * and a number are not equal: `=` is false and `<>` is true. Ordering does
+ * not, so `<`, `<=`, `>` and `>=` are all false between them.
  */
 export class SimDynamoDbComparisonCondition implements SimDynamoDbCondition {
   private readonly left: SimDynamoDbConditionOperand;

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
@@ -1,0 +1,156 @@
+import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
+import { compareSimDynamoDbValues } from "../../item/sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
+import type { SimDynamoDbConditionOperand } from "./sim-dynamodb-condition-operand.js";
+import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * The comparators a condition expression can put between two operands.
+ */
+export const simDynamoDbComparators: ReadonlySet<string> = new Set([
+  "=",
+  "<>",
+  "<",
+  "<=",
+  ">",
+  ">=",
+]);
+
+/**
+ * Whether an ordering satisfies a comparator.
+ */
+function ordered(comparator: string, order: number): boolean {
+  switch (comparator) {
+    case "<": {
+      return order < 0;
+    }
+    case "<=": {
+      return order <= 0;
+    }
+    case ">": {
+      return order > 0;
+    }
+    default: {
+      return order >= 0;
+    }
+  }
+}
+
+/**
+ * Two operands compared against each other.
+ *
+ * A comparison between two types DynamoDB does not order, such as a string and
+ * a number, is false rather than an error. That is what real DynamoDB does, and
+ * it is what lets one condition guard items that do not all carry the same
+ * attributes.
+ */
+export class SimDynamoDbComparisonCondition implements SimDynamoDbCondition {
+  private readonly left: SimDynamoDbConditionOperand;
+  private readonly comparator: string;
+  private readonly right: SimDynamoDbConditionOperand;
+
+  constructor(
+    left: SimDynamoDbConditionOperand,
+    comparator: string,
+    right: SimDynamoDbConditionOperand,
+  ) {
+    this.left = left;
+    this.comparator = comparator;
+    this.right = right;
+  }
+
+  /**
+   * Whether the two operands stand in the relation the comparator asked for.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    const left = this.left.valueIn(subject);
+    const right = this.right.valueIn(subject);
+
+    if (left === undefined || right === undefined) {
+      return false;
+    }
+
+    return this.holdsBetween(left, right);
+  }
+
+  private holdsBetween(
+    left: SimDynamoDbValue,
+    right: SimDynamoDbValue,
+  ): boolean {
+    if (this.comparator === "=") {
+      return simDynamoDbValuesEqual(left, right);
+    }
+
+    if (this.comparator === "<>") {
+      return !simDynamoDbValuesEqual(left, right);
+    }
+
+    const order = compareSimDynamoDbValues(left, right);
+
+    if (order === undefined) {
+      return false;
+    }
+
+    return ordered(this.comparator, order);
+  }
+}
+
+/**
+ * An operand between two bounds, both of which count as inside.
+ */
+export class SimDynamoDbBetweenCondition implements SimDynamoDbCondition {
+  private readonly aboveLower: SimDynamoDbComparisonCondition;
+  private readonly belowUpper: SimDynamoDbComparisonCondition;
+
+  constructor(
+    operand: SimDynamoDbConditionOperand,
+    lower: SimDynamoDbConditionOperand,
+    upper: SimDynamoDbConditionOperand,
+  ) {
+    this.aboveLower = new SimDynamoDbComparisonCondition(lower, "<=", operand);
+    this.belowUpper = new SimDynamoDbComparisonCondition(operand, "<=", upper);
+  }
+
+  /**
+   * Whether the operand is at or between the two bounds.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return (
+      this.aboveLower.holdsFor(subject) && this.belowUpper.holdsFor(subject)
+    );
+  }
+}
+
+/**
+ * An operand equal to any one of a list of others.
+ */
+export class SimDynamoDbInCondition implements SimDynamoDbCondition {
+  private readonly operand: SimDynamoDbConditionOperand;
+  private readonly candidates: readonly SimDynamoDbConditionOperand[];
+
+  constructor(
+    operand: SimDynamoDbConditionOperand,
+    candidates: readonly SimDynamoDbConditionOperand[],
+  ) {
+    this.operand = operand;
+    this.candidates = candidates;
+  }
+
+  /**
+   * Whether the operand equals any one of the candidates.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    const value = this.operand.valueIn(subject);
+
+    if (value === undefined) {
+      return false;
+    }
+
+    return this.candidates.some((candidate) => {
+      const other = candidate.valueIn(subject);
+
+      return other !== undefined && simDynamoDbValuesEqual(value, other);
+    });
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
@@ -1,0 +1,44 @@
+import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
+import { SimDynamoDbConditionParser } from "./sim-dynamodb-condition-parser.js";
+
+const expressionName = "ConditionExpression";
+
+interface SimDynamoDbConditionRequest extends SimDynamoDbExpressionParameterInput {
+  readonly ConditionExpression?: string | undefined;
+}
+
+/**
+ * Read the condition a write is guarded by, if it names one.
+ *
+ * A request with no ConditionExpression is an unconditional write, so there is
+ * nothing to check.
+ */
+export function readSimDynamoDbCondition(
+  request: SimDynamoDbConditionRequest,
+): SimDynamoDbCondition | undefined {
+  const expression = request.ConditionExpression;
+
+  if (expression === undefined) {
+    SimDynamoDbExpressionParameters.assertNoneWithout(request);
+
+    return undefined;
+  }
+
+  const parameters = new SimDynamoDbExpressionParameters(request);
+  const condition = new SimDynamoDbConditionParser({
+    tokens: SimDynamoDbExpressionTokens.of(
+      expressionName,
+      expression,
+      "the expression says nothing, and an expression cannot be empty",
+    ),
+    names: parameters.names,
+    values: parameters.values,
+  }).parse();
+
+  parameters.assertAllUsed();
+
+  return condition;
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-arguments.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-arguments.ts
@@ -82,13 +82,17 @@ export class SimDynamoDbConditionFunctionArguments {
    *
    * Asking whether something contains itself has one answer whatever the item
    * holds, so real DynamoDB refuses it rather than always answering yes.
+   *
+   * They are told apart by what they name rather than by how they print, so
+   * an attribute whose name carries a dot is not confused with the two
+   * attributes it prints as.
    */
   distinctSecond(
     operand: SimDynamoDbConditionOperand,
   ): SimDynamoDbConditionOperand {
     const sought = this.second();
 
-    if (operand.text === sought.text) {
+    if (operand.identity === sought.identity) {
       throw this.tokens.error(
         `the first operand must be distinct from the second operand for ` +
           `operator contains, and both are '${operand.text}'`,

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-arguments.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-arguments.ts
@@ -1,0 +1,114 @@
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import {
+  type SimDynamoDbConditionOperand,
+  SimDynamoDbValueOperand,
+} from "./sim-dynamodb-condition-operand.js";
+import type { SimDynamoDbConditionOperandParser } from "./sim-dynamodb-condition-operand-parser.js";
+
+/**
+ * The descriptors `attribute_type` can be asked about, which are the ones an
+ * AttributeValue carries.
+ */
+const attributeTypes: ReadonlySet<string> = new Set([
+  "S",
+  "SS",
+  "N",
+  "NS",
+  "B",
+  "BS",
+  "BOOL",
+  "NULL",
+  "L",
+  "M",
+]);
+
+interface SimDynamoDbConditionFunctionArgumentsProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly operands: SimDynamoDbConditionOperandParser;
+}
+
+/**
+ * Reads the arguments a condition function takes.
+ *
+ * Which function was called is the caller's business. What its arguments have
+ * to look like is this one's, so the rules for a second operand and for the
+ * type `attribute_type` names live in one place.
+ */
+export class SimDynamoDbConditionFunctionArguments {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly operands: SimDynamoDbConditionOperandParser;
+
+  constructor(properties: SimDynamoDbConditionFunctionArgumentsProperties) {
+    this.tokens = properties.tokens;
+    this.operands = properties.operands;
+  }
+
+  /**
+   * Read the second argument of a function that takes two.
+   */
+  second(): SimDynamoDbConditionOperand {
+    this.tokens.expectSymbol(
+      ",",
+      "syntax error; a second operand was expected, separated by a comma",
+    );
+
+    return this.operands.parse();
+  }
+
+  /**
+   * Read the type `attribute_type` is asking about.
+   *
+   * Real DynamoDB takes it as a string through ExpressionAttributeValues, and
+   * refuses anything else, so a request naming the type inline is refused here
+   * as well rather than read as an attribute called `S`.
+   */
+  attributeType(): string {
+    const operand = this.second();
+    const value = this.suppliedValue(operand);
+
+    if (value?.kind !== "S" || !attributeTypes.has(value.text)) {
+      throw this.tokens.error(
+        `the second operand of attribute_type is one of ` +
+          `${[...attributeTypes].join(", ")}, supplied through ` +
+          `ExpressionAttributeValues, and '${operand.text}' is not`,
+      );
+    }
+
+    return value.text;
+  }
+
+  /**
+   * Read the second operand of `contains`, which has to differ from the first.
+   *
+   * Asking whether something contains itself has one answer whatever the item
+   * holds, so real DynamoDB refuses it rather than always answering yes.
+   */
+  distinctSecond(
+    operand: SimDynamoDbConditionOperand,
+  ): SimDynamoDbConditionOperand {
+    const sought = this.second();
+
+    if (operand.text === sought.text) {
+      throw this.tokens.error(
+        `the first operand must be distinct from the second operand for ` +
+          `operator contains, and both are '${operand.text}'`,
+      );
+    }
+
+    return sought;
+  }
+
+  /**
+   * The value an operand carries, when it is one the request supplied rather
+   * than a place in the item.
+   */
+  private suppliedValue(
+    operand: SimDynamoDbConditionOperand,
+  ): SimDynamoDbValueOperand["value"] | undefined {
+    if (operand instanceof SimDynamoDbValueOperand) {
+      return operand.value;
+    }
+
+    return undefined;
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-parser.ts
@@ -101,7 +101,7 @@ export class SimDynamoDbConditionFunctionParser {
       }
       case "begins_with": {
         return new SimDynamoDbBeginsWithCondition(
-          this.operands.parse(),
+          this.operands.parsePath(name),
           this.arguments.second(),
         );
       }
@@ -115,7 +115,7 @@ export class SimDynamoDbConditionFunctionParser {
    * Read `contains`, whose two operands have to differ.
    */
   private contains(): SimDynamoDbCondition {
-    const operand = this.operands.parse();
+    const operand = this.operands.parsePath("contains");
 
     return new SimDynamoDbContainsCondition(
       operand,

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function-parser.ts
@@ -1,0 +1,125 @@
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
+import {
+  SimDynamoDbAttributeExistsCondition,
+  SimDynamoDbAttributeTypeCondition,
+  SimDynamoDbBeginsWithCondition,
+  SimDynamoDbContainsCondition,
+} from "./sim-dynamodb-condition-function.js";
+import { SimDynamoDbConditionFunctionArguments } from "./sim-dynamodb-condition-function-arguments.js";
+import type { SimDynamoDbConditionOperandParser } from "./sim-dynamodb-condition-operand-parser.js";
+
+/**
+ * The functions that are a condition on their own, rather than an operand.
+ *
+ * `size` is not among them: it answers with a number, so it belongs beside a
+ * comparator rather than in place of one.
+ *
+ * Real DynamoDB reads a function name in lower case only, so the same applies
+ * here. `Attribute_Exists` is an attribute name there and here.
+ */
+const functionNames: ReadonlySet<string> = new Set([
+  "attribute_exists",
+  "attribute_not_exists",
+  "attribute_type",
+  "begins_with",
+  "contains",
+]);
+
+interface SimDynamoDbConditionFunctionParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly operands: SimDynamoDbConditionOperandParser;
+}
+
+/**
+ * Reads the function calls a condition expression is made of.
+ */
+export class SimDynamoDbConditionFunctionParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly operands: SimDynamoDbConditionOperandParser;
+  private readonly arguments: SimDynamoDbConditionFunctionArguments;
+
+  constructor(properties: SimDynamoDbConditionFunctionParserProperties) {
+    this.tokens = properties.tokens;
+    this.operands = properties.operands;
+    this.arguments = new SimDynamoDbConditionFunctionArguments(properties);
+  }
+
+  /**
+   * Whether what comes next is a function call rather than an operand.
+   *
+   * A function name followed by anything but an opening bracket is an ordinary
+   * attribute name, since none of these words is reserved.
+   */
+  isFunctionCall(): boolean {
+    const token = this.tokens.peek();
+    const after = this.tokens.peek(1);
+
+    return (
+      token?.kind === "name" &&
+      functionNames.has(token.text) &&
+      after?.kind === "symbol" &&
+      after.text === "("
+    );
+  }
+
+  /**
+   * Read one function call.
+   */
+  parse(): SimDynamoDbCondition {
+    const name = this.tokens.next("a function name").text;
+    this.tokens.next("(");
+
+    const condition = this.called(name);
+    this.tokens.expectSymbol(")", `syntax error; ${name} is not closed`);
+
+    return condition;
+  }
+
+  /**
+   * Read the arguments of the function that was named, and build it.
+   */
+  private called(name: string): SimDynamoDbCondition {
+    switch (name) {
+      case "attribute_exists": {
+        return new SimDynamoDbAttributeExistsCondition(
+          this.operands.parsePath(name),
+          true,
+        );
+      }
+      case "attribute_not_exists": {
+        return new SimDynamoDbAttributeExistsCondition(
+          this.operands.parsePath(name),
+          false,
+        );
+      }
+      case "attribute_type": {
+        return new SimDynamoDbAttributeTypeCondition(
+          this.operands.parsePath(name),
+          this.arguments.attributeType(),
+        );
+      }
+      case "begins_with": {
+        return new SimDynamoDbBeginsWithCondition(
+          this.operands.parse(),
+          this.arguments.second(),
+        );
+      }
+      default: {
+        return this.contains();
+      }
+    }
+  }
+
+  /**
+   * Read `contains`, whose two operands have to differ.
+   */
+  private contains(): SimDynamoDbCondition {
+    const operand = this.operands.parse();
+
+    return new SimDynamoDbContainsCondition(
+      operand,
+      this.arguments.distinctSecond(operand),
+    );
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
@@ -1,0 +1,232 @@
+import { assertFalse, assertNonNullable, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimDynamoDbAttributeValue } from "../../command/item/item.types.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { readSimDynamoDbCondition } from "./sim-dynamodb-condition-expression.js";
+import { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * The order these conditions are evaluated against.
+ */
+const order: Readonly<Record<string, SimDynamoDbAttributeValue>> = {
+  orderId: { S: "order-1" },
+  status: { S: "shipped" },
+  version: { N: "2" },
+  note: { NULL: true },
+  tags: { SS: ["urgent", "gift"] },
+  weights: { NS: ["1", "2"] },
+  seals: { BS: [Uint8Array.from([7])] },
+  lines: { L: [{ S: "widget" }, { S: "gasket" }] },
+  address: { M: { city: { S: "Leeds" } } },
+  label: { B: Uint8Array.from([1, 2, 3]) },
+};
+
+/**
+ * The subject a condition is evaluated against.
+ */
+function subjectOf(
+  item: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): SimDynamoDbConditionSubject {
+  return new SimDynamoDbConditionSubject(
+    SimDynamoDbItem.fromAttributeValues(item),
+  );
+}
+
+/**
+ * Whether a condition holds for the order.
+ */
+function holds(
+  expression: string,
+  values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): boolean {
+  const condition = readSimDynamoDbCondition({
+    ConditionExpression: expression,
+    ExpressionAttributeValues: values,
+  });
+  assertNonNullable(condition);
+
+  return condition.holdsFor(subjectOf(order));
+}
+
+describe("DynamoDB condition expression functions", () => {
+  it("finds an attribute that is there and one that is not", () => {
+    // Given an order carrying some attributes and not others.
+    // When existence is asked about, then each answers for what is there.
+    assertTrue(holds("attribute_exists(status)"));
+    assertFalse(holds("attribute_exists(discount)"));
+    assertTrue(holds("attribute_not_exists(discount)"));
+    assertFalse(holds("attribute_not_exists(status)"));
+  });
+
+  it("counts an attribute stored as NULL as existing", () => {
+    // Given a note stored as NULL, which is a value in DynamoDB rather than an
+    // absent one.
+    // When existence is asked about, then the attribute is there.
+    assertTrue(holds("attribute_exists(note)"));
+    assertFalse(holds("attribute_not_exists(note)"));
+  });
+
+  it("finds an attribute nested inside a map or a list", () => {
+    // Given an address map and a lines list.
+    // When existence is asked about inside them, then each answers for what is
+    // at that path.
+    assertTrue(holds("attribute_exists(address.city)"));
+    assertFalse(holds("attribute_exists(address.county)"));
+    assertTrue(holds("attribute_exists(lines[1])"));
+    assertFalse(holds("attribute_exists(lines[9])"));
+  });
+
+  it("checks the type an attribute is stored as", () => {
+    // Given attributes of several types.
+    // When attribute_type is asked, then it answers for the descriptor each is
+    // stored under.
+    assertTrue(
+      holds("attribute_type(status, :type)", {
+        ":type": { S: "S" },
+      }),
+    );
+    assertFalse(
+      holds("attribute_type(status, :type)", {
+        ":type": { S: "N" },
+      }),
+    );
+    assertTrue(holds("attribute_type(tags, :type)", { ":type": { S: "SS" } }));
+    assertTrue(
+      holds("attribute_type(note, :type)", { ":type": { S: "NULL" } }),
+    );
+    assertFalse(
+      holds("attribute_type(discount, :type)", {
+        ":type": { S: "S" },
+      }),
+    );
+  });
+
+  it("checks what a string or some binary starts with", () => {
+    // Given a status and a binary label.
+    // When begins_with is asked, then each answers for its own bytes, and a
+    // string never begins with binary.
+    assertTrue(
+      holds("begins_with(status, :prefix)", {
+        ":prefix": { S: "ship" },
+      }),
+    );
+    assertFalse(
+      holds("begins_with(status, :prefix)", {
+        ":prefix": { S: "pack" },
+      }),
+    );
+    assertTrue(
+      holds("begins_with(label, :prefix)", {
+        ":prefix": { B: Uint8Array.from([1, 2]) },
+      }),
+    );
+    assertFalse(
+      holds("begins_with(label, :prefix)", {
+        ":prefix": { B: Uint8Array.from([1, 2, 3, 4]) },
+      }),
+    );
+    assertFalse(
+      holds("begins_with(status, :prefix)", {
+        ":prefix": { B: Uint8Array.from([1]) },
+      }),
+    );
+  });
+
+  it("checks what a string, a set or a list holds", () => {
+    // Given a string, a string set and a list.
+    // When contains is asked, then a string looks for a substring and the
+    // others look for a member.
+    assertTrue(holds("contains(status, :part)", { ":part": { S: "hipp" } }));
+    assertFalse(holds("contains(status, :part)", { ":part": { S: "packed" } }));
+    assertTrue(holds("contains(tags, :tag)", { ":tag": { S: "gift" } }));
+    assertFalse(holds("contains(tags, :tag)", { ":tag": { S: "boxed" } }));
+    assertTrue(holds("contains(lines, :line)", { ":line": { S: "gasket" } }));
+    assertFalse(holds("contains(version, :one)", { ":one": { N: "1" } }));
+  });
+
+  it("checks what a number set or a binary set holds", () => {
+    // Given sets whose members compare by their digits and by their bytes.
+    // When contains is asked, then each answers by value rather than by how
+    // the member was written or by object identity.
+    assertTrue(holds("contains(weights, :one)", { ":one": { N: "1.0" } }));
+    assertFalse(holds("contains(weights, :nine)", { ":nine": { N: "9" } }));
+    assertTrue(
+      holds("contains(seals, :seal)", {
+        ":seal": { B: Uint8Array.from([7]) },
+      }),
+    );
+  });
+
+  it("is false where a function's operand is not there", () => {
+    // Given functions asked about an attribute the item does not carry.
+    // When each is evaluated, then it is false rather than an error: nothing
+    // begins with anything, and nothing contains anything.
+    assertFalse(
+      holds("begins_with(discount, :part)", {
+        ":part": { S: "a" },
+      }),
+    );
+    assertFalse(holds("contains(discount, :part)", { ":part": { S: "a" } }));
+    assertFalse(holds("status IN (:part)", { ":part": { S: "a" } }));
+    assertFalse(holds("discount IN (:part)", { ":part": { S: "a" } }));
+  });
+
+  it("is false for a path reaching into the wrong kind of value", () => {
+    // Given a path reading a string as though it were a map, and a map as
+    // though it were a list.
+    // When each is evaluated, then the item simply does not have it.
+    assertFalse(holds("attribute_exists(status.city)"));
+    assertFalse(holds("attribute_exists(address[0])"));
+    assertFalse(holds("attribute_exists(address.city.first)"));
+  });
+
+  it("compares the size of what a path points at", () => {
+    // Given attributes measured in bytes and in members.
+    // When size is compared, then a string and binary measure in bytes, and a
+    // set, a list and a map in how many things they hold.
+    assertTrue(holds("size(status) = :seven", { ":seven": { N: "7" } }));
+    assertTrue(holds("size(label) = :three", { ":three": { N: "3" } }));
+    assertTrue(holds("size(tags) = :two", { ":two": { N: "2" } }));
+    assertTrue(holds("size(weights) = :two", { ":two": { N: "2" } }));
+    assertTrue(holds("size(seals) = :one", { ":one": { N: "1" } }));
+    assertTrue(holds("size(lines) = :two", { ":two": { N: "2" } }));
+    assertTrue(holds("size(address) = :one", { ":one": { N: "1" } }));
+    assertTrue(holds("size(status) > :one", { ":one": { N: "1" } }));
+  });
+
+  it("has no size for a number, a boolean or an absent attribute", () => {
+    // Given a number, which has no size, and an attribute that is not there.
+    // When size is compared, then it is false rather than an error.
+    assertFalse(holds("size(version) > :zero", { ":zero": { N: "0" } }));
+    assertFalse(holds("size(note) > :zero", { ":zero": { N: "0" } }));
+    assertFalse(holds("size(discount) > :zero", { ":zero": { N: "0" } }));
+  });
+
+  it("counts a string's size in UTF-8 bytes", () => {
+    // Given a status of seven ASCII characters, and the item's other text.
+    // When size is compared against the character count of something outside
+    // ASCII, then the bytes win: DynamoDB measures a string in bytes.
+    const condition = readSimDynamoDbCondition({
+      ConditionExpression: "size(city) = :three",
+      ExpressionAttributeValues: { ":three": { N: "3" } },
+    });
+    assertNonNullable(condition);
+
+    assertTrue(condition.holdsFor(subjectOf({ city: { S: "é!" } })));
+  });
+
+  it("reads a function name as an attribute when it is not a call", () => {
+    // Given an item with an attribute named after a function, which is not a
+    // reserved word.
+    const condition = readSimDynamoDbCondition({
+      ConditionExpression: "contains = :yes",
+      ExpressionAttributeValues: { ":yes": { S: "yes" } },
+    });
+    assertNonNullable(condition);
+
+    // When it is evaluated, then the name is read as the attribute, since
+    // nothing follows it that could open a call.
+    assertTrue(condition.holdsFor(subjectOf({ contains: { S: "yes" } })));
+  });
+});

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
@@ -1,0 +1,172 @@
+import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
+import type {
+  SimDynamoDbConditionOperand,
+  SimDynamoDbPathOperand,
+} from "./sim-dynamodb-condition-operand.js";
+import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * Whether an item has the attribute a path names.
+ *
+ * An attribute stored as NULL exists. NULL is a value in DynamoDB rather than
+ * an absent one, so an item carrying it has the attribute.
+ */
+export class SimDynamoDbAttributeExistsCondition implements SimDynamoDbCondition {
+  private readonly operand: SimDynamoDbPathOperand;
+  private readonly wanted: boolean;
+
+  constructor(operand: SimDynamoDbPathOperand, wanted: boolean) {
+    this.operand = operand;
+    this.wanted = wanted;
+  }
+
+  /**
+   * Whether the item has the attribute, or does not, as the function asked.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return (this.operand.valueIn(subject) !== undefined) === this.wanted;
+  }
+}
+
+/**
+ * Whether what a path names is of a type.
+ *
+ * The type is one of the descriptors an AttributeValue carries, given as a
+ * string through ExpressionAttributeValues.
+ */
+export class SimDynamoDbAttributeTypeCondition implements SimDynamoDbCondition {
+  private readonly operand: SimDynamoDbPathOperand;
+  private readonly type: string;
+
+  constructor(operand: SimDynamoDbPathOperand, type: string) {
+    this.operand = operand;
+    this.type = type;
+  }
+
+  /**
+   * Whether what the path names is stored under the descriptor asked about.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return this.operand.valueIn(subject)?.kind === this.type;
+  }
+}
+
+/**
+ * Whether a string or some binary starts with another.
+ *
+ * Two operands of different types never match, so a string never begins with
+ * binary however the bytes line up.
+ */
+export class SimDynamoDbBeginsWithCondition implements SimDynamoDbCondition {
+  private readonly operand: SimDynamoDbConditionOperand;
+  private readonly prefix: SimDynamoDbConditionOperand;
+
+  constructor(
+    operand: SimDynamoDbConditionOperand,
+    prefix: SimDynamoDbConditionOperand,
+  ) {
+    this.operand = operand;
+    this.prefix = prefix;
+  }
+
+  /**
+   * Whether what the path names starts with the prefix.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    const value = this.operand.valueIn(subject);
+    const prefix = this.prefix.valueIn(subject);
+
+    if (value === undefined || prefix === undefined) {
+      return false;
+    }
+
+    if (value.kind === "S" && prefix.kind === "S") {
+      return value.text.startsWith(prefix.text);
+    }
+
+    if (value.kind === "B" && prefix.kind === "B") {
+      return beginsWithBytes(value.bytes, prefix.bytes);
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Whether some bytes start with some other bytes.
+ */
+function beginsWithBytes(bytes: Uint8Array, prefix: Uint8Array): boolean {
+  if (prefix.length > bytes.length) {
+    return false;
+  }
+
+  return prefix.every((byte, at) => bytes.at(at) === byte);
+}
+
+/**
+ * Whether a string holds a substring, or a set or a list holds a member.
+ */
+export class SimDynamoDbContainsCondition implements SimDynamoDbCondition {
+  private readonly operand: SimDynamoDbConditionOperand;
+  private readonly sought: SimDynamoDbConditionOperand;
+
+  constructor(
+    operand: SimDynamoDbConditionOperand,
+    sought: SimDynamoDbConditionOperand,
+  ) {
+    this.operand = operand;
+    this.sought = sought;
+  }
+
+  /**
+   * Whether what the path names holds what was sought.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    const value = this.operand.valueIn(subject);
+    const sought = this.sought.valueIn(subject);
+
+    if (value === undefined || sought === undefined) {
+      return false;
+    }
+
+    if (value.kind === "S" && sought.kind === "S") {
+      return value.text.includes(sought.text);
+    }
+
+    return membersOf(value).some((member) =>
+      simDynamoDbValuesEqual(member, sought),
+    );
+  }
+}
+
+/**
+ * The things a set or a list holds, as values to compare against.
+ *
+ * Anything else holds no members, so `contains` over it is false.
+ */
+function membersOf(value: SimDynamoDbValue): readonly SimDynamoDbValue[] {
+  switch (value.kind) {
+    case "SS": {
+      return value.texts.map((text) => ({ kind: "S", text }));
+    }
+    case "NS": {
+      return value.numbers.map((number) => ({ kind: "N", number }));
+    }
+    case "BS": {
+      return value.bytes.map((bytes) => ({ kind: "B", bytes }));
+    }
+    case "L": {
+      return value.values;
+    }
+    case "S":
+    case "N":
+    case "B":
+    case "BOOL":
+    case "NULL":
+    case "M": {
+      return [];
+    }
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
@@ -1,0 +1,125 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import {
+  type SimDynamoDbConditionOperand,
+  SimDynamoDbPathOperand,
+  SimDynamoDbSizeOperand,
+  SimDynamoDbValueOperand,
+} from "./sim-dynamodb-condition-operand.js";
+
+/**
+ * The one function that stands where an operand does rather than being a
+ * condition of its own, because it answers with a number rather than with yes
+ * or no.
+ */
+const sizeFunctionName = "size";
+
+interface SimDynamoDbConditionOperandParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+}
+
+/**
+ * Reads the operands a condition expression compares.
+ *
+ * An operand is a document path, a value the request supplied, or the size of
+ * what a path points at. Which one it is shows in its first token, so nothing
+ * here has to look far ahead.
+ */
+export class SimDynamoDbConditionOperandParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+
+  constructor(properties: SimDynamoDbConditionOperandParserProperties) {
+    this.tokens = properties.tokens;
+    this.names = properties.names;
+    this.values = properties.values;
+  }
+
+  /**
+   * Read one operand.
+   */
+  parse(): SimDynamoDbConditionOperand {
+    const token = this.tokens.peek();
+
+    if (token?.kind === "valuePlaceholder") {
+      this.tokens.next("a value");
+
+      return new SimDynamoDbValueOperand(
+        token.text,
+        this.values.required(token.text),
+      );
+    }
+
+    if (this.isSizeCall()) {
+      return this.size();
+    }
+
+    return this.path();
+  }
+
+  /**
+   * Read an operand that has to be a document path, naming the function that
+   * will not take anything else.
+   */
+  parsePath(functionName: string): SimDynamoDbPathOperand {
+    const operand = this.parse();
+
+    if (!(operand instanceof SimDynamoDbPathOperand)) {
+      throw this.tokens.error(
+        `the first operand of ${functionName} names a place in the item, and ` +
+          `'${operand.text}' is not one`,
+      );
+    }
+
+    return operand;
+  }
+
+  /**
+   * Whether what comes next is a call to `size` rather than a path starting
+   * with an attribute of that name.
+   */
+  private isSizeCall(): boolean {
+    const token = this.tokens.peek();
+    const after = this.tokens.peek(1);
+
+    return (
+      token?.kind === "name" &&
+      token.text === sizeFunctionName &&
+      after?.kind === "symbol" &&
+      after.text === "("
+    );
+  }
+
+  /**
+   * Read `size(path)`, which is a number rather than a condition.
+   */
+  private size(): SimDynamoDbConditionOperand {
+    this.tokens.next(sizeFunctionName);
+    this.tokens.next("(");
+
+    const measured = this.path();
+    this.tokens.expectSymbol(
+      ")",
+      `syntax error; ${sizeFunctionName} is not closed`,
+    );
+
+    return new SimDynamoDbSizeOperand(measured);
+  }
+
+  /**
+   * Read a document path, which is what an operand is when it is nothing else.
+   */
+  private path(): SimDynamoDbPathOperand {
+    return new SimDynamoDbPathOperand(
+      new SimDynamoDbDocumentPathParser({
+        tokens: this.tokens,
+        names: this.names,
+      }).parse(),
+    );
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
@@ -18,6 +18,12 @@ export interface SimDynamoDbConditionOperand {
   readonly text: string;
 
   /**
+   * What this operand names, as text no other operand can produce. Two
+   * operands are the same operand when their identities match.
+   */
+  readonly identity: string;
+
+  /**
    * The value this operand has for an item, if it has one.
    */
   valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined;
@@ -35,6 +41,10 @@ export class SimDynamoDbPathOperand implements SimDynamoDbConditionOperand {
 
   get text(): string {
     return this.path.text;
+  }
+
+  get identity(): string {
+    return this.path.identity;
   }
 
   valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {
@@ -56,6 +66,13 @@ export class SimDynamoDbValueOperand implements SimDynamoDbConditionOperand {
   constructor(text: string, value: SimDynamoDbValue) {
     this.text = text;
     this.value = value;
+  }
+
+  /**
+   * A placeholder names itself, and no path can be written to look like one.
+   */
+  get identity(): string {
+    return this.text;
   }
 
   valueIn(): SimDynamoDbValue {
@@ -80,6 +97,10 @@ export class SimDynamoDbSizeOperand implements SimDynamoDbConditionOperand {
 
   get text(): string {
     return `size(${this.operand.text})`;
+  }
+
+  get identity(): string {
+    return `size(${this.operand.identity})`;
   }
 
   valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
@@ -1,0 +1,134 @@
+import { SimDynamoDbNumber } from "../../item/sim-dynamodb-number.js";
+import { simDynamoDbTextSize } from "../../item/sim-dynamodb-value-size.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * One side of a comparison in a condition expression.
+ *
+ * An operand answers with a value for the item being checked, or with nothing
+ * when the item does not have what it points at. Nothing compares to nothing,
+ * so an absent operand makes its comparison false rather than failing it.
+ */
+export interface SimDynamoDbConditionOperand {
+  /**
+   * How the expression wrote this operand, for a refusal to name.
+   */
+  readonly text: string;
+
+  /**
+   * The value this operand has for an item, if it has one.
+   */
+  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined;
+}
+
+/**
+ * An operand naming a place in the item.
+ */
+export class SimDynamoDbPathOperand implements SimDynamoDbConditionOperand {
+  public readonly path: SimDynamoDbDocumentPath;
+
+  constructor(path: SimDynamoDbDocumentPath) {
+    this.path = path;
+  }
+
+  get text(): string {
+    return this.path.text;
+  }
+
+  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {
+    return subject.valueAt(this.path);
+  }
+}
+
+/**
+ * An operand carrying a value the request supplied, through
+ * ExpressionAttributeValues.
+ *
+ * The value is the same whatever item is being checked, so nothing is looked
+ * up for it.
+ */
+export class SimDynamoDbValueOperand implements SimDynamoDbConditionOperand {
+  public readonly text: string;
+  public readonly value: SimDynamoDbValue;
+
+  constructor(text: string, value: SimDynamoDbValue) {
+    this.text = text;
+    this.value = value;
+  }
+
+  valueIn(): SimDynamoDbValue {
+    return this.value;
+  }
+}
+
+/**
+ * An operand giving the size of what a path points at.
+ *
+ * `size` is a number, so it compares against numbers. A string and binary
+ * measure in bytes, and a set, a list or a map in how many things it holds. A
+ * number, a boolean and a null have no size, so a comparison against one is
+ * false rather than an error.
+ */
+export class SimDynamoDbSizeOperand implements SimDynamoDbConditionOperand {
+  private readonly operand: SimDynamoDbPathOperand;
+
+  constructor(operand: SimDynamoDbPathOperand) {
+    this.operand = operand;
+  }
+
+  get text(): string {
+    return `size(${this.operand.text})`;
+  }
+
+  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {
+    const value = this.operand.valueIn(subject);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const size = sizeOf(value);
+
+    if (size === undefined) {
+      return undefined;
+    }
+
+    return { kind: "N", number: SimDynamoDbNumber.of(size.toString()) };
+  }
+}
+
+/**
+ * How big a stored value is, in whatever unit DynamoDB measures its type in.
+ */
+function sizeOf(value: SimDynamoDbValue): number | undefined {
+  switch (value.kind) {
+    case "S": {
+      return simDynamoDbTextSize(value.text);
+    }
+    case "B": {
+      return value.bytes.byteLength;
+    }
+    case "SS": {
+      return value.texts.length;
+    }
+    case "NS": {
+      return value.numbers.length;
+    }
+    case "BS": {
+      return value.bytes.length;
+    }
+    case "L": {
+      return value.values.length;
+    }
+    case "M": {
+      return value.entries.size;
+    }
+    case "N":
+    case "BOOL":
+    case "NULL": {
+      return undefined;
+    }
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
@@ -1,0 +1,124 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import {
+  SimDynamoDbAndCondition,
+  type SimDynamoDbCondition,
+  SimDynamoDbNotCondition,
+  SimDynamoDbOrCondition,
+} from "./sim-dynamodb-condition.js";
+import { SimDynamoDbConditionComparisonParser } from "./sim-dynamodb-condition-comparison-parser.js";
+import { SimDynamoDbConditionFunctionParser } from "./sim-dynamodb-condition-function-parser.js";
+import { SimDynamoDbConditionOperandParser } from "./sim-dynamodb-condition-operand-parser.js";
+
+interface SimDynamoDbConditionParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+}
+
+/**
+ * Reads a condition expression into the condition it describes.
+ *
+ * The methods are the precedence DynamoDB documents, one method per level: OR
+ * binds loosest, then AND, then NOT, and a comparison or a function binds
+ * tightest. Writing it this way is what makes `a = :x OR b = :y AND c = :z` the
+ * OR of `a = :x` and the AND, rather than the AND of the OR and `c = :z`.
+ *
+ * What a comparison and a function look like belongs to the parsers this one
+ * delegates to, so this class stays the precedence and nothing else.
+ */
+export class SimDynamoDbConditionParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly comparisons: SimDynamoDbConditionComparisonParser;
+  private readonly functions: SimDynamoDbConditionFunctionParser;
+
+  constructor(properties: SimDynamoDbConditionParserProperties) {
+    const operands = new SimDynamoDbConditionOperandParser({
+      tokens: properties.tokens,
+      names: properties.names,
+      values: properties.values,
+    });
+
+    this.tokens = properties.tokens;
+    this.comparisons = new SimDynamoDbConditionComparisonParser({
+      tokens: properties.tokens,
+      operands,
+    });
+    this.functions = new SimDynamoDbConditionFunctionParser({
+      tokens: properties.tokens,
+      operands,
+    });
+  }
+
+  /**
+   * Read the whole expression, refusing anything left over after it.
+   */
+  parse(): SimDynamoDbCondition {
+    const condition = this.either();
+    const remaining = this.tokens.peek();
+
+    if (remaining !== undefined) {
+      throw this.tokens.error(
+        `syntax error; '${remaining.text}' follows a complete condition`,
+      );
+    }
+
+    return condition;
+  }
+
+  /**
+   * Conditions joined by OR, which binds loosest.
+   */
+  private either(): SimDynamoDbCondition {
+    let condition = this.both();
+
+    while (this.tokens.takeKeyword("OR")) {
+      condition = new SimDynamoDbOrCondition(condition, this.both());
+    }
+
+    return condition;
+  }
+
+  /**
+   * Conditions joined by AND, which binds tighter than OR.
+   */
+  private both(): SimDynamoDbCondition {
+    let condition = this.negated();
+
+    while (this.tokens.takeKeyword("AND")) {
+      condition = new SimDynamoDbAndCondition(condition, this.negated());
+    }
+
+    return condition;
+  }
+
+  /**
+   * A condition NOT applies to, which binds tighter than AND.
+   */
+  private negated(): SimDynamoDbCondition {
+    if (this.tokens.takeKeyword("NOT")) {
+      return new SimDynamoDbNotCondition(this.negated());
+    }
+
+    return this.innermost();
+  }
+
+  /**
+   * A bracketed condition, a function call, or a comparison.
+   */
+  private innermost(): SimDynamoDbCondition {
+    if (this.tokens.takeSymbol("(")) {
+      const condition = this.either();
+      this.tokens.expectSymbol(")", "syntax error; a bracket is not closed");
+
+      return condition;
+    }
+
+    if (this.functions.isFunctionCall()) {
+      return this.functions.parse();
+    }
+
+    return this.comparisons.parse();
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-subject.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-subject.ts
@@ -1,0 +1,77 @@
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type {
+  SimDynamoDbDocumentPath,
+  SimDynamoDbDocumentPathSegment,
+} from "../sim-dynamodb-document-path.js";
+
+/**
+ * The item a condition is evaluated against.
+ *
+ * A conditional write is checked against whatever is stored under its key,
+ * which may be nothing at all. That is what makes
+ * `attribute_not_exists(id)` the way to insert only if absent: with no item
+ * there, every path resolves to nothing.
+ */
+export class SimDynamoDbConditionSubject {
+  private readonly item: SimDynamoDbItem | undefined;
+
+  constructor(item?: SimDynamoDbItem) {
+    this.item = item;
+  }
+
+  /**
+   * The value a document path points at, or nothing when the item does not
+   * have it.
+   *
+   * A path reaching into the wrong kind of value resolves to nothing rather
+   * than failing, the same way a projection passes over it: the item does not
+   * have what was asked for.
+   */
+  valueAt(path: SimDynamoDbDocumentPath): SimDynamoDbValue | undefined {
+    let value = this.asMap();
+
+    for (const segment of path.segments) {
+      if (value === undefined) {
+        return undefined;
+      }
+
+      value = this.step(value, segment);
+    }
+
+    return value;
+  }
+
+  /**
+   * Follow one step of a path, from whatever the step before reached.
+   */
+  private step(
+    value: SimDynamoDbValue,
+    segment: SimDynamoDbDocumentPathSegment,
+  ): SimDynamoDbValue | undefined {
+    if (segment.kind === "attribute" && value.kind === "M") {
+      return value.entries.get(segment.name);
+    }
+
+    if (segment.kind === "index" && value.kind === "L") {
+      return value.values.at(segment.index);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * The item as a value, so the first step of a path is taken the same way as
+   * every step after it.
+   *
+   * An item is a map of attributes, so a path starting with a list index
+   * points at nothing rather than needing a rule of its own.
+   */
+  private asMap(): SimDynamoDbValue | undefined {
+    if (this.item === undefined) {
+      return undefined;
+    }
+
+    return { kind: "M", entries: this.item.entries() };
+  }
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-validation.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-validation.iso.test.ts
@@ -1,0 +1,229 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimDynamoDbAttributeValue } from "../../command/item/item.types.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { readSimDynamoDbCondition } from "./sim-dynamodb-condition-expression.js";
+
+/**
+ * Read a condition, returning whatever it is refused with.
+ */
+function refusal(
+  expression: string,
+  values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): Error {
+  return assertThrowsError(() =>
+    readSimDynamoDbCondition({
+      ConditionExpression: expression,
+      ExpressionAttributeValues: values,
+    }),
+  );
+}
+
+describe("DynamoDB condition expression validation", () => {
+  it("refuses an empty expression", () => {
+    // Given an expression saying nothing at all.
+    // When it is read, then it is refused rather than read as a condition that
+    // always holds.
+    assertIdentical(
+      refusal(" ".repeat(3)).message,
+      "Invalid ConditionExpression: the expression says nothing, and an " +
+        "expression cannot be empty",
+    );
+  });
+
+  it("refuses a value placeholder the request never defined", () => {
+    // Given a condition comparing against a value with no entry for it.
+    // When it is read, then it is refused naming the placeholder.
+    const error = refusal("version = :two");
+
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(
+      error.message,
+      "ExpressionAttributeValues does not define :two, which an expression " +
+        "uses",
+    );
+  });
+
+  it("refuses a defined value the expression never uses", () => {
+    // Given values holding a placeholder an edited expression no longer uses.
+    // When it is read, then the leftover is refused.
+    const error = refusal("attribute_exists(status)", {
+      ":two": { N: "2" },
+    });
+
+    assertIdentical(
+      error.message,
+      "Value provided in ExpressionAttributeValues is unused in " +
+        "expressions: :two",
+    );
+  });
+
+  it("refuses values with no expression to use them in", () => {
+    // Given a request carrying values and no condition.
+    // When the condition is read, then the values are refused, since nothing
+    // would ever read them.
+    const error = assertThrowsError(() =>
+      readSimDynamoDbCondition({
+        ExpressionAttributeValues: { ":two": { N: "2" } },
+      }),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "ExpressionAttributeValues can only be specified when using expressions",
+    );
+  });
+
+  it("refuses names with no expression to use them in", () => {
+    // Given a request carrying names and no condition.
+    // When the condition is read, then the names are refused too, so neither
+    // parameter is left behind.
+    const error = assertThrowsError(() =>
+      readSimDynamoDbCondition({
+        ExpressionAttributeNames: { "#s": "status" },
+      }),
+    );
+
+    assertStringIncludes(
+      error.message,
+      "ExpressionAttributeNames can only be specified when using expressions",
+    );
+  });
+
+  it("refuses a comparison with no comparator", () => {
+    // Given two operands with nothing between them.
+    // When it is read, then it is refused saying a comparator was expected.
+    assertStringIncludes(
+      refusal("version :two", { ":two": { N: "2" } }).message,
+      "a comparator was expected, but ':two' was given",
+    );
+  });
+
+  it("refuses something left over after a complete condition", () => {
+    // Given an expression with a stray operand after its condition.
+    // When it is read, then it is refused rather than read up to the point it
+    // stopped making sense.
+    assertStringIncludes(
+      refusal("attribute_exists(status) status").message,
+      "'status' follows a complete condition",
+    );
+  });
+
+  it("refuses a bracket that is never closed", () => {
+    // Given a bracketed condition with no closing bracket.
+    // When it is read, then it is refused.
+    assertStringIncludes(
+      refusal("(attribute_exists(status)").message,
+      "a bracket is not closed",
+    );
+    assertStringIncludes(
+      refusal("attribute_exists(status").message,
+      "attribute_exists is not closed",
+    );
+    assertStringIncludes(
+      refusal("size(status = :one", { ":one": { N: "1" } }).message,
+      "size is not closed",
+    );
+  });
+
+  it("refuses BETWEEN without its AND", () => {
+    // Given a range missing the AND between its bounds.
+    // When it is read, then it is refused saying what was expected.
+    assertStringIncludes(
+      refusal("version BETWEEN :one :three", {
+        ":one": { N: "1" },
+        ":three": { N: "3" },
+      }).message,
+      "AND expected, but ':three' was given",
+    );
+  });
+
+  it("refuses an IN list that is not bracketed or not closed", () => {
+    // Given IN written without its brackets, and with only an opening one.
+    // When each is read, then both are refused.
+    assertStringIncludes(
+      refusal("status IN :one", { ":one": { S: "a" } }).message,
+      "IN takes a bracketed list",
+    );
+    assertStringIncludes(
+      refusal("status IN (:one", { ":one": { S: "a" } }).message,
+      "the IN list is not closed",
+    );
+  });
+
+  it("refuses an IN list longer than DynamoDB takes", () => {
+    // Given an IN list of 101 operands, one past the limit.
+    const values = Object.fromEntries(
+      Array.from({ length: 101 }, (_, at) => [
+        `:v${at.toString()}`,
+        { S: at.toString() },
+      ]),
+    );
+    const operands = Object.keys(values).join(", ");
+
+    // When it is read, then it is refused rather than evaluated, since real
+    // DynamoDB would refuse it too.
+    assertStringIncludes(
+      refusal(`status IN (${operands})`, values).message,
+      "IN takes at most 100 operands, and 101 were given",
+    );
+  });
+
+  it("refuses a function operand that has to be a path", () => {
+    // Given attribute_exists asked about a supplied value, which names no
+    // place in the item.
+    // When it is read, then it is refused naming the function.
+    assertStringIncludes(
+      refusal("attribute_exists(:one)", { ":one": { S: "a" } }).message,
+      "the first operand of attribute_exists names a place in the item",
+    );
+  });
+
+  it("refuses a function that is missing its second operand", () => {
+    // Given begins_with with only one operand.
+    // When it is read, then it is refused.
+    assertStringIncludes(
+      refusal("begins_with(status)").message,
+      "a second operand was expected, separated by a comma",
+    );
+  });
+
+  it("refuses an attribute_type that does not name a type", () => {
+    // Given attribute_type asked about something that is not one of the
+    // descriptors, and about a path rather than a supplied value.
+    // When each is read, then both are refused.
+    assertStringIncludes(
+      refusal("attribute_type(status, :type)", {
+        ":type": { S: "STRING" },
+      }).message,
+      "the second operand of attribute_type is one of",
+    );
+    assertStringIncludes(
+      refusal("attribute_type(status, other)").message,
+      "the second operand of attribute_type is one of",
+    );
+  });
+
+  it("refuses contains asked whether something contains itself", () => {
+    // Given contains with the same operand twice, which has one answer
+    // whatever the item holds.
+    // When it is read, then it is refused, as real DynamoDB refuses it.
+    assertStringIncludes(
+      refusal("contains(tags, tags)").message,
+      "the first operand must be distinct from the second operand for " +
+        "operator contains",
+    );
+
+    // And the refusal names a size operand the way the expression wrote it.
+    assertStringIncludes(
+      refusal("contains(size(tags), size(tags))").message,
+      "both are 'size(tags)'",
+    );
+  });
+});

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-validation.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-validation.iso.test.ts
@@ -220,10 +220,18 @@ describe("DynamoDB condition expression validation", () => {
         "operator contains",
     );
 
-    // And the refusal names a size operand the way the expression wrote it.
+    // And a first operand naming no place in the item is refused before the
+    // two are compared at all, since contains reads a path there.
     assertStringIncludes(
       refusal("contains(size(tags), size(tags))").message,
-      "both are 'size(tags)'",
+      "the first operand of contains names a place in the item",
+    );
+    assertStringIncludes(
+      refusal("begins_with(:a, :b)", {
+        ":a": { S: "a" },
+        ":b": { S: "b" },
+      }).message,
+      "the first operand of begins_with names a place in the item",
     );
   });
 });

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
@@ -1,0 +1,209 @@
+import {
+  assertFalse,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimDynamoDbAttributeValue } from "../../command/item/item.types.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { readSimDynamoDbCondition } from "./sim-dynamodb-condition-expression.js";
+import { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * The order this test guards conditions against.
+ */
+const order: Readonly<Record<string, SimDynamoDbAttributeValue>> = {
+  orderId: { S: "order-1" },
+  status: { S: "shipped" },
+  version: { N: "2" },
+  total: { N: "9007199254740993" },
+  paid: { BOOL: true },
+  note: { NULL: true },
+};
+
+/**
+ * Whether a condition holds for an item, or for no item at all.
+ */
+function holdsFor(
+  expression: string,
+  values: Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined,
+  subject: SimDynamoDbConditionSubject,
+): boolean {
+  const condition = readSimDynamoDbCondition({
+    ConditionExpression: expression,
+    ExpressionAttributeValues: values,
+  });
+  assertNonNullable(condition);
+
+  return condition.holdsFor(subject);
+}
+
+/**
+ * Whether a condition holds for the order.
+ */
+function holds(
+  expression: string,
+  values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): boolean {
+  return holdsFor(
+    expression,
+    values,
+    new SimDynamoDbConditionSubject(SimDynamoDbItem.fromAttributeValues(order)),
+  );
+}
+
+/**
+ * Whether a condition holds where the key holds nothing at all, which is what
+ * a write into a free key is checked against.
+ */
+function holdsForNothing(
+  expression: string,
+  values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): boolean {
+  return holdsFor(expression, values, new SimDynamoDbConditionSubject());
+}
+
+describe("DynamoDB condition expressions", () => {
+  it("evaluates the six comparators", () => {
+    // Given an order whose version is 2.
+    // When each comparator is evaluated against it, then each answers the way
+    // arithmetic does.
+    assertTrue(holds("version = :two", { ":two": { N: "2" } }));
+    assertFalse(holds("version <> :two", { ":two": { N: "2" } }));
+    assertTrue(holds("version < :three", { ":three": { N: "3" } }));
+    assertTrue(holds("version <= :two", { ":two": { N: "2" } }));
+    assertTrue(holds("version > :one", { ":one": { N: "1" } }));
+    assertTrue(holds("version >= :two", { ":two": { N: "2" } }));
+    assertFalse(holds("version > :two", { ":two": { N: "2" } }));
+  });
+
+  it("compares numbers past what a JavaScript number holds", () => {
+    // Given a total one above the largest whole number a double carries
+    // exactly, and a request naming the one below it.
+    // When they are compared, then they differ, because the digits are
+    // compared rather than converted.
+    assertTrue(
+      holds("total > :nearly", { ":nearly": { N: "9007199254740992" } }),
+    );
+  });
+
+  it("is false rather than an error between two different types", () => {
+    // Given a comparison between a string attribute and a number.
+    // When it is evaluated, then it is false, which is what real DynamoDB
+    // does rather than refusing the request.
+    assertFalse(holds("status = :one", { ":one": { N: "1" } }));
+    assertFalse(holds("status < :one", { ":one": { N: "1" } }));
+    assertFalse(holds("paid > :one", { ":one": { N: "1" } }));
+  });
+
+  it("is false for a path the item does not have", () => {
+    // Given a comparison naming an attribute that is not there.
+    // When it is evaluated, then it is false: nothing compares to anything.
+    assertFalse(holds("discount = :one", { ":one": { N: "1" } }));
+    assertFalse(holdsForNothing("version = :two", { ":two": { N: "2" } }));
+  });
+
+  it("evaluates BETWEEN with both bounds inside", () => {
+    // Given a version of 2 and bounds of 2 and 4.
+    // When BETWEEN is evaluated, then the lower bound counts as inside, and a
+    // range that starts above the value does not.
+    assertTrue(
+      holds("version BETWEEN :two AND :four", {
+        ":two": { N: "2" },
+        ":four": { N: "4" },
+      }),
+    );
+    assertFalse(
+      holds("version BETWEEN :three AND :four", {
+        ":three": { N: "3" },
+        ":four": { N: "4" },
+      }),
+    );
+  });
+
+  it("evaluates IN against a list of candidates", () => {
+    // Given a status of shipped and a list naming it among others.
+    // When IN is evaluated, then it holds, and a list without it does not.
+    assertTrue(
+      holds("status IN (:packed, :shipped)", {
+        ":packed": { S: "packed" },
+        ":shipped": { S: "shipped" },
+      }),
+    );
+    assertFalse(holds("status IN (:packed)", { ":packed": { S: "packed" } }));
+  });
+
+  it("binds NOT tighter than AND, and AND tighter than OR", () => {
+    // Given an expression where swapping AND and OR changes the answer:
+    // `false AND false OR true` is true read as `(false AND false) OR true`,
+    // and false read as `false AND (false OR true)`.
+    const values = {
+      ":wrong": { S: "packed" },
+      ":right": { S: "shipped" },
+    } as const;
+
+    // When it is evaluated, then AND binds tighter, so it holds.
+    assertTrue(
+      holds("status = :wrong AND status = :wrong OR status = :right", values),
+    );
+
+    // And brackets change it back, which is what says the precedence is doing
+    // the work rather than the order the operators appear in.
+    assertFalse(
+      holds("status = :wrong AND (status = :wrong OR status = :right)", values),
+    );
+
+    // And NOT applies to what follows it rather than to the whole AND, so
+    // `NOT false AND true` is true.
+    assertTrue(holds("NOT status = :wrong AND status = :right", values));
+  });
+
+  it("reads keywords in any case", () => {
+    // Given an expression written in lower case, as generated code often is.
+    // When it is evaluated, then it means the same, since DynamoDB reads its
+    // keywords whatever case they are written in.
+    assertTrue(
+      holds("version between :one and :three or version = :nine", {
+        ":one": { N: "1" },
+        ":three": { N: "3" },
+        ":nine": { N: "9" },
+      }),
+    );
+    assertTrue(holds("not version = :nine", { ":nine": { N: "9" } }));
+  });
+
+  it("reads a path through a placeholder and into nested values", () => {
+    // Given an item with a map and a list in it.
+    const nested = {
+      orderId: { S: "order-1" },
+      address: { M: { city: { S: "Leeds" } } },
+      lines: { L: [{ S: "widget" }] },
+    } as const;
+
+    // When a condition reaches into both, then it reads what is there.
+    const condition = readSimDynamoDbCondition({
+      ConditionExpression: "#a.city = :city AND lines[0] = :line",
+      ExpressionAttributeNames: { "#a": "address" },
+      ExpressionAttributeValues: {
+        ":city": { S: "Leeds" },
+        ":line": { S: "widget" },
+      },
+    });
+    assertNonNullable(condition);
+
+    const subject = new SimDynamoDbConditionSubject(
+      SimDynamoDbItem.fromAttributeValues(nested),
+    );
+
+    assertTrue(condition.holdsFor(subject));
+  });
+
+  it("reads nothing for a request with no expression", () => {
+    // Given a request that names no condition, which is an unconditional
+    // write.
+    // When the condition is read, then there is none to check.
+    assertUndefined(readSimDynamoDbCondition({}));
+  });
+});

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
@@ -89,13 +89,17 @@ describe("DynamoDB condition expressions", () => {
     );
   });
 
-  it("is false rather than an error between two different types", () => {
-    // Given a comparison between a string attribute and a number.
-    // When it is evaluated, then it is false, which is what real DynamoDB
-    // does rather than refusing the request.
+  it("compares two different types without refusing the request", () => {
+    // Given comparisons between a string attribute and a number.
+    // When they are evaluated, then none is an error, which is what real
+    // DynamoDB does. Ordering has no answer across types, so it is false.
     assertFalse(holds("status = :one", { ":one": { N: "1" } }));
     assertFalse(holds("status < :one", { ":one": { N: "1" } }));
     assertFalse(holds("paid > :one", { ":one": { N: "1" } }));
+
+    // And `<>` is true, because equality works across types and a string
+    // really is not a number.
+    assertTrue(holds("status <> :one", { ":one": { N: "1" } }));
   });
 
   it("is false for a path the item does not have", () => {
@@ -155,9 +159,14 @@ describe("DynamoDB condition expressions", () => {
       holds("status = :wrong AND (status = :wrong OR status = :right)", values),
     );
 
-    // And NOT applies to what follows it rather than to the whole AND, so
-    // `NOT false AND true` is true.
-    assertTrue(holds("NOT status = :wrong AND status = :right", values));
+    // And NOT applies to what follows it rather than to the whole
+    // expression: `NOT true OR true` is true read as `(NOT true) OR true`,
+    // and false read as `NOT (true OR true)`.
+    assertTrue(
+      holds("NOT status = :right OR status = :right", {
+        ":right": values[":right"],
+      }),
+    );
   });
 
   it("reads keywords in any case", () => {

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.ts
@@ -1,0 +1,71 @@
+import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+
+/**
+ * One condition a write is guarded by.
+ *
+ * A condition answers yes or no for the item that is stored, and never
+ * anything else: DynamoDB has no third answer for a path an item does not
+ * have. Whatever cannot be decided is false, so a write goes through only when
+ * the condition it named actually held.
+ */
+export interface SimDynamoDbCondition {
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean;
+}
+
+/**
+ * Two conditions that both have to hold.
+ */
+export class SimDynamoDbAndCondition implements SimDynamoDbCondition {
+  private readonly left: SimDynamoDbCondition;
+  private readonly right: SimDynamoDbCondition;
+
+  constructor(left: SimDynamoDbCondition, right: SimDynamoDbCondition) {
+    this.left = left;
+    this.right = right;
+  }
+
+  /**
+   * Whether both sides hold for an item.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return this.left.holdsFor(subject) && this.right.holdsFor(subject);
+  }
+}
+
+/**
+ * Two conditions where either holding is enough.
+ */
+export class SimDynamoDbOrCondition implements SimDynamoDbCondition {
+  private readonly left: SimDynamoDbCondition;
+  private readonly right: SimDynamoDbCondition;
+
+  constructor(left: SimDynamoDbCondition, right: SimDynamoDbCondition) {
+    this.left = left;
+    this.right = right;
+  }
+
+  /**
+   * Whether either side holds for an item.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return this.left.holdsFor(subject) || this.right.holdsFor(subject);
+  }
+}
+
+/**
+ * A condition that has to not hold.
+ */
+export class SimDynamoDbNotCondition implements SimDynamoDbCondition {
+  private readonly condition: SimDynamoDbCondition;
+
+  constructor(condition: SimDynamoDbCondition) {
+    this.condition = condition;
+  }
+
+  /**
+   * Whether the condition inside does not hold for an item.
+   */
+  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+    return !this.condition.holdsFor(subject);
+  }
+}

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
@@ -1,27 +1,23 @@
-import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
-import { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
-import { SimDynamoDbExpressionTokeniser } from "../sim-dynamodb-expression-tokeniser.js";
+import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { SimDynamoDbProjection } from "./sim-dynamodb-projection.js";
 
 const expressionName = "ProjectionExpression";
 
-interface SimDynamoDbProjectionRequest {
+interface SimDynamoDbProjectionRequest extends SimDynamoDbExpressionParameterInput {
   readonly ProjectionExpression?: string | undefined;
-  readonly ExpressionAttributeNames?:
-    Readonly<Record<string, string>> | undefined;
 }
 
 /**
  * Read the projection a request asks for, if it asks for one.
  *
  * A request with no ProjectionExpression asks for the whole item, so there is
- * nothing to project. Names supplied without an expression to use them in are
- * refused, as real DynamoDB refuses them: nothing would ever read them, and a
- * request carrying them has almost always lost its expression somewhere.
+ * nothing to project.
  */
 export function readSimDynamoDbProjection(
   request: SimDynamoDbProjectionRequest,
@@ -29,18 +25,22 @@ export function readSimDynamoDbProjection(
   const expression = request.ProjectionExpression;
 
   if (expression === undefined) {
-    assertNoNamesWithoutExpression(request.ExpressionAttributeNames);
+    SimDynamoDbExpressionParameters.assertNoneWithout(request);
 
     return undefined;
   }
 
-  const names = new SimDynamoDbExpressionPlaceholders({
-    parameterName: "ExpressionAttributeNames",
-    marker: "#",
-    entries: request.ExpressionAttributeNames,
-  });
-  const paths = projectedPaths(expression, names);
-  names.assertAllUsed();
+  const parameters = new SimDynamoDbExpressionParameters(request);
+  const paths = projectedPaths(
+    SimDynamoDbExpressionTokens.of(
+      expressionName,
+      expression,
+      "the expression names no attributes, and an expression cannot be empty",
+    ),
+    parameters.names,
+  );
+
+  parameters.assertAllUsed();
 
   return new SimDynamoDbProjection({ expressionName, paths });
 }
@@ -49,23 +49,9 @@ export function readSimDynamoDbProjection(
  * Read the comma-separated document paths a ProjectionExpression names.
  */
 function projectedPaths(
-  expression: string,
+  tokens: SimDynamoDbExpressionTokens,
   names: SimDynamoDbExpressionPlaceholders<string>,
 ): readonly SimDynamoDbDocumentPath[] {
-  const tokens = new SimDynamoDbExpressionTokens({
-    expressionName,
-    tokens: new SimDynamoDbExpressionTokeniser({ expressionName }).tokenise(
-      expression,
-    ),
-  });
-
-  if (tokens.atEnd) {
-    throw simDynamoDbExpressionError(
-      expressionName,
-      "the expression names no attributes, and an expression cannot be empty",
-    );
-  }
-
   const paths: SimDynamoDbDocumentPath[] = [];
 
   do {
@@ -88,20 +74,6 @@ function assertReadToEnd(tokens: SimDynamoDbExpressionTokens): void {
       expressionName,
       `syntax error; '${remaining.text}' follows a document path, where a ` +
         `comma or the end of the expression was expected`,
-    );
-  }
-}
-
-/**
- * Refuse names defined for an expression the request does not carry.
- */
-function assertNoNamesWithoutExpression(
-  entries: Readonly<Record<string, string>> | undefined,
-): void {
-  if (Object.keys(entries ?? {}).length > 0) {
-    throw new SimDynamoDbValidationException(
-      "ExpressionAttributeNames can only be specified when using expressions, " +
-        "and this request carries none",
     );
   }
 }

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
@@ -1,3 +1,5 @@
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
 /**
  * One step of a document path: an attribute of a map.
  */
@@ -40,6 +42,18 @@ export class SimDynamoDbDocumentPath {
    */
   get depth(): number {
     return this.segments.length;
+  }
+
+  /**
+   * What this path names, as text no other path can produce.
+   *
+   * Two paths that print the same are not always the same path: an attribute
+   * whose name carries a dot has to be written as a placeholder, and prints as
+   * though it were two attributes. Anything comparing paths compares this
+   * rather than the printed form.
+   */
+  get identity(): string {
+    return jsonStringify(this.segments);
   }
 
   /**

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-parameters.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-parameters.ts
@@ -1,0 +1,92 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { readSimDynamoDbValue } from "../item/sim-dynamodb-value-reader.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+import { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+
+/**
+ * The two placeholder parameters a request can carry for its expressions.
+ */
+export interface SimDynamoDbExpressionParameterInput {
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * The placeholders one request defines for its expressions.
+ *
+ * Every expression kind reads the same two parameters the same way, so they are
+ * held together here rather than assembled per expression. Both are checked
+ * once every expression on the request has been read, so a placeholder used by
+ * any one of them counts as used.
+ */
+export class SimDynamoDbExpressionParameters {
+  public readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  public readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+
+  constructor(input: SimDynamoDbExpressionParameterInput) {
+    this.names = new SimDynamoDbExpressionPlaceholders({
+      parameterName: "ExpressionAttributeNames",
+      marker: "#",
+      entries: input.ExpressionAttributeNames,
+    });
+    this.values = new SimDynamoDbExpressionPlaceholders({
+      parameterName: "ExpressionAttributeValues",
+      marker: ":",
+      entries: storedValues(input.ExpressionAttributeValues),
+    });
+  }
+
+  /**
+   * Refuse placeholders defined for an expression the request does not carry.
+   *
+   * Nothing would ever read them, and a request carrying them has almost
+   * always lost its expression somewhere.
+   */
+  static assertNoneWithout(input: SimDynamoDbExpressionParameterInput): void {
+    assertUnused(input.ExpressionAttributeNames, "Names");
+    assertUnused(input.ExpressionAttributeValues, "Values");
+  }
+
+  /**
+   * Refuse any entry no expression used.
+   */
+  assertAllUsed(): void {
+    this.names.assertAllUsed();
+    this.values.assertAllUsed();
+  }
+}
+
+/**
+ * Read the values a request supplied into the values a table holds.
+ *
+ * Reading them here is what checks them: a value an item could not carry is one
+ * no expression could ever have matched.
+ */
+function storedValues(
+  entries: Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined,
+): Readonly<Record<string, SimDynamoDbValue>> {
+  return Object.fromEntries(
+    Object.entries(entries ?? {}).map(([placeholder, value]) => [
+      placeholder,
+      readSimDynamoDbValue(value),
+    ]),
+  );
+}
+
+/**
+ * Refuse one parameter supplied with no expression to use it in.
+ */
+function assertUnused<Value>(
+  entries: Readonly<Record<string, Value>> | undefined,
+  suffix: string,
+): void {
+  if (Object.keys(entries ?? {}).length > 0) {
+    throw new SimDynamoDbValidationException(
+      `ExpressionAttribute${suffix} can only be specified when using ` +
+        `expressions, and this request carries none`,
+    );
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-symbols.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-symbols.ts
@@ -1,0 +1,46 @@
+/**
+ * The two character operators, which are read before the single characters so
+ * `<=` is one operator rather than a `<` followed by an `=`.
+ */
+const longSymbols: readonly string[] = ["<=", ">=", "<>"];
+
+/**
+ * The single characters that mean something in the expressions supported so
+ * far.
+ *
+ * This set grows as filter and update expressions arrive. Until then, a
+ * character outside it is refused rather than passed through, so an expression
+ * this simulation cannot evaluate fails rather than half works.
+ */
+const symbols: ReadonlySet<string> = new Set([
+  ".",
+  ",",
+  "[",
+  "]",
+  "-",
+  "(",
+  ")",
+  "=",
+  "<",
+  ">",
+]);
+
+/**
+ * The symbol an expression starts with, or nothing when it starts with a
+ * character no supported expression uses.
+ */
+export function readSimDynamoDbSymbol(remaining: string): string | undefined {
+  const operator = longSymbols.find((text) => remaining.startsWith(text));
+
+  if (operator !== undefined) {
+    return operator;
+  }
+
+  const character = remaining.slice(0, 1);
+
+  if (!symbols.has(character)) {
+    return undefined;
+  }
+
+  return character;
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-token-reader.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-token-reader.ts
@@ -1,4 +1,5 @@
 import { simDynamoDbExpressionError } from "./sim-dynamodb-expression-error.js";
+import { readSimDynamoDbSymbol } from "./sim-dynamodb-expression-symbols.js";
 import type {
   SimDynamoDbExpressionToken,
   SimDynamoDbExpressionTokenKind,
@@ -32,22 +33,17 @@ const digitsPattern = /^\d+/;
 const fractionPattern = /^\.\d+/;
 
 /**
- * The single characters that mean something in the expressions supported so
- * far.
- *
- * This set grows as condition, filter and update expressions arrive. Until
- * then, a character outside it is refused rather than passed through, so an
- * expression this simulation cannot evaluate fails rather than half works.
- */
-const symbols: ReadonlySet<string> = new Set([".", ",", "[", "]", "-"]);
-
-/**
  * A token before it is told where in the expression it was found.
  */
 export type SimDynamoDbUnplacedToken = Omit<
   SimDynamoDbExpressionToken,
   "position"
 >;
+
+/**
+ * A token, or nothing where the text does not start with one of that kind.
+ */
+type MaybeToken = SimDynamoDbUnplacedToken | undefined;
 
 /**
  * Reads the one token an expression starts with.
@@ -79,7 +75,7 @@ export class SimDynamoDbExpressionTokenReader {
   /**
    * Read an attribute name written into the expression itself.
    */
-  private name(remaining: string): SimDynamoDbUnplacedToken | undefined {
+  private name(remaining: string): MaybeToken {
     const text = namePattern.exec(remaining)?.[0];
 
     if (text === undefined) {
@@ -99,7 +95,7 @@ export class SimDynamoDbExpressionTokenReader {
     kind: SimDynamoDbExpressionTokenKind,
     marker: string,
     remaining: string,
-  ): SimDynamoDbUnplacedToken | undefined {
+  ): MaybeToken {
     if (!remaining.startsWith(marker)) {
       return undefined;
     }
@@ -120,7 +116,7 @@ export class SimDynamoDbExpressionTokenReader {
    * Read a number, which is its digits and the fraction after them if it has
    * one.
    */
-  private number(remaining: string): SimDynamoDbUnplacedToken | undefined {
+  private number(remaining: string): MaybeToken {
     const digits = digitsPattern.exec(remaining)?.[0];
 
     if (digits === undefined) {
@@ -137,13 +133,15 @@ export class SimDynamoDbExpressionTokenReader {
    * Read a single character that means something on its own.
    */
   private symbol(remaining: string): SimDynamoDbUnplacedToken {
-    const character = remaining.slice(0, 1);
+    const text = readSimDynamoDbSymbol(remaining);
 
-    if (!symbols.has(character)) {
-      throw this.error(`syntax error; unexpected character '${character}'`);
+    if (text === undefined) {
+      throw this.error(
+        `syntax error; unexpected character '${remaining.slice(0, 1)}'`,
+      );
     }
 
-    return { kind: "symbol", text: character };
+    return { kind: "symbol", text };
   }
 
   /**

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
@@ -96,16 +96,29 @@ describe("SimDynamoDbExpressionTokeniser", () => {
     );
   });
 
+  it("reads a two character operator as one operator", () => {
+    // Given the comparators written with two characters, which a reader
+    // taking one character at a time would split.
+    // When they are tokenised.
+    const tokens = tokenise("a <= b >= c <> d = e");
+
+    // Then each is one token, so a parser reads `<=` rather than `<` and `=`.
+    assertIdentical(tokens.at(1)?.text, "<=");
+    assertIdentical(tokens.at(3)?.text, ">=");
+    assertIdentical(tokens.at(5)?.text, "<>");
+    assertIdentical(tokens.at(7)?.text, "=");
+  });
+
   it("refuses a character that means nothing in an expression", () => {
     // Given an expression carrying a character no supported expression uses.
     // When it is tokenised, then it is refused rather than passed through to a
     // parser that would ignore it.
-    const error = assertThrowsError(() => tokenise("id = 3"));
+    const error = assertThrowsError(() => tokenise("id + 3"));
 
     assertInstanceOf(error, SimDynamoDbValidationException);
     assertIdentical(
       error.message,
-      "Invalid ProjectionExpression: syntax error; unexpected character '='",
+      "Invalid ProjectionExpression: syntax error; unexpected character '+'",
     );
   });
 

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokens.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokens.ts
@@ -1,5 +1,6 @@
 import { simDynamoDbExpressionError } from "./sim-dynamodb-expression-error.js";
 import type { SimDynamoDbExpressionToken } from "./sim-dynamodb-expression-token.js";
+import { SimDynamoDbExpressionTokeniser } from "./sim-dynamodb-expression-tokeniser.js";
 
 interface SimDynamoDbExpressionTokensProperties {
   readonly expressionName: string;
@@ -24,6 +25,32 @@ export class SimDynamoDbExpressionTokens {
   }
 
   /**
+   * Read an expression into the tokens a parser walks.
+   *
+   * An expression with nothing in it is refused here rather than by each
+   * parser, since none of them has anything to read either way. The reason
+   * says what that expression kind would have been asking for.
+   */
+  static of(
+    expressionName: string,
+    expression: string,
+    emptyReason: string,
+  ): SimDynamoDbExpressionTokens {
+    const read = new this({
+      expressionName,
+      tokens: new SimDynamoDbExpressionTokeniser({ expressionName }).tokenise(
+        expression,
+      ),
+    });
+
+    if (read.atEnd) {
+      throw simDynamoDbExpressionError(expressionName, emptyReason);
+    }
+
+    return read;
+  }
+
+  /**
    * Whether every token has been read.
    */
   get atEnd(): boolean {
@@ -32,9 +59,12 @@ export class SimDynamoDbExpressionTokens {
 
   /**
    * The next token, without reading it.
+   *
+   * An offset looks further ahead, which is what tells a function call from a
+   * document path that happens to start with the same word.
    */
-  peek(): SimDynamoDbExpressionToken | undefined {
-    return this.tokens[this.position];
+  peek(offset = 0): SimDynamoDbExpressionToken | undefined {
+    return this.tokens.at(this.position + offset);
   }
 
   /**
@@ -70,9 +100,56 @@ export class SimDynamoDbExpressionTokens {
   }
 
   /**
+   * Read a symbol the expression has to carry here.
+   */
+  expectSymbol(text: string, reason: string): void {
+    if (!this.takeSymbol(text)) {
+      throw this.error(reason);
+    }
+  }
+
+  /**
+   * Read the next token when it is a keyword, and leave it otherwise.
+   *
+   * A keyword arrives as a name, since that is what it looks like. DynamoDB
+   * reads AND, OR, NOT, BETWEEN and IN whatever case they are written in, so
+   * they are matched that way here.
+   */
+  takeKeyword(word: string): boolean {
+    const candidate = this.peek();
+
+    if (candidate?.kind !== "name" || !this.isKeyword(candidate.text, word)) {
+      return false;
+    }
+
+    this.position += 1;
+
+    return true;
+  }
+
+  /**
+   * Read a keyword the expression has to carry here.
+   */
+  expectKeyword(word: string): void {
+    if (!this.takeKeyword(word)) {
+      throw this.error(
+        `syntax error; ${word} expected, but ` +
+          `'${this.peek()?.text ?? "the end of the expression"}' was given`,
+      );
+    }
+  }
+
+  /**
    * Build the error this expression is refused with.
    */
   error(reason: string): Error {
     return simDynamoDbExpressionError(this.expressionName, reason);
+  }
+
+  /**
+   * Whether some text is a keyword, whatever case it was written in.
+   */
+  private isKeyword(text: string, word: string): boolean {
+    return text.toUpperCase() === word;
   }
 }

--- a/src/service/dynamodb/item/sim-dynamodb-number-order.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-number-order.ts
@@ -1,0 +1,45 @@
+/**
+ * Compare two runs of digits of the same length.
+ */
+function compareDigits(first: string, second: string): number {
+  if (first < second) {
+    return -1;
+  }
+
+  if (first > second) {
+    return 1;
+  }
+
+  return 0;
+}
+
+/**
+ * Compare the digits of two numbers, ignoring their signs.
+ *
+ * Both are in plain decimal notation with no leading zeros, so a longer whole
+ * part is a bigger number and two whole parts of the same length compare
+ * character by character. The fractions are then padded to the same length so
+ * `0.5` and `0.45` compare by their digits rather than by how many there are.
+ */
+export function compareSimDynamoDbMagnitudes(
+  first: string,
+  second: string,
+): number {
+  const [firstWhole = "", firstFraction = ""] = first.split(".");
+  const [secondWhole = "", secondFraction = ""] = second.split(".");
+
+  if (firstWhole.length !== secondWhole.length) {
+    return firstWhole.length - secondWhole.length;
+  }
+
+  if (firstWhole !== secondWhole) {
+    return compareDigits(firstWhole, secondWhole);
+  }
+
+  const width = Math.max(firstFraction.length, secondFraction.length);
+
+  return compareDigits(
+    firstFraction.padEnd(width, "0"),
+    secondFraction.padEnd(width, "0"),
+  );
+}

--- a/src/service/dynamodb/item/sim-dynamodb-number-range.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-number-range.ts
@@ -1,0 +1,40 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+const greatestSignificantDigits = 38;
+const greatestAdjustedExponent = 125;
+const leastAdjustedExponent = -130;
+
+/**
+ * Refuse a number outside the range real DynamoDB stores.
+ *
+ * How wide a number can be and how big it can get are limits of the store
+ * rather than of how a number is written, so they are checked here rather than
+ * beside the parsing.
+ */
+export function assertSimDynamoDbNumberInRange(
+  value: string,
+  significand: string,
+  scale: number,
+): void {
+  if (significand.length > greatestSignificantDigits) {
+    throw new SimDynamoDbValidationException(
+      `Number ${value} has ${significand.length.toString()} significant ` +
+        `digits, and DynamoDB numbers carry ${greatestSignificantDigits.toString()}`,
+    );
+  }
+
+  // The exponent the number has when written as one digit, a point and the
+  // rest, which is how DynamoDB documents its range.
+  const adjustedExponent = scale + significand.length - 1;
+
+  if (
+    adjustedExponent > greatestAdjustedExponent ||
+    adjustedExponent < leastAdjustedExponent
+  ) {
+    throw new SimDynamoDbValidationException(
+      `Number ${value} is outside the range DynamoDB stores, which is ` +
+        `1E-130 to 9.9999999999999999999999999999999999999E+125 and its ` +
+        `negative mirror`,
+    );
+  }
+}

--- a/src/service/dynamodb/item/sim-dynamodb-number.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-number.ts
@@ -1,4 +1,6 @@
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { compareSimDynamoDbMagnitudes } from "./sim-dynamodb-number-order.js";
+import { assertSimDynamoDbNumberInRange } from "./sim-dynamodb-number-range.js";
 
 /**
  * A number as DynamoDB takes it on the wire: digits, an optional fraction, and
@@ -9,10 +11,6 @@ import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 // backtracks a digit at a time rather than combinatorially.
 // eslint-disable-next-line security/detect-unsafe-regex -- no nested quantifier.
 const numberPattern = /^(-?)(\d+)(?:\.(\d+))?(?:[Ee]([+-]?\d+))?$/;
-
-const greatestSignificantDigits = 38;
-const greatestAdjustedExponent = 125;
-const leastAdjustedExponent = -130;
 
 /**
  * Render a number in plain decimal notation.
@@ -100,7 +98,7 @@ export class SimDynamoDbNumber {
     const significand = withoutLeadingZeros.replace(/0+$/, "");
     const trailingZeros = withoutLeadingZeros.length - significand.length;
 
-    this.assertInRange(value, significand, scale + trailingZeros);
+    assertSimDynamoDbNumberInRange(value, significand, scale + trailingZeros);
 
     return new this(
       plainDecimal(sign, significand, scale + trailingZeros),
@@ -109,34 +107,27 @@ export class SimDynamoDbNumber {
   }
 
   /**
-   * Refuse a number outside the range real DynamoDB stores.
+   * Compare this number with another, as DynamoDB orders numbers.
+   *
+   * The digits are compared rather than converted, so two numbers past what a
+   * JavaScript number holds still order by what they say. Converting them
+   * would round both to the same value and call them equal.
    */
-  private static assertInRange(
-    value: string,
-    significand: string,
-    scale: number,
-  ): void {
-    if (significand.length > greatestSignificantDigits) {
-      throw new SimDynamoDbValidationException(
-        `Number ${value} has ${significand.length.toString()} significant ` +
-          `digits, and DynamoDB numbers carry ${greatestSignificantDigits.toString()}`,
-      );
+  compareTo(other: SimDynamoDbNumber): number {
+    if (this.negative !== other.negative) {
+      return this.signOrder();
     }
 
-    // The exponent the number has when written as one digit, a point and the
-    // rest, which is how DynamoDB documents its range.
-    const adjustedExponent = scale + significand.length - 1;
+    const magnitude = compareSimDynamoDbMagnitudes(
+      this.withoutSign(),
+      other.withoutSign(),
+    );
 
-    if (
-      adjustedExponent > greatestAdjustedExponent ||
-      adjustedExponent < leastAdjustedExponent
-    ) {
-      throw new SimDynamoDbValidationException(
-        `Number ${value} is outside the range DynamoDB stores, which is ` +
-          `1E-130 to 9.9999999999999999999999999999999999999E+125 and its ` +
-          `negative mirror`,
-      );
+    if (this.negative) {
+      return -magnitude;
     }
+
+    return magnitude;
   }
 
   /**
@@ -147,5 +138,30 @@ export class SimDynamoDbNumber {
    */
   get sizeInBytes(): number {
     return Math.ceil(this.significantDigits / 2) + 1;
+  }
+
+  /**
+   * Whether this number is below zero.
+   */
+  private get negative(): boolean {
+    return this.text.startsWith("-");
+  }
+
+  /**
+   * Which way round this number goes against one of the other sign.
+   */
+  private signOrder(): number {
+    if (this.negative) {
+      return -1;
+    }
+
+    return 1;
+  }
+
+  /**
+   * The digits of this number, without the sign in front of them.
+   */
+  private withoutSign(): string {
+    return this.text.replace("-", "");
   }
 }

--- a/src/service/dynamodb/item/sim-dynamodb-value-comparison.iso.test.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-comparison.iso.test.ts
@@ -1,0 +1,226 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbNumber } from "./sim-dynamodb-number.js";
+import { simDynamoDbValuesEqual } from "./sim-dynamodb-value-comparison.js";
+import { compareSimDynamoDbValues } from "./sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "./sim-dynamodb-value.js";
+
+function text(value: string): SimDynamoDbValue {
+  return { kind: "S", text: value };
+}
+
+function number(value: string): SimDynamoDbValue {
+  return { kind: "N", number: SimDynamoDbNumber.of(value) };
+}
+
+function binary(...bytes: number[]): SimDynamoDbValue {
+  return { kind: "B", bytes: Uint8Array.from(bytes) };
+}
+
+function map(entries: Readonly<Record<string, string>>): SimDynamoDbValue {
+  return {
+    kind: "M",
+    entries: new Map(
+      Object.entries(entries).map(([name, value]) => [name, text(value)]),
+    ),
+  };
+}
+
+/**
+ * Which way round two values go, as -1, 0 or 1.
+ */
+function order(
+  first: SimDynamoDbValue,
+  second: SimDynamoDbValue,
+): number | undefined {
+  return Math.sign(compareSimDynamoDbValues(first, second) ?? NaN);
+}
+
+describe("compareSimDynamoDbValues", () => {
+  it("orders strings by their UTF-8 bytes", () => {
+    // Given strings that differ in case and in accent, where UTF-8 puts the
+    // capitals first and everything outside ASCII after them.
+    // When they are ordered, then they follow those bytes rather than any
+    // locale's idea of alphabetical order.
+    assertIdentical(order(text("A"), text("a")), -1);
+    assertIdentical(order(text("z"), text("é")), -1);
+    assertIdentical(order(text("abc"), text("abc")), 0);
+    assertIdentical(order(text("ab"), text("abc")), -1);
+  });
+
+  it("orders a character above the basic plane after one below it", () => {
+    // Given a character that needs a surrogate pair in UTF-16 and one that
+    // does not. JavaScript compares by code unit, which puts the pair first.
+    // When they are ordered, then the higher code point comes second, as its
+    // UTF-8 bytes do.
+    assertIdentical(order(text("\u{1F600}"), text("�")), 1);
+  });
+
+  it("orders numbers by what they say rather than by what they round to", () => {
+    // Given two numbers that differ past what a JavaScript number holds, which
+    // would round to the same value.
+    // When they are ordered, then they differ, because the digits are
+    // compared rather than converted.
+    assertIdentical(
+      order(number("9007199254740993"), number("9007199254740992")),
+      1,
+    );
+  });
+
+  it("orders numbers across signs, scales and fractions", () => {
+    // Given numbers on both sides of zero, of different lengths, and with
+    // fractions of different lengths.
+    // When they are ordered, then each goes where arithmetic puts it.
+    assertIdentical(order(number("-1"), number("1")), -1);
+    assertIdentical(order(number("1"), number("-1")), 1);
+    assertIdentical(order(number("-10"), number("-2")), -1);
+    assertIdentical(order(number("100"), number("99")), 1);
+    assertIdentical(order(number("0.5"), number("0.45")), 1);
+    assertIdentical(order(number("1.0"), number("1")), 0);
+    assertIdentical(order(number("0"), number("-0")), 0);
+    assertIdentical(order(number("1e2"), number("100")), 0);
+  });
+
+  it("orders binary as unsigned bytes", () => {
+    // Given bytes that differ where a signed comparison would disagree, since
+    // 0x80 is negative as a signed byte and above 0x01 as an unsigned one.
+    // When they are ordered, then the unsigned order wins.
+    assertIdentical(order(binary(0x80), binary(0x01)), 1);
+    assertIdentical(order(binary(1, 2), binary(1, 2, 0)), -1);
+    assertIdentical(order(binary(1, 2), binary(1, 2)), 0);
+  });
+
+  it("has no order between two different types", () => {
+    // Given a string and a number, which DynamoDB does not order against each
+    // other.
+    // When they are compared, then there is no order, which is what makes a
+    // comparison between them false rather than an error.
+    assertUndefined(compareSimDynamoDbValues(text("1"), number("1")));
+    assertUndefined(
+      compareSimDynamoDbValues({ kind: "BOOL", boolean: true }, text("true")),
+    );
+  });
+
+  it("has no order for a type DynamoDB does not order", () => {
+    // Given two booleans, which are equal or not rather than greater or less.
+    // When they are compared, then there is no order.
+    assertUndefined(
+      compareSimDynamoDbValues(
+        { kind: "BOOL", boolean: true },
+        { kind: "BOOL", boolean: false },
+      ),
+    );
+  });
+});
+
+describe("simDynamoDbValuesEqual", () => {
+  it("compares scalars by value rather than by how they were written", () => {
+    // Given values written differently for the same thing.
+    // When they are compared, then they are equal.
+    assertTrue(simDynamoDbValuesEqual(number("1.0"), number("1")));
+    assertTrue(simDynamoDbValuesEqual(binary(1, 2), binary(1, 2)));
+    assertTrue(simDynamoDbValuesEqual({ kind: "NULL" }, { kind: "NULL" }));
+    assertTrue(
+      simDynamoDbValuesEqual(
+        { kind: "BOOL", boolean: false },
+        { kind: "BOOL", boolean: false },
+      ),
+    );
+    assertFalse(
+      simDynamoDbValuesEqual(
+        { kind: "BOOL", boolean: true },
+        { kind: "BOOL", boolean: false },
+      ),
+    );
+  });
+
+  it("is never equal across two types", () => {
+    // Given a string and a number holding the same characters.
+    // When they are compared, then they are not equal, which is what makes an
+    // `=` between them false rather than an error.
+    assertFalse(simDynamoDbValuesEqual(text("1"), number("1")));
+  });
+
+  it("compares a set by its members rather than by their order", () => {
+    // Given two sets holding the same members in different orders, which is
+    // the same set: a set has no order.
+    // When they are compared, then they are equal.
+    assertTrue(
+      simDynamoDbValuesEqual(
+        { kind: "SS", texts: ["a", "b"] },
+        { kind: "SS", texts: ["b", "a"] },
+      ),
+    );
+    assertFalse(
+      simDynamoDbValuesEqual(
+        { kind: "SS", texts: ["a", "b"] },
+        { kind: "SS", texts: ["a"] },
+      ),
+    );
+    assertFalse(
+      simDynamoDbValuesEqual(
+        { kind: "SS", texts: ["a", "b"] },
+        { kind: "SS", texts: ["a", "c"] },
+      ),
+    );
+  });
+
+  it("compares number and binary sets by value", () => {
+    // Given sets whose members compare by their digits and by their bytes
+    // rather than by how they were written or by object identity.
+    // When they are compared, then they are equal.
+    assertTrue(
+      simDynamoDbValuesEqual(
+        { kind: "NS", numbers: [SimDynamoDbNumber.of("1.0")] },
+        { kind: "NS", numbers: [SimDynamoDbNumber.of("1")] },
+      ),
+    );
+    assertTrue(
+      simDynamoDbValuesEqual(
+        { kind: "BS", bytes: [Uint8Array.from([1])] },
+        { kind: "BS", bytes: [Uint8Array.from([1])] },
+      ),
+    );
+  });
+
+  it("compares a list by its elements in order", () => {
+    // Given lists holding the same elements in different orders, which is not
+    // the same list: a list has an order.
+    // When they are compared, then only the matching one is equal.
+    assertTrue(
+      simDynamoDbValuesEqual(
+        { kind: "L", values: [text("a"), number("1")] },
+        { kind: "L", values: [text("a"), number("1")] },
+      ),
+    );
+    assertFalse(
+      simDynamoDbValuesEqual(
+        { kind: "L", values: [text("a"), text("b")] },
+        { kind: "L", values: [text("b"), text("a")] },
+      ),
+    );
+    assertFalse(
+      simDynamoDbValuesEqual(
+        { kind: "L", values: [text("a")] },
+        { kind: "L", values: [text("a"), text("b")] },
+      ),
+    );
+  });
+
+  it("compares a map by its attributes and their values", () => {
+    // Given maps holding the same attributes, and maps that differ by one.
+    // When they are compared, then only the matching one is equal.
+    const leeds = map({ city: "Leeds" });
+
+    assertTrue(simDynamoDbValuesEqual(leeds, map({ city: "Leeds" })));
+    assertFalse(simDynamoDbValuesEqual(leeds, map({ city: "York" })));
+    assertFalse(simDynamoDbValuesEqual(leeds, map({ town: "Leeds" })));
+    assertFalse(simDynamoDbValuesEqual(leeds, map({})));
+  });
+});

--- a/src/service/dynamodb/item/sim-dynamodb-value-comparison.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-comparison.ts
@@ -1,0 +1,137 @@
+import { simDynamoDbBinaryText } from "./sim-dynamodb-binary.js";
+import type { SimDynamoDbNumber } from "./sim-dynamodb-number.js";
+import { compareSimDynamoDbValues } from "./sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "./sim-dynamodb-value.js";
+
+/**
+ * Whether two stored values are the same value.
+ *
+ * Every type can be compared for equality, unlike ordering. Two values of
+ * different types are never equal, which is what makes `=` between them false
+ * rather than an error.
+ *
+ * A set is equal to another set holding the same members, whatever order they
+ * arrived in, because a set has no order. A list is equal only to a list
+ * holding the same elements in the same order, because a list does.
+ */
+export function simDynamoDbValuesEqual(
+  first: SimDynamoDbValue,
+  second: SimDynamoDbValue,
+): boolean {
+  if (first.kind !== second.kind) {
+    return false;
+  }
+
+  return equalOfKind(first, second);
+}
+
+/**
+ * Whether two values already known to be the same type are the same value.
+ */
+function equalOfKind(
+  first: SimDynamoDbValue,
+  second: SimDynamoDbValue,
+): boolean {
+  switch (first.kind) {
+    case "S":
+    case "N":
+    case "B": {
+      return compareSimDynamoDbValues(first, second) === 0;
+    }
+    case "BOOL": {
+      return second.kind === "BOOL" && first.boolean === second.boolean;
+    }
+    case "NULL": {
+      return true;
+    }
+    case "SS": {
+      return second.kind === "SS" && equalMembers(first.texts, second.texts);
+    }
+    case "NS": {
+      return (
+        second.kind === "NS" &&
+        equalMembers(numberTexts(first.numbers), numberTexts(second.numbers))
+      );
+    }
+    case "BS": {
+      return (
+        second.kind === "BS" &&
+        equalMembers(binaryTexts(first.bytes), binaryTexts(second.bytes))
+      );
+    }
+    case "L": {
+      return second.kind === "L" && equalLists(first.values, second.values);
+    }
+    case "M": {
+      return second.kind === "M" && equalMaps(first.entries, second.entries);
+    }
+  }
+}
+
+/**
+ * The members of a number set, each as the digits it compares by, so two sets
+ * written differently for the same members come out the same.
+ */
+function numberTexts(numbers: readonly SimDynamoDbNumber[]): readonly string[] {
+  return numbers.map((number) => number.text);
+}
+
+/**
+ * The members of a binary set, each as the base64 it compares by, since two
+ * arrays holding the same bytes are different objects.
+ */
+function binaryTexts(members: readonly Uint8Array[]): readonly string[] {
+  return members.map((bytes) => simDynamoDbBinaryText(bytes));
+}
+
+/**
+ * Whether two sets hold the same members, in whatever order.
+ */
+function equalMembers(
+  first: readonly string[],
+  second: readonly string[],
+): boolean {
+  if (first.length !== second.length) {
+    return false;
+  }
+
+  const held = new Set(second);
+
+  return first.every((member) => held.has(member));
+}
+
+/**
+ * Whether two lists hold the same elements in the same order.
+ */
+function equalLists(
+  first: readonly SimDynamoDbValue[],
+  second: readonly SimDynamoDbValue[],
+): boolean {
+  if (first.length !== second.length) {
+    return false;
+  }
+
+  return first.every((element, at) => {
+    const other = second.at(at);
+
+    return other !== undefined && simDynamoDbValuesEqual(element, other);
+  });
+}
+
+/**
+ * Whether two maps hold the same attributes with the same values.
+ */
+function equalMaps(
+  first: ReadonlyMap<string, SimDynamoDbValue>,
+  second: ReadonlyMap<string, SimDynamoDbValue>,
+): boolean {
+  if (first.size !== second.size) {
+    return false;
+  }
+
+  return first.entries().every(([name, value]) => {
+    const other = second.get(name);
+
+    return other !== undefined && simDynamoDbValuesEqual(value, other);
+  });
+}

--- a/src/service/dynamodb/item/sim-dynamodb-value-order.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-order.ts
@@ -1,0 +1,54 @@
+import type { SimDynamoDbValue } from "./sim-dynamodb-value.js";
+
+/**
+ * Compare two runs of bytes as unsigned, which is how DynamoDB orders binary.
+ *
+ * The shorter of two values that agree as far as it goes comes first, so
+ * `[1, 2]` sorts before `[1, 2, 0]`.
+ */
+export function compareSimDynamoDbBytes(
+  first: Uint8Array,
+  second: Uint8Array,
+): number {
+  return Buffer.compare(first, second);
+}
+
+/**
+ * Compare two strings by their UTF-8 bytes, which is how DynamoDB orders them.
+ *
+ * JavaScript compares strings by UTF-16 code units, which puts characters above
+ * the basic plane before ones like `U+FFFD` rather than after them. The strings
+ * are encoded first so the order is DynamoDB's rather than the language's.
+ */
+function compareTexts(first: string, second: string): number {
+  return compareSimDynamoDbBytes(
+    Buffer.from(first, "utf8"),
+    Buffer.from(second, "utf8"),
+  );
+}
+
+/**
+ * Order two stored values, or nothing when they cannot be ordered.
+ *
+ * DynamoDB orders strings, numbers and binary, and only against a value of the
+ * same type. Anything else has no order, which is what makes a `<` between two
+ * different types false rather than an error.
+ */
+export function compareSimDynamoDbValues(
+  first: SimDynamoDbValue,
+  second: SimDynamoDbValue,
+): number | undefined {
+  if (first.kind === "S" && second.kind === "S") {
+    return compareTexts(first.text, second.text);
+  }
+
+  if (first.kind === "N" && second.kind === "N") {
+    return first.number.compareTo(second.number);
+  }
+
+  if (first.kind === "B" && second.kind === "B") {
+    return compareSimDynamoDbBytes(first.bytes, second.bytes);
+  }
+
+  return undefined;
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -132,6 +132,18 @@ export class SimDynamoDbTable {
   }
 
   /**
+   * The item already stored under the same primary key as this one.
+   *
+   * A conditional write is checked against what is there before it, and what is
+   * there is found by the key inside the item rather than by a Key of its own.
+   * The key is read the same way a write reads it, so an item that could not be
+   * written does not quietly find nothing here either.
+   */
+  public itemUnder(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
+    return this.items.get(this.itemKey.of(item));
+  }
+
+  /**
    * Read the item a primary key names, if the table holds one.
    *
    * Every write has landed by the time it returns, so this reads the latest


### PR DESCRIPTION
PutItem and DeleteItem take a ConditionExpression, checked against whatever is stored under the key before anything changes. A condition that does not hold leaves the item as it was and throws ConditionalCheckFailedException with the name and message real DynamoDB uses.

The comparison rules live beside the value model rather than inside the evaluator, since sort key conditions and filter expressions compare the same way: strings by UTF-8 bytes, numbers by their digits rather than by what they round to, and binary as unsigned bytes. Two different types have no order, so a comparison between them is false rather than an error.

Resolves https://github.com/KensioSoftware/yulin/issues/257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional writes for DynamoDB `PutItem` and `DeleteItem`.
  * Supports comparison operators, `BETWEEN`, `IN`, logical operators, document paths, and condition functions.
  * Failed conditions leave data unchanged and can return the previous item with `ALL_OLD`.
  * Added DynamoDB-compatible validation and conditional failure errors.

* **Documentation**
  * Added usage guidance and examples, including duplicate prevention and optimistic locking.

* **Tests**
  * Expanded coverage for successful writes, failures, validation, and returned prior attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->