### PR TITLE
feat: read and write simulated DynamoDB items in batches

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -891,9 +891,12 @@ Six things take the whole batch down rather than one entry of it, leaving nothin
 - a table that is not there
 - key attributes that do not match the table's key schema
 - more than one operation on the same item of one table
+- one table named twice, once by its name and once by its ARN
 - more than 25 write requests, counted across every table the request names
 - an item over the 400 KB an item holds
-- a request over 16 MB
+
+Real DynamoDB also refuses a request over 16 MB. That one is not simulated, for the reason under
+Limitations.
 
 The same key in two different tables is two items rather than one, so a batch may write both.
 
@@ -981,14 +984,17 @@ caller that needs to tell its items apart reads the key attributes off them rath
 where they are in the list.
 
 More than 100 keys in one call, counted across every table the request names, is a
-`ValidationException`. So is the same key twice for one table.
+`ValidationException`. So is the same key twice for one table, and so is one table named twice, once
+by its name and once by its ARN.
 
 Both commands answer with the map of what they could not get to, `UnprocessedItems` for a write and
 `UnprocessedKeys` for a read. Both are always empty here, since nothing is throttled, but they are
 there rather than absent, so the retry loop real code is written around still terminates:
 
 ```typescript
-let unprocessed = { OrdersTable: [{ PutRequest: { Item: item } }] };
+let unprocessed = {
+  OrdersTable: [{ PutRequest: { Item: { orderId: { S: "order-1" } } } }],
+};
 
 while (Object.keys(unprocessed).length > 0) {
   const output = await dynamoDb.batchWriteItem(

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -803,6 +803,203 @@ wanted. Naming one path twice counts the same way.
 A document path goes at most 32 levels deep, which is as far as an item nests. A negative index, a
 fractional index and a path past that depth are each a `ValidationException` naming the path.
 
+## Reading and writing items in batches
+
+`BatchWriteItem` puts and deletes items across tables in one call, and `BatchGetItem` reads them by
+primary key. Both take `RequestItems`, a map of table name or ARN to what that table is asked for.
+
+A batch write asks each table for a list of write requests, each carrying exactly one `PutRequest`
+or `DeleteRequest`.
+
+```typescript sim-dynamodb-batch-write-item
+/**
+ * Writing and deleting items across two tables in one call.
+ */
+
+import {
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "CustomersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const written = await dynamoDb.batchWriteItem(
+  new BatchWriteItemCommand({
+    RequestItems: {
+      OrdersTable: [
+        {
+          PutRequest: {
+            Item: { orderId: { S: "order-1" }, total: { N: "19.99" } },
+          },
+        },
+        {
+          PutRequest: {
+            Item: { orderId: { S: "order-2" }, total: { N: "24.99" } },
+          },
+        },
+        { DeleteRequest: { Key: { orderId: { S: "order-0" } } } },
+      ],
+      CustomersTable: [
+        { PutRequest: { Item: { customerId: { S: "customer-1" } } } },
+      ],
+    },
+  }),
+);
+
+// Nothing here is throttled, so nothing is ever left unprocessed.
+console.log(written.UnprocessedItems); // {}
+
+const output = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "OrdersTable",
+    Key: { orderId: { S: "order-2" } },
+  }),
+);
+
+console.log(output.Item?.["total"]?.N); // "24.99"
+```
+
+A put replaces the whole item under its key, exactly as `PutItem` does, and a delete names a key, so
+deleting a key that is already free succeeds. Neither answers with the item it wrote over: a batch
+has no `ReturnValues`, and no `ConditionExpression` either. A conditional write is what `PutItem`,
+`DeleteItem` and `UpdateItem` are for.
+
+Six things take the whole batch down rather than one entry of it, leaving nothing written:
+
+- a table that is not there
+- key attributes that do not match the table's key schema
+- more than one operation on the same item of one table
+- more than 25 write requests, counted across every table the request names
+- an item over the 400 KB an item holds
+- a request over 16 MB
+
+The same key in two different tables is two items rather than one, so a batch may write both.
+
+A batch read asks each table for `Keys`, and for how to read them. `ConsistentRead` and
+`ProjectionExpression` are settled per table rather than per call, so one call can read the whole of
+one table's items and part of another's.
+
+```typescript sim-dynamodb-batch-get-item
+/**
+ * Reading items from two tables in one call, projecting one of them.
+ */
+
+import {
+  BatchGetItemCommand,
+  CreateTableCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "CustomersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: { S: "order-1" },
+      total: { N: "19.99" },
+      note: { S: "gift wrapped" },
+    },
+  }),
+);
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "CustomersTable",
+    Item: { customerId: { S: "customer-1" }, name: { S: "Ada" } },
+  }),
+);
+
+const output = await dynamoDb.batchGetItem(
+  new BatchGetItemCommand({
+    RequestItems: {
+      OrdersTable: {
+        Keys: [{ orderId: { S: "order-1" } }, { orderId: { S: "order-404" } }],
+        ConsistentRead: true,
+        ProjectionExpression: "total",
+      },
+      CustomersTable: {
+        Keys: [{ customerId: { S: "customer-1" } }],
+      },
+    },
+  }),
+);
+
+// The key that holds nothing is left out rather than standing in the answer.
+console.log(output.Responses["OrdersTable"]?.length); // 1
+console.log(output.Responses["OrdersTable"]?.[0]); // { total: { N: "19.99" } }
+console.log(output.Responses["CustomersTable"]?.[0]?.["name"]?.S); // "Ada"
+console.log(output.UnprocessedKeys); // {}
+```
+
+An item that is not there is absent from `Responses`, with nothing standing in for it, so what came
+back is what was there. A table that held none of the keys it was asked for is still in `Responses`,
+with an empty list. DynamoDB reads a batch in parallel and answers in no particular order, so a
+caller that needs to tell its items apart reads the key attributes off them rather than counting on
+where they are in the list.
+
+More than 100 keys in one call, counted across every table the request names, is a
+`ValidationException`. So is the same key twice for one table.
+
+Both commands answer with the map of what they could not get to, `UnprocessedItems` for a write and
+`UnprocessedKeys` for a read. Both are always empty here, since nothing is throttled, but they are
+there rather than absent, so the retry loop real code is written around still terminates:
+
+```typescript
+let unprocessed = { OrdersTable: [{ PutRequest: { Item: item } }] };
+
+while (Object.keys(unprocessed).length > 0) {
+  const output = await dynamoDb.batchWriteItem(
+    new BatchWriteItemCommand({ RequestItems: unprocessed }),
+  );
+
+  // Always empty against the simulator, so the loop runs once.
+  unprocessed = output.UnprocessedItems;
+}
+```
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -1043,6 +1240,10 @@ authorizes against `*`.
 - `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
   `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
   `begins_with`, `contains` and `size` functions.
+- `BatchWriteItem`, putting and deleting items across tables in one call, with the 25 request cap,
+  the whole batch refusals, and an empty `UnprocessedItems`.
+- `BatchGetItem`, reading items across tables in one call, with `ConsistentRead` and
+  `ProjectionExpression` per table, the 100 key cap, and an empty `UnprocessedKeys`.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name and `Fn::GetAtt … Arn` the table ARN.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
@@ -1081,13 +1282,24 @@ authorizes against `*`.
   refuses that status anyway, for when it can.
 - Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
   is ever throttled with `ProvisionedThroughputExceededException`.
-- `UpdateTable`, `Query`, `Scan` and the batch item commands are not implemented yet.
+- `UpdateTable`, `Query` and `Scan` are not implemented yet.
+- `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
+  response stops at a size, so the branch of a batch retry loop that resends what did not go through
+  is never taken against the simulator.
+- The 16 MB limit on a batch request is not enforced. Real DynamoDB counts the request as the JSON it
+  arrived as, which is larger than the items it carries, and that inflation is not modelled: a batch
+  of 25 items under 400 KB each is under 10 MB by the sizes counted here, so nothing this simulation
+  measures ever reaches 16 MB.
+- The transactional item commands, `TransactWriteItems` and `TransactGetItems`, are not implemented
+  yet, so a batch write is the only way to change several items in one call. A batch is not a
+  transaction: it is refused whole for the failures listed above, and applied whole otherwise, but
+  nothing rolls it back afterwards.
 - A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
   Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
   stack deployed calls `simAws.backgroundTasksComplete()` first.
 - CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
   `DeletionPolicy` a template sets on a table.
-- `ProjectionExpression` is simulated on `GetItem` only. `BatchGetItem`, `Query` and `Scan` are not
+- `ProjectionExpression` is simulated on `GetItem` and `BatchGetItem`. `Query` and `Scan` are not
   implemented yet, so they have nothing to project from.
 - The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
   where part of it was asked for would hide an application reading an attribute it never requested.
@@ -1096,7 +1308,8 @@ authorizes against `*`.
   here is slower for a long expression, so an expression real DynamoDB would refuse for its size is
   evaluated.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
-  so a test cannot observe a stale read here the way it might against a real table.
+  whether a request sets it once for a read or per table for a batch read, so a test cannot observe a
+  stale read here the way it might against a real table.
 - Condition expressions are simulated on `PutItem`, `DeleteItem` and `UpdateItem` only. The
   transactional condition checks and the key condition and filter expressions of `Query` and `Scan`
   are not implemented yet, so there is nothing else to guard.

--- a/docs/services/dynamodb/sim-dynamodb-batch-get-item.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-batch-get-item.example.ts
@@ -1,0 +1,70 @@
+/**
+ * Reading items from two tables in one call, projecting one of them.
+ */
+
+import {
+  BatchGetItemCommand,
+  CreateTableCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "CustomersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: { S: "order-1" },
+      total: { N: "19.99" },
+      note: { S: "gift wrapped" },
+    },
+  }),
+);
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "CustomersTable",
+    Item: { customerId: { S: "customer-1" }, name: { S: "Ada" } },
+  }),
+);
+
+const output = await dynamoDb.batchGetItem(
+  new BatchGetItemCommand({
+    RequestItems: {
+      OrdersTable: {
+        Keys: [{ orderId: { S: "order-1" } }, { orderId: { S: "order-404" } }],
+        ConsistentRead: true,
+        ProjectionExpression: "total",
+      },
+      CustomersTable: {
+        Keys: [{ customerId: { S: "customer-1" } }],
+      },
+    },
+  }),
+);
+
+// The key that holds nothing is left out rather than standing in the answer.
+console.log(output.Responses["OrdersTable"]?.length); // 1
+console.log(output.Responses["OrdersTable"]?.[0]); // { total: { N: "19.99" } }
+console.log(output.Responses["CustomersTable"]?.[0]?.["name"]?.S); // "Ada"
+console.log(output.UnprocessedKeys); // {}

--- a/docs/services/dynamodb/sim-dynamodb-batch-write-item.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-batch-write-item.example.ts
@@ -1,0 +1,67 @@
+/**
+ * Writing and deleting items across two tables in one call.
+ */
+
+import {
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "CustomersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const written = await dynamoDb.batchWriteItem(
+  new BatchWriteItemCommand({
+    RequestItems: {
+      OrdersTable: [
+        {
+          PutRequest: {
+            Item: { orderId: { S: "order-1" }, total: { N: "19.99" } },
+          },
+        },
+        {
+          PutRequest: {
+            Item: { orderId: { S: "order-2" }, total: { N: "24.99" } },
+          },
+        },
+        { DeleteRequest: { Key: { orderId: { S: "order-0" } } } },
+      ],
+      CustomersTable: [
+        { PutRequest: { Item: { customerId: { S: "customer-1" } } } },
+      ],
+    },
+  }),
+);
+
+// Nothing here is throttled, so nothing is ever left unprocessed.
+console.log(written.UnprocessedItems); // {}
+
+const output = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "OrdersTable",
+    Key: { orderId: { S: "order-2" } },
+  }),
+);
+
+console.log(output.Item?.["total"]?.N); // "24.99"

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -354,7 +354,8 @@ The order both work in is the same, and it is what makes a batch all or nothing:
 
 1. Everything that can be read without a table is read: the request cap, the per entry shapes, the
    items, the keys and the projections. Nothing here has reached the table store.
-2. Every table is reached and the caller authorized against it.
+2. Every table is reached and the caller authorized against it. The tables are then compared, since
+   a name and an ARN are two entries naming one table, which real DynamoDB refuses.
 3. Every key is marshalled through the table's key schema, which is both the key check and what
    tells two operations on one item apart.
 4. Only then is the first item written.
@@ -373,7 +374,10 @@ The parts a batch is made of split by what they know:
   cap across every table the request names.
 - `sim-dynamodb-batch-reads.ts` does the same for a batch read, applying the 100 key cap and reading
   each table's `ProjectionExpression` through the same `readSimDynamoDbProjection` GetItem uses.
-- `assertDistinctBatchItems` is the duplicate check both use, over marshalled keys.
+- `assertDistinctBatchItems` is the duplicate item check both use, over marshalled keys.
+- `reachSimDynamoDbBatchTables` is how both reach their tables: it authorizes the caller against
+  each, and refuses a request naming one table twice, comparing the tables the references resolved
+  to rather than the references themselves.
 
 `UnprocessedItems` and `UnprocessedKeys` are always empty maps. Nothing here is throttled and no
 response stops at a size, so no request is ever left over, but the map is answered with rather than

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -49,6 +49,7 @@ Current command areas include:
 - `authorize/` (shared IAM authorization for every DynamoDB command)
 - `table/` (CreateTable, DescribeTable, ListTables and DeleteTable)
 - `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
+- `batch/` (BatchWriteItem and BatchGetItem)
 
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
@@ -341,6 +342,46 @@ c: 3 }` leaves `{ b: 1, c: 2 }`, which an implementation applying actions left t
   which item is reported, and whether the whole of it is. `UPDATED_OLD` and `UPDATED_NEW` report the
   parts the expression touched by applying a `SimDynamoDbProjection` of the action targets, which is
   the same machinery a ProjectionExpression uses.
+
+## BatchWriteItem and BatchGetItem behavior
+
+`SimDynamoDbBatchWriteItem` and `SimDynamoDbBatchGetItem` work on several items across several
+tables in one call. Both read a `RequestItems` map of table reference to what that table is asked
+for, through the shared `readSimDynamoDbBatchRequestItems`, which keeps the reference as it arrived
+so a batch read answers under the name or ARN the request used.
+
+The order both work in is the same, and it is what makes a batch all or nothing:
+
+1. Everything that can be read without a table is read: the request cap, the per entry shapes, the
+   items, the keys and the projections. Nothing here has reached the table store.
+2. Every table is reached and the caller authorized against it.
+3. Every key is marshalled through the table's key schema, which is both the key check and what
+   tells two operations on one item apart.
+4. Only then is the first item written.
+
+A batch write that fails any of those leaves nothing written, which is what real DynamoDB does: it
+rejects the whole request rather than reporting a failure per entry. That is the difference from the
+SQS batch collaborator in `src/service/sqs/command/message/sim-sqs-batch-entries.ts`, which reports
+per-entry failures in a `Failed` array while the rest of the batch goes through.
+
+The parts a batch is made of split by what they know:
+
+- `SimDynamoDbBatchWrite` is one put or delete, as the item or key it carries plus what it does to a
+  table. Both implementations answer with the key they work on, so the duplicate check and the write
+  read the same item.
+- `sim-dynamodb-batch-writes.ts` reads a whole `RequestItems` into those, applying the 25 request
+  cap across every table the request names.
+- `sim-dynamodb-batch-reads.ts` does the same for a batch read, applying the 100 key cap and reading
+  each table's `ProjectionExpression` through the same `readSimDynamoDbProjection` GetItem uses.
+- `assertDistinctBatchItems` is the duplicate check both use, over marshalled keys.
+
+`UnprocessedItems` and `UnprocessedKeys` are always empty maps. Nothing here is throttled and no
+response stops at a size, so no request is ever left over, but the map is answered with rather than
+left out so a retry loop written around it terminates.
+
+A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamoDbPutRequest` and
+`SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
+than written unconditionally.
 
 Scans, queries, indexes and streams are not implemented. Billing mode and provisioned capacity are
 read and stored by CreateTable, but nothing enforces them: no write is ever throttled.

--- a/src/service/dynamodb/command/batch/batch.command.ts
+++ b/src/service/dynamodb/command/batch/batch.command.ts
@@ -1,0 +1,120 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+
+/**
+ * Minimal structural sim DynamoDB PutRequest.
+ *
+ * A real PutRequest carries an Item and nothing else. `ConditionExpression` is
+ * declared so a request carrying one is refused by name, rather than written
+ * unconditionally by a batch that never looked at it.
+ */
+export interface SimDynamoDbPutRequest {
+  readonly Item?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ConditionExpression?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB DeleteRequest.
+ */
+export interface SimDynamoDbDeleteRequest {
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ConditionExpression?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB WriteRequest.
+ *
+ * One entry of a batch write carries exactly one of the two, which is what
+ * makes it a put or a delete.
+ */
+export interface SimDynamoDbWriteRequest {
+  readonly PutRequest?: SimDynamoDbPutRequest | undefined;
+  readonly DeleteRequest?: SimDynamoDbDeleteRequest | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchWriteItem command.
+ */
+export interface SimBatchWriteItemCommand {
+  readonly input: SimBatchWriteItemCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchWriteItem input.
+ */
+export interface SimBatchWriteItemCommandInput {
+  readonly RequestItems?:
+    Readonly<Record<string, readonly SimDynamoDbWriteRequest[]>> | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+  readonly ReturnItemCollectionMetrics?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchWriteItem output.
+ *
+ * `UnprocessedItems` is there and empty rather than absent, which is what real
+ * DynamoDB answers with when it wrote everything it was given.
+ */
+export interface SimBatchWriteItemCommandOutput {
+  // The requests are not readonly, so what came back can be given straight to
+  // the next BatchWriteItem the way a retry loop gives it.
+  readonly UnprocessedItems: Readonly<
+    Record<string, SimDynamoDbWriteRequest[]>
+  >;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB KeysAndAttributes.
+ *
+ * This is what a batch read asks one table for: the keys, and how to read the
+ * items they name. Consistency and projection are settled here rather than on
+ * the request, so one call can read one table consistently and another not.
+ */
+export interface SimDynamoDbKeysAndAttributes {
+  readonly Keys?:
+    readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] | undefined;
+  readonly ConsistentRead?: boolean | undefined;
+  readonly ProjectionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly AttributesToGet?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchGetItem command.
+ */
+export interface SimBatchGetItemCommand {
+  readonly input: SimBatchGetItemCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchGetItem input.
+ */
+export interface SimBatchGetItemCommandInput {
+  readonly RequestItems?:
+    Readonly<Record<string, SimDynamoDbKeysAndAttributes>> | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB BatchGetItem output.
+ *
+ * A key that holds nothing is absent from `Responses` rather than standing in
+ * it as an empty item, so the items that came back are the items that were
+ * there.
+ */
+export interface SimBatchGetItemCommandOutput {
+  readonly Responses: Readonly<
+    Record<
+      string,
+      readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[]
+    >
+  >;
+  readonly UnprocessedKeys: Readonly<
+    Record<string, SimDynamoDbKeysAndAttributes>
+  >;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.iso.test.ts
@@ -1,0 +1,344 @@
+import {
+  BatchGetItemCommand,
+  CreateTableCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("DynamoDB BatchGetItemCommand", () => {
+  it("reads items from two tables in one call", async () => {
+    // Given two tables, each holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "CustomersTable",
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" }, total: { N: "19.99" } },
+      }),
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "CustomersTable",
+        Item: { customerId: { S: "customer-1" }, name: { S: "Ada" } },
+      }),
+    );
+
+    // When one batch reads from both of them.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: {
+          OrdersTable: { Keys: [{ orderId: { S: "order-1" } }] },
+          CustomersTable: { Keys: [{ customerId: { S: "customer-1" } }] },
+        },
+      }),
+    );
+
+    // Then each table answers under the name it was asked by, and no key was
+    // left unread.
+    assertIdentical(
+      output.Responses["OrdersTable"]?.[0]?.["total"]?.N,
+      "19.99",
+    );
+    assertIdentical(
+      output.Responses["CustomersTable"]?.[0]?.["name"]?.S,
+      "Ada",
+    );
+    assertObjectEquals(output.UnprocessedKeys, {});
+  });
+
+  it("leaves out a key that holds nothing", async () => {
+    // Given a table holding one of the two items a read asks for.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When a batch reads both keys.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: {
+          OrdersTable: {
+            Keys: [
+              { orderId: { S: "order-1" } },
+              { orderId: { S: "order-2" } },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then only the item that was there comes back, with nothing standing in
+    // for the one that was not.
+    const items = output.Responses["OrdersTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 1);
+    assertIdentical(items[0]["orderId"]?.S, "order-1");
+  });
+
+  it("answers with an empty list for a table holding none of the keys", async () => {
+    // Given a table holding nothing.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch reads a key from it.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: {
+          OrdersTable: { Keys: [{ orderId: { S: "order-1" } }] },
+        },
+      }),
+    );
+
+    // Then the table is still in the answer, holding nothing.
+    const items = output.Responses["OrdersTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 0);
+  });
+
+  it("projects each table by its own ProjectionExpression", async () => {
+    // Given two tables, each holding an item with several attributes.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "CustomersTable",
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: {
+          orderId: { S: "order-1" },
+          total: { N: "19.99" },
+          note: { S: "gift" },
+        },
+      }),
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "CustomersTable",
+        Item: {
+          customerId: { S: "customer-1" },
+          name: { S: "Ada" },
+          address: { M: { city: { S: "London" } } },
+        },
+      }),
+    );
+
+    // When one batch asks each table for a different part of its items.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: {
+          OrdersTable: {
+            Keys: [{ orderId: { S: "order-1" } }],
+            ProjectionExpression: "#t",
+            ExpressionAttributeNames: { "#t": "total" },
+          },
+          CustomersTable: {
+            Keys: [{ customerId: { S: "customer-1" } }],
+            ProjectionExpression: "address.city",
+          },
+        },
+      }),
+    );
+
+    // Then each table answers with what it was asked for, and nothing else.
+    const order = output.Responses["OrdersTable"]?.[0];
+    assertNonNullable(order);
+    assertArrayEquals(Object.keys(order), ["total"]);
+
+    const customer = output.Responses["CustomersTable"]?.[0];
+    assertNonNullable(customer);
+    assertIdentical(customer["address"]?.M?.["city"]?.S, "London");
+    assertUndefined(customer["name"]);
+  });
+
+  it("sets ConsistentRead per table", async () => {
+    // Given two tables, each holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "CustomersTable",
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "CustomersTable",
+        Item: { customerId: { S: "customer-1" } },
+      }),
+    );
+
+    // When one batch reads one table consistently and the other not.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: {
+          OrdersTable: {
+            Keys: [{ orderId: { S: "order-1" } }],
+            ConsistentRead: true,
+          },
+          CustomersTable: {
+            Keys: [{ customerId: { S: "customer-1" } }],
+            ConsistentRead: false,
+          },
+        },
+      }),
+    );
+
+    // Then both answer with the latest write: this simulation is always
+    // strongly consistent.
+    assertIdentical(
+      output.Responses["OrdersTable"]?.[0]?.["orderId"]?.S,
+      "order-1",
+    );
+    assertIdentical(
+      output.Responses["CustomersTable"]?.[0]?.["customerId"]?.S,
+      "customer-1",
+    );
+  });
+
+  it("reads from a table named by its ARN", async () => {
+    // Given a table holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When a batch names the table by its ARN.
+    const output = await simDynamoDb.batchGetItem(
+      new BatchGetItemCommand({
+        RequestItems: { [tableArn]: { Keys: [{ orderId: { S: "order-1" } }] } },
+      }),
+    );
+
+    // Then the items come back under the ARN the request asked with.
+    assertArrayEquals(Object.keys(output.Responses), [tableArn]);
+
+    const items = Object.values(output.Responses)[0];
+    assertNonNullable(items);
+    assertIdentical(items[0]?.["orderId"]?.S, "order-1");
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
@@ -1,0 +1,113 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type {
+  SimBatchGetItemCommand,
+  SimBatchGetItemCommandOutput,
+} from "./batch.command.js";
+import {
+  readSimDynamoDbBatchReads,
+  type SimDynamoDbBatchTableReads,
+} from "./sim-dynamodb-batch-reads.js";
+import { assertDistinctBatchItems } from "./sim-dynamodb-batch-request-items.js";
+import { refuseUnsimulatedBatchReadInput } from "./sim-dynamodb-unsimulated-batch-input.js";
+
+interface SimDynamoDbBatchGetItemProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbBatchGetItemOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The BatchGetItem command.
+ *
+ * A batch reads items by primary key across tables in one call. Consistency and
+ * projection are settled per table rather than per call, so one call can read
+ * one table consistently and part of another.
+ *
+ * A key that holds nothing is left out of the answer rather than standing in it
+ * as an empty item, so what came back is what was there.
+ */
+export class SimDynamoDbBatchGetItem {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbBatchGetItemProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Read every item a batch asks for.
+   */
+  handle(
+    command: SimBatchGetItemCommand,
+    options?: SimDynamoDbBatchGetItemOptions,
+  ): SimBatchGetItemCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedBatchReadInput(input);
+
+    const requested = readSimDynamoDbBatchReads(input.RequestItems);
+    const responses = Object.fromEntries(
+      requested.map((table) => [
+        table.reference,
+        this.read(table, options?.caller),
+      ]),
+    );
+
+    // Nothing here throttles or stops at a response size, so no key is ever
+    // left unread. The map is still answered with, since that is the shape a
+    // retry loop reads.
+    return { Responses: responses, UnprocessedKeys: {}, $metadata: {} };
+  }
+
+  /**
+   * Read what one table of the batch was asked for.
+   *
+   * DynamoDB reads a batch in parallel and answers in no particular order. The
+   * items here come back in the order their keys were named, which is one of
+   * the orders that is allowed rather than one that can be relied on.
+   */
+  private read(
+    requested: SimDynamoDbBatchTableReads,
+    caller: SimAwsCaller | undefined,
+  ): readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] {
+    const table = this.access.required(
+      "dynamodb:BatchGetItem",
+      requested.reference,
+      caller,
+    );
+
+    // Marshalling every key checks it against the table's key schema, and is
+    // what tells two reads of one item apart.
+    assertDistinctBatchItems(
+      requested.keys.map((key) => table.keyOfKey(key)),
+      requested.reference,
+      "BatchGetItem",
+    );
+
+    return requested.keys
+      .map((key) => this.found(table, key, requested))
+      .filter((item) => item !== undefined);
+  }
+
+  /**
+   * Read one item, as the table it is in and the projection asked for it.
+   */
+  private found(
+    table: SimDynamoDbTable,
+    key: SimDynamoDbItem,
+    requested: SimDynamoDbBatchTableReads,
+  ): Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined {
+    const item = table.getItem(key);
+
+    if (item === undefined) {
+      return undefined;
+    }
+
+    return (requested.projection?.apply(item) ?? item).toAttributeValues();
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
@@ -12,6 +12,10 @@ import {
   type SimDynamoDbBatchTableReads,
 } from "./sim-dynamodb-batch-reads.js";
 import { assertDistinctBatchItems } from "./sim-dynamodb-batch-request-items.js";
+import {
+  reachSimDynamoDbBatchTables,
+  type SimDynamoDbBatchTable,
+} from "./sim-dynamodb-batch-tables.js";
 import { refuseUnsimulatedBatchReadInput } from "./sim-dynamodb-unsimulated-batch-input.js";
 
 interface SimDynamoDbBatchGetItemProperties {
@@ -21,6 +25,13 @@ interface SimDynamoDbBatchGetItemProperties {
 interface SimDynamoDbBatchGetItemOptions {
   readonly caller?: SimAwsCaller;
 }
+
+/**
+ * The items one table of a batch read answers with.
+ */
+type SimDynamoDbReadItems = readonly Readonly<
+  Record<string, SimDynamoDbAttributeValue>
+>[];
 
 /**
  * The BatchGetItem command.
@@ -50,12 +61,16 @@ export class SimDynamoDbBatchGetItem {
 
     refuseUnsimulatedBatchReadInput(input);
 
-    const requested = readSimDynamoDbBatchReads(input.RequestItems);
+    const reached = reachSimDynamoDbBatchTables(
+      readSimDynamoDbBatchReads(input.RequestItems),
+      {
+        access: this.access,
+        operation: "BatchGetItem",
+        caller: options?.caller,
+      },
+    );
     const responses = Object.fromEntries(
-      requested.map((table) => [
-        table.reference,
-        this.read(table, options?.caller),
-      ]),
+      reached.map((entry) => [entry.requested.reference, readItems(entry)]),
     );
 
     // Nothing here throttles or stops at a response size, so no key is ever
@@ -63,51 +78,46 @@ export class SimDynamoDbBatchGetItem {
     // retry loop reads.
     return { Responses: responses, UnprocessedKeys: {}, $metadata: {} };
   }
+}
 
-  /**
-   * Read what one table of the batch was asked for.
-   *
-   * DynamoDB reads a batch in parallel and answers in no particular order. The
-   * items here come back in the order their keys were named, which is one of
-   * the orders that is allowed rather than one that can be relied on.
-   */
-  private read(
-    requested: SimDynamoDbBatchTableReads,
-    caller: SimAwsCaller | undefined,
-  ): readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] {
-    const table = this.access.required(
-      "dynamodb:BatchGetItem",
-      requested.reference,
-      caller,
-    );
+/**
+ * Read what one table of the batch was asked for.
+ *
+ * DynamoDB reads a batch in parallel and answers in no particular order. The
+ * items here come back in the order their keys were named, which is one of the
+ * orders that is allowed rather than one that can be relied on.
+ */
+function readItems(
+  reached: SimDynamoDbBatchTable<SimDynamoDbBatchTableReads>,
+): SimDynamoDbReadItems {
+  const { table, requested } = reached;
 
-    // Marshalling every key checks it against the table's key schema, and is
-    // what tells two reads of one item apart.
-    assertDistinctBatchItems(
-      requested.keys.map((key) => table.keyOfKey(key)),
-      requested.reference,
-      "BatchGetItem",
-    );
+  // Marshalling every key checks it against the table's key schema, and is
+  // what tells two reads of one item apart.
+  assertDistinctBatchItems(
+    requested.keys.map((key) => table.keyOfKey(key)),
+    requested.reference,
+    "BatchGetItem",
+  );
 
-    return requested.keys
-      .map((key) => this.found(table, key, requested))
-      .filter((item) => item !== undefined);
+  return requested.keys
+    .map((key) => foundItem(table, key, requested))
+    .filter((item) => item !== undefined);
+}
+
+/**
+ * Read one item, as the table it is in and the projection asked for it.
+ */
+function foundItem(
+  table: SimDynamoDbTable,
+  key: SimDynamoDbItem,
+  requested: SimDynamoDbBatchTableReads,
+): Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined {
+  const item = table.getItem(key);
+
+  if (item === undefined) {
+    return undefined;
   }
 
-  /**
-   * Read one item, as the table it is in and the projection asked for it.
-   */
-  private found(
-    table: SimDynamoDbTable,
-    key: SimDynamoDbItem,
-    requested: SimDynamoDbBatchTableReads,
-  ): Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined {
-    const item = table.getItem(key);
-
-    if (item === undefined) {
-      return undefined;
-    }
-
-    return (requested.projection?.apply(item) ?? item).toAttributeValues();
-  }
+  return (requested.projection?.apply(item) ?? item).toAttributeValues();
 }

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-validation.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-validation.iso.test.ts
@@ -1,0 +1,315 @@
+import {
+  BatchGetItemCommand,
+  CreateTableCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+
+const ordersTable = new CreateTableCommand({
+  TableName: "OrdersTable",
+  KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+describe("DynamoDB BatchGetItemCommand request validation", () => {
+  it("requires RequestItems naming a table", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names no table at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(new BatchGetItemCommand({ RequestItems: {} })),
+    );
+
+    // Then it is refused, since a batch has to read something.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "BatchGetItem requires RequestItems naming at least one table",
+    );
+  });
+
+  it("requires RequestItems at all", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch carries no RequestItems.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem({ input: {} }),
+    );
+
+    // Then it is refused the same way an empty one is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "BatchGetItem requires RequestItems naming at least one table",
+    );
+  });
+
+  it("refuses a table named with no Keys at all", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names it without saying what to read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem({
+        input: { RequestItems: { OrdersTable: {} } },
+      }),
+    );
+
+    // Then it is refused the same way an empty list of keys is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "names the table OrdersTable with no Keys",
+    );
+  });
+
+  it("refuses a table named with no Keys", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names it with an empty list of keys.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: { OrdersTable: { Keys: [] } },
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "names the table OrdersTable with no Keys",
+    );
+  });
+
+  it("refuses more than 100 keys, counted across tables", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "ArchivedOrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch asks for 101 keys split between them.
+    const keys = (count: number): { orderId: { S: string } }[] =>
+      Array.from({ length: count }, (_unused, index) => ({
+        orderId: { S: `order-${String(index)}` },
+      }));
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: { Keys: keys(51) },
+            ArchivedOrdersTable: { Keys: keys(50) },
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Too many items requested for the BatchGetItem call",
+    );
+  });
+
+  it("refuses one key named twice for a table", async () => {
+    // Given a table holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When a batch asks for that key twice.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: {
+              Keys: [
+                { orderId: { S: "order-1" } },
+                { orderId: { S: "order-1" } },
+              ],
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused rather than answering with the item
+    // once or twice.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Provided list of item keys contains duplicates",
+    );
+  });
+
+  it("refuses a Key that does not match the table's key schema", async () => {
+    // Given a table keyed by a string.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch reads it by an attribute that is not part of the key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: {
+              Keys: [{ orderId: { S: "order-1" }, note: { S: "first" } }],
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, naming the attribute at fault.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The provided key element does not match the schema",
+    );
+  });
+
+  it("refuses a batch naming a table that is not there", async () => {
+    // Given a simulated DynamoDB with no tables.
+    const simDynamoDb = new SimAws().dynamoDb();
+
+    // When a batch reads from one.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            MissingTable: { Keys: [{ orderId: { S: "order-1" } }] },
+          },
+        }),
+      ),
+    );
+
+    // Then it is reported as not found.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("refuses a ProjectionExpression DynamoDB would refuse", async () => {
+    // Given a table holding nothing.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch projects two paths where one contains the other.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: {
+              Keys: [{ orderId: { S: "order-1" } }],
+              ProjectionExpression: "address, address.city",
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused whether or not the keys hold anything.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Invalid ProjectionExpression");
+  });
+
+  it("refuses the legacy AttributesToGet", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch asks for part of an item the legacy way.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: {
+              Keys: [{ orderId: { S: "order-1" } }],
+              AttributesToGet: ["total"],
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused as unsimulated, as GetItem refuses it.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "AttributesToGet");
+  });
+
+  it("refuses reporting a capacity cost nothing measures", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch asks for its consumed capacity.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: { Keys: [{ orderId: { S: "order-1" } }] },
+          },
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      ),
+    );
+
+    // Then it is refused as unsimulated rather than reported as zero.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnConsumedCapacity");
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-validation.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-validation.iso.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import {
   assertInstanceOf,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
@@ -64,7 +65,7 @@ describe("DynamoDB BatchGetItemCommand request validation", () => {
     );
   });
 
-  it("refuses a table named with no Keys at all", async () => {
+  it("refuses a table with no Keys property at all", async () => {
     // Given a table.
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
@@ -86,7 +87,7 @@ describe("DynamoDB BatchGetItemCommand request validation", () => {
     );
   });
 
-  it("refuses a table named with no Keys", async () => {
+  it("refuses a table named with an empty list of Keys", async () => {
     // Given a table.
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
@@ -215,6 +216,37 @@ describe("DynamoDB BatchGetItemCommand request validation", () => {
     assertStringIncludes(
       error.message,
       "The provided key element does not match the schema",
+    );
+  });
+
+  it("refuses one table named by both its name and its ARN", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    const creation = await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When one batch reads the same key under both references.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: { Keys: [{ orderId: { S: "order-1" } }] },
+            [tableArn]: { Keys: [{ orderId: { S: "order-1" } }] },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, since a table is named once per request whichever
+    // way it is named.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Each table name or ARN can be used only once",
     );
   });
 

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-item-iam.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-item-iam.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  BatchGetItemCommand,
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const ordersTable = new CreateTableCommand({
+  TableName: "OrdersTable",
+  KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+const archivedOrdersTable = new CreateTableCommand({
+  TableName: "ArchivedOrdersTable",
+  KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+const trustPolicy = (accountId: string): string =>
+  JSON.stringify({
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+      Action: "sts:AssumeRole",
+    },
+  });
+
+describe("DynamoDB batch item command IAM authorization", () => {
+  it("allows a Role its policy permits dynamodb:BatchWriteItem", async () => {
+    // Given a Role allowed to write items to the table in batches.
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const simDynamoDb = simAws.dynamoDb();
+    const simIam = simAws.iam();
+
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    const creation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "BatchWriter",
+        AssumeRolePolicyDocument: trustPolicy(accountId),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "BatchWriter",
+        PolicyName: "BatchWritePolicy",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "dynamodb:BatchWriteItem",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When the Role writes a batch.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+          ],
+        },
+      }),
+      { caller: { kind: "arn", arn: creation.Role.Arn } },
+    );
+
+    // Then IAM allows the request and the item is there.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(output.Item?.["orderId"]?.S, "order-1");
+  });
+
+  it("denies a batch write for a table the Role may not write to", async () => {
+    // Given a Role allowed to write to one of the two tables a batch names.
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const region = simAws.defaultRegionName;
+    const simDynamoDb = simAws.dynamoDb();
+    const simIam = simAws.iam();
+
+    await simDynamoDb.createTable(ordersTable);
+    await simDynamoDb.createTable(archivedOrdersTable);
+    await simAws.backgroundTasksComplete();
+
+    const creation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PartialBatchWriter",
+        AssumeRolePolicyDocument: trustPolicy(accountId),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "PartialBatchWriter",
+        PolicyName: "OneTablePolicy",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "dynamodb:BatchWriteItem",
+            Resource: `arn:aws:dynamodb:${region}:${accountId}:table/OrdersTable`,
+          },
+        }),
+      }),
+    );
+
+    // When the Role writes a batch naming both.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+            ArchivedOrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+          },
+        }),
+        { caller: { kind: "arn", arn: creation.Role.Arn } },
+      ),
+    );
+
+    // Then the whole batch is denied, and the table the Role could write to is
+    // untouched.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:BatchWriteItem");
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+
+  it("does not let permission to read one item read a batch", async () => {
+    // Given a Role allowed only to read one item at a time.
+    const simAws = new SimAws();
+    const accountId = simAws.defaultAccountId;
+    const simDynamoDb = simAws.dynamoDb();
+    const simIam = simAws.iam();
+
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    const creation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "SingleItemReader",
+        AssumeRolePolicyDocument: trustPolicy(accountId),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "SingleItemReader",
+        PolicyName: "GetItemPolicy",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "dynamodb:GetItem",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When the Role reads a batch.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchGetItem(
+        new BatchGetItemCommand({
+          RequestItems: {
+            OrdersTable: { Keys: [{ orderId: { S: "order-1" } }] },
+          },
+        }),
+        { caller: { kind: "arn", arn: creation.Role.Arn } },
+      ),
+    );
+
+    // Then each DynamoDB operation is its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:BatchGetItem");
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-reads.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-reads.ts
@@ -1,0 +1,92 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { readSimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection-expression.js";
+import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
+import type { SimDynamoDbKeysAndAttributes } from "./batch.command.js";
+import {
+  readSimDynamoDbBatchRequestItems,
+  type SimDynamoDbBatchTableRequest,
+} from "./sim-dynamodb-batch-request-items.js";
+import { refuseUnsimulatedBatchKeysAndAttributes } from "./sim-dynamodb-unsimulated-batch-input.js";
+
+const operation = "BatchGetItem";
+
+/**
+ * Real DynamoDB reads 100 items in one batch, counted across every table the
+ * request names rather than per table.
+ */
+const greatestKeys = 100;
+
+/**
+ * What a batch read asks one table for.
+ *
+ * The projection belongs to the table rather than to the request, so one call
+ * can read the whole of one table's items and part of another's.
+ */
+export interface SimDynamoDbBatchTableReads {
+  readonly reference: string;
+  readonly keys: readonly SimDynamoDbItem[];
+  readonly projection: SimDynamoDbProjection | undefined;
+}
+
+/**
+ * Read every key a batch asks for, before any table is reached.
+ *
+ * A ProjectionExpression DynamoDB would refuse is refused whether or not the
+ * keys hold anything, which is how the single item reads work too.
+ */
+export function readSimDynamoDbBatchReads(
+  requestItems:
+    Readonly<Record<string, SimDynamoDbKeysAndAttributes>> | undefined,
+): readonly SimDynamoDbBatchTableReads[] {
+  const tables = readSimDynamoDbBatchRequestItems(requestItems, operation);
+
+  assertWithinKeyLimit(tables);
+
+  return tables.map(({ reference, requested }) => ({
+    reference,
+    keys: readTableKeys(reference, requested),
+    projection: readSimDynamoDbProjection(requested),
+  }));
+}
+
+/**
+ * Refuse a batch asking for more items than DynamoDB reads at once.
+ */
+function assertWithinKeyLimit(
+  tables: readonly SimDynamoDbBatchTableRequest<SimDynamoDbKeysAndAttributes>[],
+): void {
+  const total = tables.reduce(
+    (count, { requested }) => count + (requested.Keys ?? []).length,
+    0,
+  );
+
+  if (total > greatestKeys) {
+    throw new SimDynamoDbValidationException(
+      `Too many items requested for the ${operation} call: ${total.toString()} ` +
+        `keys, where ${greatestKeys.toString()} is the most a batch reads`,
+    );
+  }
+}
+
+/**
+ * Read the keys one table of the batch is asked for.
+ */
+function readTableKeys(
+  reference: string,
+  requested: SimDynamoDbKeysAndAttributes,
+): readonly SimDynamoDbItem[] {
+  refuseUnsimulatedBatchKeysAndAttributes(requested);
+
+  const keys = requested.Keys ?? [];
+
+  if (keys.length === 0) {
+    throw new SimDynamoDbValidationException(
+      `${operation} names the table ${reference} with no Keys, and a batch ` +
+        `names at least one for every table it reads`,
+    );
+  }
+
+  return keys.map((key) => readSimDynamoDbKey(key));
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-request-items.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-request-items.ts
@@ -1,0 +1,63 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+
+/**
+ * What one table of a batch request asks for.
+ *
+ * The reference is the name or ARN the request used, kept as it arrived. A
+ * batch read answers under the same key the request named the table by, so the
+ * caller can find its items under what it asked with.
+ */
+export interface SimDynamoDbBatchTableRequest<Requested> {
+  readonly reference: string;
+  readonly requested: Requested;
+}
+
+/**
+ * Read the tables a batch request names.
+ *
+ * A JavaScript object cannot hold one key twice, so the rule that a table is
+ * named once per request needs nothing here. What is left is that a batch has
+ * to work on something: real DynamoDB refuses an empty RequestItems rather than
+ * answering with an empty result.
+ */
+export function readSimDynamoDbBatchRequestItems<Requested>(
+  requestItems: Readonly<Record<string, Requested>> | undefined,
+  operation: string,
+): readonly SimDynamoDbBatchTableRequest<Requested>[] {
+  const entries = Object.entries(requestItems ?? {});
+
+  if (entries.length === 0) {
+    throw new SimDynamoDbValidationException(
+      `${operation} requires RequestItems naming at least one table`,
+    );
+  }
+
+  return entries.map(([reference, requested]) => ({ reference, requested }));
+}
+
+/**
+ * Refuse a batch naming one item of a table more than once.
+ *
+ * The keys are the marshalled primary keys of one table, so two entries that
+ * name the same item are the same text whichever attribute order they arrived
+ * in. Real DynamoDB takes the whole batch down for this rather than applying
+ * one of the two, since which one it applied would be arbitrary.
+ */
+export function assertDistinctBatchItems(
+  keys: readonly string[],
+  reference: string,
+  operation: string,
+): void {
+  const seen = new Set<string>();
+
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new SimDynamoDbValidationException(
+        `Provided list of item keys contains duplicates: ${operation} names ` +
+          `one item of the table ${reference} more than once`,
+      );
+    }
+
+    seen.add(key);
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
@@ -1,0 +1,72 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+
+/**
+ * What one table of a batch asks for, against the table it names.
+ */
+export interface SimDynamoDbBatchTable<Requested> {
+  readonly table: SimDynamoDbTable;
+  readonly requested: Requested;
+}
+
+interface SimDynamoDbBatchReach {
+  readonly access: SimDynamoDbTableAccess;
+  readonly operation: string;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * Reach every table a batch names, authorizing the caller against each.
+ *
+ * AWS maps each DynamoDB operation to the `dynamodb:` action of the same name,
+ * so the operation is the action as well as what a refusal names.
+ *
+ * Every table is reached before either command does anything with one, so a
+ * batch write is refused whole rather than partly applied.
+ */
+export function reachSimDynamoDbBatchTables<
+  Requested extends { readonly reference: string },
+>(
+  requested: readonly Requested[],
+  reach: SimDynamoDbBatchReach,
+): readonly SimDynamoDbBatchTable<Requested>[] {
+  const action = `dynamodb:${reach.operation}`;
+  const reached = requested.map((entry) => ({
+    table: reach.access.required(action, entry.reference, reach.caller),
+    requested: entry,
+  }));
+
+  assertDistinctTables(reached, reach.operation);
+
+  return reached;
+}
+
+/**
+ * Refuse a batch naming one table more than once.
+ *
+ * A map cannot hold one key twice, but a name and an ARN are two keys for one
+ * table. Real DynamoDB takes each table name or ARN once per request, so the
+ * tables are compared after the references have been resolved rather than as
+ * they arrived. Checking here rather than per entry is also what keeps each
+ * command's duplicate item check whole.
+ */
+function assertDistinctTables<Requested>(
+  reached: readonly SimDynamoDbBatchTable<Requested>[],
+  operation: string,
+): void {
+  const seen = new Set<string>();
+
+  for (const { table } of reached) {
+    if (seen.has(table.tableName)) {
+      throw new SimDynamoDbValidationException(
+        `Each table name or ARN can be used only once per ${operation} ` +
+          `request, and this one names the table ${table.tableName} more ` +
+          `than once`,
+      );
+    }
+
+    seen.add(table.tableName);
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.iso.test.ts
@@ -1,0 +1,298 @@
+import {
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+describe("DynamoDB BatchWriteItemCommand", () => {
+  it("writes items to two tables in one call", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "CustomersTable",
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When one batch writes to both of them.
+    const output = await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            { PutRequest: { Item: { orderId: { S: "order-2" } } } },
+          ],
+          CustomersTable: [
+            { PutRequest: { Item: { customerId: { S: "customer-1" } } } },
+          ],
+        },
+      }),
+    );
+
+    // Then every item is there, and nothing was left unprocessed.
+    assertObjectEquals(output.UnprocessedItems, {});
+
+    const order = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-2" } },
+      }),
+    );
+    assertIdentical(order.Item?.["orderId"]?.S, "order-2");
+
+    const customer = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "CustomersTable",
+        Key: { customerId: { S: "customer-1" } },
+      }),
+    );
+    assertIdentical(customer.Item?.["customerId"]?.S, "customer-1");
+  });
+
+  it("replaces the whole item a put lands on", async () => {
+    // Given a table holding an item with two attributes.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: {
+          orderId: { S: "order-1" },
+          total: { N: "19.99" },
+          note: { S: "first" },
+        },
+      }),
+    );
+
+    // When a batch put writes the same key with one attribute.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            {
+              PutRequest: {
+                Item: { orderId: { S: "order-1" }, total: { N: "24.99" } },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then the item was replaced rather than merged into, as PutItem replaces
+    // it.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    const item = output.Item;
+    assertNonNullable(item);
+    assertIdentical(item["total"]?.N, "24.99");
+    assertUndefined(item["note"]);
+  });
+
+  it("puts and deletes different items of one table in one call", async () => {
+    // Given a table holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When a batch writes one item and deletes another.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-2" } } } },
+            { DeleteRequest: { Key: { orderId: { S: "order-1" } } } },
+          ],
+        },
+      }),
+    );
+
+    // Then both landed.
+    const written = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-2" } },
+      }),
+    );
+    assertIdentical(written.Item?.["orderId"]?.S, "order-2");
+
+    const deleted = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(deleted.Item);
+  });
+
+  it("deletes a key that holds nothing", async () => {
+    // Given a table holding no items.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch deletes a key nothing was ever written under.
+    const output = await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { DeleteRequest: { Key: { orderId: { S: "order-1" } } } },
+          ],
+        },
+      }),
+    );
+
+    // Then it succeeds, as a delete names a key rather than an item.
+    assertObjectEquals(output.UnprocessedItems, {});
+  });
+
+  it("writes to a table named by its ARN", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When a batch names the table by its ARN.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          [tableArn]: [{ PutRequest: { Item: { orderId: { S: "order-1" } } } }],
+        },
+      }),
+    );
+
+    // Then it is the same table.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(output.Item?.["orderId"]?.S, "order-1");
+  });
+
+  it("takes the 25 requests a batch write holds", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch writes exactly 25 items.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: Array.from({ length: 25 }, (_unused, index) => ({
+            PutRequest: { Item: { orderId: { S: `order-${String(index)}` } } },
+          })),
+        },
+      }),
+    );
+
+    // Then all of them are there.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-24" } },
+      }),
+    );
+    assertIdentical(output.Item?.["orderId"]?.S, "order-24");
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
@@ -1,17 +1,15 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type {
   SimBatchWriteItemCommand,
   SimBatchWriteItemCommandOutput,
 } from "./batch.command.js";
 import { assertDistinctBatchItems } from "./sim-dynamodb-batch-request-items.js";
-import type { SimDynamoDbBatchWrite } from "./sim-dynamodb-batch-write.js";
-import {
-  readSimDynamoDbBatchWrites,
-  type SimDynamoDbBatchTableWrites,
-} from "./sim-dynamodb-batch-writes.js";
+import { reachSimDynamoDbBatchTables } from "./sim-dynamodb-batch-tables.js";
+import { readSimDynamoDbBatchWrites } from "./sim-dynamodb-batch-writes.js";
 import { refuseUnsimulatedBatchWriteInput } from "./sim-dynamodb-unsimulated-batch-input.js";
+
+const operation = "BatchWriteItem";
 
 interface SimDynamoDbBatchWriteItemProperties {
   readonly access: SimDynamoDbTableAccess;
@@ -19,14 +17,6 @@ interface SimDynamoDbBatchWriteItemProperties {
 
 interface SimDynamoDbBatchWriteItemOptions {
   readonly caller?: SimAwsCaller;
-}
-
-/**
- * The writes of one table, against the table they are for.
- */
-interface SimDynamoDbPlannedWrites {
-  readonly table: SimDynamoDbTable;
-  readonly writes: readonly SimDynamoDbBatchWrite[];
 }
 
 /**
@@ -58,11 +48,24 @@ export class SimDynamoDbBatchWriteItem {
 
     refuseUnsimulatedBatchWriteInput(input);
 
-    const requested = readSimDynamoDbBatchWrites(input.RequestItems);
-    const planned = requested.map((table) => this.plan(table, options?.caller));
+    const reached = reachSimDynamoDbBatchTables(
+      readSimDynamoDbBatchWrites(input.RequestItems),
+      { access: this.access, operation, caller: options?.caller },
+    );
 
-    for (const { table, writes } of planned) {
-      for (const write of writes) {
+    // Marshalling every key checks it against the table's key schema, and is
+    // what tells two operations on one item apart. Every table is checked
+    // before any of them is written to.
+    for (const { table, requested } of reached) {
+      assertDistinctBatchItems(
+        requested.writes.map((write) => write.keyIn(table)),
+        requested.reference,
+        operation,
+      );
+    }
+
+    for (const { table, requested } of reached) {
+      for (const write of requested.writes) {
         write.applyTo(table);
       }
     }
@@ -70,29 +73,5 @@ export class SimDynamoDbBatchWriteItem {
     // Nothing here throttles, so nothing is ever left unprocessed. The map is
     // still answered with, since that is the shape a retry loop reads.
     return { UnprocessedItems: {}, $metadata: {} };
-  }
-
-  /**
-   * Reach the table one part of the batch names, and check its keys.
-   */
-  private plan(
-    requested: SimDynamoDbBatchTableWrites,
-    caller: SimAwsCaller | undefined,
-  ): SimDynamoDbPlannedWrites {
-    const table = this.access.required(
-      "dynamodb:BatchWriteItem",
-      requested.reference,
-      caller,
-    );
-
-    // Marshalling every key checks it against the table's key schema, and is
-    // what tells two operations on one item apart.
-    assertDistinctBatchItems(
-      requested.writes.map((write) => write.keyIn(table)),
-      requested.reference,
-      "BatchWriteItem",
-    );
-
-    return { table, writes: requested.writes };
   }
 }

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
@@ -1,0 +1,98 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type {
+  SimBatchWriteItemCommand,
+  SimBatchWriteItemCommandOutput,
+} from "./batch.command.js";
+import { assertDistinctBatchItems } from "./sim-dynamodb-batch-request-items.js";
+import type { SimDynamoDbBatchWrite } from "./sim-dynamodb-batch-write.js";
+import {
+  readSimDynamoDbBatchWrites,
+  type SimDynamoDbBatchTableWrites,
+} from "./sim-dynamodb-batch-writes.js";
+import { refuseUnsimulatedBatchWriteInput } from "./sim-dynamodb-unsimulated-batch-input.js";
+
+interface SimDynamoDbBatchWriteItemProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbBatchWriteItemOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The writes of one table, against the table they are for.
+ */
+interface SimDynamoDbPlannedWrites {
+  readonly table: SimDynamoDbTable;
+  readonly writes: readonly SimDynamoDbBatchWrite[];
+}
+
+/**
+ * The BatchWriteItem command.
+ *
+ * A batch puts and deletes items across tables in one call. Each put is a whole
+ * replacement, as PutItem is, and each delete names a key, so deleting a key
+ * that is already free succeeds. Neither reports the item it wrote over.
+ *
+ * A batch write is refused whole rather than partly applied: everything is
+ * read, every table reached and every key checked before the first item is
+ * written, so a request DynamoDB would reject leaves the tables as they were.
+ */
+export class SimDynamoDbBatchWriteItem {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbBatchWriteItemProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Apply every put and delete a batch asks for.
+   */
+  handle(
+    command: SimBatchWriteItemCommand,
+    options?: SimDynamoDbBatchWriteItemOptions,
+  ): SimBatchWriteItemCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedBatchWriteInput(input);
+
+    const requested = readSimDynamoDbBatchWrites(input.RequestItems);
+    const planned = requested.map((table) => this.plan(table, options?.caller));
+
+    for (const { table, writes } of planned) {
+      for (const write of writes) {
+        write.applyTo(table);
+      }
+    }
+
+    // Nothing here throttles, so nothing is ever left unprocessed. The map is
+    // still answered with, since that is the shape a retry loop reads.
+    return { UnprocessedItems: {}, $metadata: {} };
+  }
+
+  /**
+   * Reach the table one part of the batch names, and check its keys.
+   */
+  private plan(
+    requested: SimDynamoDbBatchTableWrites,
+    caller: SimAwsCaller | undefined,
+  ): SimDynamoDbPlannedWrites {
+    const table = this.access.required(
+      "dynamodb:BatchWriteItem",
+      requested.reference,
+      caller,
+    );
+
+    // Marshalling every key checks it against the table's key schema, and is
+    // what tells two operations on one item apart.
+    assertDistinctBatchItems(
+      requested.writes.map((write) => write.keyIn(table)),
+      requested.reference,
+      "BatchWriteItem",
+    );
+
+    return { table, writes: requested.writes };
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-limits.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-limits.iso.test.ts
@@ -193,6 +193,14 @@ describe("DynamoDB BatchWriteItemCommand whole batch refusals", () => {
 
     // Then both went through: two operations on one item are two operations on
     // one item of one table.
+    const order = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(order.Item?.["orderId"]?.S, "order-1");
+
     const archived = await simDynamoDb.getItem(
       new GetItemCommand({
         TableName: "ArchivedOrdersTable",

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-limits.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-limits.iso.test.ts
@@ -1,0 +1,346 @@
+import {
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+
+describe("DynamoDB BatchWriteItemCommand whole batch refusals", () => {
+  it("refuses more than 25 requests, counted across tables", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "CustomersTable",
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch carries 26 requests split between them.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: Array.from({ length: 13 }, (_unused, index) => ({
+              PutRequest: {
+                Item: { orderId: { S: `order-${String(index)}` } },
+              },
+            })),
+            CustomersTable: Array.from({ length: 13 }, (_unused, index) => ({
+              PutRequest: {
+                Item: { customerId: { S: `customer-${String(index)}` } },
+              },
+            })),
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, and nothing was written.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Too many items requested for the BatchWriteItem call",
+    );
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-0" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+
+  it("refuses two operations on the same item", async () => {
+    // Given a table holding an item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: { S: "order-1" }, note: { S: "first" } },
+      }),
+    );
+
+    // When one batch puts and deletes the same key, alongside a write that
+    // would otherwise have gone through.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-2" } } } },
+              {
+                PutRequest: {
+                  Item: { orderId: { S: "order-1" }, note: { S: "second" } },
+                },
+              },
+              { DeleteRequest: { Key: { orderId: { S: "order-1" } } } },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, and neither write was applied.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Provided list of item keys contains duplicates",
+    );
+
+    const untouched = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(untouched.Item?.["note"]?.S, "first");
+
+    const unwritten = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-2" } },
+      }),
+    );
+    assertUndefined(unwritten.Item);
+  });
+
+  it("takes the same key in two different tables", async () => {
+    // Given two tables whose keys are named the same way.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "ArchivedOrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When one batch writes the same key to both.
+    await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+          ],
+          ArchivedOrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+          ],
+        },
+      }),
+    );
+
+    // Then both went through: two operations on one item are two operations on
+    // one item of one table.
+    const archived = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "ArchivedOrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(archived.Item?.["orderId"]?.S, "order-1");
+  });
+
+  it("refuses a batch naming a table that is not there", async () => {
+    // Given one table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch writes to it and to a table that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+            MissingTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, including the part that named a table
+    // that is there.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+
+  it("refuses a key that does not match the table's key schema", async () => {
+    // Given a table keyed by a string.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch puts one item keyed by a number, after one that is fine.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+              { PutRequest: { Item: { orderId: { N: "2" } } } },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, and the item that was fine is not there
+    // either.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Type mismatch for key attribute");
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+
+  it("refuses an item over the 400 KB an item holds", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a batch carries an item bigger than that.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+              {
+                PutRequest: {
+                  Item: {
+                    orderId: { S: "order-2" },
+                    padding: { S: "x".repeat(400 * 1024) },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, and the item that fits is not written.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Item size has exceeded the maximum");
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-validation.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-validation.iso.test.ts
@@ -1,12 +1,15 @@
 import {
   BatchWriteItemCommand,
   CreateTableCommand,
+  GetItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   assertInstanceOf,
+  assertNonNullable,
   assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -216,6 +219,58 @@ describe("DynamoDB BatchWriteItemCommand request validation", () => {
       error.message,
       "A DeleteRequest takes no ConditionExpression",
     );
+  });
+
+  it("refuses one table named by both its name and its ARN", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When one batch writes the same item under both references.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              {
+                PutRequest: {
+                  Item: { orderId: { S: "order-1" }, note: { S: "first" } },
+                },
+              },
+            ],
+            [tableArn]: [
+              {
+                PutRequest: {
+                  Item: { orderId: { S: "order-1" }, note: { S: "second" } },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the whole batch is refused, since a table is named once per
+    // request whichever way it is named, and nothing was written.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Each table name or ARN can be used only once",
+    );
+
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertUndefined(output.Item);
   });
 
   it("refuses reporting a capacity cost nothing measures", async () => {

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-validation.iso.test.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-validation.iso.test.ts
@@ -1,0 +1,296 @@
+import {
+  BatchWriteItemCommand,
+  CreateTableCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+
+const ordersTable = new CreateTableCommand({
+  TableName: "OrdersTable",
+  KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+describe("DynamoDB BatchWriteItemCommand request validation", () => {
+  it("requires RequestItems naming a table", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names no table at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({ RequestItems: {} }),
+      ),
+    );
+
+    // Then it is refused, since a batch has to write something.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "BatchWriteItem requires RequestItems naming at least one table",
+    );
+  });
+
+  it("refuses a table named with no write requests", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names it with an empty list.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({ RequestItems: { OrdersTable: [] } }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "names the table OrdersTable with no write requests",
+    );
+  });
+
+  it("refuses a WriteRequest carrying both a put and a delete", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When one request asks for both.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              {
+                PutRequest: { Item: { orderId: { S: "order-1" } } },
+                DeleteRequest: { Key: { orderId: { S: "order-1" } } },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than one of the two being guessed at.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "carries both");
+  });
+
+  it("refuses a WriteRequest carrying neither a put nor a delete", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When one request asks for neither.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({ RequestItems: { OrdersTable: [{}] } }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "carries neither");
+  });
+
+  it("requires an Item on a PutRequest", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a put carries no Item.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem({
+        input: { RequestItems: { OrdersTable: [{ PutRequest: {} }] } },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A PutRequest requires an Item");
+  });
+
+  it("requires a Key on a DeleteRequest", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a delete carries no Key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem({
+        input: { RequestItems: { OrdersTable: [{ DeleteRequest: {} }] } },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A Key is required");
+  });
+
+  it("refuses a ConditionExpression on a PutRequest", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a put in a batch asks to be conditional.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem({
+        input: {
+          RequestItems: {
+            OrdersTable: [
+              {
+                PutRequest: {
+                  Item: { orderId: { S: "order-1" } },
+                  ConditionExpression: "attribute_not_exists(orderId)",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is refused by name: a batch write is unconditional.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A PutRequest takes no ConditionExpression",
+    );
+  });
+
+  it("refuses a ConditionExpression on a DeleteRequest", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a delete in a batch asks to be conditional.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem({
+        input: {
+          RequestItems: {
+            OrdersTable: [
+              {
+                DeleteRequest: {
+                  Key: { orderId: { S: "order-1" } },
+                  ConditionExpression: "attribute_exists(orderId)",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is refused by name.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A DeleteRequest takes no ConditionExpression",
+    );
+  });
+
+  it("refuses reporting a capacity cost nothing measures", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch asks for its consumed capacity.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+          },
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      ),
+    );
+
+    // Then it is refused as unsimulated rather than reported as zero.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnConsumedCapacity");
+  });
+
+  it("refuses reporting item collection sizes nothing tracks", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch asks for item collection metrics.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.batchWriteItem(
+        new BatchWriteItemCommand({
+          RequestItems: {
+            OrdersTable: [
+              { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+            ],
+          },
+          ReturnItemCollectionMetrics: "SIZE",
+        }),
+      ),
+    );
+
+    // Then it is refused as unsimulated.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnItemCollectionMetrics");
+  });
+
+  it("takes the reporting inputs that ask for nothing", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.createTable(ordersTable);
+    await simAws.backgroundTasksComplete();
+
+    // When a batch names NONE for both, which is what it already does.
+    const output = await simDynamoDb.batchWriteItem(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: { S: "order-1" } } } },
+          ],
+        },
+        ReturnConsumedCapacity: "NONE",
+        ReturnItemCollectionMetrics: "NONE",
+      }),
+    );
+
+    // Then the write goes through.
+    assertObjectEquals(output.UnprocessedItems, {});
+  });
+});

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write.ts
@@ -1,0 +1,143 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
+import type {
+  SimDynamoDbDeleteRequest,
+  SimDynamoDbPutRequest,
+  SimDynamoDbWriteRequest,
+} from "./batch.command.js";
+
+/**
+ * One put or delete a batch write asks for.
+ *
+ * Every write knows two things: which item of a table it works on, and what it
+ * does to that table. Keeping both here is what lets a batch check its keys
+ * before it applies anything, since the check and the write read the same item.
+ */
+export interface SimDynamoDbBatchWrite {
+  /**
+   * The primary key this write works on, as the table marshals it.
+   */
+  keyIn(table: SimDynamoDbTable): string;
+
+  /**
+   * Apply this write to the table.
+   */
+  applyTo(table: SimDynamoDbTable): void;
+}
+
+/**
+ * A put in a batch write, which replaces the whole item as PutItem does.
+ */
+class SimDynamoDbBatchPut implements SimDynamoDbBatchWrite {
+  private readonly item: SimDynamoDbItem;
+
+  constructor(item: SimDynamoDbItem) {
+    this.item = item;
+  }
+
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfItem(this.item);
+  }
+
+  applyTo(table: SimDynamoDbTable): void {
+    table.putItem(this.item);
+  }
+}
+
+/**
+ * A delete in a batch write, which names a key rather than an item, so a key
+ * that is already free is deleted successfully.
+ */
+class SimDynamoDbBatchDelete implements SimDynamoDbBatchWrite {
+  private readonly key: SimDynamoDbItem;
+
+  constructor(key: SimDynamoDbItem) {
+    this.key = key;
+  }
+
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfKey(this.key);
+  }
+
+  applyTo(table: SimDynamoDbTable): void {
+    table.deleteItem(this.key);
+  }
+}
+
+/**
+ * Read one entry of a batch write.
+ *
+ * A WriteRequest carries exactly one of a PutRequest and a DeleteRequest. Both
+ * or neither is refused rather than guessed at, since either guess would write
+ * something the request did not ask for.
+ */
+export function readSimDynamoDbBatchWrite(
+  request: SimDynamoDbWriteRequest,
+): SimDynamoDbBatchWrite {
+  const { PutRequest: put, DeleteRequest: remove } = request;
+
+  if (put !== undefined && remove !== undefined) {
+    throw new SimDynamoDbValidationException(
+      "A WriteRequest carries exactly one of PutRequest and DeleteRequest, " +
+        "and this one carries both",
+    );
+  }
+
+  if (put !== undefined) {
+    return new SimDynamoDbBatchPut(readPutItem(put));
+  }
+
+  if (remove !== undefined) {
+    return new SimDynamoDbBatchDelete(readDeleteKey(remove));
+  }
+
+  throw new SimDynamoDbValidationException(
+    "A WriteRequest carries exactly one of PutRequest and DeleteRequest, and " +
+      "this one carries neither",
+  );
+}
+
+/**
+ * Read the item a batch put writes.
+ */
+function readPutItem(request: SimDynamoDbPutRequest): SimDynamoDbItem {
+  assertUnconditional(request.ConditionExpression, "PutRequest");
+
+  if (request.Item === undefined) {
+    throw new SimDynamoDbValidationException("A PutRequest requires an Item");
+  }
+
+  return SimDynamoDbItem.fromAttributeValues(request.Item);
+}
+
+/**
+ * Read the key a batch delete removes.
+ */
+function readDeleteKey(request: SimDynamoDbDeleteRequest): SimDynamoDbItem {
+  assertUnconditional(request.ConditionExpression, "DeleteRequest");
+
+  return readSimDynamoDbKey(request.Key);
+}
+
+/**
+ * Refuse a condition on one entry of a batch.
+ *
+ * Real DynamoDB has no ConditionExpression on a batch write request at all: a
+ * batch trades the conditions of PutItem and DeleteItem for writing 25 items at
+ * once. A condition that was never evaluated would let a write through that
+ * DynamoDB would have turned away, so it is refused rather than dropped.
+ */
+function assertUnconditional(
+  expression: string | undefined,
+  parameter: string,
+): void {
+  if (expression !== undefined) {
+    throw new SimDynamoDbValidationException(
+      `A ${parameter} takes no ConditionExpression: a batch write is ` +
+        `unconditional, so PutItem, DeleteItem or UpdateItem is where a ` +
+        `condition belongs`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-writes.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-writes.ts
@@ -1,0 +1,90 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbWriteRequest } from "./batch.command.js";
+import {
+  readSimDynamoDbBatchRequestItems,
+  type SimDynamoDbBatchTableRequest,
+} from "./sim-dynamodb-batch-request-items.js";
+import {
+  readSimDynamoDbBatchWrite,
+  type SimDynamoDbBatchWrite,
+} from "./sim-dynamodb-batch-write.js";
+
+const operation = "BatchWriteItem";
+
+/**
+ * Real DynamoDB takes 25 put or delete requests in one batch, counted across
+ * every table the request names rather than per table.
+ */
+const greatestWriteRequests = 25;
+
+/**
+ * The writes a batch asks one table for.
+ */
+export interface SimDynamoDbBatchTableWrites {
+  readonly reference: string;
+  readonly writes: readonly SimDynamoDbBatchWrite[];
+}
+
+/**
+ * Read every write a batch asks for, before any of them is applied.
+ *
+ * Nothing here reaches a table. A batch write is refused whole rather than
+ * partly applied, so everything that can be checked without a table is checked
+ * first, and the keys are checked against their tables after that.
+ */
+export function readSimDynamoDbBatchWrites(
+  requestItems:
+    Readonly<Record<string, readonly SimDynamoDbWriteRequest[]>> | undefined,
+): readonly SimDynamoDbBatchTableWrites[] {
+  const tables = readSimDynamoDbBatchRequestItems(requestItems, operation);
+
+  assertWithinRequestLimit(tables);
+
+  return tables.map(({ reference, requested }) => ({
+    reference,
+    writes: readTableWrites(reference, requested),
+  }));
+}
+
+/**
+ * Refuse a batch carrying more requests than DynamoDB writes at once.
+ *
+ * The count is checked before the requests are read, so a batch that is too
+ * long is told so rather than being told about the first item in it that has
+ * something else wrong.
+ */
+function assertWithinRequestLimit(
+  tables: readonly SimDynamoDbBatchTableRequest<
+    readonly SimDynamoDbWriteRequest[]
+  >[],
+): void {
+  const total = tables.reduce(
+    (count, { requested }) => count + requested.length,
+    0,
+  );
+
+  if (total > greatestWriteRequests) {
+    throw new SimDynamoDbValidationException(
+      `Too many items requested for the ${operation} call: ${total.toString()} ` +
+        `requests, where ${greatestWriteRequests.toString()} is the most a ` +
+        `batch takes`,
+    );
+  }
+}
+
+/**
+ * Read the writes one table of the batch asks for.
+ */
+function readTableWrites(
+  reference: string,
+  requests: readonly SimDynamoDbWriteRequest[],
+): readonly SimDynamoDbBatchWrite[] {
+  if (requests.length === 0) {
+    throw new SimDynamoDbValidationException(
+      `${operation} names the table ${reference} with no write requests, and ` +
+        `a batch names at least one for every table it works on`,
+    );
+  }
+
+  return requests.map((request) => readSimDynamoDbBatchWrite(request));
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-unsimulated-batch-input.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-unsimulated-batch-input.ts
@@ -1,0 +1,62 @@
+import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-input.js";
+import type {
+  SimBatchGetItemCommandInput,
+  SimBatchWriteItemCommandInput,
+  SimDynamoDbKeysAndAttributes,
+} from "./batch.command.js";
+
+/**
+ * Refuse the BatchWriteItem inputs this simulation does not model.
+ */
+export function refuseUnsimulatedBatchWriteInput(
+  input: SimBatchWriteItemCommandInput,
+): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("BatchWriteItem");
+
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+  unsimulated.refuseReporting(
+    input.ReturnItemCollectionMetrics,
+    "ReturnItemCollectionMetrics",
+    "reporting item collection sizes nothing here tracks",
+  );
+}
+
+/**
+ * Refuse the BatchGetItem inputs this simulation does not model.
+ */
+export function refuseUnsimulatedBatchReadInput(
+  input: SimBatchGetItemCommandInput,
+): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("BatchGetItem");
+
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+}
+
+/**
+ * Refuse what one table of a batch read asks for and this simulation does not
+ * model.
+ *
+ * `AttributesToGet` is the way of asking for part of an item that
+ * `ProjectionExpression` replaced, and GetItem refuses it for the same reason:
+ * an item that came back whole where part of it was asked for would hide an
+ * application reading an attribute it never requested.
+ */
+export function refuseUnsimulatedBatchKeysAndAttributes(
+  requested: SimDynamoDbKeysAndAttributes,
+): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("BatchGetItem");
+
+  unsimulated.refuse(
+    (requested.AttributesToGet ?? []).length > 0,
+    "AttributesToGet",
+    "answering with the whole item where part of it was asked for",
+  );
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from "vitest";
 import {
+  BatchGetItemCommand,
+  BatchWriteItemCommand,
   CreateTableCommand,
   DeleteItemCommand,
   DeleteTableCommand,
@@ -12,9 +14,11 @@ import {
   UpdateItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
+  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertUndefined,
@@ -127,6 +131,55 @@ describe("simulated DynamoDB SDK Command routing", () => {
       }),
     );
     assertUndefined(missOut.Item);
+  });
+
+  it("round-trips batch Item Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: "BatchTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const writeOut = await client.send(
+      new BatchWriteItemCommand({
+        RequestItems: {
+          BatchTable: [
+            {
+              PutRequest: {
+                Item: { id: { S: "item-1" }, name: { S: "First item" } },
+              },
+            },
+            { PutRequest: { Item: { id: { S: "item-2" } } } },
+          ],
+        },
+      }),
+    );
+    assertObjectEquals(writeOut.UnprocessedItems, {});
+
+    const readOut = await client.send(
+      new BatchGetItemCommand({
+        RequestItems: {
+          BatchTable: {
+            Keys: [{ id: { S: "item-1" } }, { id: { S: "missing" } }],
+            ProjectionExpression: "#n",
+            ExpressionAttributeNames: { "#n": "name" },
+          },
+        },
+      }),
+    );
+    const items = readOut.Responses?.["BatchTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 1);
+    assertObjectEquals(items[0], { name: { S: "First item" } });
+    assertObjectEquals(readOut.UnprocessedKeys, {});
   });
 
   it("does not give a denied run-as caller root privileges", async () => {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -15,6 +15,10 @@ import type {
   SimPutItemCommand,
   SimUpdateItemCommand,
 } from "../command/item/item.command.js";
+import type {
+  SimBatchGetItemCommand,
+  SimBatchWriteItemCommand,
+} from "../command/batch/batch.command.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
 /**
@@ -86,6 +90,22 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simDynamoDatabase.deleteItem(
             command as SimDeleteItemCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "BatchWriteItemCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.batchWriteItem(
+            command as SimBatchWriteItemCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "BatchGetItemCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.batchGetItem(
+            command as SimBatchGetItemCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -4,6 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { SimDynamoDbAuthorizer } from "./command/authorize/sim-dynamodb-authorizer.js";
+import { SimDynamoDbBatchGetItem } from "./command/batch/sim-dynamodb-batch-get-item.js";
+import { SimDynamoDbBatchWriteItem } from "./command/batch/sim-dynamodb-batch-write-item.js";
 import { SimDynamoDbDeleteItem } from "./command/item/sim-dynamodb-delete-item.js";
 import { SimDynamoDbGetItem } from "./command/item/sim-dynamodb-get-item.js";
 import { SimDynamoDbPutItem } from "./command/item/sim-dynamodb-put-item.js";
@@ -32,6 +34,12 @@ import type {
   SimUpdateItemCommand,
   SimUpdateItemCommandOutput,
 } from "./command/item/item.command.js";
+import type {
+  SimBatchGetItemCommand,
+  SimBatchGetItemCommandOutput,
+  SimBatchWriteItemCommand,
+  SimBatchWriteItemCommandOutput,
+} from "./command/batch/batch.command.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
@@ -67,6 +75,8 @@ export class SimDynamoDb {
   private readonly itemReads: SimDynamoDbGetItem;
   private readonly itemDeletions: SimDynamoDbDeleteItem;
   private readonly itemUpdates: SimDynamoDbUpdateItem;
+  private readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
+  private readonly itemBatchReads: SimDynamoDbBatchGetItem;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
   private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
     dynamoDb: this,
@@ -102,6 +112,10 @@ export class SimDynamoDb {
     this.itemReads = new SimDynamoDbGetItem({ access: this.access });
     this.itemDeletions = new SimDynamoDbDeleteItem({ access: this.access });
     this.itemUpdates = new SimDynamoDbUpdateItem({ access: this.access });
+    this.itemBatchWrites = new SimDynamoDbBatchWriteItem({
+      access: this.access,
+    });
+    this.itemBatchReads = new SimDynamoDbBatchGetItem({ access: this.access });
   }
 
   /**
@@ -191,6 +205,28 @@ export class SimDynamoDb {
   ): Promise<SimUpdateItemCommandOutput> {
     await this.background.sequence();
     return this.itemUpdates.handle(command, options);
+  }
+
+  /**
+   * Handle a Batch Write Item Command from the SDK.
+   */
+  async batchWriteItem(
+    command: SimBatchWriteItemCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimBatchWriteItemCommandOutput> {
+    await this.background.sequence();
+    return this.itemBatchWrites.handle(command, options);
+  }
+
+  /**
+   * Handle a Batch Get Item Command from the SDK.
+   */
+  async batchGetItem(
+    command: SimBatchGetItemCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimBatchGetItemCommandOutput> {
+    await this.background.sequence();
+    return this.itemBatchReads.handle(command, options);
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -144,6 +144,25 @@ export class SimDynamoDbTable {
   }
 
   /**
+   * The primary key an item is stored under, as this table marshals it.
+   *
+   * A batch write tells two operations on the same item apart by comparing
+   * these, which is why the key is readable rather than only usable. Reading it
+   * checks the item against the key schema, so a key a write would refuse is
+   * refused here too.
+   */
+  public keyOfItem(item: SimDynamoDbItem): string {
+    return this.itemKey.of(item);
+  }
+
+  /**
+   * The primary key a request's Key names, as this table marshals it.
+   */
+  public keyOfKey(key: SimDynamoDbItem): string {
+    return this.itemKey.ofKey(key);
+  }
+
+  /**
    * Read the item a primary key names, if the table holds one.
    *
    * Every write has landed by the time it returns, so this reads the latest


### PR DESCRIPTION
BatchWriteItem puts and deletes items across tables in one call, and BatchGetItem reads them by primary key. Both take a table name or ARN in RequestItems and answer with an empty UnprocessedItems or UnprocessedKeys.

A batch write is refused whole rather than partly applied: an unknown table, a key that does not match the key schema, two operations on one item, more than 25 requests or an item over 400 KB each leave nothing written. A batch read settles ConsistentRead and ProjectionExpression per table, and leaves out a key that holds nothing.

The 16 MB request limit is not enforced, and is documented under Limitations with the reason.

Resolves https://github.com/KensioSoftware/yulin/issues/260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DynamoDB batch read and write support across multiple tables.
  * Batch reads support projections, consistency settings, missing items, and table ARN references.
  * Batch writes support putting and deleting items with atomic validation.
  * Added SDK command routing and practical batch operation examples.

* **Documentation**
  * Documented supported batch operations, limits, validation behavior, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->