### PR TITLE
feat: expire simulated DynamoDB items with time to live

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1350,7 +1350,8 @@ altogether. Here the answers stay lined up with the Gets that asked for them.
 
 `UpdateTimeToLive` names the attribute a table expires items by, and `DescribeTimeToLive` reports
 it. The attribute holds epoch seconds in a Number. An item without it, or holding a String or
-anything else, never expires, and that is not an error.
+anything else, never expires, and that is not an error. Nor does an item whose timestamp is more
+than five years in the past, which DynamoDB treats as a malformed value rather than as long overdue.
 
 Expiry runs on [the simulated clock](../../time/). Moving the clock forward is what deletes items
 whose time to live has run out, so one `advanceBy` expires a table's sessions alongside whatever
@@ -1446,8 +1447,12 @@ console.log(collected.Item === undefined); // true
 work has run, which is the sequence a table's own status goes through. Switching it off goes through
 `DISABLING` to `DISABLED`, and a `DISABLED` table reports no attribute name.
 
-DynamoDB takes one `UpdateTimeToLive` per table per hour. That hour is measured on the simulated
-clock, so a second call inside it is a `ValidationException` and
+An `UpdateTimeToLive` asking for the state the table is already in is a `ValidationException`, as it
+is on AWS, so code that has to be idempotent reads `DescribeTimeToLive` first. Changing the
+attribute an enabled table expires by means switching time to live off and then on again.
+
+DynamoDB also takes one `UpdateTimeToLive` per table per hour. That hour is measured on the
+simulated clock, so a second call inside it is a `ValidationException` and
 `simAws.clock().advanceBy({ hours: 1 })` is what lets the next one through.
 
 Switching time to live on reaches the items already on the table, since their attributes were only
@@ -1757,9 +1762,9 @@ nothing is written.
 - Time to live deletions publish no stream records. Real DynamoDB writes one with a `userIdentity`
   of type `Service`, which is how an application tells a TTL deletion from an application's own, and
   streams are not simulated here.
-- `UpdateTimeToLive` does not refuse switching time to live to the state it is already in. Real
-  DynamoDB answers that with a `ValidationException`. The one update per hour rule catches a repeat
-  inside the hour, so what is accepted here is a repeat an hour or more later.
+- The five year time to live eligibility rule counts 1825 days rather than five calendar years, so
+  an item whose timestamp sits within a couple of days of the boundary may be treated differently
+  here to how AWS treats it.
 - DynamoDB streams are not simulated. A `StreamSpecification` with `StreamEnabled` set is refused,
   so a table whose changes nothing is publishing cannot be created by accident. One that switches
   streams off describes the table this simulation already makes, so it is accepted.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1346,6 +1346,115 @@ console.log(output.Responses[1]); // {}
 That is the difference from `BatchGetItem`, which leaves a missing item out of its answer
 altogether. Here the answers stay lined up with the Gets that asked for them.
 
+## Expiring items with time to live
+
+`UpdateTimeToLive` names the attribute a table expires items by, and `DescribeTimeToLive` reports
+it. The attribute holds epoch seconds in a Number. An item without it, or holding a String or
+anything else, never expires, and that is not an error.
+
+Expiry runs on [the simulated clock](../../time/). Moving the clock forward is what deletes items
+whose time to live has run out, so one `advanceBy` expires a table's sessions alongside whatever
+else that advance causes elsewhere in the simulation. There is nothing else for a test to call.
+
+Deletion is not immediate. Real DynamoDB marks an item expired at its timestamp and deletes it
+typically within 48 hours, and reads keep returning it until then. That gap is simulated, so a test
+can advance an hour past a session's expiry, see the session come back from `GetItem`, and find out
+that the code under test needs to cope with it.
+
+```typescript sim-dynamodb-time-to-live
+/**
+ * Items expiring as the simulated clock moves past their time to live.
+ */
+
+import {
+  CreateTableCommand,
+  DescribeTimeToLiveCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-01T09:00:00.000Z")),
+});
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "SessionsTable",
+    KeySchema: [{ AttributeName: "sessionId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "sessionId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+await dynamoDb.updateTimeToLive(
+  new UpdateTimeToLiveCommand({
+    TableName: "SessionsTable",
+    TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const described = await dynamoDb.describeTimeToLive(
+  new DescribeTimeToLiveCommand({ TableName: "SessionsTable" }),
+);
+
+console.log(described.TimeToLiveDescription?.TimeToLiveStatus); // "ENABLED"
+
+// A session that expires in an hour.
+const nowSeconds = Math.floor(simAws.now().getTime() / 1000);
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "SessionsTable",
+    Item: {
+      sessionId: { S: "abc" },
+      expiresAt: { N: String(nowSeconds + 3600) },
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 2 });
+
+const stale = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "SessionsTable",
+    Key: { sessionId: { S: "abc" } },
+  }),
+);
+
+// Expired an hour ago, and still there, as it would be on AWS.
+console.log(stale.Item === undefined); // false
+
+await simAws.clock().advanceBy({ days: 3 });
+
+const collected = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "SessionsTable",
+    Key: { sessionId: { S: "abc" } },
+  }),
+);
+
+// Past the deletion window, with nothing else asked of the simulation.
+console.log(collected.Item === undefined); // true
+```
+
+`UpdateTimeToLive` moves the status to `ENABLING` and it settles on `ENABLED` once the background
+work has run, which is the sequence a table's own status goes through. Switching it off goes through
+`DISABLING` to `DISABLED`, and a `DISABLED` table reports no attribute name.
+
+DynamoDB takes one `UpdateTimeToLive` per table per hour. That hour is measured on the simulated
+clock, so a second call inside it is a `ValidationException` and
+`simAws.clock().advanceBy({ hours: 1 })` is what lets the next one through.
+
+Switching time to live on reaches the items already on the table, since their attributes were only
+inert while it was off. A removal already scheduled is checked again when it comes due, so an item
+overwritten with a later timestamp, or one on a table whose time to live has since been switched
+off, stays where it is.
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -1603,8 +1712,12 @@ nothing is written.
   which a missing item is an entry with no `Item`.
 - `Tags` on `CreateTable`, with `TagResource`, `UntagResource` and `ListTagsOfResource` addressing
   the table by ARN, the key, value and count rules DynamoDB applies, and `NextToken` paging.
+- `UpdateTimeToLive` and `DescribeTimeToLive`, moving through `ENABLING` and `DISABLING` to settle,
+  with the one update per hour rule measured on the simulated clock. Items expire as the clock moves
+  past their deletion window, with no sweep for a test to call.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
-  table name, `Fn::GetAtt … Arn` the table ARN, and `Tags` deploying a tagged table.
+  table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
+  expires items, and `Tags` deploying a tagged table.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
 
 ## Limitations
@@ -1631,8 +1744,22 @@ nothing is written.
 - Tables are the only taggable DynamoDB resource here. Backups and global table replicas are not
   simulated, so an ARN naming one of those names nothing. Real DynamoDB also copies a table's tags
   onto its secondary indexes, which have nothing to copy to yet.
-- Time to live is not simulated. There is no `UpdateTimeToLive` or `DescribeTimeToLive`, and no item
-  expires.
+- The time to live deletion window is a fixed 48 hours, where AWS promises only that an expired item
+  is typically deleted within 48 hours. A simulation has to pick a point in that range, and this
+  picks the far end, because that is the longest an expired item can still be readable and so is the
+  behaviour an application has to cope with. A test can rely on an item surviving its TTL timestamp,
+  and on it being gone once the window has passed. It should not assert that an expired item is
+  still there partway through the window, since real DynamoDB may well have collected it by then.
+- Time to live expiry is dispatched by moving the clock through `simAws.clock()`, not by real time
+  elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
+  is until something moves the clock. A simulated DynamoDB constructed standalone as
+  `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
+- Time to live deletions publish no stream records. Real DynamoDB writes one with a `userIdentity`
+  of type `Service`, which is how an application tells a TTL deletion from an application's own, and
+  streams are not simulated here.
+- `UpdateTimeToLive` does not refuse switching time to live to the state it is already in. Real
+  DynamoDB answers that with a `ValidationException`. The one update per hour rule catches a repeat
+  inside the hour, so what is accepted here is a repeat an hour or more later.
 - DynamoDB streams are not simulated. A `StreamSpecification` with `StreamEnabled` set is refused,
   so a table whose changes nothing is publishing cannot be created by accident. One that switches
   streams off describes the table this simulation already makes, so it is accepted.

--- a/docs/services/dynamodb/sim-dynamodb-time-to-live.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-time-to-live.example.ts
@@ -1,0 +1,78 @@
+/**
+ * Items expiring as the simulated clock moves past their time to live.
+ */
+
+import {
+  CreateTableCommand,
+  DescribeTimeToLiveCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-01T09:00:00.000Z")),
+});
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "SessionsTable",
+    KeySchema: [{ AttributeName: "sessionId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "sessionId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+await dynamoDb.updateTimeToLive(
+  new UpdateTimeToLiveCommand({
+    TableName: "SessionsTable",
+    TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const described = await dynamoDb.describeTimeToLive(
+  new DescribeTimeToLiveCommand({ TableName: "SessionsTable" }),
+);
+
+console.log(described.TimeToLiveDescription?.TimeToLiveStatus); // "ENABLED"
+
+// A session that expires in an hour.
+const nowSeconds = Math.floor(simAws.now().getTime() / 1000);
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "SessionsTable",
+    Item: {
+      sessionId: { S: "abc" },
+      expiresAt: { N: String(nowSeconds + 3600) },
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 2 });
+
+const stale = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "SessionsTable",
+    Key: { sessionId: { S: "abc" } },
+  }),
+);
+
+// Expired an hour ago, and still there, as it would be on AWS.
+console.log(stale.Item === undefined); // false
+
+await simAws.clock().advanceBy({ days: 3 });
+
+const collected = await dynamoDb.getItem(
+  new GetItemCommand({
+    TableName: "SessionsTable",
+    Key: { sessionId: { S: "abc" } },
+  }),
+);
+
+// Past the deletion window, with nothing else asked of the simulation.
+console.log(collected.Item === undefined); // true

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -253,8 +253,10 @@ runs on a clock a test can control: `await simSdk.simAws.clock().advanceBy({ hou
 
 ## Limitations
 
-- Nothing schedules work on the clock yet. There are no scheduled event sources such as EventBridge
-  rules, so advancing time currently affects timestamps and expiry rather than triggering anything.
+- There are no scheduled event sources such as EventBridge rules, so nothing here is driven by a
+  cron or rate expression. What the clock does drive is state that falls due: a Secrets Manager
+  recovery window running out, or a DynamoDB item passing its
+  [time to live](../services/dynamodb/#expiring-items-with-time-to-live) deletion window.
 - Only `SimAws` exposes time control. Services constructed standalone, such as `new SimS3()`, get
   their own real clock and no way to move it.
 - A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -52,6 +52,7 @@ Current command areas include:
 - `batch/` (BatchWriteItem and BatchGetItem)
 - `transact/` (TransactWriteItems and TransactGetItems)
 - `tag/` (TagResource, UntagResource and ListTagsOfResource)
+- `time-to-live/` (UpdateTimeToLive and DescribeTimeToLive)
 
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
@@ -669,6 +670,31 @@ Current uses:
   write that is there, so nothing about it waits on the scheduler.
 - `SimDynamoDbTransactionTokens` reads the scheduler's clock, which is what makes the ten minute
   `ClientRequestToken` window something `simAws.clock().advanceBy(...)` can move past.
+- UpdateTimeToLive schedules the settle that takes the status from ENABLING to ENABLED, or from
+  DISABLING to DISABLED, the same way table activation is scheduled.
+- `SimDynamoDbTableExpiry` uses `scheduleAt` rather than `schedule`, so an item's removal is due at
+  a simulated instant rather than on the next drain. Only moving the clock through `simAws.clock()`
+  dispatches it, which is why `backgroundTasksComplete()` does not expire anything.
+
+## Time to live
+
+Time to live lives under `time-to-live/`, away from the commands that switch it on, because it is
+table state rather than request handling.
+
+- `SimDynamoDbTimeToLive` is one table's setting: the status, the attribute name, and when it was
+  last updated. It owns the one update per table per hour rule, measured on the simulated clock.
+- `SimDynamoDbTimeToLiveSpecification` is a checked `TimeToLiveSpecification`. Real DynamoDB
+  requires both fields even when switching time to live off, so both are required here.
+- `simDynamoDbItemDeletionInstant` works out when an item should be deleted, which is 48 hours after
+  its TTL timestamp rather than on it. That window is the deliberate divergence: AWS promises a
+  range and this picks the far end. The reasoning is in the constant's comment.
+- `SimDynamoDbTableExpiry` schedules the removal and re-checks at fire time, the same shape as
+  `SimSecretsManagerSecretExpiry`. The re-check recomputes the deletion instant from whatever is
+  under the key now, so one check covers a deleted item, an overwrite with a later TTL, a TTL
+  attribute that has gone or changed type, and time to live having been switched off.
+
+`SimDynamoDbTable.putItem()` is the single hook. Every write in the service goes through it,
+including batch and transactional ones, so nothing needs a scheduling call of its own.
 
 Tests that need eventual state should call the broader sim AWS background-drain helper, for example:
 

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -682,12 +682,14 @@ Time to live lives under `time-to-live/`, away from the commands that switch it 
 table state rather than request handling.
 
 - `SimDynamoDbTimeToLive` is one table's setting: the status, the attribute name, and when it was
-  last updated. It owns the one update per table per hour rule, measured on the simulated clock.
+  last updated. It owns the two rules an update has to pass: that it changes the state, and that it
+  is at least an hour after the last one. Both are measured on the simulated clock.
 - `SimDynamoDbTimeToLiveSpecification` is a checked `TimeToLiveSpecification`. Real DynamoDB
   requires both fields even when switching time to live off, so both are required here.
 - `simDynamoDbItemDeletionInstant` works out when an item should be deleted, which is 48 hours after
   its TTL timestamp rather than on it. That window is the deliberate divergence: AWS promises a
-  range and this picks the far end. The reasoning is in the constant's comment.
+  range and this picks the far end. The reasoning is in the constant's comment. It also applies the
+  five year eligibility rule, which is why it takes the instant to read the timestamp against.
 - `SimDynamoDbTableExpiry` schedules the removal and re-checks at fire time, the same shape as
   `SimSecretsManagerSecretExpiry`. The re-check recomputes the deletion instant from whatever is
   under the key now, so one check covers a deleted item, an overwrite with a later TTL, a TTL

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-time-to-live.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-time-to-live.iso.test.ts
@@ -1,0 +1,126 @@
+import {
+  DescribeTimeToLiveCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
+
+/**
+ * The instant this suite starts from.
+ */
+const startedAt = new Date("2026-08-01T09:00:00.000Z");
+
+/**
+ * That instant as the epoch seconds a TTL attribute carries.
+ */
+const startedAtSeconds = String(Math.floor(startedAt.getTime() / 1000));
+
+describe("DynamoDB CloudFormation Table time to live", () => {
+  it("deploys a table that expires items by the attribute the template names", async () => {
+    // Given a template setting a time to live attribute, as a CDK table with
+    // timeToLiveAttribute set emits.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "sessions-stack",
+      template: {
+        Resources: {
+          SessionsTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "sessions",
+            partitionKeyName: "sessionId",
+            properties: {
+              TimeToLiveSpecification: {
+                AttributeName: "expiresAt",
+                Enabled: true,
+              },
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then DescribeTimeToLive reports the attribute, as it would for a table
+    // an SDK caller had updated.
+    const described = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "sessions" }),
+      );
+    assertIdentical(
+      described.TimeToLiveDescription?.TimeToLiveStatus,
+      "ENABLED",
+    );
+    assertIdentical(described.TimeToLiveDescription.AttributeName, "expiresAt");
+
+    // And the deployed table really expires items, rather than only reporting
+    // that it would.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "sessions",
+        Item: {
+          sessionId: { S: "abc" },
+          expiresAt: { N: startedAtSeconds },
+        },
+      }),
+    );
+
+    await simAws.clock().advanceBy({ days: 3 });
+
+    const read = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: "sessions",
+        Key: { sessionId: { S: "abc" } },
+      }),
+    );
+    assertUndefined(read.Item);
+  });
+
+  it("deploys a table whose template switches time to live off", async () => {
+    // Given a template naming an attribute but leaving time to live off.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "sessions-stack",
+      template: {
+        Resources: {
+          SessionsTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "sessions",
+            partitionKeyName: "sessionId",
+            properties: {
+              TimeToLiveSpecification: {
+                AttributeName: "expiresAt",
+                Enabled: false,
+              },
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    // Then the table is there, expiring nothing.
+    const described = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "sessions" }),
+      );
+    assertNonNullable(described.TimeToLiveDescription);
+    assertIdentical(
+      described.TimeToLiveDescription.TimeToLiveStatus,
+      "DISABLED",
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-validation.iso.test.ts
@@ -51,8 +51,8 @@ describe("DynamoDB CloudFormation Table validation", () => {
   });
 
   it("skips a table with a property that is not simulated", async () => {
-    // Given a template asking for a time to live, which is not simulated, in a
-    // stack with another Resource in it.
+    // Given a template asking for point in time recovery, which is not
+    // simulated, in a stack with another Resource in it.
     const simAws = new SimAws();
 
     // When the template is deployed.
@@ -63,9 +63,8 @@ describe("DynamoDB CloudFormation Table validation", () => {
           OrdersTable: simCfnDynamoDbTableResourceFactory.make({
             tableName: "orders",
             properties: {
-              TimeToLiveSpecification: {
-                AttributeName: "expiresAt",
-                Enabled: true,
+              PointInTimeRecoverySpecification: {
+                PointInTimeRecoveryEnabled: true,
               },
             },
           }),
@@ -82,8 +81,8 @@ describe("DynamoDB CloudFormation Table validation", () => {
     assertTrue(resource.skipped);
     assertStringIncludes(
       resource.skippedReason ?? "",
-      "TimeToLiveSpecification is a real AWS::DynamoDB::Table property that " +
-        "simulated DynamoDB does not simulate",
+      "PointInTimeRecoverySpecification is a real AWS::DynamoDB::Table " +
+        "property that simulated DynamoDB does not simulate",
     );
     assertUndefined(simAws.dynamoDb().findTable("orders"));
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -70,6 +70,11 @@ export class SimCfnDynamoDbTableCreator {
    * CreateTable has no TimeToLiveSpecification of its own on real DynamoDB
    * either, so CloudFormation makes the table and then updates it, and this
    * does the same through the ordinary UpdateTimeToLive command.
+   *
+   * A template asking for time to live to be off describes the state a new
+   * table is already in, and DynamoDB refuses an UpdateTimeToLive that asks for
+   * the state it is already in, so there is nothing to send. The specification
+   * is still read, so a template holding the wrong shape is still refused.
    */
   private async applyTimeToLive(
     name: string,
@@ -77,7 +82,7 @@ export class SimCfnDynamoDbTableCreator {
   ): Promise<void> {
     const specification = tableProperties.timeToLiveSpecification();
 
-    if (specification === undefined) {
+    if (specification?.Enabled !== true) {
       return;
     }
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -53,6 +53,8 @@ export class SimCfnDynamoDbTableCreator {
       },
     });
 
+    await this.applyTimeToLive(name, tableProperties);
+
     const table = this.dynamoDb.findTable(name);
     assertDefined(
       table,
@@ -60,5 +62,27 @@ export class SimCfnDynamoDbTableCreator {
     );
 
     return table;
+  }
+
+  /**
+   * Switch the table's time to live on, when the template asked for it.
+   *
+   * CreateTable has no TimeToLiveSpecification of its own on real DynamoDB
+   * either, so CloudFormation makes the table and then updates it, and this
+   * does the same through the ordinary UpdateTimeToLive command.
+   */
+  private async applyTimeToLive(
+    name: string,
+    tableProperties: SimCfnDynamoDbTableProperties,
+  ): Promise<void> {
+    const specification = tableProperties.timeToLiveSpecification();
+
+    if (specification === undefined) {
+      return;
+    }
+
+    await this.dynamoDb.updateTimeToLive({
+      input: { TableName: name, TimeToLiveSpecification: specification },
+    });
   }
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -7,7 +7,9 @@ import type {
   SimDynamoDbProvisionedThroughput,
   SimDynamoDbTagInput,
 } from "../../command/table/table.types.js";
+import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
 import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
+import { readSimCfnDynamoDbTableTimeToLive } from "./sim-cfn-dynamodb-table-time-to-live.js";
 import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
 
 /**
@@ -137,6 +139,14 @@ export class SimCfnDynamoDbTableProperties {
    */
   deletionProtectionEnabled(): boolean | undefined {
     return this.values.boolean("DeletionProtectionEnabled");
+  }
+
+  /**
+   * The time to live the template asks for, when it asks for one.
+   */
+  timeToLiveSpecification():
+    SimDynamoDbTimeToLiveSpecificationInput | undefined {
+    return readSimCfnDynamoDbTableTimeToLive(this.values);
   }
 
   /**

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -16,15 +16,15 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "TableClass",
   "TableName",
   "Tags",
+  "TimeToLiveSpecification",
 ]);
 
 /**
  * Real AWS::DynamoDB::Table properties this simulation does not model.
  *
  * Each one changes what the table does. A table deployed without its secondary
- * indexes would answer queries differently, and one deployed without its time
- * to live would hold items that should have expired, so the Resource is
- * skipped rather than deployed as something else.
+ * indexes would answer queries differently, so the Resource is skipped rather
+ * than deployed as something else.
  */
 const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ContributorInsightsSpecification",
@@ -37,7 +37,6 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ResourcePolicy",
   "SSESpecification",
   "StreamSpecification",
-  "TimeToLiveSpecification",
   "WarmThroughput",
 ]);
 

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-time-to-live.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-time-to-live.ts
@@ -1,0 +1,25 @@
+import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * Read the time to live an AWS::DynamoDB::Table Resource asks for.
+ *
+ * A CDK table with `timeToLiveAttribute` set emits this, so it is the ordinary
+ * way a deployed table comes to expire items. The values go through
+ * UpdateTimeToLive rather than being applied here, so a template naming no
+ * attribute is refused in the same words an SDK caller would get.
+ */
+export function readSimCfnDynamoDbTableTimeToLive(
+  values: SimCfnDynamoDbTableValues,
+): SimDynamoDbTimeToLiveSpecificationInput | undefined {
+  const specification = values.object("TimeToLiveSpecification");
+
+  if (specification === undefined) {
+    return undefined;
+  }
+
+  return {
+    AttributeName: specification.string("AttributeName"),
+    Enabled: specification.boolean("Enabled"),
+  };
+}

--- a/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
@@ -10,6 +10,7 @@ import { SimDynamoDbGetItem } from "./item/sim-dynamodb-get-item.js";
 import { SimDynamoDbPutItem } from "./item/sim-dynamodb-put-item.js";
 import { SimDynamoDbUpdateItem } from "./item/sim-dynamodb-update-item.js";
 import { SimDynamoDbTagCommands } from "./tag/sim-dynamodb-tag-commands.js";
+import { SimDynamoDbTimeToLiveCommands } from "./time-to-live/sim-dynamodb-time-to-live-commands.js";
 import { SimDynamoDbCreateTable } from "./table/sim-dynamodb-create-table.js";
 import { SimDynamoDbTableAccess } from "./table/sim-dynamodb-table-access.js";
 import { SimDynamoDbTableCommands } from "./table/sim-dynamodb-table-commands.js";
@@ -44,6 +45,7 @@ export class SimDynamoDbCommandHandlers {
   public readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
   public readonly itemTransactReads: SimDynamoDbTransactGetItems;
   public readonly tags: SimDynamoDbTagCommands;
+  public readonly timeToLive: SimDynamoDbTimeToLiveCommands;
 
   constructor(properties: SimDynamoDbCommandHandlersProperties) {
     const { tables, accountRegionScope, background } = properties;
@@ -77,5 +79,6 @@ export class SimDynamoDbCommandHandlers {
     });
     this.itemTransactReads = new SimDynamoDbTransactGetItems({ access });
     this.tags = new SimDynamoDbTagCommands({ access });
+    this.timeToLive = new SimDynamoDbTimeToLiveCommands({ access, background });
   }
 }

--- a/src/service/dynamodb/command/sim-dynamodb-command.types.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command.types.ts
@@ -1,0 +1,66 @@
+/**
+ * The sim DynamoDB Command types, gathered for the service facade.
+ */
+export type {
+  SimCreateTableCommand,
+  SimCreateTableCommandInput,
+  SimCreateTableCommandOutput,
+  SimDeleteTableCommand,
+  SimDeleteTableCommandInput,
+  SimDeleteTableCommandOutput,
+  SimDescribeTableCommand,
+  SimDescribeTableCommandInput,
+  SimDescribeTableCommandOutput,
+  SimListTablesCommand,
+  SimListTablesCommandInput,
+  SimListTablesCommandOutput,
+} from "./table/table.command.js";
+export type {
+  SimDeleteItemCommand,
+  SimDeleteItemCommandInput,
+  SimDeleteItemCommandOutput,
+  SimGetItemCommand,
+  SimGetItemCommandInput,
+  SimGetItemCommandOutput,
+  SimPutItemCommand,
+  SimPutItemCommandInput,
+  SimPutItemCommandOutput,
+  SimUpdateItemCommand,
+  SimUpdateItemCommandInput,
+  SimUpdateItemCommandOutput,
+} from "./item/item.command.js";
+export type {
+  SimBatchGetItemCommand,
+  SimBatchGetItemCommandInput,
+  SimBatchGetItemCommandOutput,
+  SimBatchWriteItemCommand,
+  SimBatchWriteItemCommandInput,
+  SimBatchWriteItemCommandOutput,
+} from "./batch/batch.command.js";
+export type {
+  SimTransactGetItemsCommand,
+  SimTransactGetItemsCommandInput,
+  SimTransactGetItemsCommandOutput,
+  SimTransactWriteItemsCommand,
+  SimTransactWriteItemsCommandInput,
+  SimTransactWriteItemsCommandOutput,
+} from "./transact/transact.command.js";
+export type {
+  SimListTagsOfResourceCommand,
+  SimListTagsOfResourceCommandInput,
+  SimListTagsOfResourceCommandOutput,
+  SimTagResourceCommand,
+  SimTagResourceCommandInput,
+  SimTagResourceCommandOutput,
+  SimUntagResourceCommand,
+  SimUntagResourceCommandInput,
+  SimUntagResourceCommandOutput,
+} from "./tag/tag.command.js";
+export type {
+  SimDescribeTimeToLiveCommand,
+  SimDescribeTimeToLiveCommandInput,
+  SimDescribeTimeToLiveCommandOutput,
+  SimUpdateTimeToLiveCommand,
+  SimUpdateTimeToLiveCommandInput,
+  SimUpdateTimeToLiveCommandOutput,
+} from "./time-to-live/time-to-live.command.js";

--- a/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.iso.test.ts
+++ b/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.iso.test.ts
@@ -34,6 +34,22 @@ async function timeToLiveStatus(
   return described.TimeToLiveDescription?.TimeToLiveStatus;
 }
 
+/**
+ * Read the attribute a table expires items by.
+ */
+async function timeToLiveAttribute(
+  simAws: SimAws,
+  tableName: string,
+): Promise<string | undefined> {
+  const described = await simAws
+    .dynamoDb()
+    .describeTimeToLive(
+      new DescribeTimeToLiveCommand({ TableName: tableName }),
+    );
+
+  return described.TimeToLiveDescription?.AttributeName;
+}
+
 describe("DynamoDB UpdateTimeToLiveCommand", () => {
   it("moves through ENABLING to ENABLED", async () => {
     // Given a table.
@@ -137,17 +153,20 @@ describe("DynamoDB UpdateTimeToLiveCommand", () => {
     );
     await simAws.backgroundTasksComplete();
 
-    // When it is updated again inside the hour.
+    // When it is switched off again inside the hour.
     const error = await assertThrowsErrorAsync(async () =>
       simDynamoDb.updateTimeToLive(
         new UpdateTimeToLiveCommand({
           TableName: "Sessions",
-          TimeToLiveSpecification: { Enabled: true, AttributeName: "goneAt" },
+          TimeToLiveSpecification: {
+            Enabled: false,
+            AttributeName: "expiresAt",
+          },
         }),
       ),
     );
 
-    // Then it is refused, and the table keeps the attribute it had.
+    // Then it is refused.
     assertInstanceOf(error, SimDynamoDbValidationException);
     assertStringIncludes(
       error.message,
@@ -159,10 +178,74 @@ describe("DynamoDB UpdateTimeToLiveCommand", () => {
     const later = await simDynamoDb.updateTimeToLive(
       new UpdateTimeToLiveCommand({
         TableName: "Sessions",
-        TimeToLiveSpecification: { Enabled: true, AttributeName: "goneAt" },
+        TimeToLiveSpecification: { Enabled: false, AttributeName: "expiresAt" },
       }),
     );
-    assertIdentical(later.TimeToLiveSpecification?.AttributeName, "goneAt");
+    assertIdentical(later.TimeToLiveSpecification?.AttributeName, "expiresAt");
+  });
+
+  it("refuses an update asking for the state the table is already in", async () => {
+    // Given a table with time to live already switched on.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // And well past the hour, so the rate rule is not what answers.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // When it is switched on again, naming a different attribute.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateTimeToLive(
+        new UpdateTimeToLiveCommand({
+          TableName: "Sessions",
+          TimeToLiveSpecification: { Enabled: true, AttributeName: "goneAt" },
+        }),
+      ),
+    );
+
+    // Then it is refused, as real DynamoDB refuses it. Changing the attribute
+    // means switching time to live off and on again.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "is already ENABLED");
+
+    // And the table still expires items by the attribute it had.
+    assertIdentical(await timeToLiveAttribute(simAws, "Sessions"), "expiresAt");
+  });
+
+  it("refuses switching time to live off on a table that never had it on", async () => {
+    // Given a table nothing has set time to live on, so it is DISABLED.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+
+    // When time to live is switched off.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().updateTimeToLive(
+        new UpdateTimeToLiveCommand({
+          TableName: "Sessions",
+          TimeToLiveSpecification: {
+            Enabled: false,
+            AttributeName: "expiresAt",
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than taken as a no-op.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "is already DISABLED");
   });
 
   it("refuses an update to a table that is not there", async () => {

--- a/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.iso.test.ts
+++ b/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.iso.test.ts
@@ -1,0 +1,230 @@
+import {
+  DescribeTimeToLiveCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+
+/**
+ * Read a table's time to live status.
+ */
+async function timeToLiveStatus(
+  simAws: SimAws,
+  tableName: string,
+): Promise<string | undefined> {
+  const described = await simAws
+    .dynamoDb()
+    .describeTimeToLive(
+      new DescribeTimeToLiveCommand({ TableName: tableName }),
+    );
+
+  return described.TimeToLiveDescription?.TimeToLiveStatus;
+}
+
+describe("DynamoDB UpdateTimeToLiveCommand", () => {
+  it("moves through ENABLING to ENABLED", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+
+    // When time to live is switched on.
+    const update = await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+
+    // Then the response carries what the request asked for.
+    assertIdentical(update.TimeToLiveSpecification?.AttributeName, "expiresAt");
+    assertTrue(update.TimeToLiveSpecification.Enabled);
+
+    // And the table reports it as still enabling.
+    assertIdentical(await timeToLiveStatus(simAws, "Sessions"), "ENABLING");
+
+    // And it settles on ENABLED once the scheduled work has run.
+    await simAws.backgroundTasksComplete();
+    const settled = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "Sessions" }),
+      );
+    assertIdentical(settled.TimeToLiveDescription?.TimeToLiveStatus, "ENABLED");
+    assertIdentical(settled.TimeToLiveDescription.AttributeName, "expiresAt");
+  });
+
+  it("moves through DISABLING to DISABLED", async () => {
+    // Given a table with time to live switched on.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // And an hour has passed, since DynamoDB takes one update per hour.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // When time to live is switched off.
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: false, AttributeName: "expiresAt" },
+      }),
+    );
+
+    // Then the table reports it as still disabling, by the same attribute.
+    const disabling = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "Sessions" }),
+      );
+    assertIdentical(
+      disabling.TimeToLiveDescription?.TimeToLiveStatus,
+      "DISABLING",
+    );
+    assertIdentical(disabling.TimeToLiveDescription.AttributeName, "expiresAt");
+
+    // And once it settles the table expires items by no attribute at all.
+    await simAws.backgroundTasksComplete();
+    const disabled = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "Sessions" }),
+      );
+    assertIdentical(
+      disabled.TimeToLiveDescription?.TimeToLiveStatus,
+      "DISABLED",
+    );
+    assertUndefined(disabled.TimeToLiveDescription.AttributeName);
+  });
+
+  it("takes one update per table per hour", async () => {
+    // Given a table that has just had its time to live updated.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDb.updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When it is updated again inside the hour.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateTimeToLive(
+        new UpdateTimeToLiveCommand({
+          TableName: "Sessions",
+          TimeToLiveSpecification: { Enabled: true, AttributeName: "goneAt" },
+        }),
+      ),
+    );
+
+    // Then it is refused, and the table keeps the attribute it had.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "one UpdateTimeToLive per table per hour",
+    );
+
+    // And an hour later the same update is taken.
+    await simAws.clock().advanceBy({ hours: 1 });
+    const later = await simDynamoDb.updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "goneAt" },
+      }),
+    );
+    assertIdentical(later.TimeToLiveSpecification?.AttributeName, "goneAt");
+  });
+
+  it("refuses an update to a table that is not there", async () => {
+    // Given a simulated DynamoDB holding no tables.
+    const simDynamoDb = new SimAws().dynamoDb();
+
+    // When time to live is updated on a table that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateTimeToLive(
+        new UpdateTimeToLiveCommand({
+          TableName: "Sessions",
+          TimeToLiveSpecification: {
+            Enabled: true,
+            AttributeName: "expiresAt",
+          },
+        }),
+      ),
+    );
+
+    // Then the missing table is reported.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+    assertStringIncludes(error.message, "No DynamoDB Table named Sessions");
+  });
+});
+
+describe("DynamoDB DescribeTimeToLiveCommand", () => {
+  it("reports a table that has never had time to live set as DISABLED", async () => {
+    // Given a table nothing has set time to live on.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions" },
+      simAws,
+    );
+
+    // When its time to live is described.
+    const described = await simAws
+      .dynamoDb()
+      .describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "Sessions" }),
+      );
+
+    // Then it is disabled, and expires items by no attribute.
+    assertIdentical(
+      described.TimeToLiveDescription?.TimeToLiveStatus,
+      "DISABLED",
+    );
+    assertUndefined(described.TimeToLiveDescription.AttributeName);
+  });
+
+  it("refuses a describe of a table that is not there", async () => {
+    // Given a simulated DynamoDB holding no tables.
+    const simDynamoDb = new SimAws().dynamoDb();
+
+    // When a table that does not exist is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.describeTimeToLive(
+        new DescribeTimeToLiveCommand({ TableName: "Sessions" }),
+      ),
+    );
+
+    // Then the missing table is reported.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+    assertStringIncludes(error.message, "No DynamoDB Table named Sessions");
+  });
+});

--- a/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.ts
+++ b/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-commands.ts
@@ -1,0 +1,84 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbTimeToLiveSpecification } from "../../time-to-live/sim-dynamodb-time-to-live-specification.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type {
+  SimDescribeTimeToLiveCommand,
+  SimDescribeTimeToLiveCommandOutput,
+  SimUpdateTimeToLiveCommand,
+  SimUpdateTimeToLiveCommandOutput,
+} from "./time-to-live.command.js";
+
+interface SimDynamoDbTimeToLiveCommandsProperties {
+  readonly access: SimDynamoDbTableAccess;
+  readonly background: BackgroundScheduler;
+}
+
+interface SimDynamoDbTimeToLiveCommandsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The commands that switch a table's time to live on and off, and report it.
+ */
+export class SimDynamoDbTimeToLiveCommands {
+  private readonly access: SimDynamoDbTableAccess;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimDynamoDbTimeToLiveCommandsProperties) {
+    this.access = properties.access;
+    this.background = properties.background;
+  }
+
+  /**
+   * Switch a table's time to live on or off.
+   *
+   * The status goes to ENABLING or DISABLING at once and settles once the
+   * background work has run, which is the sequence real DynamoDB goes through.
+   * The response carries the specification the request gave, as AWS answers
+   * while the change is still in progress.
+   */
+  updateTimeToLive(
+    command: SimUpdateTimeToLiveCommand,
+    options?: SimDynamoDbTimeToLiveCommandsOptions,
+  ): SimUpdateTimeToLiveCommandOutput {
+    const table = this.access.required(
+      "dynamodb:UpdateTimeToLive",
+      command.input.TableName,
+      options?.caller,
+    );
+    const specification = SimDynamoDbTimeToLiveSpecification.fromInput(
+      command.input.TimeToLiveSpecification,
+    );
+
+    table.updateTimeToLive(specification, this.background.now());
+    this.background.schedule(() => table.settleTimeToLive());
+
+    return {
+      TimeToLiveSpecification: {
+        AttributeName: specification.attributeName,
+        Enabled: specification.enabled,
+      },
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Report a table's time to live.
+   */
+  describeTimeToLive(
+    command: SimDescribeTimeToLiveCommand,
+    options?: SimDynamoDbTimeToLiveCommandsOptions,
+  ): SimDescribeTimeToLiveCommandOutput {
+    const table = this.access.required(
+      "dynamodb:DescribeTimeToLive",
+      command.input.TableName,
+      options?.caller,
+    );
+
+    return {
+      TimeToLiveDescription: table.timeToLiveDescription(),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-validation.iso.test.ts
+++ b/src/service/dynamodb/command/time-to-live/sim-dynamodb-time-to-live-validation.iso.test.ts
@@ -1,0 +1,98 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDbTimeToLiveSpecificationInput } from "./time-to-live.types.js";
+
+/**
+ * Update time to live with a specification real DynamoDB would refuse, and read
+ * the refusal.
+ *
+ * The commands are built structurally rather than from the SDK, since the SDK's
+ * own types stop some of this input at the compiler and a caller not using them
+ * still reaches the same validation.
+ */
+async function refusedTimeToLiveUpdate(
+  specification: SimDynamoDbTimeToLiveSpecificationInput | undefined,
+): Promise<Error> {
+  const simAws = new SimAws();
+  await simDynamoDbCreatedTableFactory.make({ tableName: "Sessions" }, simAws);
+
+  return await assertThrowsErrorAsync(async () =>
+    simAws.dynamoDb().updateTimeToLive({
+      input: { TableName: "Sessions", TimeToLiveSpecification: specification },
+    }),
+  );
+}
+
+describe("DynamoDB UpdateTimeToLiveCommand validation", () => {
+  it("requires a specification", async () => {
+    // When time to live is updated with no specification.
+    const error = await refusedTimeToLiveUpdate(undefined);
+
+    // Then the missing specification is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TimeToLiveSpecification is required to update time to live",
+    );
+  });
+
+  it("requires an attribute name", async () => {
+    // When time to live is switched on without naming an attribute.
+    const error = await refusedTimeToLiveUpdate({ Enabled: true });
+
+    // Then the missing attribute name is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TimeToLiveSpecification.AttributeName is required",
+    );
+  });
+
+  it("refuses an empty attribute name", async () => {
+    // When time to live is switched on with an empty attribute name.
+    const error = await refusedTimeToLiveUpdate({
+      Enabled: true,
+      AttributeName: "",
+    });
+
+    // Then it is refused the same way a missing one is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TimeToLiveSpecification.AttributeName is required",
+    );
+  });
+
+  it("refuses an attribute name longer than DynamoDB takes", async () => {
+    // When time to live names an attribute of 256 characters.
+    const error = await refusedTimeToLiveUpdate({
+      Enabled: true,
+      AttributeName: "e".repeat(256),
+    });
+
+    // Then the length is reported against the limit.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "has a length of 256");
+  });
+
+  it("requires Enabled either way", async () => {
+    // When a specification names an attribute but does not say whether time to
+    // live is on. Real DynamoDB requires both fields, including when switching
+    // time to live off.
+    const error = await refusedTimeToLiveUpdate({ AttributeName: "expiresAt" });
+
+    // Then the missing field is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "TimeToLiveSpecification.Enabled is required",
+    );
+  });
+});

--- a/src/service/dynamodb/command/time-to-live/time-to-live.command.ts
+++ b/src/service/dynamodb/command/time-to-live/time-to-live.command.ts
@@ -1,0 +1,57 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimDynamoDbTimeToLiveDescription,
+  SimDynamoDbTimeToLiveSpecificationInput,
+} from "./time-to-live.types.js";
+
+/**
+ * Minimal structural sim DynamoDB UpdateTimeToLive command.
+ */
+export interface SimUpdateTimeToLiveCommand {
+  readonly input: SimUpdateTimeToLiveCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB UpdateTimeToLive input.
+ *
+ * `TableName` takes the table's name or its ARN, as real DynamoDB does.
+ */
+export interface SimUpdateTimeToLiveCommandInput {
+  readonly TableName?: string | undefined;
+  readonly TimeToLiveSpecification?:
+    SimDynamoDbTimeToLiveSpecificationInput | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB UpdateTimeToLive output.
+ *
+ * The specification comes back as the request gave it, which is what real
+ * DynamoDB answers with while the change is still ENABLING or DISABLING.
+ */
+export interface SimUpdateTimeToLiveCommandOutput {
+  readonly TimeToLiveSpecification?:
+    SimDynamoDbTimeToLiveSpecificationInput | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim DynamoDB DescribeTimeToLive command.
+ */
+export interface SimDescribeTimeToLiveCommand {
+  readonly input: SimDescribeTimeToLiveCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB DescribeTimeToLive input.
+ */
+export interface SimDescribeTimeToLiveCommandInput {
+  readonly TableName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB DescribeTimeToLive output.
+ */
+export interface SimDescribeTimeToLiveCommandOutput {
+  readonly TimeToLiveDescription?: SimDynamoDbTimeToLiveDescription | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/time-to-live/time-to-live.types.ts
+++ b/src/service/dynamodb/command/time-to-live/time-to-live.types.ts
@@ -1,0 +1,31 @@
+/**
+ * The statuses DynamoDB reports a table's time to live in.
+ *
+ * An update moves it to ENABLING or DISABLING and it settles on ENABLED or
+ * DISABLED, the same two-step a table's own status goes through.
+ */
+export type SimDynamoDbTimeToLiveStatus =
+  "ENABLING" | "DISABLING" | "ENABLED" | "DISABLED";
+
+/**
+ * Minimal structural sim DynamoDB TimeToLiveSpecification.
+ *
+ * Both fields are required by real DynamoDB, including when switching time to
+ * live off, so both are typed as loosely as the wire carries them and checked
+ * rather than being made optional here.
+ */
+export interface SimDynamoDbTimeToLiveSpecificationInput {
+  readonly AttributeName?: string | undefined;
+  readonly Enabled?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB TimeToLiveDescription.
+ *
+ * `AttributeName` is left out once time to live is DISABLED, as real DynamoDB
+ * leaves it out: the table no longer expires items by any attribute.
+ */
+export interface SimDynamoDbTimeToLiveDescription {
+  readonly TimeToLiveStatus: SimDynamoDbTimeToLiveStatus;
+  readonly AttributeName?: string | undefined;
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -6,6 +6,7 @@ import {
   DeleteItemCommand,
   DeleteTableCommand,
   DescribeTableCommand,
+  DescribeTimeToLiveCommand,
   DynamoDBClient,
   GetItemCommand,
   ListTablesCommand,
@@ -17,6 +18,7 @@ import {
   TransactWriteItemsCommand,
   UntagResourceCommand,
   UpdateItemCommand,
+  UpdateTimeToLiveCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   assertArrayLength,
@@ -279,6 +281,39 @@ describe("simulated DynamoDB SDK Command routing", () => {
     assertNonNullable(listed.Tags);
     assertArrayLength(listed.Tags, 1);
     assertObjectEquals(listed.Tags[0], { Key: "Owner", Value: "platform" });
+  });
+
+  it("round-trips time to live Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: "SessionsTable",
+        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const update = await client.send(
+      new UpdateTimeToLiveCommand({
+        TableName: "SessionsTable",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    assertIdentical(update.TimeToLiveSpecification?.AttributeName, "expiresAt");
+    await simSdk.simAws.backgroundTasksComplete();
+
+    const described = await client.send(
+      new DescribeTimeToLiveCommand({ TableName: "SessionsTable" }),
+    );
+    assertIdentical(
+      described.TimeToLiveDescription?.TimeToLiveStatus,
+      "ENABLED",
+    );
   });
 
   it("does not give a denied run-as caller root privileges", async () => {

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -28,6 +28,10 @@ import type {
   SimTransactGetItemsCommand,
   SimTransactWriteItemsCommand,
 } from "../command/transact/transact.command.js";
+import type {
+  SimDescribeTimeToLiveCommand,
+  SimUpdateTimeToLiveCommand,
+} from "../command/time-to-live/time-to-live.command.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
 /**
@@ -147,6 +151,22 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simDynamoDatabase.listTagsOfResource(
             command as SimListTagsOfResourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "UpdateTimeToLiveCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.updateTimeToLive(
+            command as SimUpdateTimeToLiveCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeTimeToLiveCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDatabase.describeTimeToLive(
+            command as SimDescribeTimeToLiveCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -4,47 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { SimDynamoDbCommandHandlers } from "./command/sim-dynamodb-command-handlers.js";
+import type * as simDynamoDbCommands from "./command/sim-dynamodb-command.types.js";
 import { SimDynamoDbTableStore } from "./table/sim-dynamodb-table-store.js";
-import type {
-  SimCreateTableCommand,
-  SimCreateTableCommandOutput,
-  SimDeleteTableCommand,
-  SimDeleteTableCommandOutput,
-  SimDescribeTableCommand,
-  SimDescribeTableCommandOutput,
-  SimListTablesCommand,
-  SimListTablesCommandOutput,
-} from "./command/table/table.command.js";
-import type {
-  SimDeleteItemCommand,
-  SimDeleteItemCommandOutput,
-  SimGetItemCommand,
-  SimGetItemCommandOutput,
-  SimPutItemCommand,
-  SimPutItemCommandOutput,
-  SimUpdateItemCommand,
-  SimUpdateItemCommandOutput,
-} from "./command/item/item.command.js";
-import type {
-  SimBatchGetItemCommand,
-  SimBatchGetItemCommandOutput,
-  SimBatchWriteItemCommand,
-  SimBatchWriteItemCommandOutput,
-} from "./command/batch/batch.command.js";
-import type {
-  SimTransactGetItemsCommand,
-  SimTransactGetItemsCommandOutput,
-  SimTransactWriteItemsCommand,
-  SimTransactWriteItemsCommandOutput,
-} from "./command/transact/transact.command.js";
-import type {
-  SimListTagsOfResourceCommand,
-  SimListTagsOfResourceCommandOutput,
-  SimTagResourceCommand,
-  SimTagResourceCommandOutput,
-  SimUntagResourceCommand,
-  SimUntagResourceCommandOutput,
-} from "./command/tag/tag.command.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import {
@@ -98,9 +59,9 @@ export class SimDynamoDb {
    * Handle a Create Table Command from the SDK.
    */
   async createTable(
-    command: SimCreateTableCommand,
+    command: simDynamoDbCommands.SimCreateTableCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimCreateTableCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimCreateTableCommandOutput> {
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
     return this.commands.tableCreation.handle(command, options);
@@ -110,9 +71,9 @@ export class SimDynamoDb {
    * Handle a Describe Table Command from the SDK.
    */
   async describeTable(
-    command: SimDescribeTableCommand,
+    command: simDynamoDbCommands.SimDescribeTableCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimDescribeTableCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimDescribeTableCommandOutput> {
     await this.background.sequence();
     return this.commands.tables.describeTable(command, options);
   }
@@ -121,9 +82,9 @@ export class SimDynamoDb {
    * Handle a List Tables Command from the SDK.
    */
   async listTables(
-    command: SimListTablesCommand,
+    command: simDynamoDbCommands.SimListTablesCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimListTablesCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimListTablesCommandOutput> {
     await this.background.sequence();
     return this.commands.tables.listTables(command, options);
   }
@@ -132,9 +93,9 @@ export class SimDynamoDb {
    * Handle a Delete Table Command from the SDK.
    */
   async deleteTable(
-    command: SimDeleteTableCommand,
+    command: simDynamoDbCommands.SimDeleteTableCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimDeleteTableCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimDeleteTableCommandOutput> {
     await this.background.sequence();
     return this.commands.tables.deleteTable(command, options);
   }
@@ -143,9 +104,9 @@ export class SimDynamoDb {
    * Handle a Put Item Command from the SDK.
    */
   async putItem(
-    command: SimPutItemCommand,
+    command: simDynamoDbCommands.SimPutItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimPutItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimPutItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemWrites.handle(command, options);
   }
@@ -154,9 +115,9 @@ export class SimDynamoDb {
    * Handle a Get Item Command from the SDK.
    */
   async getItem(
-    command: SimGetItemCommand,
+    command: simDynamoDbCommands.SimGetItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimGetItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimGetItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemReads.handle(command, options);
   }
@@ -165,9 +126,9 @@ export class SimDynamoDb {
    * Handle a Delete Item Command from the SDK.
    */
   async deleteItem(
-    command: SimDeleteItemCommand,
+    command: simDynamoDbCommands.SimDeleteItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimDeleteItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimDeleteItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemDeletions.handle(command, options);
   }
@@ -176,9 +137,9 @@ export class SimDynamoDb {
    * Handle an Update Item Command from the SDK.
    */
   async updateItem(
-    command: SimUpdateItemCommand,
+    command: simDynamoDbCommands.SimUpdateItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimUpdateItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimUpdateItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemUpdates.handle(command, options);
   }
@@ -187,9 +148,9 @@ export class SimDynamoDb {
    * Handle a Batch Write Item Command from the SDK.
    */
   async batchWriteItem(
-    command: SimBatchWriteItemCommand,
+    command: simDynamoDbCommands.SimBatchWriteItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimBatchWriteItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimBatchWriteItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemBatchWrites.handle(command, options);
   }
@@ -198,9 +159,9 @@ export class SimDynamoDb {
    * Handle a Batch Get Item Command from the SDK.
    */
   async batchGetItem(
-    command: SimBatchGetItemCommand,
+    command: simDynamoDbCommands.SimBatchGetItemCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimBatchGetItemCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimBatchGetItemCommandOutput> {
     await this.background.sequence();
     return this.commands.itemBatchReads.handle(command, options);
   }
@@ -209,9 +170,9 @@ export class SimDynamoDb {
    * Handle a Transact Write Items Command from the SDK.
    */
   async transactWriteItems(
-    command: SimTransactWriteItemsCommand,
+    command: simDynamoDbCommands.SimTransactWriteItemsCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimTransactWriteItemsCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimTransactWriteItemsCommandOutput> {
     await this.background.sequence();
     return this.commands.itemTransactWrites.handle(command, options);
   }
@@ -220,9 +181,9 @@ export class SimDynamoDb {
    * Handle a Transact Get Items Command from the SDK.
    */
   async transactGetItems(
-    command: SimTransactGetItemsCommand,
+    command: simDynamoDbCommands.SimTransactGetItemsCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimTransactGetItemsCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimTransactGetItemsCommandOutput> {
     await this.background.sequence();
     return this.commands.itemTransactReads.handle(command, options);
   }
@@ -231,9 +192,9 @@ export class SimDynamoDb {
    * Handle a Tag Resource Command from the SDK.
    */
   async tagResource(
-    command: SimTagResourceCommand,
+    command: simDynamoDbCommands.SimTagResourceCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimTagResourceCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimTagResourceCommandOutput> {
     await this.background.sequence();
     return this.commands.tags.tagResource(command, options);
   }
@@ -242,9 +203,9 @@ export class SimDynamoDb {
    * Handle an Untag Resource Command from the SDK.
    */
   async untagResource(
-    command: SimUntagResourceCommand,
+    command: simDynamoDbCommands.SimUntagResourceCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimUntagResourceCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimUntagResourceCommandOutput> {
     await this.background.sequence();
     return this.commands.tags.untagResource(command, options);
   }
@@ -253,11 +214,33 @@ export class SimDynamoDb {
    * Handle a List Tags Of Resource Command from the SDK.
    */
   async listTagsOfResource(
-    command: SimListTagsOfResourceCommand,
+    command: simDynamoDbCommands.SimListTagsOfResourceCommand,
     options?: SimDynamoDbRequestOptions,
-  ): Promise<SimListTagsOfResourceCommandOutput> {
+  ): Promise<simDynamoDbCommands.SimListTagsOfResourceCommandOutput> {
     await this.background.sequence();
     return this.commands.tags.listTagsOfResource(command, options);
+  }
+
+  /**
+   * Handle an Update Time To Live Command from the SDK.
+   */
+  async updateTimeToLive(
+    command: simDynamoDbCommands.SimUpdateTimeToLiveCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simDynamoDbCommands.SimUpdateTimeToLiveCommandOutput> {
+    await this.background.sequence();
+    return this.commands.timeToLive.updateTimeToLive(command, options);
+  }
+
+  /**
+   * Handle a Describe Time To Live Command from the SDK.
+   */
+  async describeTimeToLive(
+    command: simDynamoDbCommands.SimDescribeTimeToLiveCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simDynamoDbCommands.SimDescribeTimeToLiveCommandOutput> {
+    await this.background.sequence();
+    return this.commands.timeToLive.describeTimeToLive(command, options);
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-items.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-items.ts
@@ -30,6 +30,16 @@ export class SimDynamoDbTableItems {
   }
 
   /**
+   * Every item held here, with the key it is held under.
+   *
+   * Switching time to live on has to reach items that were already written, so
+   * the items are readable as a whole rather than only one key at a time.
+   */
+  entries(): ReadonlyMap<string, SimDynamoDbItem> {
+    return this.items;
+  }
+
+  /**
    * Remove the item held under a key, and answer with whatever was removed.
    *
    * A key holding nothing is not a failure. DynamoDB deletes by key rather than

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -10,6 +10,10 @@ import type {
   SimDynamoDbTableStatus,
 } from "../command/table/table.types.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTimeToLiveDescription } from "../command/time-to-live/time-to-live.types.js";
+import { SimDynamoDbTableExpiry } from "../time-to-live/sim-dynamodb-table-expiry.js";
+import { SimDynamoDbTimeToLive } from "../time-to-live/sim-dynamodb-time-to-live.js";
+import type { SimDynamoDbTimeToLiveSpecification } from "../time-to-live/sim-dynamodb-time-to-live-specification.js";
 import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
@@ -65,6 +69,8 @@ export class SimDynamoDbTable {
   private readonly items = new SimDynamoDbTableItems();
   private readonly itemKey: SimDynamoDbItemKey;
   private readonly lifecycle: SimDynamoDbTableLifecycle;
+  private readonly timeToLive: SimDynamoDbTimeToLive;
+  private readonly expiry: SimDynamoDbTableExpiry;
 
   constructor(properties: SimDynamoDbTableProperties) {
     const {
@@ -90,6 +96,12 @@ export class SimDynamoDbTable {
     this.lifecycle = new SimDynamoDbTableLifecycle({
       tableName: name.value,
       deletionProtectionEnabled,
+    });
+    this.timeToLive = new SimDynamoDbTimeToLive(name.value);
+    this.expiry = new SimDynamoDbTableExpiry({
+      items: this.items,
+      timeToLive: this.timeToLive,
+      background,
     });
     this.creationDateTime = background.now();
   }
@@ -140,7 +152,42 @@ export class SimDynamoDbTable {
    * write once it is durable, so a read that follows it finds it.
    */
   public putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.items.put(this.itemKey.of(item), item);
+    const key = this.itemKey.of(item);
+    const replaced = this.items.put(key, item);
+
+    this.expiry.scheduleFor(key, item);
+
+    return replaced;
+  }
+
+  /**
+   * Take an UpdateTimeToLive on this table.
+   *
+   * Switching it on reaches the items already there as well as the ones written
+   * afterwards, since their TTL attributes were only inert while it was off.
+   */
+  updateTimeToLive(
+    specification: SimDynamoDbTimeToLiveSpecification,
+    at: Date,
+  ): void {
+    this.timeToLive.update(specification, at);
+    this.expiry.scheduleForAll();
+  }
+
+  /**
+   * Finish an UpdateTimeToLive, moving it off ENABLING or DISABLING.
+   */
+  settleTimeToLive(): Promise<void> {
+    this.timeToLive.settle();
+
+    return Promise.resolve();
+  }
+
+  /**
+   * Describe this table's time to live the way DynamoDB reports it.
+   */
+  timeToLiveDescription(): SimDynamoDbTimeToLiveDescription {
+    return this.timeToLive.description();
   }
 
   /**

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-expiring-table.factory.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-expiring-table.factory.ts
@@ -1,0 +1,66 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+
+/**
+ * What a test asks for when it wants a table that expires its items.
+ */
+export interface SimDynamoDbExpiringTableInput {
+  readonly tableName: string;
+  readonly partitionKeyName: string;
+
+  /**
+   * The attribute items expire by, holding epoch seconds in a Number.
+   */
+  readonly attributeName: string;
+}
+
+/**
+ * Creates a table with time to live already switched on.
+ *
+ * The table went through CreateTable and UpdateTimeToLive, so it is the table
+ * an application would have rather than one built around the commands. Both
+ * have settled by the time this answers: a test asking for an expiring table is
+ * asking for one that is already ENABLED.
+ *
+ * ```typescript
+ * const table = await simDynamoDbExpiringTableFactory.make(
+ *   { tableName: "Sessions", attributeName: "expiresAt" },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbExpiringTableFactory = new AsyncMappedFactory<
+  SimDynamoDbExpiringTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "Sessions",
+    partitionKeyName: "sessionId",
+    attributeName: "expiresAt",
+  }),
+  async (input, simAws) => {
+    const table = await simDynamoDbCreatedTableFactory.make(
+      {
+        tableName: input.tableName,
+        partitionKeyName: input.partitionKeyName,
+      },
+      simAws,
+    );
+
+    await simAws.dynamoDb().updateTimeToLive({
+      input: {
+        TableName: input.tableName,
+        TimeToLiveSpecification: {
+          Enabled: true,
+          AttributeName: input.attributeName,
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    return table;
+  },
+);

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.iso.test.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.iso.test.ts
@@ -164,6 +164,21 @@ describe("DynamoDB item expiry", () => {
     assertNonNullable(await getSession(simAws, "abc"));
   });
 
+  it("never expires an item whose TTL is more than five years past", async () => {
+    // Given a session whose expiry is six years behind the write, which is what
+    // a value in the wrong unit tends to look like.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(-6 * 365 * 24 * 60 * 60) });
+
+    // When the clock moves a long way on.
+    await simAws.clock().advanceBy({ days: 400 });
+
+    // Then the session is still there. Real DynamoDB leaves an item alone once
+    // its timestamp is that far in the past, treating it as malformed rather
+    // than as long overdue.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
   it("never expires an item whose TTL is too large to be an instant", async () => {
     // Given a session whose expiry holds a number far past any date.
     const simAws = await expiringSessions();

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.iso.test.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.iso.test.ts
@@ -1,0 +1,201 @@
+import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertNonNullable, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+import { simDynamoDbExpiringTableFactory } from "./sim-dynamodb-expiring-table.factory.js";
+
+/**
+ * The instant every test here starts from, so the arithmetic in each one is
+ * against a known number rather than against whenever the suite ran.
+ */
+const startedAt = new Date("2026-08-01T09:00:00.000Z");
+
+/**
+ * A simulation holding one table that expires items by `expiresAt`.
+ */
+async function expiringSessions(): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+
+  await simDynamoDbExpiringTableFactory.make({}, simAws);
+
+  return simAws;
+}
+
+/**
+ * Epoch seconds a TTL attribute carries, a number of seconds from the start.
+ */
+function ttlSeconds(offsetSeconds: number): string {
+  return String(Math.floor(startedAt.getTime() / 1000) + offsetSeconds);
+}
+
+/**
+ * Write a session, expiring by whatever the caller puts in `expiresAt`.
+ */
+async function putSession(
+  simAws: SimAws,
+  sessionId: string,
+  expiresAt: SimDynamoDbAttributeValue | undefined,
+): Promise<void> {
+  await simAws.dynamoDb().putItem({
+    input: {
+      TableName: "Sessions",
+      Item: {
+        sessionId: { S: sessionId },
+        ...(expiresAt !== undefined && { expiresAt }),
+      },
+    },
+  });
+}
+
+/**
+ * Read a session back, if the table still holds it.
+ */
+async function getSession(
+  simAws: SimAws,
+  sessionId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const read = await simAws.dynamoDb().getItem(
+    new GetItemCommand({
+      TableName: "Sessions",
+      Key: { sessionId: { S: sessionId } },
+    }),
+  );
+
+  return read.Item;
+}
+
+describe("DynamoDB item expiry", () => {
+  it("keeps returning an item whose TTL timestamp has passed", async () => {
+    // Given a session that expires an hour from now.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(3600) });
+
+    // When the clock moves an hour past that.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // Then the session is still readable, as it would be on AWS: DynamoDB
+    // deletes an expired item within about 48 hours rather than on the
+    // timestamp.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("deletes an item once its deletion window has passed", async () => {
+    // Given a session that expires an hour from now.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(3600) });
+
+    // When the clock moves past the window, with nothing else asked of the
+    // simulation.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the session has gone.
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("measures the window as 48 hours from the TTL timestamp", async () => {
+    // Given a session that expired on the hour it was written.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(0) });
+
+    // When the clock reaches a minute short of 48 hours after that.
+    await simAws.clock().advanceBy({ hours: 47, minutes: 59 });
+
+    // Then the session is still there.
+    assertNonNullable(await getSession(simAws, "abc"));
+
+    // And it goes on the 48th hour, measured from the timestamp rather than
+    // from the write or from the advance.
+    await simAws.clock().advanceBy({ minutes: 1 });
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("leaves an item alone until the clock next moves", async () => {
+    // Given a session written with a TTL that ran out long ago.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(-7 * 24 * 60 * 60) });
+
+    // Then a read straight after the write still finds it, since nothing
+    // dispatches expiry until simulated time moves.
+    assertNonNullable(await getSession(simAws, "abc"));
+
+    // And the smallest movement of the clock takes it.
+    await simAws.clock().advanceBy({ milliseconds: 1 });
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("never expires an item with no TTL attribute", async () => {
+    // Given a session carrying no expiry at all.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", undefined);
+
+    // When the clock moves a long way on.
+    await simAws.clock().advanceBy({ days: 400 });
+
+    // Then the session is still there.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("never expires an item whose TTL attribute is not a Number", async () => {
+    // Given a session whose expiry was written as a String, which is the
+    // ordinary way to get this wrong.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { S: ttlSeconds(0) });
+
+    // When the clock moves past when it would have expired.
+    await simAws.clock().advanceBy({ days: 400 });
+
+    // Then the session is still there, and that is not an error: real DynamoDB
+    // skips an attribute it cannot read as epoch seconds.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("never expires an item whose TTL is in the future", async () => {
+    // Given a session that expires in a year.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: ttlSeconds(365 * 24 * 60 * 60) });
+
+    // When the clock moves on by less than that.
+    await simAws.clock().advanceBy({ days: 200 });
+
+    // Then the session is still there.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("never expires an item whose TTL is too large to be an instant", async () => {
+    // Given a session whose expiry holds a number far past any date.
+    const simAws = await expiringSessions();
+    await putSession(simAws, "abc", { N: "9".repeat(30) });
+
+    // When the clock moves on.
+    await simAws.clock().advanceBy({ days: 400 });
+
+    // Then the session is still there rather than the simulation failing on an
+    // unreadable instant.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("expires nothing on a table with time to live switched off", async () => {
+    // Given a table nothing has switched time to live on for.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions", partitionKeyName: "sessionId" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "Sessions",
+        Item: { sessionId: { S: "abc" }, expiresAt: { N: ttlSeconds(0) } },
+      }),
+    );
+
+    // When the clock moves a long way past the TTL timestamp.
+    await simAws.clock().advanceBy({ days: 400 });
+
+    // Then the item is still there. The attribute means nothing until an
+    // UpdateTimeToLive says it does.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+});

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.ts
@@ -18,6 +18,18 @@ import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 const deletionWindowMilliseconds = 48 * 60 * 60 * 1000;
 
 /**
+ * How far back a TTL timestamp can be and still be acted on.
+ *
+ * Real DynamoDB leaves an item alone when its timestamp is more than five years
+ * in the past. The rule guards against a malformed value: epoch milliseconds
+ * written where epoch seconds belong lands far in the future, and the reverse
+ * mistake lands far in the past, and neither is what the application meant.
+ *
+ * Five calendar years vary in length, so this is 1825 days.
+ */
+const eligibilityWindowMilliseconds = 5 * 365 * 24 * 60 * 60 * 1000;
+
+/**
  * The furthest instant a JavaScript Date reaches.
  */
 const greatestInstantMilliseconds = 8_640_000_000_000_000;
@@ -28,11 +40,13 @@ const greatestInstantMilliseconds = 8_640_000_000_000_000;
  * The attribute holds epoch seconds in a Number. An item without the attribute,
  * or holding a String or anything else, never expires, and that is not an
  * error: real DynamoDB skips it rather than refusing it. A number too large to
- * stand for an instant is skipped the same way.
+ * stand for an instant is skipped the same way, and so is one more than five
+ * years before `at`.
  */
 export function simDynamoDbItemDeletionInstant(
   item: SimDynamoDbItem,
   attributeName: string,
+  at: Date,
 ): Date | undefined {
   const value = item.attribute(attributeName);
 
@@ -43,7 +57,13 @@ export function simDynamoDbItemDeletionInstant(
   // Always a finite number: DynamoDB refuses anything outside its own range on
   // the way in, which is far inside what a JavaScript number holds.
   const seconds = Number(value.number.text);
-  const instant = seconds * 1000 + deletionWindowMilliseconds;
+  const expiry = seconds * 1000;
+
+  if (at.getTime() - expiry > eligibilityWindowMilliseconds) {
+    return undefined;
+  }
+
+  const instant = expiry + deletionWindowMilliseconds;
 
   if (Math.abs(instant) > greatestInstantMilliseconds) {
     return undefined;

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-item-expiry.ts
@@ -1,0 +1,53 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+
+/**
+ * How long after its TTL timestamp an expired item is deleted.
+ *
+ * Real DynamoDB does not delete on the timestamp. It marks the item expired and
+ * typically deletes it within 48 hours, and reads keep returning it until then,
+ * which is why the AWS docs tell you to filter expired items on read rather
+ * than trust they have gone.
+ *
+ * AWS promises a window rather than an instant, so a simulation has to pick a
+ * point in it. This picks the far end, because that is the longest an expired
+ * item can still be readable and so is the behaviour an application has to cope
+ * with. A test can rely on an item surviving its TTL timestamp, and on it being
+ * gone once the window has passed. It should not rely on one still being there
+ * partway through the window: real DynamoDB may well have collected it by then.
+ */
+const deletionWindowMilliseconds = 48 * 60 * 60 * 1000;
+
+/**
+ * The furthest instant a JavaScript Date reaches.
+ */
+const greatestInstantMilliseconds = 8_640_000_000_000_000;
+
+/**
+ * When an item's TTL attribute says it should be deleted, if it says so at all.
+ *
+ * The attribute holds epoch seconds in a Number. An item without the attribute,
+ * or holding a String or anything else, never expires, and that is not an
+ * error: real DynamoDB skips it rather than refusing it. A number too large to
+ * stand for an instant is skipped the same way.
+ */
+export function simDynamoDbItemDeletionInstant(
+  item: SimDynamoDbItem,
+  attributeName: string,
+): Date | undefined {
+  const value = item.attribute(attributeName);
+
+  if (value?.kind !== "N") {
+    return undefined;
+  }
+
+  // Always a finite number: DynamoDB refuses anything outside its own range on
+  // the way in, which is far inside what a JavaScript number holds.
+  const seconds = Number(value.number.text);
+  const instant = seconds * 1000 + deletionWindowMilliseconds;
+
+  if (Math.abs(instant) > greatestInstantMilliseconds) {
+    return undefined;
+  }
+
+  return new Date(instant);
+}

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.iso.test.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  DeleteItemCommand,
+  GetItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+import { assertNonNullable, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+import { simDynamoDbExpiringTableFactory } from "./sim-dynamodb-expiring-table.factory.js";
+
+/**
+ * The instant every test here starts from.
+ */
+const startedAt = new Date("2026-08-01T09:00:00.000Z");
+
+/**
+ * Epoch seconds a TTL attribute carries, a number of hours from the start.
+ */
+function ttlHours(offsetHours: number): string {
+  return String(Math.floor(startedAt.getTime() / 1000) + offsetHours * 60 * 60);
+}
+
+/**
+ * Write a session expiring at a TTL timestamp.
+ */
+async function putSession(
+  simAws: SimAws,
+  sessionId: string,
+  expiresAt: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "Sessions",
+      Item: { sessionId: { S: sessionId }, expiresAt: { N: expiresAt } },
+    }),
+  );
+}
+
+/**
+ * Read a session back, if the table still holds it.
+ */
+async function getSession(
+  simAws: SimAws,
+  sessionId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const read = await simAws.dynamoDb().getItem(
+    new GetItemCommand({
+      TableName: "Sessions",
+      Key: { sessionId: { S: sessionId } },
+    }),
+  );
+
+  return read.Item;
+}
+
+describe("DynamoDB table expiry", () => {
+  it("keeps an item overwritten with a later TTL", async () => {
+    // Given a session that expired on the hour it was written.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "abc", ttlHours(0));
+
+    // And it is written again, expiring a week later, before its window runs
+    // out.
+    await putSession(simAws, "abc", ttlHours(24 * 7));
+
+    // When the clock passes the window the first write would have gone in.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the session is still there. The scheduled removal found an item
+    // that is no longer expired and left it alone.
+    assertNonNullable(await getSession(simAws, "abc"));
+
+    // And it goes once the second TTL's own window runs out.
+    await simAws.clock().advanceBy({ days: 7 });
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("keeps an item once time to live is switched off", async () => {
+    // Given a session that expired on the hour it was written.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "abc", ttlHours(0));
+
+    // And time to live is switched off an hour later, before the window runs
+    // out.
+    await simAws.clock().advanceBy({ hours: 1 });
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: false, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the clock passes the window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the session is still there.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("expires items that were already there when time to live was switched on", async () => {
+    // Given a table with items written before time to live meant anything.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "Sessions", partitionKeyName: "sessionId" },
+      simAws,
+    );
+    await putSession(simAws, "abc", ttlHours(0));
+
+    // When time to live is switched on, and the clock passes the window.
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "Sessions",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the item that was already there has gone. Its TTL attribute was
+    // only inert while time to live was off.
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("leaves an item whose TTL attribute was taken off it", async () => {
+    // Given a session that expired on the hour it was written.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "abc", ttlHours(0));
+
+    // And the expiry attribute is taken off it before the window runs out.
+    await simAws.dynamoDb().updateItem(
+      new UpdateItemCommand({
+        TableName: "Sessions",
+        Key: { sessionId: { S: "abc" } },
+        UpdateExpression: "REMOVE expiresAt",
+      }),
+    );
+
+    // When the clock passes the window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the session is still there. An item with no TTL attribute expires by
+    // nothing, however it came to have none.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("finds nothing to remove when the item has already gone", async () => {
+    // Given a session the application deleted before its window ran out.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "abc", ttlHours(0));
+    await simAws.dynamoDb().deleteItem(
+      new DeleteItemCommand({
+        TableName: "Sessions",
+        Key: { sessionId: { S: "abc" } },
+      }),
+    );
+
+    // When the clock passes the window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the scheduled removal had nothing to do, rather than failing on a
+    // key holding nothing.
+    assertUndefined(await getSession(simAws, "abc"));
+  });
+
+  it("leaves a deleted item's expiry with nothing to do", async () => {
+    // Given a session that has already been deleted by the application.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "abc", ttlHours(0));
+    await simAws.dynamoDb().deleteItem(
+      new DeleteItemCommand({
+        TableName: "Sessions",
+        Key: { sessionId: { S: "abc" } },
+      }),
+    );
+
+    // And a new session written under the same key, expiring much later.
+    await putSession(simAws, "abc", ttlHours(24 * 7));
+
+    // When the clock passes the deleted session's window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the new session is untouched, rather than taken by the removal the
+    // deleted one had scheduled.
+    assertNonNullable(await getSession(simAws, "abc"));
+  });
+
+  it("expires items in due order as one advance passes each window", async () => {
+    // Given two sessions expiring a day apart.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbExpiringTableFactory.make({}, simAws);
+    await putSession(simAws, "first", ttlHours(0));
+    await putSession(simAws, "second", ttlHours(24));
+
+    // When the clock moves past the first window but not the second.
+    await simAws.clock().advanceBy({ hours: 49 });
+
+    // Then only the first has gone.
+    assertUndefined(await getSession(simAws, "first"));
+    assertNonNullable(await getSession(simAws, "second"));
+
+    // And the second goes on the advance that reaches its own window.
+    await simAws.clock().advanceBy({ hours: 24 });
+    assertUndefined(await getSession(simAws, "second"));
+  });
+});

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.ts
@@ -1,0 +1,103 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbTableItems } from "../table/sim-dynamodb-table-items.js";
+import { simDynamoDbItemDeletionInstant } from "./sim-dynamodb-item-expiry.js";
+import type { SimDynamoDbTimeToLive } from "./sim-dynamodb-time-to-live.js";
+
+interface SimDynamoDbTableExpiryProperties {
+  readonly items: SimDynamoDbTableItems;
+  readonly timeToLive: SimDynamoDbTimeToLive;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Removes a table's items once their time to live has run out.
+ *
+ * The removal is scheduled on the simulation's clock rather than the host's, so
+ * moving simulated time past an item's deletion window is what takes it away.
+ * That is what lets one `advanceBy` expire a table's sessions alongside
+ * whatever else the same advance causes elsewhere in the simulation, rather
+ * than the test having to ask for the expiry separately.
+ */
+export class SimDynamoDbTableExpiry {
+  private readonly items: SimDynamoDbTableItems;
+  private readonly timeToLive: SimDynamoDbTimeToLive;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimDynamoDbTableExpiryProperties) {
+    this.items = properties.items;
+    this.timeToLive = properties.timeToLive;
+    this.background = properties.background;
+  }
+
+  /**
+   * Arrange for an item to be gone once its deletion window runs out.
+   *
+   * An item whose window has already passed is scheduled for an instant behind
+   * the clock, which nothing dispatches until the clock next moves. So a read
+   * straight after writing an already expired item still finds it, as it would
+   * on AWS.
+   */
+  scheduleFor(key: string, item: SimDynamoDbItem): void {
+    const attributeName = this.timeToLive.enabledAttributeName();
+
+    if (attributeName === undefined) {
+      return;
+    }
+
+    const at = simDynamoDbItemDeletionInstant(item, attributeName);
+
+    if (at === undefined) {
+      return;
+    }
+
+    this.background.scheduleAt(at, (): Promise<void> => {
+      this.removeIfExpired(key);
+
+      return Promise.resolve();
+    });
+  }
+
+  /**
+   * Arrange for every item already on the table to expire.
+   *
+   * Switching time to live on gives meaning to TTL attributes that were inert
+   * while it was off, so the items that already carry one are scheduled too.
+   */
+  scheduleForAll(): void {
+    for (const [key, item] of this.items.entries()) {
+      this.scheduleFor(key, item);
+    }
+  }
+
+  /**
+   * Remove an item, if it is still the expired item that was scheduled.
+   *
+   * The deletion instant is worked out again from whatever is under the key
+   * now, against the time to live the table has now. One re-check covers
+   * everything that should call the removal off: the item was deleted,
+   * overwritten with a later TTL, or had its TTL attribute removed or changed
+   * to something that is not a Number, or time to live was switched off.
+   */
+  private removeIfExpired(key: string): void {
+    const attributeName = this.timeToLive.enabledAttributeName();
+
+    if (attributeName === undefined) {
+      return;
+    }
+
+    const item = this.items.get(key);
+
+    if (item === undefined) {
+      return;
+    }
+
+    const at = simDynamoDbItemDeletionInstant(item, attributeName);
+
+    if (at === undefined || at.getTime() > this.background.now().getTime()) {
+      return;
+    }
+
+    this.items.remove(key);
+  }
+}

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-table-expiry.ts
@@ -37,6 +37,9 @@ export class SimDynamoDbTableExpiry {
    * the clock, which nothing dispatches until the clock next moves. So a read
    * straight after writing an already expired item still finds it, as it would
    * on AWS.
+   *
+   * The five year eligibility rule is read against the time of the write, which
+   * is when real DynamoDB would first look at the item.
    */
   scheduleFor(key: string, item: SimDynamoDbItem): void {
     const attributeName = this.timeToLive.enabledAttributeName();
@@ -45,7 +48,11 @@ export class SimDynamoDbTableExpiry {
       return;
     }
 
-    const at = simDynamoDbItemDeletionInstant(item, attributeName);
+    const at = simDynamoDbItemDeletionInstant(
+      item,
+      attributeName,
+      this.background.now(),
+    );
 
     if (at === undefined) {
       return;
@@ -92,9 +99,10 @@ export class SimDynamoDbTableExpiry {
       return;
     }
 
-    const at = simDynamoDbItemDeletionInstant(item, attributeName);
+    const now = this.background.now();
+    const at = simDynamoDbItemDeletionInstant(item, attributeName, now);
 
-    if (at === undefined || at.getTime() > this.background.now().getTime()) {
+    if (at === undefined || at.getTime() > now.getTime()) {
       return;
     }
 

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live-specification.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live-specification.ts
@@ -1,0 +1,79 @@
+import type { SimDynamoDbTimeToLiveSpecificationInput } from "../command/time-to-live/time-to-live.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * DynamoDB attribute names run from 1 to 255 characters.
+ */
+const greatestAttributeNameLength = 255;
+
+/**
+ * What an UpdateTimeToLive request asks for, once it has been checked.
+ *
+ * Real DynamoDB requires both fields, including when switching time to live
+ * off, so a request naming no attribute is refused rather than read as one
+ * asking to leave the attribute as it was.
+ */
+export class SimDynamoDbTimeToLiveSpecification {
+  public readonly attributeName: string;
+  public readonly enabled: boolean;
+
+  private constructor(attributeName: string, enabled: boolean) {
+    this.attributeName = attributeName;
+    this.enabled = enabled;
+  }
+
+  /**
+   * Read the specification a request carries.
+   */
+  static fromInput(
+    input: SimDynamoDbTimeToLiveSpecificationInput | undefined,
+  ): SimDynamoDbTimeToLiveSpecification {
+    if (input === undefined) {
+      throw new SimDynamoDbValidationException(
+        `TimeToLiveSpecification is required to update time to live`,
+      );
+    }
+
+    return new this(
+      this.readAttributeName(input.AttributeName),
+      this.readEnabled(input.Enabled),
+    );
+  }
+
+  /**
+   * The attribute items are expired by.
+   */
+  private static readAttributeName(attributeName: string | undefined): string {
+    if (attributeName === undefined || attributeName.length === 0) {
+      throw new SimDynamoDbValidationException(
+        `TimeToLiveSpecification.AttributeName is required, naming the ` +
+          `attribute items expire by`,
+      );
+    }
+
+    if (attributeName.length > greatestAttributeNameLength) {
+      throw new SimDynamoDbValidationException(
+        `TimeToLiveSpecification.AttributeName has a length of ` +
+          `${attributeName.length.toString()}, where 1 to ` +
+          `${greatestAttributeNameLength.toString()} characters is what ` +
+          `DynamoDB takes`,
+      );
+    }
+
+    return attributeName;
+  }
+
+  /**
+   * Whether the request is switching time to live on or off.
+   */
+  private static readEnabled(enabled: boolean | undefined): boolean {
+    if (typeof enabled !== "boolean") {
+      throw new SimDynamoDbValidationException(
+        `TimeToLiveSpecification.Enabled is required, and must be true or ` +
+          `false`,
+      );
+    }
+
+    return enabled;
+  }
+}

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live.ts
@@ -1,0 +1,127 @@
+import type {
+  SimDynamoDbTimeToLiveDescription,
+  SimDynamoDbTimeToLiveStatus,
+} from "../command/time-to-live/time-to-live.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbTimeToLiveSpecification } from "./sim-dynamodb-time-to-live-specification.js";
+
+/**
+ * Real DynamoDB takes one UpdateTimeToLive per table per hour.
+ */
+const updateWindowMilliseconds = 60 * 60 * 1000;
+
+/**
+ * One table's time to live setting.
+ *
+ * An update moves the status to ENABLING or DISABLING and the scheduled work
+ * settles it on ENABLED or DISABLED, which is the same two-step the table's own
+ * status goes through. Nothing here expires anything: this is what a table
+ * expires items by, and `SimDynamoDbTableExpiry` is what acts on it.
+ */
+export class SimDynamoDbTimeToLive {
+  private readonly tableName: string;
+  #status: SimDynamoDbTimeToLiveStatus = "DISABLED";
+  #attributeName: string | undefined;
+  #updatedAt: Date | undefined;
+
+  constructor(tableName: string) {
+    this.tableName = tableName;
+  }
+
+  /**
+   * Where this table's time to live is now.
+   */
+  get status(): SimDynamoDbTimeToLiveStatus {
+    return this.#status;
+  }
+
+  /**
+   * The attribute items expire by, while time to live is on.
+   *
+   * ENABLING counts as on and DISABLING as off, since each is on its way to
+   * that state and the scheduled work settles it within the same turn.
+   */
+  enabledAttributeName(): string | undefined {
+    if (this.#status === "ENABLED" || this.#status === "ENABLING") {
+      return this.#attributeName;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Take an update, refusing one that comes too soon after the last.
+   */
+  update(specification: SimDynamoDbTimeToLiveSpecification, at: Date): void {
+    this.assertUpdatable(at);
+
+    this.#attributeName = specification.attributeName;
+    this.#updatedAt = at;
+    this.#status = this.statusFor(specification.enabled);
+  }
+
+  /**
+   * Finish an update that was scheduled.
+   *
+   * A DISABLED table reports no attribute name, as real DynamoDB reports none,
+   * so the attribute is forgotten rather than left describing a table that no
+   * longer expires anything.
+   */
+  settle(): void {
+    if (this.#status === "ENABLING") {
+      this.#status = "ENABLED";
+
+      return;
+    }
+
+    if (this.#status === "DISABLING") {
+      this.#status = "DISABLED";
+      this.#attributeName = undefined;
+    }
+  }
+
+  /**
+   * Describe this time to live the way DynamoDB reports it.
+   */
+  description(): SimDynamoDbTimeToLiveDescription {
+    return {
+      TimeToLiveStatus: this.#status,
+      AttributeName: this.#attributeName,
+    };
+  }
+
+  /**
+   * Where an update is heading.
+   */
+  private statusFor(enabled: boolean): SimDynamoDbTimeToLiveStatus {
+    if (enabled) {
+      return "ENABLING";
+    }
+
+    return "DISABLING";
+  }
+
+  /**
+   * Refuse a second update inside the hour.
+   *
+   * The hour is measured on the simulation's clock, so a test moves past it
+   * with `simAws.clock().advanceBy({ hours: 1 })` rather than by waiting.
+   */
+  private assertUpdatable(at: Date): void {
+    if (this.#updatedAt === undefined) {
+      return;
+    }
+
+    const elapsed = at.getTime() - this.#updatedAt.getTime();
+
+    if (elapsed >= updateWindowMilliseconds) {
+      return;
+    }
+
+    throw new SimDynamoDbValidationException(
+      `Time to live on Table ${this.tableName} was last updated at ` +
+        `${this.#updatedAt.toISOString()}, and DynamoDB takes one ` +
+        `UpdateTimeToLive per table per hour`,
+    );
+  }
+}

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-time-to-live.ts
@@ -42,7 +42,7 @@ export class SimDynamoDbTimeToLive {
    * that state and the scheduled work settles it within the same turn.
    */
   enabledAttributeName(): string | undefined {
-    if (this.#status === "ENABLED" || this.#status === "ENABLING") {
+    if (this.isOn) {
       return this.#attributeName;
     }
 
@@ -50,9 +50,11 @@ export class SimDynamoDbTimeToLive {
   }
 
   /**
-   * Take an update, refusing one that comes too soon after the last.
+   * Take an update, refusing one that asks for the state it is already in or
+   * that comes too soon after the last.
    */
   update(specification: SimDynamoDbTimeToLiveSpecification, at: Date): void {
+    this.assertChanges(specification.enabled);
     this.assertUpdatable(at);
 
     this.#attributeName = specification.attributeName;
@@ -99,6 +101,34 @@ export class SimDynamoDbTimeToLive {
     }
 
     return "DISABLING";
+  }
+
+  /**
+   * Refuse an update asking for the state the table is already in.
+   *
+   * Real DynamoDB refuses this rather than treating it as a no-op, which is why
+   * code that has to be idempotent reads DescribeTimeToLive first. Changing the
+   * attribute an enabled table expires by means switching time to live off and
+   * on again, since an update that leaves it enabled is refused whatever
+   * attribute it names.
+   */
+  private assertChanges(enabled: boolean): void {
+    if (enabled !== this.isOn) {
+      return;
+    }
+
+    throw new SimDynamoDbValidationException(
+      `Time to live on Table ${this.tableName} is already ` +
+        `${this.#status}, and DynamoDB refuses an UpdateTimeToLive asking ` +
+        `for the state it is already in`,
+    );
+  }
+
+  /**
+   * Whether time to live is on, or on its way to being on.
+   */
+  private get isOn(): boolean {
+    return this.#status === "ENABLED" || this.#status === "ENABLING";
   }
 
   /**


### PR DESCRIPTION
UpdateTimeToLive and DescribeTimeToLive, with the status settling through ENABLING or DISABLING and the one update per table per hour rule measured on the simulated clock.

Items expire as the clock moves forward. The removal is scheduled 48 hours after the TTL timestamp rather than on it, so a test can advance past a session's expiry, find it still readable as it would be on AWS, and then advance past the window to see it go. Nothing else to call.

TimeToLiveSpecification becomes a supported AWS::DynamoDB::Table property.

Resolves https://github.com/KensioSoftware/yulin/issues/263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DynamoDB time-to-live support for enabling, disabling, and describing TTL settings.
  - Expired items now use simulated time and are deleted after the documented 48-hour window.
  - Added CloudFormation and SDK support for configuring and querying TTL.

- **Documentation**
  - Added usage examples, configuration guidance, lifecycle details, and documented limitations.

- **Tests**
  - Added coverage for TTL validation, status transitions, throttling, expiration behavior, and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->