### PR TITLE
feat: read and write simulated DynamoDB items in transactions

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1006,6 +1006,246 @@ while (Object.keys(unprocessed).length > 0) {
 }
 ```
 
+## Reading and writing items in transactions
+
+`TransactWriteItems` applies up to 100 actions in one step. Either all of them happen or none of
+them do, so two items that have to agree with each other can be written together.
+
+Each action carries exactly one of `Put`, `Update`, `Delete` and `ConditionCheck`, and names its own
+table. A `ConditionCheck` writes nothing: it is how a transaction says that an item it is not
+changing has to hold for the items it is changing to be written.
+
+What a test usually wants to show is the failure. A transaction that succeeds looks the same as two
+separate writes, so what is worth asserting is that a failed condition on the second action left the
+first one unwritten.
+
+```typescript sim-dynamodb-transact-write-items
+/**
+ * Writing a ledger entry and the balance it moves, or writing neither.
+ */
+
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "AccountsTable",
+    KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "accountId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "LedgerTable",
+    KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+// The account is closed, so the balance may not move.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "AccountsTable",
+    Item: {
+      accountId: { S: "account-1" },
+      balance: { N: "100" },
+      status: { S: "closed" },
+    },
+  }),
+);
+
+const ledgerEntry = {
+  Put: {
+    TableName: "LedgerTable",
+    Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+  },
+};
+
+const balanceUpdate = {
+  Update: {
+    TableName: "AccountsTable",
+    Key: { accountId: { S: "account-1" } },
+    UpdateExpression: "SET balance = balance - :amount",
+    ConditionExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":amount": { N: "25" },
+      ":open": { S: "open" },
+    },
+  },
+};
+
+try {
+  await dynamoDb.transactWriteItems(
+    new TransactWriteItemsCommand({
+      TransactItems: [ledgerEntry, balanceUpdate],
+    }),
+  );
+} catch (error) {
+  const cancelled = error as {
+    name: string;
+    CancellationReasons?: { Code: string; Message?: string }[];
+  };
+
+  console.log(cancelled.name); // "TransactionCanceledException"
+  console.log(cancelled.CancellationReasons);
+  // [
+  //   { Code: "None" },
+  //   {
+  //     Code: "ConditionalCheckFailed",
+  //     Message: "The conditional request failed.",
+  //   },
+  // ]
+}
+
+// The first action is reported even though nothing was wrong with it, and the
+// ledger entry it would have written is not there.
+const entry = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "LedgerTable",
+    Key: { entryId: { S: "entry-1" } },
+  }),
+);
+
+console.log(entry.Item); // undefined
+```
+
+`CancellationReasons` lines up with `TransactItems`. There is one entry per action, in the same
+order, including the actions that would have gone through, which carry the code `None`. The codes
+have no `Exception` suffix, so a failed condition reads as `ConditionalCheckFailed` rather than as
+the `ConditionalCheckFailedException` a single `PutItem` throws.
+
+An action that sets `ReturnValuesOnConditionCheckFailure` to `ALL_OLD` gets `Item` on its
+cancellation reason, holding the item as it was, so a retry needs no second read.
+
+Five things refuse the request outright rather than cancelling it, with nothing written either way:
+
+- more than 100 actions
+- an action carrying more than one of `Put`, `Update`, `Delete` and `ConditionCheck`, or none of them
+- two actions on the same item of one table
+- a table that is not there, or a key that does not match its key schema
+- an update that would move the item's primary key
+
+One table may be named as often as the transaction likes, which is the difference from a batch. What
+it may not do is touch one item twice.
+
+### Retrying a transaction
+
+`ClientRequestToken` makes a retry idempotent. Replaying a token with the same actions inside ten
+minutes succeeds without applying the writes again, and replaying it with different actions gives
+`IdempotentParameterMismatchException`. Only a transaction that was applied is remembered, so
+retrying one that was cancelled runs it again.
+
+The ten minutes are measured on the simulated clock, so a test moves past the window rather than
+waiting for it:
+
+```typescript
+const withdrawal = {
+  TransactItems: [
+    {
+      Update: {
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+        UpdateExpression: "SET balance = balance - :amount",
+        ExpressionAttributeValues: { ":amount": { N: "25" } },
+      },
+    },
+  ],
+  ClientRequestToken: "6b6b1a1e-0e2d-4d3f-9f5a-1c0f2b3d4e5f",
+};
+
+// The balance moves once, however many times the call is retried.
+await dynamoDb.transactWriteItems(new TransactWriteItemsCommand(withdrawal));
+await dynamoDb.transactWriteItems(new TransactWriteItemsCommand(withdrawal));
+
+// Past the window, the same token is a new transaction, and it moves again.
+await simAws.clock().advanceBy({ minutes: 10 });
+await dynamoDb.transactWriteItems(new TransactWriteItemsCommand(withdrawal));
+```
+
+### Reading in a transaction
+
+`TransactGetItems` reads up to 100 items in one step, and is always strongly consistent, so there is
+no `ConsistentRead` to set. Each `Get` names its own table, and takes a `ProjectionExpression`.
+
+```typescript sim-dynamodb-transact-get-items
+/**
+ * Reading two items in one step, one of which is not there.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  TransactGetItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "AccountsTable",
+    KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "accountId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "AccountsTable",
+    Item: {
+      accountId: { S: "account-1" },
+      balance: { N: "100" },
+      status: { S: "open" },
+    },
+  }),
+);
+
+const output = await dynamoDb.transactGetItems(
+  new TransactGetItemsCommand({
+    TransactItems: [
+      {
+        Get: {
+          TableName: "AccountsTable",
+          Key: { accountId: { S: "account-1" } },
+          ProjectionExpression: "balance",
+        },
+      },
+      {
+        Get: {
+          TableName: "AccountsTable",
+          Key: { accountId: { S: "account-404" } },
+        },
+      },
+    ],
+  }),
+);
+
+// Responses is positional and is never compacted, so a missing item is an
+// entry with no Item rather than nothing at all.
+console.log(output.Responses[0]); // { Item: { balance: { N: "100" } } }
+console.log(output.Responses[1]); // {}
+```
+
+That is the difference from `BatchGetItem`, which leaves a missing item out of its answer
+altogether. Here the answers stay lined up with the Gets that asked for them.
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -1224,6 +1464,12 @@ unauthorized caller cannot find out which names are taken.
 in the same way, each against the `dynamodb:` action of its own name. `ListTables` names no table, so it
 authorizes against `*`.
 
+A transaction is authorized as the operations it is made of rather than as itself. Each action of a
+`TransactWriteItems` needs `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` or
+`dynamodb:ConditionCheckItem` against the table it names, and each `Get` of a `TransactGetItems`
+needs `dynamodb:GetItem`. A caller refused any one of them is refused the whole transaction, so
+nothing is written.
+
 ## Available functionality
 
 - `CreateTable`, with table name, key schema, attribute definition, billing mode and throughput
@@ -1250,6 +1496,11 @@ authorizes against `*`.
   the whole batch refusals, and an empty `UnprocessedItems`.
 - `BatchGetItem`, reading items across tables in one call, with `ConsistentRead` and
   `ProjectionExpression` per table, the 100 key cap, and an empty `UnprocessedKeys`.
+- `TransactWriteItems`, applying up to 100 `Put`, `Update`, `Delete` and `ConditionCheck` actions in
+  one step, with `TransactionCanceledException` carrying a cancellation reason per action, and
+  `ClientRequestToken` making a retry idempotent for ten simulated minutes.
+- `TransactGetItems`, reading up to 100 items in one step, with a positional `Responses` array in
+  which a missing item is an entry with no `Item`.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name and `Fn::GetAtt … Arn` the table ARN.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
@@ -1296,17 +1547,27 @@ authorizes against `*`.
   arrived as, which is larger than the items it carries, and that inflation is not modelled: a batch
   of 25 items under 400 KB each is under 10 MB by the sizes counted here, so nothing this simulation
   measures ever reaches 16 MB.
-- The transactional item commands, `TransactWriteItems` and `TransactGetItems`, are not implemented
-  yet, so a batch write is the only way to change several items in one call. A batch is not a
-  transaction: it is refused whole for the failures listed above, and applied whole otherwise, but
-  nothing rolls it back afterwards.
+- `TransactionConflictException` and `TransactionInProgressException` are not modelled. Every call
+  here is serialised in one process, so no transaction ever meets another one working on the same
+  item, and neither error is reachable.
+- Only `None` and `ConditionalCheckFailed` appear as cancellation codes. Nothing here is throttled
+  and no item collection is tracked, so `ProvisionedThroughputExceeded` and
+  `ItemCollectionSizeLimitExceeded` never happen, and input DynamoDB would report as a
+  `ValidationError` per action is refused up front as a `ValidationException` for the whole request.
+- The 4 MB limit on a transactional write is counted from the items and keys the actions carry,
+  rather than from the JSON the request arrived as, which is larger. A transaction near the limit
+  here is near the limit there, but the byte counts are not identical.
+- A `ClientRequestToken` is compared against the `TransactItems` as the JSON they arrived as, so a
+  retry that names the same actions in a different order reads as a different request and is refused
+  rather than replayed. A retry of the same call sends the same JSON, so this shows up only in a
+  test that rebuilds the request by hand.
 - A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
   Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
   stack deployed calls `simAws.backgroundTasksComplete()` first.
 - CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
   `DeletionPolicy` a template sets on a table.
-- `ProjectionExpression` is simulated on `GetItem` and `BatchGetItem`. `Query` and `Scan` are not
-  implemented yet, so they have nothing to project from.
+- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. `Query`
+  and `Scan` are not implemented yet, so they have nothing to project from.
 - The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
   where part of it was asked for would hide an application reading an attribute it never requested.
   `ProjectionExpression` replaced it, and real DynamoDB has built nothing on it since.
@@ -1316,9 +1577,9 @@ authorizes against `*`.
 - Reads are always strongly consistent. `ConsistentRead` is accepted either way and changes nothing,
   whether a request sets it once for a read or per table for a batch read, so a test cannot observe a
   stale read here the way it might against a real table.
-- Condition expressions are simulated on `PutItem`, `DeleteItem` and `UpdateItem` only. The
-  transactional condition checks and the key condition and filter expressions of `Query` and `Scan`
-  are not implemented yet, so there is nothing else to guard.
+- Condition expressions are simulated on `PutItem`, `DeleteItem`, `UpdateItem` and the actions of
+  `TransactWriteItems`. The key condition and filter expressions of `Query` and `Scan` are not
+  implemented yet, so there is nothing else to guard.
 - Two update actions cannot write to overlapping paths, so `ADD tags :added DELETE tags :gone` in one
   expression is refused as it is on AWS. Taking members out of a set an expression also adds to is a
   second update.

--- a/docs/services/dynamodb/sim-dynamodb-transact-get-items.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-transact-get-items.example.ts
@@ -1,0 +1,60 @@
+/**
+ * Reading two items in one step, one of which is not there.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  TransactGetItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "AccountsTable",
+    KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "accountId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "AccountsTable",
+    Item: {
+      accountId: { S: "account-1" },
+      balance: { N: "100" },
+      status: { S: "open" },
+    },
+  }),
+);
+
+const output = await dynamoDb.transactGetItems(
+  new TransactGetItemsCommand({
+    TransactItems: [
+      {
+        Get: {
+          TableName: "AccountsTable",
+          Key: { accountId: { S: "account-1" } },
+          ProjectionExpression: "balance",
+        },
+      },
+      {
+        Get: {
+          TableName: "AccountsTable",
+          Key: { accountId: { S: "account-404" } },
+        },
+      },
+    ],
+  }),
+);
+
+// Responses is positional and is never compacted, so a missing item is an
+// entry with no Item rather than nothing at all.
+console.log(output.Responses[0]); // { Item: { balance: { N: "100" } } }
+console.log(output.Responses[1]); // {}

--- a/docs/services/dynamodb/sim-dynamodb-transact-write-items.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-transact-write-items.example.ts
@@ -1,0 +1,100 @@
+/**
+ * Writing a ledger entry and the balance it moves, or writing neither.
+ */
+
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "AccountsTable",
+    KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "accountId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "LedgerTable",
+    KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+// The account is closed, so the balance may not move.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "AccountsTable",
+    Item: {
+      accountId: { S: "account-1" },
+      balance: { N: "100" },
+      status: { S: "closed" },
+    },
+  }),
+);
+
+const ledgerEntry = {
+  Put: {
+    TableName: "LedgerTable",
+    Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+  },
+};
+
+const balanceUpdate = {
+  Update: {
+    TableName: "AccountsTable",
+    Key: { accountId: { S: "account-1" } },
+    UpdateExpression: "SET balance = balance - :amount",
+    ConditionExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":amount": { N: "25" },
+      ":open": { S: "open" },
+    },
+  },
+};
+
+try {
+  await dynamoDb.transactWriteItems(
+    new TransactWriteItemsCommand({
+      TransactItems: [ledgerEntry, balanceUpdate],
+    }),
+  );
+} catch (error) {
+  const cancelled = error as {
+    name: string;
+    CancellationReasons?: { Code: string; Message?: string }[];
+  };
+
+  console.log(cancelled.name); // "TransactionCanceledException"
+  console.log(cancelled.CancellationReasons);
+  // [
+  //   { Code: "None" },
+  //   {
+  //     Code: "ConditionalCheckFailed",
+  //     Message: "The conditional request failed.",
+  //   },
+  // ]
+}
+
+// The first action is reported even though nothing was wrong with it, and the
+// ledger entry it would have written is not there.
+const entry = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "LedgerTable",
+    Key: { entryId: { S: "entry-1" } },
+  }),
+);
+
+console.log(entry.Item); // undefined

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -413,8 +413,10 @@ The parts a transaction is made of split by what they know:
 
 - `SimDynamoDbTransactWrite` is one action, as the item or key it carries, the condition guarding
   it, the IAM action it needs and what it does to a table. The four implementations are in
-  `sim-dynamodb-transact-actions.ts`, and each reads itself from the request, so what a Put requires
-  lives with the Put.
+  `sim-dynamodb-transact-put-action.ts`, `sim-dynamodb-transact-update-action.ts` and
+  `sim-dynamodb-transact-key-actions.ts`, which holds the delete and the condition check together
+  since both are a key and a condition against what is stored under it. Each file reads its own
+  action from the request, so what a Put requires lives with the Put.
 - `sim-dynamodb-transact-write.ts` reads one entry into one of those, refusing an entry carrying two
   of the four or none of them.
 - `sim-dynamodb-transact-writes.ts` reads a whole `TransactItems`, applying the 100 action cap and

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -50,6 +50,7 @@ Current command areas include:
 - `table/` (CreateTable, DescribeTable, ListTables and DeleteTable)
 - `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
 - `batch/` (BatchWriteItem and BatchGetItem)
+- `transact/` (TransactWriteItems and TransactGetItems)
 
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
@@ -390,6 +391,61 @@ than written unconditionally.
 Scans, queries, indexes and streams are not implemented. Billing mode and provisioned capacity are
 read and stored by CreateTable, but nothing enforces them: no write is ever throttled.
 
+## TransactWriteItems and TransactGetItems behavior
+
+`SimDynamoDbTransactWriteItems` and `SimDynamoDbTransactGetItems` work on several items across
+several tables in one step, where either all of it happens or none of it does.
+
+Atomicity here follows from the order the work is done in rather than from unwinding a partial
+write:
+
+1. Everything that can be read without a table is read: the action count, which of the four actions
+   each entry carries, the items, the keys, the expressions and the request size.
+2. Every table is reached and the caller authorized against it. A transaction is authorized as the
+   operations it is made of, so each action carries its own `dynamodb:` action, and a ConditionCheck
+   needs `dynamodb:ConditionCheckItem`.
+3. Every key is marshalled through its table's key schema, which is both the key check and what
+   tells two actions on one item apart. Unlike a batch, one table may be named as often as the
+   request likes.
+4. Every action is checked against what is stored, and only then does the first of them write.
+
+The parts a transaction is made of split by what they know:
+
+- `SimDynamoDbTransactWrite` is one action, as the item or key it carries, the condition guarding
+  it, the IAM action it needs and what it does to a table. The four implementations are in
+  `sim-dynamodb-transact-actions.ts`, and each reads itself from the request, so what a Put requires
+  lives with the Put.
+- `sim-dynamodb-transact-write.ts` reads one entry into one of those, refusing an entry carrying two
+  of the four or none of them.
+- `sim-dynamodb-transact-writes.ts` reads a whole `TransactItems`, applying the 100 action cap and
+  the 4 MB request size.
+- `sim-dynamodb-transact-gets.ts` does the same for a transactional read, reading each `Get`'s
+  `ProjectionExpression` through the same `readSimDynamoDbProjection` GetItem uses.
+- `reachSimDynamoDbTransactTables` is how both reach their tables, and where the one-action-per-item
+  rule is applied.
+- `sim-dynamodb-transact-cancellation.ts` is the check and the writing, in that order. It asks every
+  action whether it applies, turning a `SimDynamoDbConditionalCheckFailedException` into that
+  action's cancellation reason and leaving anything else to throw, since a request DynamoDB would
+  refuse is refused rather than cancelled. Only once every action has answered does the first of
+  them write.
+
+Every action is checked rather than stopping at the first failure, because a caller reads which of
+its actions failed out of `CancellationReasons`. The reasons line up with the request positionally,
+including the actions nothing was wrong with, which carry `None`.
+
+`SimDynamoDbTransactionTokens` is the idempotency of `ClientRequestToken`. It holds the payload a
+token was used with and when, so a replay inside ten minutes is answered without applying anything,
+and a replay with a different payload is refused. The window is measured on the simulated clock,
+which is why `SimDynamoDbTransactWriteItems` takes one. Only a transaction that was applied is
+recorded, since one that was cancelled never happened.
+
+The replay is checked after the request has been read and the caller authorized, rather than before.
+Real IAM evaluates a request before the service handles it, so a caller with no permission is
+refused whichever token it carries.
+
+A transactional read answers positionally too. `Responses` is never compacted: a key holding nothing
+gives an entry with no `Item`, where BatchGetItem leaves the item out altogether.
+
 ## Expressions
 
 `expression/` holds the parts every DynamoDB expression parameter is made of. Projections,
@@ -538,6 +594,16 @@ Current specialized errors:
   - used when a ConditionExpression did not hold, with the message real DynamoDB uses so SDK error
     handling matches. It carries the stored item when the request asked for it with
     `ReturnValuesOnConditionCheckFailure`.
+- `SimDynamoDbTransactionCanceledException`
+  - name: `TransactionCanceledException`
+  - HTTP status: `400`
+  - used when any action of a transactional write could not be applied. It carries
+    `CancellationReasons`, one per action and in request order, and lists the codes in its message
+    the way real DynamoDB does.
+- `SimDynamoDbIdempotentParameterMismatchException`
+  - name: `IdempotentParameterMismatchException`
+  - HTTP status: `400`
+  - used when a `ClientRequestToken` is replayed inside its window with a different request
 - `SimDynamoDbUnsupportedOperation`
   - name: `UnsupportedOperation`
   - HTTP status: `400`
@@ -563,6 +629,8 @@ Current uses:
   DELETING to gone.
 - `SimDynamoDbTable.putItem()` writes the item at once. A write a caller has been told about is a
   write that is there, so nothing about it waits on the scheduler.
+- `SimDynamoDbTransactionTokens` reads the scheduler's clock, which is what makes the ten minute
+  `ClientRequestToken` window something `simAws.clock().advanceBy(...)` can move past.
 
 Tests that need eventual state should call the broader sim AWS background-drain helper, for example:
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.iso.test.ts
@@ -1,0 +1,311 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbTransactionCanceledException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A ledger and the account balances its entries move, as two tables.
+ */
+async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "AccountsTable",
+      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "accountId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "LedgerTable",
+      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+/**
+ * A closed account, which the conditions these tests write are about.
+ */
+async function closedAccount(simDynamoDb: SimDynamoDb): Promise<void> {
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "AccountsTable",
+      Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+    }),
+  );
+}
+
+/**
+ * A ledger entry, and an update that only moves an open account's balance.
+ */
+const ledgerEntry = {
+  Put: {
+    TableName: "LedgerTable",
+    Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+  },
+};
+
+const balanceUpdate = {
+  Update: {
+    TableName: "AccountsTable",
+    Key: { accountId: { S: "account-1" } },
+    UpdateExpression: "SET balance = :moved",
+    ConditionExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":moved": { N: "25" },
+      ":open": { S: "open" },
+    },
+  },
+};
+
+describe("DynamoDB transactional write cancellation", () => {
+  it("reports every action, including the one nothing was wrong with", async () => {
+    // Given a closed account.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await closedAccount(simDynamoDb);
+
+    // When a transaction writes an entry and moves the balance of it.
+    const cancelled = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [ledgerEntry, balanceUpdate],
+        }),
+      ),
+    );
+
+    // Then the reasons line up with the actions, and the first one is reported
+    // even though nothing was wrong with it.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    const reasons = cancelled.CancellationReasons;
+    assertArrayLength(reasons, 2);
+    assertObjectEquals(reasons[0], { Code: "None" });
+    assertObjectEquals(reasons[1], {
+      Code: "ConditionalCheckFailed",
+      Message: "The conditional request failed.",
+    });
+    assertIdentical(
+      cancelled.message,
+      "Transaction cancelled, please refer cancellation reasons for " +
+        "specific reasons [None, ConditionalCheckFailed]",
+    );
+  });
+
+  it("leaves the action that would have gone through unwritten", async () => {
+    // Given a closed account.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await closedAccount(simDynamoDb);
+
+    // When the transaction is cancelled.
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [ledgerEntry, balanceUpdate],
+        }),
+      ),
+    );
+
+    // Then neither item was written.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(entry.Item);
+
+    const account = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+      }),
+    );
+    assertUndefined(account.Item?.["balance"]);
+  });
+
+  it("puts the item on the reason for ALL_OLD", async () => {
+    // Given a closed account.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await closedAccount(simDynamoDb);
+
+    // When the action that fails asked for the item it lost to.
+    const cancelled = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: "AccountsTable",
+                Key: { accountId: { S: "account-1" } },
+                ConditionExpression: "#status = :open",
+                ExpressionAttributeNames: { "#status": "status" },
+                ExpressionAttributeValues: { ":open": { S: "open" } },
+                ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the reason carries the item as it was, so a retry needs no second
+    // read.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    const reasons = cancelled.CancellationReasons;
+    assertArrayLength(reasons, 1);
+    assertObjectEquals(reasons[0], {
+      Code: "ConditionalCheckFailed",
+      Message: "The conditional request failed.",
+      Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+    });
+  });
+
+  it("leaves the item off the reason when the key holds nothing", async () => {
+    // Given a table holding no items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When an action asking for ALL_OLD fails against a key holding nothing.
+    const cancelled = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Delete: {
+                TableName: "AccountsTable",
+                Key: { accountId: { S: "account-1" } },
+                ConditionExpression: "attribute_exists(accountId)",
+                ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then there is no item to report, so the reason carries none.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    const reasons = cancelled.CancellationReasons;
+    assertArrayLength(reasons, 1);
+    assertObjectEquals(reasons[0], {
+      Code: "ConditionalCheckFailed",
+      Message: "The conditional request failed.",
+    });
+  });
+
+  it("reports every action whose condition failed", async () => {
+    // Given a closed account and a ledger entry that is already there.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await closedAccount(simDynamoDb);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" } },
+      }),
+    );
+
+    // When both actions of a transaction are guarded by a condition that does
+    // not hold.
+    const cancelled = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: { S: "entry-1" } },
+                ConditionExpression: "attribute_not_exists(entryId)",
+              },
+            },
+            balanceUpdate,
+          ],
+        }),
+      ),
+    );
+
+    // Then neither is reported as fine, since checking stops at nothing.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    const reasons = cancelled.CancellationReasons;
+    assertArrayLength(reasons, 2);
+    assertObjectEquals(reasons[0], {
+      Code: "ConditionalCheckFailed",
+      Message: "The conditional request failed.",
+    });
+    assertObjectEquals(reasons[1], {
+      Code: "ConditionalCheckFailed",
+      Message: "The conditional request failed.",
+    });
+  });
+
+  it("cancels a transaction a Put's own condition turns away", async () => {
+    // Given a ledger entry that is already there.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" }, amount: { N: "10" } },
+      }),
+    );
+
+    // When a transaction tries to insert it again.
+    const cancelled = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+                ConditionExpression: "attribute_not_exists(entryId)",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the item is left exactly as it was.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertIdentical(entry.Item?.["amount"]?.N, "10");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.iso.test.ts
@@ -1,5 +1,4 @@
 import {
-  CreateTableCommand,
   GetItemCommand,
   PutItemCommand,
   TransactWriteItemsCommand,
@@ -15,48 +14,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimDynamoDbTransactionCanceledException } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * A ledger and the account balances its entries move, as two tables.
- */
-async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "AccountsTable",
-      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
-      AttributeDefinitions: [
-        { AttributeName: "accountId", AttributeType: "S" },
-      ],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "LedgerTable",
-      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  return simDynamoDb;
-}
-
-/**
- * A closed account, which the conditions these tests write are about.
- */
-async function closedAccount(simDynamoDb: SimDynamoDb): Promise<void> {
-  await simDynamoDb.putItem(
-    new PutItemCommand({
-      TableName: "AccountsTable",
-      Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
-    }),
-  );
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 /**
  * A ledger entry, and an update that only moves an open account's balance.
@@ -86,9 +44,23 @@ describe("DynamoDB transactional write cancellation", () => {
   it("reports every action, including the one nothing was wrong with", async () => {
     // Given a closed account.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
 
-    await closedAccount(simDynamoDb);
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+      }),
+    );
 
     // When a transaction writes an entry and moves the balance of it.
     const cancelled = await assertThrowsErrorAsync(async () =>
@@ -119,9 +91,23 @@ describe("DynamoDB transactional write cancellation", () => {
   it("leaves the action that would have gone through unwritten", async () => {
     // Given a closed account.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
 
-    await closedAccount(simDynamoDb);
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+      }),
+    );
 
     // When the transaction is cancelled.
     await assertThrowsErrorAsync(async () =>
@@ -153,9 +139,19 @@ describe("DynamoDB transactional write cancellation", () => {
   it("puts the item on the reason for ALL_OLD", async () => {
     // Given a closed account.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
 
-    await closedAccount(simDynamoDb);
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+      }),
+    );
 
     // When the action that fails asked for the item it lost to.
     const cancelled = await assertThrowsErrorAsync(async () =>
@@ -192,7 +188,12 @@ describe("DynamoDB transactional write cancellation", () => {
   it("leaves the item off the reason when the key holds nothing", async () => {
     // Given a table holding no items.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
 
     // When an action asking for ALL_OLD fails against a key holding nothing.
     const cancelled = await assertThrowsErrorAsync(async () =>
@@ -225,9 +226,23 @@ describe("DynamoDB transactional write cancellation", () => {
   it("reports every action whose condition failed", async () => {
     // Given a closed account and a ledger entry that is already there.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
 
-    await closedAccount(simDynamoDb);
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, status: { S: "closed" } },
+      }),
+    );
     await simDynamoDb.putItem(
       new PutItemCommand({
         TableName: "LedgerTable",
@@ -271,7 +286,12 @@ describe("DynamoDB transactional write cancellation", () => {
   it("cancels a transaction a Put's own condition turns away", async () => {
     // Given a ledger entry that is already there.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     await simDynamoDb.putItem(
       new PutItemCommand({

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.ts
@@ -1,0 +1,106 @@
+import {
+  SimDynamoDbConditionalCheckFailedException,
+  SimDynamoDbTransactionCanceledException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTransactTarget } from "./sim-dynamodb-transact-tables.js";
+import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
+import type { SimDynamoDbCancellationReason } from "./transact.command.js";
+
+/**
+ * The code an action that was fine carries.
+ *
+ * Every action is reported, so the actions that would have gone through are in
+ * the answer too. That is what makes the reasons line up with the request.
+ */
+const none = "None";
+
+/**
+ * The code an action whose ConditionExpression did not hold carries.
+ *
+ * The codes have no `Exception` suffix, unlike the errors of the same name that
+ * the single item commands throw.
+ */
+const conditionalCheckFailed = "ConditionalCheckFailed";
+
+/**
+ * Apply every action of a transaction, or none of them.
+ *
+ * Nothing is written until every action has been checked against what is
+ * stored, which is what makes a transaction one step rather than a run of
+ * writes that might stop part way.
+ */
+export function applySimDynamoDbTransaction(
+  targets: readonly SimDynamoDbTransactTarget<SimDynamoDbTransactWrite>[],
+): void {
+  assertApplies(targets);
+
+  for (const { item, table } of targets) {
+    item.applyTo(table);
+  }
+}
+
+/**
+ * Refuse a transaction any of whose actions could not be applied.
+ *
+ * Every action is checked, not just up to the first failure, since a caller
+ * reads which of its actions failed out of the cancellation reasons. Nothing
+ * has been written by the time this throws.
+ */
+function assertApplies(
+  targets: readonly SimDynamoDbTransactTarget<SimDynamoDbTransactWrite>[],
+): void {
+  const reasons = targets.map(({ item, table }) => reasonFor(item, table));
+
+  if (reasons.every((reason) => reason.Code === none)) {
+    return;
+  }
+
+  throw new SimDynamoDbTransactionCanceledException(reasons);
+}
+
+/**
+ * Why one action was cancelled, or that it was not.
+ *
+ * A condition that did not hold is this action's own failure, so it becomes its
+ * reason. Anything else is the request being wrong rather than the transaction
+ * being cancelled, so it is left to throw.
+ */
+function reasonFor(
+  write: SimDynamoDbTransactWrite,
+  table: SimDynamoDbTable,
+): SimDynamoDbCancellationReason {
+  try {
+    write.assertApplicableTo(table);
+  } catch (error) {
+    if (error instanceof SimDynamoDbConditionalCheckFailedException) {
+      return conditionFailure(error);
+    }
+
+    throw error;
+  }
+
+  return { Code: none };
+}
+
+/**
+ * The reason a failed condition gives.
+ *
+ * `Item` is only there when the action asked for it with
+ * `ReturnValuesOnConditionCheckFailure`, and only when there was an item to
+ * report. A condition that turned away a write to a key holding nothing gives a
+ * reason with no `Item`.
+ */
+function conditionFailure(
+  thrown: SimDynamoDbConditionalCheckFailedException,
+): SimDynamoDbCancellationReason {
+  if (thrown.Item === undefined) {
+    return { Code: conditionalCheckFailed, Message: thrown.message };
+  }
+
+  return {
+    Code: conditionalCheckFailed,
+    Message: thrown.message,
+    Item: thrown.Item,
+  };
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.iso.test.ts
@@ -1,0 +1,379 @@
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  TransactGetItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * An account and a ledger entry, in two tables.
+ */
+async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "AccountsTable",
+      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "accountId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "LedgerTable",
+      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "AccountsTable",
+      Item: {
+        accountId: { S: "account-1" },
+        balance: { N: "100" },
+        status: { S: "open" },
+      },
+    }),
+  );
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "LedgerTable",
+      Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+describe("DynamoDB TransactGetItemsCommand", () => {
+  it("reads items from two tables in one call", async () => {
+    // Given an account and a ledger entry.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When one transactional read asks for both.
+    const output = await simDynamoDb.transactGetItems(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+            },
+          },
+          {
+            Get: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: "entry-1" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the answers are in the order the Gets were named.
+    assertArrayLength(output.Responses, 2);
+    assertIdentical(output.Responses[0].Item?.["balance"]?.N, "100");
+    assertIdentical(output.Responses[1].Item?.["amount"]?.N, "25");
+  });
+
+  it("answers a key that holds nothing with an entry carrying no Item", async () => {
+    // Given an account and a ledger entry.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a read asks for a key nothing was written under, between two that
+    // hold something.
+    const output = await simDynamoDb.transactGetItems(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+            },
+          },
+          {
+            Get: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-404" } },
+            },
+          },
+          {
+            Get: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: "entry-1" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the answers are never compacted, so the ones that were there are
+    // still where the request put them.
+    assertArrayLength(output.Responses, 3);
+    assertUndefined(output.Responses[1].Item);
+    assertObjectEquals(output.Responses[1], {});
+    assertIdentical(output.Responses[2].Item?.["amount"]?.N, "25");
+  });
+
+  it("projects the attributes one Get asks for", async () => {
+    // Given an account holding three attributes.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When one Get names a ProjectionExpression.
+    const output = await simDynamoDb.transactGetItems(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+              ProjectionExpression: "balance, #status",
+              ExpressionAttributeNames: { "#status": "status" },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then it answers with those attributes and nothing else.
+    assertObjectEquals(output.Responses[0]?.Item, {
+      balance: { N: "100" },
+      status: { S: "open" },
+    });
+  });
+
+  it("reads a table named by its ARN", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "LedgerTable",
+        KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "entryId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" } },
+      }),
+    );
+
+    // When a transactional read names the table by its ARN.
+    const output = await simDynamoDb.transactGetItems(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: creation.TableDescription?.TableArn ?? "",
+              Key: { entryId: { S: "entry-1" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then it is the same table.
+    assertIdentical(output.Responses[0]?.Item?.["entryId"]?.S, "entry-1");
+  });
+
+  it("requires TransactItems naming a Get", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional read asks for nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({ TransactItems: [] }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactGetItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("requires TransactItems at all", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional read names no Gets at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems({ input: {} }),
+    );
+
+    // Then it is refused the same way an empty list is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactGetItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("refuses more Gets than a transaction takes", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional read asks for 101 items.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: Array.from({ length: 101 }, (_unused, index) => ({
+            Get: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: `entry-${String(index)}` } },
+            },
+          })),
+        }),
+      ),
+    );
+
+    // Then it is refused before the Gets are read.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "101 actions, where 100 is the most a transaction takes",
+    );
+  });
+
+  it("refuses an entry carrying no Get", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When one entry names nothing to read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems({ input: { TransactItems: [{}] } }),
+    );
+
+    // Then it is refused rather than read as an empty request.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A TransactGetItem carries a Get");
+  });
+
+  it("refuses two Gets of one item", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional read asks for the same item twice.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole read is refused, as a transactional write naming one item
+    // twice is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Transaction request cannot include multiple operations on one item",
+    );
+  });
+
+  it("refuses a read naming a table that is not there", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When one Get names a table that was never created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "ArchivedLedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole read is refused.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("refuses the read reporting inputs this simulation does not model", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional read asks for a capacity cost.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      ),
+    );
+
+    // Then it is refused by name rather than reported on.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnConsumedCapacity");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.iso.test.ts
@@ -1,77 +1,44 @@
 import {
-  CreateTableCommand,
   PutItemCommand,
   TransactGetItemsCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   assertArrayLength,
   assertIdentical,
-  assertInstanceOf,
   assertObjectEquals,
-  assertStringIncludes,
-  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import {
-  SimDynamoDbResourceNotFoundException,
-  SimDynamoDbUnsupportedOperation,
-  SimDynamoDbValidationException,
-} from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * An account and a ledger entry, in two tables.
- */
-async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "AccountsTable",
-      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
-      AttributeDefinitions: [
-        { AttributeName: "accountId", AttributeType: "S" },
-      ],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "LedgerTable",
-      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  await simDynamoDb.putItem(
-    new PutItemCommand({
-      TableName: "AccountsTable",
-      Item: {
-        accountId: { S: "account-1" },
-        balance: { N: "100" },
-        status: { S: "open" },
-      },
-    }),
-  );
-  await simDynamoDb.putItem(
-    new PutItemCommand({
-      TableName: "LedgerTable",
-      Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
-    }),
-  );
-
-  return simDynamoDb;
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 describe("DynamoDB TransactGetItemsCommand", () => {
   it("reads items from two tables in one call", async () => {
     // Given an account and a ledger entry.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+      }),
+    );
 
     // When one transactional read asks for both.
     const output = await simDynamoDb.transactGetItems(
@@ -102,7 +69,29 @@ describe("DynamoDB TransactGetItemsCommand", () => {
   it("answers a key that holds nothing with an entry carrying no Item", async () => {
     // Given an account and a ledger entry.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+      }),
+    );
 
     // When a read asks for a key nothing was written under, between two that
     // hold something.
@@ -142,7 +131,23 @@ describe("DynamoDB TransactGetItemsCommand", () => {
   it("projects the attributes one Get asks for", async () => {
     // Given an account holding three attributes.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: {
+          accountId: { S: "account-1" },
+          balance: { N: "100" },
+          status: { S: "open" },
+        },
+      }),
+    );
 
     // When one Get names a ProjectionExpression.
     const output = await simDynamoDb.transactGetItems(
@@ -161,28 +166,22 @@ describe("DynamoDB TransactGetItemsCommand", () => {
     );
 
     // Then it answers with those attributes and nothing else.
-    assertObjectEquals(output.Responses[0]?.Item, {
+    assertArrayLength(output.Responses, 1);
+    assertObjectEquals(output.Responses[0].Item, {
       balance: { N: "100" },
       status: { S: "open" },
     });
   });
 
   it("reads a table named by its ARN", async () => {
-    // Given a table.
+    // Given a table holding an entry.
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    const creation = await simDynamoDb.createTable(
-      new CreateTableCommand({
-        TableName: "LedgerTable",
-        KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-        AttributeDefinitions: [
-          { AttributeName: "entryId", AttributeType: "S" },
-        ],
-        BillingMode: "PAY_PER_REQUEST",
-      }),
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
     );
-    await simAws.backgroundTasksComplete();
 
     await simDynamoDb.putItem(
       new PutItemCommand({
@@ -197,7 +196,7 @@ describe("DynamoDB TransactGetItemsCommand", () => {
         TransactItems: [
           {
             Get: {
-              TableName: creation.TableDescription?.TableArn ?? "",
+              TableName: table.arn,
               Key: { entryId: { S: "entry-1" } },
             },
           },
@@ -206,174 +205,7 @@ describe("DynamoDB TransactGetItemsCommand", () => {
     );
 
     // Then it is the same table.
-    assertIdentical(output.Responses[0]?.Item?.["entryId"]?.S, "entry-1");
-  });
-
-  it("requires TransactItems naming a Get", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When a transactional read asks for nothing.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems(
-        new TransactGetItemsCommand({ TransactItems: [] }),
-      ),
-    );
-
-    // Then it is refused.
-    assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(
-      error.message,
-      "TransactGetItems requires TransactItems naming at least one action",
-    );
-  });
-
-  it("requires TransactItems at all", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When a transactional read names no Gets at all.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems({ input: {} }),
-    );
-
-    // Then it is refused the same way an empty list is.
-    assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(
-      error.message,
-      "TransactGetItems requires TransactItems naming at least one action",
-    );
-  });
-
-  it("refuses more Gets than a transaction takes", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When a transactional read asks for 101 items.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems(
-        new TransactGetItemsCommand({
-          TransactItems: Array.from({ length: 101 }, (_unused, index) => ({
-            Get: {
-              TableName: "LedgerTable",
-              Key: { entryId: { S: `entry-${String(index)}` } },
-            },
-          })),
-        }),
-      ),
-    );
-
-    // Then it is refused before the Gets are read.
-    assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(
-      error.message,
-      "101 actions, where 100 is the most a transaction takes",
-    );
-  });
-
-  it("refuses an entry carrying no Get", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When one entry names nothing to read.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems({ input: { TransactItems: [{}] } }),
-    );
-
-    // Then it is refused rather than read as an empty request.
-    assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(error.message, "A TransactGetItem carries a Get");
-  });
-
-  it("refuses two Gets of one item", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When a transactional read asks for the same item twice.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems(
-        new TransactGetItemsCommand({
-          TransactItems: [
-            {
-              Get: {
-                TableName: "LedgerTable",
-                Key: { entryId: { S: "entry-1" } },
-              },
-            },
-            {
-              Get: {
-                TableName: "LedgerTable",
-                Key: { entryId: { S: "entry-1" } },
-              },
-            },
-          ],
-        }),
-      ),
-    );
-
-    // Then the whole read is refused, as a transactional write naming one item
-    // twice is.
-    assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(
-      error.message,
-      "Transaction request cannot include multiple operations on one item",
-    );
-  });
-
-  it("refuses a read naming a table that is not there", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When one Get names a table that was never created.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems(
-        new TransactGetItemsCommand({
-          TransactItems: [
-            {
-              Get: {
-                TableName: "ArchivedLedgerTable",
-                Key: { entryId: { S: "entry-1" } },
-              },
-            },
-          ],
-        }),
-      ),
-    );
-
-    // Then the whole read is refused.
-    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
-  });
-
-  it("refuses the read reporting inputs this simulation does not model", async () => {
-    // Given two tables.
-    const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
-
-    // When a transactional read asks for a capacity cost.
-    const error = await assertThrowsErrorAsync(async () =>
-      simDynamoDb.transactGetItems(
-        new TransactGetItemsCommand({
-          TransactItems: [
-            {
-              Get: {
-                TableName: "LedgerTable",
-                Key: { entryId: { S: "entry-1" } },
-              },
-            },
-          ],
-          ReturnConsumedCapacity: "TOTAL",
-        }),
-      ),
-    );
-
-    // Then it is refused by name rather than reported on.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "ReturnConsumedCapacity");
+    assertArrayLength(output.Responses, 1);
+    assertIdentical(output.Responses[0].Item?.["entryId"]?.S, "entry-1");
   });
 });

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-items.ts
@@ -1,0 +1,59 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { readSimDynamoDbTransactGets } from "./sim-dynamodb-transact-gets.js";
+import { reachSimDynamoDbTransactTables } from "./sim-dynamodb-transact-tables.js";
+import { refuseUnsimulatedTransactGetInput } from "./sim-dynamodb-unsimulated-transact-input.js";
+import type {
+  SimTransactGetItemsCommand,
+  SimTransactGetItemsCommandOutput,
+} from "./transact.command.js";
+
+interface SimDynamoDbTransactGetItemsProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbTransactGetItemsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The TransactGetItems command.
+ *
+ * A transactional read reads items by primary key across tables in one call,
+ * and always reads them strongly consistently, so there is no `ConsistentRead`
+ * to set.
+ *
+ * `Responses` is positional and is never compacted: there is one entry per Get,
+ * in the order the Gets were named, and a key that holds nothing gives an entry
+ * with no `Item`. That is what makes a transactional read different from a
+ * batch read, which leaves a missing item out altogether.
+ */
+export class SimDynamoDbTransactGetItems {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbTransactGetItemsProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Read every item a transaction asks for.
+   */
+  handle(
+    command: SimTransactGetItemsCommand,
+    options?: SimDynamoDbTransactGetItemsOptions,
+  ): SimTransactGetItemsCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedTransactGetInput(input);
+
+    const targets = reachSimDynamoDbTransactTables(
+      readSimDynamoDbTransactGets(input.TransactItems),
+      { access: this.access, caller: options?.caller },
+    );
+
+    return {
+      Responses: targets.map(({ item, table }) => item.readFrom(table)),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-validation.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-get-validation.iso.test.ts
@@ -1,0 +1,219 @@
+import { TransactGetItemsCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+describe("DynamoDB TransactGetItemsCommand request validation", () => {
+  it("requires TransactItems naming a Get", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When a transactional read asks for nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({ TransactItems: [] }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactGetItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("requires TransactItems at all", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When a transactional read names no Gets at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems({ input: {} }),
+    );
+
+    // Then it is refused the same way an empty list is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactGetItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("refuses more Gets than a transaction takes", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When a transactional read asks for 101 items.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: Array.from({ length: 101 }, (_unused, index) => ({
+            Get: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: `entry-${String(index)}` } },
+            },
+          })),
+        }),
+      ),
+    );
+
+    // Then it is refused before the Gets are read.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "101 actions, where 100 is the most a transaction takes",
+    );
+  });
+
+  it("refuses an entry carrying no Get", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When one entry names nothing to read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems({ input: { TransactItems: [{}] } }),
+    );
+
+    // Then it is refused rather than read as an empty request.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A TransactGetItem carries a Get");
+  });
+
+  it("refuses two Gets of one item", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When a transactional read asks for the same item twice.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole read is refused, as a transactional write naming one item
+    // twice is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Transaction request cannot include multiple operations on one item",
+    );
+  });
+
+  it("refuses a read naming a table that is not there", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When one Get names a table that was never created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "ArchivedLedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole read is refused.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("refuses the read reporting inputs this simulation does not model", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
+
+    // When a transactional read asks for a capacity cost.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      ),
+    );
+
+    // Then it is refused by name rather than reported on.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ReturnConsumedCapacity");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-gets.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-gets.ts
@@ -1,0 +1,106 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { readSimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection-expression.js";
+import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
+import { assertSimDynamoDbTransactItemCount } from "./sim-dynamodb-transact-items.js";
+import type {
+  SimDynamoDbItemResponse,
+  SimDynamoDbTransactGet,
+  SimDynamoDbTransactGetItem,
+} from "./transact.command.js";
+
+const operation = "TransactGetItems";
+
+/**
+ * One Get of a transactional read.
+ *
+ * A transactional read is always strongly consistent, so there is no
+ * `ConsistentRead` to settle: every Get reads the latest item under its key.
+ */
+export class SimDynamoDbTransactRead {
+  public readonly action = "dynamodb:GetItem";
+  public readonly reference: string | undefined;
+
+  private readonly key: SimDynamoDbItem;
+  private readonly projection: SimDynamoDbProjection | undefined;
+
+  private constructor(
+    reference: string | undefined,
+    key: SimDynamoDbItem,
+    projection: SimDynamoDbProjection | undefined,
+  ) {
+    this.reference = reference;
+    this.key = key;
+    this.projection = projection;
+  }
+
+  /**
+   * Read the Get one action of a transactional read carries.
+   */
+  static of(request: SimDynamoDbTransactGet): SimDynamoDbTransactRead {
+    return new this(
+      request.TableName,
+      readSimDynamoDbKey(request.Key),
+      readSimDynamoDbProjection(request),
+    );
+  }
+
+  /**
+   * The primary key this Get reads, as the table marshals it.
+   */
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfKey(this.key);
+  }
+
+  /**
+   * Read this Get's item, as the table it is in and the projection asked for
+   * it.
+   *
+   * A key holding nothing answers with an entry carrying no `Item`, rather than
+   * with nothing at all, so the answers line up with the Gets that asked for
+   * them.
+   */
+  readFrom(table: SimDynamoDbTable): SimDynamoDbItemResponse {
+    const item = table.getItem(this.key);
+
+    if (item === undefined) {
+      return {};
+    }
+
+    return { Item: (this.projection?.apply(item) ?? item).toAttributeValues() };
+  }
+}
+
+/**
+ * Read every Get a transactional read asks for, before any table is reached.
+ *
+ * A ProjectionExpression DynamoDB would refuse is refused whether or not the
+ * keys hold anything, which is how the other reads work too.
+ */
+export function readSimDynamoDbTransactGets(
+  items: readonly SimDynamoDbTransactGetItem[] | undefined,
+): readonly SimDynamoDbTransactRead[] {
+  const requested = items ?? [];
+
+  assertSimDynamoDbTransactItemCount(requested.length, operation);
+
+  return requested.map((item) => readGet(item));
+}
+
+/**
+ * Read one entry of a transactional read.
+ *
+ * A TransactGetItem carries a Get and nothing else, so an entry without one is
+ * refused rather than read as an empty request.
+ */
+function readGet(item: SimDynamoDbTransactGetItem): SimDynamoDbTransactRead {
+  if (item.Get === undefined) {
+    throw new SimDynamoDbValidationException(
+      "A TransactGetItem carries a Get, and this one carries none",
+    );
+  }
+
+  return SimDynamoDbTransactRead.of(item.Get);
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-idempotency.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-idempotency.iso.test.ts
@@ -1,0 +1,310 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbIdempotentParameterMismatchException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * An account holding a balance of 100.
+ */
+async function accountWithBalance(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "AccountsTable",
+      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "accountId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "AccountsTable",
+      Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The balance the account is currently holding.
+ */
+async function balanceOf(
+  simDynamoDb: SimDynamoDb,
+): Promise<string | undefined> {
+  const output = await simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "AccountsTable",
+      Key: { accountId: { S: "account-1" } },
+    }),
+  );
+
+  return output.Item?.["balance"]?.N;
+}
+
+/**
+ * A transaction that takes 25 off the balance.
+ */
+const withdrawal = {
+  TransactItems: [
+    {
+      Update: {
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+        UpdateExpression: "SET balance = balance - :amount",
+        ExpressionAttributeValues: { ":amount": { N: "25" } },
+      },
+    },
+  ],
+  ClientRequestToken: "6b6b1a1e-0e2d-4d3f-9f5a-1c0f2b3d4e5f",
+};
+
+describe("DynamoDB transactional write idempotency", () => {
+  it("does not apply the writes again for the same token and payload", async () => {
+    // Given an account that has already had a withdrawal applied to it.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // When the same call is retried under the same token.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // Then the balance moved once, as the retry was the same request rather
+    // than a second one.
+    assertIdentical(await balanceOf(simDynamoDb), "75");
+  });
+
+  it("refuses a token replayed with a different payload", async () => {
+    // Given an account that has already had a withdrawal applied to it.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // When the same token is used for a different transaction.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Update: {
+                TableName: "AccountsTable",
+                Key: { accountId: { S: "account-1" } },
+                UpdateExpression: "SET balance = balance - :amount",
+                ExpressionAttributeValues: { ":amount": { N: "50" } },
+              },
+            },
+          ],
+          ClientRequestToken: withdrawal.ClientRequestToken,
+        }),
+      ),
+    );
+
+    // Then it is refused, and the balance is left where the first call put it.
+    assertInstanceOf(error, SimDynamoDbIdempotentParameterMismatchException);
+    assertIdentical(await balanceOf(simDynamoDb), "75");
+  });
+
+  it("applies the writes again once the token window has passed", async () => {
+    // Given an account that has already had a withdrawal applied to it.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // When ten simulated minutes pass and the same call is made again.
+    await simAws.clock().advanceBy({ minutes: 10 });
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // Then it is a new transaction rather than a retry of the old one.
+    assertIdentical(await balanceOf(simDynamoDb), "50");
+  });
+
+  it("still treats a token inside the window as a retry", async () => {
+    // Given an account that has already had a withdrawal applied to it.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // When nine simulated minutes pass and the same call is made again.
+    await simAws.clock().advanceBy({ minutes: 9 });
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // Then the balance moved once.
+    assertIdentical(await balanceOf(simDynamoDb), "75");
+  });
+
+  it("does not remember a transaction that was cancelled", async () => {
+    // Given a transaction that was cancelled by its condition.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    const guarded = {
+      TransactItems: [
+        {
+          Put: {
+            TableName: "AccountsTable",
+            Item: { accountId: { S: "account-2" } },
+            ConditionExpression: "attribute_exists(accountId)",
+          },
+        },
+      ],
+      ClientRequestToken: "e2f0a1b2-c3d4-4e5f-8a9b-0c1d2e3f4a5b",
+    };
+
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(new TransactWriteItemsCommand(guarded)),
+    );
+
+    // When the same token is used for a transaction that can be applied.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "AccountsTable",
+              Item: { accountId: { S: "account-2" } },
+            },
+          },
+        ],
+        ClientRequestToken: guarded.ClientRequestToken,
+      }),
+    );
+
+    // Then it runs, since a transaction that was cancelled never happened.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-2" } },
+      }),
+    );
+    assertIdentical(output.Item?.["accountId"]?.S, "account-2");
+  });
+
+  it("refuses a ClientRequestToken of a length DynamoDB does not take", async () => {
+    // Given an account.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    // When a transaction carries an empty token.
+    const empty = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          ...withdrawal,
+          ClientRequestToken: "",
+        }),
+      ),
+    );
+
+    // And when it carries one of 37 characters.
+    const long = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          ...withdrawal,
+          ClientRequestToken: "x".repeat(37),
+        }),
+      ),
+    );
+
+    // Then both are refused, and nothing was written either time.
+    assertInstanceOf(empty, SimDynamoDbValidationException);
+    assertStringIncludes(empty.message, "ClientRequestToken has a length of 0");
+    assertInstanceOf(long, SimDynamoDbValidationException);
+    assertStringIncludes(long.message, "ClientRequestToken has a length of 37");
+    assertIdentical(await balanceOf(simDynamoDb), "100");
+  });
+
+  it("applies each transaction that carries no token", async () => {
+    // Given an account.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    const untokened = {
+      TransactItems: withdrawal.TransactItems,
+    };
+
+    // When the same transaction is made twice with no token.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(untokened),
+    );
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(untokened),
+    );
+
+    // Then both are applied, since nothing said they were the same call.
+    assertIdentical(await balanceOf(simDynamoDb), "50");
+  });
+
+  it("leaves a table alone when a mismatched token is refused", async () => {
+    // Given an account with no second account beside it.
+    const simAws = new SimAws();
+    const simDynamoDb = await accountWithBalance(simAws);
+
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand(withdrawal),
+    );
+
+    // When a mismatched replay asks for a write.
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "AccountsTable",
+                Item: { accountId: { S: "account-2" } },
+              },
+            },
+          ],
+          ClientRequestToken: withdrawal.ClientRequestToken,
+        }),
+      ),
+    );
+
+    // Then nothing was written.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-2" } },
+      }),
+    );
+    assertUndefined(output.Item);
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-idempotency.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-idempotency.iso.test.ts
@@ -1,5 +1,4 @@
 import {
-  CreateTableCommand,
   GetItemCommand,
   PutItemCommand,
   TransactWriteItemsCommand,
@@ -18,34 +17,7 @@ import {
   SimDynamoDbValidationException,
 } from "../../error/dynamodb.error.js";
 import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * An account holding a balance of 100.
- */
-async function accountWithBalance(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "AccountsTable",
-      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
-      AttributeDefinitions: [
-        { AttributeName: "accountId", AttributeType: "S" },
-      ],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  await simDynamoDb.putItem(
-    new PutItemCommand({
-      TableName: "AccountsTable",
-      Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
-    }),
-  );
-
-  return simDynamoDb;
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 /**
  * The balance the account is currently holding.
@@ -84,7 +56,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("does not apply the writes again for the same token and payload", async () => {
     // Given an account that has already had a withdrawal applied to it.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand(withdrawal),
@@ -103,7 +86,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("refuses a token replayed with a different payload", async () => {
     // Given an account that has already had a withdrawal applied to it.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand(withdrawal),
@@ -136,7 +130,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("applies the writes again once the token window has passed", async () => {
     // Given an account that has already had a withdrawal applied to it.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand(withdrawal),
@@ -155,7 +160,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("still treats a token inside the window as a retry", async () => {
     // Given an account that has already had a withdrawal applied to it.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand(withdrawal),
@@ -174,7 +190,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("does not remember a transaction that was cancelled", async () => {
     // Given a transaction that was cancelled by its condition.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     const guarded = {
       TransactItems: [
@@ -221,7 +248,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("refuses a ClientRequestToken of a length DynamoDB does not take", async () => {
     // Given an account.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     // When a transaction carries an empty token.
     const empty = await assertThrowsErrorAsync(async () =>
@@ -254,7 +292,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("applies each transaction that carries no token", async () => {
     // Given an account.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     const untokened = {
       TransactItems: withdrawal.TransactItems,
@@ -275,7 +324,18 @@ describe("DynamoDB transactional write idempotency", () => {
   it("leaves a table alone when a mismatched token is refused", async () => {
     // Given an account with no second account beside it.
     const simAws = new SimAws();
-    const simDynamoDb = await accountWithBalance(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
 
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand(withdrawal),

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-item-iam.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-item-iam.iso.test.ts
@@ -1,11 +1,9 @@
 import {
-  CreateTableCommand,
   GetItemCommand,
   PutItemCommand,
   TransactGetItemsCommand,
   TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   assertIdentical,
   assertInstanceOf,
@@ -15,53 +13,8 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-
-const ledgerTable = new CreateTableCommand({
-  TableName: "LedgerTable",
-  KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-  AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-  BillingMode: "PAY_PER_REQUEST",
-});
-
-const trustPolicy = (accountId: string): string =>
-  JSON.stringify({
-    Version: "2012-10-17",
-    Statement: {
-      Effect: "Allow",
-      Principal: { AWS: `arn:aws:iam::${accountId}:root` },
-      Action: "sts:AssumeRole",
-    },
-  });
-
-/**
- * A Role allowed the DynamoDB actions it is given, and nothing else.
- */
-async function roleAllowed(
-  simAws: SimAws,
-  roleName: string,
-  actions: readonly string[],
-): Promise<string> {
-  const simIam = simAws.iam();
-  const creation = await simIam.createRole(
-    new CreateRoleCommand({
-      RoleName: roleName,
-      AssumeRolePolicyDocument: trustPolicy(simAws.defaultAccountId),
-    }),
-  );
-
-  await simIam.putRolePolicy(
-    new PutRolePolicyCommand({
-      RoleName: roleName,
-      PolicyName: `${roleName}Policy`,
-      PolicyDocument: JSON.stringify({
-        Version: "2012-10-17",
-        Statement: { Effect: "Allow", Action: actions, Resource: "*" },
-      }),
-    }),
-  );
-
-  return creation.Role.Arn;
-}
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 describe("DynamoDB transactional item command IAM authorization", () => {
   it("authorizes a transaction as the operations it is made of", async () => {
@@ -69,13 +22,18 @@ describe("DynamoDB transactional item command IAM authorization", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    await simDynamoDb.createTable(ledgerTable);
-    await simAws.backgroundTasksComplete();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
-    const arn = await roleAllowed(simAws, "LedgerWriter", [
-      "dynamodb:PutItem",
-      "dynamodb:UpdateItem",
-    ]);
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "LedgerWriter",
+        actions: ["dynamodb:PutItem", "dynamodb:UpdateItem"],
+      },
+      simAws,
+    );
 
     // When the Role writes a transaction doing both.
     await simDynamoDb.transactWriteItems(
@@ -97,7 +55,7 @@ describe("DynamoDB transactional item command IAM authorization", () => {
           },
         ],
       }),
-      { caller: { kind: "arn", arn } },
+      { caller: { kind: "arn", arn: role.Arn } },
     );
 
     // Then IAM allows the request, since a transaction needs the actions of
@@ -116,8 +74,10 @@ describe("DynamoDB transactional item command IAM authorization", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    await simDynamoDb.createTable(ledgerTable);
-    await simAws.backgroundTasksComplete();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     await simDynamoDb.putItem(
       new PutItemCommand({
@@ -126,9 +86,10 @@ describe("DynamoDB transactional item command IAM authorization", () => {
       }),
     );
 
-    const arn = await roleAllowed(simAws, "PutOnlyWriter", [
-      "dynamodb:PutItem",
-    ]);
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "PutOnlyWriter", actions: ["dynamodb:PutItem"] },
+      simAws,
+    );
 
     // When the Role writes a transaction that puts one item and deletes
     // another.
@@ -150,7 +111,7 @@ describe("DynamoDB transactional item command IAM authorization", () => {
             },
           ],
         }),
-        { caller: { kind: "arn", arn } },
+        { caller: { kind: "arn", arn: role.Arn } },
       ),
     );
 
@@ -180,12 +141,15 @@ describe("DynamoDB transactional item command IAM authorization", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    await simDynamoDb.createTable(ledgerTable);
-    await simAws.backgroundTasksComplete();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
-    const arn = await roleAllowed(simAws, "CheckLessWriter", [
-      "dynamodb:PutItem",
-    ]);
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "CheckLessWriter", actions: ["dynamodb:PutItem"] },
+      simAws,
+    );
 
     // When the Role writes a transaction guarded by a condition check.
     const error = await assertThrowsErrorAsync(async () =>
@@ -207,7 +171,7 @@ describe("DynamoDB transactional item command IAM authorization", () => {
             },
           ],
         }),
-        { caller: { kind: "arn", arn } },
+        { caller: { kind: "arn", arn: role.Arn } },
       ),
     );
 
@@ -221,8 +185,10 @@ describe("DynamoDB transactional item command IAM authorization", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    await simDynamoDb.createTable(ledgerTable);
-    await simAws.backgroundTasksComplete();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     const entry = {
       TransactItems: [
@@ -238,12 +204,15 @@ describe("DynamoDB transactional item command IAM authorization", () => {
 
     await simDynamoDb.transactWriteItems(new TransactWriteItemsCommand(entry));
 
-    const arn = await roleAllowed(simAws, "NoWriter", ["dynamodb:GetItem"]);
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "NoWriter", actions: ["dynamodb:GetItem"] },
+      simAws,
+    );
 
     // When a Role with no permission to write replays the same token.
     const error = await assertThrowsErrorAsync(async () =>
       simDynamoDb.transactWriteItems(new TransactWriteItemsCommand(entry), {
-        caller: { kind: "arn", arn },
+        caller: { kind: "arn", arn: role.Arn },
       }),
     );
 
@@ -258,12 +227,15 @@ describe("DynamoDB transactional item command IAM authorization", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    await simDynamoDb.createTable(ledgerTable);
-    await simAws.backgroundTasksComplete();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
-    const arn = await roleAllowed(simAws, "WriteOnlyReader", [
-      "dynamodb:PutItem",
-    ]);
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "WriteOnlyReader", actions: ["dynamodb:PutItem"] },
+      simAws,
+    );
 
     // When the Role reads a transaction.
     const error = await assertThrowsErrorAsync(async () =>
@@ -278,7 +250,7 @@ describe("DynamoDB transactional item command IAM authorization", () => {
             },
           ],
         }),
-        { caller: { kind: "arn", arn } },
+        { caller: { kind: "arn", arn: role.Arn } },
       ),
     );
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-item-iam.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-item-iam.iso.test.ts
@@ -1,0 +1,290 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactGetItemsCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const ledgerTable = new CreateTableCommand({
+  TableName: "LedgerTable",
+  KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+const trustPolicy = (accountId: string): string =>
+  JSON.stringify({
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+      Action: "sts:AssumeRole",
+    },
+  });
+
+/**
+ * A Role allowed the DynamoDB actions it is given, and nothing else.
+ */
+async function roleAllowed(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<string> {
+  const simIam = simAws.iam();
+  const creation = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: trustPolicy(simAws.defaultAccountId),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: `${roleName}Policy`,
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: actions, Resource: "*" },
+      }),
+    }),
+  );
+
+  return creation.Role.Arn;
+}
+
+describe("DynamoDB transactional item command IAM authorization", () => {
+  it("authorizes a transaction as the operations it is made of", async () => {
+    // Given a Role allowed to put and to update items.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(ledgerTable);
+    await simAws.backgroundTasksComplete();
+
+    const arn = await roleAllowed(simAws, "LedgerWriter", [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+    ]);
+
+    // When the Role writes a transaction doing both.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: "entry-1" } },
+            },
+          },
+          {
+            Update: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: "entry-2" } },
+              UpdateExpression: "SET amount = :amount",
+              ExpressionAttributeValues: { ":amount": { N: "25" } },
+            },
+          },
+        ],
+      }),
+      { caller: { kind: "arn", arn } },
+    );
+
+    // Then IAM allows the request, since a transaction needs the actions of
+    // the operations it carries rather than one of its own.
+    const output = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertIdentical(output.Item?.["entryId"]?.S, "entry-1");
+  });
+
+  it("denies a transaction carrying an action the Role may not take", async () => {
+    // Given a Role allowed to put items but not to delete them.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(ledgerTable);
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-2" } },
+      }),
+    );
+
+    const arn = await roleAllowed(simAws, "PutOnlyWriter", [
+      "dynamodb:PutItem",
+    ]);
+
+    // When the Role writes a transaction that puts one item and deletes
+    // another.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: { S: "entry-1" } },
+              },
+            },
+            {
+              Delete: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-2" } },
+              },
+            },
+          ],
+        }),
+        { caller: { kind: "arn", arn } },
+      ),
+    );
+
+    // Then the whole transaction is denied, and neither item was touched.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:DeleteItem");
+
+    const written = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(written.Item);
+
+    const deleted = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-2" } },
+      }),
+    );
+    assertIdentical(deleted.Item?.["entryId"]?.S, "entry-2");
+  });
+
+  it("needs dynamodb:ConditionCheckItem for a ConditionCheck", async () => {
+    // Given a Role allowed to put items but not to check them.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(ledgerTable);
+    await simAws.backgroundTasksComplete();
+
+    const arn = await roleAllowed(simAws, "CheckLessWriter", [
+      "dynamodb:PutItem",
+    ]);
+
+    // When the Role writes a transaction guarded by a condition check.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-2" } },
+                ConditionExpression: "attribute_exists(entryId)",
+              },
+            },
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+        { caller: { kind: "arn", arn } },
+      ),
+    );
+
+    // Then it is denied, since a condition check is an action of its own.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:ConditionCheckItem");
+  });
+
+  it("denies a caller replaying a token it has no permission for", async () => {
+    // Given a transaction that has already been applied under a token.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(ledgerTable);
+    await simAws.backgroundTasksComplete();
+
+    const entry = {
+      TransactItems: [
+        {
+          Put: {
+            TableName: "LedgerTable",
+            Item: { entryId: { S: "entry-1" } },
+          },
+        },
+      ],
+      ClientRequestToken: "0a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d",
+    };
+
+    await simDynamoDb.transactWriteItems(new TransactWriteItemsCommand(entry));
+
+    const arn = await roleAllowed(simAws, "NoWriter", ["dynamodb:GetItem"]);
+
+    // When a Role with no permission to write replays the same token.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(new TransactWriteItemsCommand(entry), {
+        caller: { kind: "arn", arn },
+      }),
+    );
+
+    // Then it is denied rather than answered as a retry, since IAM evaluates a
+    // request before the service handles it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:PutItem");
+  });
+
+  it("needs dynamodb:GetItem for a transactional read", async () => {
+    // Given a Role allowed to write items but not to read them.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(ledgerTable);
+    await simAws.backgroundTasksComplete();
+
+    const arn = await roleAllowed(simAws, "WriteOnlyReader", [
+      "dynamodb:PutItem",
+    ]);
+
+    // When the Role reads a transaction.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactGetItems(
+        new TransactGetItemsCommand({
+          TransactItems: [
+            {
+              Get: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+        { caller: { kind: "arn", arn } },
+      ),
+    );
+
+    // Then it is denied: a transactional read is authorized as the GetItem it
+    // is made of.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:GetItem");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-items.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-items.ts
@@ -1,0 +1,34 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+
+/**
+ * Real DynamoDB takes 100 actions in one transaction, whether it is reading or
+ * writing them.
+ */
+const greatestActions = 100;
+
+/**
+ * Refuse a transaction with nothing to do, or with more than DynamoDB applies
+ * at once.
+ *
+ * The count is checked before the actions are read, so a transaction that is
+ * too long is told so rather than told about the first action in it that has
+ * something else wrong.
+ */
+export function assertSimDynamoDbTransactItemCount(
+  count: number,
+  operation: string,
+): void {
+  if (count === 0) {
+    throw new SimDynamoDbValidationException(
+      `${operation} requires TransactItems naming at least one action`,
+    );
+  }
+
+  if (count > greatestActions) {
+    throw new SimDynamoDbValidationException(
+      `Too many items requested for the ${operation} call: ` +
+        `${count.toString()} actions, where ${greatestActions.toString()} is ` +
+        `the most a transaction takes`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-key-actions.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-key-actions.ts
@@ -1,0 +1,109 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { SimDynamoDbConditionCheck } from "../item/sim-dynamodb-condition-check.js";
+import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
+import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
+import type {
+  SimDynamoDbTransactConditionCheck,
+  SimDynamoDbTransactDelete,
+} from "./transact.command.js";
+
+/**
+ * An action of a transaction that names one item by its Key.
+ *
+ * A delete and a condition check are both a key and a condition against what is
+ * stored under it. What they do once the condition holds is all that differs.
+ */
+abstract class SimDynamoDbTransactKeyAction implements SimDynamoDbTransactWrite {
+  public abstract readonly action: string;
+  public readonly reference: string | undefined;
+
+  protected readonly key: SimDynamoDbItem;
+
+  private readonly check: SimDynamoDbConditionCheck;
+
+  constructor(
+    reference: string | undefined,
+    key: SimDynamoDbItem,
+    check: SimDynamoDbConditionCheck,
+  ) {
+    this.reference = reference;
+    this.key = key;
+    this.check = check;
+  }
+
+  sizeInBytes(): number {
+    return this.key.sizeInBytes();
+  }
+
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfKey(this.key);
+  }
+
+  assertApplicableTo(table: SimDynamoDbTable): void {
+    this.check.assertHoldsFor(table.getItem(this.key));
+  }
+
+  abstract applyTo(table: SimDynamoDbTable): void;
+}
+
+/**
+ * A delete in a transaction, which names a key rather than an item, so a key
+ * that is already free is deleted successfully.
+ */
+class SimDynamoDbTransactDeleteAction extends SimDynamoDbTransactKeyAction {
+  public readonly action = "dynamodb:DeleteItem";
+
+  applyTo(table: SimDynamoDbTable): void {
+    table.deleteItem(this.key);
+  }
+}
+
+/**
+ * A condition check in a transaction, which writes nothing.
+ *
+ * It is how a transaction says that an item it is not changing has to hold for
+ * the items it is changing to be written.
+ */
+class SimDynamoDbTransactConditionCheckAction extends SimDynamoDbTransactKeyAction {
+  public readonly action = "dynamodb:ConditionCheckItem";
+
+  applyTo(): void {
+    // A condition check changes nothing. What it does happened when its
+    // condition was checked against the item it names.
+  }
+}
+
+/**
+ * Read the Delete one action of a transaction carries.
+ */
+export function readSimDynamoDbTransactDelete(
+  request: SimDynamoDbTransactDelete,
+): SimDynamoDbTransactWrite {
+  return new SimDynamoDbTransactDeleteAction(
+    request.TableName,
+    readSimDynamoDbKey(request.Key),
+    SimDynamoDbConditionCheck.read(request, "TransactWriteItems"),
+  );
+}
+
+/**
+ * Read the ConditionCheck one action of a transaction carries.
+ */
+export function readSimDynamoDbTransactConditionCheck(
+  request: SimDynamoDbTransactConditionCheck,
+): SimDynamoDbTransactWrite {
+  if (request.ConditionExpression === undefined) {
+    throw new SimDynamoDbValidationException(
+      "A ConditionCheck requires a ConditionExpression, which is the whole of " +
+        "what it does",
+    );
+  }
+
+  return new SimDynamoDbTransactConditionCheckAction(
+    request.TableName,
+    readSimDynamoDbKey(request.Key),
+    SimDynamoDbConditionCheck.read(request, "TransactWriteItems"),
+  );
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-put-action.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-put-action.ts
@@ -1,0 +1,60 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { SimDynamoDbConditionCheck } from "../item/sim-dynamodb-condition-check.js";
+import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
+import type { SimDynamoDbTransactPut } from "./transact.command.js";
+
+/**
+ * A put in a transaction, which replaces the whole item as PutItem does.
+ */
+class SimDynamoDbTransactPutAction implements SimDynamoDbTransactWrite {
+  public readonly action = "dynamodb:PutItem";
+  public readonly reference: string | undefined;
+
+  private readonly item: SimDynamoDbItem;
+  private readonly check: SimDynamoDbConditionCheck;
+
+  constructor(
+    reference: string | undefined,
+    item: SimDynamoDbItem,
+    check: SimDynamoDbConditionCheck,
+  ) {
+    this.reference = reference;
+    this.item = item;
+    this.check = check;
+  }
+
+  sizeInBytes(): number {
+    return this.item.sizeInBytes();
+  }
+
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfItem(this.item);
+  }
+
+  assertApplicableTo(table: SimDynamoDbTable): void {
+    this.check.assertHoldsFor(table.itemUnder(this.item));
+  }
+
+  applyTo(table: SimDynamoDbTable): void {
+    table.putItem(this.item);
+  }
+}
+
+/**
+ * Read the Put one action of a transaction carries.
+ */
+export function readSimDynamoDbTransactPut(
+  request: SimDynamoDbTransactPut,
+): SimDynamoDbTransactWrite {
+  if (request.Item === undefined) {
+    throw new SimDynamoDbValidationException("A Put requires an Item");
+  }
+
+  return new SimDynamoDbTransactPutAction(
+    request.TableName,
+    SimDynamoDbItem.fromAttributeValues(request.Item),
+    SimDynamoDbConditionCheck.read(request, "TransactWriteItems"),
+  );
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-tables.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-tables.ts
@@ -1,0 +1,81 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+
+/**
+ * What every action of a transaction knows about where it is pointing.
+ */
+interface SimDynamoDbTransactItem {
+  readonly reference: string | undefined;
+  readonly action: string;
+
+  keyIn(table: SimDynamoDbTable): string;
+}
+
+/**
+ * One action of a transaction, against the table it names.
+ */
+export interface SimDynamoDbTransactTarget<Item> {
+  readonly item: Item;
+  readonly table: SimDynamoDbTable;
+}
+
+interface SimDynamoDbTransactReach {
+  readonly access: SimDynamoDbTableAccess;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * Reach the table every action of a transaction names, authorizing the caller
+ * against each.
+ *
+ * A transaction is authorized as the operations it is made of rather than as
+ * itself, so each action carries the `dynamodb:` action it needs. A caller
+ * allowed to put but not to delete is refused a transaction that does both.
+ *
+ * Every table is reached and every key marshalled before anything is written,
+ * so a transaction DynamoDB would refuse leaves the tables as they were.
+ */
+export function reachSimDynamoDbTransactTables<
+  Item extends SimDynamoDbTransactItem,
+>(
+  items: readonly Item[],
+  reach: SimDynamoDbTransactReach,
+): readonly SimDynamoDbTransactTarget<Item>[] {
+  const targets = items.map((item) => ({
+    item,
+    table: reach.access.required(item.action, item.reference, reach.caller),
+  }));
+
+  assertDistinctItems(targets);
+
+  return targets;
+}
+
+/**
+ * Refuse a transaction naming one item more than once.
+ *
+ * Unlike a batch, a transaction may name one table as often as it likes: what
+ * it may not do is touch one item twice, whichever actions the two are. The
+ * keys are the marshalled primary keys, so two actions on the same item are the
+ * same text whichever attribute order they arrived in.
+ */
+function assertDistinctItems<Item extends SimDynamoDbTransactItem>(
+  targets: readonly SimDynamoDbTransactTarget<Item>[],
+): void {
+  const seen = new Set<string>();
+
+  for (const { item, table } of targets) {
+    const key = `${table.tableName}: ${item.keyIn(table)}`;
+
+    if (seen.has(key)) {
+      throw new SimDynamoDbValidationException(
+        `Transaction request cannot include multiple operations on one item: ` +
+          `the table ${table.tableName} is named twice for the same item`,
+      );
+    }
+
+    seen.add(key);
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-update-action.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-update-action.ts
@@ -1,0 +1,68 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
+import { SimDynamoDbUpdatePlan } from "../item/sim-dynamodb-update-plan.js";
+import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
+import type { SimDynamoDbTransactUpdate } from "./transact.command.js";
+
+/**
+ * An update in a transaction, which changes part of the item its Key names.
+ */
+class SimDynamoDbTransactUpdateAction implements SimDynamoDbTransactWrite {
+  public readonly action = "dynamodb:UpdateItem";
+  public readonly reference: string | undefined;
+
+  private readonly key: SimDynamoDbItem;
+  private readonly plan: SimDynamoDbUpdatePlan;
+
+  constructor(
+    reference: string | undefined,
+    key: SimDynamoDbItem,
+    plan: SimDynamoDbUpdatePlan,
+  ) {
+    this.reference = reference;
+    this.key = key;
+    this.plan = plan;
+  }
+
+  sizeInBytes(): number {
+    return this.key.sizeInBytes();
+  }
+
+  keyIn(table: SimDynamoDbTable): string {
+    return table.keyOfKey(this.key);
+  }
+
+  assertApplicableTo(table: SimDynamoDbTable): void {
+    this.plan.check.assertHoldsFor(table.getItem(this.key));
+    this.plan.assertLeavesKeyAlone(table.keySchema.attributeNames());
+  }
+
+  applyTo(table: SimDynamoDbTable): void {
+    table.putItem(this.plan.applyTo(table.getItem(this.key), this.key));
+  }
+}
+
+/**
+ * Read the Update one action of a transaction carries.
+ *
+ * A transactional update names its UpdateExpression, where UpdateItem takes a
+ * request without one as an upsert of the Key.
+ */
+export function readSimDynamoDbTransactUpdate(
+  request: SimDynamoDbTransactUpdate,
+): SimDynamoDbTransactWrite {
+  if (request.UpdateExpression === undefined) {
+    throw new SimDynamoDbValidationException(
+      "An Update requires an UpdateExpression, since a transaction has no " +
+        "upsert of a Key on its own",
+    );
+  }
+
+  return new SimDynamoDbTransactUpdateAction(
+    request.TableName,
+    readSimDynamoDbKey(request.Key),
+    SimDynamoDbUpdatePlan.read(request, "TransactWriteItems"),
+  );
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.iso.test.ts
@@ -1,0 +1,362 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A ledger and the account balances its entries move, as two tables.
+ */
+async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "AccountsTable",
+      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "accountId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "LedgerTable",
+      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+/**
+ * The account these tests move money in and out of.
+ */
+async function storedAccount(
+  simDynamoDb: SimDynamoDb,
+): Promise<Record<string, { readonly N?: string; readonly S?: string }>> {
+  const output = await simDynamoDb.getItem(
+    new GetItemCommand({
+      TableName: "AccountsTable",
+      Key: { accountId: { S: "account-1" } },
+    }),
+  );
+
+  assertNonNullable(output.Item);
+
+  return output.Item;
+}
+
+describe("DynamoDB TransactWriteItemsCommand", () => {
+  it("writes a ledger entry and the balance it moves in one call", async () => {
+    // Given an account holding a balance.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, balance: { N: "100" } },
+      }),
+    );
+
+    // When one transaction writes the entry and moves the balance.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: "entry-1" }, amount: { N: "25" } },
+            },
+          },
+          {
+            Update: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+              UpdateExpression: "SET balance = balance - :amount",
+              ExpressionAttributeValues: { ":amount": { N: "25" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then both landed.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertIdentical(entry.Item?.["amount"]?.N, "25");
+
+    const account = await storedAccount(simDynamoDb);
+    assertIdentical(account["balance"]?.N, "75");
+  });
+
+  it("deletes one item and puts another in one call", async () => {
+    // Given an account and a ledger entry.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: { S: "entry-1" } },
+      }),
+    );
+
+    // When one transaction deletes the entry and writes the account.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Delete: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: "entry-1" } },
+            },
+          },
+          {
+            Put: {
+              TableName: "AccountsTable",
+              Item: { accountId: { S: "account-1" }, balance: { N: "0" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the entry is gone and the account is there.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(entry.Item);
+
+    const account = await storedAccount(simDynamoDb);
+    assertIdentical(account["balance"]?.N, "0");
+  });
+
+  it("deletes a key that holds nothing", async () => {
+    // Given a table holding no items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transaction deletes a key nothing was written under.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Delete: {
+              TableName: "LedgerTable",
+              Key: { entryId: { S: "entry-1" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then it succeeds, as a delete names a key rather than an item.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(entry.Item);
+  });
+
+  it("writes when a ConditionCheck on another item holds", async () => {
+    // Given an open account.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: { S: "account-1" }, status: { S: "open" } },
+      }),
+    );
+
+    // When a transaction checks the account and writes an entry against it.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            ConditionCheck: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+              ConditionExpression: "#status = :open",
+              ExpressionAttributeNames: { "#status": "status" },
+              ExpressionAttributeValues: { ":open": { S: "open" } },
+            },
+          },
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: "entry-1" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the entry is written, and the account the check named is unchanged.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertIdentical(entry.Item?.["entryId"]?.S, "entry-1");
+
+    const account = await storedAccount(simDynamoDb);
+    assertIdentical(account["status"]?.S, "open");
+  });
+
+  it("upserts an item an Update names when the key holds nothing", async () => {
+    // Given a table holding no items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transactional update names a key nothing is stored under.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Update: {
+              TableName: "AccountsTable",
+              Key: { accountId: { S: "account-1" } },
+              UpdateExpression: "SET balance = :opening",
+              ExpressionAttributeValues: { ":opening": { N: "10" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then the item is built from the Key and what the update set, as
+    // UpdateItem builds it.
+    const account = await storedAccount(simDynamoDb);
+    assertIdentical(account["accountId"]?.S, "account-1");
+    assertIdentical(account["balance"]?.N, "10");
+  });
+
+  it("names one table for several of its items", async () => {
+    // Given a table holding no items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transaction writes two items of the same table.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: "entry-1" } },
+            },
+          },
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: "entry-2" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then both are there. A transaction names one table as often as it likes,
+    // where a batch names it once.
+    const second = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-2" } },
+      }),
+    );
+    assertIdentical(second.Item?.["entryId"]?.S, "entry-2");
+  });
+
+  it("writes to a table named by its ARN", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "LedgerTable",
+        KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "entryId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When a transaction names the table by its ARN.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          { Put: { TableName: tableArn, Item: { entryId: { S: "entry-1" } } } },
+        ],
+      }),
+    );
+
+    // Then it is the same table.
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertIdentical(entry.Item?.["entryId"]?.S, "entry-1");
+  });
+
+  it("takes the 100 actions a transaction holds", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTables(simAws);
+
+    // When a transaction writes exactly 100 items.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: Array.from({ length: 100 }, (_unused, index) => ({
+          Put: {
+            TableName: "LedgerTable",
+            Item: { entryId: { S: `entry-${String(index)}` } },
+          },
+        })),
+      }),
+    );
+
+    // Then all of them are there.
+    const last = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-99" } },
+      }),
+    );
+    assertIdentical(last.Item?.["entryId"]?.S, "entry-99");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.iso.test.ts
@@ -1,70 +1,27 @@
 import {
-  CreateTableCommand,
   GetItemCommand,
   PutItemCommand,
   TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
-import {
-  assertIdentical,
-  assertNonNullable,
-  assertUndefined,
-} from "@kensio/smartass";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * A ledger and the account balances its entries move, as two tables.
- */
-async function ledgerTables(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "AccountsTable",
-      KeySchema: [{ AttributeName: "accountId", KeyType: "HASH" }],
-      AttributeDefinitions: [
-        { AttributeName: "accountId", AttributeType: "S" },
-      ],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "LedgerTable",
-      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  return simDynamoDb;
-}
-
-/**
- * The account these tests move money in and out of.
- */
-async function storedAccount(
-  simDynamoDb: SimDynamoDb,
-): Promise<Record<string, { readonly N?: string; readonly S?: string }>> {
-  const output = await simDynamoDb.getItem(
-    new GetItemCommand({
-      TableName: "AccountsTable",
-      Key: { accountId: { S: "account-1" } },
-    }),
-  );
-
-  assertNonNullable(output.Item);
-
-  return output.Item;
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 describe("DynamoDB TransactWriteItemsCommand", () => {
   it("writes a ledger entry and the balance it moves in one call", async () => {
-    // Given an account holding a balance.
+    // Given an account holding a balance, and a ledger to record it in.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     await simDynamoDb.putItem(
       new PutItemCommand({
@@ -104,14 +61,28 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
     );
     assertIdentical(entry.Item?.["amount"]?.N, "25");
 
-    const account = await storedAccount(simDynamoDb);
-    assertIdentical(account["balance"]?.N, "75");
+    const account = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+      }),
+    );
+    assertIdentical(account.Item?.["balance"]?.N, "75");
   });
 
   it("deletes one item and puts another in one call", async () => {
-    // Given an account and a ledger entry.
+    // Given a ledger entry, and an account holding nothing yet.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     await simDynamoDb.putItem(
       new PutItemCommand({
@@ -149,14 +120,24 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
     );
     assertUndefined(entry.Item);
 
-    const account = await storedAccount(simDynamoDb);
-    assertIdentical(account["balance"]?.N, "0");
+    const account = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+      }),
+    );
+    assertIdentical(account.Item?.["balance"]?.N, "0");
   });
 
   it("deletes a key that holds nothing", async () => {
     // Given a table holding no items.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction deletes a key nothing was written under.
     await simDynamoDb.transactWriteItems(
@@ -183,9 +164,18 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
   });
 
   it("writes when a ConditionCheck on another item holds", async () => {
-    // Given an open account.
+    // Given an open account, and a ledger to write against it.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     await simDynamoDb.putItem(
       new PutItemCommand({
@@ -226,14 +216,24 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
     );
     assertIdentical(entry.Item?.["entryId"]?.S, "entry-1");
 
-    const account = await storedAccount(simDynamoDb);
-    assertIdentical(account["status"]?.S, "open");
+    const account = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+      }),
+    );
+    assertIdentical(account.Item?.["status"]?.S, "open");
   });
 
   it("upserts an item an Update names when the key holds nothing", async () => {
     // Given a table holding no items.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "AccountsTable", partitionKeyName: "accountId" },
+      simAws,
+    );
 
     // When a transactional update names a key nothing is stored under.
     await simDynamoDb.transactWriteItems(
@@ -253,15 +253,25 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
 
     // Then the item is built from the Key and what the update set, as
     // UpdateItem builds it.
-    const account = await storedAccount(simDynamoDb);
-    assertIdentical(account["accountId"]?.S, "account-1");
-    assertIdentical(account["balance"]?.N, "10");
+    const account = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "AccountsTable",
+        Key: { accountId: { S: "account-1" } },
+      }),
+    );
+    assertIdentical(account.Item?.["accountId"]?.S, "account-1");
+    assertIdentical(account.Item["balance"]?.N, "10");
   });
 
   it("names one table for several of its items", async () => {
     // Given a table holding no items.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction writes two items of the same table.
     await simDynamoDb.transactWriteItems(
@@ -299,26 +309,18 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
     const simAws = new SimAws();
     const simDynamoDb = simAws.dynamoDb();
 
-    const creation = await simDynamoDb.createTable(
-      new CreateTableCommand({
-        TableName: "LedgerTable",
-        KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-        AttributeDefinitions: [
-          { AttributeName: "entryId", AttributeType: "S" },
-        ],
-        BillingMode: "PAY_PER_REQUEST",
-      }),
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
     );
-    await simAws.backgroundTasksComplete();
-
-    const tableArn = creation.TableDescription?.TableArn;
-    assertNonNullable(tableArn);
 
     // When a transaction names the table by its ARN.
     await simDynamoDb.transactWriteItems(
       new TransactWriteItemsCommand({
         TransactItems: [
-          { Put: { TableName: tableArn, Item: { entryId: { S: "entry-1" } } } },
+          {
+            Put: { TableName: table.arn, Item: { entryId: { S: "entry-1" } } },
+          },
         ],
       }),
     );
@@ -336,7 +338,12 @@ describe("DynamoDB TransactWriteItemsCommand", () => {
   it("takes the 100 actions a transaction holds", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTables(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction writes exactly 100 items.
     await simDynamoDb.transactWriteItems(

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-items.ts
@@ -1,0 +1,80 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { applySimDynamoDbTransaction } from "./sim-dynamodb-transact-cancellation.js";
+import { reachSimDynamoDbTransactTables } from "./sim-dynamodb-transact-tables.js";
+import { readSimDynamoDbTransactWrites } from "./sim-dynamodb-transact-writes.js";
+import {
+  readSimDynamoDbClientRequestToken,
+  SimDynamoDbTransactionTokens,
+  simDynamoDbTransactionPayload,
+} from "./sim-dynamodb-transaction-tokens.js";
+import { refuseUnsimulatedTransactWriteInput } from "./sim-dynamodb-unsimulated-transact-input.js";
+import type {
+  SimTransactWriteItemsCommand,
+  SimTransactWriteItemsCommandOutput,
+} from "./transact.command.js";
+
+interface SimDynamoDbTransactWriteItemsProperties {
+  readonly access: SimDynamoDbTableAccess;
+  readonly clock: SimClock;
+}
+
+interface SimDynamoDbTransactWriteItemsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The TransactWriteItems command.
+ *
+ * A transaction puts, updates, deletes and condition checks items across tables
+ * in one call, and either all of it happens or none of it does. Every action is
+ * checked against what is stored before the first of them writes anything, so
+ * atomicity here follows from the order the work is done in rather than from
+ * unwinding a partial write.
+ *
+ * A failed condition cancels the whole transaction with
+ * `TransactionCanceledException`, carrying one cancellation reason per action
+ * in request order, including the actions that would have gone through.
+ */
+export class SimDynamoDbTransactWriteItems {
+  private readonly access: SimDynamoDbTableAccess;
+  private readonly tokens: SimDynamoDbTransactionTokens;
+
+  constructor(properties: SimDynamoDbTransactWriteItemsProperties) {
+    this.access = properties.access;
+    this.tokens = new SimDynamoDbTransactionTokens({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Apply every action a transaction asks for, or none of them.
+   */
+  handle(
+    command: SimTransactWriteItemsCommand,
+    options?: SimDynamoDbTransactWriteItemsOptions,
+  ): SimTransactWriteItemsCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedTransactWriteInput(input);
+
+    const token = readSimDynamoDbClientRequestToken(input.ClientRequestToken);
+    const payload = simDynamoDbTransactionPayload(input.TransactItems);
+    const targets = reachSimDynamoDbTransactTables(
+      readSimDynamoDbTransactWrites(input.TransactItems),
+      { access: this.access, caller: options?.caller },
+    );
+
+    // A retry under a token this simulation has already applied writes nothing
+    // again, which is what makes the retry idempotent. The request is still
+    // read and the caller still authorized against every table it names, since
+    // IAM evaluates a request before the service handles it.
+    if (!this.tokens.isReplayOf(token, payload)) {
+      applySimDynamoDbTransaction(targets);
+      this.tokens.record(token, payload);
+    }
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-limits.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-limits.iso.test.ts
@@ -1,7 +1,4 @@
-import {
-  CreateTableCommand,
-  TransactWriteItemsCommand,
-} from "@aws-sdk/client-dynamodb";
+import { TransactWriteItemsCommand } from "@aws-sdk/client-dynamodb";
 import {
   assertInstanceOf,
   assertStringIncludes,
@@ -13,26 +10,7 @@ import {
   SimDynamoDbUnsupportedOperation,
   SimDynamoDbValidationException,
 } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * A ledger table, holding nothing yet.
- */
-async function ledgerTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "LedgerTable",
-      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  return simDynamoDb;
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 const entryPut = {
   Put: { TableName: "LedgerTable", Item: { entryId: { S: "entry-1" } } },
@@ -42,7 +20,12 @@ describe("DynamoDB transactional write limits and reporting", () => {
   it("refuses a transaction over the size a request holds", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When 100 items of 45 KB each are written in one transaction.
     const padding = "x".repeat(45 * 1024);
@@ -75,7 +58,12 @@ describe("DynamoDB transactional write limits and reporting", () => {
   it("refuses the write reporting inputs this simulation does not model", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction asks for a capacity cost.
     const capacity = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-limits.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-limits.iso.test.ts
@@ -1,0 +1,106 @@
+import {
+  CreateTableCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A ledger table, holding nothing yet.
+ */
+async function ledgerTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "LedgerTable",
+      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+const entryPut = {
+  Put: { TableName: "LedgerTable", Item: { entryId: { S: "entry-1" } } },
+};
+
+describe("DynamoDB transactional write limits and reporting", () => {
+  it("refuses a transaction over the size a request holds", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When 100 items of 45 KB each are written in one transaction.
+    const padding = "x".repeat(45 * 1024);
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: Array.from({ length: 100 }, (_unused, index) => ({
+            Put: {
+              TableName: "LedgerTable",
+              Item: {
+                entryId: { S: `entry-${String(index)}` },
+                padding: { S: padding },
+              },
+            },
+          })),
+        }),
+      ),
+    );
+
+    // Then the transaction is refused for its size, though every item in it is
+    // under the 400 KB an item holds.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Transaction request size has exceeded the maximum allowed size of " +
+        "4194304 bytes",
+    );
+  });
+
+  it("refuses the write reporting inputs this simulation does not model", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a transaction asks for a capacity cost.
+    const capacity = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [entryPut],
+          ReturnConsumedCapacity: "TOTAL",
+        }),
+      ),
+    );
+
+    // And when it asks for item collection sizes.
+    const metrics = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [entryPut],
+          ReturnItemCollectionMetrics: "SIZE",
+        }),
+      ),
+    );
+
+    // Then both are refused by name rather than reported on.
+    assertInstanceOf(capacity, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(capacity.message, "ReturnConsumedCapacity");
+    assertInstanceOf(metrics, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(metrics.message, "ReturnItemCollectionMetrics");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-validation.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-validation.iso.test.ts
@@ -1,5 +1,4 @@
 import {
-  CreateTableCommand,
   GetItemCommand,
   TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
@@ -15,26 +14,7 @@ import {
   SimDynamoDbResourceNotFoundException,
   SimDynamoDbValidationException,
 } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-
-/**
- * A ledger table, holding nothing yet.
- */
-async function ledgerTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDb.createTable(
-    new CreateTableCommand({
-      TableName: "LedgerTable",
-      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-
-  return simDynamoDb;
-}
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
 
 const entryPut = {
   Put: { TableName: "LedgerTable", Item: { entryId: { S: "entry-1" } } },
@@ -44,7 +24,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires TransactItems naming an action", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction asks for nothing.
     const error = await assertThrowsErrorAsync(async () =>
@@ -64,7 +49,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires TransactItems at all", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction names no actions at all, under a token.
     const error = await assertThrowsErrorAsync(async () =>
@@ -84,7 +74,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses more actions than a transaction takes", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction asks for 101 actions.
     const error = await assertThrowsErrorAsync(async () =>
@@ -111,7 +106,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses an entry carrying two of the four actions", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When one entry asks for both a put and a delete.
     const error = await assertThrowsErrorAsync(async () =>
@@ -141,7 +141,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses an entry carrying none of the four actions", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When one entry asks for nothing.
     const error = await assertThrowsErrorAsync(async () =>
@@ -158,7 +163,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires an Item on a Put", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a put carries no Item.
     const error = await assertThrowsErrorAsync(async () =>
@@ -175,7 +185,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires an UpdateExpression on an Update", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When an update says nothing to change.
     const error = await assertThrowsErrorAsync(async () =>
@@ -205,7 +220,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires a ConditionExpression on a ConditionCheck", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a condition check names no condition.
     const error = await assertThrowsErrorAsync(async () =>
@@ -234,7 +254,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("requires a Key on a Delete", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a delete carries no Key.
     const error = await assertThrowsErrorAsync(async () =>
@@ -251,7 +276,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses two actions on one item of a table", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When a transaction writes and deletes the same item.
     const error = await assertThrowsErrorAsync(async () =>
@@ -282,7 +312,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses a transaction naming a table that is not there", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When one action names a table that was never created.
     const error = await assertThrowsErrorAsync(async () =>
@@ -316,7 +351,12 @@ describe("DynamoDB TransactWriteItemsCommand request validation", () => {
   it("refuses an update that would move the primary key", async () => {
     // Given a table.
     const simAws = new SimAws();
-    const simDynamoDb = await ledgerTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "LedgerTable", partitionKeyName: "entryId" },
+      simAws,
+    );
 
     // When one action writes to a key attribute.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-validation.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-validation.iso.test.ts
@@ -1,0 +1,352 @@
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A ledger table, holding nothing yet.
+ */
+async function ledgerTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable(
+    new CreateTableCommand({
+      TableName: "LedgerTable",
+      KeySchema: [{ AttributeName: "entryId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "entryId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+const entryPut = {
+  Put: { TableName: "LedgerTable", Item: { entryId: { S: "entry-1" } } },
+};
+
+describe("DynamoDB TransactWriteItemsCommand request validation", () => {
+  it("requires TransactItems naming an action", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a transaction asks for nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({ TransactItems: [] }),
+      ),
+    );
+
+    // Then it is refused, since a transaction has to do something.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactWriteItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("requires TransactItems at all", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a transaction names no actions at all, under a token.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems({
+        input: { ClientRequestToken: "a-token" },
+      }),
+    );
+
+    // Then it is refused the same way an empty list is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TransactWriteItems requires TransactItems naming at least one action",
+    );
+  });
+
+  it("refuses more actions than a transaction takes", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a transaction asks for 101 actions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: Array.from({ length: 101 }, (_unused, index) => ({
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: { S: `entry-${String(index)}` } },
+            },
+          })),
+        }),
+      ),
+    );
+
+    // Then it is refused before the actions are read.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "101 actions, where 100 is the most a transaction takes",
+    );
+  });
+
+  it("refuses an entry carrying two of the four actions", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When one entry asks for both a put and a delete.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: { S: "entry-1" } },
+              },
+              Delete: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then it is refused rather than one of the two being guessed at.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "this one carries Put and Delete");
+  });
+
+  it("refuses an entry carrying none of the four actions", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When one entry asks for nothing.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({ TransactItems: [{}] }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "this one carries none of them");
+  });
+
+  it("requires an Item on a Put", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a put carries no Item.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems({
+        input: { TransactItems: [{ Put: { TableName: "LedgerTable" } }] },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A Put requires an Item");
+  });
+
+  it("requires an UpdateExpression on an Update", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When an update says nothing to change.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems({
+        input: {
+          TransactItems: [
+            {
+              Update: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then it is refused, where UpdateItem would take it as an upsert of the
+    // Key.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "An Update requires an UpdateExpression",
+    );
+  });
+
+  it("requires a ConditionExpression on a ConditionCheck", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a condition check names no condition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems({
+        input: {
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then it is refused, since checking nothing is not a check.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A ConditionCheck requires a ConditionExpression",
+    );
+  });
+
+  it("requires a Key on a Delete", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a delete carries no Key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems({
+        input: { TransactItems: [{ Delete: { TableName: "LedgerTable" } }] },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A Key is required");
+  });
+
+  it("refuses two actions on one item of a table", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When a transaction writes and deletes the same item.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            entryPut,
+            {
+              Delete: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole transaction is refused, since which of the two applied
+    // would be arbitrary.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Transaction request cannot include multiple operations on one item",
+    );
+  });
+
+  it("refuses a transaction naming a table that is not there", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When one action names a table that was never created.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            entryPut,
+            {
+              Put: {
+                TableName: "ArchivedLedgerTable",
+                Item: { entryId: { S: "entry-2" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the whole transaction is refused, and nothing is written.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(entry.Item);
+  });
+
+  it("refuses an update that would move the primary key", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ledgerTable(simAws);
+
+    // When one action writes to a key attribute.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            entryPut,
+            {
+              Update: {
+                TableName: "LedgerTable",
+                Key: { entryId: { S: "entry-2" } },
+                UpdateExpression: "SET entryId = :moved",
+                ExpressionAttributeValues: { ":moved": { S: "entry-3" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the request is refused rather than cancelled, and the action that
+    // was fine is not written either.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+
+    const entry = await simDynamoDb.getItem(
+      new GetItemCommand({
+        TableName: "LedgerTable",
+        Key: { entryId: { S: "entry-1" } },
+      }),
+    );
+    assertUndefined(entry.Item);
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write.ts
@@ -1,0 +1,150 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import {
+  readSimDynamoDbTransactConditionCheck,
+  readSimDynamoDbTransactDelete,
+} from "./sim-dynamodb-transact-key-actions.js";
+import { readSimDynamoDbTransactPut } from "./sim-dynamodb-transact-put-action.js";
+import { readSimDynamoDbTransactUpdate } from "./sim-dynamodb-transact-update-action.js";
+import type { SimDynamoDbTransactWriteItem } from "./transact.command.js";
+
+/**
+ * One action of a transactional write.
+ *
+ * Every action knows the table it names, the IAM action it asks for, which item
+ * of that table it works on, what has to hold for it, and what it does. Keeping
+ * all of that here is what lets a transaction check every action before it
+ * applies any of them, since the check and the write read the same item.
+ */
+export interface SimDynamoDbTransactWrite {
+  /**
+   * The table name or ARN this action names.
+   */
+  readonly reference: string | undefined;
+
+  /**
+   * The IAM action this one asks for.
+   *
+   * A transaction is authorized as the operations it is made of rather than as
+   * itself, so a put in a transaction needs `dynamodb:PutItem` and a condition
+   * check needs `dynamodb:ConditionCheckItem`.
+   */
+  readonly action: string;
+
+  /**
+   * The bytes this action counts towards the size of the transaction.
+   */
+  sizeInBytes(): number;
+
+  /**
+   * The primary key this action works on, as the table marshals it.
+   */
+  keyIn(table: SimDynamoDbTable): string;
+
+  /**
+   * Refuse this action against the table it names, before anything is written.
+   *
+   * A condition that does not hold throws
+   * `SimDynamoDbConditionalCheckFailedException`, which the transaction turns
+   * into the cancellation reason for this action. Anything else the action asks
+   * for and the table will not take is a `SimDynamoDbValidationException`, which
+   * refuses the whole request rather than cancelling it.
+   */
+  assertApplicableTo(table: SimDynamoDbTable): void;
+
+  /**
+   * Apply this action to the table.
+   */
+  applyTo(table: SimDynamoDbTable): void;
+}
+
+/**
+ * One entry of a transactional write, and how to read it.
+ */
+interface SimDynamoDbTransactWriteReader {
+  readonly name: string;
+  read(): SimDynamoDbTransactWrite;
+}
+
+/**
+ * Read one entry of a transactional write.
+ *
+ * A TransactWriteItem carries exactly one of Put, Update, Delete and
+ * ConditionCheck. Both or neither is refused rather than guessed at, since
+ * either guess would write something the request did not ask for.
+ */
+export function readSimDynamoDbTransactWrite(
+  item: SimDynamoDbTransactWriteItem,
+): SimDynamoDbTransactWrite {
+  const readers = readersOf(item);
+  const [only] = readers;
+
+  if (only === undefined) {
+    throw new SimDynamoDbValidationException(
+      "A TransactWriteItem carries exactly one of Put, Update, Delete and " +
+        "ConditionCheck, and this one carries none of them",
+    );
+  }
+
+  if (readers.length > 1) {
+    throw new SimDynamoDbValidationException(
+      "A TransactWriteItem carries exactly one of Put, Update, Delete and " +
+        `ConditionCheck, and this one carries ${readers
+          .map((reader) => reader.name)
+          .join(" and ")}`,
+    );
+  }
+
+  return only.read();
+}
+
+/**
+ * The actions one entry carries, in the order the request declares them.
+ *
+ * Nothing is read here beyond which of the four are there, so an entry carrying
+ * two of them is told that rather than told what is wrong inside the first one.
+ */
+function readersOf(
+  item: SimDynamoDbTransactWriteItem,
+): readonly SimDynamoDbTransactWriteReader[] {
+  const {
+    Put: put,
+    Update: update,
+    Delete: remove,
+    ConditionCheck: check,
+  } = item;
+  const readers: SimDynamoDbTransactWriteReader[] = [];
+
+  if (put !== undefined) {
+    readers.push({
+      name: "Put",
+      read: (): SimDynamoDbTransactWrite => readSimDynamoDbTransactPut(put),
+    });
+  }
+
+  if (update !== undefined) {
+    readers.push({
+      name: "Update",
+      read: (): SimDynamoDbTransactWrite =>
+        readSimDynamoDbTransactUpdate(update),
+    });
+  }
+
+  if (remove !== undefined) {
+    readers.push({
+      name: "Delete",
+      read: (): SimDynamoDbTransactWrite =>
+        readSimDynamoDbTransactDelete(remove),
+    });
+  }
+
+  if (check !== undefined) {
+    readers.push({
+      name: "ConditionCheck",
+      read: (): SimDynamoDbTransactWrite =>
+        readSimDynamoDbTransactConditionCheck(check),
+    });
+  }
+
+  return readers;
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-writes.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-writes.ts
@@ -1,0 +1,56 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { assertSimDynamoDbTransactItemCount } from "./sim-dynamodb-transact-items.js";
+import {
+  readSimDynamoDbTransactWrite,
+  type SimDynamoDbTransactWrite,
+} from "./sim-dynamodb-transact-write.js";
+import type { SimDynamoDbTransactWriteItem } from "./transact.command.js";
+
+const operation = "TransactWriteItems";
+
+/**
+ * Real DynamoDB stops a transactional write at 4 MB of request.
+ */
+const greatestRequestBytes = 4 * 1024 * 1024;
+
+/**
+ * Read every action a transactional write asks for, before any table is
+ * reached.
+ *
+ * Nothing here reaches a table. A transaction is applied whole or not at all,
+ * so everything that can be checked without a table is checked first, and the
+ * keys and conditions are checked against their tables after that.
+ */
+export function readSimDynamoDbTransactWrites(
+  items: readonly SimDynamoDbTransactWriteItem[] | undefined,
+): readonly SimDynamoDbTransactWrite[] {
+  const requested = items ?? [];
+
+  assertSimDynamoDbTransactItemCount(requested.length, operation);
+
+  const writes = requested.map((item) => readSimDynamoDbTransactWrite(item));
+
+  assertWithinSizeLimit(writes);
+
+  return writes;
+}
+
+/**
+ * Refuse a transaction carrying more than DynamoDB takes in one request.
+ *
+ * The bytes counted are the items and keys the actions carry, which is close to
+ * the request size rather than equal to it. Real DynamoDB counts the JSON the
+ * request arrived as, and that is bigger than the values inside it.
+ */
+function assertWithinSizeLimit(
+  writes: readonly SimDynamoDbTransactWrite[],
+): void {
+  const total = writes.reduce((bytes, write) => bytes + write.sizeInBytes(), 0);
+
+  if (total > greatestRequestBytes) {
+    throw new SimDynamoDbValidationException(
+      `Transaction request size has exceeded the maximum allowed size of ` +
+        `${greatestRequestBytes.toString()} bytes, at ${total.toString()} bytes`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transaction-tokens.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transaction-tokens.ts
@@ -1,0 +1,150 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  SimDynamoDbIdempotentParameterMismatchException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTransactWriteItem } from "./transact.command.js";
+
+/**
+ * Real DynamoDB remembers a ClientRequestToken for ten minutes.
+ */
+const idempotencyWindowMilliseconds = 10 * 60 * 1000;
+
+/**
+ * The longest ClientRequestToken real DynamoDB takes.
+ */
+const greatestTokenLength = 36;
+
+/**
+ * A transaction that has already been applied under a token.
+ */
+interface SimDynamoDbTransactionRecord {
+  readonly payload: string;
+  readonly at: Date;
+}
+
+interface SimDynamoDbTransactionTokensProperties {
+  readonly clock: SimClock;
+}
+
+/**
+ * The ClientRequestTokens one simulated DynamoDB has seen.
+ *
+ * A token makes a retry idempotent: replaying it with the same actions inside
+ * the ten minute window succeeds without applying them again, and replaying it
+ * with different actions is refused. The window is measured on the simulated
+ * clock, so a test moves past it with `simAws.clock().advanceBy(...)` rather
+ * than by waiting.
+ *
+ * Only a transaction that was applied is recorded. One that was cancelled or
+ * refused never happened, so retrying it under the same token runs it again.
+ */
+export class SimDynamoDbTransactionTokens {
+  private readonly clock: SimClock;
+  private readonly records = new Map<string, SimDynamoDbTransactionRecord>();
+
+  constructor(properties: SimDynamoDbTransactionTokensProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Whether this request has already been applied under this token.
+   *
+   * A token replayed with a different request is refused rather than answered
+   * either way: applying it would write something the first call did not, and
+   * reporting the first call's success would hide that it never ran.
+   */
+  isReplayOf(requestToken: string | undefined, payload: string): boolean {
+    if (requestToken === undefined) {
+      return false;
+    }
+
+    const record = this.recordUnder(requestToken);
+
+    if (record === undefined) {
+      return false;
+    }
+
+    if (record.payload !== payload) {
+      throw new SimDynamoDbIdempotentParameterMismatchException(
+        `Request parameters differ from the request already made with the ` +
+          `ClientRequestToken ${requestToken}`,
+      );
+    }
+
+    return true;
+  }
+
+  /**
+   * Remember a transaction that was applied, so a retry does not apply it
+   * again.
+   */
+  record(requestToken: string | undefined, payload: string): void {
+    if (requestToken === undefined) {
+      return;
+    }
+
+    this.records.set(requestToken, { payload, at: this.clock.now() });
+  }
+
+  /**
+   * The transaction this token stands for, while it still stands for one.
+   *
+   * A token past the window is forgotten as it is read, so the same token can
+   * be used again for something else afterwards.
+   */
+  private recordUnder(
+    requestToken: string,
+  ): SimDynamoDbTransactionRecord | undefined {
+    const record = this.records.get(requestToken);
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    const elapsed = this.clock.now().getTime() - record.at.getTime();
+
+    if (elapsed >= idempotencyWindowMilliseconds) {
+      this.records.delete(requestToken);
+
+      return undefined;
+    }
+
+    return record;
+  }
+}
+
+/**
+ * Read the ClientRequestToken a request carries, if it carries one.
+ */
+export function readSimDynamoDbClientRequestToken(
+  requestToken: string | undefined,
+): string | undefined {
+  if (requestToken === undefined) {
+    return undefined;
+  }
+
+  if (requestToken.length === 0 || requestToken.length > greatestTokenLength) {
+    throw new SimDynamoDbValidationException(
+      `ClientRequestToken has a length of ${requestToken.length.toString()}, where ` +
+        `1 to ${greatestTokenLength.toString()} characters is what DynamoDB ` +
+        `takes`,
+    );
+  }
+
+  return requestToken;
+}
+
+/**
+ * The request a token stands for, as text two requests can be compared by.
+ *
+ * The actions are what a retry has to repeat. Comparing them as the JSON they
+ * arrived as means a request that names the same things in a different order
+ * reads as a different request, which is stricter than comparing them field by
+ * field but is what a retry of the same call sends anyway.
+ */
+export function simDynamoDbTransactionPayload(
+  items: readonly SimDynamoDbTransactWriteItem[] | undefined,
+): string {
+  return JSON.stringify(items ?? []);
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-unsimulated-transact-input.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-unsimulated-transact-input.ts
@@ -1,0 +1,40 @@
+import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-input.js";
+import type {
+  SimTransactGetItemsCommandInput,
+  SimTransactWriteItemsCommandInput,
+} from "./transact.command.js";
+
+/**
+ * Refuse the TransactWriteItems inputs this simulation does not model.
+ */
+export function refuseUnsimulatedTransactWriteInput(
+  input: SimTransactWriteItemsCommandInput,
+): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("TransactWriteItems");
+
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+  unsimulated.refuseReporting(
+    input.ReturnItemCollectionMetrics,
+    "ReturnItemCollectionMetrics",
+    "reporting item collection sizes nothing here tracks",
+  );
+}
+
+/**
+ * Refuse the TransactGetItems inputs this simulation does not model.
+ */
+export function refuseUnsimulatedTransactGetInput(
+  input: SimTransactGetItemsCommandInput,
+): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("TransactGetItems");
+
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+}

--- a/src/service/dynamodb/command/transact/transact.command.ts
+++ b/src/service/dynamodb/command/transact/transact.command.ts
@@ -1,0 +1,166 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+
+/**
+ * What every action of a transactional write carries.
+ *
+ * Each action names its own table and carries its own condition, so one
+ * transaction can guard each of the items it touches differently.
+ */
+interface SimDynamoDbTransactAction {
+  readonly TableName?: string | undefined;
+  readonly ConditionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ReturnValuesOnConditionCheckFailure?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB transactional Put.
+ */
+export interface SimDynamoDbTransactPut extends SimDynamoDbTransactAction {
+  readonly Item?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB transactional Update.
+ *
+ * A transactional update names its `UpdateExpression`, where UpdateItem takes a
+ * request without one as an upsert of the Key.
+ */
+export interface SimDynamoDbTransactUpdate extends SimDynamoDbTransactAction {
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly UpdateExpression?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB transactional Delete.
+ */
+export interface SimDynamoDbTransactDelete extends SimDynamoDbTransactAction {
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB transactional ConditionCheck.
+ *
+ * A condition check writes nothing. It is how a transaction says that an item
+ * it is not changing has to hold for the items it is changing to be written.
+ */
+export interface SimDynamoDbTransactConditionCheck extends SimDynamoDbTransactAction {
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactWriteItem.
+ *
+ * One entry carries exactly one of the four, which is what makes it a put, an
+ * update, a delete or a condition check.
+ */
+export interface SimDynamoDbTransactWriteItem {
+  readonly Put?: SimDynamoDbTransactPut | undefined;
+  readonly Update?: SimDynamoDbTransactUpdate | undefined;
+  readonly Delete?: SimDynamoDbTransactDelete | undefined;
+  readonly ConditionCheck?: SimDynamoDbTransactConditionCheck | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactWriteItems command.
+ */
+export interface SimTransactWriteItemsCommand {
+  readonly input: SimTransactWriteItemsCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactWriteItems input.
+ */
+export interface SimTransactWriteItemsCommandInput {
+  readonly TransactItems?: readonly SimDynamoDbTransactWriteItem[] | undefined;
+  readonly ClientRequestToken?: string | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+  readonly ReturnItemCollectionMetrics?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactWriteItems output.
+ *
+ * A transactional write reports nothing about the items it wrote. It applied
+ * every action or none of them, so there is nothing to say per action.
+ */
+export interface SimTransactWriteItemsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB transactional Get.
+ *
+ * There is no `ConsistentRead` here. A transactional read is always strongly
+ * consistent, so there is nothing to ask for.
+ */
+export interface SimDynamoDbTransactGet {
+  readonly TableName?: string | undefined;
+  readonly Key?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ProjectionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactGetItem.
+ */
+export interface SimDynamoDbTransactGetItem {
+  readonly Get?: SimDynamoDbTransactGet | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactGetItems command.
+ */
+export interface SimTransactGetItemsCommand {
+  readonly input: SimTransactGetItemsCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactGetItems input.
+ */
+export interface SimTransactGetItemsCommandInput {
+  readonly TransactItems?: readonly SimDynamoDbTransactGetItem[] | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+}
+
+/**
+ * What one Get of a transactional read answers with.
+ *
+ * A key that holds nothing gives an entry with no `Item`, rather than being
+ * left out, so the answers line up with the Gets that asked for them.
+ */
+export interface SimDynamoDbItemResponse {
+  readonly Item?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TransactGetItems output.
+ */
+export interface SimTransactGetItemsCommandOutput {
+  readonly Responses: readonly SimDynamoDbItemResponse[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Why one action of a cancelled transaction was cancelled.
+ *
+ * There is one of these per action, in request order, including the actions
+ * nothing was wrong with, which carry the code `None`.
+ */
+export interface SimDynamoDbCancellationReason {
+  readonly Code: string;
+  readonly Message?: string | undefined;
+  readonly Item?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}

--- a/src/service/dynamodb/error/dynamodb.error.ts
+++ b/src/service/dynamodb/error/dynamodb.error.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbCancellationReason } from "../command/transact/transact.command.js";
 
 /**
  * Minimal metadata shape for simulated DynamoDB errors.
@@ -75,6 +76,52 @@ export class SimDynamoDbConditionalCheckFailedException extends SimDynamoDbError
   constructor(item?: Readonly<Record<string, SimDynamoDbAttributeValue>>) {
     super("The conditional request failed.", { httpStatusCode: 400 });
     this.Item = item;
+  }
+}
+
+/**
+ * Simulated DynamoDB TransactionCanceledException error.
+ *
+ * This is what a transactional write fails with when any of its actions could
+ * not be applied. Nothing was written: the actions are checked before the first
+ * of them changes anything.
+ *
+ * `CancellationReasons` lines up with the `TransactItems` of the request, one
+ * entry per action and in the same order, including the actions nothing was
+ * wrong with. Those carry the code `None`, which is how a caller reads which of
+ * its actions was the one that failed.
+ *
+ * The message lists the codes in the same order, as real DynamoDB does, so an
+ * application logging the message alone still records which action failed.
+ */
+export class SimDynamoDbTransactionCanceledException extends SimDynamoDbError {
+  public override readonly name = "TransactionCanceledException";
+
+  public readonly CancellationReasons: readonly SimDynamoDbCancellationReason[];
+
+  constructor(reasons: readonly SimDynamoDbCancellationReason[]) {
+    super(
+      `Transaction cancelled, please refer cancellation reasons for specific ` +
+        `reasons [${reasons.map((reason) => reason.Code).join(", ")}]`,
+      { httpStatusCode: 400 },
+    );
+    this.CancellationReasons = reasons;
+  }
+}
+
+/**
+ * Simulated DynamoDB IdempotentParameterMismatchException error.
+ *
+ * A ClientRequestToken makes a retry idempotent, so it stands for the request
+ * it was first used with. Replaying it with a different request inside the
+ * idempotency window is refused rather than applied, since either applying it
+ * or answering with the first request's result would be wrong.
+ */
+export class SimDynamoDbIdempotentParameterMismatchException extends SimDynamoDbError {
+  public override readonly name = "IdempotentParameterMismatchException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
   }
 }
 

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -11,6 +11,8 @@ import {
   ListTablesCommand,
   PutItemCommand,
   QueryCommand,
+  TransactGetItemsCommand,
+  TransactWriteItemsCommand,
   UpdateItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
@@ -180,6 +182,60 @@ describe("simulated DynamoDB SDK Command routing", () => {
     assertArrayLength(items, 1);
     assertObjectEquals(items[0], { name: { S: "First item" } });
     assertObjectEquals(readOut.UnprocessedKeys, {});
+  });
+
+  it("round-trips transactional Item Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: "TransactTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    await client.send(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "TransactTable",
+              Item: { id: { S: "item-1" }, name: { S: "First item" } },
+            },
+          },
+          {
+            Update: {
+              TableName: "TransactTable",
+              Key: { id: { S: "item-2" } },
+              UpdateExpression: "SET #n = :name",
+              ExpressionAttributeNames: { "#n": "name" },
+              ExpressionAttributeValues: { ":name": { S: "Second item" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    const readOut = await client.send(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          { Get: { TableName: "TransactTable", Key: { id: { S: "item-2" } } } },
+          {
+            Get: { TableName: "TransactTable", Key: { id: { S: "missing" } } },
+          },
+        ],
+      }),
+    );
+    const responses = readOut.Responses;
+    assertNonNullable(responses);
+    assertArrayLength(responses, 2);
+    assertIdentical(responses[0].Item?.["name"]?.S, "Second item");
+    assertObjectEquals(responses[1], {});
   });
 
   it("does not give a denied run-as caller root privileges", async () => {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -19,6 +19,10 @@ import type {
   SimBatchGetItemCommand,
   SimBatchWriteItemCommand,
 } from "../command/batch/batch.command.js";
+import type {
+  SimTransactGetItemsCommand,
+  SimTransactWriteItemsCommand,
+} from "../command/transact/transact.command.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
 /**
@@ -106,6 +110,22 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simDynamoDatabase.batchGetItem(
             command as SimBatchGetItemCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "TransactWriteItemsCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.transactWriteItems(
+            command as SimTransactWriteItemsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "TransactGetItemsCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.transactGetItems(
+            command as SimTransactGetItemsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -40,6 +40,14 @@ import type {
   SimBatchWriteItemCommand,
   SimBatchWriteItemCommandOutput,
 } from "./command/batch/batch.command.js";
+import type {
+  SimTransactGetItemsCommand,
+  SimTransactGetItemsCommandOutput,
+  SimTransactWriteItemsCommand,
+  SimTransactWriteItemsCommandOutput,
+} from "./command/transact/transact.command.js";
+import { SimDynamoDbTransactGetItems } from "./command/transact/sim-dynamodb-transact-get-items.js";
+import { SimDynamoDbTransactWriteItems } from "./command/transact/sim-dynamodb-transact-write-items.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
@@ -77,6 +85,8 @@ export class SimDynamoDb {
   private readonly itemUpdates: SimDynamoDbUpdateItem;
   private readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
   private readonly itemBatchReads: SimDynamoDbBatchGetItem;
+  private readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
+  private readonly itemTransactReads: SimDynamoDbTransactGetItems;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
   private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
     dynamoDb: this,
@@ -116,6 +126,13 @@ export class SimDynamoDb {
       access: this.access,
     });
     this.itemBatchReads = new SimDynamoDbBatchGetItem({ access: this.access });
+    this.itemTransactWrites = new SimDynamoDbTransactWriteItems({
+      access: this.access,
+      clock: background,
+    });
+    this.itemTransactReads = new SimDynamoDbTransactGetItems({
+      access: this.access,
+    });
   }
 
   /**
@@ -227,6 +244,28 @@ export class SimDynamoDb {
   ): Promise<SimBatchGetItemCommandOutput> {
     await this.background.sequence();
     return this.itemBatchReads.handle(command, options);
+  }
+
+  /**
+   * Handle a Transact Write Items Command from the SDK.
+   */
+  async transactWriteItems(
+    command: SimTransactWriteItemsCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimTransactWriteItemsCommandOutput> {
+    await this.background.sequence();
+    return this.itemTransactWrites.handle(command, options);
+  }
+
+  /**
+   * Handle a Transact Get Items Command from the SDK.
+   */
+  async transactGetItems(
+    command: SimTransactGetItemsCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimTransactGetItemsCommandOutput> {
+    await this.background.sequence();
+    return this.itemTransactReads.handle(command, options);
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-created-table.factory.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-created-table.factory.ts
@@ -1,0 +1,88 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimDynamoDbBillingMode,
+  SimDynamoDbScalarAttributeType,
+} from "../command/table/table.types.js";
+import type { SimDynamoDbTable } from "./sim-dynamodb-table.js";
+
+/**
+ * What a test asks for when it wants a table to work on.
+ *
+ * A table is mostly its name and its key, and the rest of a CreateTable request
+ * is the same every time. Naming the key as one attribute rather than as a key
+ * schema and a matching attribute definition is what makes a table one line
+ * here.
+ */
+export interface SimDynamoDbCreatedTableInput {
+  readonly tableName: string;
+  readonly partitionKeyName: string;
+  readonly partitionKeyType: SimDynamoDbScalarAttributeType;
+  readonly billingMode: SimDynamoDbBillingMode;
+}
+
+/**
+ * Creates a table a simulated DynamoDB knows about, through CreateTable.
+ *
+ * This is the table an application would have: it went through the ordinary
+ * command, so it was checked the way a real request is checked. Use
+ * `simDynamoDbTableFactory` instead for a table on its own, with no simulated
+ * DynamoDB holding it.
+ *
+ * The table is ACTIVE by the time this answers. Creating one schedules its
+ * activation, and a test that has just asked for a table is asking for one it
+ * can write to, so the scheduled work is drained here rather than in every
+ * caller.
+ *
+ * ```typescript
+ * const table = await simDynamoDbCreatedTableFactory.make(
+ *   { tableName: "OrdersTable", partitionKeyName: "orderId" },
+ *   simAws,
+ * );
+ * ```
+ *
+ * The table is created in the default Account and Region of the simulated AWS
+ * it is given. A test working in another scope calls CreateTable itself.
+ */
+export const simDynamoDbCreatedTableFactory = new AsyncMappedFactory<
+  SimDynamoDbCreatedTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "FoobarTable",
+    partitionKeyName: "id",
+    partitionKeyType: "S",
+    billingMode: "PAY_PER_REQUEST",
+  }),
+  async (input, simAws) => {
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable({
+      input: {
+        TableName: input.tableName,
+        KeySchema: [{ AttributeName: input.partitionKeyName, KeyType: "HASH" }],
+        AttributeDefinitions: [
+          {
+            AttributeName: input.partitionKeyName,
+            AttributeType: input.partitionKeyType,
+          },
+        ],
+        BillingMode: input.billingMode,
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // A name CreateTable accepted is a table the store holds, so this is only
+    // missing if something is wrong with the simulator itself.
+    const table = simDynamoDb.findTable(input.tableName);
+    assertDefined(
+      table,
+      `Simulated DynamoDB created the table ${input.tableName} and then did ` +
+        `not hold it`,
+    );
+
+    return table;
+  },
+);

--- a/src/service/iam/role/sim-iam-role-with-policy.factory.ts
+++ b/src/service/iam/role/sim-iam-role-with-policy.factory.ts
@@ -1,0 +1,84 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCreateRoleCommandOutput } from "../command/role/create-role/create-role.command.js";
+import { simIamPolicyDocumentFactory } from "../policy/sim-iam-policy-document.factory.js";
+
+/**
+ * What a test asks for when it wants a Role that may do something.
+ *
+ * The actions and the resource are what the test is about. The trust policy,
+ * the policy name and the two commands it takes to get there are the same every
+ * time, so they are not asked for.
+ */
+export interface SimIamRoleWithPolicyInput {
+  readonly roleName: string;
+  readonly policyName: string;
+  readonly actions: readonly string[];
+  readonly resource: string;
+}
+
+/**
+ * The Role a CreateRole request answers with.
+ */
+export type SimIamCreatedRole = SimCreateRoleCommandOutput["Role"];
+
+/**
+ * Creates a Role allowed the actions it is given, and nothing else.
+ *
+ * This is the caller an authorization test needs: something to pass as
+ * `{ caller: { kind: "arn", arn: role.Arn } }` that IAM will allow one thing
+ * and refuse another.
+ *
+ * ```typescript
+ * const role = await simIamRoleWithPolicyFactory.make(
+ *   { roleName: "OrderWriter", actions: ["dynamodb:PutItem"] },
+ *   simAws,
+ * );
+ * ```
+ *
+ * The Role is assumable by the Account root of the simulated AWS it is given,
+ * which is the trust every test here wants and none of them is about. A Role
+ * trusted by a service, or one allowed several resources, is two ordinary
+ * commands with `simIamPolicyDocumentFactory` supplying the documents.
+ */
+export const simIamRoleWithPolicyFactory = new AsyncMappedFactory<
+  SimIamRoleWithPolicyInput,
+  SimIamCreatedRole,
+  SimAws
+>(
+  () => ({
+    roleName: "ApplicationRole",
+    policyName: "ApplicationPolicy",
+    actions: [],
+    resource: "*",
+  }),
+  async (input, simAws) => {
+    const simIam = simAws.iam();
+
+    const creation = await simIam.createRole({
+      input: {
+        RoleName: input.roleName,
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: {
+              AWS: `arn:aws:iam::${simAws.defaultAccountId}:root`,
+            },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      },
+    });
+
+    await simIam.putRolePolicy({
+      input: {
+        RoleName: input.roleName,
+        PolicyName: input.policyName,
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: input.actions, Resource: input.resource },
+        }),
+      },
+    });
+
+    return creation.Role;
+  },
+);


### PR DESCRIPTION
TransactWriteItems applies up to 100 Put, Update, Delete and ConditionCheck actions in one step, and cancels the whole request with positional CancellationReasons when any condition fails. ClientRequestToken makes a retry idempotent for ten simulated minutes. TransactGetItems reads up to 100 items with a positional Responses array in which a missing item is an entry with no Item.

Resolves https://github.com/KensioSoftware/yulin/issues/261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DynamoDB transactional writes, including atomic Put, Update, Delete, and condition-check operations.
  * Added transactional reads with ordered responses, projections, and support for missing items.
  * Added conditional cancellation reasons, transaction limits, validation, IAM authorization, and idempotent retries.
  * Added simulated DynamoDB transaction errors for cancellation and parameter mismatches.
  * Added examples demonstrating transactional reads and writes.

* **Documentation**
  * Expanded DynamoDB documentation with transaction capabilities, limitations, authorization, and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->