### PR TITLE
feat: tag simulated DynamoDB tables

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -228,6 +228,106 @@ console.log(description.Table?.TableStatus); // "ACTIVE"
 
 `DeleteTable` takes the table's name or its ARN, as `DescribeTable` does.
 
+## Tagging tables
+
+A table is tagged by `CreateTable`, or afterwards by `TagResource`. `UntagResource` takes tags off,
+and `ListTagsOfResource` reads them back. The three tag commands name their resource by ARN, in
+`ResourceArn`, where the table commands take a name or an ARN.
+
+```typescript sim-dynamodb-tag-table
+/**
+ * Tagging a table on creation and afterwards, and reading the tags back.
+ */
+
+import {
+  CreateTableCommand,
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+const creation = await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    Tags: [{ Key: "Environment", Value: "test" }],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const tableArn = creation.TableDescription?.TableArn ?? "";
+
+await dynamoDb.tagResource(
+  new TagResourceCommand({
+    ResourceArn: tableArn,
+    Tags: [
+      { Key: "Owner", Value: "platform" },
+      // A key that is already there has its value replaced.
+      { Key: "Environment", Value: "staging" },
+    ],
+  }),
+);
+
+await dynamoDb.untagResource(
+  new UntagResourceCommand({ ResourceArn: tableArn, TagKeys: ["Owner"] }),
+);
+
+const { Tags } = await dynamoDb.listTagsOfResource(
+  new ListTagsOfResourceCommand({ ResourceArn: tableArn }),
+);
+
+console.log(Tags); // [{ Key: "Environment", Value: "staging" }]
+```
+
+`TagResource` and `UntagResource` answer with an empty body, so `ListTagsOfResource` is the only way
+to see what either did. Untagging a key that is not there is not an error: the request asks for a
+table without that key, and that is what it gets either way.
+
+The rules a tag is held to are DynamoDB's:
+
+- a key is 1 to 128 characters, and a value is 0 to 256, so a key with nothing to say about itself
+  is a tag with an empty value
+- both are written with letters, whitespace, digits and `+ - = . _ : /`, which is narrower than
+  the set some other AWS services take: there is no `@` in it
+- a key beginning `aws:` is refused, since that prefix is AWS's to assign
+- a resource holds 50 tags
+
+A request that breaks one of those is refused whole, so a call carrying one good tag and one bad one
+leaves the table's tags exactly as they were.
+
+`ListTagsOfResource` pages with `NextToken`, and leaves the token off the last page:
+
+```typescript
+const tags = [];
+let nextToken: string | undefined;
+
+do {
+  const page = await dynamoDb.listTagsOfResource(
+    new ListTagsOfResourceCommand({
+      ResourceArn: tableArn,
+      NextToken: nextToken,
+    }),
+  );
+
+  tags.push(...page.Tags);
+  nextToken = page.NextToken;
+} while (nextToken !== undefined);
+```
+
+A page carries 25 tags. The API has no page size parameter, so that number is this simulator's
+rather than DynamoDB's: it is half of the 50 a resource holds, so an ordinarily tagged table lists
+in one page and a test that wants to see a `NextToken` can reach one with 26 tags.
+
+An `AWS::DynamoDB::Table` template property of `Tags` is deployed the same way, so a CDK app calling
+`Tags.of(stack).add("Environment", "test")` gets a tagged table.
+
 ## Writing items
 
 `PutItem` writes one item, replacing the whole item under its primary key rather than merging into
@@ -1441,7 +1541,7 @@ would read as a working stream to whatever the template handed it to.
 
 A property with behaviour that is not simulated skips the resource, with a reason naming the
 property, and the rest of the stack still deploys: `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`,
-`TimeToLiveSpecification`, `Tags`, `StreamSpecification`, `KinesisStreamSpecification`,
+`TimeToLiveSpecification`, `StreamSpecification`, `KinesisStreamSpecification`,
 `SSESpecification`, `PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`,
 `ImportSourceSpecification`, `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property
 `AWS::DynamoDB::Table` does not have fails the resource instead, since that is a template real
@@ -1501,8 +1601,10 @@ nothing is written.
   `ClientRequestToken` making a retry idempotent for ten simulated minutes.
 - `TransactGetItems`, reading up to 100 items in one step, with a positional `Responses` array in
   which a missing item is an entry with no `Item`.
+- `Tags` on `CreateTable`, with `TagResource`, `UntagResource` and `ListTagsOfResource` addressing
+  the table by ARN, the key, value and count rules DynamoDB applies, and `NextToken` paging.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
-  table name and `Fn::GetAtt … Arn` the table ARN.
+  table name, `Fn::GetAtt … Arn` the table ARN, and `Tags` deploying a tagged table.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
 
 ## Limitations
@@ -1511,8 +1613,24 @@ nothing is written.
   `LocalSecondaryIndexes` are refused rather than dropped, since a table missing an index it was
   asked for would answer queries differently to the real one. An empty list asks for no index, so it
   is accepted.
-- Table tags are not simulated. A non-empty `Tags` list is refused rather than dropped, and there is
-  no `TagResource`, `UntagResource` or `ListTagsOfResource`.
+- Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent, so
+  a real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
+  with none. Here the change is there by the time the call returns, so a test cannot observe the
+  window a retry would be written for.
+- A `ListTagsOfResource` page carries 25 tags. The API has no page size parameter, so the number is
+  this simulator's choice rather than DynamoDB's, and a real page may hold a different number.
+- The 10 KB limit on the total size of a resource's tags is not enforced. The 50 tag count and the
+  key and value lengths are, and 50 tags of the greatest key and value length are over 10 KB, so a
+  set of tags real DynamoDB would refuse for its size is accepted here.
+- Exceeding the 50 tag limit is a `ValidationException`. Real DynamoDB documents
+  `LimitExceededException` for `TagResource`, but describes it entirely in terms of how many table
+  operations are running at once, which is a different thing from how many tags a table carries.
+- Tag based IAM condition keys are not simulated. `aws:RequestTag`, `aws:ResourceTag` and
+  `aws:TagKeys` are not evaluated, so a policy that allows tagging only under a particular key
+  allows all of it here.
+- Tables are the only taggable DynamoDB resource here. Backups and global table replicas are not
+  simulated, so an ARN naming one of those names nothing. Real DynamoDB also copies a table's tags
+  onto its secondary indexes, which have nothing to copy to yet.
 - Time to live is not simulated. There is no `UpdateTimeToLive` or `DescribeTimeToLive`, and no item
   expires.
 - DynamoDB streams are not simulated. A `StreamSpecification` with `StreamEnabled` set is refused,

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1526,7 +1526,7 @@ console.log(stack.outputs.get("OrdersTableArn")?.value);
 ```
 
 The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
-`ProvisionedThroughput`, `TableClass` and `DeletionProtectionEnabled`. Each one is passed to
+`ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled` and `Tags`. Each one is passed to
 `CreateTable` rather than applied here, so a value the template gets wrong fails the same way it
 would for an SDK caller.
 

--- a/docs/services/dynamodb/sim-dynamodb-tag-table.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-tag-table.example.ts
@@ -1,0 +1,49 @@
+/**
+ * Tagging a table on creation and afterwards, and reading the tags back.
+ */
+
+import {
+  CreateTableCommand,
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+const creation = await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    Tags: [{ Key: "Environment", Value: "test" }],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const tableArn = creation.TableDescription?.TableArn ?? "";
+
+await dynamoDb.tagResource(
+  new TagResourceCommand({
+    ResourceArn: tableArn,
+    Tags: [
+      { Key: "Owner", Value: "platform" },
+      // A key that is already there has its value replaced.
+      { Key: "Environment", Value: "staging" },
+    ],
+  }),
+);
+
+await dynamoDb.untagResource(
+  new UntagResourceCommand({ ResourceArn: tableArn, TagKeys: ["Owner"] }),
+);
+
+const { Tags } = await dynamoDb.listTagsOfResource(
+  new ListTagsOfResourceCommand({ ResourceArn: tableArn }),
+);
+
+console.log(Tags); // [{ Key: "Environment", Value: "staging" }]

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-table.loc.test.ts
@@ -1,11 +1,14 @@
 import {
   DescribeTableCommand,
   GetItemCommand,
+  ListTagsOfResourceCommand,
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
+  assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertObjectEquals,
   assertStringStartsWith,
   assertTypeString,
 } from "@kensio/smartass";
@@ -26,7 +29,7 @@ const accountIdOneOnes = "111111111111" as SimAwsAccountId;
 describe("Sim CDK DynamoDB Table deployment local integration", () => {
   it("deploys a CDK table an SDK caller then writes to and reads from", async () => {
     // Given a CDK stack with an unnamed on-demand table with a partition and a
-    // sort key.
+    // sort key, and a tag applied to everything in the stack.
     const cdkProject = new TestCdkProject();
     await cdkProject.writeCdkAppFile(
       `
@@ -43,6 +46,8 @@ const ordersTable = new dynamodb.Table(stack, "OrdersTable", {
   sortKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
   billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
 });
+
+cdk.Tags.of(stack).add("Environment", "test");
 
 new cdk.CfnOutput(stack, "OrdersTableName", {
   value: ordersTable.tableName,
@@ -97,6 +102,16 @@ app.synth();
       stack.outputs.get("OrdersTableArn")?.value,
       described.Table.TableArn,
     );
+
+    // And the tag the stack applied is on the table, since CDK puts it on
+    // every taggable Resource in the template.
+    const tags = await scoped.dynamoDb().listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: described.Table.TableArn,
+      }),
+    );
+    assertArrayLength(tags.Tags, 1);
+    assertObjectEquals(tags.Tags[0], { Key: "Environment", Value: "test" });
 
     // And an item written to it reads back off it.
     await scoped.dynamoDb().putItem(

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -51,6 +51,7 @@ Current command areas include:
 - `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
 - `batch/` (BatchWriteItem and BatchGetItem)
 - `transact/` (TransactWriteItems and TransactGetItems)
+- `tag/` (TagResource, UntagResource and ListTagsOfResource)
 
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
@@ -85,6 +86,7 @@ Table state lives under `table/`.
 - current table status
 - key schema and attribute definitions
 - billing mode, provisioned throughput, table class and deletion protection
+- tags
 - in-memory items
 
 A table is built from values that have already been checked, not from a command object. Anything
@@ -134,6 +136,40 @@ For a table with partition key `pk` and sort key `sk`, the internal key includes
 
 This is an implementation detail, but it is important when changing item storage because `putItem()`
 uses the key schema to overwrite items with the same primary key.
+
+## Tagging behavior
+
+`SimDynamoDbTableTags` is the tags one table holds, and `SimDynamoDbTableTag` is one of them. Every
+rule a tag is held to lives on the tag itself: the key and value lengths, the characters a tag is
+written with, and the reserved `aws:` prefix. A tag that arrived with CreateTable is checked the same
+way one from TagResource is, because it is the same class reading it.
+
+The 50 tag limit belongs to the collection rather than the tag, since it is about how many there are.
+Real DynamoDB answers it with a `ValidationException` rather than the `LimitExceededException` its
+API reference lists for TagResource, which is documented entirely in terms of how many table
+operations are running at once.
+
+A request is read whole before any of it is kept, so a call carrying one good tag and one bad one
+leaves the table's tags exactly as they were. `TagResource` replaces the value of a key that is
+already there, which is what makes it a way of changing a tag as well as adding one, and
+`UntagResource` takes a key that is not there in its stride: it asks for a state rather than a
+change.
+
+`SimDynamoDbTagCommands` implements all three commands. They reach their table through the same
+`SimDynamoDbTableAccess` every other command uses, so an ARN naming no table gives
+`SimDynamoDbResourceNotFoundException` and an unauthorized caller is refused before the lookup. Each
+authorizes the `dynamodb:` action of its own name.
+
+Unlike the table commands, a tag command takes an ARN only. A bare table name is refused rather than
+resolved, since real DynamoDB would refuse it too, and finding the table anyway would let a test pass
+on a request AWS rejects.
+
+`SimDynamoDbTagPage` pages ListTagsOfResource. The API has no page size parameter, so 25 is this
+simulator's choice: half of the 50 a resource holds, so an ordinarily tagged table lists in one page
+while a test can still reach a `NextToken`. As with ListTables, the token is the key to resume after
+rather than an opaque cursor, so it still works when the tag it names has since been removed. Tags
+are ordered by UTF-8 bytes, which is one of the orders DynamoDB allows and the one that makes paging
+resumable.
 
 ## Item and attribute model
 

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-tags.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-tags.iso.test.ts
@@ -1,7 +1,11 @@
-import { ListTagsOfResourceCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeTableCommand,
+  ListTagsOfResourceCommand,
+} from "@aws-sdk/client-dynamodb";
 import {
   assertArrayLength,
   assertInstanceOf,
+  assertNonNullable,
   assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -9,51 +13,28 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
-
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
-
-function simAwsInEuWest2(): SimAws {
-  return new SimAws({
-    defaultAccountId: accountIdOneOnes,
-    defaultRegionName: "eu-west-2",
-  });
-}
-
-/**
- * A table Resource with the properties every one of these tests needs.
- */
-function tableProperties(
-  tags: SimCfnTemplateValueRecord[],
-): SimCfnTemplateValueRecord {
-  return {
-    TableName: "orders",
-    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
-    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
-    BillingMode: "PAY_PER_REQUEST",
-    Tags: tags,
-  };
-}
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
 
 describe("DynamoDB CloudFormation Table tagging", () => {
   it("creates a table carrying the tags the template puts on it", async () => {
     // Given a template tagging its table, as a CDK app applying Tags.of does.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: tableProperties([
-              { Key: "Environment", Value: "test" },
-              { Key: "Owner", Value: "platform" },
-            ]),
-          },
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            properties: {
+              Tags: [
+                { Key: "Environment", Value: "test" },
+                { Key: "Owner", Value: "platform" },
+              ],
+            },
+          }),
         },
       },
     });
@@ -61,9 +42,14 @@ describe("DynamoDB CloudFormation Table tagging", () => {
     await simAws.backgroundTasksComplete();
 
     // Then the tags are on the table an SDK caller reads.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+    assertNonNullable(described.Table?.TableArn);
+
     const output = await simAws.dynamoDb().listTagsOfResource(
       new ListTagsOfResourceCommand({
-        ResourceArn: "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+        ResourceArn: described.Table.TableArn,
       }),
     );
 
@@ -74,7 +60,7 @@ describe("DynamoDB CloudFormation Table tagging", () => {
 
   it("fails the Resource for a tag DynamoDB would refuse", async () => {
     // Given a template tagging its table under the reserved aws: prefix.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const error = await assertThrowsErrorAsync(async () => {
@@ -82,12 +68,10 @@ describe("DynamoDB CloudFormation Table tagging", () => {
         stackName: "orders-stack",
         template: {
           Resources: {
-            OrdersTable: {
-              Type: "AWS::DynamoDB::Table",
-              Properties: tableProperties([
-                { Key: "aws:owner", Value: "platform" },
-              ]),
-            },
+            OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+              tableName: "orders",
+              properties: { Tags: [{ Key: "aws:owner", Value: "platform" }] },
+            }),
           },
         },
       });

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-tags.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-tags.iso.test.ts
@@ -1,0 +1,104 @@
+import { ListTagsOfResourceCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+function simAwsInEuWest2(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountIdOneOnes,
+    defaultRegionName: "eu-west-2",
+  });
+}
+
+/**
+ * A table Resource with the properties every one of these tests needs.
+ */
+function tableProperties(
+  tags: SimCfnTemplateValueRecord[],
+): SimCfnTemplateValueRecord {
+  return {
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    Tags: tags,
+  };
+}
+
+describe("DynamoDB CloudFormation Table tagging", () => {
+  it("creates a table carrying the tags the template puts on it", async () => {
+    // Given a template tagging its table, as a CDK app applying Tags.of does.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: {
+            Type: "AWS::DynamoDB::Table",
+            Properties: tableProperties([
+              { Key: "Environment", Value: "test" },
+              { Key: "Owner", Value: "platform" },
+            ]),
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the tags are on the table an SDK caller reads.
+    const output = await simAws.dynamoDb().listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+      }),
+    );
+
+    assertArrayLength(output.Tags, 2);
+    assertObjectEquals(output.Tags[0], { Key: "Environment", Value: "test" });
+    assertObjectEquals(output.Tags[1], { Key: "Owner", Value: "platform" });
+  });
+
+  it("fails the Resource for a tag DynamoDB would refuse", async () => {
+    // Given a template tagging its table under the reserved aws: prefix.
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersTable: {
+              Type: "AWS::DynamoDB::Table",
+              Properties: tableProperties([
+                { Key: "aws:owner", Value: "platform" },
+              ]),
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the table fails rather than being skipped, since the template is
+    // wrong rather than the simulation stopping short. CreateTable is what
+    // refuses it, so the reason is the one an SDK caller would read.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "begins with the reserved aws: prefix");
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
@@ -10,16 +10,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-
-/**
- * The key schema and definitions a valid table carries, so a test can change
- * one property without restating the rest.
- */
-const validKeyProperties = {
-  KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-  AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-  BillingMode: "PAY_PER_REQUEST",
-};
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
 
 describe("DynamoDB CloudFormation Table validation", () => {
   it("fails a table the CreateTable rules refuse", async () => {
@@ -33,17 +24,14 @@ describe("DynamoDB CloudFormation Table validation", () => {
         stackName: "orders-stack",
         template: {
           Resources: {
-            OrdersTable: {
-              Type: "AWS::DynamoDB::Table",
-              Properties: {
-                TableName: "orders",
-                KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+            OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+              tableName: "orders",
+              properties: {
                 AttributeDefinitions: [
                   { AttributeName: "customerId", AttributeType: "S" },
                 ],
-                BillingMode: "PAY_PER_REQUEST",
               },
-            },
+            }),
           },
         },
       });
@@ -72,17 +60,15 @@ describe("DynamoDB CloudFormation Table validation", () => {
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              ...validKeyProperties,
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            properties: {
               TimeToLiveSpecification: {
                 AttributeName: "expiresAt",
                 Enabled: true,
               },
             },
-          },
+          }),
           OrdersBucket: { Type: "AWS::S3::Bucket" },
         },
       },
@@ -116,8 +102,10 @@ describe("DynamoDB CloudFormation Table validation", () => {
       template: {
         Resources: {
           OrdersTable: {
+            ...simCfnDynamoDbTableResourceFactory.make({
+              tableName: "orders",
+            }),
             Type: "AWS::DynamoDB::GlobalTable",
-            Properties: { TableName: "orders", ...validKeyProperties },
           },
         },
       },
@@ -147,14 +135,12 @@ describe("DynamoDB CloudFormation Table validation", () => {
       template: {
         Parameters: { TableProtected: { Type: "String" } },
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              ...validKeyProperties,
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            properties: {
               DeletionProtectionEnabled: { Ref: "TableProtected" },
             },
-          },
+          }),
         },
       },
     });
@@ -177,14 +163,12 @@ describe("DynamoDB CloudFormation Table validation", () => {
       template: {
         Parameters: { TableProtected: { Type: "String" } },
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              ...validKeyProperties,
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            properties: {
               DeletionProtectionEnabled: { Ref: "TableProtected" },
             },
-          },
+          }),
         },
       },
     });

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
@@ -14,36 +14,18 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
-
-function simAwsInEuWest2(): SimAws {
-  return new SimAws({
-    defaultAccountId: accountIdOneOnes,
-    defaultRegionName: "eu-west-2",
-  });
-}
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
 
 /**
- * A template holding one on-demand table with a partition and a sort key.
+ * A template holding one unnamed on-demand table with a partition and a sort
+ * key.
  */
 const ordersTableTemplate = {
   Resources: {
-    OrdersTable: {
-      Type: "AWS::DynamoDB::Table",
-      Properties: {
-        KeySchema: [
-          { AttributeName: "customerId", KeyType: "HASH" },
-          { AttributeName: "orderId", KeyType: "RANGE" },
-        ],
-        AttributeDefinitions: [
-          { AttributeName: "customerId", AttributeType: "S" },
-          { AttributeName: "orderId", AttributeType: "S" },
-        ],
-        BillingMode: "PAY_PER_REQUEST",
-      },
-    },
+    OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+      partitionKeyName: "customerId",
+      sortKeyName: "orderId",
+    }),
   },
   Outputs: {
     OrdersTableName: { Value: { Ref: "OrdersTable" } },
@@ -53,30 +35,22 @@ const ordersTableTemplate = {
 describe("DynamoDB CloudFormation Table deployment", () => {
   it("creates a table carrying the key schema and attribute definitions", async () => {
     // Given a template declaring a named table.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              KeySchema: [
-                { AttributeName: "customerId", KeyType: "HASH" },
-                { AttributeName: "orderId", KeyType: "RANGE" },
-              ],
-              AttributeDefinitions: [
-                { AttributeName: "customerId", AttributeType: "S" },
-                { AttributeName: "orderId", AttributeType: "S" },
-              ],
-              BillingMode: "PAY_PER_REQUEST",
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            partitionKeyName: "customerId",
+            sortKeyName: "orderId",
+            properties: {
               TableClass: "STANDARD_INFREQUENT_ACCESS",
               DeletionProtectionEnabled: true,
             },
-          },
+          }),
         },
       },
     });
@@ -96,7 +70,8 @@ describe("DynamoDB CloudFormation Table deployment", () => {
     assertIdentical(described.Table.TableStatus, "ACTIVE");
     assertIdentical(
       described.Table.TableArn,
-      "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+      `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:table/orders`,
     );
     assertIdentical(
       described.Table.KeySchema.at(0)?.AttributeName,
@@ -121,28 +96,23 @@ describe("DynamoDB CloudFormation Table deployment", () => {
   it("provisions a table with the throughput the template sets", async () => {
     // Given a template asking for provisioned capacity, as CDK emits for a
     // table with no billing mode of its own.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-              AttributeDefinitions: [
-                { AttributeName: "id", AttributeType: "S" },
-              ],
-              BillingMode: "PROVISIONED",
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            billingMode: "PROVISIONED",
+            properties: {
               ProvisionedThroughput: {
                 ReadCapacityUnits: 5,
                 WriteCapacityUnits: 3,
               },
             },
-          },
+          }),
         },
       },
     });
@@ -164,7 +134,7 @@ describe("DynamoDB CloudFormation Table deployment", () => {
   it("provisions capacity a template Parameter supplies as a string", async () => {
     // Given a template taking its read capacity from a Parameter, which
     // resolves to a string rather than the number a literal property carries.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed with a value for it.
     const stack = await simAws.cloudFormation().deployTemplate({
@@ -173,6 +143,9 @@ describe("DynamoDB CloudFormation Table deployment", () => {
       template: {
         Parameters: { TableReadCapacity: { Type: "Number" } },
         Resources: {
+          // Written out rather than built, since this is the one table here
+          // with no BillingMode at all: the Parameter resolves into the
+          // provisioned capacity CreateTable then defaults to.
           OrdersTable: {
             Type: "AWS::DynamoDB::Table",
             Properties: {
@@ -205,24 +178,16 @@ describe("DynamoDB CloudFormation Table deployment", () => {
 
   it("resolves Ref to the table name and Fn::GetAtt Arn to the table ARN", async () => {
     // Given a template referencing its table both ways.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-              AttributeDefinitions: [
-                { AttributeName: "id", AttributeType: "S" },
-              ],
-              BillingMode: "PAY_PER_REQUEST",
-            },
-          },
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+          }),
         },
         Outputs: {
           TableRef: { Value: { Ref: "OrdersTable" } },
@@ -235,15 +200,19 @@ describe("DynamoDB CloudFormation Table deployment", () => {
     // Then Ref is the table name, as AWS::DynamoDB::Table Ref is, so it can be
     // handed straight to PutItem.
     assertIdentical(stack.outputs.get("TableRef")?.value, "orders");
+
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
     assertIdentical(
       stack.outputs.get("TableArn")?.value,
-      "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+      described.Table?.TableArn,
     );
   });
 
   it("writes and reads an item through the table a Ref names", async () => {
     // Given a deployed table whose name the stack outputs.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
       template: ordersTableTemplate,
@@ -279,7 +248,7 @@ describe("DynamoDB CloudFormation Table deployment", () => {
   it("names an unnamed table after the stack and its logical ID", async () => {
     // Given a template leaving TableName out, as CDK does for a table with no
     // explicit name.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await simAws.cloudFormation().deployTemplate({
@@ -299,7 +268,7 @@ describe("DynamoDB CloudFormation Table deployment", () => {
 
   it("gives two stacks deploying one template two differently named tables", async () => {
     // Given one template with no TableName in it, deployed twice.
-    const simAws = simAwsInEuWest2();
+    const simAws = new SimAws();
 
     // When both stacks are deployed.
     const first = await simAws.cloudFormation().deployTemplate({
@@ -336,17 +305,9 @@ describe("DynamoDB CloudFormation Table deployment", () => {
       stackName: "orders-stack",
       template: {
         Resources: {
-          OrdersTable: {
-            Type: "AWS::DynamoDB::Table",
-            Properties: {
-              TableName: "orders",
-              KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-              AttributeDefinitions: [
-                { AttributeName: "id", AttributeType: "S" },
-              ],
-              BillingMode: "PAY_PER_REQUEST",
-            },
-          },
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+          }),
         },
         Outputs: {
           TableArn: { Value: { "Fn::GetAtt": ["OrdersTable", "Arn"] } },

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -49,6 +49,7 @@ export class SimCfnDynamoDbTableCreator {
         ProvisionedThroughput: tableProperties.provisionedThroughput(),
         TableClass: tableProperties.tableClass(),
         DeletionProtectionEnabled: tableProperties.deletionProtectionEnabled(),
+        Tags: tableProperties.tags(),
       },
     });
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-properties.ts
@@ -1,0 +1,66 @@
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The key a template gives its table, as the attributes it is made of.
+ */
+export interface SimCfnDynamoDbTableKey {
+  readonly partitionKeyName: string;
+  readonly partitionKeyType: string;
+  readonly sortKeyName: string | undefined;
+  readonly sortKeyType: string;
+}
+
+/**
+ * One attribute a table's key is made of.
+ */
+interface SimCfnDynamoDbTableKeyAttribute {
+  readonly name: string;
+  readonly type: string;
+  readonly keyType: string;
+}
+
+/**
+ * The `KeySchema` and `AttributeDefinitions` properties of a table's key.
+ *
+ * A template states the key in two places and has to keep them in step, which
+ * is a thing a test writing a template out by hand gets wrong. Building both
+ * from the same attributes is what keeps them together.
+ */
+export function simCfnDynamoDbTableKeyProperties(
+  key: SimCfnDynamoDbTableKey,
+): SimCfnTemplateValueRecord {
+  const attributes = keyAttributes(key);
+
+  return {
+    KeySchema: attributes.map((attribute) => ({
+      AttributeName: attribute.name,
+      KeyType: attribute.keyType,
+    })),
+    AttributeDefinitions: attributes.map((attribute) => ({
+      AttributeName: attribute.name,
+      AttributeType: attribute.type,
+    })),
+  };
+}
+
+/**
+ * The attributes the key is made of, in key schema order.
+ */
+function keyAttributes(
+  key: SimCfnDynamoDbTableKey,
+): readonly SimCfnDynamoDbTableKeyAttribute[] {
+  const partitionKey = {
+    name: key.partitionKeyName,
+    type: key.partitionKeyType,
+    keyType: "HASH",
+  };
+
+  if (key.sortKeyName === undefined) {
+    return [partitionKey];
+  }
+
+  return [
+    partitionKey,
+    { name: key.sortKeyName, type: key.sortKeyType, keyType: "RANGE" },
+  ];
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.iso.test.ts
@@ -6,31 +6,22 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
-import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceFactory } from "../../../cloudformation/resource/sim-cfn-resource.factory.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimDynamoDbCfnResourceFactory } from "../sim-cfn-dynamodb-resource-factory.js";
-
-const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+import { simCfnDynamoDbTableResourceFactory } from "./sim-cfn-dynamodb-table-resource.factory.js";
 
 /**
- * The key schema and definitions a valid table carries, so a test can change
- * one property without restating the rest.
+ * A table Resource with one property broken, which is what each of these tests
+ * is about. Everything else comes from the factory, so a test states the
+ * property it is breaking and nothing else.
  */
-const validKeyProperties = {
-  KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-  AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-  BillingMode: "PAY_PER_REQUEST",
-};
-
-function tableResource(properties: SimCfnTemplateValueRecord): SimCfnResource {
-  return new SimCfnResource({
-    accountRegionScope: {
-      accountId: accountIdOneOnes,
-      regionName: "eu-west-2",
-    },
-    logicalId: "BadTable",
-    template: { Type: "AWS::DynamoDB::Table", Properties: properties },
+function tableBreaking(
+  properties: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return simCfnDynamoDbTableResourceFactory.make({
+    tableName: "orders",
+    properties,
   });
 }
 
@@ -39,7 +30,7 @@ function tableResource(properties: SimCfnTemplateValueRecord): SimCfnResource {
  * rejects with. Keeps the property reading under test without a whole stack.
  */
 async function createTableResource(
-  properties: SimCfnTemplateValueRecord,
+  template: SimCfnTemplateValueRecord,
 ): Promise<Error> {
   const simAws = new SimAws();
   const factory = new SimDynamoDbCfnResourceFactory({
@@ -47,10 +38,11 @@ async function createTableResource(
   });
 
   return await assertThrowsErrorAsync(async () => {
-    return await factory.create("Table", tableResource(properties), {
-      simAws,
-      resources: new Map(),
-    });
+    return await factory.create(
+      "Table",
+      simCfnResourceFactory.make({ logicalId: "BadTable", template }),
+      { simAws, resources: new Map() },
+    );
   });
 }
 
@@ -58,10 +50,11 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a TableName that is not a string", async () => {
     // Given a template carrying something other than a name as TableName.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: 42,
-      ...validKeyProperties,
-    });
+    const error = await createTableResource(
+      simCfnDynamoDbTableResourceFactory.make({
+        properties: { TableName: 42 },
+      }),
+    );
 
     assertIdentical(
       error.message,
@@ -73,11 +66,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a KeySchema that is not a list", async () => {
     // Given a template carrying an object where the key schema list belongs.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: { AttributeName: "id", KeyType: "HASH" },
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-    });
+    const error = await createTableResource(
+      tableBreaking({ KeySchema: { AttributeName: "id", KeyType: "HASH" } }),
+    );
 
     assertIdentical(
       error.message,
@@ -90,11 +81,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // Given a template carrying a plain string where a key schema element
     // belongs.
     // When the Resource is created, then the refusal names the position.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: ["id"],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-    });
+    const error = await createTableResource(
+      tableBreaking({ KeySchema: ["id"] }),
+    );
 
     assertIdentical(
       error.message,
@@ -106,11 +95,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a key schema attribute name that is not a string", async () => {
     // Given a template carrying a number where an attribute name belongs.
     // When the Resource is created, then the refusal names the property path.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: 1, KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-    });
+    const error = await createTableResource(
+      tableBreaking({ KeySchema: [{ AttributeName: 1, KeyType: "HASH" }] }),
+    );
 
     assertIdentical(
       error.message,
@@ -122,11 +109,11 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses an attribute definition type that is not a string", async () => {
     // Given a template carrying a number where an attribute type belongs.
     // When the Resource is created, then the refusal names the property path.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: 3 }],
-    });
+    const error = await createTableResource(
+      tableBreaking({
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: 3 }],
+      }),
+    );
 
     assertIdentical(
       error.message,
@@ -138,12 +125,7 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a BillingMode that is not a string", async () => {
     // Given a template carrying a number where the billing mode belongs.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      BillingMode: 1,
-    });
+    const error = await createTableResource(tableBreaking({ BillingMode: 1 }));
 
     assertIdentical(
       error.message,
@@ -155,11 +137,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a TableClass that is not a string", async () => {
     // Given a template carrying a list where the table class belongs.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: "orders",
-      ...validKeyProperties,
-      TableClass: ["STANDARD"],
-    });
+    const error = await createTableResource(
+      tableBreaking({ TableClass: ["STANDARD"] }),
+    );
 
     assertIdentical(
       error.message,
@@ -171,12 +151,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
   it("refuses a ProvisionedThroughput that is not an object", async () => {
     // Given a template carrying a number where the throughput object belongs.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: 5,
-    });
+    const error = await createTableResource(
+      tableBreaking({ ProvisionedThroughput: 5 }),
+    );
 
     assertIdentical(
       error.message,
@@ -189,15 +166,14 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // Given a template carrying a word where a capacity belongs.
     // When the Resource is created, then it is refused rather than read as
     // nothing, which would look like a missing capacity instead.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: "plenty",
-        WriteCapacityUnits: 1,
-      },
-    });
+    const error = await createTableResource(
+      tableBreaking({
+        ProvisionedThroughput: {
+          ReadCapacityUnits: "plenty",
+          WriteCapacityUnits: 1,
+        },
+      }),
+    );
 
     assertIdentical(
       error.message,
@@ -210,15 +186,14 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // Given a template carrying whitespace where a capacity belongs, which
     // Number() would otherwise read as zero.
     // When the Resource is created, then it is refused.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: "  ",
-      },
-    });
+    const error = await createTableResource(
+      tableBreaking({
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 1,
+          WriteCapacityUnits: "  ",
+        },
+      }),
+    );
 
     assertIdentical(
       error.message,
@@ -231,11 +206,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // Given a template carrying something else as DeletionProtectionEnabled.
     // When the Resource is created, then it is refused rather than read as
     // false, since a table left unprotected is the wrong way to fail.
-    const error = await createTableResource({
-      TableName: "orders",
-      ...validKeyProperties,
-      DeletionProtectionEnabled: "yes",
-    });
+    const error = await createTableResource(
+      tableBreaking({ DeletionProtectionEnabled: "yes" }),
+    );
 
     assertIdentical(
       error.message,
@@ -248,7 +221,12 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // Given a template with no KeySchema in it at all.
     // When the Resource is created, then the refusal is the one CreateTable
     // gives, rather than a second wording for the same missing property.
-    const error = await createTableResource({ TableName: "orders" });
+    // Written out rather than built, since the factory always gives a table a
+    // key and this is the table without one.
+    const error = await createTableResource({
+      Type: "AWS::DynamoDB::Table",
+      Properties: { TableName: "orders" },
+    });
 
     assertStringIncludes(
       error.message,
@@ -257,14 +235,14 @@ describe("AWS::DynamoDB::Table property reading", () => {
   });
 
   it("leaves a half-filled ProvisionedThroughput for CreateTable to refuse", async () => {
-    // Given a template naming a read capacity and no write capacity.
+    // Given a provisioned table naming a read capacity and no write capacity.
     // When the Resource is created, then CreateTable refuses the missing one.
-    const error = await createTableResource({
-      TableName: "orders",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: { ReadCapacityUnits: 5 },
-    });
+    const error = await createTableResource(
+      tableBreaking({
+        BillingMode: "PROVISIONED",
+        ProvisionedThroughput: { ReadCapacityUnits: 5 },
+      }),
+    );
 
     assertStringIncludes(
       error.message,
@@ -277,11 +255,9 @@ describe("AWS::DynamoDB::Table property reading", () => {
     // which real CloudFormation refuses too.
     // When the Resource is created, then it is refused rather than skipped:
     // nothing is missing from the simulation, the template is wrong.
-    const error = await createTableResource({
-      TableName: "orders",
-      ...validKeyProperties,
-      ReadCapacityUnits: 5,
-    });
+    const error = await createTableResource(
+      tableBreaking({ ReadCapacityUnits: 5 }),
+    );
 
     assertIdentical(
       error.message,

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -5,6 +5,7 @@ import type {
   SimDynamoDbAttributeDefinitionInput,
   SimDynamoDbKeySchemaElementInput,
   SimDynamoDbProvisionedThroughput,
+  SimDynamoDbTagInput,
 } from "../../command/table/table.types.js";
 import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
 import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
@@ -116,6 +117,19 @@ export class SimCfnDynamoDbTableProperties {
    */
   tableClass(): string | undefined {
     return this.values.string("TableClass");
+  }
+
+  /**
+   * The tags the template puts on the table.
+   *
+   * A CDK app calling `Tags.of(stack).add(...)` puts these on every taggable
+   * Resource in the template, so a tagged table is the ordinary case rather
+   * than an unusual one.
+   */
+  tags(): readonly SimDynamoDbTagInput[] {
+    return this.values.list("Tags").map((tag) => {
+      return { Key: tag.string("Key"), Value: tag.string("Value") };
+    });
   }
 
   /**

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -15,6 +15,7 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "ProvisionedThroughput",
   "TableClass",
   "TableName",
+  "Tags",
 ]);
 
 /**
@@ -36,7 +37,6 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ResourcePolicy",
   "SSESpecification",
   "StreamSpecification",
-  "Tags",
   "TimeToLiveSpecification",
   "WarmThroughput",
 ]);

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-resource.factory.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-resource.factory.ts
@@ -1,0 +1,82 @@
+import { MappedFactory } from "@kensio/part-factory";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnDynamoDbTableKeyProperties } from "./sim-cfn-dynamodb-table-key-properties.js";
+
+/**
+ * What a test asks for when it wants an `AWS::DynamoDB::Table` Resource.
+ *
+ * A table is mostly its name and its key, and the rest of the Resource is the
+ * same every time. `properties` is what the template says beyond that, and it
+ * is applied last, so a test that needs a property of its own states that one
+ * property rather than the whole Resource.
+ */
+export interface SimCfnDynamoDbTableResourceInput {
+  /**
+   * The name the template gives the table, where nothing leaves `TableName`
+   * out, as CDK does for a table it lets CloudFormation name.
+   */
+  readonly tableName: string | undefined;
+  readonly partitionKeyName: string;
+  readonly partitionKeyType: string;
+
+  /**
+   * The sort key the table has, where nothing gives it a partition key alone.
+   */
+  readonly sortKeyName: string | undefined;
+  readonly sortKeyType: string;
+  readonly billingMode: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Builds the `AWS::DynamoDB::Table` Resource a template carries.
+ *
+ * ```typescript
+ * template: {
+ *   Resources: {
+ *     OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+ *       tableName: "orders",
+ *       properties: { Tags: [{ Key: "Environment", Value: "test" }] },
+ *     }),
+ *   },
+ * }
+ * ```
+ *
+ * Nothing here decides what a property is allowed to be. The Resource is
+ * deployed through the ordinary CloudFormation path, so a value this builds is
+ * checked by the same CreateTable rules an SDK caller's table is.
+ */
+export const simCfnDynamoDbTableResourceFactory = new MappedFactory<
+  SimCfnDynamoDbTableResourceInput,
+  SimCfnTemplateValueRecord
+>(
+  () => ({
+    tableName: undefined,
+    partitionKeyName: "id",
+    partitionKeyType: "S",
+    sortKeyName: undefined,
+    sortKeyType: "S",
+    billingMode: "PAY_PER_REQUEST",
+    properties: {},
+  }),
+  (input) => ({
+    Type: "AWS::DynamoDB::Table",
+    Properties: {
+      ...namedBy(input.tableName),
+      ...simCfnDynamoDbTableKeyProperties(input),
+      BillingMode: input.billingMode,
+      ...input.properties,
+    },
+  }),
+);
+
+/**
+ * The `TableName` property, for a template that names its table.
+ */
+function namedBy(tableName: string | undefined): SimCfnTemplateValueRecord {
+  if (tableName === undefined) {
+    return {};
+  }
+
+  return { TableName: tableName };
+}

--- a/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
@@ -1,0 +1,81 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimDynamoDbTableStore } from "../table/sim-dynamodb-table-store.js";
+import { SimDynamoDbAuthorizer } from "./authorize/sim-dynamodb-authorizer.js";
+import { SimDynamoDbBatchGetItem } from "./batch/sim-dynamodb-batch-get-item.js";
+import { SimDynamoDbBatchWriteItem } from "./batch/sim-dynamodb-batch-write-item.js";
+import { SimDynamoDbDeleteItem } from "./item/sim-dynamodb-delete-item.js";
+import { SimDynamoDbGetItem } from "./item/sim-dynamodb-get-item.js";
+import { SimDynamoDbPutItem } from "./item/sim-dynamodb-put-item.js";
+import { SimDynamoDbUpdateItem } from "./item/sim-dynamodb-update-item.js";
+import { SimDynamoDbTagCommands } from "./tag/sim-dynamodb-tag-commands.js";
+import { SimDynamoDbCreateTable } from "./table/sim-dynamodb-create-table.js";
+import { SimDynamoDbTableAccess } from "./table/sim-dynamodb-table-access.js";
+import { SimDynamoDbTableCommands } from "./table/sim-dynamodb-table-commands.js";
+import { SimDynamoDbTransactGetItems } from "./transact/sim-dynamodb-transact-get-items.js";
+import { SimDynamoDbTransactWriteItems } from "./transact/sim-dynamodb-transact-write-items.js";
+
+interface SimDynamoDbCommandHandlersProperties {
+  readonly tables: SimDynamoDbTableStore;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The command handlers of one simulated DynamoDB, grouped by what they work on.
+ *
+ * Every one of them authorizes against the same IAM and reaches the same table
+ * store, so they are wired together here rather than one at a time in the
+ * service facade. That keeps `SimDynamoDb` what it should be: state plus
+ * delegation.
+ */
+export class SimDynamoDbCommandHandlers {
+  public readonly access: SimDynamoDbTableAccess;
+  public readonly tableCreation: SimDynamoDbCreateTable;
+  public readonly tables: SimDynamoDbTableCommands;
+  public readonly itemWrites: SimDynamoDbPutItem;
+  public readonly itemReads: SimDynamoDbGetItem;
+  public readonly itemDeletions: SimDynamoDbDeleteItem;
+  public readonly itemUpdates: SimDynamoDbUpdateItem;
+  public readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
+  public readonly itemBatchReads: SimDynamoDbBatchGetItem;
+  public readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
+  public readonly itemTransactReads: SimDynamoDbTransactGetItems;
+  public readonly tags: SimDynamoDbTagCommands;
+
+  constructor(properties: SimDynamoDbCommandHandlersProperties) {
+    const { tables, accountRegionScope, background } = properties;
+    const authorizer = new SimDynamoDbAuthorizer({
+      iam: properties.iam,
+      accountRegionScope,
+    });
+    const access = new SimDynamoDbTableAccess({
+      tables,
+      authorizer,
+      accountRegionScope,
+    });
+
+    this.access = access;
+    this.tableCreation = new SimDynamoDbCreateTable({
+      tables,
+      authorizer,
+      accountRegionScope,
+      background,
+    });
+    this.tables = new SimDynamoDbTableCommands({ tables, access, background });
+    this.itemWrites = new SimDynamoDbPutItem({ access });
+    this.itemReads = new SimDynamoDbGetItem({ access });
+    this.itemDeletions = new SimDynamoDbDeleteItem({ access });
+    this.itemUpdates = new SimDynamoDbUpdateItem({ access });
+    this.itemBatchWrites = new SimDynamoDbBatchWriteItem({ access });
+    this.itemBatchReads = new SimDynamoDbBatchGetItem({ access });
+    this.itemTransactWrites = new SimDynamoDbTransactWriteItems({
+      access,
+      clock: background,
+    });
+    this.itemTransactReads = new SimDynamoDbTransactGetItems({ access });
+    this.tags = new SimDynamoDbTagCommands({ access });
+  }
+}

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
@@ -9,6 +9,7 @@ import { simDynamoDbTableArn } from "../../table/sim-dynamodb-table-arn.js";
 import { SimDynamoDbTableBilling } from "../../table/sim-dynamodb-table-billing.js";
 import { readSimDynamoDbTableClass } from "../../table/sim-dynamodb-table-class.js";
 import { SimDynamoDbTableName } from "../../table/sim-dynamodb-table-name.js";
+import { SimDynamoDbTableTags } from "../../table/sim-dynamodb-table-tags.js";
 import type { SimDynamoDbTableStore } from "../../table/sim-dynamodb-table-store.js";
 import type { SimDynamoDbAuthorizer } from "../authorize/sim-dynamodb-authorizer.js";
 import type {
@@ -125,6 +126,7 @@ export class SimDynamoDbCreateTable {
       billing: SimDynamoDbTableBilling.fromInput(input),
       tableClass: readSimDynamoDbTableClass(input.TableClass),
       deletionProtectionEnabled: input.DeletionProtectionEnabled,
+      tags: SimDynamoDbTableTags.fromInput(input.Tags),
       background: this.background,
     });
   }

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
@@ -54,18 +54,6 @@ describe("DynamoDB CreateTableCommand unsimulated input", () => {
     assertStringIncludes(error.message, "Local secondary indexes");
   });
 
-  it("refuses tags", async () => {
-    // When a table is created with tags.
-    const error = await refusedCreateTable({
-      ...tableInput,
-      Tags: [{ Key: "team", Value: "platform" }],
-    });
-
-    // Then the tags are refused rather than dropped.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "Table tags");
-  });
-
   it("refuses a stream specification", async () => {
     // When a table is created with a stream.
     const error = await refusedCreateTable({

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
@@ -10,15 +10,14 @@ import type { SimCreateTableCommandInput } from "./table.command.js";
  * would outlive a time to live that was never applied. Refusing is the louder
  * failure, and the one that happens here rather than in a deployment.
  *
- * Only input that asks for something is refused. An empty index or tag list,
- * and a stream or encryption specification that is switched off, describe the
- * table this simulation already makes, so they are let through.
+ * Only input that asks for something is refused. An empty index list, and a
+ * stream or encryption specification that is switched off, describe the table
+ * this simulation already makes, so they are let through.
  */
 export function refuseUnsimulatedTableInput(
   input: SimCreateTableCommandInput,
 ): void {
   refuseSecondaryIndexes(input);
-  refuseTags(input);
   refuseStreams(input);
   refuseEncryption(input);
   refuseThroughputExtras(input);
@@ -47,18 +46,6 @@ function refuseSecondaryIndexes(input: SimCreateTableCommandInput): void {
     throw new SimDynamoDbUnsupportedOperation(
       "Local secondary indexes are not simulated, so CreateTable refuses " +
         "them rather than creating a table that is missing them",
-    );
-  }
-}
-
-/**
- * Refuse tags a table would be found and billed by.
- */
-function refuseTags(input: SimCreateTableCommandInput): void {
-  if ((input.Tags ?? []).length > 0) {
-    throw new SimDynamoDbUnsupportedOperation(
-      "Table tags are not simulated, so CreateTable refuses them rather than " +
-        "dropping them",
     );
   }
 }

--- a/src/service/dynamodb/command/table/table.command.ts
+++ b/src/service/dynamodb/command/table/table.command.ts
@@ -8,7 +8,7 @@ import type {
   SimDynamoDbSseSpecification,
   SimDynamoDbStreamSpecification,
   SimDynamoDbTableDescription,
-  SimDynamoDbTag,
+  SimDynamoDbTagInput,
   SimDynamoDbWarmThroughput,
 } from "./table.types.js";
 
@@ -39,7 +39,7 @@ export interface SimCreateTableCommandInput {
     readonly SimDynamoDbSecondaryIndexInput[] | undefined;
   readonly LocalSecondaryIndexes?:
     readonly SimDynamoDbSecondaryIndexInput[] | undefined;
-  readonly Tags?: readonly SimDynamoDbTag[] | undefined;
+  readonly Tags?: readonly SimDynamoDbTagInput[] | undefined;
   readonly StreamSpecification?: SimDynamoDbStreamSpecification | undefined;
   readonly SSESpecification?: SimDynamoDbSseSpecification | undefined;
   readonly ResourcePolicy?: string | undefined;

--- a/src/service/dynamodb/command/table/table.types.ts
+++ b/src/service/dynamodb/command/table/table.types.ts
@@ -87,11 +87,21 @@ export interface SimDynamoDbTableClassSummary {
 }
 
 /**
- * Minimal structural sim DynamoDB tag.
+ * Minimal structural sim DynamoDB tag, as a request carries it.
  */
-export interface SimDynamoDbTag {
+export interface SimDynamoDbTagInput {
   readonly Key?: string | undefined;
   readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB tag, as a resource reports it.
+ *
+ * A tag that is held has both halves, where a request may be missing either.
+ */
+export interface SimDynamoDbTag {
+  readonly Key: string;
+  readonly Value: string;
 }
 
 /**

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-commands.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-commands.ts
@@ -1,0 +1,112 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { SimDynamoDbTagPage } from "./sim-dynamodb-tag-page.js";
+import {
+  reachSimDynamoDbTagResource,
+  readSimDynamoDbTagKeys,
+  readSimDynamoDbTags,
+} from "./sim-dynamodb-tag-request.js";
+import type {
+  SimListTagsOfResourceCommand,
+  SimListTagsOfResourceCommandOutput,
+  SimTagResourceCommand,
+  SimTagResourceCommandOutput,
+  SimUntagResourceCommand,
+  SimUntagResourceCommandOutput,
+} from "./tag.command.js";
+
+interface SimDynamoDbTagCommandsProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbTagCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that tag, untag and list the tags of a resource.
+ *
+ * All three name their resource by ARN, and all three reach it the same way, so
+ * an ARN naming no table gives ResourceNotFoundException and an unauthorized
+ * caller is refused before the lookup. Each authorizes the `dynamodb:` action of
+ * its own name.
+ */
+export class SimDynamoDbTagCommands {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbTagCommandsProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Add tags to a resource, replacing the value of any key already there.
+   *
+   * The answer is empty, as DynamoDB's is, so ListTagsOfResource is how a
+   * caller sees what this did.
+   */
+  tagResource(
+    command: SimTagResourceCommand,
+    options?: SimDynamoDbTagCommandsOptions,
+  ): SimTagResourceCommandOutput {
+    const table = reachSimDynamoDbTagResource({
+      access: this.access,
+      action: "dynamodb:TagResource",
+      resourceArn: command.input.ResourceArn,
+      caller: options?.caller,
+    });
+
+    table.tags.apply(readSimDynamoDbTags(command.input.Tags));
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Take tags off a resource.
+   *
+   * A key that is not there is not an error: the request asks for a resource
+   * without that key, and that is what it gets either way.
+   */
+  untagResource(
+    command: SimUntagResourceCommand,
+    options?: SimDynamoDbTagCommandsOptions,
+  ): SimUntagResourceCommandOutput {
+    const table = reachSimDynamoDbTagResource({
+      access: this.access,
+      action: "dynamodb:UntagResource",
+      resourceArn: command.input.ResourceArn,
+      caller: options?.caller,
+    });
+
+    table.tags.remove(readSimDynamoDbTagKeys(command.input.TagKeys));
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * List the tags a resource holds, a page at a time.
+   */
+  listTagsOfResource(
+    command: SimListTagsOfResourceCommand,
+    options?: SimDynamoDbTagCommandsOptions,
+  ): SimListTagsOfResourceCommandOutput {
+    const table = reachSimDynamoDbTagResource({
+      access: this.access,
+      action: "dynamodb:ListTagsOfResource",
+      resourceArn: command.input.ResourceArn,
+      caller: options?.caller,
+    });
+    const page = new SimDynamoDbTagPage(
+      table.tags.ordered(),
+      command.input.NextToken,
+    );
+    const tags = page.tags.map((tag) => tag.toTag());
+
+    // The token is left off the last page, rather than answered as undefined,
+    // so a caller looping until it is gone terminates.
+    if (page.nextToken === undefined) {
+      return { Tags: tags, $metadata: {} };
+    }
+
+    return { Tags: tags, NextToken: page.nextToken, $metadata: {} };
+  }
+}

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-commands.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-commands.ts
@@ -48,6 +48,9 @@ export class SimDynamoDbTagCommands {
     command: SimTagResourceCommand,
     options?: SimDynamoDbTagCommandsOptions,
   ): SimTagResourceCommandOutput {
+    // The request is read before the resource is reached, so a request
+    // DynamoDB would refuse is refused whether or not the table is there.
+    const tags = readSimDynamoDbTags(command.input.Tags);
     const table = reachSimDynamoDbTagResource({
       access: this.access,
       action: "dynamodb:TagResource",
@@ -55,7 +58,7 @@ export class SimDynamoDbTagCommands {
       caller: options?.caller,
     });
 
-    table.tags.apply(readSimDynamoDbTags(command.input.Tags));
+    table.tags.apply(tags);
 
     return { $metadata: {} };
   }
@@ -70,6 +73,7 @@ export class SimDynamoDbTagCommands {
     command: SimUntagResourceCommand,
     options?: SimDynamoDbTagCommandsOptions,
   ): SimUntagResourceCommandOutput {
+    const keys = readSimDynamoDbTagKeys(command.input.TagKeys);
     const table = reachSimDynamoDbTagResource({
       access: this.access,
       action: "dynamodb:UntagResource",
@@ -77,7 +81,7 @@ export class SimDynamoDbTagCommands {
       caller: options?.caller,
     });
 
-    table.tags.remove(readSimDynamoDbTagKeys(command.input.TagKeys));
+    table.tags.remove(keys);
 
     return { $metadata: {} };
   }

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-iam.iso.test.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-iam.iso.test.ts
@@ -1,0 +1,186 @@
+import {
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+describe("DynamoDB tag command IAM authorization", () => {
+  it("allows a Role its policy permits to tag and untag", async () => {
+    // Given a Role allowed to change and read a table's tags.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Tagger",
+        actions: [
+          "dynamodb:TagResource",
+          "dynamodb:UntagResource",
+          "dynamodb:ListTagsOfResource",
+        ],
+      },
+      simAws,
+    );
+    const caller = { caller: { kind: "arn", arn: role.Arn } } as const;
+
+    // When the Role tags the table, takes one off and lists the rest.
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [
+          { Key: "Environment", Value: "test" },
+          { Key: "Owner", Value: "platform" },
+        ],
+      }),
+      caller,
+    );
+    await simDynamoDb.untagResource(
+      new UntagResourceCommand({
+        ResourceArn: table.arn,
+        TagKeys: ["Owner"],
+      }),
+      caller,
+    );
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+      caller,
+    );
+
+    // Then IAM allows all three.
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], { Key: "Environment", Value: "test" });
+  });
+
+  it("denies a Role that may read tags but not change them", async () => {
+    // Given a Role allowed only to list tags.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "TagReader", actions: ["dynamodb:ListTagsOfResource"] },
+      simAws,
+    );
+    const caller = { caller: { kind: "arn", arn: role.Arn } } as const;
+
+    // When the Role tries to tag the table.
+    const tagging = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.tagResource(
+        new TagResourceCommand({
+          ResourceArn: table.arn,
+          Tags: [{ Key: "Environment", Value: "test" }],
+        }),
+        caller,
+      ),
+    );
+
+    // And when it tries to take a tag off.
+    const untagging = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.untagResource(
+        new UntagResourceCommand({
+          ResourceArn: table.arn,
+          TagKeys: ["Environment"],
+        }),
+        caller,
+      ),
+    );
+
+    // Then each is denied against its own action, and nothing was tagged.
+    assertInstanceOf(tagging, SimIamAccessDenied);
+    assertIdentical(tagging.action, "dynamodb:TagResource");
+    assertInstanceOf(untagging, SimIamAccessDenied);
+    assertIdentical(untagging.action, "dynamodb:UntagResource");
+
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+      caller,
+    );
+    assertArrayLength(output.Tags, 0);
+  });
+
+  it("denies a Role that may change tags but not read them", async () => {
+    // Given a Role allowed only to tag.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "TagWriter", actions: ["dynamodb:TagResource"] },
+      simAws,
+    );
+
+    // When the Role lists the tags.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then reading tags is its own action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:ListTagsOfResource");
+  });
+
+  it("denies a tag command for a table the Role may not reach", async () => {
+    // Given a Role allowed to tag one table only.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+    const customers = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "CustomersTable", partitionKeyName: "customerId" },
+      simAws,
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "OrdersTagger",
+        actions: ["dynamodb:TagResource"],
+        resource:
+          `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+          `${simAws.defaultAccountId}:table/OrdersTable`,
+      },
+      simAws,
+    );
+
+    // When it tags the other one.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.tagResource(
+        new TagResourceCommand({
+          ResourceArn: customers.arn,
+          Tags: [{ Key: "Environment", Value: "test" }],
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then the table ARN is what the policy is evaluated against.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:TagResource");
+  });
+});

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-page.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-page.ts
@@ -1,0 +1,66 @@
+import type { SimDynamoDbTableTag } from "../../table/sim-dynamodb-table-tag.js";
+import { compareSimDynamoDbTextBytes } from "../../table/sim-dynamodb-table-order.js";
+
+/**
+ * How many tags one page of ListTagsOfResource carries.
+ *
+ * The API has no page size parameter, so this is the simulator's choice rather
+ * than DynamoDB's. It is half of the 50 tags a resource holds, so a resource
+ * tagged the way most are lists in one page, and a test that wants to see a
+ * NextToken can reach one without inventing hundreds of tags.
+ */
+const pageSize = 25;
+
+/**
+ * One page of tags, as ListTagsOfResource hands them out.
+ *
+ * The token is the key the next page resumes after rather than an opaque
+ * cursor, which is what makes a token still work when the tag it names has
+ * since been removed. It follows the ListTables token in that.
+ */
+export class SimDynamoDbTagPage {
+  public readonly tags: readonly SimDynamoDbTableTag[];
+  public readonly nextToken: string | undefined;
+
+  constructor(tags: readonly SimDynamoDbTableTag[], nextToken?: string) {
+    const remaining = after(tags, nextToken);
+
+    this.tags = remaining.slice(0, pageSize);
+    this.nextToken = tokenFor(remaining, this.tags);
+  }
+}
+
+/**
+ * The tags left to list after the key a request resumes from.
+ */
+function after(
+  tags: readonly SimDynamoDbTableTag[],
+  nextToken: string | undefined,
+): readonly SimDynamoDbTableTag[] {
+  if (nextToken === undefined) {
+    return tags;
+  }
+
+  return tags.filter(
+    (tag) => compareSimDynamoDbTextBytes(tag.key, nextToken) > 0,
+  );
+}
+
+/**
+ * The token to resume from, when there is anything left to resume for.
+ *
+ * A token on the last page would send a caller looping until it got an empty
+ * page, so DynamoDB leaves it off and so does this.
+ */
+function tokenFor(
+  remaining: readonly SimDynamoDbTableTag[],
+  page: readonly SimDynamoDbTableTag[],
+): string | undefined {
+  const last = page.at(-1);
+
+  if (last === undefined || page.length === remaining.length) {
+    return undefined;
+  }
+
+  return last.key;
+}

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-paging.iso.test.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-paging.iso.test.ts
@@ -1,0 +1,194 @@
+import {
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDbTag } from "../table/table.types.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+/**
+ * A tag key that sorts in the order the tags were made, so a page can be
+ * asserted on.
+ */
+function numberedKey(index: number): string {
+  return `Tag${index.toString().padStart(2, "0")}`;
+}
+
+describe("DynamoDB ListTagsOfResource paging", () => {
+  it("pages at 25 tags and leaves the token off the last page", async () => {
+    // Given a table holding 26 tags, which is one more than a page.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: Array.from({ length: 26 }, (_unused, index) => ({
+          Key: numberedKey(index),
+          Value: "test",
+        })),
+      }),
+    );
+
+    // When the first page is read.
+    const first = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+
+    // Then it carries a page of tags and the key to resume after.
+    assertArrayLength(first.Tags, 25);
+    assertIdentical(first.Tags[0].Key, "Tag00");
+    assertIdentical(first.NextToken, "Tag24");
+
+    // And the page after it carries the rest, with no token to follow.
+    const second = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: table.arn,
+        NextToken: first.NextToken,
+      }),
+    );
+    assertArrayLength(second.Tags, 1);
+    assertObjectEquals(second.Tags[0], { Key: "Tag25", Value: "test" });
+    assertUndefined(second.NextToken);
+  });
+
+  it("reads every tag through a loop that follows the token", async () => {
+    // Given a table holding 50 tags, which is as many as a resource holds.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: Array.from({ length: 50 }, (_unused, index) => ({
+          Key: numberedKey(index),
+          Value: "test",
+        })),
+      }),
+    );
+
+    // When a caller loops until the token is gone.
+    const tags: SimDynamoDbTag[] = [];
+    let nextToken: string | undefined;
+
+    do {
+      // A page can only be asked for once the one before it has answered with
+      // its token, which is what a caller paging through tags does.
+      // eslint-disable-next-line no-await-in-loop
+      const page = await simDynamoDb.listTagsOfResource(
+        new ListTagsOfResourceCommand({
+          ResourceArn: table.arn,
+          NextToken: nextToken,
+        }),
+      );
+
+      tags.push(...page.Tags);
+      nextToken = page.NextToken;
+    } while (nextToken !== undefined);
+
+    // Then it read all of them, in key order, and the loop terminated.
+    assertArrayLength(tags, 50);
+    assertIdentical(tags[0].Key, "Tag00");
+    assertIdentical(tags.at(-1)?.Key, "Tag49");
+  });
+
+  it("resumes from a token whose tag has since been removed", async () => {
+    // Given a table holding 26 tags, and a token from its first page.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: Array.from({ length: 26 }, (_unused, index) => ({
+          Key: numberedKey(index),
+          Value: "test",
+        })),
+      }),
+    );
+
+    const first = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+    const nextToken = first.NextToken;
+    assertNonNullable(nextToken);
+
+    // When the tag the token names is taken off before the next page is read.
+    await simDynamoDb.untagResource(
+      new UntagResourceCommand({
+        ResourceArn: table.arn,
+        TagKeys: [nextToken],
+      }),
+    );
+
+    const second = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({
+        ResourceArn: table.arn,
+        NextToken: nextToken,
+      }),
+    );
+
+    // Then the page still resumes after it, since the token is a key rather
+    // than a remembered position.
+    assertArrayLength(second.Tags, 1);
+    assertObjectEquals(second.Tags[0], { Key: "Tag25", Value: "test" });
+  });
+
+  it("lists tags in key order rather than the order they were applied", async () => {
+    // Given a table tagged in an order of its own.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [
+          { Key: "Owner", Value: "platform" },
+          { Key: "Environment", Value: "test" },
+          { Key: "Application", Value: "ledger" },
+        ],
+      }),
+    );
+
+    // When the tags are listed.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+
+    // Then they come back ordered by key, which is one of the orders DynamoDB
+    // allows and the one a page resumes through.
+    assertArrayLength(output.Tags, 3);
+    assertObjectEquals(output.Tags[0], { Key: "Application", Value: "ledger" });
+    assertObjectEquals(output.Tags[1], { Key: "Environment", Value: "test" });
+    assertObjectEquals(output.Tags[2], { Key: "Owner", Value: "platform" });
+  });
+});

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-request.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-request.ts
@@ -1,0 +1,91 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type { SimDynamoDbTagInput } from "../table/table.types.js";
+
+interface SimDynamoDbTagResourceReach {
+  readonly access: SimDynamoDbTableAccess;
+  readonly action: string;
+  readonly resourceArn: string | undefined;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * Find the resource a tag command names, refusing the caller before looking it
+ * up.
+ *
+ * A table is the only taggable DynamoDB resource this simulation has. Backups
+ * and global table replicas are not simulated, so an ARN naming one of those is
+ * an ARN naming nothing.
+ */
+export function reachSimDynamoDbTagResource(
+  reach: SimDynamoDbTagResourceReach,
+): SimDynamoDbTable {
+  const arn = readResourceArn(reach.resourceArn, reach.action);
+
+  return reach.access.requiredByName(
+    reach.action,
+    reach.access.reference(arn),
+    reach.caller,
+  );
+}
+
+/**
+ * Read the ARN a tag command names its resource by.
+ *
+ * The tag commands take an ARN where the table commands take a name or an ARN.
+ * A bare table name is refused rather than resolved, since a caller passing one
+ * to real DynamoDB would be refused too, and finding the table anyway would let
+ * a test pass on a request AWS rejects.
+ */
+function readResourceArn(
+  resourceArn: string | undefined,
+  action: string,
+): string {
+  const arn = resourceArn ?? "";
+
+  if (!arn.startsWith("arn:")) {
+    throw new SimDynamoDbValidationException(
+      `${action.replace("dynamodb:", "")} requires a ResourceArn naming the ` +
+        `resource to work on, as an ARN rather than a name`,
+    );
+  }
+
+  return arn;
+}
+
+/**
+ * Read the tags a TagResource request carries.
+ *
+ * `Tags` is a required parameter, so a request without one is refused rather
+ * than taken as a call that changes nothing.
+ */
+export function readSimDynamoDbTags(
+  tags: readonly SimDynamoDbTagInput[] | undefined,
+): readonly SimDynamoDbTagInput[] {
+  if (tags === undefined) {
+    throw new SimDynamoDbValidationException(
+      "TagResource requires Tags naming what to tag the resource with",
+    );
+  }
+
+  return tags;
+}
+
+/**
+ * Read the keys an UntagResource request names.
+ *
+ * `TagKeys` is a required parameter, as `Tags` is on the way in.
+ */
+export function readSimDynamoDbTagKeys(
+  tagKeys: readonly string[] | undefined,
+): readonly string[] {
+  if (tagKeys === undefined) {
+    throw new SimDynamoDbValidationException(
+      "UntagResource requires TagKeys naming what to take off the resource",
+    );
+  }
+
+  return tagKeys;
+}

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-resource-arn.iso.test.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-resource-arn.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+/**
+ * The ARN of a table nothing created, in the scope the request is made in.
+ */
+function missingTableArn(simAws: SimAws): string {
+  return (
+    `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+    `${simAws.defaultAccountId}:table/MissingTable`
+  );
+}
+
+describe("DynamoDB tag command resource ARNs", () => {
+  it("refuses an ARN naming no table", async () => {
+    // Given a simulated DynamoDB holding a different table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    const arn = missingTableArn(simAws);
+
+    // When each of the tag commands names a table that is not there.
+    const tagging = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.tagResource(
+        new TagResourceCommand({
+          ResourceArn: arn,
+          Tags: [{ Key: "Environment", Value: "test" }],
+        }),
+      ),
+    );
+    const untagging = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.untagResource(
+        new UntagResourceCommand({
+          ResourceArn: arn,
+          TagKeys: ["Environment"],
+        }),
+      ),
+    );
+    const listing = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: arn }),
+      ),
+    );
+
+    // Then all three answer the same way.
+    assertInstanceOf(tagging, SimDynamoDbResourceNotFoundException);
+    assertInstanceOf(untagging, SimDynamoDbResourceNotFoundException);
+    assertInstanceOf(listing, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("refuses a table name where an ARN belongs", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When a tag command names it by name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: "OrdersTable" }),
+      ),
+    );
+
+    // Then it is refused rather than resolved, since real DynamoDB takes an
+    // ARN here.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ListTagsOfResource requires a ResourceArn naming the resource to work " +
+        "on, as an ARN rather than a name",
+    );
+  });
+
+  it("requires a ResourceArn", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a tag command names no resource at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().tagResource({
+        input: { Tags: [{ Key: "Environment", Value: "test" }] },
+      }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "TagResource requires a ResourceArn");
+  });
+
+  it("requires the Tags and TagKeys a request works with", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When a tag request names no tags, and an untag request names no keys.
+    const tagging = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().tagResource({ input: { ResourceArn: table.arn } }),
+    );
+    const untagging = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().untagResource({ input: { ResourceArn: table.arn } }),
+    );
+
+    // Then both are refused, since each parameter is required rather than a
+    // call that changes nothing.
+    assertInstanceOf(tagging, SimDynamoDbValidationException);
+    assertStringIncludes(tagging.message, "TagResource requires Tags");
+    assertInstanceOf(untagging, SimDynamoDbValidationException);
+    assertStringIncludes(untagging.message, "UntagResource requires TagKeys");
+  });
+
+  it("refuses an ARN that names no DynamoDB table", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When the ARN belongs to another service.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().listTagsOfResource(
+        new ListTagsOfResourceCommand({
+          ResourceArn: `arn:aws:s3:::orders-bucket`,
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "is not a table ARN");
+  });
+
+  it("refuses an ARN naming another Account", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When the ARN names a table in another Account.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().listTagsOfResource(
+        new ListTagsOfResourceCommand({
+          ResourceArn:
+            `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+            `999999999999:table/OrdersTable`,
+        }),
+      ),
+    );
+
+    // Then it is refused rather than resolved to the local table of that name,
+    // as the table commands refuse it.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(
+      error.message,
+      "names a table in another Account or Region",
+    );
+  });
+});

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-resource.iso.test.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-resource.iso.test.ts
@@ -1,0 +1,228 @@
+import {
+  CreateTableCommand,
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+describe("DynamoDB resource tagging", () => {
+  it("keeps the tags CreateTable was given", async () => {
+    // Given a table created with tags.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const creation = await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "OrdersTable",
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        Tags: [
+          { Key: "Environment", Value: "test" },
+          { Key: "Owner", Value: "platform" },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When the tags are listed off it.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: tableArn }),
+    );
+
+    // Then both are there, and there is no page left to read.
+    assertArrayLength(output.Tags, 2);
+    assertObjectEquals(output.Tags[0], { Key: "Environment", Value: "test" });
+    assertObjectEquals(output.Tags[1], { Key: "Owner", Value: "platform" });
+    assertUndefined(output.NextToken);
+  });
+
+  it("adds tags to a table that was created without any", async () => {
+    // Given an untagged table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When it is tagged.
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "Environment", Value: "test" }],
+      }),
+    );
+
+    // Then the tag is on it.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], { Key: "Environment", Value: "test" });
+  });
+
+  it("replaces the value of a key that is already there", async () => {
+    // Given a table tagged with an environment.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "Environment", Value: "test" }],
+      }),
+    );
+
+    // When the same key is tagged again with another value.
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "Environment", Value: "staging" }],
+      }),
+    );
+
+    // Then the value changed rather than a second entry appearing.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], {
+      Key: "Environment",
+      Value: "staging",
+    });
+  });
+
+  it("takes the keys UntagResource names off", async () => {
+    // Given a table with three tags.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [
+          { Key: "Environment", Value: "test" },
+          { Key: "Owner", Value: "platform" },
+          { Key: "Project", Value: "ledger" },
+        ],
+      }),
+    );
+
+    // When two of them are taken off, along with a key that was never there.
+    await simDynamoDb.untagResource(
+      new UntagResourceCommand({
+        ResourceArn: table.arn,
+        TagKeys: ["Environment", "Project", "NeverThere"],
+      }),
+    );
+
+    // Then the rest is left, and the key that was not there was not an error.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], { Key: "Owner", Value: "platform" });
+  });
+
+  it("lists nothing for a table that was never tagged", async () => {
+    // Given an untagged table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When its tags are listed.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+
+    // Then it answers with an empty list rather than refusing.
+    assertArrayLength(output.Tags, 0);
+    assertUndefined(output.NextToken);
+  });
+
+  it("takes a tag with an empty value", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When it is tagged with a key that says nothing about itself.
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "Temporary", Value: "" }],
+      }),
+    );
+
+    // Then the tag is there, since a tag value may be empty where a key may
+    // not.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+    );
+    assertIdentical(output.Tags[0]?.Value, "");
+  });
+
+  it("keeps the tags of two tables apart", async () => {
+    // Given two tables.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    const orders = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+    const customers = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "CustomersTable", partitionKeyName: "customerId" },
+      simAws,
+    );
+
+    // When one of them is tagged.
+    await simDynamoDb.tagResource(
+      new TagResourceCommand({
+        ResourceArn: orders.arn,
+        Tags: [{ Key: "Environment", Value: "test" }],
+      }),
+    );
+
+    // Then the other is untouched.
+    const output = await simDynamoDb.listTagsOfResource(
+      new ListTagsOfResourceCommand({ ResourceArn: customers.arn }),
+    );
+    assertArrayLength(output.Tags, 0);
+  });
+});

--- a/src/service/dynamodb/command/tag/sim-dynamodb-tag-validation.iso.test.ts
+++ b/src/service/dynamodb/command/tag/sim-dynamodb-tag-validation.iso.test.ts
@@ -1,0 +1,273 @@
+import {
+  CreateTableCommand,
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDbTagInput } from "../table/table.types.js";
+
+/**
+ * The error tagging a table with these tags is refused with.
+ */
+async function refusedTags(
+  tags: readonly SimDynamoDbTagInput[],
+): Promise<Error> {
+  const simAws = new SimAws();
+  const table = await simDynamoDbCreatedTableFactory.make(
+    { tableName: "OrdersTable", partitionKeyName: "orderId" },
+    simAws,
+  );
+
+  return await assertThrowsErrorAsync(async () =>
+    simAws
+      .dynamoDb()
+      .tagResource({ input: { ResourceArn: table.arn, Tags: tags } }),
+  );
+}
+
+describe("DynamoDB tag validation", () => {
+  it("requires a key", async () => {
+    // When a tag carries no key.
+    const error = await refusedTags([{ Value: "test" }]);
+
+    // Then it is refused, since a tag is held under its key.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A Tag requires a Key of at least one character",
+    );
+  });
+
+  it("requires a value", async () => {
+    // When a tag carries no value.
+    const error = await refusedTags([{ Key: "Environment" }]);
+
+    // Then it is refused, though an empty value would have been taken.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The tag 'Environment' requires a Value",
+    );
+  });
+
+  it("refuses a key longer than a tag key holds", async () => {
+    // When a key of 129 characters is used.
+    const error = await refusedTags([{ Key: "e".repeat(129), Value: "test" }]);
+
+    // Then it is refused with the length named.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "is 129 characters, where 128 is the most a tag key holds",
+    );
+  });
+
+  it("refuses a value longer than a tag value holds", async () => {
+    // When a value of 257 characters is used.
+    const error = await refusedTags([
+      { Key: "Environment", Value: "t".repeat(257) },
+    ]);
+
+    // Then it is refused with the length named.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "is 257 characters, where 256 is the most a tag value holds",
+    );
+  });
+
+  it("refuses a key with a character a tag is not written with", async () => {
+    // When a key carries an @, which DynamoDB does not take even though some
+    // other AWS services do.
+    const error = await refusedTags([{ Key: "owner@team", Value: "test" }]);
+
+    // Then it is refused, naming what a tag is written with.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Tag key 'owner@team' has a character a tag does not take",
+    );
+  });
+
+  it("refuses a value with a character a tag is not written with", async () => {
+    // When a value carries a comma.
+    const error = await refusedTags([
+      { Key: "Environment", Value: "test,staging" },
+    ]);
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The value of the tag 'Environment' has a character a tag does not take",
+    );
+  });
+
+  it("takes the punctuation a tag is written with", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When a tag uses every character DynamoDB allows beyond letters and
+    // digits.
+    await simAws.dynamoDb().tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "cost centre/team_1", Value: "a+b-c=d.e_f:g/h 1" }],
+      }),
+    );
+
+    // Then it is taken.
+    const output = await simAws
+      .dynamoDb()
+      .listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+      );
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], {
+      Key: "cost centre/team_1",
+      Value: "a+b-c=d.e_f:g/h 1",
+    });
+  });
+
+  it("refuses a key under the reserved aws: prefix", async () => {
+    // When a key AWS assigns to itself is used.
+    const error = await refusedTags([
+      { Key: "aws:cloudformation:stack-name", Value: "TestStack" },
+    ]);
+
+    // Then it is refused rather than held alongside the tags AWS assigns.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "begins with the reserved aws: prefix");
+  });
+
+  it("refuses more tags than a resource holds", async () => {
+    // When 51 tags are applied at once.
+    const error = await refusedTags(
+      Array.from({ length: 51 }, (_unused, index) => ({
+        Key: `Tag${String(index)}`,
+        Value: "test",
+      })),
+    );
+
+    // Then it is refused for the count, saying what it would have left.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A DynamoDB resource holds 50 tags, and this request would leave it " +
+        "holding 51",
+    );
+  });
+
+  it("counts the tags already there towards the limit", async () => {
+    // Given a table holding 50 tags.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simAws.dynamoDb().tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: Array.from({ length: 50 }, (_unused, index) => ({
+          Key: `Tag${String(index)}`,
+          Value: "test",
+        })),
+      }),
+    );
+
+    // When one more key is added.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().tagResource(
+        new TagResourceCommand({
+          ResourceArn: table.arn,
+          Tags: [{ Key: "OneTooMany", Value: "test" }],
+        }),
+      ),
+    );
+
+    // Then it is refused, and replacing one of the 50 would have been fine.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "would leave it holding 51");
+  });
+
+  it("leaves the tags as they were when a request is refused", async () => {
+    // Given a tagged table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "OrdersTable", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    await simAws.dynamoDb().tagResource(
+      new TagResourceCommand({
+        ResourceArn: table.arn,
+        Tags: [{ Key: "Environment", Value: "test" }],
+      }),
+    );
+
+    // When a request carrying a good tag and a bad one is made.
+    await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().tagResource(
+        new TagResourceCommand({
+          ResourceArn: table.arn,
+          Tags: [
+            { Key: "Owner", Value: "platform" },
+            { Key: "Environment", Value: "test,staging" },
+          ],
+        }),
+      ),
+    );
+
+    // Then neither was applied: the whole request is read before any of it is
+    // kept.
+    const output = await simAws
+      .dynamoDb()
+      .listTagsOfResource(
+        new ListTagsOfResourceCommand({ ResourceArn: table.arn }),
+      );
+    assertArrayLength(output.Tags, 1);
+    assertObjectEquals(output.Tags[0], { Key: "Environment", Value: "test" });
+  });
+
+  it("refuses the table when CreateTable carries a bad tag", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with a tag DynamoDB would refuse.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().createTable(
+        new CreateTableCommand({
+          TableName: "OrdersTable",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          Tags: [{ Key: "aws:owner", Value: "platform" }],
+        }),
+      ),
+    );
+
+    // Then no table was created, since the tags are checked before the name is
+    // taken.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+
+    const listed = await simAws.dynamoDb().listTables({ input: {} });
+    assertArrayLength(listed.TableNames, 0);
+  });
+});

--- a/src/service/dynamodb/command/tag/tag.command.ts
+++ b/src/service/dynamodb/command/tag/tag.command.ts
@@ -1,0 +1,85 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimDynamoDbTag,
+  SimDynamoDbTagInput,
+} from "../table/table.types.js";
+
+/**
+ * Minimal structural sim DynamoDB TagResource command.
+ */
+export interface SimTagResourceCommand {
+  readonly input: SimTagResourceCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB TagResource input.
+ *
+ * The resource is named by its ARN rather than by its name, which is how every
+ * tag command names one.
+ */
+export interface SimTagResourceCommandInput {
+  readonly ResourceArn?: string | undefined;
+  readonly Tags?: readonly SimDynamoDbTagInput[] | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TagResource output.
+ *
+ * Real DynamoDB answers with an empty body, so `ListTagsOfResource` is the only
+ * way to see what a tag request did.
+ */
+export interface SimTagResourceCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB UntagResource command.
+ */
+export interface SimUntagResourceCommand {
+  readonly input: SimUntagResourceCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB UntagResource input.
+ */
+export interface SimUntagResourceCommandInput {
+  readonly ResourceArn?: string | undefined;
+  readonly TagKeys?: readonly string[] | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB UntagResource output.
+ */
+export interface SimUntagResourceCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB ListTagsOfResource command.
+ */
+export interface SimListTagsOfResourceCommand {
+  readonly input: SimListTagsOfResourceCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB ListTagsOfResource input.
+ *
+ * There is no page size to ask for. The API has no such parameter, so how many
+ * tags a page carries is the service's to decide.
+ */
+export interface SimListTagsOfResourceCommandInput {
+  readonly ResourceArn?: string | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB ListTagsOfResource output.
+ *
+ * `NextToken` is absent on the last page, so a caller looping until it is gone
+ * terminates.
+ */
+export interface SimListTagsOfResourceCommandOutput {
+  readonly Tags: readonly SimDynamoDbTag[];
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -10,9 +10,12 @@ import {
   GetItemCommand,
   ListTablesCommand,
   PutItemCommand,
+  ListTagsOfResourceCommand,
   QueryCommand,
+  TagResourceCommand,
   TransactGetItemsCommand,
   TransactWriteItemsCommand,
+  UntagResourceCommand,
   UpdateItemCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
@@ -236,6 +239,46 @@ describe("simulated DynamoDB SDK Command routing", () => {
     assertArrayLength(responses, 2);
     assertIdentical(responses[0].Item?.["name"]?.S, "Second item");
     assertObjectEquals(responses[1], {});
+  });
+
+  it("round-trips tag Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    const creation = await client.send(
+      new CreateTableCommand({
+        TableName: "TaggedTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+        Tags: [{ Key: "Environment", Value: "test" }],
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const tableArn = creation.TableDescription?.TableArn;
+    assertNonNullable(tableArn);
+
+    await client.send(
+      new TagResourceCommand({
+        ResourceArn: tableArn,
+        Tags: [{ Key: "Owner", Value: "platform" }],
+      }),
+    );
+    await client.send(
+      new UntagResourceCommand({
+        ResourceArn: tableArn,
+        TagKeys: ["Environment"],
+      }),
+    );
+
+    const listed = await client.send(
+      new ListTagsOfResourceCommand({ ResourceArn: tableArn }),
+    );
+    assertNonNullable(listed.Tags);
+    assertArrayLength(listed.Tags, 1);
+    assertObjectEquals(listed.Tags[0], { Key: "Owner", Value: "platform" });
   });
 
   it("does not give a denied run-as caller root privileges", async () => {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -20,6 +20,11 @@ import type {
   SimBatchWriteItemCommand,
 } from "../command/batch/batch.command.js";
 import type {
+  SimListTagsOfResourceCommand,
+  SimTagResourceCommand,
+  SimUntagResourceCommand,
+} from "../command/tag/tag.command.js";
+import type {
   SimTransactGetItemsCommand,
   SimTransactWriteItemsCommand,
 } from "../command/transact/transact.command.js";
@@ -118,6 +123,30 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simDynamoDatabase.transactWriteItems(
             command as SimTransactWriteItemsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "TagResourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.tagResource(
+            command as SimTagResourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UntagResourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.untagResource(
+            command as SimUntagResourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListTagsOfResourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.listTagsOfResource(
+            command as SimListTagsOfResourceCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -3,16 +3,7 @@ import {
   BackgroundTasks,
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import { SimDynamoDbAuthorizer } from "./command/authorize/sim-dynamodb-authorizer.js";
-import { SimDynamoDbBatchGetItem } from "./command/batch/sim-dynamodb-batch-get-item.js";
-import { SimDynamoDbBatchWriteItem } from "./command/batch/sim-dynamodb-batch-write-item.js";
-import { SimDynamoDbDeleteItem } from "./command/item/sim-dynamodb-delete-item.js";
-import { SimDynamoDbGetItem } from "./command/item/sim-dynamodb-get-item.js";
-import { SimDynamoDbPutItem } from "./command/item/sim-dynamodb-put-item.js";
-import { SimDynamoDbUpdateItem } from "./command/item/sim-dynamodb-update-item.js";
-import { SimDynamoDbCreateTable } from "./command/table/sim-dynamodb-create-table.js";
-import { SimDynamoDbTableAccess } from "./command/table/sim-dynamodb-table-access.js";
-import { SimDynamoDbTableCommands } from "./command/table/sim-dynamodb-table-commands.js";
+import { SimDynamoDbCommandHandlers } from "./command/sim-dynamodb-command-handlers.js";
 import { SimDynamoDbTableStore } from "./table/sim-dynamodb-table-store.js";
 import type {
   SimCreateTableCommand,
@@ -46,8 +37,14 @@ import type {
   SimTransactWriteItemsCommand,
   SimTransactWriteItemsCommandOutput,
 } from "./command/transact/transact.command.js";
-import { SimDynamoDbTransactGetItems } from "./command/transact/sim-dynamodb-transact-get-items.js";
-import { SimDynamoDbTransactWriteItems } from "./command/transact/sim-dynamodb-transact-write-items.js";
+import type {
+  SimListTagsOfResourceCommand,
+  SimListTagsOfResourceCommandOutput,
+  SimTagResourceCommand,
+  SimTagResourceCommandOutput,
+  SimUntagResourceCommand,
+  SimUntagResourceCommandOutput,
+} from "./command/tag/tag.command.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
@@ -74,19 +71,8 @@ interface SimDynamoDatabaseProperties {
  */
 export class SimDynamoDb {
   private readonly tables = new SimDynamoDbTableStore();
-
-  private readonly access: SimDynamoDbTableAccess;
   private readonly background: BackgroundScheduler;
-  private readonly tableCreation: SimDynamoDbCreateTable;
-  private readonly tableCommands: SimDynamoDbTableCommands;
-  private readonly itemWrites: SimDynamoDbPutItem;
-  private readonly itemReads: SimDynamoDbGetItem;
-  private readonly itemDeletions: SimDynamoDbDeleteItem;
-  private readonly itemUpdates: SimDynamoDbUpdateItem;
-  private readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
-  private readonly itemBatchReads: SimDynamoDbBatchGetItem;
-  private readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
-  private readonly itemTransactReads: SimDynamoDbTransactGetItems;
+  private readonly commands: SimDynamoDbCommandHandlers;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
   private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
     dynamoDb: this,
@@ -99,39 +85,12 @@ export class SimDynamoDb {
       background = new BackgroundTasks(),
     } = properties;
 
-    const authorizer = new SimDynamoDbAuthorizer({ iam, accountRegionScope });
-
     this.background = background;
-    this.access = new SimDynamoDbTableAccess({
+    this.commands = new SimDynamoDbCommandHandlers({
       tables: this.tables,
-      authorizer,
       accountRegionScope,
-    });
-    this.tableCreation = new SimDynamoDbCreateTable({
-      tables: this.tables,
-      authorizer,
-      accountRegionScope,
+      iam,
       background,
-    });
-    this.tableCommands = new SimDynamoDbTableCommands({
-      tables: this.tables,
-      access: this.access,
-      background,
-    });
-    this.itemWrites = new SimDynamoDbPutItem({ access: this.access });
-    this.itemReads = new SimDynamoDbGetItem({ access: this.access });
-    this.itemDeletions = new SimDynamoDbDeleteItem({ access: this.access });
-    this.itemUpdates = new SimDynamoDbUpdateItem({ access: this.access });
-    this.itemBatchWrites = new SimDynamoDbBatchWriteItem({
-      access: this.access,
-    });
-    this.itemBatchReads = new SimDynamoDbBatchGetItem({ access: this.access });
-    this.itemTransactWrites = new SimDynamoDbTransactWriteItems({
-      access: this.access,
-      clock: background,
-    });
-    this.itemTransactReads = new SimDynamoDbTransactGetItems({
-      access: this.access,
     });
   }
 
@@ -144,7 +103,7 @@ export class SimDynamoDb {
   ): Promise<SimCreateTableCommandOutput> {
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
-    return this.tableCreation.handle(command, options);
+    return this.commands.tableCreation.handle(command, options);
   }
 
   /**
@@ -155,7 +114,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimDescribeTableCommandOutput> {
     await this.background.sequence();
-    return this.tableCommands.describeTable(command, options);
+    return this.commands.tables.describeTable(command, options);
   }
 
   /**
@@ -166,7 +125,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimListTablesCommandOutput> {
     await this.background.sequence();
-    return this.tableCommands.listTables(command, options);
+    return this.commands.tables.listTables(command, options);
   }
 
   /**
@@ -177,7 +136,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimDeleteTableCommandOutput> {
     await this.background.sequence();
-    return this.tableCommands.deleteTable(command, options);
+    return this.commands.tables.deleteTable(command, options);
   }
 
   /**
@@ -188,7 +147,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimPutItemCommandOutput> {
     await this.background.sequence();
-    return this.itemWrites.handle(command, options);
+    return this.commands.itemWrites.handle(command, options);
   }
 
   /**
@@ -199,7 +158,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimGetItemCommandOutput> {
     await this.background.sequence();
-    return this.itemReads.handle(command, options);
+    return this.commands.itemReads.handle(command, options);
   }
 
   /**
@@ -210,7 +169,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimDeleteItemCommandOutput> {
     await this.background.sequence();
-    return this.itemDeletions.handle(command, options);
+    return this.commands.itemDeletions.handle(command, options);
   }
 
   /**
@@ -221,7 +180,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimUpdateItemCommandOutput> {
     await this.background.sequence();
-    return this.itemUpdates.handle(command, options);
+    return this.commands.itemUpdates.handle(command, options);
   }
 
   /**
@@ -232,7 +191,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimBatchWriteItemCommandOutput> {
     await this.background.sequence();
-    return this.itemBatchWrites.handle(command, options);
+    return this.commands.itemBatchWrites.handle(command, options);
   }
 
   /**
@@ -243,7 +202,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimBatchGetItemCommandOutput> {
     await this.background.sequence();
-    return this.itemBatchReads.handle(command, options);
+    return this.commands.itemBatchReads.handle(command, options);
   }
 
   /**
@@ -254,7 +213,7 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimTransactWriteItemsCommandOutput> {
     await this.background.sequence();
-    return this.itemTransactWrites.handle(command, options);
+    return this.commands.itemTransactWrites.handle(command, options);
   }
 
   /**
@@ -265,7 +224,40 @@ export class SimDynamoDb {
     options?: SimDynamoDbRequestOptions,
   ): Promise<SimTransactGetItemsCommandOutput> {
     await this.background.sequence();
-    return this.itemTransactReads.handle(command, options);
+    return this.commands.itemTransactReads.handle(command, options);
+  }
+
+  /**
+   * Handle a Tag Resource Command from the SDK.
+   */
+  async tagResource(
+    command: SimTagResourceCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimTagResourceCommandOutput> {
+    await this.background.sequence();
+    return this.commands.tags.tagResource(command, options);
+  }
+
+  /**
+   * Handle an Untag Resource Command from the SDK.
+   */
+  async untagResource(
+    command: SimUntagResourceCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimUntagResourceCommandOutput> {
+    await this.background.sequence();
+    return this.commands.tags.untagResource(command, options);
+  }
+
+  /**
+   * Handle a List Tags Of Resource Command from the SDK.
+   */
+  async listTagsOfResource(
+    command: SimListTagsOfResourceCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<SimListTagsOfResourceCommandOutput> {
+    await this.background.sequence();
+    return this.commands.tags.listTagsOfResource(command, options);
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-order.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-order.ts
@@ -1,11 +1,11 @@
 /**
- * Order two table names the way DynamoDB orders them, by UTF-8 bytes.
+ * Order two pieces of text by their UTF-8 bytes.
  *
- * A table name is ASCII, so this is the same order the characters are in, but
- * comparing the bytes is what DynamoDB documents, and it keeps the order the
- * same whatever locale the host is running in.
+ * Comparing bytes keeps an order the same whatever locale the host is running
+ * in, which is what lets a test create things concurrently and still assert a
+ * deterministic listing.
  */
-export function compareSimDynamoDbTableNames(
+export function compareSimDynamoDbTextBytes(
   first: string,
   second: string,
 ): number {
@@ -13,4 +13,17 @@ export function compareSimDynamoDbTableNames(
     Buffer.from(first, "utf8"),
     Buffer.from(second, "utf8"),
   );
+}
+
+/**
+ * Order two table names the way DynamoDB orders them, by UTF-8 bytes.
+ *
+ * A table name is ASCII, so this is the same order the characters are in, but
+ * comparing the bytes is what DynamoDB documents.
+ */
+export function compareSimDynamoDbTableNames(
+  first: string,
+  second: string,
+): number {
+  return compareSimDynamoDbTextBytes(first, second);
 }

--- a/src/service/dynamodb/table/sim-dynamodb-table-tag.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-tag.ts
@@ -1,0 +1,129 @@
+import type {
+  SimDynamoDbTag,
+  SimDynamoDbTagInput,
+} from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * Real DynamoDB takes a tag key of up to 128 characters, and a value of up to
+ * 256. A value may be empty, where a key may not.
+ */
+const greatestKeyLength = 128;
+const greatestValueLength = 256;
+
+/**
+ * The characters a tag is written with: letters, whitespace, digits and a few
+ * punctuation marks.
+ *
+ * This is DynamoDB's own set, which is narrower than the one some other AWS
+ * services take: there is no `@` in it.
+ */
+const allowedCharacters = /^[\p{L}\p{N}\s+\-=._:/]*$/u;
+
+/**
+ * The prefix AWS assigns tags under, which a caller may not.
+ */
+const reservedPrefix = "aws:";
+
+/**
+ * One tag on a simulated DynamoDB resource.
+ *
+ * A tag is a key and a value, both checked on the way in. Everything that makes
+ * a key or a value acceptable is here rather than in the commands, so a tag
+ * that arrived with CreateTable is held to what a tag from TagResource is.
+ */
+export class SimDynamoDbTableTag {
+  public readonly key: string;
+  public readonly value: string;
+
+  private constructor(key: string, value: string) {
+    this.key = key;
+    this.value = value;
+  }
+
+  /**
+   * Read a tag a request carries.
+   */
+  static fromInput(input: SimDynamoDbTagInput): SimDynamoDbTableTag {
+    const key = readKey(input.Key);
+
+    return new this(key, readValue(input.Value, key));
+  }
+
+  /**
+   * Report this tag the way DynamoDB reports it.
+   */
+  toTag(): SimDynamoDbTag {
+    return { Key: this.key, Value: this.value };
+  }
+}
+
+/**
+ * Read the key a tag is held under.
+ */
+function readKey(key: string | undefined): string {
+  if (key === undefined || key.length === 0) {
+    throw new SimDynamoDbValidationException(
+      "A Tag requires a Key of at least one character",
+    );
+  }
+
+  if (key.length > greatestKeyLength) {
+    throw new SimDynamoDbValidationException(
+      `Tag key '${key}' is ${key.length.toString()} characters, where ` +
+        `${greatestKeyLength.toString()} is the most a tag key holds`,
+    );
+  }
+
+  if (key.startsWith(reservedPrefix)) {
+    throw new SimDynamoDbValidationException(
+      `Tag key '${key}' begins with the reserved ${reservedPrefix} prefix, ` +
+        `which AWS assigns to tags of its own rather than a caller assigning ` +
+        `it`,
+    );
+  }
+
+  assertWritable(key, `Tag key '${key}'`);
+
+  return key;
+}
+
+/**
+ * Read the value a tag holds.
+ *
+ * A tag value may be empty, where a key may not: DynamoDB takes a key on its
+ * own as a label with nothing to say about it.
+ */
+function readValue(value: string | undefined, key: string): string {
+  if (value === undefined) {
+    throw new SimDynamoDbValidationException(
+      `The tag '${key}' requires a Value, which may be empty`,
+    );
+  }
+
+  if (value.length > greatestValueLength) {
+    throw new SimDynamoDbValidationException(
+      `The value of the tag '${key}' is ${value.length.toString()} ` +
+        `characters, where ${greatestValueLength.toString()} is the most a ` +
+        `tag value holds`,
+    );
+  }
+
+  assertWritable(value, `The value of the tag '${key}'`);
+
+  return value;
+}
+
+/**
+ * Refuse text with a character a tag is not written with.
+ */
+function assertWritable(text: string, subject: string): void {
+  if (allowedCharacters.test(text)) {
+    return;
+  }
+
+  throw new SimDynamoDbValidationException(
+    `${subject} has a character a tag does not take. Letters, whitespace, ` +
+      `digits and + - = . _ : / are what a tag is written with.`,
+  );
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table-tags.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-tags.ts
@@ -1,0 +1,110 @@
+import type { SimDynamoDbTagInput } from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbTableTag } from "./sim-dynamodb-table-tag.js";
+import { compareSimDynamoDbTextBytes } from "./sim-dynamodb-table-order.js";
+
+/**
+ * Real DynamoDB holds 50 tags on a resource.
+ *
+ * Tags AWS assigns itself are outside this, but a caller cannot assign one of
+ * those, so every tag here counts towards it.
+ */
+const greatestTags = 50;
+
+/**
+ * The tags one simulated DynamoDB resource holds.
+ *
+ * A key appears once. Tagging a key that is already there replaces its value
+ * rather than adding a second entry, which is what makes TagResource a way of
+ * changing a tag as well as adding one.
+ */
+export class SimDynamoDbTableTags {
+  private tags: ReadonlyMap<string, SimDynamoDbTableTag>;
+
+  private constructor(tags: ReadonlyMap<string, SimDynamoDbTableTag>) {
+    this.tags = tags;
+  }
+
+  /**
+   * Read the tags a request carries, which may be none at all.
+   */
+  static fromInput(
+    input: readonly SimDynamoDbTagInput[] | undefined,
+  ): SimDynamoDbTableTags {
+    const tags = new this(new Map());
+
+    tags.apply(input ?? []);
+
+    return tags;
+  }
+
+  /**
+   * Add the tags a request carries, replacing the value of any key already
+   * held.
+   *
+   * The whole request is read and counted before anything is kept, so a request
+   * DynamoDB would refuse leaves the tags exactly as they were.
+   */
+  apply(input: readonly SimDynamoDbTagInput[]): void {
+    const applied = new Map(this.tags);
+
+    for (const entry of input) {
+      const tag = SimDynamoDbTableTag.fromInput(entry);
+
+      applied.set(tag.key, tag);
+    }
+
+    assertWithinLimit(applied.size);
+
+    this.tags = applied;
+  }
+
+  /**
+   * Take the tags a request names off, leaving the rest.
+   *
+   * A key that is not there is not an error. UntagResource asks for a state
+   * rather than for a change, and that state is a resource without that key.
+   */
+  remove(keys: readonly string[]): void {
+    const left = new Map(this.tags);
+
+    for (const key of keys) {
+      left.delete(key);
+    }
+
+    this.tags = left;
+  }
+
+  /**
+   * Every tag this resource holds, ordered by key.
+   *
+   * DynamoDB says nothing about the order it lists tags in. Ordering them by
+   * UTF-8 bytes, as table names are ordered, is one of the orders it allows,
+   * and it is what lets a page resume at the key after the last one listed.
+   */
+  ordered(): readonly SimDynamoDbTableTag[] {
+    return this.tags
+      .values()
+      .toArray()
+      .toSorted((first, second) =>
+        compareSimDynamoDbTextBytes(first.key, second.key),
+      );
+  }
+}
+
+/**
+ * Refuse a resource holding more tags than DynamoDB holds.
+ *
+ * Real DynamoDB answers this with a ValidationException rather than the
+ * LimitExceededException its API reference lists for TagResource. That error is
+ * documented entirely in terms of how many table operations are running at
+ * once, which is a different thing from how many tags a table is carrying.
+ */
+function assertWithinLimit(size: number): void {
+  if (size > greatestTags) {
+    throw new SimDynamoDbValidationException(
+      `A DynamoDB resource holds ${greatestTags.toString()} tags, and this ` +
+        `request would leave it holding ${size.toString()}`,
+    );
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -14,6 +14,7 @@ import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
 import { SimDynamoDbTableLifecycle } from "./sim-dynamodb-table-lifecycle.js";
+import { SimDynamoDbTableTags } from "./sim-dynamodb-table-tags.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -30,6 +31,7 @@ interface SimDynamoDbTableProperties {
   readonly billing: SimDynamoDbTableBilling;
   readonly tableClass?: SimDynamoDbTableClass | undefined;
   readonly deletionProtectionEnabled?: boolean | undefined;
+  readonly tags?: SimDynamoDbTableTags;
   readonly background?: BackgroundScheduler;
 }
 
@@ -52,6 +54,14 @@ export class SimDynamoDbTable {
   public readonly tableClass: SimDynamoDbTableClass | undefined;
   public readonly deletionProtectionEnabled: boolean;
 
+  /**
+   * The tags this table carries.
+   *
+   * Tags are the table's own state rather than something a command holds, so
+   * TagResource, UntagResource and ListTagsOfResource all work through this.
+   */
+  public readonly tags: SimDynamoDbTableTags;
+
   private readonly items = new SimDynamoDbTableItems();
   private readonly itemKey: SimDynamoDbItemKey;
   private readonly lifecycle: SimDynamoDbTableLifecycle;
@@ -63,6 +73,7 @@ export class SimDynamoDbTable {
       attributeDefinitions,
       billing,
       deletionProtectionEnabled = false,
+      tags = SimDynamoDbTableTags.fromInput([]),
       background = new BackgroundTasks(),
     } = properties;
 
@@ -74,6 +85,7 @@ export class SimDynamoDbTable {
     this.billing = billing;
     this.tableClass = properties.tableClass;
     this.deletionProtectionEnabled = deletionProtectionEnabled;
+    this.tags = tags;
     this.itemKey = new SimDynamoDbItemKey(keySchema, attributeDefinitions);
     this.lifecycle = new SimDynamoDbTableLifecycle({
       tableName: name.value,


### PR DESCRIPTION
CreateTable takes Tags, and TagResource, UntagResource and ListTagsOfResource work on a table by ARN, with DynamoDB's key, value, character set and 50 tag rules, and NextToken paging at 25 tags a page. AWS::DynamoDB::Table deploys its Tags, so a CDK stack applying Tags.of(...) gets a tagged table.

Resolves https://github.com/KensioSoftware/yulin/issues/262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DynamoDB table tagging support during table creation and through tag, untag, and list-tags operations.
  * Added CloudFormation support for deploying table tags.
  * Added validation for tag keys, values, reserved prefixes, and the 50-tag limit.
  * Added paginated tag listings with deterministic ordering and continuation tokens.

* **Documentation**
  * Updated DynamoDB documentation and examples to describe tagging behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->