### PR TITLE
feat: update simulated DynamoDB items with SET and REMOVE update expr…

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -367,10 +367,135 @@ reports nothing removed. Its `ReturnValues` takes `NONE` and `ALL_OLD`, as `PutI
 
 Both take the table's name or its ARN, as the table commands do.
 
+## Updating items
+
+`UpdateItem` changes part of an item, where `PutItem` replaces the whole thing. What to change is
+written as an `UpdateExpression` made of a `SET` clause, a `REMOVE` clause, or both in either order.
+Each keyword appears at most once, and the actions inside a clause are separated by commas.
+
+A `SET` action is `path = operand`, where an operand is a value from `ExpressionAttributeValues`,
+another document path, or `if_not_exists(path, operand)`. An update expression carries no literals,
+so every constant arrives through `ExpressionAttributeValues`. A `REMOVE` action is a document path
+on its own, and removing an attribute that is not there succeeds without changing the item.
+
+Every action reads the item as it stood before the request, rather than the item being built. So
+this expression, against `{ a: 1, b: 2, c: 3 }`:
+
+```text
+REMOVE a SET b = a, c = b
+```
+
+leaves `{ b: 1, c: 2 }`. Both assignments read the values from before the update, and `a` is still
+there to be read even though the `REMOVE` is written first.
+
+```typescript sim-dynamodb-update-item
+/**
+ * Changing part of an item, against the item as it stood before the update.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: {
+      orderId: { S: "order-1" },
+      a: { N: "1" },
+      b: { N: "2" },
+      c: { N: "3" },
+      draft: { BOOL: true },
+    },
+  }),
+);
+
+// Both assignments read the values from before the update, so removing `a`
+// first does not take it away from the assignment reading it.
+const updated = await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    UpdateExpression: "REMOVE a, draft SET b = a, c = b",
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(updated.Attributes?.["b"]?.N); // "1"
+console.log(updated.Attributes?.["c"]?.N); // "2"
+console.log(updated.Attributes?.["a"]); // undefined
+
+// if_not_exists keeps a value that is already there, and assigns one when it
+// is not.
+const defaulted = await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    UpdateExpression: "SET #s = if_not_exists(#s, :packing)",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: { ":packing": { S: "packing" } },
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(defaulted.Attributes?.["status"]?.S); // "packing"
+
+// UpdateItem upserts, so a key holding nothing gets an item built from the Key
+// and the SET actions.
+await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-2" } },
+    UpdateExpression: "SET #s = :new",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: { ":new": { S: "new" } },
+  }),
+);
+```
+
+An assignment reading a document path the item does not have is a `ValidationException` rather than
+an assignment of nothing, as it is on AWS. `if_not_exists` is how an expression says what to assign
+when the attribute may be absent.
+
+Assigning into a map the item does not carry is a `ValidationException` too. `SET address.city = :c`
+needs an `address` map to write into, and an update does not make one on the way past.
+
+An update cannot move an item's primary key. Assigning to a key attribute, or removing one, is a
+`ValidationException` naming the attribute, since the request already names the item it works on
+through its `Key`.
+
+A request with no `UpdateExpression` at all still writes. It leaves a stored item as it was, and
+creates one holding nothing but the `Key` when the key held nothing.
+
+`ReturnValues` takes `NONE`, `ALL_OLD` and `ALL_NEW`. `ALL_OLD` answers with the item as it stood
+before the update, and carries nothing when the key held nothing. `ALL_NEW` answers with the item as
+it now is.
+
+`UpdateItem` takes a `ConditionExpression` as well, checked the same way as on the other writes.
+Both expressions draw on the same `ExpressionAttributeNames` and `ExpressionAttributeValues`, and a
+placeholder used by either counts as used.
+
 ## Conditional writes
 
-`PutItem` and `DeleteItem` take a `ConditionExpression`, which is checked against whatever is stored
-under the key before anything changes. A condition that does not hold leaves the item exactly as it
+`PutItem`, `DeleteItem` and `UpdateItem` take a `ConditionExpression`, which is checked against
+whatever is stored under the key before anything changes. A condition that does not hold leaves the item exactly as it
 was and throws `ConditionalCheckFailedException`, with the name and message real DynamoDB uses.
 
 That is how a write becomes an insert if absent, and how a version attribute becomes optimistic
@@ -773,8 +898,8 @@ the ARN `Fn::GetAtt` gives.
 it looks the name up. A caller with no permission is denied whether or not the name is free, so an
 unauthorized caller cannot find out which names are taken.
 
-`DescribeTable`, `PutItem`, `GetItem` and `DeleteItem` authorize against the table ARN in the same
-way, each against the `dynamodb:` action of its own name. `ListTables` names no table, so it
+`DescribeTable`, `PutItem`, `GetItem`, `DeleteItem` and `UpdateItem` authorize against the table ARN
+in the same way, each against the `dynamodb:` action of its own name. `ListTables` names no table, so it
 authorizes against `*`.
 
 ## Available functionality
@@ -793,7 +918,10 @@ authorizes against `*`.
 - `ProjectionExpression` on `GetItem`, with document paths, list indexing and `ExpressionAttributeNames`
   placeholders.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
-- `ConditionExpression` on `PutItem` and `DeleteItem`, with the six comparators, `BETWEEN`, `IN`,
+- `UpdateItem`, with `SET` and `REMOVE` update expressions, `if_not_exists`, upserting when the key
+  holds nothing, and `NONE`, `ALL_OLD` and `ALL_NEW` for `ReturnValues`. Every action reads the item
+  as it stood before the update.
+- `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
   `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
   `begins_with`, `contains` and `size` functions.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
@@ -834,7 +962,7 @@ authorizes against `*`.
   refuses that status anyway, for when it can.
 - Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
   is ever throttled with `ProvisionedThroughputExceededException`.
-- `UpdateTable`, `UpdateItem`, `Query`, `Scan` and the batch item commands are not implemented yet.
+- `UpdateTable`, `Query`, `Scan` and the batch item commands are not implemented yet.
 - A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
   Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
   stack deployed calls `simAws.backgroundTasksComplete()` first.
@@ -850,9 +978,21 @@ authorizes against `*`.
   evaluated.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
   so a test cannot observe a stale read here the way it might against a real table.
-- Condition expressions are simulated on `PutItem` and `DeleteItem` only. `UpdateItem`, the
+- Condition expressions are simulated on `PutItem`, `DeleteItem` and `UpdateItem` only. The
   transactional condition checks and the key condition and filter expressions of `Query` and `Scan`
   are not implemented yet, so there is nothing else to guard.
+- The `ADD` and `DELETE` clauses of an update expression are refused rather than applied, and so are
+  arithmetic such as `SET n = n + :one`, `list_append`, and list element paths such as
+  `SET lines[0] = :line`. An update that quietly left one of them out would leave a test passing
+  against an item the real call would have changed.
+- `UPDATED_OLD` and `UPDATED_NEW` are refused. Both answer with the attributes the update touched,
+  which is a different answer to the whole item rather than a smaller one, and nothing here tracks
+  which attributes those were.
+- The legacy `AttributeUpdates` is refused rather than ignored, for the same reason `Expected` is.
+  `UpdateExpression` replaced it, and real DynamoDB has built nothing on it since.
+- A `REMOVE` whose path reaches through an attribute that is missing, or that is not a map, changes
+  nothing rather than being refused. `REMOVE` names a place rather than a value, so there was nothing
+  there to remove either way.
 - The legacy `Expected` and `ConditionalOperator` are refused rather than ignored, since an
   expectation that is never evaluated would let a write or a delete through that DynamoDB would have
   turned away. `ConditionExpression` replaced them, and real DynamoDB has built nothing on them

--- a/docs/services/dynamodb/sim-dynamodb-update-item.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-update-item.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Changing part of an item, against the item as it stood before the update.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "FoobarTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "FoobarTable",
+    Item: {
+      orderId: { S: "order-1" },
+      a: { N: "1" },
+      b: { N: "2" },
+      c: { N: "3" },
+      draft: { BOOL: true },
+    },
+  }),
+);
+
+// Both assignments read the values from before the update, so removing `a`
+// first does not take it away from the assignment reading it.
+const updated = await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    UpdateExpression: "REMOVE a, draft SET b = a, c = b",
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(updated.Attributes?.["b"]?.N); // "1"
+console.log(updated.Attributes?.["c"]?.N); // "2"
+console.log(updated.Attributes?.["a"]); // undefined
+
+// if_not_exists keeps a value that is already there, and assigns one when it
+// is not.
+const defaulted = await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-1" } },
+    UpdateExpression: "SET #s = if_not_exists(#s, :packing)",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: { ":packing": { S: "packing" } },
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(defaulted.Attributes?.["status"]?.S); // "packing"
+
+// UpdateItem upserts, so a key holding nothing gets an item built from the Key
+// and the SET actions.
+await dynamoDb.updateItem(
+  new UpdateItemCommand({
+    TableName: "FoobarTable",
+    Key: { orderId: { S: "order-2" } },
+    UpdateExpression: "SET #s = :new",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: { ":new": { S: "new" } },
+  }),
+);

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -48,7 +48,7 @@ Current command areas include:
 
 - `authorize/` (shared IAM authorization for every DynamoDB command)
 - `table/` (CreateTable, DescribeTable, ListTables and DeleteTable)
-- `item/` (PutItem, GetItem, DeleteItem, and the structural types for the item commands)
+- `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
 
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
@@ -302,9 +302,45 @@ Important behavior:
   use them in is a `ValidationException` rather than an unsupported operation, because real DynamoDB
   refuses that too. DeleteItem refuses the same conditional write and reporting inputs PutItem does.
 
-Scans, queries, indexes, condition expressions and streams are not implemented. Billing mode and
-provisioned capacity are read and stored by CreateTable, but nothing enforces them: no write is ever
-throttled.
+## UpdateItem behavior
+
+`SimDynamoDbUpdateItem` changes part of an item, where PutItem replaces the whole thing. It reaches
+its table the same way, and reads its `Key` through the same `readSimDynamoDbKey`.
+
+The order it works in matters:
+
+1. `refuseUnsimulatedItemUpdateInput` refuses the inputs this simulation does not model, including
+   the legacy `AttributeUpdates`.
+2. `SimDynamoDbUpdatePlan` reads both expressions, before the table is reached.
+3. The table is found and the caller authorized against `dynamodb:UpdateItem`.
+4. The condition is checked against what is stored.
+5. The update is refused if it would move the primary key, and then applied.
+
+`SimDynamoDbUpdatePlan` is what holds an update and its condition together. UpdateItem is the first
+command to carry two expressions at once, and both draw on the same `ExpressionAttributeNames` and
+`ExpressionAttributeValues`. Reading them against one `SimDynamoDbExpressionParameters` is what lets
+a placeholder used by either count as used, so `parseSimDynamoDbCondition` takes the parameters
+rather than reading them from the request the way `readSimDynamoDbCondition` does.
+
+Important behavior:
+
+- every action is evaluated against `SimDynamoDbItemSnapshot` of the item as it stood before the
+  request, rather than against the item being built. `REMOVE a SET b = a, c = b` on `{ a: 1, b: 2,
+c: 3 }` leaves `{ b: 1, c: 2 }`, which an implementation applying actions left to right answers
+  differently.
+- UpdateItem upserts. With nothing stored under the key, the new item is built from the `Key` plus
+  the SET actions, and the snapshot every action reads holds nothing.
+- a SET operand pointing at an attribute the item does not have is a `ValidationException`, as it is
+  on AWS. `if_not_exists` is how an expression says what to assign when the attribute may be absent.
+- assigning into a map the item does not carry is a `ValidationException`. An update does not make a
+  map on the way past.
+- an update cannot move the primary key. `SimDynamoDbUpdate.assertLeavesKeyAlone` refuses an action
+  writing to a key attribute, since the request already names the item it works on.
+- `ReturnValues` takes `NONE`, `ALL_OLD` and `ALL_NEW`, through the same `SimDynamoDbReturnValues`
+  the other item writes use. `UPDATED_OLD` and `UPDATED_NEW` are refused by name.
+
+Scans, queries, indexes and streams are not implemented. Billing mode and provisioned capacity are
+read and stored by CreateTable, but nothing enforces them: no write is ever throttled.
 
 ## Expressions
 
@@ -335,11 +371,13 @@ The shared parts:
 - `simDynamoDbExpressionError` builds every refusal, so they all read as
   `Invalid <parameter>: <reason>`. A request can carry several expressions, so naming which one was
   wrong matters.
+- `SimDynamoDbItemSnapshot` is the item an expression is read against: the item stored under the
+  key, which may be nothing at all. That is what makes `attribute_not_exists(id)` an insert if
+  absent, since every path resolves to nothing when there is no item. Conditions and updates both
+  read it, which is why it sits here rather than with either of them.
 
 `expression/condition/` reads a ConditionExpression into a `SimDynamoDbCondition`, which answers yes
-or no for a `SimDynamoDbConditionSubject`: the item stored under the key, which may be nothing at
-all. That is what makes `attribute_not_exists(id)` an insert if absent, since every path resolves to
-nothing when there is no item.
+or no for a snapshot.
 
 `SimDynamoDbConditionParser` is recursive descent with one method per precedence level, so the
 precedence DynamoDB documents is the shape of the class rather than a table somewhere. The operands
@@ -357,6 +395,25 @@ which is what makes a comparison between them false rather than an error.
 the expression before the table is reached, so an expression DynamoDB would refuse is refused
 whether or not the key holds anything, and it throws
 `SimDynamoDbConditionalCheckFailedException` before anything is written.
+
+`expression/update/` reads an UpdateExpression into a `SimDynamoDbUpdate`, which is the actions it
+asks for. `SimDynamoDbUpdateParser` reads the clauses, each keyword at most once and in either
+order, and `SimDynamoDbUpdateOperandParser` reads what a SET action assigns.
+
+The parts an update is made of split by what they know:
+
+- `SimDynamoDbUpdateTarget` is where an action writes. It is a document path that has been checked
+  for what an update can change, and it holds the attribute names rather than the segments, since a
+  list element path is refused.
+- `SimDynamoDbUpdateDocument` is the item being built. Nothing reads from it, which is what keeps
+  the snapshot rule true however the actions are ordered.
+- `SimDynamoDbUpdateOperand` is what a SET action assigns: a supplied value, a document path, or
+  `if_not_exists`. Update expressions have no literals, so every constant arrives through
+  `ExpressionAttributeValues`.
+
+The parts of an update expression real DynamoDB has and this simulation does not apply are refused
+rather than dropped, in `sim-dynamodb-update-refusal.ts`: the ADD and DELETE clauses, arithmetic,
+`list_append`, and list element paths.
 
 `expression/projection/` is the other consumer. `readSimDynamoDbProjection` reads a
 `ProjectionExpression` and its names into a `SimDynamoDbProjection`, and `SimDynamoDbProjectionNode`

--- a/src/service/dynamodb/command/item/item.command.ts
+++ b/src/service/dynamodb/command/item/item.command.ts
@@ -1,6 +1,7 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type {
   SimDynamoDbAttributeValue,
+  SimDynamoDbAttributeValueUpdate,
   SimDynamoDbExpectedAttributeValue,
 } from "./item.types.js";
 
@@ -115,6 +116,50 @@ export interface SimDeleteItemCommandInput {
  * Minimal structural sim DynamoDB DeleteItem output.
  */
 export interface SimDeleteItemCommandOutput {
+  readonly Attributes?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB UpdateItem command.
+ */
+export interface SimUpdateItemCommand {
+  readonly input: SimUpdateItemCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB UpdateItem input.
+ *
+ * `AttributeUpdates` is the legacy way of saying what to change, which
+ * `UpdateExpression` replaced. It is declared so a request carrying one is
+ * refused by name.
+ */
+export interface SimUpdateItemCommandInput {
+  readonly TableName?: string | undefined;
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly UpdateExpression?: string | undefined;
+  readonly ReturnValues?: string | undefined;
+  readonly ConditionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+  readonly ReturnItemCollectionMetrics?: string | undefined;
+  readonly ReturnValuesOnConditionCheckFailure?: string | undefined;
+  readonly AttributeUpdates?:
+    Readonly<Record<string, SimDynamoDbAttributeValueUpdate>> | undefined;
+  readonly Expected?:
+    Readonly<Record<string, SimDynamoDbExpectedAttributeValue>> | undefined;
+  readonly ConditionalOperator?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB UpdateItem output.
+ */
+export interface SimUpdateItemCommandOutput {
   readonly Attributes?:
     Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
   readonly $metadata: SimResponseMetadata;

--- a/src/service/dynamodb/command/item/item.types.ts
+++ b/src/service/dynamodb/command/item/item.types.ts
@@ -137,6 +137,18 @@ export type SimDynamoDbAttributeValue =
     };
 
 /**
+ * Minimal structural sim DynamoDB attribute value update.
+ *
+ * This is the older way of changing part of an item, which simulated DynamoDB
+ * refuses rather than models. It is declared so a request carrying one is
+ * refused by name.
+ */
+export interface SimDynamoDbAttributeValueUpdate {
+  readonly Value?: SimDynamoDbAttributeValue | undefined;
+  readonly Action?: string | undefined;
+}
+
+/**
  * Minimal structural sim DynamoDB expected attribute value.
  *
  * This is the older conditional write input, which simulated DynamoDB refuses

--- a/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
@@ -4,7 +4,7 @@ import {
 } from "../../error/dynamodb.error.js";
 import { readSimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition-expression.js";
 import type { SimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition.js";
-import { SimDynamoDbConditionSubject } from "../../expression/condition/sim-dynamodb-condition-subject.js";
+import { SimDynamoDbItemSnapshot } from "../../expression/sim-dynamodb-item-snapshot.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbAttributeValue } from "./item.types.js";
 
@@ -53,8 +53,22 @@ export class SimDynamoDbConditionCheck {
     input: SimDynamoDbConditionCheckInput,
     operation: string,
   ): SimDynamoDbConditionCheck {
+    return this.of(readSimDynamoDbCondition(input), input, operation);
+  }
+
+  /**
+   * Guard a write with a condition that has already been read.
+   *
+   * UpdateItem reads its condition alongside its update expression, since the
+   * two share the request's placeholders, and then hands the condition here.
+   */
+  static of(
+    condition: SimDynamoDbCondition | undefined,
+    input: SimDynamoDbConditionCheckInput,
+    operation: string,
+  ): SimDynamoDbConditionCheck {
     return new this({
-      condition: readSimDynamoDbCondition(input),
+      condition,
       reportsItem: this.reportsItemFor(input, operation),
     });
   }
@@ -93,7 +107,7 @@ export class SimDynamoDbConditionCheck {
       return;
     }
 
-    if (this.condition.holdsFor(new SimDynamoDbConditionSubject(existing))) {
+    if (this.condition.holdsFor(new SimDynamoDbItemSnapshot(existing))) {
       return;
     }
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-item-command-iam.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-item-command-iam.iso.test.ts
@@ -3,6 +3,7 @@ import {
   DeleteItemCommand,
   GetItemCommand,
   PutItemCommand,
+  UpdateItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
@@ -105,6 +106,32 @@ async function allow(
         }),
       }),
     );
+}
+
+/**
+ * An update setting the note on the one item this scope holds.
+ */
+function noteUpdate(): UpdateItemCommand {
+  return new UpdateItemCommand({
+    TableName: "ItemTable",
+    Key: { id: { S: "item-1" } },
+    UpdateExpression: "SET note = :note",
+    ExpressionAttributeValues: { ":note": { S: "second" } },
+  });
+}
+
+/**
+ * The note on the item this scope holds.
+ */
+async function storedNote(scope: ItemScope): Promise<string | undefined> {
+  const output = await scope.simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "ItemTable",
+      Key: { id: { S: "item-1" } },
+    }),
+  );
+
+  return output.Item?.["note"]?.S;
 }
 
 describe("DynamoDB GetItemCommand IAM authorization", () => {
@@ -244,5 +271,46 @@ describe("DynamoDB DeleteItemCommand IAM authorization", () => {
       }),
     );
     assertIdentical(output.Item?.["note"]?.S, "first");
+  });
+});
+
+describe("DynamoDB UpdateItemCommand IAM authorization", () => {
+  it("allows a Role its policy permits dynamodb:UpdateItem", async () => {
+    // Given a Role allowed to update items in the table.
+    const scope = await itemScope();
+    const roleArn = await roleArnFor(scope, "ItemUpdater");
+    await allow(scope, "ItemUpdater", "dynamodb:UpdateItem");
+
+    // When the Role updates an item.
+    await scope.simDynamoDb.updateItem(noteUpdate(), {
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    // Then IAM allows the request and the change landed.
+    assertIdentical(await storedNote(scope), "second");
+  });
+
+  it("denies the update before it changes anything", async () => {
+    // Given a Role allowed only to write whole items.
+    const scope = await itemScope();
+    const roleArn = await roleArnFor(scope, "WholeItemWriter");
+    await allow(scope, "WholeItemWriter", "dynamodb:PutItem");
+
+    // When the Role attempts to update one.
+    const error = await assertThrowsErrorAsync(async () =>
+      scope.simDynamoDb.updateItem(noteUpdate(), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then each DynamoDB operation is its own IAM action, and the item is as
+    // it was.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:UpdateItem");
+    assertIdentical(
+      error.resource,
+      `arn:aws:dynamodb:${scope.region}:${scope.accountId}:table/ItemTable`,
+    );
+    assertIdentical(await storedNote(scope), "first");
   });
 });

--- a/src/service/dynamodb/command/item/sim-dynamodb-return-values.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-return-values.ts
@@ -1,14 +1,37 @@
-import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
 
 /**
  * The values PutItem and DeleteItem take for ReturnValues. Both answer with the
  * item they replaced or removed, or with nothing at all, so the other modes
  * UpdateItem has are not valid for either.
  */
-const modes: ReadonlySet<string> = new Set(["NONE", "ALL_OLD"]);
+const writeModes: ReadonlySet<string> = new Set(["NONE", "ALL_OLD"]);
 
 /**
- * What a request asks to be given back of the item that was there before it.
+ * The values UpdateItem takes. It changes part of an item rather than replacing
+ * it, so it can answer with the item as it was or as it now is.
+ */
+const updateModes: ReadonlySet<string> = new Set([
+  "NONE",
+  "ALL_OLD",
+  "ALL_NEW",
+]);
+
+/**
+ * The values real UpdateItem takes and this simulation does not report. Both
+ * answer with the attributes the update touched, which is a different answer to
+ * the whole item rather than a smaller one.
+ */
+const unsimulatedUpdateModes: ReadonlySet<string> = new Set([
+  "UPDATED_OLD",
+  "UPDATED_NEW",
+]);
+
+/**
+ * What a request asks to be given back of the item it changed.
  */
 export class SimDynamoDbReturnValues {
   private readonly mode: string;
@@ -18,12 +41,49 @@ export class SimDynamoDbReturnValues {
   }
 
   /**
-   * Read the ReturnValues a request carries, naming the operation that will
-   * not take it when it names a mode that operation does not have.
+   * Read the ReturnValues a write carries, naming the operation that will not
+   * take it when it names a mode that operation does not have.
    */
   static read(
     value: string | undefined,
     operation: string,
+  ): SimDynamoDbReturnValues {
+    return this.oneOf(value, operation, writeModes, "NONE or ALL_OLD");
+  }
+
+  /**
+   * Read the ReturnValues an update carries.
+   *
+   * The two modes that report only the attributes the update touched are
+   * refused by name, rather than answered with the whole item.
+   */
+  static readForUpdate(
+    value: string | undefined,
+    operation: string,
+  ): SimDynamoDbReturnValues {
+    if (value !== undefined && unsimulatedUpdateModes.has(value)) {
+      throw new SimDynamoDbUnsupportedOperation(
+        `ReturnValues ${value} is not simulated, so ${operation} refuses it ` +
+          `rather than answering with more of the item than was asked for`,
+      );
+    }
+
+    return this.oneOf(
+      value,
+      operation,
+      updateModes,
+      "NONE, ALL_OLD or ALL_NEW",
+    );
+  }
+
+  /**
+   * Read a ReturnValues against the modes one operation has.
+   */
+  private static oneOf(
+    value: string | undefined,
+    operation: string,
+    modes: ReadonlySet<string>,
+    taken: string,
   ): SimDynamoDbReturnValues {
     if (value === undefined) {
       return new this("NONE");
@@ -32,7 +92,7 @@ export class SimDynamoDbReturnValues {
     if (!modes.has(value)) {
       throw new SimDynamoDbValidationException(
         `Return values set to invalid value: ${value}. ${operation} takes ` +
-          `NONE or ALL_OLD.`,
+          `${taken}.`,
       );
     }
 
@@ -44,5 +104,12 @@ export class SimDynamoDbReturnValues {
    */
   wantsOldItem(): boolean {
     return this.mode === "ALL_OLD";
+  }
+
+  /**
+   * Whether the request asked for the item as it now is.
+   */
+  wantsNewItem(): boolean {
+    return this.mode === "ALL_NEW";
   }
 }

--- a/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-update-input.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-unsimulated-item-update-input.ts
@@ -1,0 +1,24 @@
+import type { SimUpdateItemCommandInput } from "./item.command.js";
+import { SimDynamoDbUnsimulatedInput } from "./sim-dynamodb-unsimulated-input.js";
+import { refuseUnsimulatedItemWriteInput } from "./sim-dynamodb-unsimulated-item-write-input.js";
+
+/**
+ * Refuse the UpdateItem request inputs this simulation does not model.
+ *
+ * UpdateItem takes the same conditional write and reporting inputs the other
+ * item writes do, and one of its own. `AttributeUpdates` is the change
+ * `UpdateExpression` replaced, and real DynamoDB has built nothing on it since.
+ * An update that was never applied would leave a test passing against an item
+ * the real call would have changed, so it is refused rather than dropped.
+ */
+export function refuseUnsimulatedItemUpdateInput(
+  input: SimUpdateItemCommandInput,
+): void {
+  refuseUnsimulatedItemWriteInput(input, "UpdateItem");
+
+  new SimDynamoDbUnsimulatedInput("UpdateItem").refuseNamed(
+    input.AttributeUpdates,
+    "AttributeUpdates",
+    "applying a change it does not read",
+  );
+}

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item-paths.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item-paths.iso.test.ts
@@ -1,0 +1,158 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimDynamoDbAttributeValue } from "./item.types.js";
+
+/**
+ * A table holding one order with an address nested inside it.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: {
+        orderId: { S: "order-1" },
+        status: { S: "packing" },
+        address: {
+          M: {
+            city: { S: "Leeds" },
+            postcode: { S: "LS1 1AA" },
+            geo: { M: { lat: { N: "53.8" }, lon: { N: "-1.5" } } },
+          },
+        },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The item stored under the one key these tests use.
+ */
+async function storedOrder(
+  simDynamoDb: SimDynamoDb,
+): Promise<Readonly<Record<string, SimDynamoDbAttributeValue>>> {
+  const output = await simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "FooTable",
+      Key: { orderId: { S: "order-1" } },
+    }),
+  );
+
+  assertNonNullable(output.Item);
+
+  return output.Item;
+}
+
+describe("DynamoDB UpdateItemCommand document paths", () => {
+  it("writes into a map an item already carries", async () => {
+    // Given an order carrying an address.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When one attribute inside the map is set and another removed.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET address.city = :city REMOVE address.postcode",
+        ExpressionAttributeValues: { ":city": { S: "York" } },
+      }),
+    );
+
+    // Then the map holds the new value, and the rest of the item is untouched.
+    const stored = await storedOrder(simDynamoDb);
+    const address = stored["address"]?.M;
+    assertNonNullable(address);
+    assertIdentical(address["city"]?.S, "York");
+    assertUndefined(address["postcode"]);
+    assertIdentical(stored["status"]?.S, "packing");
+  });
+
+  it("writes into a map inside a map", async () => {
+    // Given an order whose address carries a location.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a path two levels down is written and its neighbour removed.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET address.geo.lat = :lat REMOVE address.geo.lon",
+        ExpressionAttributeValues: { ":lat": { N: "54" } },
+      }),
+    );
+
+    // Then only that far down changed, and everything around it is as it was.
+    const stored = await storedOrder(simDynamoDb);
+    const geo = stored["address"]?.M?.["geo"]?.M;
+    assertNonNullable(geo);
+    assertIdentical(geo["lat"]?.N, "54");
+    assertUndefined(geo["lon"]);
+    assertIdentical(stored["address"]?.M?.["city"]?.S, "Leeds");
+  });
+
+  it("leaves a removal reaching into something that is not a map alone", async () => {
+    // Given an order whose status is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a removal reaches inside that string.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "REMOVE #s.detail",
+        ExpressionAttributeNames: { "#s": "status" },
+      }),
+    );
+
+    // Then there was nothing there to remove, and the status is as it was.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "packing");
+  });
+
+  it("copies a value from one place in the item to another", async () => {
+    // Given an order with an address on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an assignment reads a document path rather than a value.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET billingCity = address.city",
+      }),
+    );
+
+    // Then the value was copied out of the map.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["billingCity"]?.S, "Leeds");
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item-return-values.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item-return-values.iso.test.ts
@@ -1,0 +1,171 @@
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  type ReturnValue,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table with one string partition key, holding nothing yet.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+/**
+ * An order at the status given.
+ */
+async function orderAt(
+  simDynamoDb: SimDynamoDb,
+  status: string,
+): Promise<void> {
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: { orderId: { S: "order-1" }, status: { S: status } },
+    }),
+  );
+}
+
+/**
+ * An update setting the status, asking for whatever the mode names back.
+ */
+function updateTo(
+  status: string,
+  returnValues?: ReturnValue,
+): UpdateItemCommand {
+  return new UpdateItemCommand({
+    TableName: "FooTable",
+    Key: { orderId: { S: "order-1" } },
+    UpdateExpression: "SET #s = :status",
+    ExpressionAttributeNames: { "#s": "status" },
+    ExpressionAttributeValues: { ":status": { S: status } },
+    ReturnValues: returnValues,
+  });
+}
+
+describe("DynamoDB UpdateItemCommand ReturnValues", () => {
+  it("answers with nothing by default", async () => {
+    // Given an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await orderAt(simDynamoDb, "packing");
+
+    // When an update asks for nothing back.
+    const output = await simDynamoDb.updateItem(updateTo("shipped"));
+
+    // Then it answers with no attributes.
+    assertUndefined(output.Attributes);
+  });
+
+  it("answers with the item as it was for ALL_OLD", async () => {
+    // Given an order that is packing.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await orderAt(simDynamoDb, "packing");
+
+    // When an update asks for the item it changed.
+    const output = await simDynamoDb.updateItem(updateTo("shipped", "ALL_OLD"));
+
+    // Then it answers with the item as it stood before the update.
+    assertIdentical(output.Attributes?.["status"]?.S, "packing");
+  });
+
+  it("answers with nothing for ALL_OLD when the key held nothing", async () => {
+    // Given a table holding nothing.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update creates the item and asks for the one it changed.
+    const output = await simDynamoDb.updateItem(updateTo("packing", "ALL_OLD"));
+
+    // Then there is no Attributes at all, since there was no item to report.
+    assertUndefined(output.Attributes);
+  });
+
+  it("answers with the item as it now is for ALL_NEW", async () => {
+    // Given an order that is packing.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await orderAt(simDynamoDb, "packing");
+
+    // When an update asks for the item it left.
+    const output = await simDynamoDb.updateItem(updateTo("shipped", "ALL_NEW"));
+
+    // Then it answers with the whole item, changes and all.
+    assertNonNullable(output.Attributes);
+    assertIdentical(output.Attributes["status"]?.S, "shipped");
+    assertIdentical(output.Attributes["orderId"]?.S, "order-1");
+  });
+
+  it("refuses the modes that report only what the update touched", async () => {
+    // Given an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await orderAt(simDynamoDb, "packing");
+
+    // When an update asks for the attributes it changed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateItem(updateTo("shipped", "UPDATED_NEW")),
+    );
+
+    // Then it is refused by name rather than answered with the whole item.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnValues UPDATED_NEW");
+  });
+
+  it("refuses a mode UpdateItem does not have", async () => {
+    // Given an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await orderAt(simDynamoDb, "packing");
+
+    // When an update asks for something that is not a mode at all. The SDK
+    // types rule this out, so the request is built the way one arriving over
+    // the wire would be.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateItem({
+        input: {
+          TableName: "FooTable",
+          Key: { orderId: { S: "order-1" } },
+          UpdateExpression: "REMOVE status",
+          ReturnValues: "EVERYTHING",
+        },
+      }),
+    );
+
+    // Then it is a ValidationException naming the modes it does have.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "UpdateItem takes NONE, ALL_OLD or ALL_NEW.",
+    );
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item-unsimulated.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item-unsimulated.iso.test.ts
@@ -1,0 +1,196 @@
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+  type UpdateItemCommandInput,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbUnsupportedOperation } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table holding one order with a counter and a list on it.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: {
+        orderId: { S: "order-1" },
+        counter: { N: "1" },
+        lines: { L: [{ S: "first" }] },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The error an update on that order is refused with.
+ */
+async function refusalOf(
+  simDynamoDb: SimDynamoDb,
+  input: Omit<UpdateItemCommandInput, "TableName" | "Key">,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () =>
+    simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        ...input,
+      }),
+    ),
+  );
+}
+
+describe("DynamoDB UpdateItemCommand unsimulated input", () => {
+  it("refuses the ADD clause", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update asks to add to a number.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "ADD counter :one",
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then it is refused by name, rather than left out of the change.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "The ADD clause");
+  });
+
+  it("refuses the DELETE clause", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update asks to take a member out of a set.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "DELETE colours :red",
+      ExpressionAttributeValues: { ":red": { SS: ["red"] } },
+    });
+
+    // Then it is refused by name.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "The DELETE clause");
+  });
+
+  it("refuses arithmetic in a SET action", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update counts up.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET counter = counter + :one",
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then it is refused by name rather than as an unexpected character.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "Arithmetic in an update expression");
+  });
+
+  it("refuses subtraction in a SET action", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update counts down.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET counter = counter - :one",
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then it is refused the same way.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "Arithmetic in an update expression");
+  });
+
+  it("refuses a function it does not apply", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update appends to a list.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET lines = list_append(lines, :more)",
+      ExpressionAttributeValues: { ":more": { L: [{ S: "second" }] } },
+    });
+
+    // Then the function is refused by name.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(
+      error.message,
+      "The update expression function list_append",
+    );
+  });
+
+  it("refuses writing to a list element", async () => {
+    // Given a table holding an order with a list on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update assigns to one element of that list.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET lines[0] = :line",
+      ExpressionAttributeValues: { ":line": { S: "second" } },
+    });
+
+    // Then it is refused, since nothing here shifts a list around.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "The list element path 'lines[0]'");
+  });
+
+  it("refuses removing a list element", async () => {
+    // Given a table holding an order with a list on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update removes one element of that list.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "REMOVE lines[0]",
+    });
+
+    // Then it is refused the same way.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "The list element path 'lines[0]'");
+  });
+
+  it("refuses the legacy AttributeUpdates", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update says what to change the old way.
+    const error = await refusalOf(simDynamoDb, {
+      AttributeUpdates: {
+        status: { Value: { S: "shipped" }, Action: "PUT" },
+      },
+    });
+
+    // Then it is refused by name, rather than leaving the item unchanged.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "AttributeUpdates is not simulated");
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item-validation.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item-validation.iso.test.ts
@@ -1,0 +1,329 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+  type UpdateItemCommandInput,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table holding one order with an address on it.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "FooTable",
+      Item: {
+        orderId: { S: "order-1" },
+        status: { S: "packing" },
+        address: { M: { city: { S: "Leeds" } } },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The error an update on that order is refused with.
+ */
+async function refusalOf(
+  simDynamoDb: SimDynamoDb,
+  input: Omit<UpdateItemCommandInput, "TableName" | "Key">,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () =>
+    simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        ...input,
+      }),
+    ),
+  );
+}
+
+describe("DynamoDB UpdateItemCommand validation", () => {
+  it("refuses a clause keyword written twice", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When one expression opens two SET clauses.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET a = :one SET b = :two",
+      ExpressionAttributeValues: { ":one": { N: "1" }, ":two": { N: "2" } },
+    });
+
+    // Then it is refused the way real DynamoDB refuses it.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      `The "SET" section can only be used once in an update expression;`,
+    );
+  });
+
+  it("refuses an expression that starts with something other than a clause", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the expression opens with a word that is not a clause keyword.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "PUT a = :one",
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then the refusal names the expression and what was expected.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Invalid UpdateExpression");
+    assertStringIncludes(error.message, "SET or REMOVE expected");
+  });
+
+  it("refuses a SET action that assigns nothing", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When a SET action leaves out its '='.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET a :one",
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then it is refused as a syntax error.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "assigns to a document path with '='");
+  });
+
+  it("refuses an empty update expression", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the expression says nothing.
+    const error = await refusalOf(simDynamoDb, { UpdateExpression: "  " });
+
+    // Then it is refused rather than read as an update that does nothing.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "an expression cannot be empty");
+  });
+
+  it("refuses a placeholder the request does not define", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the expression uses a value nothing defines.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET a = :missing",
+    });
+
+    // Then the refusal names the placeholder.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ExpressionAttributeValues does not define :missing",
+    );
+  });
+
+  it("refuses a placeholder no expression uses", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When the request defines a value the expressions do not use.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET a = :one",
+      ConditionExpression: "attribute_exists(orderId)",
+      ExpressionAttributeValues: { ":one": { N: "1" }, ":spare": { N: "2" } },
+    });
+
+    // Then it is refused, naming the one that went unused rather than the one
+    // the update expression used.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "unused in expressions: :spare");
+  });
+
+  it("refuses a request carrying placeholders and no expression to use them in", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update says nothing to change and still defines a value.
+    const error = await refusalOf(simDynamoDb, {
+      ExpressionAttributeValues: { ":one": { N: "1" } },
+    });
+
+    // Then it is refused rather than quietly ignored.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "can only be specified when using expressions",
+    );
+  });
+
+  it("refuses an assignment into a map the item does not have", async () => {
+    // Given an order with no billing address.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an assignment reaches into that missing attribute.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET billing.city = :city",
+      ExpressionAttributeValues: { ":city": { S: "York" } },
+    });
+
+    // Then it is refused, as real DynamoDB refuses it rather than making the
+    // map on the way past.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The document path provided in the update expression is invalid for update",
+    );
+    assertStringIncludes(error.message, "billing.city");
+  });
+
+  it("refuses an assignment reading an attribute the item does not have", async () => {
+    // Given an order with no note on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an assignment reads that attribute.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET copy = note",
+    });
+
+    // Then it is refused rather than assigning nothing, which is what
+    // if_not_exists is for.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "refers to an attribute that does not exist in the item: 'note'",
+    );
+  });
+
+  it("refuses an if_not_exists whose fallback is missing too", async () => {
+    // Given an order with neither a note nor a draft note on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an assignment falls back from one to the other.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET copy = if_not_exists(note, draft)",
+    });
+
+    // Then it is refused, naming the whole call rather than one part of it.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "'if_not_exists(note, draft)'");
+  });
+
+  it("refuses two actions writing over each other", async () => {
+    // Given a table holding an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When one action writes inside what another one removes.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET address.city = :city REMOVE address",
+      ExpressionAttributeValues: { ":city": { S: "York" } },
+    });
+
+    // Then the pair is refused, since it does not say what the item should end
+    // up with.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Two document paths overlap");
+  });
+
+  it("refuses an update that would change the primary key", async () => {
+    // Given a table keyed by order ID.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update assigns to that key attribute.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET orderId = :other",
+      ExpressionAttributeValues: { ":other": { S: "order-2" } },
+    });
+
+    // Then it is refused, since it names one item and would write another.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Cannot update attribute orderId. This attribute is part of the key",
+    );
+
+    // And the order is where it was.
+    const stored = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(stored.Item?.["status"]?.S, "packing");
+  });
+
+  it("refuses an update that would remove the primary key", async () => {
+    // Given a table keyed by order ID.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update removes that key attribute.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "REMOVE orderId",
+    });
+
+    // Then it is refused the same way an assignment to it is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Cannot remove attribute orderId. This attribute is part of the key",
+    );
+  });
+
+  it("refuses an update that would make the item bigger than DynamoDB holds", async () => {
+    // Given an order already carrying most of the 400 KB an item can.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: {
+          orderId: { S: "order-1" },
+          notes: { S: "n".repeat(300 * 1024) },
+        },
+      }),
+    );
+
+    // When an update adds another attribute that takes it past the limit.
+    const error = await refusalOf(simDynamoDb, {
+      UpdateExpression: "SET more = :more",
+      ExpressionAttributeValues: { ":more": { S: "m".repeat(200 * 1024) } },
+    });
+
+    // Then the write is refused, as it would be for a PutItem of that item.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Item size has exceeded");
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item.iso.test.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item.iso.test.ts
@@ -1,0 +1,313 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbConditionalCheckFailedException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimDynamoDbAttributeValue } from "./item.types.js";
+
+/**
+ * A table with one string partition key, holding nothing yet.
+ */
+async function tableFor(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "FooTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+/**
+ * The item stored under the one key these tests use, which every one of them
+ * leaves an item under.
+ */
+async function storedOrder(
+  simDynamoDb: SimDynamoDb,
+): Promise<Readonly<Record<string, SimDynamoDbAttributeValue>>> {
+  const output = await simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "FooTable",
+      Key: { orderId: { S: "order-1" } },
+    }),
+  );
+
+  assertNonNullable(output.Item);
+
+  return output.Item;
+}
+
+describe("DynamoDB UpdateItemCommand", () => {
+  it("changes the attributes a SET names and leaves the rest alone", async () => {
+    // Given an order holding a status and a version.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: {
+          orderId: { S: "order-1" },
+          status: { S: "packing" },
+          version: { N: "1" },
+        },
+      }),
+    );
+
+    // When one attribute is set.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET #s = :status",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: { ":status": { S: "shipped" } },
+      }),
+    );
+
+    // Then that attribute changed, and the others are as they were.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "shipped");
+    assertIdentical(stored["version"]?.N, "1");
+    assertIdentical(stored["orderId"]?.S, "order-1");
+  });
+
+  it("reads every action against the item as it stood before the update", async () => {
+    // Given an order holding three numbers.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: {
+          orderId: { S: "order-1" },
+          a: { N: "1" },
+          b: { N: "2" },
+          c: { N: "3" },
+        },
+      }),
+    );
+
+    // When one expression removes an attribute the assignments read.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "REMOVE a SET b = a, c = b",
+      }),
+    );
+
+    // Then both assignments took the values from before the update, and the
+    // REMOVE written first did not take `a` away from the assignment reading it.
+    const stored = await storedOrder(simDynamoDb);
+    assertUndefined(stored["a"]);
+    assertIdentical(stored["b"]?.N, "1");
+    assertIdentical(stored["c"]?.N, "2");
+  });
+
+  it("removes an attribute that is not there without changing the item", async () => {
+    // Given an order with no note on it.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, status: { S: "packing" } },
+      }),
+    );
+
+    // When the note is removed anyway.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "REMOVE note",
+      }),
+    );
+
+    // Then the update succeeded and the item is exactly as it was.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "packing");
+    assertUndefined(stored["note"]);
+  });
+
+  it("keeps a value if_not_exists finds, and assigns one it does not", async () => {
+    // Given an order that already has a status and no note.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, status: { S: "packing" } },
+      }),
+    );
+
+    // When both are given a default.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression:
+          "SET #s = if_not_exists(#s, :new), note = if_not_exists(note, :none)",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":new": { S: "new" },
+          ":none": { S: "no note" },
+        },
+      }),
+    );
+
+    // Then the stored status won, and the note took the default.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "packing");
+    assertIdentical(stored["note"]?.S, "no note");
+  });
+
+  it("creates the item from the Key and the SET actions when the key holds nothing", async () => {
+    // Given a table holding nothing.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update names a key nothing is stored under.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET #s = :status",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: { ":status": { S: "packing" } },
+      }),
+    );
+
+    // Then the item was created, holding the Key and what the update set.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["orderId"]?.S, "order-1");
+    assertIdentical(stored["status"]?.S, "packing");
+  });
+
+  it("changes nothing when the condition guarding it does not hold", async () => {
+    // Given an order at version 2.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, version: { N: "2" } },
+      }),
+    );
+
+    // When an update insists on the version it last read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateItem(
+        new UpdateItemCommand({
+          TableName: "FooTable",
+          Key: { orderId: { S: "order-1" } },
+          UpdateExpression: "SET #s = :status",
+          ConditionExpression: "version = :was",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: {
+            ":status": { S: "shipped" },
+            ":was": { N: "1" },
+          },
+        }),
+      ),
+    );
+
+    // Then it failed the way a conditional write does, and the item is as it
+    // was: the placeholders of both expressions were read as one set.
+    assertInstanceOf(error, SimDynamoDbConditionalCheckFailedException);
+    const stored = await storedOrder(simDynamoDb);
+    assertUndefined(stored["status"]);
+    assertIdentical(stored["version"]?.N, "2");
+  });
+
+  it("writes when the condition guarding it holds", async () => {
+    // Given an order at version 1.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, version: { N: "1" } },
+      }),
+    );
+
+    // When an update names the version it last read.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+        UpdateExpression: "SET #s = :status",
+        ConditionExpression: "version = :was",
+        ExpressionAttributeNames: { "#s": "status" },
+        ExpressionAttributeValues: {
+          ":status": { S: "shipped" },
+          ":was": { N: "1" },
+        },
+      }),
+    );
+
+    // Then the change went through.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "shipped");
+  });
+
+  it("leaves the item alone when the request carries no update expression", async () => {
+    // Given an order.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FooTable",
+        Item: { orderId: { S: "order-1" }, status: { S: "packing" } },
+      }),
+    );
+
+    // When an update says nothing to change.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then the item is exactly as it was.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["status"]?.S, "packing");
+  });
+
+  it("creates an item holding only the Key when the request says nothing to change", async () => {
+    // Given a table holding nothing.
+    const simAws = new SimAws();
+    const simDynamoDb = await tableFor(simAws);
+
+    // When an update names a key nothing is stored under and changes nothing.
+    await simDynamoDb.updateItem(
+      new UpdateItemCommand({
+        TableName: "FooTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then UpdateItem still upserted, so the item is there with its key.
+    const stored = await storedOrder(simDynamoDb);
+    assertIdentical(stored["orderId"]?.S, "order-1");
+  });
+});

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
@@ -1,0 +1,95 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type {
+  SimUpdateItemCommand,
+  SimUpdateItemCommandOutput,
+} from "./item.command.js";
+import { readSimDynamoDbKey } from "./sim-dynamodb-key-input.js";
+import { SimDynamoDbReturnValues } from "./sim-dynamodb-return-values.js";
+import { refuseUnsimulatedItemUpdateInput } from "./sim-dynamodb-unsimulated-item-update-input.js";
+import { SimDynamoDbUpdatePlan } from "./sim-dynamodb-update-plan.js";
+
+interface SimDynamoDbUpdateItemProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbUpdateItemOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The UpdateItem command.
+ *
+ * UpdateItem changes part of an item rather than replacing it, which is what
+ * makes it different from PutItem. It upserts: a key holding nothing gets an
+ * item built from the Key and whatever the update sets.
+ *
+ * Every action of the update expression reads the item as it stood before the
+ * request, rather than the item being built, so the actions of one expression
+ * do not see each other's work.
+ */
+export class SimDynamoDbUpdateItem {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbUpdateItemProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Change an item, and answer with the item before or after it when asked to.
+   */
+  handle(
+    command: SimUpdateItemCommand,
+    options?: SimDynamoDbUpdateItemOptions,
+  ): SimUpdateItemCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedItemUpdateInput(input);
+
+    // The expressions are read before the table is reached, so one DynamoDB
+    // would refuse is refused whether or not the key holds anything.
+    const plan = SimDynamoDbUpdatePlan.read(input, "UpdateItem");
+    const table = this.access.required(
+      "dynamodb:UpdateItem",
+      input.TableName,
+      options?.caller,
+    );
+    const asked = SimDynamoDbReturnValues.readForUpdate(
+      input.ReturnValues,
+      "UpdateItem",
+    );
+    const key = readSimDynamoDbKey(input.Key);
+    const existing = table.getItem(key);
+
+    plan.check.assertHoldsFor(existing);
+    plan.assertLeavesKeyAlone(table.keySchema.attributeNames());
+
+    const updated = plan.applyTo(existing, key);
+    table.putItem(updated);
+
+    return this.answer(asked, existing, updated);
+  }
+
+  /**
+   * Answer with as much of the item as the request asked for.
+   *
+   * ALL_OLD carries nothing when the key held nothing, since there was no item
+   * to report. ALL_NEW always carries one, since an update always leaves one.
+   */
+  private answer(
+    asked: SimDynamoDbReturnValues,
+    existing: SimDynamoDbItem | undefined,
+    updated: SimDynamoDbItem,
+  ): SimUpdateItemCommandOutput {
+    if (asked.wantsNewItem()) {
+      return { Attributes: updated.toAttributeValues(), $metadata: {} };
+    }
+
+    if (!asked.wantsOldItem() || existing === undefined) {
+      return { $metadata: {} };
+    }
+
+    return { Attributes: existing.toAttributeValues(), $metadata: {} };
+  }
+}

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-plan.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-plan.ts
@@ -1,0 +1,107 @@
+import { parseSimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition-expression.js";
+import type { SimDynamoDbCondition } from "../../expression/condition/sim-dynamodb-condition.js";
+import type { SimDynamoDbExpressionParameterInput } from "../../expression/sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionParameters } from "../../expression/sim-dynamodb-expression-parameters.js";
+import { parseSimDynamoDbUpdate } from "../../expression/update/sim-dynamodb-update-expression.js";
+import type { SimDynamoDbUpdate } from "../../expression/update/sim-dynamodb-update.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { SimDynamoDbConditionCheck } from "./sim-dynamodb-condition-check.js";
+
+interface SimDynamoDbUpdatePlanInput extends SimDynamoDbExpressionParameterInput {
+  readonly UpdateExpression?: string | undefined;
+  readonly ConditionExpression?: string | undefined;
+  readonly ReturnValuesOnConditionCheckFailure?: string | undefined;
+}
+
+interface SimDynamoDbUpdatePlanProperties {
+  readonly update: SimDynamoDbUpdate | undefined;
+  readonly check: SimDynamoDbConditionCheck;
+}
+
+/**
+ * What an UpdateItem request says to do, and what it is guarded by.
+ *
+ * An update carries two expressions, and both draw on the same
+ * `ExpressionAttributeNames` and `ExpressionAttributeValues`. Reading them
+ * together is what lets a placeholder used by either count as used, so a
+ * request naming one only in its UpdateExpression is not refused for it.
+ */
+export class SimDynamoDbUpdatePlan {
+  public readonly check: SimDynamoDbConditionCheck;
+
+  private readonly update: SimDynamoDbUpdate | undefined;
+
+  private constructor(properties: SimDynamoDbUpdatePlanProperties) {
+    this.update = properties.update;
+    this.check = properties.check;
+  }
+
+  /**
+   * Read the expressions a request carries, before anything is looked up.
+   *
+   * An expression DynamoDB would refuse is refused whether or not the key holds
+   * anything, so a bad expression fails the same way every time.
+   */
+  static read(
+    input: SimDynamoDbUpdatePlanInput,
+    operation: string,
+  ): SimDynamoDbUpdatePlan {
+    const expression = input.UpdateExpression;
+
+    if (expression === undefined) {
+      return new this({
+        update: undefined,
+        check: SimDynamoDbConditionCheck.read(input, operation),
+      });
+    }
+
+    const parameters = new SimDynamoDbExpressionParameters(input);
+    const update = parseSimDynamoDbUpdate(expression, parameters);
+    const condition = conditionIn(input.ConditionExpression, parameters);
+
+    parameters.assertAllUsed();
+
+    return new this({
+      update,
+      check: SimDynamoDbConditionCheck.of(condition, input, operation),
+    });
+  }
+
+  /**
+   * Refuse an update that would move the item's primary key.
+   */
+  assertLeavesKeyAlone(keyAttributeNames: readonly string[]): void {
+    this.update?.assertLeavesKeyAlone(keyAttributeNames);
+  }
+
+  /**
+   * The item this update makes of the one that was there.
+   *
+   * A request with no UpdateExpression still writes: UpdateItem upserts, so it
+   * leaves the stored item alone or creates one holding nothing but the Key.
+   */
+  applyTo(
+    existing: SimDynamoDbItem | undefined,
+    key: SimDynamoDbItem,
+  ): SimDynamoDbItem {
+    if (this.update === undefined) {
+      return existing ?? key;
+    }
+
+    return this.update.applyTo(existing, key);
+  }
+}
+
+/**
+ * Read the condition guarding an update, if it names one.
+ */
+function conditionIn(
+  expression: string | undefined,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbCondition | undefined {
+  if (expression === undefined) {
+    return undefined;
+  }
+
+  return parseSimDynamoDbCondition(expression, parameters);
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
@@ -3,7 +3,7 @@ import { compareSimDynamoDbValues } from "../../item/sim-dynamodb-value-order.js
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
 import type { SimDynamoDbConditionOperand } from "./sim-dynamodb-condition-operand.js";
-import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * The comparators a condition expression can put between two operands.
@@ -67,7 +67,7 @@ export class SimDynamoDbComparisonCondition implements SimDynamoDbCondition {
   /**
    * Whether the two operands stand in the relation the comparator asked for.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     const left = this.left.valueIn(subject);
     const right = this.right.valueIn(subject);
 
@@ -119,7 +119,7 @@ export class SimDynamoDbBetweenCondition implements SimDynamoDbCondition {
   /**
    * Whether the operand is at or between the two bounds.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return (
       this.aboveLower.holdsFor(subject) && this.belowUpper.holdsFor(subject)
     );
@@ -144,7 +144,7 @@ export class SimDynamoDbInCondition implements SimDynamoDbCondition {
   /**
    * Whether the operand equals any one of the candidates.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     const value = this.operand.valueIn(subject);
 
     if (value === undefined) {

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
@@ -28,7 +28,28 @@ export function readSimDynamoDbCondition(
   }
 
   const parameters = new SimDynamoDbExpressionParameters(request);
-  const condition = new SimDynamoDbConditionParser({
+  const condition = parseSimDynamoDbCondition(expression, parameters);
+
+  parameters.assertAllUsed();
+
+  return condition;
+}
+
+/**
+ * Read one ConditionExpression against placeholders that have already been
+ * gathered.
+ *
+ * A request can carry a condition alongside another expression, and both draw
+ * on the same `ExpressionAttributeNames` and `ExpressionAttributeValues`.
+ * Parsing against the parameters rather than against the request is what lets
+ * an UpdateItem check its placeholders once both of its expressions have been
+ * read.
+ */
+export function parseSimDynamoDbCondition(
+  expression: string,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbCondition {
+  return new SimDynamoDbConditionParser({
     tokens: SimDynamoDbExpressionTokens.of(
       expressionName,
       expression,
@@ -37,8 +58,4 @@ export function readSimDynamoDbCondition(
     names: parameters.names,
     values: parameters.values,
   }).parse();
-
-  parameters.assertAllUsed();
-
-  return condition;
 }

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "vitest";
 import type { SimDynamoDbAttributeValue } from "../../command/item/item.types.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import { readSimDynamoDbCondition } from "./sim-dynamodb-condition-expression.js";
-import { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * The order these conditions are evaluated against.
@@ -27,10 +27,8 @@ const order: Readonly<Record<string, SimDynamoDbAttributeValue>> = {
  */
 function subjectOf(
   item: Readonly<Record<string, SimDynamoDbAttributeValue>>,
-): SimDynamoDbConditionSubject {
-  return new SimDynamoDbConditionSubject(
-    SimDynamoDbItem.fromAttributeValues(item),
-  );
+): SimDynamoDbItemSnapshot {
+  return new SimDynamoDbItemSnapshot(SimDynamoDbItem.fromAttributeValues(item));
 }
 
 /**

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
@@ -5,7 +5,7 @@ import type {
   SimDynamoDbConditionOperand,
   SimDynamoDbPathOperand,
 } from "./sim-dynamodb-condition-operand.js";
-import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * Whether an item has the attribute a path names.
@@ -25,7 +25,7 @@ export class SimDynamoDbAttributeExistsCondition implements SimDynamoDbCondition
   /**
    * Whether the item has the attribute, or does not, as the function asked.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return (this.operand.valueIn(subject) !== undefined) === this.wanted;
   }
 }
@@ -48,7 +48,7 @@ export class SimDynamoDbAttributeTypeCondition implements SimDynamoDbCondition {
   /**
    * Whether what the path names is stored under the descriptor asked about.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return this.operand.valueIn(subject)?.kind === this.type;
   }
 }
@@ -74,7 +74,7 @@ export class SimDynamoDbBeginsWithCondition implements SimDynamoDbCondition {
   /**
    * Whether what the path names starts with the prefix.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     const value = this.operand.valueIn(subject);
     const prefix = this.prefix.valueIn(subject);
 
@@ -123,7 +123,7 @@ export class SimDynamoDbContainsCondition implements SimDynamoDbCondition {
   /**
    * Whether what the path names holds what was sought.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     const value = this.operand.valueIn(subject);
     const sought = this.sought.valueIn(subject);
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand.ts
@@ -2,7 +2,7 @@ import { SimDynamoDbNumber } from "../../item/sim-dynamodb-number.js";
 import { simDynamoDbTextSize } from "../../item/sim-dynamodb-value-size.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
-import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * One side of a comparison in a condition expression.
@@ -26,7 +26,7 @@ export interface SimDynamoDbConditionOperand {
   /**
    * The value this operand has for an item, if it has one.
    */
-  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined;
+  valueIn(subject: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined;
 }
 
 /**
@@ -47,7 +47,7 @@ export class SimDynamoDbPathOperand implements SimDynamoDbConditionOperand {
     return this.path.identity;
   }
 
-  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {
+  valueIn(subject: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined {
     return subject.valueAt(this.path);
   }
 }
@@ -103,7 +103,7 @@ export class SimDynamoDbSizeOperand implements SimDynamoDbConditionOperand {
     return `size(${this.operand.identity})`;
   }
 
-  valueIn(subject: SimDynamoDbConditionSubject): SimDynamoDbValue | undefined {
+  valueIn(subject: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined {
     const value = this.operand.valueIn(subject);
 
     if (value === undefined) {

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
@@ -9,7 +9,7 @@ import { describe, it } from "vitest";
 import type { SimDynamoDbAttributeValue } from "../../command/item/item.types.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import { readSimDynamoDbCondition } from "./sim-dynamodb-condition-expression.js";
-import { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * The order this test guards conditions against.
@@ -29,7 +29,7 @@ const order: Readonly<Record<string, SimDynamoDbAttributeValue>> = {
 function holdsFor(
   expression: string,
   values: Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined,
-  subject: SimDynamoDbConditionSubject,
+  subject: SimDynamoDbItemSnapshot,
 ): boolean {
   const condition = readSimDynamoDbCondition({
     ConditionExpression: expression,
@@ -50,7 +50,7 @@ function holds(
   return holdsFor(
     expression,
     values,
-    new SimDynamoDbConditionSubject(SimDynamoDbItem.fromAttributeValues(order)),
+    new SimDynamoDbItemSnapshot(SimDynamoDbItem.fromAttributeValues(order)),
   );
 }
 
@@ -62,7 +62,7 @@ function holdsForNothing(
   expression: string,
   values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
 ): boolean {
-  return holdsFor(expression, values, new SimDynamoDbConditionSubject());
+  return holdsFor(expression, values, new SimDynamoDbItemSnapshot());
 }
 
 describe("DynamoDB condition expressions", () => {
@@ -202,7 +202,7 @@ describe("DynamoDB condition expressions", () => {
     });
     assertNonNullable(condition);
 
-    const subject = new SimDynamoDbConditionSubject(
+    const subject = new SimDynamoDbItemSnapshot(
       SimDynamoDbItem.fromAttributeValues(nested),
     );
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.ts
@@ -1,4 +1,4 @@
-import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subject.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
 
 /**
  * One condition a write is guarded by.
@@ -9,7 +9,7 @@ import type { SimDynamoDbConditionSubject } from "./sim-dynamodb-condition-subje
  * the condition it named actually held.
  */
 export interface SimDynamoDbCondition {
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean;
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean;
 }
 
 /**
@@ -27,7 +27,7 @@ export class SimDynamoDbAndCondition implements SimDynamoDbCondition {
   /**
    * Whether both sides hold for an item.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return this.left.holdsFor(subject) && this.right.holdsFor(subject);
   }
 }
@@ -47,7 +47,7 @@ export class SimDynamoDbOrCondition implements SimDynamoDbCondition {
   /**
    * Whether either side holds for an item.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return this.left.holdsFor(subject) || this.right.holdsFor(subject);
   }
 }
@@ -65,7 +65,7 @@ export class SimDynamoDbNotCondition implements SimDynamoDbCondition {
   /**
    * Whether the condition inside does not hold for an item.
    */
-  holdsFor(subject: SimDynamoDbConditionSubject): boolean {
+  holdsFor(subject: SimDynamoDbItemSnapshot): boolean {
     return !this.condition.holdsFor(subject);
   }
 }

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-symbols.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-symbols.ts
@@ -8,9 +8,12 @@ const longSymbols: readonly string[] = ["<=", ">=", "<>"];
  * The single characters that mean something in the expressions supported so
  * far.
  *
- * This set grows as filter and update expressions arrive. Until then, a
- * character outside it is refused rather than passed through, so an expression
- * this simulation cannot evaluate fails rather than half works.
+ * This set grows as filter expressions arrive. Until then, a character outside
+ * it is refused rather than passed through, so an expression this simulation
+ * cannot evaluate fails rather than half works.
+ *
+ * `+` is here for the arithmetic an update expression can carry, which is read
+ * so that it can be refused by name rather than as an unexpected character.
  */
 const symbols: ReadonlySet<string> = new Set([
   ".",
@@ -18,6 +21,7 @@ const symbols: ReadonlySet<string> = new Set([
   "[",
   "]",
   "-",
+  "+",
   "(",
   ")",
   "=",

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-tokeniser.iso.test.ts
@@ -113,12 +113,12 @@ describe("SimDynamoDbExpressionTokeniser", () => {
     // Given an expression carrying a character no supported expression uses.
     // When it is tokenised, then it is refused rather than passed through to a
     // parser that would ignore it.
-    const error = assertThrowsError(() => tokenise("id + 3"));
+    const error = assertThrowsError(() => tokenise("id * 3"));
 
     assertInstanceOf(error, SimDynamoDbValidationException);
     assertIdentical(
       error.message,
-      "Invalid ProjectionExpression: syntax error; unexpected character '+'",
+      "Invalid ProjectionExpression: syntax error; unexpected character '*'",
     );
   });
 

--- a/src/service/dynamodb/expression/sim-dynamodb-item-snapshot.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-item-snapshot.ts
@@ -1,19 +1,23 @@
-import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
-import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
 import type {
   SimDynamoDbDocumentPath,
   SimDynamoDbDocumentPathSegment,
-} from "../sim-dynamodb-document-path.js";
+} from "./sim-dynamodb-document-path.js";
 
 /**
- * The item a condition is evaluated against.
+ * The item an expression is read against, as it stood when the request reached
+ * it.
  *
  * A conditional write is checked against whatever is stored under its key,
- * which may be nothing at all. That is what makes
- * `attribute_not_exists(id)` the way to insert only if absent: with no item
- * there, every path resolves to nothing.
+ * which may be nothing at all. That is what makes `attribute_not_exists(id)`
+ * the way to insert only if absent: with no item there, every path resolves to
+ * nothing.
+ *
+ * An update expression reads the same snapshot. Every action reads it rather
+ * than the item being built, so `REMOVE a SET b = a` still finds `a`.
  */
-export class SimDynamoDbConditionSubject {
+export class SimDynamoDbItemSnapshot {
   private readonly item: SimDynamoDbItem | undefined;
 
   constructor(item?: SimDynamoDbItem) {

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-action.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-action.ts
@@ -1,0 +1,85 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
+import type { SimDynamoDbUpdateDocument } from "./sim-dynamodb-update-document.js";
+import type { SimDynamoDbUpdateOperand } from "./sim-dynamodb-update-operand.js";
+import type { SimDynamoDbUpdateTarget } from "./sim-dynamodb-update-target.js";
+
+/**
+ * One thing an update expression does to an item.
+ *
+ * Every action reads the snapshot of the item as it stood before the update and
+ * writes into the item being built, so the actions of one expression do not see
+ * each other's work.
+ */
+export interface SimDynamoDbUpdateAction {
+  /** Where in the item this action writes. */
+  readonly target: SimDynamoDbUpdateTarget;
+
+  /** What this action does, for a refusal to name. */
+  readonly verb: string;
+
+  applyTo(
+    document: SimDynamoDbUpdateDocument,
+    snapshot: SimDynamoDbItemSnapshot,
+  ): void;
+}
+
+/**
+ * `path = operand`, which writes a value where the path points.
+ *
+ * An operand pointing at an attribute the item does not have is refused rather
+ * than treated as nothing, as real DynamoDB refuses it. `if_not_exists` is how
+ * an expression says what to assign when the attribute may be absent.
+ */
+export class SimDynamoDbSetAction implements SimDynamoDbUpdateAction {
+  public readonly target: SimDynamoDbUpdateTarget;
+  public readonly verb = "update";
+
+  private readonly operand: SimDynamoDbUpdateOperand;
+
+  constructor(
+    target: SimDynamoDbUpdateTarget,
+    operand: SimDynamoDbUpdateOperand,
+  ) {
+    this.target = target;
+    this.operand = operand;
+  }
+
+  /**
+   * Write what the operand works out to, where the target points.
+   */
+  applyTo(
+    document: SimDynamoDbUpdateDocument,
+    snapshot: SimDynamoDbItemSnapshot,
+  ): void {
+    const value = this.operand.valueIn(snapshot);
+
+    if (value === undefined) {
+      throw new SimDynamoDbValidationException(
+        `The provided expression refers to an attribute that does not exist ` +
+          `in the item: '${this.operand.text}'`,
+      );
+    }
+
+    document.set(this.target, value);
+  }
+}
+
+/**
+ * `path`, which takes away whatever the path points at.
+ */
+export class SimDynamoDbRemoveAction implements SimDynamoDbUpdateAction {
+  public readonly target: SimDynamoDbUpdateTarget;
+  public readonly verb = "remove";
+
+  constructor(target: SimDynamoDbUpdateTarget) {
+    this.target = target;
+  }
+
+  /**
+   * Take away whatever the target points at.
+   */
+  applyTo(document: SimDynamoDbUpdateDocument): void {
+    document.remove(this.target);
+  }
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-document.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-document.ts
@@ -1,0 +1,126 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbUpdateTarget } from "./sim-dynamodb-update-target.js";
+
+/**
+ * The item an update is building.
+ *
+ * It starts as the item that was there, or as the Key when there was none, and
+ * each action writes into it. Nothing reads from it: an action reads the
+ * snapshot of the item as it stood before the update, so what one action writes
+ * is not what the next one sees.
+ */
+export class SimDynamoDbUpdateDocument {
+  private attributes: ReadonlyMap<string, SimDynamoDbValue>;
+
+  constructor(attributes: ReadonlyMap<string, SimDynamoDbValue>) {
+    this.attributes = attributes;
+  }
+
+  /**
+   * Write a value where a target points.
+   */
+  set(target: SimDynamoDbUpdateTarget, value: SimDynamoDbValue): void {
+    const written = new Map(this.attributes);
+
+    written.set(
+      target.head,
+      valueWith(written.get(target.head), target.rest, value, target),
+    );
+
+    this.attributes = written;
+  }
+
+  /**
+   * Take away whatever a target points at.
+   *
+   * A target pointing at nothing is not a failure. REMOVE names a place rather
+   * than a value, so removing an attribute that is not there asks for the state
+   * the item is already in.
+   */
+  remove(target: SimDynamoDbUpdateTarget): void {
+    const written = new Map(this.attributes);
+    const kept = valueWithout(written.get(target.head), target.rest);
+
+    if (kept === undefined) {
+      written.delete(target.head);
+    } else {
+      written.set(target.head, kept);
+    }
+
+    this.attributes = written;
+  }
+
+  /**
+   * The item this update made.
+   */
+  toItem(): SimDynamoDbItem {
+    return SimDynamoDbItem.ofUpdatedAttributes(this.attributes);
+  }
+}
+
+/**
+ * A value with something written into it, at the names below it.
+ *
+ * With no names left, the value itself is what was written. Otherwise the value
+ * has to be a map, since an update cannot make one on the way past: real
+ * DynamoDB refuses `SET address.city = :c` where the item has no `address`.
+ */
+function valueWith(
+  value: SimDynamoDbValue | undefined,
+  names: readonly string[],
+  written: SimDynamoDbValue,
+  target: SimDynamoDbUpdateTarget,
+): SimDynamoDbValue {
+  const head = names.at(0);
+
+  if (head === undefined) {
+    return written;
+  }
+
+  if (value?.kind !== "M") {
+    throw new SimDynamoDbValidationException(
+      `The document path provided in the update expression is invalid for ` +
+        `update: '${target.text}' reaches into an attribute that is not a map`,
+    );
+  }
+
+  const entries = new Map(value.entries);
+  entries.set(
+    head,
+    valueWith(entries.get(head), names.slice(1), written, target),
+  );
+
+  return { kind: "M", entries };
+}
+
+/**
+ * A value with whatever the names below it point at taken away, or nothing when
+ * the value itself is what was pointed at.
+ */
+function valueWithout(
+  value: SimDynamoDbValue | undefined,
+  names: readonly string[],
+): SimDynamoDbValue | undefined {
+  const head = names.at(0);
+
+  if (head === undefined) {
+    return undefined;
+  }
+
+  if (value?.kind !== "M") {
+    return value;
+  }
+
+  const kept = valueWithout(value.entries.get(head), names.slice(1));
+  const entries = new Map(value.entries);
+
+  if (kept === undefined) {
+    entries.delete(head);
+  } else {
+    entries.set(head, kept);
+  }
+
+  return { kind: "M", entries };
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-expression.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-expression.ts
@@ -1,0 +1,29 @@
+import type { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { updateExpressionName } from "./sim-dynamodb-update-refusal.js";
+import { SimDynamoDbUpdateParser } from "./sim-dynamodb-update-parser.js";
+import type { SimDynamoDbUpdate } from "./sim-dynamodb-update.js";
+
+/**
+ * Read one UpdateExpression against placeholders that have already been
+ * gathered.
+ *
+ * An update expression carries no literals, so everything it assigns arrives
+ * through `ExpressionAttributeValues`. It shares those placeholders with the
+ * ConditionExpression the same request may carry, which is why the parameters
+ * are passed in rather than read here.
+ */
+export function parseSimDynamoDbUpdate(
+  expression: string,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbUpdate {
+  return new SimDynamoDbUpdateParser({
+    tokens: SimDynamoDbExpressionTokens.of(
+      updateExpressionName,
+      expression,
+      "the expression says nothing, and an expression cannot be empty",
+    ),
+    names: parameters.names,
+    values: parameters.values,
+  }).parse();
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-operand-parser.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-operand-parser.ts
@@ -1,0 +1,153 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import {
+  SimDynamoDbIfNotExistsOperand,
+  type SimDynamoDbUpdateOperand,
+  SimDynamoDbUpdatePathOperand,
+  SimDynamoDbUpdateValueOperand,
+} from "./sim-dynamodb-update-operand.js";
+import { simDynamoDbUpdateUnsupported } from "./sim-dynamodb-update-refusal.js";
+
+/**
+ * The one function a SET action can call in the expressions supported so far.
+ */
+const ifNotExistsName = "if_not_exists";
+
+/**
+ * The operators an update expression can carry between two operands, which this
+ * simulation does not work out.
+ */
+const arithmetic: ReadonlySet<string> = new Set(["+", "-"]);
+
+interface SimDynamoDbUpdateOperandParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+}
+
+/**
+ * Reads what a SET action assigns.
+ *
+ * An operand is a value the request supplied, a document path, or an
+ * `if_not_exists` call. Which one it is shows in its first token, so nothing
+ * here has to look far ahead.
+ */
+export class SimDynamoDbUpdateOperandParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+
+  constructor(properties: SimDynamoDbUpdateOperandParserProperties) {
+    this.tokens = properties.tokens;
+    this.names = properties.names;
+    this.values = properties.values;
+  }
+
+  /**
+   * Read one operand, refusing arithmetic on what follows it.
+   */
+  parse(): SimDynamoDbUpdateOperand {
+    const operand = this.operand();
+
+    this.refuseArithmetic();
+
+    return operand;
+  }
+
+  /**
+   * Read a document path, which is what both `if_not_exists` and a bare operand
+   * point with.
+   */
+  private parsePath(): SimDynamoDbUpdatePathOperand {
+    return new SimDynamoDbUpdatePathOperand(
+      new SimDynamoDbDocumentPathParser({
+        tokens: this.tokens,
+        names: this.names,
+      }).parse(),
+    );
+  }
+
+  /**
+   * Read whichever of the three shapes an operand is.
+   */
+  private operand(): SimDynamoDbUpdateOperand {
+    const token = this.tokens.peek();
+
+    if (token?.kind === "valuePlaceholder") {
+      this.tokens.next("a value");
+
+      return new SimDynamoDbUpdateValueOperand(
+        token.text,
+        this.values.required(token.text),
+      );
+    }
+
+    if (this.isFunctionCall()) {
+      return this.call();
+    }
+
+    return this.parsePath();
+  }
+
+  /**
+   * Whether what comes next is a function call rather than a path starting with
+   * an attribute of that name.
+   */
+  private isFunctionCall(): boolean {
+    const token = this.tokens.peek();
+    const after = this.tokens.peek(1);
+
+    return (
+      token?.kind === "name" && after?.kind === "symbol" && after.text === "("
+    );
+  }
+
+  /**
+   * Read a function call, refusing every function but `if_not_exists`.
+   */
+  private call(): SimDynamoDbUpdateOperand {
+    const name = this.tokens.next("a function name").text;
+    this.tokens.next("(");
+
+    if (name !== ifNotExistsName) {
+      throw simDynamoDbUpdateUnsupported(
+        `The update expression function ${name}`,
+        "working out a value it cannot build",
+      );
+    }
+
+    const stored = this.parsePath();
+    this.tokens.expectSymbol(
+      ",",
+      `syntax error; ${ifNotExistsName} takes a document path and a value`,
+    );
+
+    const otherwise = this.parse();
+    this.tokens.expectSymbol(
+      ")",
+      `syntax error; ${ifNotExistsName} is not closed`,
+    );
+
+    return new SimDynamoDbIfNotExistsOperand(stored, otherwise);
+  }
+
+  /**
+   * Refuse the arithmetic an update expression can carry between two operands.
+   *
+   * `SET n = n + :one` is a valid update on AWS. Reading the operator and
+   * refusing it by name says so, where leaving `+` out of the expressions this
+   * simulation reads at all would refuse it as an unexpected character.
+   */
+  private refuseArithmetic(): void {
+    const token = this.tokens.peek();
+
+    if (token?.kind === "symbol" && arithmetic.has(token.text)) {
+      throw simDynamoDbUpdateUnsupported(
+        `Arithmetic in an update expression, at '${token.text}'`,
+        "assigning a value it has not worked out",
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-operand.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-operand.ts
@@ -1,0 +1,89 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import type { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
+
+/**
+ * What a SET action assigns.
+ *
+ * An operand answers with a value read from the item as it stood before the
+ * update, or with nothing when the item does not have what it points at. An
+ * update has no literals, so every constant arrives through
+ * `ExpressionAttributeValues`.
+ */
+export interface SimDynamoDbUpdateOperand {
+  /**
+   * How the expression wrote this operand, for a refusal to name.
+   */
+  readonly text: string;
+
+  /**
+   * The value this operand has for the item, if it has one.
+   */
+  valueIn(snapshot: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined;
+}
+
+/**
+ * An operand carrying a value the request supplied, through
+ * `ExpressionAttributeValues`.
+ */
+export class SimDynamoDbUpdateValueOperand implements SimDynamoDbUpdateOperand {
+  public readonly text: string;
+
+  private readonly value: SimDynamoDbValue;
+
+  constructor(text: string, value: SimDynamoDbValue) {
+    this.text = text;
+    this.value = value;
+  }
+
+  valueIn(): SimDynamoDbValue {
+    return this.value;
+  }
+}
+
+/**
+ * An operand naming a place in the item.
+ */
+export class SimDynamoDbUpdatePathOperand implements SimDynamoDbUpdateOperand {
+  private readonly path: SimDynamoDbDocumentPath;
+
+  constructor(path: SimDynamoDbDocumentPath) {
+    this.path = path;
+  }
+
+  get text(): string {
+    return this.path.text;
+  }
+
+  valueIn(snapshot: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined {
+    return snapshot.valueAt(this.path);
+  }
+}
+
+/**
+ * `if_not_exists(path, operand)`, which is how a SET action leaves a value that
+ * is already there alone.
+ *
+ * The stored value wins when the path has one. Otherwise the second operand is
+ * what gets assigned, which is what makes this the way to set a default.
+ */
+export class SimDynamoDbIfNotExistsOperand implements SimDynamoDbUpdateOperand {
+  private readonly stored: SimDynamoDbUpdatePathOperand;
+  private readonly otherwise: SimDynamoDbUpdateOperand;
+
+  constructor(
+    stored: SimDynamoDbUpdatePathOperand,
+    otherwise: SimDynamoDbUpdateOperand,
+  ) {
+    this.stored = stored;
+    this.otherwise = otherwise;
+  }
+
+  get text(): string {
+    return `if_not_exists(${this.stored.text}, ${this.otherwise.text})`;
+  }
+
+  valueIn(snapshot: SimDynamoDbItemSnapshot): SimDynamoDbValue | undefined {
+    return this.stored.valueIn(snapshot) ?? this.otherwise.valueIn(snapshot);
+  }
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-parser.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-parser.ts
@@ -1,0 +1,148 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import {
+  SimDynamoDbRemoveAction,
+  type SimDynamoDbUpdateAction,
+  SimDynamoDbSetAction,
+} from "./sim-dynamodb-update-action.js";
+import { SimDynamoDbUpdateOperandParser } from "./sim-dynamodb-update-operand-parser.js";
+import {
+  simDynamoDbUpdateError,
+  simDynamoDbUpdateUnsupported,
+} from "./sim-dynamodb-update-refusal.js";
+import { SimDynamoDbUpdateTarget } from "./sim-dynamodb-update-target.js";
+import { SimDynamoDbUpdate } from "./sim-dynamodb-update.js";
+
+/**
+ * The clause keywords this simulation applies.
+ */
+const simulatedClauses: ReadonlySet<string> = new Set(["SET", "REMOVE"]);
+
+/**
+ * The clause keywords real DynamoDB has and this simulation does not apply.
+ */
+const unsimulatedClauses: ReadonlySet<string> = new Set(["ADD", "DELETE"]);
+
+interface SimDynamoDbUpdateParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+}
+
+/**
+ * Reads an UpdateExpression into the actions it asks for.
+ *
+ * An expression is a run of clauses, each of which is a keyword and then its
+ * comma-separated actions. The clauses may come in either order, and each
+ * keyword appears at most once.
+ */
+export class SimDynamoDbUpdateParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly operands: SimDynamoDbUpdateOperandParser;
+  private readonly clauses = new Set<string>();
+  private readonly actions: SimDynamoDbUpdateAction[] = [];
+
+  constructor(properties: SimDynamoDbUpdateParserProperties) {
+    this.tokens = properties.tokens;
+    this.names = properties.names;
+    this.operands = new SimDynamoDbUpdateOperandParser(properties);
+  }
+
+  /**
+   * Read the whole expression.
+   */
+  parse(): SimDynamoDbUpdate {
+    do {
+      this.clause();
+    } while (!this.tokens.atEnd);
+
+    return new SimDynamoDbUpdate(this.actions);
+  }
+
+  /**
+   * Read one clause, which is its keyword and then its actions.
+   */
+  private clause(): void {
+    const word = this.keyword();
+
+    if (this.clauses.has(word)) {
+      throw simDynamoDbUpdateError(
+        `The "${word}" section can only be used once in an update expression;`,
+      );
+    }
+
+    this.clauses.add(word);
+
+    if (word === "SET") {
+      this.setActions();
+
+      return;
+    }
+
+    this.removeActions();
+  }
+
+  /**
+   * Read the keyword a clause starts with.
+   */
+  private keyword(): string {
+    const token = this.tokens.next("SET or REMOVE");
+    const word = token.text.toUpperCase();
+
+    if (token.kind === "name" && unsimulatedClauses.has(word)) {
+      throw simDynamoDbUpdateUnsupported(
+        `The ${word} clause of an update expression`,
+        "applying a change this simulation cannot work out",
+      );
+    }
+
+    if (token.kind !== "name" || !simulatedClauses.has(word)) {
+      throw simDynamoDbUpdateError(
+        `syntax error; SET or REMOVE expected, but '${token.text}' was given`,
+      );
+    }
+
+    return word;
+  }
+
+  /**
+   * Read the `path = operand` actions of a SET clause.
+   */
+  private setActions(): void {
+    do {
+      const target = this.target();
+      this.tokens.expectSymbol(
+        "=",
+        `syntax error; a SET action assigns to a document path with '='`,
+      );
+
+      this.actions.push(
+        new SimDynamoDbSetAction(target, this.operands.parse()),
+      );
+    } while (this.tokens.takeSymbol(","));
+  }
+
+  /**
+   * Read the document paths of a REMOVE clause.
+   */
+  private removeActions(): void {
+    do {
+      this.actions.push(new SimDynamoDbRemoveAction(this.target()));
+    } while (this.tokens.takeSymbol(","));
+  }
+
+  /**
+   * Read the document path one action writes to.
+   */
+  private target(): SimDynamoDbUpdateTarget {
+    return new SimDynamoDbUpdateTarget(
+      new SimDynamoDbDocumentPathParser({
+        tokens: this.tokens,
+        names: this.names,
+      }).parse(),
+    );
+  }
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-refusal.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-refusal.ts
@@ -1,0 +1,37 @@
+import {
+  SimDynamoDbUnsupportedOperation,
+  type SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
+
+/**
+ * The request parameter an update expression arrives in, which every refusal
+ * names.
+ */
+export const updateExpressionName = "UpdateExpression";
+
+/**
+ * Refuse an update expression DynamoDB would refuse too.
+ */
+export function simDynamoDbUpdateError(
+  reason: string,
+): SimDynamoDbValidationException {
+  return simDynamoDbExpressionError(updateExpressionName, reason);
+}
+
+/**
+ * Refuse part of an update expression real DynamoDB accepts and this simulation
+ * does not model.
+ *
+ * This is deliberately not a ValidationException. The expression is a valid one,
+ * so the refusal says the simulation stops short rather than that the request
+ * was wrong.
+ */
+export function simDynamoDbUpdateUnsupported(
+  what: string,
+  reason: string,
+): SimDynamoDbUnsupportedOperation {
+  return new SimDynamoDbUnsupportedOperation(
+    `${what} is not simulated, so UpdateItem refuses it rather than ${reason}`,
+  );
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-target.iso.test.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-target.iso.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertFalse,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import { SimDynamoDbUpdateTarget } from "./sim-dynamodb-update-target.js";
+
+/**
+ * A target for the attributes named, in the order they nest.
+ */
+function targetFor(...names: readonly string[]): SimDynamoDbUpdateTarget {
+  return new SimDynamoDbUpdateTarget(
+    new SimDynamoDbDocumentPath(
+      names.map((name) => ({ kind: "attribute", name })),
+    ),
+  );
+}
+
+describe("DynamoDB update target", () => {
+  it("refuses a document path that names no attribute", () => {
+    // Given a document path with no segments, which a parsed path never is.
+    const path = new SimDynamoDbDocumentPath([]);
+
+    // When an update action is pointed at it.
+    const error = assertThrowsError(() => new SimDynamoDbUpdateTarget(path));
+
+    // Then it is refused rather than pointed at the item itself.
+    assertStringIncludes(error.message, "document path attribute");
+  });
+
+  it("finds the paths that write over each other", () => {
+    // Given targets naming an attribute, something inside it, and a sibling.
+    const address = targetFor("address");
+    const city = targetFor("address", "city");
+    const status = targetFor("status");
+
+    // Then a path containing another overlaps it, whichever way round they are
+    // compared, and two that share nothing do not.
+    assertTrue(address.overlaps(city));
+    assertTrue(city.overlaps(address));
+    assertFalse(address.overlaps(status));
+  });
+});

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-target.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-target.ts
@@ -1,0 +1,105 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type {
+  SimDynamoDbDocumentPath,
+  SimDynamoDbDocumentPathSegment,
+} from "../sim-dynamodb-document-path.js";
+import {
+  simDynamoDbUpdateError,
+  simDynamoDbUpdateUnsupported,
+} from "./sim-dynamodb-update-refusal.js";
+
+/**
+ * Where in an item one update action writes.
+ *
+ * A target is a document path that has been checked for what an update can
+ * change: attribute names all the way down, since list element paths are not
+ * simulated. Holding the names rather than the segments is what lets the item
+ * be written a level at a time.
+ */
+export class SimDynamoDbUpdateTarget {
+  /** The attribute this path starts at, which the table's key schema may name. */
+  public readonly head: string;
+
+  /** The attributes below the first one, which may be none. */
+  public readonly rest: readonly string[];
+
+  /** The path written back out, for a refusal to name. */
+  public readonly text: string;
+
+  private readonly names: readonly string[];
+
+  constructor(path: SimDynamoDbDocumentPath) {
+    const names = path.segments.map((segment) => attributeName(segment, path));
+    const head = names.at(0);
+
+    assertDefined(head, "DynamoDB update expression document path attribute");
+
+    this.head = head;
+    this.rest = names.slice(1);
+    this.names = names;
+    this.text = path.text;
+  }
+
+  /**
+   * Whether this target and another point at the same place, or one of them
+   * points inside the other.
+   *
+   * Two actions writing to overlapping paths do not say which of them the item
+   * should end up with, so real DynamoDB refuses the pair.
+   */
+  overlaps(other: SimDynamoDbUpdateTarget): boolean {
+    const depth = Math.min(this.names.length, other.names.length);
+    const theirs = other.names.slice(0, depth);
+
+    return this.names
+      .slice(0, depth)
+      .every((name, index) => name === theirs.at(index));
+  }
+
+  /**
+   * Whether this target writes to one of the attributes named.
+   *
+   * Only the attribute the path starts at counts. A key attribute is a scalar,
+   * so nothing inside another attribute is ever part of the key.
+   */
+  namesOneOf(attributeNames: readonly string[]): boolean {
+    return attributeNames.includes(this.head);
+  }
+}
+
+/**
+ * The attribute name one segment of an update target is.
+ */
+function attributeName(
+  segment: SimDynamoDbDocumentPathSegment,
+  path: SimDynamoDbDocumentPath,
+): string {
+  if (segment.kind === "index") {
+    throw simDynamoDbUpdateUnsupported(
+      `The list element path '${path.text}'`,
+      "writing an element real DynamoDB would shift the list around",
+    );
+  }
+
+  return segment.name;
+}
+
+/**
+ * Refuse an update whose actions write over each other.
+ */
+export function assertSimDynamoDbUpdateTargetsAgree(
+  targets: readonly SimDynamoDbUpdateTarget[],
+): void {
+  for (const [index, target] of targets.entries()) {
+    const overlapping = targets
+      .slice(index + 1)
+      .find((other) => target.overlaps(other));
+
+    if (overlapping !== undefined) {
+      throw simDynamoDbUpdateError(
+        `Two document paths overlap with each other; must remove or rewrite ` +
+          `one of these paths: '${target.text}' and '${overlapping.text}'`,
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update.ts
@@ -1,0 +1,64 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
+import type { SimDynamoDbUpdateAction } from "./sim-dynamodb-update-action.js";
+import { SimDynamoDbUpdateDocument } from "./sim-dynamodb-update-document.js";
+import { assertSimDynamoDbUpdateTargetsAgree } from "./sim-dynamodb-update-target.js";
+
+/**
+ * What one UpdateExpression does to an item.
+ *
+ * The actions are held in the order they were written, but the order they are
+ * applied in does not change the answer: each one reads the item as it stood
+ * before the update, so `REMOVE a SET b = a` still finds `a`.
+ */
+export class SimDynamoDbUpdate {
+  private readonly actions: readonly SimDynamoDbUpdateAction[];
+
+  constructor(actions: readonly SimDynamoDbUpdateAction[]) {
+    assertSimDynamoDbUpdateTargetsAgree(actions.map((action) => action.target));
+
+    this.actions = actions;
+  }
+
+  /**
+   * Refuse an update that would move an item's primary key.
+   *
+   * A key attribute names which item this is, so changing one would make this a
+   * write to a different item. Real DynamoDB refuses it, and UpdateItem takes
+   * the key it works on from the request's `Key`.
+   */
+  assertLeavesKeyAlone(keyAttributeNames: readonly string[]): void {
+    for (const action of this.actions) {
+      if (action.target.namesOneOf(keyAttributeNames)) {
+        throw new SimDynamoDbValidationException(
+          `One or more parameter values were invalid: Cannot ${action.verb} ` +
+            `attribute ${action.target.text}. This attribute is part of the key`,
+        );
+      }
+    }
+  }
+
+  /**
+   * The item this update makes of the one that was there.
+   *
+   * UpdateItem upserts, so with nothing stored under the key the new item is
+   * built from the Key the request named. Every action still reads the snapshot,
+   * which holds nothing in that case.
+   */
+  applyTo(
+    existing: SimDynamoDbItem | undefined,
+    key: SimDynamoDbItem,
+  ): SimDynamoDbItem {
+    const snapshot = new SimDynamoDbItemSnapshot(existing);
+    const document = new SimDynamoDbUpdateDocument(
+      existing?.entries() ?? key.entries(),
+    );
+
+    for (const action of this.actions) {
+      action.applyTo(document, snapshot);
+    }
+
+    return document.toItem();
+  }
+}

--- a/src/service/dynamodb/item/sim-dynamodb-item.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-item.ts
@@ -62,6 +62,23 @@ export class SimDynamoDbItem {
   }
 
   /**
+   * Hold the attributes an update made of an item.
+   *
+   * The values were all checked on the way in, either as part of the item that
+   * was there or as an expression value. What the update may have changed is
+   * how big the item is, so that is checked again.
+   */
+  static ofUpdatedAttributes(
+    attributes: ReadonlyMap<string, SimDynamoDbValue>,
+  ): SimDynamoDbItem {
+    const item = new this(attributes);
+
+    item.assertWithinSizeLimit();
+
+    return item;
+  }
+
+  /**
    * Get one of this item's attributes, if it has it.
    */
   attribute(name: string): SimDynamoDbValue | undefined {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -8,6 +8,7 @@ import {
   GetItemCommand,
   ListTablesCommand,
   PutItemCommand,
+  QueryCommand,
   UpdateItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
@@ -98,6 +99,18 @@ describe("simulated DynamoDB SDK Command routing", () => {
     );
     assertIdentical(readOut.Item?.["name"]?.S, "First item");
 
+    const updateOut = await client.send(
+      new UpdateItemCommand({
+        TableName: "ItemTable",
+        Key: { id: { S: "item-1" } },
+        UpdateExpression: "SET #n = :name",
+        ExpressionAttributeNames: { "#n": "name" },
+        ExpressionAttributeValues: { ":name": { S: "Renamed item" } },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+    assertIdentical(updateOut.Attributes?.["name"]?.S, "Renamed item");
+
     const removalOut = await client.send(
       new DeleteItemCommand({
         TableName: "ItemTable",
@@ -105,7 +118,7 @@ describe("simulated DynamoDB SDK Command routing", () => {
         ReturnValues: "ALL_OLD",
       }),
     );
-    assertIdentical(removalOut.Attributes?.["name"]?.S, "First item");
+    assertIdentical(removalOut.Attributes?.["name"]?.S, "Renamed item");
 
     const missOut = await client.send(
       new GetItemCommand({
@@ -156,15 +169,15 @@ describe("simulated DynamoDB SDK Command routing", () => {
 
     const error = await assertThrowsErrorAsync(async () => {
       await client.send(
-        new UpdateItemCommand({
+        new QueryCommand({
           TableName: "InterceptTable",
-          Key: { id: { S: "item-1" } },
-          UpdateExpression: "SET #n = :n",
+          KeyConditionExpression: "id = :id",
+          ExpressionAttributeValues: { ":id": { S: "item-1" } },
         }),
       );
     });
 
-    assertStringIncludes(error.message, "UpdateItemCommand");
+    assertStringIncludes(error.message, "QueryCommand");
     assertStringIncludes(error.message, "PutItemCommand");
   });
 });

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -13,6 +13,7 @@ import type {
   SimDeleteItemCommand,
   SimGetItemCommand,
   SimPutItemCommand,
+  SimUpdateItemCommand,
 } from "../command/item/item.command.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
@@ -69,6 +70,14 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simDynamoDatabase.getItem(
             command as SimGetItemCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateItemCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.updateItem(
+            command as SimUpdateItemCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -7,6 +7,7 @@ import { SimDynamoDbAuthorizer } from "./command/authorize/sim-dynamodb-authoriz
 import { SimDynamoDbDeleteItem } from "./command/item/sim-dynamodb-delete-item.js";
 import { SimDynamoDbGetItem } from "./command/item/sim-dynamodb-get-item.js";
 import { SimDynamoDbPutItem } from "./command/item/sim-dynamodb-put-item.js";
+import { SimDynamoDbUpdateItem } from "./command/item/sim-dynamodb-update-item.js";
 import { SimDynamoDbCreateTable } from "./command/table/sim-dynamodb-create-table.js";
 import { SimDynamoDbTableAccess } from "./command/table/sim-dynamodb-table-access.js";
 import { SimDynamoDbTableCommands } from "./command/table/sim-dynamodb-table-commands.js";
@@ -28,6 +29,8 @@ import type {
   SimGetItemCommandOutput,
   SimPutItemCommand,
   SimPutItemCommandOutput,
+  SimUpdateItemCommand,
+  SimUpdateItemCommandOutput,
 } from "./command/item/item.command.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
@@ -63,6 +66,7 @@ export class SimDynamoDb {
   private readonly itemWrites: SimDynamoDbPutItem;
   private readonly itemReads: SimDynamoDbGetItem;
   private readonly itemDeletions: SimDynamoDbDeleteItem;
+  private readonly itemUpdates: SimDynamoDbUpdateItem;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
   private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
     dynamoDb: this,
@@ -97,6 +101,7 @@ export class SimDynamoDb {
     this.itemWrites = new SimDynamoDbPutItem({ access: this.access });
     this.itemReads = new SimDynamoDbGetItem({ access: this.access });
     this.itemDeletions = new SimDynamoDbDeleteItem({ access: this.access });
+    this.itemUpdates = new SimDynamoDbUpdateItem({ access: this.access });
   }
 
   /**
@@ -175,6 +180,17 @@ export class SimDynamoDb {
   ): Promise<SimDeleteItemCommandOutput> {
     await this.background.sequence();
     return this.itemDeletions.handle(command, options);
+  }
+
+  /**
+   * Handle an Update Item Command from the SDK.
+   */
+  async updateItem(
+    command: SimUpdateItemCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimUpdateItemCommandOutput> {
+    await this.background.sequence();
+    return this.itemUpdates.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
…essions

UpdateItem reads an UpdateExpression made of SET and REMOVE clauses, in either order and each at most once. Every action is evaluated against the item as it stood before the request, so the actions of one expression do not see each other's work. It upserts from the Key when nothing is stored, takes a ConditionExpression sharing its placeholders, and answers NONE, ALL_OLD or ALL_NEW.

Resolves https://github.com/KensioSoftware/yulin/issues/258