### PR TITLE
feat: use the DynamoDB document client against simulated DynamoDB

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -170,6 +170,76 @@ intercept only specific Commands, pass an allow list of Command classes or names
 `simSdk.intercept(s3Client, { commands: [GetObjectCommand] })`. Commands outside the allow list
 throw a diagnostic error.
 
+## The DynamoDB document client
+
+`@aws-sdk/lib-dynamodb` lets application code write `{ id: "a", count: 1 }` rather than
+`{ id: { S: "a" }, count: { N: "1" } }`. Intercept the document client and its Commands reach
+simulated DynamoDB with the values converted, so code written against it needs no changes to run
+against the simulator.
+
+```typescript sim-sdk-document-client
+/**
+ * An intercepted DynamoDB document client, writing plain JavaScript values.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+
+// The document client is what gets intercepted, not the client it was built
+// from.
+simSdk.intercept(documents);
+
+// A document client forwards a Command it has no document form of, so the
+// table is created through the same client.
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+await documents.send(
+  new PutCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: "order-1", total: 42, paid: true },
+  }),
+);
+
+const read = await documents.send(
+  new GetCommand({ TableName: "OrdersTable", Key: { orderId: "order-1" } }),
+);
+
+console.log(read.Item?.["total"]); // 42
+console.log(read.Item?.["paid"]); // true
+```
+
+`DynamoDBDocumentClient.from(client)` builds a separate object rather than wrapping the client in
+place, and that object is not an instance of `DynamoDBClient`. Intercepting the base client
+therefore does nothing for Commands sent through the document client. Intercept the document
+client. Both can be intercepted at once, and they reach the same simulated tables, since the
+document client shares the base client's config and so resolves the same Account and Region.
+
+The real document client converts values in middleware, which runs inside the `send` that
+interception replaces. So the conversion happens at the interception boundary instead, using the
+option defaults `lib-dynamodb` sets rather than the `util-dynamodb` ones. Which native types map to
+which descriptors is in
+[the sim DynamoDB docs](../services/dynamodb/README.md#the-document-client).
+
 ## Supported services and Commands
 
 All simulated services support SDK interception: ACM, CloudFormation, CloudFront, Cognito, DynamoDB,
@@ -192,3 +262,8 @@ Both kinds of gap are refused on send rather than misbehaving silently, with a d
 - Simulated errors carry SDK-shaped `name` and `$metadata`, but are not instances of the real SDK
   exception classes: match errors with `error.name`, not `instanceof`.
 - The callback form of `send(command, callback)` is not supported; use the promise form.
+- The translate config a document client is built with,
+  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`, is not read. The
+  conversion always uses the defaults, so `removeUndefinedValues: true` in particular does not
+  apply: an `undefined` attribute is refused here where AWS would have dropped it. The refusal names
+  the attribute and says so.

--- a/docs/sdk/sim-sdk-document-client.example.ts
+++ b/docs/sdk/sim-sdk-document-client.example.ts
@@ -1,0 +1,48 @@
+/**
+ * An intercepted DynamoDB document client, writing plain JavaScript values.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+
+// The document client is what gets intercepted, not the client it was built
+// from.
+simSdk.intercept(documents);
+
+// A document client forwards a Command it has no document form of, so the
+// table is created through the same client.
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+await documents.send(
+  new PutCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: "order-1", total: 42, paid: true },
+  }),
+);
+
+const read = await documents.send(
+  new GetCommand({ TableName: "OrdersTable", Key: { orderId: "order-1" } }),
+);
+
+console.log(read.Item?.["total"]); // 42
+console.log(read.Item?.["paid"]); // true

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1609,20 +1609,20 @@ Commands sent through the document one. See
 
 ### Which native types map to which descriptors
 
-| Written as                                        | Stored as | Read back as         |
-| ------------------------------------------------- | --------- | -------------------- |
-| `string`                                          | `S`       | `string`             |
-| `number`                                          | `N`       | `number`             |
-| `bigint`                                          | `N`       | `number` or `bigint` |
-| `NumberValue`                                     | `N`       | `number` or `bigint` |
-| `boolean`                                         | `BOOL`    | `boolean`            |
-| `null`                                            | `NULL`    | `null`               |
-| `Uint8Array`, `Buffer` and the other typed arrays | `B`       | `Uint8Array`         |
-| `Set` of strings                                  | `SS`      | `Set` of strings     |
-| `Set` of numbers or bigints                       | `NS`      | `Set` of numbers     |
-| `Set` of binary                                   | `BS`      | `Set` of binary      |
-| `Array`                                           | `L`       | `Array`              |
-| plain object, `Map`                               | `M`       | plain object         |
+| Written as                                        | Stored as | Read back as                |
+| ------------------------------------------------- | --------- | --------------------------- |
+| `string`                                          | `S`       | `string`                    |
+| `number`                                          | `N`       | `number`                    |
+| `bigint`                                          | `N`       | `number` or `bigint`        |
+| `NumberValue`                                     | `N`       | `number` or `bigint`        |
+| `boolean`                                         | `BOOL`    | `boolean`                   |
+| `null`                                            | `NULL`    | `null`                      |
+| `Uint8Array`, `Buffer` and the other typed arrays | `B`       | `Uint8Array`                |
+| `Set` of strings                                  | `SS`      | `Set` of strings            |
+| `Set` of numbers, bigints or `NumberValue`        | `NS`      | `Set` of numbers or bigints |
+| `Set` of binary                                   | `BS`      | `Set` of binary             |
+| `Array`                                           | `L`       | `Array`                     |
+| plain object, `Map`                               | `M`       | plain object                |
 
 A class instance is not converted. The real document client refuses one unless it was built with
 `convertClassInstanceToMap`, so an object with behaviour is not quietly flattened into attributes.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1523,6 +1523,125 @@ one member and are refused as a duplicate.
 Lists and maps nest up to 32 levels, and one item is at most 400 KB counting its attribute names as
 well as its values. Both are `ValidationException` when exceeded.
 
+## The document client
+
+`@aws-sdk/lib-dynamodb` takes plain JavaScript values in place of AttributeValues. Intercept a
+`DynamoDBDocumentClient` and its Commands reach simulated DynamoDB with the values converted, so
+code written against the document client runs against the simulator unchanged.
+
+```typescript sim-dynamodb-document-client
+/**
+ * Reading and writing items as plain JavaScript with the document client.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+// Nested objects, lists and Sets all go in as themselves.
+await documents.send(
+  new PutCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: "order-1",
+      total: 42,
+      paid: false,
+      lines: [{ sku: "widget", quantity: 2 }],
+      tags: new Set(["priority", "gift"]),
+    },
+  }),
+);
+
+const updated = await documents.send(
+  new UpdateCommand({
+    TableName: "OrdersTable",
+    Key: { orderId: "order-1" },
+    UpdateExpression: "SET paid = :paid",
+    ExpressionAttributeValues: { ":paid": true },
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(updated.Attributes?.["paid"]); // true
+
+const read = await documents.send(
+  new GetCommand({ TableName: "OrdersTable", Key: { orderId: "order-1" } }),
+);
+
+const lines = read.Item?.["lines"] as { sku: string; quantity: number }[];
+console.log(lines[0]?.quantity); // 2
+
+const tags = read.Item?.["tags"] as Set<string>;
+console.log(tags.has("priority")); // true
+```
+
+`PutCommand`, `GetCommand`, `DeleteCommand`, `UpdateCommand`, `BatchWriteCommand` and
+`BatchGetCommand` are converted. A document Command with no route here, such as
+`TransactWriteCommand`, is refused by name before anything tries to convert its values.
+
+Intercept the document client itself. `DynamoDBDocumentClient.from(client)` builds a separate object
+that is not an instance of `DynamoDBClient`, so intercepting the base client does nothing for
+Commands sent through the document one. See
+[the SDK docs](../../sdk/README.md#the-dynamodb-document-client).
+
+### Which native types map to which descriptors
+
+| Written as                                        | Stored as | Read back as         |
+| ------------------------------------------------- | --------- | -------------------- |
+| `string`                                          | `S`       | `string`             |
+| `number`                                          | `N`       | `number`             |
+| `bigint`                                          | `N`       | `number` or `bigint` |
+| `NumberValue`                                     | `N`       | `number` or `bigint` |
+| `boolean`                                         | `BOOL`    | `boolean`            |
+| `null`                                            | `NULL`    | `null`               |
+| `Uint8Array`, `Buffer` and the other typed arrays | `B`       | `Uint8Array`         |
+| `Set` of strings                                  | `SS`      | `Set` of strings     |
+| `Set` of numbers or bigints                       | `NS`      | `Set` of numbers     |
+| `Set` of binary                                   | `BS`      | `Set` of binary      |
+| `Array`                                           | `L`       | `Array`              |
+| plain object, `Map`                               | `M`       | plain object         |
+
+A class instance is not converted. The real document client refuses one unless it was built with
+`convertClassInstanceToMap`, so an object with behaviour is not quietly flattened into attributes.
+
+### Numbers through the document client
+
+A simulated table holds a number's digits exactly, but the document client converts to and from
+JavaScript numbers, and that is where digits are lost. It is the same loss AWS has, so a test that
+passes here is telling you something true about the real thing.
+
+- Writing a `number` outside the safe integer range is refused rather than stored already rounded.
+  Write a `bigint`, or a `NumberValue` from `@aws-sdk/lib-dynamodb`, to keep the digits.
+- Reading a stored number outside the safe integer range gives a `bigint`.
+- Reading a stored decimal with more digits than a JavaScript number carries gives a rounded
+  `number`. The table still holds every digit; the rounding is the document client's. Read through
+  an ordinary `GetItemCommand` to see the stored digits.
+- Reading a stored number that is outside the safe integer range and is not whole is refused, since
+  there is nothing to answer with.
+
 ## Table names and ARNs
 
 A table name is 3 to 255 characters of letters, numbers, underscores, hyphens and periods. The name
@@ -1724,9 +1843,21 @@ nothing is written.
   table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
   expires items, and `Tags` deploying a tagged table.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
+- The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
+  `UpdateCommand`, `BatchWriteCommand` and `BatchGetCommand` converting native JavaScript values on
+  the way in and out.
 
 ## Limitations
 
+- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted, since
+  the first two are operations this simulation does not have yet. `TransactWriteCommand` and
+  `TransactGetCommand` are the exception: the operations behind them are simulated, so only the
+  document form is missing. All of them are refused by name rather than half converted.
+- A document client's translate config is not read, so the marshalling options it was built with do
+  not apply. See [the SDK docs](../../sdk/README.md#limitations).
+- `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
+  client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
+  the operation rather than by the conversion.
 - Global and local secondary indexes are not simulated. `GlobalSecondaryIndexes` and
   `LocalSecondaryIndexes` are refused rather than dropped, since a table missing an index it was
   asked for would answer queries differently to the real one. An empty list asks for no index, so it

--- a/docs/services/dynamodb/sim-dynamodb-document-client.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-document-client.example.ts
@@ -1,0 +1,66 @@
+/**
+ * Reading and writing items as plain JavaScript with the document client.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+// Nested objects, lists and Sets all go in as themselves.
+await documents.send(
+  new PutCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: "order-1",
+      total: 42,
+      paid: false,
+      lines: [{ sku: "widget", quantity: 2 }],
+      tags: new Set(["priority", "gift"]),
+    },
+  }),
+);
+
+const updated = await documents.send(
+  new UpdateCommand({
+    TableName: "OrdersTable",
+    Key: { orderId: "order-1" },
+    UpdateExpression: "SET paid = :paid",
+    ExpressionAttributeValues: { ":paid": true },
+    ReturnValues: "ALL_NEW",
+  }),
+);
+
+console.log(updated.Attributes?.["paid"]); // true
+
+const read = await documents.send(
+  new GetCommand({ TableName: "OrdersTable", Key: { orderId: "order-1" } }),
+);
+
+const lines = read.Item?.["lines"] as { sku: string; quantity: number }[];
+console.log(lines[0]?.quantity); // 2
+
+const tags = read.Item?.["tags"] as Set<string>;
+console.log(tags.has("priority")); // true

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@aws-sdk/client-sqs": "^3.1097.0",
     "@aws-sdk/client-ssm": "^3.1095.0",
     "@aws-sdk/client-sts": "^3.1095.0",
+    "@aws-sdk/lib-dynamodb": "^3.1100.0",
     "@aws-sdk/s3-request-presigner": "^3.1095.0",
     "@eslint/js": "^10.0.1",
     "@kensio/smartass": "^1.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.1095.0
         version: 3.1095.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.1100.0
+        version: 3.1100.0(@aws-sdk/client-dynamodb@3.1095.0)
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1095.0
         version: 3.1095.0
@@ -250,6 +253,10 @@ packages:
     resolution: {integrity: sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
     engines: {node: '>=20.0.0'}
@@ -354,6 +361,12 @@ packages:
     resolution: {integrity: sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/lib-dynamodb@3.1100.0':
+    resolution: {integrity: sha512-pVXmJ8gFO7Nu8Geded66kZtQJYbuDt+bO1+jjDpBr40SiLWqFOCt5HGhA2cIs9KoQkITMF7UOLRaZ+RBg4nPBw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1100.0
+
   '@aws-sdk/middleware-endpoint-discovery@3.972.26':
     resolution: {integrity: sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==}
     engines: {node: '>=20.0.0'}
@@ -405,6 +418,12 @@ packages:
   '@aws-sdk/types@3.974.2':
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-dynamodb@3.996.7':
+    resolution: {integrity: sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1088.0
 
   '@aws-sdk/xml-builder@3.972.37':
     resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
@@ -827,6 +846,10 @@ packages:
     resolution: {integrity: sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.14':
     resolution: {integrity: sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==}
     engines: {node: '>=18.0.0'}
@@ -845,6 +868,10 @@ packages:
 
   '@smithy/signature-v4@5.6.10':
     resolution: {integrity: sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.14.14':
@@ -2218,9 +2245,20 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.61':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2228,7 +2266,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.62':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2244,7 +2282,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.63':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/fetch-http-handler': 5.6.11
@@ -2254,7 +2292,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.64':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/fetch-http-handler': 5.6.11
@@ -2274,7 +2312,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.973.6':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/credential-provider-env': 3.972.62
       '@aws-sdk/credential-provider-http': 3.972.64
       '@aws-sdk/credential-provider-login': 3.972.68
@@ -2290,7 +2328,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.973.7':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/credential-provider-env': 3.972.62
       '@aws-sdk/credential-provider-http': 3.972.64
       '@aws-sdk/credential-provider-login': 3.972.69
@@ -2322,7 +2360,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.68':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2331,7 +2369,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.69':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2391,7 +2429,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.61':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2399,7 +2437,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.62':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
       '@smithy/types': 4.16.1
@@ -2415,7 +2453,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.973.5':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/token-providers': 3.1095.0
       '@aws-sdk/types': 3.974.2
@@ -2425,7 +2463,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.973.6':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/token-providers': 3.1096.0
       '@aws-sdk/types': 3.974.2
@@ -2445,7 +2483,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.67':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.35
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2454,7 +2492,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.68':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2480,6 +2518,15 @@ snapshots:
   '@aws-sdk/endpoint-cache@3.972.9':
     dependencies:
       mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-dynamodb@3.1100.0(@aws-sdk/client-dynamodb@3.1095.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1095.0
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/util-dynamodb': 3.996.7(@aws-sdk/client-dynamodb@3.1095.0)
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-endpoint-discovery@3.972.26':
@@ -2514,7 +2561,7 @@ snapshots:
 
   '@aws-sdk/nested-clients@3.997.35':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/signature-v4-multi-region': 3.996.42
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2525,7 +2572,7 @@ snapshots:
 
   '@aws-sdk/nested-clients@3.997.36':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/signature-v4-multi-region': 3.996.42
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2563,7 +2610,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1095.0':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2572,7 +2619,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1096.0':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.2
       '@aws-sdk/nested-clients': 3.997.36
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.0
@@ -2591,6 +2638,11 @@ snapshots:
   '@aws-sdk/types@3.974.2':
     dependencies:
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-dynamodb@3.996.7(@aws-sdk/client-dynamodb@3.1095.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1095.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.37':
@@ -2879,6 +2931,11 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.14':
     dependencies:
       '@smithy/core': 3.31.0
@@ -2904,6 +2961,12 @@ snapshots:
   '@smithy/signature-v4@5.6.10':
     dependencies:
       '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -54,6 +54,9 @@ Current command areas include:
 - `tag/` (TagResource, UntagResource and ListTagsOfResource)
 - `time-to-live/` (UpdateTimeToLive and DescribeTimeToLive)
 
+The `@aws-sdk/lib-dynamodb` document client's Commands are handled under `document/` rather than
+here, since they are the same operations with a conversion around them.
+
 `table/` is the layout newer commands follow: one directory per group of related commands, with the
 structural command types in `table.command.ts`, the value and description shapes they are made of in
 `table.types.ts`, and one class per command or closely related group. `item/` follows the same shape
@@ -675,6 +678,41 @@ Current uses:
 - `SimDynamoDbTableExpiry` uses `scheduleAt` rather than `schedule`, so an item's removal is due at
   a simulated instant rather than on the next drain. Only moving the clock through `simAws.clock()`
   dispatches it, which is why `backgroundTasksComplete()` does not expire anything.
+
+## The document client
+
+`document/` handles `@aws-sdk/lib-dynamodb` Commands, which carry native JavaScript values rather
+than AttributeValues.
+
+The real document client converts in middleware added to the underlying Command's stack, and that
+middleware is reached through `resolveMiddleware`, which `installSendPatch` replaces. So an
+intercepted send never runs it and the conversion happens at the interception boundary instead.
+
+- `sim-dynamodb-document-marshall.ts` reads a native value as an AttributeValue, and
+  `-unmarshall.ts` reads one back. The rules and their order are `convertToAttr` and
+  `convertToNative` from `util-dynamodb`, restated here rather than imported: no implementation file
+  imports the AWS SDK, and `lib-dynamodb` is a devDependency. `-number.ts`, `-set.ts` and
+  `-binary.ts` hold the parts with rules of their own.
+- The option defaults `lib-dynamodb` sets, `convertTopLevelContainer` and
+  `convertWithoutMapWrapper`, amount to converting one value at a time with no top-level unwrapping,
+  which is what these functions do. The `util-dynamodb` defaults would drop the `M` wrapper off a
+  nested object, which is not an attribute value at all.
+- `sim-dynamodb-document-path.ts` says where in a Command the native values sit, since a Command
+  carries ordinary request values everywhere else. `-command-paths.ts` states them per Command,
+  mirroring the key nodes the real client declares on its own Commands, which are `protected` and so
+  not read from it.
+- `sim-dynamodb-document-route.ts` converts, sends to the ordinary facade method, and converts back.
+  `-routes.ts` builds one per Command for the SDK router to merge in.
+
+A document Command is named differently to the Command it stands for, so `PutCommand` and
+`PutItemCommand` route separately. One with no route, such as `TransactWriteCommand`, is refused by
+name before anything tries to convert its values.
+
+Which object a user intercepts is settled: the document client itself.
+`DynamoDBDocumentClient.from(client)` builds a separate object that extends the same `Client` base as
+`DynamoDBClient` rather than extending `DynamoDBClient`, so patching the base client's send does not
+reach it. It does share the base client's `config`, so `serviceId` and `region` resolve the same way
+for both.
 
 ## Time to live
 

--- a/src/service/dynamodb/document/sim-dynamodb-document-binary.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-binary.ts
@@ -1,0 +1,36 @@
+/**
+ * The kinds the document client reads as binary.
+ *
+ * They are recognised by constructor name rather than by `instanceof`, which is
+ * how the real document client recognises them: a value built in another realm,
+ * such as a Buffer from a different module instance, fails an `instanceof`
+ * check while still being the thing it says it is.
+ */
+const binaryConstructorNames: ReadonlySet<string> = new Set([
+  "ArrayBuffer",
+  "Blob",
+  "Buffer",
+  "DataView",
+  "File",
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+]);
+
+/**
+ * Whether a value is one the document client stores as a binary attribute.
+ */
+export function isSimDynamoDbDocumentBinary(value: unknown): boolean {
+  const name = (value as { constructor?: { name?: string } } | undefined)
+    ?.constructor?.name;
+
+  return name !== undefined && binaryConstructorNames.has(name);
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-client.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-client.iso.test.ts
@@ -247,6 +247,48 @@ describe("simulated DynamoDB document client", () => {
     assertUndefined(read.Item);
   });
 
+  it("puts and deletes in one batch write", async () => {
+    // Given a table holding one item.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // When one batch both writes another item and deletes that one.
+    await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: "order-2", total: 7 } } },
+            { DeleteRequest: { Key: { orderId: "order-1" } } },
+          ],
+        },
+      }),
+    );
+
+    // Then both happened, so the two kinds of request are converted at the
+    // places each carries its values.
+    const read = await documents.send(
+      new BatchGetCommand({
+        RequestItems: {
+          OrdersTable: {
+            Keys: [{ orderId: "order-1" }, { orderId: "order-2" }],
+          },
+        },
+      }),
+    );
+
+    const items = read.Responses?.["OrdersTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 1);
+    assertObjectEquals(items[0], { orderId: "order-2", total: 7 });
+  });
+
   it("leaves a batch get key that holds nothing out of the answer", async () => {
     // Given a table holding one of the two items asked for.
     using simSdk = new SimSdk();

--- a/src/service/dynamodb/document/sim-dynamodb-document-client.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-client.iso.test.ts
@@ -1,0 +1,277 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  BatchGetCommand,
+  BatchWriteCommand,
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+/**
+ * An intercepted document client, and the table its Commands work on.
+ *
+ * The table is created through the ordinary CreateTable Command, sent through
+ * the same document client: a document client forwards a Command it has no
+ * document form of, so a test needs only the one client.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "OrdersTable",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
+}
+
+describe("simulated DynamoDB document client", () => {
+  it("round-trips native values through a Put and a Get", async () => {
+    // Given an intercepted document client.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an item is written as plain JavaScript.
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42, paid: true, note: null },
+      }),
+    );
+
+    // Then it reads back as plain JavaScript, with no AttributeValues either
+    // way.
+    const read = await documents.send(
+      new GetCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+      }),
+    );
+
+    assertObjectEquals(read.Item, {
+      orderId: "order-1",
+      total: 42,
+      paid: true,
+      note: null,
+    });
+  });
+
+  it("writes what the equivalent AttributeValue Command would have written", async () => {
+    // Given an item written through the document client.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // Then the ordinary GetItem Command, which converts nothing, reads it back
+    // as the descriptors a table holds rather than as the native values the
+    // request was written with.
+    const read = await simSdk.simAws
+      .region("eu-west-2")
+      .dynamoDb()
+      .getItem(
+        new GetItemCommand({
+          TableName: "OrdersTable",
+          Key: { orderId: { S: "order-1" } },
+        }),
+      );
+
+    assertObjectEquals(read.Item, {
+      orderId: { S: "order-1" },
+      total: { N: "42" },
+    });
+  });
+
+  it("round-trips an Update with native expression values", async () => {
+    // Given an item to update.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // When it is updated with expression values written natively.
+    const updated = await documents.send(
+      new UpdateCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+        UpdateExpression: "SET #t = :total, shipped = :shipped",
+        ExpressionAttributeNames: { "#t": "total" },
+        ExpressionAttributeValues: { ":total": 99, ":shipped": true },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+
+    // Then the attributes come back native.
+    assertObjectEquals(updated.Attributes, {
+      orderId: "order-1",
+      total: 99,
+      shipped: true,
+    });
+  });
+
+  it("round-trips a Delete answering with the item it removed", async () => {
+    // Given an item to delete.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // When it is deleted, asking for what was there.
+    const removed = await documents.send(
+      new DeleteCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+        ReturnValues: "ALL_OLD",
+      }),
+    );
+
+    // Then the removed item comes back native, and the key holds nothing.
+    assertObjectEquals(removed.Attributes, { orderId: "order-1", total: 42 });
+
+    const read = await documents.send(
+      new GetCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+      }),
+    );
+    assertUndefined(read.Item);
+  });
+
+  it("round-trips a batch write and a batch get", async () => {
+    // Given an intercepted document client.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When items are written in a batch, natively.
+    const written = await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: "order-1", total: 42 } } },
+            { PutRequest: { Item: { orderId: "order-2", total: 7 } } },
+          ],
+        },
+      }),
+    );
+    assertObjectEquals(written.UnprocessedItems, {});
+
+    // Then they read back in a batch, natively.
+    const read = await documents.send(
+      new BatchGetCommand({
+        RequestItems: {
+          OrdersTable: {
+            Keys: [{ orderId: "order-1" }, { orderId: "order-2" }],
+          },
+        },
+      }),
+    );
+
+    const items = read.Responses?.["OrdersTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 2);
+    assertObjectEquals(items[0], { orderId: "order-1", total: 42 });
+    assertObjectEquals(items[1], { orderId: "order-2", total: 7 });
+    assertObjectEquals(read.UnprocessedKeys, {});
+  });
+
+  it("deletes in a batch by a native key", async () => {
+    // Given an item written in a batch.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          OrdersTable: [
+            { PutRequest: { Item: { orderId: "order-1", total: 42 } } },
+          ],
+        },
+      }),
+    );
+
+    // When it is deleted in a batch.
+    await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          OrdersTable: [{ DeleteRequest: { Key: { orderId: "order-1" } } }],
+        },
+      }),
+    );
+
+    // Then it has gone.
+    const read = await documents.send(
+      new GetCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+      }),
+    );
+    assertUndefined(read.Item);
+  });
+
+  it("leaves a batch get key that holds nothing out of the answer", async () => {
+    // Given a table holding one of the two items asked for.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // When both are read.
+    const read = await documents.send(
+      new BatchGetCommand({
+        RequestItems: {
+          OrdersTable: { Keys: [{ orderId: "order-1" }, { orderId: "gone" }] },
+        },
+      }),
+    );
+
+    // Then only the one that is there comes back, as BatchGetItem answers.
+    const items = read.Responses?.["OrdersTable"];
+    assertNonNullable(items);
+    assertArrayLength(items, 1);
+    assertObjectEquals(items[0], { orderId: "order-1", total: 42 });
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
@@ -1,0 +1,109 @@
+import {
+  simDynamoDbDocumentEach,
+  simDynamoDbDocumentFields,
+  type SimDynamoDbDocumentPath,
+  simDynamoDbDocumentValues,
+} from "./sim-dynamodb-document-path.js";
+
+/**
+ * Where the attribute values sit in one document Command.
+ */
+export interface SimDynamoDbDocumentCommandPaths {
+  readonly input: SimDynamoDbDocumentPath;
+  readonly output: SimDynamoDbDocumentPath;
+}
+
+/**
+ * What a write answers with.
+ *
+ * `ItemCollectionMetrics` is not converted, because it is only reported when a
+ * request asks for it with `ReturnItemCollectionMetrics`, which simulated
+ * DynamoDB refuses.
+ */
+const writtenAttributes = simDynamoDbDocumentFields({
+  Attributes: simDynamoDbDocumentValues(),
+});
+
+/**
+ * A list of records of values, which is what a batch's keys and a batch's
+ * answered items both are.
+ */
+const valueRecords = simDynamoDbDocumentEach(simDynamoDbDocumentValues());
+
+/**
+ * One put or delete in a batch write.
+ */
+const batchWriteRequest = simDynamoDbDocumentFields({
+  PutRequest: simDynamoDbDocumentFields({ Item: simDynamoDbDocumentValues() }),
+  DeleteRequest: simDynamoDbDocumentFields({
+    Key: simDynamoDbDocumentValues(),
+  }),
+});
+
+/**
+ * The put and delete requests every table takes in a batch write.
+ */
+const batchWriteRequests = simDynamoDbDocumentEach(
+  simDynamoDbDocumentEach(batchWriteRequest),
+);
+
+/**
+ * The keys every table is read by in a batch get.
+ */
+const batchGetKeys = simDynamoDbDocumentEach(
+  simDynamoDbDocumentFields({ Keys: valueRecords }),
+);
+
+/**
+ * Where each supported document Command carries native values.
+ *
+ * These mirror the key nodes the real document client declares on its own
+ * Commands, which are internal to it, so they are stated here rather than read
+ * off the Command. A wrong one shows up as a value reaching a simulated table
+ * unconverted, which the round trip tests catch.
+ *
+ * They stop short of the real ones in one place. `Expected`,
+ * `ConditionalOperator` and `AttributeUpdates` are the conditional write and
+ * the update that expressions replaced, and simulated DynamoDB refuses all
+ * three, so a request carrying one never reaches a conversion. Converting input
+ * that is about to be refused would only move the refusal.
+ */
+export const simDynamoDbDocumentCommandPaths = {
+  put: {
+    input: simDynamoDbDocumentFields({
+      Item: simDynamoDbDocumentValues(),
+      ExpressionAttributeValues: simDynamoDbDocumentValues(),
+    }),
+    output: writtenAttributes,
+  },
+  get: {
+    input: simDynamoDbDocumentFields({ Key: simDynamoDbDocumentValues() }),
+    output: simDynamoDbDocumentFields({ Item: simDynamoDbDocumentValues() }),
+  },
+  remove: {
+    input: simDynamoDbDocumentFields({
+      Key: simDynamoDbDocumentValues(),
+      ExpressionAttributeValues: simDynamoDbDocumentValues(),
+    }),
+    output: writtenAttributes,
+  },
+  update: {
+    input: simDynamoDbDocumentFields({
+      Key: simDynamoDbDocumentValues(),
+      ExpressionAttributeValues: simDynamoDbDocumentValues(),
+    }),
+    output: writtenAttributes,
+  },
+  batchWrite: {
+    input: simDynamoDbDocumentFields({ RequestItems: batchWriteRequests }),
+    output: simDynamoDbDocumentFields({ UnprocessedItems: batchWriteRequests }),
+  },
+  batchGet: {
+    input: simDynamoDbDocumentFields({ RequestItems: batchGetKeys }),
+    output: simDynamoDbDocumentFields({
+      // Table, then item in that table's list, then attribute in that item.
+      Responses: simDynamoDbDocumentEach(valueRecords),
+      UnprocessedKeys: batchGetKeys,
+    }),
+  },
+} as const satisfies Readonly<Record<string, SimDynamoDbDocumentCommandPaths>>;

--- a/src/service/dynamodb/document/sim-dynamodb-document-guards.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-guards.iso.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js";
+import { simDynamoDbDocumentNativeValue } from "./sim-dynamodb-document-unmarshall.js";
+
+/**
+ * The two refusals a request cannot reach through a document Command, tested
+ * where they are rather than through the client.
+ *
+ * A Set holding undefined is refused before the members are read, and neither
+ * the SDK's own types nor a simulated table produce the values that get there,
+ * so the conversion is called directly.
+ */
+describe("simulated DynamoDB document conversion guards", () => {
+  it("refuses a Set holding undefined", () => {
+    // When a Set carrying an undefined member is converted.
+    const error = assertThrowsError(() =>
+      simDynamoDbDocumentSetAttribute(new Set([undefined]), "input.Item.tags"),
+    );
+
+    // Then it is refused as an undefined value rather than as an empty set,
+    // which is the set it would otherwise look like.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "Set holding undefined");
+    assertStringIncludes(error.message, "removeUndefinedValues");
+  });
+
+  it("refuses an AttributeValue carrying no type it knows", () => {
+    // When something with no descriptor at all is read back.
+    const error = assertThrowsError(() =>
+      simDynamoDbDocumentNativeValue({} as never, "output.Item.value"),
+    );
+
+    // Then it is refused, naming where it sat. Nothing a simulated table holds
+    // reaches this, so it stands for the simulator itself going wrong rather
+    // than for anything a request did.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "output.Item.value");
+    assertStringIncludes(error.message, "no attribute type");
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
@@ -1,0 +1,212 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  ListTablesCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk, SimSdkUnsupportedCommandError } from "../../../sdk/index.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+
+/**
+ * Create the table these tests work on, through an already-intercepted client.
+ */
+const ordersTable = new CreateTableCommand({
+  TableName: "OrdersTable",
+  KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+  AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+  BillingMode: "PAY_PER_REQUEST",
+});
+
+async function createTable(
+  simSdk: SimSdk,
+  documents: DynamoDBDocumentClient,
+): Promise<void> {
+  await documents.send(ordersTable);
+  await simSdk.simAws.backgroundTasksComplete();
+}
+
+describe("simulated DynamoDB document client interception", () => {
+  it("is the document client that gets intercepted, not the client it was built from", async () => {
+    // Given a base client and a document client built from it.
+    using simSdk = new SimSdk();
+    const base = new DynamoDBClient({ region: "eu-west-2" });
+    const documents = DynamoDBDocumentClient.from(base);
+
+    // Then the document client is a separate object rather than a kind of base
+    // client, which is why intercepting the base one does not reach it.
+    assertFalse(documents instanceof DynamoDBClient);
+
+    // And intercepting the base client leaves the document client's own send
+    // alone.
+    simSdk.intercept(base);
+    assertUndefined(Object.getOwnPropertyDescriptor(documents, "send"));
+
+    // So it is the document client a test intercepts.
+    simSdk.intercept(documents);
+    await createTable(simSdk, documents);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+    const read = await documents.send(
+      new GetCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+      }),
+    );
+
+    assertObjectEquals(read.Item, { orderId: "order-1", total: 42 });
+  });
+
+  it("reaches the same simulated tables from both clients at once", async () => {
+    // Given both a base client and the document client built from it, each
+    // intercepted.
+    using simSdk = new SimSdk();
+    const base = new DynamoDBClient({ region: "eu-west-2" });
+    const documents = DynamoDBDocumentClient.from(base);
+    simSdk.intercept(base);
+    simSdk.intercept(documents);
+
+    // The table is created through the base client, so the two are working on
+    // state neither of them made alone.
+    await base.send(ordersTable);
+    await simSdk.simAws.backgroundTasksComplete();
+
+    // When an item is written through the document client.
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // Then the base client sees the table it was written to. The document
+    // client shares the base client's config, so both resolve the same
+    // Account and Region.
+    const listed = await base.send(new ListTablesCommand({}));
+    assertArrayEquals(listed.TableNames ?? [], ["OrdersTable"]);
+  });
+
+  it("refuses a document Command the simulator has no route for", async () => {
+    // Given an intercepted document client.
+    using simSdk = new SimSdk();
+    const documents = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: "eu-west-2" }),
+    );
+    simSdk.intercept(documents);
+    await createTable(simSdk, documents);
+
+    // When a document Command with no route is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "OrdersTable",
+                Item: { orderId: "order-1" },
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    // Then it is refused by name, before anything tries to convert its values.
+    assertInstanceOf(error, SimSdkUnsupportedCommandError);
+    assertStringIncludes(error.message, "TransactWriteCommand");
+    assertStringIncludes(error.message, "PutCommand");
+  });
+
+  it("authorizes a document Command as the caller sending it", async () => {
+    // Given an intercepted document client and a table to write to.
+    using simSdk = new SimSdk();
+    const accountId = simSdk.simAws.defaultAccountId;
+    const documents = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: "eu-west-2" }),
+    );
+    simSdk.intercept(documents);
+    await createTable(simSdk, documents);
+
+    // When a document Command is sent as a caller with no IAM permissions.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simSdk.simAws.runAs(
+        { kind: "arn", arn: `arn:aws:iam::${accountId}:role/NoPermsRole` },
+        async () => {
+          await documents.send(
+            new PutCommand({
+              TableName: "OrdersTable",
+              Item: { orderId: "order-1", total: 42 },
+            }),
+          );
+        },
+      );
+    });
+
+    // Then it is denied. Converting the values changes nothing about who the
+    // request is authorized as.
+    assertInstanceOf(error, SimIamAccessDenied);
+
+    // And nothing was written under the Account root default.
+    const read = await documents.send(
+      new GetCommand({
+        TableName: "OrdersTable",
+        Key: { orderId: "order-1" },
+      }),
+    );
+    assertUndefined(read.Item);
+  });
+
+  it("refuses a document Command outside an interception's allow list", async () => {
+    // Given an interception that only allows some Commands.
+    using simSdk = new SimSdk();
+    const documents = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: "eu-west-2" }),
+    );
+    simSdk.intercept(documents, {
+      commands: [CreateTableCommand, PutCommand],
+    });
+    await createTable(simSdk, documents);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "OrdersTable",
+        Item: { orderId: "order-1", total: 42 },
+      }),
+    );
+
+    // When a Command outside the list is sent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new GetCommand({
+          TableName: "OrdersTable",
+          Key: { orderId: "order-1" },
+        }),
+      );
+    });
+
+    // Then it is refused by name, the same way any other Command outside the
+    // list is.
+    assertIdentical(error.name, "SimSdkCommandNotInterceptedError");
+    assertStringIncludes(error.message, "GetCommand");
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
@@ -1,0 +1,179 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
+import { simDynamoDbDocumentNumberAttribute } from "./sim-dynamodb-document-number.js";
+import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js";
+
+/**
+ * A value carrying its own Number attribute, which is what lib-dynamodb's
+ * `NumberValue` is.
+ *
+ * It is recognised by the method rather than by its class, since importing the
+ * SDK from simulated AWS is not something this package does. That is also what
+ * lets a `NumberValue` from a different copy of the SDK work here.
+ */
+interface SimDynamoDbDocumentNumberValue {
+  toAttributeValue: () => { N: string };
+}
+
+/**
+ * Read a native JavaScript value as the AttributeValue it stands for.
+ *
+ * This is the conversion the document client does in middleware, which an
+ * intercepted send never reaches. The rules are the real ones, in the real
+ * order, so a value that reaches a simulated table through the document client
+ * is the value that would have reached the real one.
+ *
+ * `undefined` is refused rather than dropped. The real document client drops it
+ * when the client was built with `removeUndefinedValues`, which is a translate
+ * config this simulation does not read yet, so refusing is what keeps a test
+ * from passing against an item AWS would have written differently.
+ */
+export function simDynamoDbDocumentAttributeValue(
+  value: unknown,
+  path: string,
+): SimDynamoDbAttributeValue {
+  if (value === undefined) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is undefined. The real document client drops it only when it ` +
+        `was built with removeUndefinedValues, which simulated DynamoDB does ` +
+        `not read yet, so leave the attribute out instead`,
+    );
+  }
+
+  if (value === null) {
+    return { NULL: true };
+  }
+
+  if (Array.isArray(value)) {
+    return { L: listMembers(value, path) };
+  }
+
+  return containerOrScalar(value, path);
+}
+
+/**
+ * Read a value that is not null, undefined or a list.
+ */
+function containerOrScalar(
+  value: unknown,
+  path: string,
+): SimDynamoDbAttributeValue {
+  if (value instanceof Set) {
+    return simDynamoDbDocumentSetAttribute(value, path);
+  }
+
+  if (value instanceof Map) {
+    return { M: mapEntries([...value], path) };
+  }
+
+  if (isPlainObject(value)) {
+    return { M: mapEntries(Object.entries(value), path) };
+  }
+
+  return scalar(value, path);
+}
+
+/**
+ * Read a value that stands for one attribute on its own.
+ */
+function scalar(value: unknown, path: string): SimDynamoDbAttributeValue {
+  if (isSimDynamoDbDocumentBinary(value)) {
+    return { B: value as Uint8Array };
+  }
+
+  if (typeof value === "boolean") {
+    return { BOOL: value };
+  }
+
+  if (typeof value === "number") {
+    return simDynamoDbDocumentNumberAttribute(value, path);
+  }
+
+  if (isNumberValue(value)) {
+    return { N: value.toAttributeValue().N };
+  }
+
+  if (typeof value === "bigint") {
+    return { N: value.toString() };
+  }
+
+  if (typeof value === "string") {
+    return { S: value };
+  }
+
+  throw new SimDynamoDbDocumentValueError(
+    `${path} is a ${typeof value} the document client has no attribute type ` +
+      `for`,
+  );
+}
+
+/**
+ * The members of a list, with the functions left out as the real one leaves
+ * them out.
+ */
+function listMembers(
+  values: readonly unknown[],
+  path: string,
+): readonly SimDynamoDbAttributeValue[] {
+  return values
+    .filter((member) => typeof member !== "function")
+    .map((member, index) =>
+      simDynamoDbDocumentAttributeValue(member, `${path}[${index.toString()}]`),
+    );
+}
+
+/**
+ * The entries of a map, with the functions left out.
+ */
+function mapEntries(
+  entries: readonly (readonly [unknown, unknown])[],
+  path: string,
+): Record<string, SimDynamoDbAttributeValue> {
+  const attributes: Record<string, SimDynamoDbAttributeValue> = {};
+
+  for (const [name, member] of entries) {
+    if (typeof member === "function") {
+      continue;
+    }
+
+    const key = String(name);
+
+    // eslint-disable-next-line security/detect-object-injection -- an attribute name the request wrote, copied into an object built here.
+    attributes[key] = simDynamoDbDocumentAttributeValue(
+      member,
+      `${path}.${key}`,
+    );
+  }
+
+  return attributes;
+}
+
+/**
+ * Whether a value is an object the document client reads as a map.
+ *
+ * A class instance is not one. The real document client refuses it unless it
+ * was built with `convertClassInstanceToMap`, so an object with behaviour is
+ * not quietly flattened into attributes.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object") {
+    return false;
+  }
+
+  const name = (value as { constructor?: { name?: string } }).constructor?.name;
+
+  return name === "Object" || name === undefined;
+}
+
+/**
+ * Whether a value carries its own Number attribute.
+ */
+function isNumberValue(
+  value: unknown,
+): value is SimDynamoDbDocumentNumberValue {
+  return (
+    typeof (value as SimDynamoDbDocumentNumberValue).toAttributeValue ===
+    "function"
+  );
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
@@ -1,20 +1,11 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
 import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
-import { simDynamoDbDocumentNumberAttribute } from "./sim-dynamodb-document-number.js";
+import {
+  isSimDynamoDbDocumentNumberValue,
+  simDynamoDbDocumentNumberAttribute,
+} from "./sim-dynamodb-document-number.js";
 import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js";
-
-/**
- * A value carrying its own Number attribute, which is what lib-dynamodb's
- * `NumberValue` is.
- *
- * It is recognised by the method rather than by its class, since importing the
- * SDK from simulated AWS is not something this package does. That is also what
- * lets a `NumberValue` from a different copy of the SDK work here.
- */
-interface SimDynamoDbDocumentNumberValue {
-  toAttributeValue: () => { N: string };
-}
 
 /**
  * Read a native JavaScript value as the AttributeValue it stands for.
@@ -90,7 +81,7 @@ function scalar(value: unknown, path: string): SimDynamoDbAttributeValue {
     return simDynamoDbDocumentNumberAttribute(value, path);
   }
 
-  if (isNumberValue(value)) {
+  if (isSimDynamoDbDocumentNumberValue(value)) {
     return { N: value.toAttributeValue().N };
   }
 
@@ -139,11 +130,15 @@ function mapEntries(
 
     const key = String(name);
 
-    // eslint-disable-next-line security/detect-object-injection -- an attribute name the request wrote, copied into an object built here.
-    attributes[key] = simDynamoDbDocumentAttributeValue(
-      member,
-      `${path}.${key}`,
-    );
+    // Defined rather than assigned, so an attribute named `__proto__` becomes
+    // an ordinary attribute instead of reaching the prototype setter. The real
+    // document client assigns, and so loses that attribute.
+    Object.defineProperty(attributes, key, {
+      value: simDynamoDbDocumentAttributeValue(member, `${path}.${key}`),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
 
   return attributes;
@@ -164,16 +159,4 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   const name = (value as { constructor?: { name?: string } }).constructor?.name;
 
   return name === "Object" || name === undefined;
-}
-
-/**
- * Whether a value carries its own Number attribute.
- */
-function isNumberValue(
-  value: unknown,
-): value is SimDynamoDbDocumentNumberValue {
-  return (
-    typeof (value as SimDynamoDbDocumentNumberValue).toAttributeValue ===
-    "function"
-  );
 }

--- a/src/service/dynamodb/document/sim-dynamodb-document-number.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-number.ts
@@ -1,0 +1,65 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+
+/**
+ * Read a JavaScript number as a Number attribute.
+ *
+ * The document client refuses a number outside the safe integer range rather
+ * than storing one that has already lost digits. A simulated table holds the
+ * digits it is given exactly, so this refusal is the only thing standing
+ * between an application and a silently rounded identifier, which is why it is
+ * kept rather than relaxed. A decimal inside the range is written as it stands.
+ */
+export function simDynamoDbDocumentNumberAttribute(
+  value: number,
+  path: string,
+): SimDynamoDbAttributeValue {
+  if (!Number.isFinite(value)) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is ${value.toString()}, and DynamoDB has no such number`,
+    );
+  }
+
+  if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is ${value.toString()}, which is outside the range a ` +
+        `JavaScript number holds exactly. Write it as a bigint, or as a ` +
+        `NumberValue from @aws-sdk/lib-dynamodb, so its digits survive`,
+    );
+  }
+
+  return { N: value.toString() };
+}
+
+/**
+ * Read a Number attribute back as the document client answers with it.
+ *
+ * A number the safe integer range holds comes back as a JavaScript number. One
+ * outside it comes back as a bigint, which is what the real document client
+ * does rather than rounding it away. A value that is outside the range and is
+ * not whole, such as a decimal carrying more digits than a JavaScript number
+ * does, has nothing to come back as and is refused.
+ */
+export function simDynamoDbDocumentNativeNumber(
+  text: string,
+  path: string,
+): number | bigint {
+  const value = Number(text);
+  const outsideSafeRange =
+    Number.isFinite(value) &&
+    (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER);
+
+  if (!outsideSafeRange) {
+    return value;
+  }
+
+  try {
+    return BigInt(text);
+  } catch {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} holds ${text}, which is outside the range a JavaScript ` +
+        `number holds exactly and is not a whole number, so the document ` +
+        `client has nothing to answer with`,
+    );
+  }
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-number.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-number.ts
@@ -2,6 +2,32 @@ import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
 
 /**
+ * A value carrying its own Number attribute, which is what lib-dynamodb's
+ * `NumberValue` is.
+ *
+ * It is recognised by the method rather than by its class, since importing the
+ * SDK from simulated AWS is not something this package does. That is also what
+ * lets a `NumberValue` from a different copy of the SDK work here.
+ */
+export interface SimDynamoDbDocumentNumberValue {
+  toAttributeValue: () => { N: string };
+}
+
+/**
+ * Whether a value carries its own Number attribute.
+ */
+export function isSimDynamoDbDocumentNumberValue(
+  value: unknown,
+): value is SimDynamoDbDocumentNumberValue {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as SimDynamoDbDocumentNumberValue).toAttributeValue ===
+      "function"
+  );
+}
+
+/**
  * Read a JavaScript number as a Number attribute.
  *
  * The document client refuses a number outside the safe integer range rather

--- a/src/service/dynamodb/document/sim-dynamodb-document-path.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-path.iso.test.ts
@@ -1,0 +1,98 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import {
+  simDynamoDbDocumentEach,
+  simDynamoDbDocumentFields,
+  simDynamoDbDocumentValues,
+} from "./sim-dynamodb-document-path.js";
+
+/**
+ * A conversion that marks what it was given with where it sat, so a test can
+ * see where a path reached and where it did not.
+ */
+const marked = (value: unknown, path: string): unknown =>
+  `${String(value)}@${path}`;
+
+describe("simulated DynamoDB document paths", () => {
+  it("converts every member of a record", () => {
+    // Given a path to a record of values, such as an Item.
+    const path = simDynamoDbDocumentValues();
+
+    // When a record is converted.
+    const converted = path.convert({ id: "a", total: 1 }, marked, "Item");
+
+    // Then every member went through the conversion, named by where it sat.
+    assertObjectEquals(converted, {
+      id: "a@Item.id",
+      total: "1@Item.total",
+    });
+  });
+
+  it("converts every member of a list", () => {
+    // Given a path to a list of values.
+    const path = simDynamoDbDocumentValues();
+
+    // When a list is converted.
+    const converted = path.convert(["a", "b"], marked, "Keys") as string[];
+
+    // Then every member went through it, indexed by position.
+    assertArrayEquals(converted, ["a@Keys[0]", "b@Keys[1]"]);
+  });
+
+  it("leaves the fields it does not name alone", () => {
+    // Given a path naming one field of a request.
+    const path = simDynamoDbDocumentFields({
+      Key: simDynamoDbDocumentValues(),
+    });
+
+    // When a request carrying other fields is converted.
+    const converted = path.convert(
+      { TableName: "T", ConsistentRead: true, Key: { id: "a" } },
+      marked,
+      "input",
+    );
+
+    // Then the other fields are carried through as they were.
+    assertObjectEquals(converted, {
+      TableName: "T",
+      ConsistentRead: true,
+      Key: { id: "a@input.Key.id" },
+    });
+  });
+
+  it("leaves out a field the request left out", () => {
+    // Given a path naming a field the request does not carry.
+    const path = simDynamoDbDocumentFields({
+      ExpressionAttributeValues: simDynamoDbDocumentValues(),
+    });
+
+    // When the request is converted.
+    const converted = path.convert({ TableName: "T" }, marked, "input");
+
+    // Then it is not added as an empty one, so the operation sees the request
+    // it was given.
+    assertObjectEquals(converted, { TableName: "T" });
+  });
+
+  it("carries a value that is not a record or a list through untouched", () => {
+    // Given paths that expect containers.
+    const each = simDynamoDbDocumentEach(simDynamoDbDocumentValues());
+    const fields = simDynamoDbDocumentFields({
+      Key: simDynamoDbDocumentValues(),
+    });
+
+    // When something that is neither is converted, which is what a request
+    // written the wrong way round carries.
+    // Then it is passed on as it stands, so the operation is what refuses it,
+    // in its own words, rather than the conversion failing first.
+    assertIdentical(
+      each.convert("not a record", marked, "input"),
+      "not a record",
+    );
+    assertIdentical(fields.convert(42, marked, "input"), 42);
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-path.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-path.ts
@@ -1,0 +1,146 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+
+/**
+ * Convert one attribute value, in whichever direction is being applied.
+ */
+export type SimDynamoDbDocumentConversion = (
+  value: unknown,
+  path: string,
+) => unknown;
+
+/**
+ * Where in a document Command's input or output the attribute values sit.
+ *
+ * A document Command carries native values at some of its fields and ordinary
+ * request values at the rest, so a conversion cannot simply walk the whole
+ * request. This is the same shape the real document client describes those
+ * places with, and each Command states its own.
+ */
+export interface SimDynamoDbDocumentPath {
+  /**
+   * Answer with a copy of a value, converted at the places this path names.
+   */
+  convert(
+    value: unknown,
+    conversion: SimDynamoDbDocumentConversion,
+    path: string,
+  ): unknown;
+}
+
+/**
+ * One attribute value, converted where it stands.
+ */
+class SimDynamoDbDocumentValuePath implements SimDynamoDbDocumentPath {
+  convert(
+    value: unknown,
+    conversion: SimDynamoDbDocumentConversion,
+    path: string,
+  ): unknown {
+    return conversion(value, path);
+  }
+}
+
+/**
+ * Every member of a record or a list, each read through the same path.
+ */
+class SimDynamoDbDocumentEachPath implements SimDynamoDbDocumentPath {
+  private readonly member: SimDynamoDbDocumentPath;
+
+  constructor(member: SimDynamoDbDocumentPath) {
+    this.member = member;
+  }
+
+  convert(
+    value: unknown,
+    conversion: SimDynamoDbDocumentConversion,
+    path: string,
+  ): unknown {
+    if (Array.isArray(value)) {
+      return value.map((member, index) =>
+        this.member.convert(member, conversion, `${path}[${index.toString()}]`),
+      );
+    }
+
+    if (!isRecord(value)) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([name, member]) => [
+        name,
+        this.member.convert(member, conversion, `${path}.${name}`),
+      ]),
+    );
+  }
+}
+
+/**
+ * Named fields of a record, with everything else carried through untouched.
+ *
+ * A field the request left out is left out, rather than added as an empty one,
+ * so a Command reaches the simulated service with the fields it was given.
+ */
+class SimDynamoDbDocumentFieldsPath implements SimDynamoDbDocumentPath {
+  private readonly fields: ReadonlyMap<string, SimDynamoDbDocumentPath>;
+
+  constructor(fields: Readonly<Record<string, SimDynamoDbDocumentPath>>) {
+    this.fields = new Map(Object.entries(fields));
+  }
+
+  convert(
+    value: unknown,
+    conversion: SimDynamoDbDocumentConversion,
+    path: string,
+  ): unknown {
+    if (!isRecord(value)) {
+      return value;
+    }
+
+    const converted: Record<string, unknown> = { ...value };
+
+    for (const [name, field] of this.fields) {
+      // eslint-disable-next-line security/detect-object-injection -- a field name this path declares, not one the request chose.
+      const member = value[name];
+
+      if (member !== undefined) {
+        // eslint-disable-next-line security/detect-object-injection -- the same declared field name.
+        converted[name] = field.convert(member, conversion, `${path}.${name}`);
+      }
+    }
+
+    return converted;
+  }
+}
+
+/**
+ * A path to one attribute value.
+ */
+export function simDynamoDbDocumentValue(): SimDynamoDbDocumentPath {
+  return new SimDynamoDbDocumentValuePath();
+}
+
+/**
+ * A path to a record or list whose every member is one attribute value, which
+ * is what an Item, a Key and a set of expression values are.
+ */
+export function simDynamoDbDocumentValues(): SimDynamoDbDocumentPath {
+  return simDynamoDbDocumentEach(simDynamoDbDocumentValue());
+}
+
+/**
+ * A path through every member of a record or list.
+ */
+export function simDynamoDbDocumentEach(
+  member: SimDynamoDbDocumentPath,
+): SimDynamoDbDocumentPath {
+  return new SimDynamoDbDocumentEachPath(member);
+}
+
+/**
+ * A path through named fields of a record.
+ */
+export function simDynamoDbDocumentFields(
+  fields: Readonly<Record<string, SimDynamoDbDocumentPath>>,
+): SimDynamoDbDocumentPath {
+  return new SimDynamoDbDocumentFieldsPath(fields);
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-route.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-route.ts
@@ -1,0 +1,71 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+} from "../../../sdk/index.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbRequestOptions } from "../sim-dynamodb.js";
+import { simDynamoDbDocumentAttributeValue } from "./sim-dynamodb-document-marshall.js";
+import type { SimDynamoDbDocumentPath } from "./sim-dynamodb-document-path.js";
+import { simDynamoDbDocumentNativeValue } from "./sim-dynamodb-document-unmarshall.js";
+
+/**
+ * Send one already-converted request to a simulated DynamoDB operation.
+ */
+type SimDynamoDbDocumentSend = (
+  input: object,
+  options: SimDynamoDbRequestOptions | undefined,
+) => Promise<object>;
+
+interface SimDynamoDbDocumentRouteProperties {
+  readonly input: SimDynamoDbDocumentPath;
+  readonly output: SimDynamoDbDocumentPath;
+  readonly send: SimDynamoDbDocumentSend;
+}
+
+/**
+ * One document client Command routed to the operation it stands for.
+ *
+ * The document client marshals in middleware, and an intercepted send replaces
+ * the send that would have run that middleware, so the conversion happens here
+ * instead. Everything after it is the ordinary operation: the same validation,
+ * the same authorization, the same simulated table.
+ */
+export class SimDynamoDbDocumentRoute {
+  private readonly input: SimDynamoDbDocumentPath;
+  private readonly output: SimDynamoDbDocumentPath;
+  private readonly send: SimDynamoDbDocumentSend;
+
+  constructor(properties: SimDynamoDbDocumentRouteProperties) {
+    this.input = properties.input;
+    this.output = properties.output;
+    this.send = properties.send;
+  }
+
+  /**
+   * The route the SDK interception engine calls.
+   */
+  route(): SimSdkCommandRoute {
+    return async (command, context): Promise<unknown> => {
+      const input = this.input.convert(
+        command.input,
+        (value, path) => simDynamoDbDocumentAttributeValue(value, path),
+        "input",
+      );
+
+      const output = await this.send(
+        input as object,
+        simSdkCallerOptions(context),
+      );
+
+      return this.output.convert(
+        output,
+        (value, path) =>
+          simDynamoDbDocumentNativeValue(
+            value as SimDynamoDbAttributeValue,
+            path,
+          ),
+        "output",
+      );
+    };
+  }
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
@@ -1,0 +1,94 @@
+import type { SimSdkCommandRoute } from "../../../sdk/index.js";
+import type * as simDynamoDbCommands from "../command/sim-dynamodb-command.types.js";
+import type {
+  SimDynamoDb,
+  SimDynamoDbRequestOptions,
+} from "../sim-dynamodb.js";
+import {
+  type SimDynamoDbDocumentCommandPaths,
+  simDynamoDbDocumentCommandPaths as paths,
+} from "./sim-dynamodb-document-command-paths.js";
+import { SimDynamoDbDocumentRoute } from "./sim-dynamodb-document-route.js";
+
+/**
+ * Send one converted request to the simulated operation it stands for.
+ */
+type SimDynamoDbDocumentSend = (
+  input: never,
+  options: SimDynamoDbRequestOptions | undefined,
+) => Promise<object>;
+
+/**
+ * Build the routed entry for one document Command.
+ */
+function documentRoute(
+  name: string,
+  commandPaths: SimDynamoDbDocumentCommandPaths,
+  send: SimDynamoDbDocumentSend,
+): readonly [string, SimSdkCommandRoute] {
+  return [
+    name,
+    new SimDynamoDbDocumentRoute({
+      input: commandPaths.input,
+      output: commandPaths.output,
+      send: async (input, options) => await send(input as never, options),
+    }).route(),
+  ];
+}
+
+/**
+ * The routes that handle `@aws-sdk/lib-dynamodb` document client Commands.
+ *
+ * A document Command is named differently to the Command it stands for, so
+ * `PutCommand` and `PutItemCommand` route separately and only the document one
+ * converts. Everything after the conversion is the ordinary operation: the same
+ * validation, the same authorization, the same simulated table.
+ *
+ * An operation with no document route here, such as a document
+ * `TransactWriteCommand`, is refused by name like any other unsupported
+ * Command, rather than failing part way through a conversion.
+ */
+export function simDynamoDbDocumentRoutes(
+  dynamoDb: SimDynamoDb,
+): readonly (readonly [string, SimSdkCommandRoute])[] {
+  return [
+    documentRoute(
+      "PutCommand",
+      paths.put,
+      async (input: simDynamoDbCommands.SimPutItemCommandInput, options) =>
+        await dynamoDb.putItem({ input }, options),
+    ),
+    documentRoute(
+      "GetCommand",
+      paths.get,
+      async (input: simDynamoDbCommands.SimGetItemCommandInput, options) =>
+        await dynamoDb.getItem({ input }, options),
+    ),
+    documentRoute(
+      "DeleteCommand",
+      paths.remove,
+      async (input: simDynamoDbCommands.SimDeleteItemCommandInput, options) =>
+        await dynamoDb.deleteItem({ input }, options),
+    ),
+    documentRoute(
+      "UpdateCommand",
+      paths.update,
+      async (input: simDynamoDbCommands.SimUpdateItemCommandInput, options) =>
+        await dynamoDb.updateItem({ input }, options),
+    ),
+    documentRoute(
+      "BatchWriteCommand",
+      paths.batchWrite,
+      async (
+        input: simDynamoDbCommands.SimBatchWriteItemCommandInput,
+        options,
+      ) => await dynamoDb.batchWriteItem({ input }, options),
+    ),
+    documentRoute(
+      "BatchGetCommand",
+      paths.batchGet,
+      async (input: simDynamoDbCommands.SimBatchGetItemCommandInput, options) =>
+        await dynamoDb.batchGetItem({ input }, options),
+    ),
+  ];
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-set.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-set.ts
@@ -1,15 +1,19 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
 import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
-import { simDynamoDbDocumentNumberAttribute } from "./sim-dynamodb-document-number.js";
+import {
+  isSimDynamoDbDocumentNumberValue,
+  simDynamoDbDocumentNumberAttribute,
+} from "./sim-dynamodb-document-number.js";
 
 /**
  * Read a JavaScript Set as one of DynamoDB's three set attributes.
  *
  * The kind is decided by the first member, as the real document client decides
  * it. A set holding more than one kind is not caught here: the members are all
- * read as the first one's kind, and a member that cannot be read that way is
- * refused further down, where the table reads the value.
+ * read as the first one's kind, and one that cannot be read that way is refused
+ * further down, where the table reads the value. That is what the real one
+ * does, so a set written this way behaves the same either side.
  *
  * DynamoDB has no empty set, so an empty one is refused rather than written as
  * something else.
@@ -18,20 +22,37 @@ export function simDynamoDbDocumentSetAttribute(
   set: ReadonlySet<unknown>,
   path: string,
 ): SimDynamoDbAttributeValue {
-  const members = [...set];
-  const first = members[0];
-
-  if (first === undefined) {
+  if (set.size === 0) {
     throw new SimDynamoDbDocumentValueError(
       `${path} is an empty Set, and DynamoDB has no empty set`,
     );
   }
 
+  if (set.has(undefined)) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is a Set holding undefined. The real document client drops it ` +
+        `only when it was built with removeUndefinedValues, which simulated ` +
+        `DynamoDB does not read yet`,
+    );
+  }
+
+  return membersAttribute([...set], path);
+}
+
+/**
+ * Read the members of a set that is known to hold something.
+ */
+function membersAttribute(
+  members: readonly unknown[],
+  path: string,
+): SimDynamoDbAttributeValue {
+  const first = members[0];
+
   if (typeof first === "string") {
     return { SS: members.map(String) };
   }
 
-  if (typeof first === "number" || typeof first === "bigint") {
+  if (isNumberMember(first)) {
     return {
       NS: members.map((member, index) => numberText(member, path, index)),
     };
@@ -48,11 +69,29 @@ export function simDynamoDbDocumentSetAttribute(
 }
 
 /**
+ * Whether a member says the set is a number set.
+ *
+ * A `NumberValue` counts, since it is how a set of numbers past what a
+ * JavaScript number holds is written.
+ */
+function isNumberMember(member: unknown): boolean {
+  return (
+    typeof member === "number" ||
+    typeof member === "bigint" ||
+    isSimDynamoDbDocumentNumberValue(member)
+  );
+}
+
+/**
  * The digits one member of a number set is written with.
  */
 function numberText(member: unknown, path: string, index: number): string {
   if (typeof member === "bigint") {
     return member.toString();
+  }
+
+  if (isSimDynamoDbDocumentNumberValue(member)) {
+    return member.toAttributeValue().N;
   }
 
   const attribute = simDynamoDbDocumentNumberAttribute(

--- a/src/service/dynamodb/document/sim-dynamodb-document-set.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-set.ts
@@ -1,0 +1,65 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
+import { simDynamoDbDocumentNumberAttribute } from "./sim-dynamodb-document-number.js";
+
+/**
+ * Read a JavaScript Set as one of DynamoDB's three set attributes.
+ *
+ * The kind is decided by the first member, as the real document client decides
+ * it. A set holding more than one kind is not caught here: the members are all
+ * read as the first one's kind, and a member that cannot be read that way is
+ * refused further down, where the table reads the value.
+ *
+ * DynamoDB has no empty set, so an empty one is refused rather than written as
+ * something else.
+ */
+export function simDynamoDbDocumentSetAttribute(
+  set: ReadonlySet<unknown>,
+  path: string,
+): SimDynamoDbAttributeValue {
+  const members = [...set];
+  const first = members[0];
+
+  if (first === undefined) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is an empty Set, and DynamoDB has no empty set`,
+    );
+  }
+
+  if (typeof first === "string") {
+    return { SS: members.map(String) };
+  }
+
+  if (typeof first === "number" || typeof first === "bigint") {
+    return {
+      NS: members.map((member, index) => numberText(member, path, index)),
+    };
+  }
+
+  if (isSimDynamoDbDocumentBinary(first)) {
+    return { BS: members.map((member) => member as Uint8Array) };
+  }
+
+  throw new SimDynamoDbDocumentValueError(
+    `${path} is a Set of ${typeof first}, where DynamoDB has string, number ` +
+      `and binary sets`,
+  );
+}
+
+/**
+ * The digits one member of a number set is written with.
+ */
+function numberText(member: unknown, path: string, index: number): string {
+  if (typeof member === "bigint") {
+    return member.toString();
+  }
+
+  const attribute = simDynamoDbDocumentNumberAttribute(
+    Number(member),
+    `${path}[${index.toString()}]`,
+  );
+
+  // A number attribute is the only thing that function answers with.
+  return attribute.N ?? "";
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-unmarshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-unmarshall.ts
@@ -84,8 +84,15 @@ export function simDynamoDbDocumentNativeValues(
   const native: Record<string, unknown> = {};
 
   for (const [name, value] of Object.entries(values)) {
-    // eslint-disable-next-line security/detect-object-injection -- an attribute name the table holds, copied into an object built here.
-    native[name] = simDynamoDbDocumentNativeValue(value, `${path}.${name}`);
+    // Defined rather than assigned, so an attribute named `__proto__` comes
+    // back as an ordinary attribute instead of reaching the prototype setter.
+    // The real document client assigns, and so loses that attribute.
+    Object.defineProperty(native, name, {
+      value: simDynamoDbDocumentNativeValue(value, `${path}.${name}`),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
 
   return native;

--- a/src/service/dynamodb/document/sim-dynamodb-document-unmarshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-unmarshall.ts
@@ -1,0 +1,92 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import { simDynamoDbDocumentNativeNumber } from "./sim-dynamodb-document-number.js";
+
+/**
+ * Read an AttributeValue back as the native value the document client answers
+ * with.
+ *
+ * Sets come back as JavaScript Sets, binary as the bytes it was stored as, and
+ * a map or list as a plain object or array of native values. That is the
+ * conversion the document client does on the way out, which an intercepted send
+ * never reaches.
+ */
+export function simDynamoDbDocumentNativeValue(
+  value: SimDynamoDbAttributeValue,
+  path: string,
+): unknown {
+  if (value.NULL !== undefined) {
+    return null;
+  }
+
+  if (value.BOOL !== undefined) {
+    return value.BOOL;
+  }
+
+  if (value.S !== undefined) {
+    return value.S;
+  }
+
+  if (value.N !== undefined) {
+    return simDynamoDbDocumentNativeNumber(value.N, path);
+  }
+
+  if (value.B !== undefined) {
+    return value.B;
+  }
+
+  return container(value, path);
+}
+
+/**
+ * Read the attributes that hold other values.
+ */
+function container(value: SimDynamoDbAttributeValue, path: string): unknown {
+  if (value.L !== undefined) {
+    return value.L.map((member, index) =>
+      simDynamoDbDocumentNativeValue(member, `${path}[${index.toString()}]`),
+    );
+  }
+
+  if (value.M !== undefined) {
+    return simDynamoDbDocumentNativeValues(value.M, path);
+  }
+
+  if (value.SS !== undefined) {
+    return new Set(value.SS);
+  }
+
+  if (value.NS !== undefined) {
+    return new Set(
+      value.NS.map((member, index) =>
+        simDynamoDbDocumentNativeNumber(member, `${path}[${index.toString()}]`),
+      ),
+    );
+  }
+
+  if (value.BS !== undefined) {
+    return new Set(value.BS);
+  }
+
+  throw new SimDynamoDbDocumentValueError(
+    `${path} carries no attribute type the document client can read`,
+  );
+}
+
+/**
+ * Read a record of AttributeValues back as native values, which is what an
+ * Item, a Key or a set of expression values comes back as.
+ */
+export function simDynamoDbDocumentNativeValues(
+  values: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+  path: string,
+): Record<string, unknown> {
+  const native: Record<string, unknown> = {};
+
+  for (const [name, value] of Object.entries(values)) {
+    // eslint-disable-next-line security/detect-object-injection -- an attribute name the table holds, copied into an object built here.
+    native[name] = simDynamoDbDocumentNativeValue(value, `${path}.${name}`);
+  }
+
+  return native;
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-value-kinds.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-value-kinds.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  type AttributeValue,
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "ValuesTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
+}
+
+/**
+ * Write one attribute natively and read the whole item back natively.
+ */
+async function roundTrip(
+  documents: DynamoDBDocumentClient,
+  value: unknown,
+): Promise<unknown> {
+  await documents.send(
+    new PutCommand({ TableName: "ValuesTable", Item: { id: "a", value } }),
+  );
+
+  const read = await documents.send(
+    new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+  );
+
+  return read.Item?.["value"];
+}
+
+/**
+ * Write one attribute as a descriptor and read it back natively, for the kinds
+ * a document client writes differently to how it reads them.
+ */
+async function readNatively(
+  simSdk: SimSdk,
+  documents: DynamoDBDocumentClient,
+  attribute: AttributeValue,
+): Promise<unknown> {
+  await simSdk.simAws
+    .region("eu-west-2")
+    .dynamoDb()
+    .putItem(
+      new PutItemCommand({
+        TableName: "ValuesTable",
+        Item: { id: { S: "a" }, value: attribute },
+      }),
+    );
+
+  const read = await documents.send(
+    new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+  );
+
+  return read.Item?.["value"];
+}
+
+describe("simulated DynamoDB document value kinds", () => {
+  it("writes a Map as a map attribute", async () => {
+    // Given an item carrying a Map, which the document client takes as well as
+    // a plain object.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "ValuesTable",
+        Item: {
+          id: "a",
+          value: new Map([
+            ["street", "1 High St"],
+            ["town", "Reading"],
+          ]),
+        },
+      }),
+    );
+
+    // When it is read back.
+    const read = await documents.send(
+      new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+    );
+
+    // Then it comes back as a plain object, which is what a map attribute
+    // reads as. The Map was a way of writing it, not a kind DynamoDB holds.
+    assertObjectEquals(read.Item?.["value"], {
+      street: "1 High St",
+      town: "Reading",
+    });
+  });
+
+  it("round-trips a binary set", async () => {
+    // Given an item carrying a Set of bytes.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it goes out and comes back.
+    const read = await roundTrip(
+      documents,
+      new Set([new Uint8Array([1, 2]), new Uint8Array([3, 4])]),
+    );
+
+    // Then it is a Set of the same bytes.
+    assertInstanceOf(read, Set);
+    assertArrayEquals(
+      [...read].map((member) => [...(member as Uint8Array)].join(",")),
+      ["1,2", "3,4"],
+    );
+  });
+
+  it("writes a Set of bigints as a number set", async () => {
+    // Given an item carrying a Set of bigints.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "ValuesTable",
+        Item: { id: "a", value: new Set([9_007_199_254_740_993n, 2n]) },
+      }),
+    );
+
+    // When the descriptors are read.
+    const stored = await simSdk.simAws
+      .region("eu-west-2")
+      .dynamoDb()
+      .getItem(
+        new GetItemCommand({
+          TableName: "ValuesTable",
+          Key: { id: { S: "a" } },
+        }),
+      );
+
+    // Then the digits survive, which is why a bigint is the way to write a
+    // large number.
+    assertObjectEquals(stored.Item?.["value"], {
+      NS: ["9007199254740993", "2"],
+    });
+  });
+
+  it("leaves a function out of a map, as the real client leaves it out", async () => {
+    // Given an item carrying an object with a method on it.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written and read back.
+    const read = await roundTrip(documents, {
+      street: "1 High St",
+      format: () => "1 High St",
+    });
+
+    // Then only the data is there.
+    assertObjectEquals(read, { street: "1 High St" });
+  });
+
+  it("refuses a Set of a kind DynamoDB has no set for", async () => {
+    // Given an item carrying a Set of booleans.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: new Set([true, false]) },
+        }),
+      );
+    });
+
+    // Then it is refused, naming what DynamoDB does have.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "Set of boolean");
+  });
+
+  it("refuses a number that is not a number", async () => {
+    // Given an item carrying a value arithmetic went wrong on.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: NaN },
+        }),
+      );
+    });
+
+    // Then it is refused, since DynamoDB has no such number.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "DynamoDB has no such number");
+  });
+
+  it("refuses to read a stored number it has nothing to answer with", async () => {
+    // Given a table holding a decimal too large for a JavaScript number and
+    // not whole, written through the ordinary Command so nothing converted it.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is read through the document client.
+    const error = await assertThrowsErrorAsync(async () => {
+      await readNatively(simSdk, documents, { N: "12345678901234567890.5" });
+    });
+
+    // Then it is refused rather than rounded away silently: a bigint cannot
+    // carry the fraction, and a JavaScript number cannot carry the digits.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "nothing to answer with");
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-value-kinds.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-value-kinds.iso.test.ts
@@ -8,10 +8,12 @@ import {
 import {
   DynamoDBDocumentClient,
   GetCommand,
+  NumberValue,
   PutCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
   assertArrayEquals,
+  assertIdentical,
   assertInstanceOf,
   assertObjectEquals,
   assertStringIncludes,
@@ -20,30 +22,6 @@ import {
 import { describe, it } from "vitest";
 import { SimSdk } from "../../../sdk/index.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
-
-/**
- * An intercepted document client over a table keyed by `id`.
- */
-async function interceptedDocuments(
-  simSdk: SimSdk,
-): Promise<DynamoDBDocumentClient> {
-  const documents = DynamoDBDocumentClient.from(
-    new DynamoDBClient({ region: "eu-west-2" }),
-  );
-  simSdk.intercept(documents);
-
-  await documents.send(
-    new CreateTableCommand({
-      TableName: "ValuesTable",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simSdk.simAws.backgroundTasksComplete();
-
-  return documents;
-}
 
 /**
  * Write one attribute natively and read the whole item back natively.
@@ -87,6 +65,30 @@ async function readNatively(
   );
 
   return read.Item?.["value"];
+}
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "ValuesTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
 }
 
 describe("simulated DynamoDB document value kinds", () => {
@@ -169,6 +171,75 @@ describe("simulated DynamoDB document value kinds", () => {
     assertObjectEquals(stored.Item?.["value"], {
       NS: ["9007199254740993", "2"],
     });
+  });
+
+  it("writes a Set of NumberValues as a number set", async () => {
+    // Given an item carrying a Set of decimals too long for a JavaScript
+    // number, which is the case NumberValue exists for.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+    const value = new Set([
+      NumberValue.from("1.2345678901234567890123456789"),
+      NumberValue.from("2.3456789012345678901234567890"),
+    ]);
+
+    await documents.send(
+      new PutCommand({ TableName: "ValuesTable", Item: { id: "a", value } }),
+    );
+
+    // When the descriptors are read.
+    const stored = await simSdk.simAws
+      .region("eu-west-2")
+      .dynamoDb()
+      .getItem(
+        new GetItemCommand({
+          TableName: "ValuesTable",
+          Key: { id: { S: "a" } },
+        }),
+      );
+
+    // Then every digit of every member survives.
+    assertObjectEquals(stored.Item?.["value"], {
+      NS: ["1.2345678901234567890123456789", "2.345678901234567890123456789"],
+    });
+  });
+
+  it("reads a number set member past the safe range back as a bigint", async () => {
+    // Given a table holding a number set with a member no JavaScript number
+    // carries exactly.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is read through the document client.
+    const read = await readNatively(simSdk, documents, {
+      NS: ["9007199254740993", "2"],
+    });
+
+    // Then the large member is a bigint and the small one is a number, the
+    // same rule a single number attribute follows.
+    assertInstanceOf(read, Set);
+    assertArrayEquals([...read], [9_007_199_254_740_993n, 2]);
+  });
+
+  it("keeps an attribute named __proto__ as an ordinary attribute", async () => {
+    // Given a nested attribute with the one name that reaches an object's
+    // prototype when it is assigned rather than defined. The key is written
+    // out rather than named in the literal, since a literal `__proto__` sets
+    // the prototype instead of making an attribute.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+    const name = "__proto__";
+
+    // When it is written and read back.
+    const read = await roundTrip(documents, { [name]: "not a prototype" });
+
+    // Then it is still an attribute of its own, rather than having quietly
+    // become the object's prototype. The real document client assigns, and so
+    // loses it.
+    assertIdentical(
+      Object.getOwnPropertyDescriptor(read as object, name)?.value,
+      "not a prototype",
+    );
   });
 
   it("leaves a function out of a map, as the real client leaves it out", async () => {

--- a/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
@@ -1,0 +1,322 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  NumberValue,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertIdentical,
+  assertArrayEquals,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "ValuesTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
+}
+
+/**
+ * Write one attribute natively and read the whole item back natively.
+ */
+async function roundTrip(
+  documents: DynamoDBDocumentClient,
+  value: unknown,
+): Promise<unknown> {
+  await documents.send(
+    new PutCommand({ TableName: "ValuesTable", Item: { id: "a", value } }),
+  );
+
+  const read = await documents.send(
+    new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+  );
+
+  return read.Item?.["value"];
+}
+
+/**
+ * Write one attribute natively and read the descriptors it was stored as.
+ */
+async function storedAs(
+  simSdk: SimSdk,
+  documents: DynamoDBDocumentClient,
+  value: unknown,
+): Promise<unknown> {
+  await documents.send(
+    new PutCommand({ TableName: "ValuesTable", Item: { id: "a", value } }),
+  );
+
+  const read = await simSdk.simAws
+    .region("eu-west-2")
+    .dynamoDb()
+    .getItem(
+      new GetItemCommand({
+        TableName: "ValuesTable",
+        Key: { id: { S: "a" } },
+      }),
+    );
+
+  return read.Item?.["value"];
+}
+
+describe("simulated DynamoDB document values", () => {
+  it("wraps a nested object as a map attribute", async () => {
+    // Given an item carrying a nested object.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written, then read as descriptors.
+    const stored = await storedAs(simSdk, documents, { street: "1 High St" });
+
+    // Then the nested object is an M attribute. The document client's own
+    // marshalling default is what puts the wrapper there: the util-dynamodb
+    // default would have stored the bare record, which is not an attribute
+    // value at all.
+    assertObjectEquals(stored, { M: { street: { S: "1 High St" } } });
+  });
+
+  it("wraps a nested list as a list attribute", async () => {
+    // Given an item carrying a list of mixed values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written, then read as descriptors.
+    const stored = await storedAs(simSdk, documents, ["a", 1, true]);
+
+    // Then it is an L attribute holding one descriptor per member.
+    assertObjectEquals(stored, {
+      L: [{ S: "a" }, { N: "1" }, { BOOL: true }],
+    });
+  });
+
+  it("round-trips a nested object and list", async () => {
+    // Given an item carrying nesting several levels deep.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    const value = {
+      lines: [{ sku: "a", quantity: 2 }],
+      address: { postcode: "SW1A 1AA", tags: ["home"] },
+    };
+
+    // When it goes out and comes back.
+    const read = await roundTrip(documents, value);
+
+    // Then it is the same plain JavaScript it went in as.
+    assertObjectEquals(read, value);
+  });
+
+  it("round-trips a string set as a Set", async () => {
+    // Given an item carrying a Set of strings.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it goes out and comes back.
+    const read = await roundTrip(documents, new Set(["a", "b"]));
+
+    // Then it is a Set again, rather than the array a list would give.
+    assertInstanceOf(read, Set);
+    assertArrayEquals([...read], ["a", "b"]);
+  });
+
+  it("round-trips a number set as a Set of numbers", async () => {
+    // Given an item carrying a Set of numbers.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it goes out and comes back.
+    const read = await roundTrip(documents, new Set([1, 2]));
+
+    // Then the members are numbers again.
+    assertInstanceOf(read, Set);
+    assertArrayEquals([...read], [1, 2]);
+  });
+
+  it("round-trips binary as the bytes it was given", async () => {
+    // Given an item carrying bytes.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When they go out and come back.
+    const read = await roundTrip(documents, new Uint8Array([1, 2, 3]));
+
+    // Then they are the same bytes.
+    assertInstanceOf(read, Uint8Array);
+    assertArrayEquals([...read], [1, 2, 3]);
+  });
+
+  it("refuses an undefined attribute rather than dropping it", async () => {
+    // Given an item carrying an undefined value.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: undefined },
+        }),
+      );
+    });
+
+    // Then it is refused, naming where it sat and why the real client would
+    // have dropped it.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "input.Item.value is undefined");
+    assertStringIncludes(error.message, "removeUndefinedValues");
+  });
+
+  it("refuses an empty Set, as DynamoDB has no empty set", async () => {
+    // Given an item carrying an empty Set.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: new Set() },
+        }),
+      );
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "empty Set");
+  });
+
+  it("names the path inside a nested value it cannot convert", async () => {
+    // Given an item carrying something with no attribute type, buried in a
+    // list inside a map.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: { lines: [Symbol("nope")] } },
+        }),
+      );
+    });
+
+    // Then the refusal says where it sat, which the real client does not.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "input.Item.value.lines[0]");
+  });
+});
+
+describe("simulated DynamoDB document numbers", () => {
+  it("round-trips a bigint past the safe integer range", async () => {
+    // Given a number too large for a JavaScript number to hold exactly.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written as a bigint.
+    const read = await roundTrip(documents, 9_007_199_254_740_993n);
+
+    // Then it comes back as a bigint with its digits intact, which is what the
+    // real document client answers with rather than rounding it.
+    assertIdentical(read, 9_007_199_254_740_993n);
+  });
+
+  it("refuses a number past the safe integer range", async () => {
+    // Given a number that has already lost digits by the time it is written.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ValuesTable",
+          Item: { id: "a", value: Number.MAX_SAFE_INTEGER + 10 },
+        }),
+      );
+    });
+
+    // Then it is refused rather than stored rounded, and the refusal says what
+    // to write instead.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "bigint");
+    assertStringIncludes(error.message, "NumberValue");
+  });
+
+  it("keeps every digit of a NumberValue", async () => {
+    // Given a decimal with more digits than a JavaScript number carries.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+    const digits = "1.2345678901234567890123456789";
+
+    // When it is written as a NumberValue, which is the way the document
+    // client offers for exactly this.
+    const stored = await storedAs(simSdk, documents, NumberValue.from(digits));
+
+    // Then the table holds every digit.
+    assertObjectEquals(stored, { N: digits });
+  });
+
+  it("rounds a stored decimal the way the document client rounds it", async () => {
+    // Given a decimal held exactly by the simulated table, written through the
+    // ordinary Command so nothing converts it.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+    const digits = "1.2345678901234567890123456789";
+
+    await storedAs(simSdk, documents, NumberValue.from(digits));
+
+    // When it is read through the document client.
+    const read = await documents.send(
+      new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+    );
+
+    // Then it comes back as a JavaScript number, having lost the digits a
+    // JavaScript number cannot hold.
+    assertIdentical(read.Item?.["value"], 1.2345678901234567);
+
+    // And the table still holds every digit, so the loss is the document
+    // client's, here as on AWS.
+    const stored = await simSdk.simAws
+      .region("eu-west-2")
+      .dynamoDb()
+      .getItem(
+        new GetItemCommand({
+          TableName: "ValuesTable",
+          Key: { id: { S: "a" } },
+        }),
+      );
+    assertObjectEquals(stored.Item?.["value"], { N: digits });
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
@@ -22,30 +22,6 @@ import { SimSdk } from "../../../sdk/index.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
 
 /**
- * An intercepted document client over a table keyed by `id`.
- */
-async function interceptedDocuments(
-  simSdk: SimSdk,
-): Promise<DynamoDBDocumentClient> {
-  const documents = DynamoDBDocumentClient.from(
-    new DynamoDBClient({ region: "eu-west-2" }),
-  );
-  simSdk.intercept(documents);
-
-  await documents.send(
-    new CreateTableCommand({
-      TableName: "ValuesTable",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      BillingMode: "PAY_PER_REQUEST",
-    }),
-  );
-  await simSdk.simAws.backgroundTasksComplete();
-
-  return documents;
-}
-
-/**
  * Write one attribute natively and read the whole item back natively.
  */
 async function roundTrip(
@@ -86,6 +62,30 @@ async function storedAs(
     );
 
   return read.Item?.["value"];
+}
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "ValuesTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
 }
 
 describe("simulated DynamoDB document values", () => {
@@ -289,8 +289,8 @@ describe("simulated DynamoDB document numbers", () => {
   });
 
   it("rounds a stored decimal the way the document client rounds it", async () => {
-    // Given a decimal held exactly by the simulated table, written through the
-    // ordinary Command so nothing converts it.
+    // Given a decimal written through the document client as a NumberValue,
+    // which is what carries its digits through the conversion into the table.
     using simSdk = new SimSdk();
     const documents = await interceptedDocuments(simSdk);
     const digits = "1.2345678901234567890123456789";

--- a/src/service/dynamodb/error/dynamodb.error.ts
+++ b/src/service/dynamodb/error/dynamodb.error.ts
@@ -126,6 +126,24 @@ export class SimDynamoDbIdempotentParameterMismatchException extends SimDynamoDb
 }
 
 /**
+ * Simulated DynamoDB DocumentValueError.
+ *
+ * Real DynamoDB has no error of this name, and neither does the real document
+ * client, which refuses a value it cannot convert with a plain Error. It is
+ * what the simulated document client layer refuses one with, before the request
+ * reaches the simulated service, which is where the real one refuses it too.
+ *
+ * The message names the path the value sits at, which the real one does not.
+ */
+export class SimDynamoDbDocumentValueError extends SimDynamoDbError {
+  public override readonly name = "DocumentValueError";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated DynamoDB UnsupportedOperation error.
  *
  * Real DynamoDB has no error of this name. It is what simulated DynamoDB

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -32,6 +32,7 @@ import type {
   SimDescribeTimeToLiveCommand,
   SimUpdateTimeToLiveCommand,
 } from "../command/time-to-live/time-to-live.command.js";
+import { simDynamoDbDocumentRoutes } from "../document/sim-dynamodb-document-routes.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
 /**
@@ -178,6 +179,9 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
             simSdkCallerOptions(context),
           ),
       ],
+      // The document client's Commands, which carry native JavaScript values
+      // and so are converted on the way in and out.
+      ...simDynamoDbDocumentRoutes(simDynamoDatabase),
     ]);
   }
 


### PR DESCRIPTION
Routes lib-dynamodb's PutCommand, GetCommand, DeleteCommand, UpdateCommand, BatchWriteCommand and BatchGetCommand, converting native JavaScript values on the way in and out.

The real document client converts in middleware reached through resolveMiddleware, which an intercepted send replaces, so the conversion happens at the interception boundary instead. It uses lib-dynamodb's own option defaults rather than the util-dynamodb ones.

Intercept the document client itself: DynamoDBDocumentClient.from builds a separate object that does not extend DynamoDBClient, so intercepting the base client does not reach it.

Resolves https://github.com/KensioSoftware/yulin/issues/265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated DynamoDB document-client support for native JavaScript values.
  * Supports document operations including reads, writes, updates, deletes, batch requests, nested maps and lists, sets, binary values, and bigints.
  * Added conversion and validation for numbers, including safe handling of large integers.
  * Added clear errors for unsupported or invalid document values.
* **Documentation**
  * Added setup guides and examples covering document-client interception and common workflows.
* **Tests**
  * Added comprehensive coverage for conversion, routing, authorization, shared table state, and supported commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->