### PR TITLE
feat: query a simulated DynamoDB table by partition key and sort key

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1008,6 +1008,9 @@ The grammar is closed, and deliberately narrower than a `ConditionExpression`. E
 - the same key attribute tested twice
 - a `BETWEEN` whose upper bound is below its lower bound, or whose bounds are different types
 - a value written into the expression rather than supplied through `ExpressionAttributeValues`
+- a value whose type is not the one the table declared for that key attribute, such as comparing an
+  `S` sort key against an `N`. A key attribute has one type, so the condition could never hold, and
+  an empty page would read as a collection that happens to hold nothing.
 
 An attribute name that is a DynamoDB reserved word is written as a `#name` placeholder and defined in
 `ExpressionAttributeNames`, as in any other expression.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -903,6 +903,192 @@ wanted. Naming one path twice counts the same way.
 A document path goes at most 32 levels deep, which is as far as an item nests. A negative index, a
 fractional index and a path past that depth are each a `ValidationException` naming the path.
 
+## Querying an item collection
+
+A table with a sort key holds an item collection under each partition key: the items with that
+partition key, ordered by their sort key. `Query` reads one of those collections.
+
+`KeyConditionExpression` says which. It is one equality on the partition key, optionally joined by
+`AND` to one condition on the sort key. The sort key condition is `=`, `<`, `<=`, `>`, `>=`,
+`BETWEEN` or `begins_with`, and both bounds of a `BETWEEN` are inside the range.
+
+```typescript sim-dynamodb-query
+/**
+ * Reading a customer's orders back in sort key order.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const orderId of ["2026-03-01", "2026-01-14", "2027-01-02"]) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+    }),
+  );
+}
+
+const page = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression:
+      "customerId = :customer AND begins_with(orderId, :prefix)",
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":prefix": { S: "2026-" },
+    },
+  }),
+);
+
+console.log(page.Items?.map((item) => item["orderId"]?.S));
+// [ "2026-01-14", "2026-03-01" ]
+
+console.log(page.Count); // 2
+console.log(page.ScannedCount); // 2
+
+// ScanIndexForward reads the collection backwards.
+const newestFirst = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+    ScanIndexForward: false,
+  }),
+);
+
+console.log(newestFirst.Items?.map((item) => item["orderId"]?.S));
+// [ "2027-01-02", "2026-03-01", "2026-01-14" ]
+```
+
+The order is DynamoDB's rather than JavaScript's. A String sort key orders by its UTF-8 bytes, a
+Binary one as unsigned bytes, and a Number one by value however it was written, so `1E2` and `100`
+are one key rather than two and `9` sorts below `20`.
+
+`begins_with` reads a prefix of a String or Binary sort key. Against a Number sort key it is a
+`ValidationException`, as it is on AWS: a number is stored as a value rather than as the digits it
+was written with, so it has no prefix.
+
+A query on a table with no sort key is allowed, and reads the one item under the partition key.
+
+### What a key condition can say
+
+The grammar is closed, and deliberately narrower than a `ConditionExpression`. Each of these is a
+`ValidationException` naming what was wrong:
+
+- a key condition that does not test the partition key for equality
+- a range operator or `begins_with` applied to the partition key
+- an operator or function a sort key condition does not take, such as `<>` or `contains`
+- an attribute that is not part of the table's primary key
+- `OR` or `NOT` anywhere
+- the same key attribute tested twice
+- a `BETWEEN` whose upper bound is below its lower bound, or whose bounds are different types
+- a value written into the expression rather than supplied through `ExpressionAttributeValues`
+
+An attribute name that is a DynamoDB reserved word is written as a `#name` placeholder and defined in
+`ExpressionAttributeNames`, as in any other expression.
+
+### Paging a collection
+
+`Limit` counts the items a query evaluated. `LastEvaluatedKey` is the primary key of the item the
+walk stopped on, and the next request passes it back as `ExclusiveStartKey` to resume after it.
+
+```typescript sim-dynamodb-query-paging
+/**
+ * Paging through an item collection until the token runs out.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "EventsTable",
+    KeySchema: [
+      { AttributeName: "streamId", KeyType: "HASH" },
+      { AttributeName: "eventId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "streamId", AttributeType: "S" },
+      { AttributeName: "eventId", AttributeType: "N" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const eventId of ["1", "2", "3"]) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "EventsTable",
+      Item: { streamId: { S: "stream-1" }, eventId: { N: eventId } },
+    }),
+  );
+}
+
+const read: string[] = [];
+let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+do {
+  const page = await dynamoDb.query(
+    new QueryCommand({
+      TableName: "EventsTable",
+      KeyConditionExpression: "streamId = :stream",
+      ExpressionAttributeValues: { ":stream": { S: "stream-1" } },
+      Limit: 2,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  read.push(...(page.Items ?? []).map((item) => item["eventId"]?.N ?? ""));
+  exclusiveStartKey = page.LastEvaluatedKey;
+} while (exclusiveStartKey !== undefined);
+
+console.log(read); // [ "1", "2", "3" ]
+```
+
+`LastEvaluatedKey` is left out only when the key range ran out inside the `Limit`. Reaching the limit
+on the last matching item still hands out a token, and the next call answers with an empty page and
+no token. That is what real DynamoDB does, since it cannot know the range is exhausted without
+looking past it, so a loop like the one above is the way to read a whole collection.
+
+A token still works when the item it names has since been deleted: it says where to resume rather
+than which position to return to. A token from a different partition key is refused, since it names
+a collection this query is not reading.
+
 ## Reading and writing items in batches
 
 `BatchWriteItem` puts and deletes items across tables in one call, and `BatchGetItem` reads them by
@@ -1822,6 +2008,8 @@ nothing is written.
 - `UpdateItem`, with `SET`, `REMOVE`, `ADD` and `DELETE` update expressions, `if_not_exists`,
   `list_append`, decimal arithmetic, list element paths, upserting when the key holds nothing, and
   all five `ReturnValues` modes. Every action reads the item as it stood before the update.
+- `Query`, reading one item collection in sort key order, with the seven sort key conditions,
+  `ScanIndexForward`, and `Limit`, `LastEvaluatedKey` and `ExclusiveStartKey` paging.
 - `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
   `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
   `begins_with`, `contains` and `size` functions.
@@ -1849,10 +2037,12 @@ nothing is written.
 
 ## Limitations
 
-- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted, since
-  the first two are operations this simulation does not have yet. `TransactWriteCommand` and
-  `TransactGetCommand` are the exception: the operations behind them are simulated, so only the
-  document form is missing. All of them are refused by name rather than half converted.
+- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted. `Scan`
+  and PartiQL are operations this simulation does not have yet. `Query`, `TransactWriteCommand` and
+  `TransactGetCommand` are simulated as operations, so only the document form is missing: for the
+  transaction Commands that is simply not written yet, and for `Query` it is because
+  `@aws-sdk/lib-dynamodb` and `@aws-sdk/client-dynamodb` both name their Command `QueryCommand`,
+  which the interception routes by. All of them are refused by name rather than half converted.
 - A document client's translate config is not read, so the marshalling options it was built with do
   not apply. See [the SDK docs](../../sdk/README.md#limitations).
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
@@ -1860,8 +2050,8 @@ nothing is written.
   the operation rather than by the conversion.
 - Global and local secondary indexes are not simulated. `GlobalSecondaryIndexes` and
   `LocalSecondaryIndexes` are refused rather than dropped, since a table missing an index it was
-  asked for would answer queries differently to the real one. An empty list asks for no index, so it
-  is accepted.
+  asked for would answer queries differently to the real one, and a `Query` naming an `IndexName` is
+  refused for the same reason. An empty list asks for no index, so it is accepted.
 - Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent, so
   a real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
   with none. Here the change is there by the time the call returns, so a test cannot observe the
@@ -1920,7 +2110,21 @@ nothing is written.
   refuses that status anyway, for when it can.
 - Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
   is ever throttled with `ProvisionedThroughputExceededException`.
-- `UpdateTable`, `Query` and `Scan` are not implemented yet.
+- `UpdateTable` and `Scan` are not implemented yet.
+- A query page is never cut short by size. Real DynamoDB stops a page at 1 MB and hands out a
+  `LastEvaluatedKey`, which is not modelled here, so a page breaks only on a `Limit`. A test reading
+  a large collection with no `Limit` gets all of it in one page where a real one would page.
+- Nothing here throttles or measures a query, so `ReturnConsumedCapacity` is refused unless it names
+  `NONE`, and a `Limit` is the only thing that ends a page early.
+- A key condition takes no brackets. `(customerId = :c) AND orderId > :o` is refused here, where real
+  DynamoDB accepts it. The shape of a key condition is fixed, so there is nothing for brackets to
+  group, and being stricter is the direction that fails safely: it is a puzzling refusal here rather
+  than a query that means something different on AWS.
+- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused on `Query`, since
+  each of them changes which items a query answers with or which parts of them. `Select` naming
+  `ALL_ATTRIBUTES` is the default a table query already behaves as, so it is accepted.
+- `Count` and `ScannedCount` are always the same number. They differ only when a `FilterExpression`
+  drops items a query evaluated, and filters are not simulated.
 - `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
   response stops at a size, so the branch of a batch retry loop that resends what did not go through
   is never taken against the simulator.
@@ -1947,8 +2151,8 @@ nothing is written.
   stack deployed calls `simAws.backgroundTasksComplete()` first.
 - CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
   `DeletionPolicy` a template sets on a table.
-- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. `Query`
-  and `Scan` are not implemented yet, so they have nothing to project from.
+- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. On `Query`
+  it is refused rather than ignored, and `Scan` is not implemented yet.
 - The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
   where part of it was asked for would hide an application reading an attribute it never requested.
   `ProjectionExpression` replaced it, and real DynamoDB has built nothing on it since.
@@ -1959,8 +2163,8 @@ nothing is written.
   whether a request sets it once for a read or per table for a batch read, so a test cannot observe a
   stale read here the way it might against a real table.
 - Condition expressions are simulated on `PutItem`, `DeleteItem`, `UpdateItem` and the actions of
-  `TransactWriteItems`. The key condition and filter expressions of `Query` and `Scan` are not
-  implemented yet, so there is nothing else to guard.
+  `TransactWriteItems`, and key conditions on `Query`. Filter expressions are not implemented yet, on
+  either `Query` or `Scan`.
 - Two update actions cannot write to overlapping paths, so `ADD tags :added DELETE tags :gone` in one
   expression is refused as it is on AWS. Taking members out of a set an expression also adds to is a
   second update.

--- a/docs/services/dynamodb/sim-dynamodb-query-paging.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-query-paging.example.ts
@@ -1,0 +1,60 @@
+/**
+ * Paging through an item collection until the token runs out.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { AttributeValue } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "EventsTable",
+    KeySchema: [
+      { AttributeName: "streamId", KeyType: "HASH" },
+      { AttributeName: "eventId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "streamId", AttributeType: "S" },
+      { AttributeName: "eventId", AttributeType: "N" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const eventId of ["1", "2", "3"]) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "EventsTable",
+      Item: { streamId: { S: "stream-1" }, eventId: { N: eventId } },
+    }),
+  );
+}
+
+const read: string[] = [];
+let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+do {
+  const page = await dynamoDb.query(
+    new QueryCommand({
+      TableName: "EventsTable",
+      KeyConditionExpression: "streamId = :stream",
+      ExpressionAttributeValues: { ":stream": { S: "stream-1" } },
+      Limit: 2,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  read.push(...(page.Items ?? []).map((item) => item["eventId"]?.N ?? ""));
+  exclusiveStartKey = page.LastEvaluatedKey;
+} while (exclusiveStartKey !== undefined);
+
+console.log(read); // [ "1", "2", "3" ]

--- a/docs/services/dynamodb/sim-dynamodb-query.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-query.example.ts
@@ -1,0 +1,70 @@
+/**
+ * Reading a customer's orders back in sort key order.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const orderId of ["2026-03-01", "2026-01-14", "2027-01-02"]) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+    }),
+  );
+}
+
+const page = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression:
+      "customerId = :customer AND begins_with(orderId, :prefix)",
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":prefix": { S: "2026-" },
+    },
+  }),
+);
+
+console.log(page.Items?.map((item) => item["orderId"]?.S));
+// [ "2026-01-14", "2026-03-01" ]
+
+console.log(page.Count); // 2
+console.log(page.ScannedCount); // 2
+
+// ScanIndexForward reads the collection backwards.
+const newestFirst = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+    ScanIndexForward: false,
+  }),
+);
+
+console.log(newestFirst.Items?.map((item) => item["orderId"]?.S));
+// [ "2027-01-02", "2026-03-01", "2026-01-14" ]

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -606,7 +606,10 @@ The parts split by what they know:
 - The three terms are a class each, in `sim-dynamodb-comparison-key-term.ts`,
   `sim-dynamodb-between-key-term.ts` and `sim-dynamodb-begins-with-key-term.ts`. Each knows what it
   refuses: a BETWEEN whose bounds run backwards or are different types, and a `begins_with` against a
-  Number sort key.
+  Number sort key. `assertUsableOn` is where a term is held to the type the table declared for the
+  key attribute, through the shared `assertSimDynamoDbKeyValueType`. A value of another type is
+  refused rather than matching nothing, since an empty page would read as a collection that happens
+  to hold nothing.
 - `SimDynamoDbKeyConditionTerms` holds the terms to the key schema once the table has been reached,
   and answers with a `SimDynamoDbKeyCondition`: the partition key value whose collection is read, and
   the run of it the sort key condition asks for.

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -49,6 +49,7 @@ Current command areas include:
 - `authorize/` (shared IAM authorization for every DynamoDB command)
 - `table/` (CreateTable, DescribeTable, ListTables and DeleteTable)
 - `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
+- `query/` (Query)
 - `batch/` (BatchWriteItem and BatchGetItem)
 - `transact/` (TransactWriteItems and TransactGetItems)
 - `tag/` (TagResource, UntagResource and ListTagsOfResource)
@@ -384,6 +385,55 @@ c: 3 }` leaves `{ b: 1, c: 2 }`, which an implementation applying actions left t
   parts the expression touched by applying a `SimDynamoDbProjection` of the action targets, which is
   the same machinery a ProjectionExpression uses.
 
+## Query behavior
+
+`SimDynamoDbQuery` reads one item collection: the items under one partition key, in sort key order.
+It reaches its table the same way the item commands do, and authorizes `dynamodb:Query` before the
+lookup.
+
+The order it works in is the order the other commands follow, with one addition:
+
+1. `refuseUnsimulatedQueryInput` refuses the inputs this simulation does not model.
+2. `readSimDynamoDbKeyCondition` reads the `KeyConditionExpression`, before the table is reached, so
+   an expression DynamoDB would refuse is refused whether or not the table is there.
+3. The table is found and the caller authorized.
+4. `SimDynamoDbKeyConditionTerms.forTable` reads the terms against the table's key schema, which is
+   the part that could not be checked without it: which attribute is the partition key, and what type
+   the sort key is.
+5. The collection is gathered, walked, and cut to a page.
+
+The parts a query is made of split by what they know:
+
+- `expression/key-condition/` reads the expression. It is a closed grammar of its own rather than the
+  general condition grammar, for the reason in the Expressions section below.
+- `SimDynamoDbItemCollection` under `table/` is the items one key condition names, in sort key order.
+  A table holds its items in a map keyed by the marshalled primary key, which carries no order at
+  all, so a collection is gathered and ordered when it is read. `SimDynamoDbSortKeyOrder` is the
+  order itself, and is where a table with no sort key stops mattering: such a table holds at most one
+  item under a partition key, so every question about ordering has a trivial answer.
+- `SimDynamoDbItemPage` under `command/item/` is `Limit` and `LastEvaluatedKey`. It takes items and a
+  key schema rather than a query, so `Scan` can use it unchanged.
+- `readSimDynamoDbQueryStartKey` reads the `ExclusiveStartKey`. It goes through the table's own key
+  reading, so a token that is not a whole primary key is refused the way any Key is, and then checks
+  that it names the collection being read.
+
+Important behavior:
+
+- `ScanIndexForward` defaults to true. Setting it to false reads the collection backwards, and
+  resumes backwards too.
+- `Limit` counts the items a walk evaluated. Nothing filters a query yet, so that is also the number
+  it answers with, and `Count` and `ScannedCount` are the same.
+- `LastEvaluatedKey` is there whenever the walk stopped at the limit, including when it stopped on
+  the last matching item. A caller looping until the token is absent therefore reads one empty page
+  at the end, which is what real DynamoDB does: it cannot know the range is exhausted without looking
+  past it.
+- `ExclusiveStartKey` resumes exclusively, by comparing sort keys rather than by looking the item up,
+  so a token still works when the item it names has since been deleted. That is the same choice
+  `ListTables` and `ListTagsOfResource` make.
+- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused by name, since each
+  changes which items a query answers with or which parts of them. `Select: ALL_ATTRIBUTES` is the
+  default a table query already behaves as, so it is let through.
+
 ## BatchWriteItem and BatchGetItem behavior
 
 `SimDynamoDbBatchWriteItem` and `SimDynamoDbBatchGetItem` work on several items across several
@@ -428,8 +478,8 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Scans, queries, indexes and streams are not implemented. Billing mode and provisioned capacity are
-read and stored by CreateTable, but nothing enforces them: no write is ever throttled.
+Scans, indexes and streams are not implemented. Billing mode and provisioned capacity are read and
+stored by CreateTable, but nothing enforces them: no write is ever throttled.
 
 ## TransactWriteItems and TransactGetItems behavior
 
@@ -530,12 +580,36 @@ precedence DynamoDB documents is the shape of the class rather than a table some
 and the function calls have parsers of their own, because deciding whether `size` is a call or an
 attribute named `size` is a different job from deciding whether an OR binds looser than an AND.
 
-The comparison rules live in `item/sim-dynamodb-value-comparison.ts` rather than inside the
-evaluator, because sort key conditions and filter expressions compare the same way when `Query` and
-`Scan` arrive. Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare
-through `SimDynamoDbNumber.compareTo` so digits past what a JavaScript number holds still order
-correctly, and binary compares as unsigned bytes. Two values of different types have no order at all,
-which is what makes a comparison between them false rather than an error.
+The comparison rules live in `item/sim-dynamodb-value-comparison.ts` and
+`item/sim-dynamodb-value-order.ts` rather than inside the evaluator, because a sort key condition
+compares the same way a condition expression does, and a filter expression will when `Scan` arrives.
+Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare through
+`SimDynamoDbNumber.compareTo` so digits past what a JavaScript number holds still order correctly,
+and binary compares as unsigned bytes. Two values of different types have no order at all, which is
+what makes a comparison between them false rather than an error. `simDynamoDbValueBeginsWith` in
+`item/sim-dynamodb-value-prefix.ts` is the same arrangement for a prefix, which `begins_with` asks
+for in both grammars.
+
+`expression/key-condition/` reads a KeyConditionExpression into the terms it is made of. It is a
+grammar of its own rather than a use of the condition parser, and deliberately so: sharing one parser
+would let a query accept `OR`, which real DynamoDB refuses in a key condition, and that is the kind
+of divergence that passes here and fails on deploy.
+
+The parts split by what they know:
+
+- `SimDynamoDbKeyConditionParser` reads the shape a key condition is allowed to take. It knows
+  nothing about which attribute is the partition key, since that belongs to the table.
+- `SimDynamoDbKeyConditionOperands` reads the three pieces every term is built from: the key
+  attribute, the comparator, and the value.
+- `SimDynamoDbKeyConditionRefusals` is what a key condition is refused for being rather than for what
+  it says: `OR`, `NOT`, brackets, a function that is not `begins_with`, and a dereferenced attribute.
+- The three terms are a class each, in `sim-dynamodb-comparison-key-term.ts`,
+  `sim-dynamodb-between-key-term.ts` and `sim-dynamodb-begins-with-key-term.ts`. Each knows what it
+  refuses: a BETWEEN whose bounds run backwards or are different types, and a `begins_with` against a
+  Number sort key.
+- `SimDynamoDbKeyConditionTerms` holds the terms to the key schema once the table has been reached,
+  and answers with a `SimDynamoDbKeyCondition`: the partition key value whose collection is read, and
+  the run of it the sort key condition asks for.
 
 `SimDynamoDbConditionCheck` under `command/item/` is what PutItem and DeleteItem both use. It reads
 the expression before the table is reached, so an expression DynamoDB would refuse is refused

--- a/src/service/dynamodb/command/item/item.types.ts
+++ b/src/service/dynamodb/command/item/item.types.ts
@@ -1,5 +1,11 @@
 /**
  * Minimal structural sim DynamoDB AttributeValue.
+ *
+ * The arrays are mutable and `$unknown` is a mutable tuple, matching the shape
+ * the AWS SDK declares, so a value the simulator answers with can be passed
+ * straight back into an SDK Command. That is what a paging loop does with a
+ * `LastEvaluatedKey`, and a readonly array here would make the SDK's own types
+ * refuse it.
  */
 export type SimDynamoDbAttributeValue =
   | {
@@ -27,7 +33,7 @@ export type SimDynamoDbAttributeValue =
       readonly SS?: never;
     }
   | {
-      readonly BS: readonly Uint8Array[];
+      readonly BS: Uint8Array[];
       readonly B?: never;
       readonly BOOL?: never;
       readonly L?: never;
@@ -39,7 +45,7 @@ export type SimDynamoDbAttributeValue =
       readonly SS?: never;
     }
   | {
-      readonly L: readonly SimDynamoDbAttributeValue[];
+      readonly L: SimDynamoDbAttributeValue[];
       readonly B?: never;
       readonly BOOL?: never;
       readonly BS?: never;
@@ -75,7 +81,7 @@ export type SimDynamoDbAttributeValue =
       readonly SS?: never;
     }
   | {
-      readonly NS: readonly string[];
+      readonly NS: string[];
       readonly B?: never;
       readonly BOOL?: never;
       readonly BS?: never;
@@ -111,7 +117,7 @@ export type SimDynamoDbAttributeValue =
       readonly SS?: never;
     }
   | {
-      readonly SS: readonly string[];
+      readonly SS: string[];
       readonly B?: never;
       readonly BOOL?: never;
       readonly BS?: never;
@@ -123,7 +129,7 @@ export type SimDynamoDbAttributeValue =
       readonly S?: never;
     }
   | {
-      readonly $unknown: readonly [string, unknown];
+      readonly $unknown: [string, unknown];
       readonly B?: never;
       readonly BOOL?: never;
       readonly BS?: never;
@@ -146,6 +152,19 @@ export type SimDynamoDbAttributeValue =
 export interface SimDynamoDbAttributeValueUpdate {
   readonly Value?: SimDynamoDbAttributeValue | undefined;
   readonly Action?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB legacy condition.
+ *
+ * This is the older way of saying which items a read wants, which
+ * `KeyConditionExpression` and `FilterExpression` replaced. It is declared so a
+ * request carrying one is refused by name.
+ */
+export interface SimDynamoDbLegacyCondition {
+  readonly ComparisonOperator?: string | undefined;
+  readonly AttributeValueList?:
+    readonly SimDynamoDbAttributeValue[] | undefined;
 }
 
 /**

--- a/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
@@ -1,0 +1,80 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
+import { simDynamoDbPrimaryKeyAttributes } from "../../table/sim-dynamodb-primary-key.js";
+import type { SimDynamoDbAttributeValue } from "./item.types.js";
+
+/**
+ * Read the page size a request asks for.
+ *
+ * A request with no `Limit` reads everything the key range holds. Real DynamoDB
+ * stops a page at 1 MB instead, which is not modelled here, so a page breaks
+ * only on a `Limit`.
+ */
+function readLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return Infinity;
+  }
+
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    throw new SimDynamoDbValidationException(
+      `Limit ${limit.toString()} is invalid. It is a whole number of at ` +
+        `least 1.`,
+    );
+  }
+
+  return limit;
+}
+
+interface SimDynamoDbItemPageProperties {
+  /** The items the walk reached, already in the order they are read in. */
+  readonly items: readonly SimDynamoDbItem[];
+  readonly limit: number | undefined;
+  readonly keySchema: SimDynamoDbKeySchema;
+}
+
+/**
+ * One page of items, as a Query hands them out.
+ *
+ * `Limit` counts the items a walk evaluated rather than the items it answers
+ * with, which is the same number here because nothing filters a query yet. The
+ * distinction matters once `FilterExpression` arrives, and the walk is written
+ * around evaluation so it keeps meaning the same thing.
+ *
+ * `LastEvaluatedKey` is there whenever the walk stopped at the limit, including
+ * when it stopped on the last matching item. A caller looping until the token
+ * is absent therefore reads one empty page at the end. That is what real
+ * DynamoDB does: it cannot know the range is exhausted without looking past it.
+ *
+ * Scan pages the same way, so this takes items and a key schema rather than a
+ * query.
+ */
+export class SimDynamoDbItemPage {
+  public readonly items: readonly SimDynamoDbItem[];
+  public readonly lastEvaluatedKey:
+    Record<string, SimDynamoDbAttributeValue> | undefined;
+
+  constructor(properties: SimDynamoDbItemPageProperties) {
+    const limit = readLimit(properties.limit);
+
+    this.items = properties.items.slice(0, limit);
+    this.lastEvaluatedKey = this.tokenFor(properties.keySchema, limit);
+  }
+
+  /**
+   * The key to resume from, when the walk stopped at the limit rather than at
+   * the end of the range.
+   */
+  private tokenFor(
+    keySchema: SimDynamoDbKeySchema,
+    limit: number,
+  ): Record<string, SimDynamoDbAttributeValue> | undefined {
+    const last = this.items.at(-1);
+
+    if (last === undefined || this.items.length < limit) {
+      return undefined;
+    }
+
+    return simDynamoDbPrimaryKeyAttributes(last, keySchema);
+  }
+}

--- a/src/service/dynamodb/command/query/query.command.ts
+++ b/src/service/dynamodb/command/query/query.command.ts
@@ -1,0 +1,64 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimDynamoDbAttributeValue,
+  SimDynamoDbLegacyCondition,
+} from "../item/item.types.js";
+
+/**
+ * Minimal structural sim DynamoDB Query command.
+ */
+export interface SimQueryCommand {
+  readonly input: SimQueryCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB Query input.
+ *
+ * The inputs this simulation does not model are declared as well as the ones it
+ * does, so a request that asks for one of them is refused by name rather than
+ * given a page that means something else.
+ */
+export interface SimQueryCommandInput {
+  readonly TableName?: string | undefined;
+  readonly KeyConditionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ScanIndexForward?: boolean | undefined;
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartKey?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly ConsistentRead?: boolean | undefined;
+  readonly IndexName?: string | undefined;
+  readonly FilterExpression?: string | undefined;
+  readonly ProjectionExpression?: string | undefined;
+  readonly Select?: string | undefined;
+  readonly ReturnConsumedCapacity?: string | undefined;
+  readonly AttributesToGet?: readonly string[] | undefined;
+  readonly KeyConditions?:
+    Readonly<Record<string, SimDynamoDbLegacyCondition>> | undefined;
+  readonly QueryFilter?:
+    Readonly<Record<string, SimDynamoDbLegacyCondition>> | undefined;
+  readonly ConditionalOperator?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Query output.
+ *
+ * `Count` and `ScannedCount` are the same number here, since nothing filters a
+ * query yet: every item the walk evaluated is an item it answers with.
+ *
+ * `LastEvaluatedKey` is absent only when the key range ran out inside the
+ * `Limit`, so a caller loops until it is gone rather than until the page is
+ * short.
+ */
+export interface SimQueryCommandOutput {
+  readonly Items?:
+    readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] | undefined;
+  readonly Count?: number | undefined;
+  readonly ScannedCount?: number | undefined;
+  readonly LastEvaluatedKey?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-iam.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-iam.iso.test.ts
@@ -1,0 +1,180 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * One simulated Account and Region, with a table holding one item collection.
+ */
+interface QueryScope {
+  readonly accountId: string;
+  readonly region: string;
+  readonly simAws: SimAws;
+  readonly simDynamoDb: SimDynamoDb;
+}
+
+/**
+ * A scope with a collection to read.
+ */
+async function queryScope(): Promise<QueryScope> {
+  const accountId = makeSimAwsAccountId();
+  const region = makeAwsRegionName();
+  const simAws = new SimAws();
+  const simDynamoDb = simAws.account(accountId).region(region).dynamoDb();
+
+  await simDynamoDb.createTable({
+    input: {
+      TableName: "OrdersTable",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    },
+  });
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem({
+    input: {
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-1" }, orderId: { S: "order-1" } },
+    },
+  });
+
+  return { accountId, region, simAws, simDynamoDb };
+}
+
+/**
+ * A Role that may assume itself from the Account root, and nothing else.
+ */
+async function roleArnFor(
+  scope: QueryScope,
+  roleName: string,
+): Promise<string> {
+  const creation = await scope.simAws
+    .account(scope.accountId)
+    .iam()
+    .createRole(
+      new CreateRoleCommand({
+        RoleName: roleName,
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${scope.accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+  return creation.Role.Arn;
+}
+
+/**
+ * Allow one DynamoDB action on the table this scope holds.
+ */
+async function allow(
+  scope: QueryScope,
+  roleName: string,
+  action: string,
+): Promise<void> {
+  await scope.simAws
+    .account(scope.accountId)
+    .iam()
+    .putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: roleName,
+        PolicyName: `${action.replace(":", "")}Policy`,
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: action,
+            Resource: `arn:aws:dynamodb:${scope.region}:${scope.accountId}:table/OrdersTable`,
+          },
+        }),
+      }),
+    );
+}
+
+/**
+ * The query these tests authorize.
+ */
+function collectionQuery(): QueryCommand {
+  return new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+  });
+}
+
+describe("DynamoDB QueryCommand IAM authorization", () => {
+  it("allows a Role its policy permits dynamodb:Query", async () => {
+    // Given a Role allowed to query the table.
+    const scope = await queryScope();
+    const roleArn = await roleArnFor(scope, "CollectionReader");
+    await allow(scope, "CollectionReader", "dynamodb:Query");
+
+    // When the Role reads the collection.
+    const output = await scope.simDynamoDb.query(collectionQuery(), {
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    // Then IAM allows the request.
+    assertArrayLength(output.Items ?? [], 1);
+  });
+
+  it("implicitly denies a Role with no matching policy", async () => {
+    // Given a Role with no DynamoDB permissions.
+    const scope = await queryScope();
+    const roleArn = await roleArnFor(scope, "NoQueryRole");
+
+    // When the Role attempts to read the collection.
+    const error = await assertThrowsErrorAsync(async () =>
+      scope.simDynamoDb.query(collectionQuery(), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then IAM denies the request, naming the action and the table ARN.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:Query");
+    assertIdentical(
+      error.resource,
+      `arn:aws:dynamodb:${scope.region}:${scope.accountId}:table/OrdersTable`,
+    );
+  });
+
+  it("does not let permission to read one item read a collection", async () => {
+    // Given a Role allowed only to read one item at a time.
+    const scope = await queryScope();
+    const roleArn = await roleArnFor(scope, "GetOnlyRole");
+    await allow(scope, "GetOnlyRole", "dynamodb:GetItem");
+
+    // When the Role attempts to query.
+    const error = await assertThrowsErrorAsync(async () =>
+      scope.simDynamoDb.query(collectionQuery(), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then each DynamoDB operation is its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:Query");
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-paging.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-paging.iso.test.ts
@@ -1,0 +1,161 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbCreatedTableFactory } from "../../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type { SimQueryCommandOutput } from "./query.command.js";
+
+/**
+ * A table holding one customer's three orders.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  await Promise.all(
+    ["order-1", "order-2", "order-3"].map(async (orderId) =>
+      simDynamoDb.putItem({
+        input: {
+          TableName: "OrdersTable",
+          Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+        },
+      }),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * Read one page of the collection, resuming after a token when there is one.
+ *
+ * The token goes straight back the way a caller passes it, rather than being
+ * rebuilt, since that is what a paging loop does.
+ */
+async function queryPage(
+  simDynamoDb: SimDynamoDb,
+  limit: number | undefined,
+  exclusiveStartKey?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): Promise<SimQueryCommandOutput> {
+  return await simDynamoDb.query({
+    input: {
+      TableName: "OrdersTable",
+      KeyConditionExpression: "customerId = :customer",
+      ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    },
+  });
+}
+
+/**
+ * The sort keys a page came back with, in the order they came back in.
+ */
+function orderIds(output: SimQueryCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB QueryCommand paging", () => {
+  it("stops a page at the Limit and says where to resume", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When two of them are asked for.
+    const output = await queryPage(simDynamoDb, 2);
+
+    // Then the page stops at the limit, and the token names the item it
+    // stopped on.
+    assertArrayEquals(orderIds(output), ["order-1", "order-2"]);
+
+    const token = output.LastEvaluatedKey;
+    assertNonNullable(token);
+    assertIdentical(token["orderId"]?.S, "order-2");
+    assertIdentical(token["customerId"]?.S, "c-1");
+  });
+
+  it("leaves the token off when the collection ran out inside the Limit", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When more than the collection holds is asked for.
+    const output = await queryPage(simDynamoDb, 10);
+
+    // Then the whole collection comes back with nothing left to resume for.
+    assertArrayLength(output.Items ?? [], 3);
+    assertUndefined(output.LastEvaluatedKey);
+  });
+
+  it("hands out a token even when the Limit fell on the last item", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When exactly as many as the collection holds are asked for.
+    const output = await queryPage(simDynamoDb, 3);
+
+    // Then there is still a token, since the walk stopped at the limit rather
+    // than at the end of the range.
+    assertArrayLength(output.Items ?? [], 3);
+    assertNonNullable(output.LastEvaluatedKey);
+
+    // And the next page is empty, with nothing left to resume for.
+    const next = await queryPage(simDynamoDb, 3, output.LastEvaluatedKey);
+
+    assertArrayLength(next.Items ?? [], 0);
+    assertUndefined(next.LastEvaluatedKey);
+  });
+
+  it("reads the whole collection when no Limit is given", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read with no page size at all.
+    const output = await queryPage(simDynamoDb, undefined);
+
+    // Then everything comes back: nothing here stops a page at 1 MB.
+    assertArrayLength(output.Items ?? [], 3);
+    assertUndefined(output.LastEvaluatedKey);
+  });
+
+  it("empties the page of a table with no sort key once resumed", async () => {
+    // Given a table keyed by partition key alone, holding one item.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "UsersTable", partitionKeyName: "userId" },
+      simAws,
+    );
+
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "UsersTable",
+        Item: { userId: { S: "user-1" } },
+      },
+    });
+
+    // When the query resumes after that item.
+    const output = await simDynamoDb.query({
+      input: {
+        TableName: "UsersTable",
+        KeyConditionExpression: "userId = :user",
+        ExpressionAttributeValues: { ":user": { S: "user-1" } },
+        ExclusiveStartKey: { userId: { S: "user-1" } },
+      },
+    });
+
+    // Then there is nothing after it: a collection with no sort key holds one
+    // item.
+    assertArrayLength(output.Items ?? [], 0);
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-resume.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-resume.iso.test.ts
@@ -1,0 +1,222 @@
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type {
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "./query.command.js";
+
+/**
+ * A key a query resumes after, as a page hands it back.
+ */
+type QueryToken = Readonly<Record<string, SimDynamoDbAttributeValue>>;
+
+/**
+ * A table holding one customer's three orders, and one belonging to another.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  await Promise.all(
+    ["order-1", "order-2", "order-3"].map(async (orderId) =>
+      simDynamoDb.putItem({
+        input: {
+          TableName: "OrdersTable",
+          Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+        },
+      }),
+    ),
+  );
+
+  await simDynamoDb.putItem({
+    input: {
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-2" }, orderId: { S: "order-1" } },
+    },
+  });
+
+  return simDynamoDb;
+}
+
+/**
+ * Read one page of the collection, with anything else a test wants to say.
+ */
+async function queryPage(
+  simDynamoDb: SimDynamoDb,
+  input: SimQueryCommandInput,
+): Promise<SimQueryCommandOutput> {
+  return await simDynamoDb.query({
+    input: {
+      TableName: "OrdersTable",
+      KeyConditionExpression: "customerId = :customer",
+      ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      ...input,
+    },
+  });
+}
+
+/**
+ * The sort keys a page came back with, in the order they came back in.
+ */
+function orderIds(output: SimQueryCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+/**
+ * Page the whole collection one item at a time, gathering what each page held.
+ *
+ * A caller pages until the token is gone rather than until a page is short,
+ * which is what the walk is written for, so the reading is written that way
+ * too.
+ */
+async function readPaged(
+  simDynamoDb: SimDynamoDb,
+  after: QueryToken | undefined,
+  read: readonly string[],
+): Promise<readonly string[]> {
+  const output = await queryPage(simDynamoDb, {
+    Limit: 1,
+    ExclusiveStartKey: after,
+  });
+  const gathered = [...read, ...orderIds(output)];
+
+  if (output.LastEvaluatedKey === undefined) {
+    return gathered;
+  }
+
+  return await readPaged(simDynamoDb, output.LastEvaluatedKey, gathered);
+}
+
+describe("DynamoDB QueryCommand resuming", () => {
+  it("reads every item exactly once when paging the collection", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is paged one item at a time until the token is gone.
+    const read = await readPaged(simDynamoDb, undefined, []);
+
+    // Then every item was read once, in order, and the paging terminated.
+    assertArrayEquals(read, ["order-1", "order-2", "order-3"]);
+  });
+
+  it("resumes backwards for ScanIndexForward false", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read backwards, resuming after the second item.
+    const output = await queryPage(simDynamoDb, {
+      ScanIndexForward: false,
+      ExclusiveStartKey: {
+        customerId: { S: "c-1" },
+        orderId: { S: "order-2" },
+      },
+    });
+
+    // Then it carries on the way it was going, which is downwards.
+    assertArrayEquals(orderIds(output), ["order-1"]);
+  });
+
+  it("resumes after an item that has since been deleted", async () => {
+    // Given a table holding three orders, one of which is then removed.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+    const first = await queryPage(simDynamoDb, { Limit: 1 });
+    assertNonNullable(first.LastEvaluatedKey);
+
+    await simDynamoDb.deleteItem({
+      input: {
+        TableName: "OrdersTable",
+        Key: { customerId: { S: "c-1" }, orderId: { S: "order-1" } },
+      },
+    });
+
+    // When the next page resumes after the item that has gone.
+    const output = await queryPage(simDynamoDb, {
+      ExclusiveStartKey: first.LastEvaluatedKey,
+    });
+
+    // Then the token still works: it is a key to resume after rather than a
+    // remembered position.
+    assertArrayEquals(orderIds(output), ["order-2", "order-3"]);
+  });
+
+  it.each([0, -1, 1.5])("refuses a Limit of %s", async (limit) => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a page size no request could mean is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      queryPage(simDynamoDb, { Limit: limit }),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "whole number of at least 1");
+  });
+
+  it("refuses an ExclusiveStartKey from another item collection", async () => {
+    // Given a table holding orders for two customers.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query resumes from a key belonging to the other customer.
+    const error = await assertThrowsErrorAsync(async () =>
+      queryPage(simDynamoDb, {
+        ExclusiveStartKey: {
+          customerId: { S: "c-2" },
+          orderId: { S: "order-1" },
+        },
+      }),
+    );
+
+    // Then it is refused rather than read from the start of the collection.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "different item collection");
+  });
+
+  it("refuses an ExclusiveStartKey that is not a whole primary key", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query resumes from a key missing the sort key.
+    const error = await assertThrowsErrorAsync(async () =>
+      queryPage(simDynamoDb, {
+        ExclusiveStartKey: { customerId: { S: "c-1" } },
+      }),
+    );
+
+    // Then it is refused the way any incomplete Key is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "orderId");
+  });
+
+  it("refuses an ExclusiveStartKey naming no attribute at all", async () => {
+    // Given a table holding three orders for one customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query resumes from an empty key.
+    const error = await assertThrowsErrorAsync(async () =>
+      queryPage(simDynamoDb, { ExclusiveStartKey: {} }),
+    );
+
+    // Then it is refused, since it names no item to resume after.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "names no attribute at all");
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-sort-key.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-sort-key.iso.test.ts
@@ -1,0 +1,285 @@
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimQueryCommandOutput } from "./query.command.js";
+
+/**
+ * A table whose sort key is a string, holding one collection of four items.
+ */
+async function stringSortKeyTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make(
+    {
+      tableName: "EventsTable",
+      partitionKeyName: "streamId",
+      sortKeyName: "eventId",
+    },
+    simAws,
+  );
+
+  await Promise.all(
+    ["a-1", "a-2", "b-1", "b-2"].map(async (eventId) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "EventsTable",
+          Item: { streamId: { S: "stream-1" }, eventId: { S: eventId } },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * A table whose sort key is a number, holding numbers written several ways.
+ */
+async function numberSortKeyTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make(
+    {
+      tableName: "ReadingsTable",
+      partitionKeyName: "sensorId",
+      sortKeyName: "takenAt",
+      sortKeyType: "N",
+    },
+    simAws,
+  );
+
+  await Promise.all(
+    ["100", "9", "1E2", "20"].map(async (takenAt) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "ReadingsTable",
+          Item: { sensorId: { S: "sensor-1" }, takenAt: { N: takenAt } },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The sort keys a page came back with, in the order they came back in.
+ */
+function eventIds(output: SimQueryCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["eventId"]?.S ?? "");
+}
+
+describe("DynamoDB QueryCommand sort key conditions", () => {
+  it.each([
+    { condition: "eventId = :value", value: "a-2", expected: ["a-2"] },
+    { condition: "eventId < :value", value: "a-2", expected: ["a-1"] },
+    { condition: "eventId <= :value", value: "a-2", expected: ["a-1", "a-2"] },
+    { condition: "eventId > :value", value: "a-2", expected: ["b-1", "b-2"] },
+    {
+      condition: "eventId >= :value",
+      value: "a-2",
+      expected: ["a-2", "b-1", "b-2"],
+    },
+    {
+      condition: "begins_with(eventId, :value)",
+      value: "b-",
+      expected: ["b-1", "b-2"],
+    },
+  ])("reads the collection with $condition", async (example) => {
+    // Given a table holding one stream's events.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the collection is read with a sort key condition.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "EventsTable",
+        KeyConditionExpression: `streamId = :stream AND ${example.condition}`,
+        ExpressionAttributeValues: {
+          ":stream": { S: "stream-1" },
+          ":value": { S: example.value },
+        },
+      }),
+    );
+
+    // Then the run of the collection it names comes back, in sort key order.
+    assertArrayEquals(eventIds(output), example.expected);
+  });
+
+  it("reads the run BETWEEN two bounds, both of them inside", async () => {
+    // Given a table holding one stream's events.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the collection is read between two of its sort keys.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "EventsTable",
+        KeyConditionExpression:
+          "streamId = :stream AND eventId BETWEEN :lower AND :upper",
+        ExpressionAttributeValues: {
+          ":stream": { S: "stream-1" },
+          ":lower": { S: "a-2" },
+          ":upper": { S: "b-1" },
+        },
+      }),
+    );
+
+    // Then both bounds are in the run.
+    assertArrayEquals(eventIds(output), ["a-2", "b-1"]);
+  });
+
+  it("refuses a BETWEEN whose upper bound is below its lower bound", async () => {
+    // Given a table holding one stream's events.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the bounds are the wrong way round.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression:
+            "streamId = :stream AND eventId BETWEEN :lower AND :upper",
+          ExpressionAttributeValues: {
+            ":stream": { S: "stream-1" },
+            ":lower": { S: "b-1" },
+            ":upper": { S: "a-2" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, since the range names no items at all.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "upper bound at or above");
+  });
+
+  it("refuses a BETWEEN whose bounds are not the same type", async () => {
+    // Given a table holding one stream's events.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When one bound is a string and the other a number.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression:
+            "streamId = :stream AND eventId BETWEEN :lower AND :upper",
+          ExpressionAttributeValues: {
+            ":stream": { S: "stream-1" },
+            ":lower": { S: "a-1" },
+            ":upper": { N: "5" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: two types have no order to sit between.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "not the same type");
+  });
+
+  it("orders a Number sort key by value rather than by its digits", async () => {
+    // Given a table holding readings whose keys are written several ways.
+    const simAws = new SimAws();
+    const simDynamoDb = await numberSortKeyTable(simAws);
+
+    // When the whole collection is read.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "ReadingsTable",
+        KeyConditionExpression: "sensorId = :sensor",
+        ExpressionAttributeValues: { ":sensor": { S: "sensor-1" } },
+      }),
+    );
+
+    // Then the numbers order by value, and `1E2` and `100` were one key rather
+    // than two.
+    assertArrayEquals(
+      (output.Items ?? []).map((item) => item["takenAt"]?.N ?? ""),
+      ["9", "20", "100"],
+    );
+  });
+
+  it("reads a run of a Number sort key by value", async () => {
+    // Given a table holding readings.
+    const simAws = new SimAws();
+    const simDynamoDb = await numberSortKeyTable(simAws);
+
+    // When a run of the collection is read.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "ReadingsTable",
+        KeyConditionExpression: "sensorId = :sensor AND takenAt >= :from",
+        ExpressionAttributeValues: {
+          ":sensor": { S: "sensor-1" },
+          ":from": { N: "20" },
+        },
+      }),
+    );
+
+    // Then the comparison is numeric rather than textual: `9` is below `20`.
+    assertArrayEquals(
+      (output.Items ?? []).map((item) => item["takenAt"]?.N ?? ""),
+      ["20", "100"],
+    );
+  });
+
+  it("refuses begins_with against a Number sort key", async () => {
+    // Given a table whose sort key is a number.
+    const simAws = new SimAws();
+    const simDynamoDb = await numberSortKeyTable(simAws);
+
+    // When a prefix of that sort key is asked for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "ReadingsTable",
+          KeyConditionExpression:
+            "sensorId = :sensor AND begins_with(takenAt, :prefix)",
+          ExpressionAttributeValues: {
+            ":sensor": { S: "sensor-1" },
+            ":prefix": { N: "1" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: a number is stored as a value rather than as the
+    // digits it was written with, so it has no prefix.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "String or Binary sort key");
+  });
+
+  it("answers with nothing for a sort key condition of another type", async () => {
+    // Given a table whose sort key is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the sort key is compared against a number.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "EventsTable",
+        KeyConditionExpression: "streamId = :stream AND eventId > :value",
+        ExpressionAttributeValues: {
+          ":stream": { S: "stream-1" },
+          ":value": { N: "1" },
+        },
+      }),
+    );
+
+    // Then nothing matches, since two types have no order between them.
+    assertArrayEquals(eventIds(output), []);
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-sort-key.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-sort-key.iso.test.ts
@@ -262,24 +262,104 @@ describe("DynamoDB QueryCommand sort key conditions", () => {
     assertStringIncludes(error.message, "String or Binary sort key");
   });
 
-  it("answers with nothing for a sort key condition of another type", async () => {
+  it("refuses a sort key condition against another type", async () => {
     // Given a table whose sort key is a string.
     const simAws = new SimAws();
     const simDynamoDb = await stringSortKeyTable(simAws);
 
     // When the sort key is compared against a number.
-    const output = await simDynamoDb.query(
-      new QueryCommand({
-        TableName: "EventsTable",
-        KeyConditionExpression: "streamId = :stream AND eventId > :value",
-        ExpressionAttributeValues: {
-          ":stream": { S: "stream-1" },
-          ":value": { N: "1" },
-        },
-      }),
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression: "streamId = :stream AND eventId > :value",
+          ExpressionAttributeValues: {
+            ":stream": { S: "stream-1" },
+            ":value": { N: "1" },
+          },
+        }),
+      ),
     );
 
-    // Then nothing matches, since two types have no order between them.
-    assertArrayEquals(eventIds(output), []);
+    // Then it is refused rather than answered with an empty page. A sort key
+    // has one type, so the condition could never hold, and an empty page would
+    // read as a collection that happens to hold nothing.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "does not match schema type");
+    assertStringIncludes(error.message, "eventId");
+  });
+
+  it("refuses a partition key compared against another type", async () => {
+    // Given a table whose partition key is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the partition key is named by a number.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression: "streamId = :stream",
+          ExpressionAttributeValues: { ":stream": { N: "1" } },
+        }),
+      ),
+    );
+
+    // Then it is refused too: it names an item collection that cannot exist.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "streamId");
+  });
+
+  it("refuses a BETWEEN whose bounds are not the sort key's type", async () => {
+    // Given a table whose sort key is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When the range is written over numbers, which agree with each other but
+    // not with the table.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression:
+            "streamId = :stream AND eventId BETWEEN :lower AND :upper",
+          ExpressionAttributeValues: {
+            ":stream": { S: "stream-1" },
+            ":lower": { N: "1" },
+            ":upper": { N: "9" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "does not match schema type");
+  });
+
+  it("refuses a begins_with prefix that is not the sort key's type", async () => {
+    // Given a table whose sort key is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await stringSortKeyTable(simAws);
+
+    // When a binary prefix is asked for against it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "EventsTable",
+          KeyConditionExpression:
+            "streamId = :stream AND begins_with(eventId, :prefix)",
+          ExpressionAttributeValues: {
+            ":stream": { S: "stream-1" },
+            ":prefix": { B: new Uint8Array([1, 2]) },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: a string never begins with binary however the bytes
+    // line up.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "does not match schema type");
   });
 });

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-start-key.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-start-key.ts
@@ -1,0 +1,78 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+
+interface SimDynamoDbQueryStartKeyProperties {
+  readonly table: SimDynamoDbTable;
+  readonly keyCondition: SimDynamoDbKeyCondition;
+  readonly exclusiveStartKey:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Read the key a query resumes after, if the request carries one.
+ *
+ * The token a page hands out is the primary key of the item the walk stopped
+ * on, so it is read back as a Key: the same rules apply as to the Key of a
+ * GetItem, and an attribute that is not part of the primary key, a missing key
+ * element or a type mismatch are refused the same way.
+ *
+ * It also has to name the item collection the query is reading. A token from
+ * another partition names a place this walk never reaches, so it is refused
+ * rather than quietly reading from the start.
+ */
+export function readSimDynamoDbQueryStartKey(
+  properties: SimDynamoDbQueryStartKeyProperties,
+): SimDynamoDbItem | undefined {
+  const { table, keyCondition } = properties;
+  const attributeValues = properties.exclusiveStartKey;
+
+  if (attributeValues === undefined) {
+    return undefined;
+  }
+
+  if (Object.keys(attributeValues).length === 0) {
+    throw new SimDynamoDbValidationException(
+      "An ExclusiveStartKey names the item to resume after, and this one " +
+        "names no attribute at all",
+    );
+  }
+
+  const startKey = SimDynamoDbItem.fromAttributeValues(attributeValues);
+
+  // Reading the key through the table checks it against the key schema, which
+  // is what makes a token DynamoDB would refuse refused here too.
+  table.keyOfKey(startKey);
+
+  assertSamePartition(startKey, table, keyCondition);
+
+  return startKey;
+}
+
+/**
+ * Refuse a token from an item collection other than the one being read.
+ */
+function assertSamePartition(
+  startKey: SimDynamoDbItem,
+  table: SimDynamoDbTable,
+  keyCondition: SimDynamoDbKeyCondition,
+): void {
+  const attributeName = table.keySchema.hashKeyAttributeName;
+  const value = startKey.attribute(attributeName);
+
+  assertDefined(
+    value,
+    `partition key ${attributeName} of an ExclusiveStartKey`,
+  );
+
+  if (!simDynamoDbValuesEqual(value, keyCondition.partitionKeyValue)) {
+    throw new SimDynamoDbValidationException(
+      `The ExclusiveStartKey names the partition key ${attributeName} of a ` +
+        `different item collection to the one the KeyConditionExpression reads`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-validation.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-validation.iso.test.ts
@@ -1,0 +1,269 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table keyed by customer and order, with no items in it.
+ *
+ * A key condition is refused for what it says rather than for what it finds, so
+ * nothing has to be written for these.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  return simDynamoDb;
+}
+
+/**
+ * A value for every placeholder an expression uses.
+ *
+ * The placeholders and the expression have to agree in both directions, so
+ * supplying exactly what each expression names is what keeps these refusals
+ * about what the key condition says rather than about a value that was missing
+ * or spare.
+ */
+function valuesFor(expression: string): Record<string, { S: string }> {
+  const placeholders = expression.match(/:\w+/g) ?? [];
+
+  return Object.fromEntries(
+    placeholders.map((placeholder) => [placeholder, { S: "value" }]),
+  );
+}
+
+/**
+ * Read a collection with a key condition, and answer with what it was refused
+ * for.
+ */
+async function refusalFor(
+  keyConditionExpression: string,
+): Promise<SimDynamoDbValidationException> {
+  const simAws = new SimAws();
+  const simDynamoDb = await ordersTable(simAws);
+
+  const error = await assertThrowsErrorAsync(async () =>
+    simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: keyConditionExpression,
+        ExpressionAttributeValues: valuesFor(keyConditionExpression),
+      }),
+    ),
+  );
+
+  assertInstanceOf(error, SimDynamoDbValidationException);
+
+  return error;
+}
+
+describe("DynamoDB QueryCommand key condition validation", () => {
+  it("requires a KeyConditionExpression", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query names no key condition at all.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(new QueryCommand({ TableName: "OrdersTable" })),
+    );
+
+    // Then it is refused: a query reads one item collection, and nothing says
+    // which.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A KeyConditionExpression is required");
+  });
+
+  it("refuses a key condition that does not name the partition key", async () => {
+    // When only the sort key is tested.
+    const error = await refusalFor("orderId = :order");
+
+    // Then it is refused, naming the partition key it wanted.
+    assertStringIncludes(error.message, "does not name the partition key");
+    assertStringIncludes(error.message, "customerId");
+  });
+
+  it.each([
+    "customerId > :customer",
+    "customerId BETWEEN :customer AND :order",
+  ])(
+    "refuses a range operator on the partition key in '%s'",
+    async (keyCondition) => {
+      // When the partition key is given a range rather than an equality.
+      const error = await refusalFor(keyCondition);
+
+      // Then it is refused: a query reads one item collection rather than a
+      // range of them.
+      assertStringIncludes(error.message, "takes only =");
+    },
+  );
+
+  it("refuses begins_with on the partition key", async () => {
+    // When the partition key is given a prefix.
+    const error = await refusalFor("begins_with(customerId, :customer)");
+
+    // Then it is refused the same way any other range on it is.
+    assertStringIncludes(error.message, "takes only =");
+  });
+
+  it("refuses a key condition naming an attribute outside the key", async () => {
+    // When an ordinary attribute is tested alongside the partition key.
+    const error = await refusalFor(
+      "customerId = :customer AND status = :other",
+    );
+
+    // Then it is refused rather than filtered by, which is what
+    // FilterExpression is for.
+    assertStringIncludes(error.message, "status is not part of the table's");
+  });
+
+  it.each(["OR", "or"])("refuses %s in a key condition", async (word) => {
+    // When two key conditions are joined by OR.
+    const error = await refusalFor(
+      `customerId = :customer ${word} orderId = :order`,
+    );
+
+    // Then it is refused: a key condition joins its two terms with AND only.
+    assertStringIncludes(error.message, "OR is not part of a key condition");
+  });
+
+  it("refuses NOT in a key condition", async () => {
+    // When a key condition is negated.
+    const error = await refusalFor("NOT customerId = :customer");
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "NOT is not part of a key condition");
+  });
+
+  it("refuses an unsupported operator on the sort key", async () => {
+    // When the sort key is tested for inequality.
+    const error = await refusalFor(
+      "customerId = :customer AND orderId <> :order",
+    );
+
+    // Then it is refused: a query reads a contiguous run of the sort key.
+    assertStringIncludes(error.message, "is not a key condition operator");
+  });
+
+  it("refuses a function a key condition does not take", async () => {
+    // When the sort key is tested with a condition expression function.
+    const error = await refusalFor(
+      "customerId = :customer AND contains(orderId, :order)",
+    );
+
+    // Then it is refused, naming the one function a sort key condition uses.
+    assertStringIncludes(error.message, "is not a key condition function");
+    assertStringIncludes(error.message, "begins_with");
+  });
+
+  it("refuses a bracketed key condition", async () => {
+    // When a term is bracketed.
+    const error = await refusalFor("(customerId = :customer)");
+
+    // Then it is refused. This is stricter than real DynamoDB, and is recorded
+    // under Limitations in the usage docs.
+    assertStringIncludes(error.message, "takes no brackets");
+  });
+
+  it("refuses a key condition naming the same attribute twice", async () => {
+    // When the partition key is tested twice.
+    const error = await refusalFor(
+      "customerId = :customer AND customerId = :customer",
+    );
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "more than once");
+  });
+
+  it("refuses a document path in a key condition", async () => {
+    // When a key condition dereferences the attribute it names.
+    const error = await refusalFor("customerId.city = :customer");
+
+    // Then it is refused: a key is scalar and cannot be nested.
+    assertStringIncludes(error.message, "top-level attribute");
+  });
+
+  it("refuses a key condition comparing against a literal", async () => {
+    // When a value is written into the expression rather than supplied.
+    const error = await refusalFor("customerId = 5");
+
+    // Then it is refused: key conditions have no literals.
+    assertStringIncludes(error.message, "ExpressionAttributeValues");
+  });
+
+  it("refuses a key condition starting with something that is not a name", async () => {
+    // When a term starts with a value placeholder.
+    const error = await refusalFor(":customer = customerId");
+
+    // Then it is refused, naming what was expected.
+    assertStringIncludes(error.message, "a key attribute name was expected");
+  });
+
+  it("refuses an empty KeyConditionExpression", async () => {
+    // When the expression says nothing.
+    const error = await refusalFor(" ".repeat(3));
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "the expression says nothing");
+  });
+
+  it("refuses anything left over after a complete key condition", async () => {
+    // When a third term follows without an AND.
+    const error = await refusalFor("customerId = :customer orderId = :order");
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "follows a complete key condition");
+  });
+
+  it("refuses a placeholder the request does not define", async () => {
+    // When a key condition uses a value the request never supplied.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :missing",
+          ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+        }),
+      ),
+    );
+
+    // Then it is refused, naming the placeholder.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, ":missing");
+  });
+
+  it("refuses a supplied value no key condition used", async () => {
+    // When the request supplies a value the expression never names.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :customer",
+          ExpressionAttributeValues: {
+            ":customer": { S: "c-1" },
+            ":spare": { S: "unused" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, which is what a request hits after an expression is
+    // edited and the old placeholder is left behind.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, ":spare");
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.iso.test.ts
@@ -1,0 +1,313 @@
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { SimDynamoDbResourceNotFoundException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type { SimQueryCommandOutput } from "./query.command.js";
+
+/**
+ * A table keyed by customer and order, holding one customer's item collection
+ * and one item belonging to another customer.
+ *
+ * The items are written out of order, so the order a query answers in is the
+ * collection's rather than the order they arrived in.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  await Promise.all(
+    ["2026-03", "2026-01", "2027-01", "2026-02"].map(async (orderId) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "OrdersTable",
+          Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+        }),
+      ),
+    ),
+  );
+
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-2" }, orderId: { S: "2026-01" } },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The sort keys a page came back with, in the order they came back in.
+ */
+function orderIds(output: SimQueryCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB QueryCommand", () => {
+  it("answers with the whole item collection in sort key order", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read by its partition key alone.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      }),
+    );
+
+    // Then every item under that partition key comes back in ascending sort
+    // key order, and the other customer's order is not among them.
+    assertArrayEquals(orderIds(output), [
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2027-01",
+    ]);
+  });
+
+  it("reads the collection backwards for ScanIndexForward false", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read backwards.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+        ScanIndexForward: false,
+      }),
+    );
+
+    // Then the same items come back in the opposite order.
+    assertArrayEquals(orderIds(output), [
+      "2027-01",
+      "2026-03",
+      "2026-02",
+      "2026-01",
+    ]);
+  });
+
+  it("counts the items it evaluated and the items it answered with", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When part of the collection is read.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression:
+          "customerId = :customer AND begins_with(orderId, :prefix)",
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":prefix": { S: "2026-" },
+        },
+      }),
+    );
+
+    // Then both counts are the number of items answered with, since nothing
+    // filters a query.
+    assertIdentical(output.Count, 3);
+    assertIdentical(output.ScannedCount, 3);
+  });
+
+  it("answers with the whole item rather than only its key", async () => {
+    // Given a table holding an order carrying more than its key.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: {
+          customerId: { S: "c-3" },
+          orderId: { S: "2026-01" },
+          total: { N: "19.99" },
+        },
+      }),
+    );
+
+    // When the collection is read.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-3" } },
+      }),
+    );
+
+    // Then the attributes beyond the key come back too.
+    const item = output.Items?.at(0);
+    assertNonNullable(item);
+    assertIdentical(item["total"]?.N, "19.99");
+  });
+
+  it("answers with an empty page for a partition key holding nothing", async () => {
+    // Given a table holding orders for other customers.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a partition key nothing was written under is read.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "nobody" } },
+      }),
+    );
+
+    // Then the page is empty rather than missing, and there is nothing to
+    // resume from.
+    assertArrayLength(output.Items ?? [], 0);
+    assertIdentical(output.Count, 0);
+    assertUndefined(output.LastEvaluatedKey);
+  });
+
+  it("reads a table that has no sort key", async () => {
+    // Given a table keyed by partition key alone.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "UsersTable",
+        KeySchema: [{ AttributeName: "userId", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "userId", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "UsersTable",
+        Item: { userId: { S: "user-1" }, note: { S: "first" } },
+      }),
+    );
+
+    // When the partition key is queried.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "UsersTable",
+        KeyConditionExpression: "userId = :user",
+        ExpressionAttributeValues: { ":user": { S: "user-1" } },
+      }),
+    );
+
+    // Then the one item under it comes back: a collection with no sort key
+    // holds at most one.
+    assertArrayLength(output.Items ?? [], 1);
+    assertIdentical(output.Items?.at(0)?.["note"]?.S, "first");
+  });
+
+  it("reads a key attribute written as a name placeholder", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the key attributes are named through ExpressionAttributeNames.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "#customer = :customer AND #order > :after",
+        ExpressionAttributeNames: {
+          "#customer": "customerId",
+          "#order": "orderId",
+        },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":after": { S: "2026-02" },
+        },
+      }),
+    );
+
+    // Then the placeholders stand for the key attributes.
+    assertArrayEquals(orderIds(output), ["2026-03", "2027-01"]);
+  });
+
+  it.each([true, false])(
+    "answers with the latest write for ConsistentRead %s",
+    async (consistentRead) => {
+      // Given a table holding one customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When the collection is read either consistently or not.
+      const output = await simDynamoDb.query(
+        new QueryCommand({
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :customer",
+          ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+          ConsistentRead: consistentRead,
+        }),
+      );
+
+      // Then every write is there either way: this simulation is always
+      // strongly consistent.
+      assertArrayLength(output.Items ?? [], 4);
+    },
+  );
+
+  it("reads a collection by the table ARN", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+    const description = await simDynamoDb.describeTable({
+      input: { TableName: "OrdersTable" },
+    });
+    const tableArn = description.Table?.TableArn;
+    assertNonNullable(tableArn);
+
+    // When the collection is read by the table's ARN rather than its name.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: tableArn,
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      }),
+    );
+
+    // Then it is the same table.
+    assertArrayLength(output.Items ?? [], 4);
+  });
+
+  it("reports a table that is not there", async () => {
+    // Given a simulated DynamoDB with no tables.
+    const simDynamoDb = new SimAws().dynamoDb();
+
+    // When a collection is read from a table that does not exist.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "MissingTable",
+          KeyConditionExpression: "customerId = :customer",
+          ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+        }),
+      ),
+    );
+
+    // Then it is reported as not found.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -1,0 +1,84 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { readSimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition-expression.js";
+import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type {
+  SimQueryCommand,
+  SimQueryCommandOutput,
+} from "./query.command.js";
+import { readSimDynamoDbQueryStartKey } from "./sim-dynamodb-query-start-key.js";
+import { refuseUnsimulatedQueryInput } from "./sim-dynamodb-unsimulated-query-input.js";
+
+interface SimDynamoDbQueryProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbQueryOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The Query command.
+ *
+ * A query reads one item collection: the items under one partition key, in sort
+ * key order. That is the whole of it, and it is why the key condition is a
+ * closed grammar rather than the general condition grammar.
+ */
+export class SimDynamoDbQuery {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbQueryProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Read a page of the item collection a key condition names.
+   */
+  handle(
+    command: SimQueryCommand,
+    options?: SimDynamoDbQueryOptions,
+  ): SimQueryCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedQueryInput(input);
+
+    // The key condition is read before the table is reached, so an expression
+    // DynamoDB would refuse is refused whether or not the table is there. What
+    // is left is the part that needs the key schema, which is read once the
+    // table has been found.
+    const terms = readSimDynamoDbKeyCondition(input);
+    const table = this.access.required(
+      "dynamodb:Query",
+      input.TableName,
+      options?.caller,
+    );
+    const keyCondition = terms.forTable(table);
+
+    // The token names an item of the collection being read, so it can only be
+    // checked once that collection is known.
+    const after = readSimDynamoDbQueryStartKey({
+      table,
+      keyCondition,
+      exclusiveStartKey: input.ExclusiveStartKey,
+    });
+
+    const page = new SimDynamoDbItemPage({
+      items: table.itemCollection(keyCondition).walk({
+        forward: input.ScanIndexForward ?? true,
+        after,
+      }),
+      limit: input.Limit,
+      keySchema: table.keySchema,
+    });
+
+    return {
+      Items: page.items.map((item) => item.toAttributeValues()),
+      // Nothing filters a query yet, so every item the walk evaluated is an
+      // item the page carries.
+      Count: page.items.length,
+      ScannedCount: page.items.length,
+      LastEvaluatedKey: page.lastEvaluatedKey,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
@@ -1,0 +1,120 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { SimDynamoDbUnsupportedOperation } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table keyed by customer and order, holding nothing.
+ *
+ * These inputs are refused before the table is read, so there is nothing to
+ * write.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  return simDynamoDb;
+}
+
+/**
+ * The key condition every one of these queries carries.
+ */
+const keyCondition = {
+  TableName: "OrdersTable",
+  KeyConditionExpression: "customerId = :customer",
+  ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+};
+
+describe("DynamoDB QueryCommand unsimulated input", () => {
+  it.each([
+    { name: "IndexName", input: { IndexName: "ByStatus" } },
+    { name: "FilterExpression", input: { FilterExpression: "status = :s" } },
+    {
+      name: "ProjectionExpression",
+      input: { ProjectionExpression: "orderId" },
+    },
+    { name: "Select", input: { Select: "COUNT" } },
+    { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
+    {
+      name: "KeyConditions",
+      input: {
+        KeyConditions: {
+          customerId: {
+            ComparisonOperator: "EQ",
+            AttributeValueList: [{ S: "c-1" }],
+          },
+        },
+      },
+    },
+    {
+      name: "QueryFilter",
+      input: {
+        QueryFilter: {
+          status: {
+            ComparisonOperator: "EQ",
+            AttributeValueList: [{ S: "shipped" }],
+          },
+        },
+      },
+    },
+    { name: "ConditionalOperator", input: { ConditionalOperator: "AND" } },
+    {
+      name: "ReturnConsumedCapacity",
+      input: { ReturnConsumedCapacity: "TOTAL" },
+    },
+  ])("refuses $name by name", async (example) => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query asks for something this simulation does not model.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query({ input: { ...keyCondition, ...example.input } }),
+    );
+
+    // Then it is refused by name rather than answered with a page that means
+    // something else.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, example.name);
+  });
+
+  it.each(["ALL_ATTRIBUTES", undefined])(
+    "takes a Select of %s, which asks for what it already does",
+    async (select) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a query names the Select a table query already behaves as.
+      const output = await simDynamoDb.query({
+        input: { ...keyCondition, Select: select },
+      });
+
+      // Then it is let through, since whole items are what it answers with.
+      assertArrayLength(output.Items ?? [], 0);
+    },
+  );
+
+  it("takes a ReturnConsumedCapacity of NONE", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query asks for the capacity reporting it already does.
+    const output = await simDynamoDb.query(
+      new QueryCommand({ ...keyCondition, ReturnConsumedCapacity: "NONE" }),
+    );
+
+    // Then it is let through.
+    assertArrayLength(output.Items ?? [], 0);
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
@@ -1,0 +1,69 @@
+import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-input.js";
+import type { SimQueryCommandInput } from "./query.command.js";
+
+/**
+ * The `Select` a query already behaves as, which asks for whole items.
+ *
+ * Real DynamoDB defaults to this for a query against a table rather than an
+ * index, so a request naming it asks for what this simulation already does.
+ */
+const simulatedSelect = "ALL_ATTRIBUTES";
+
+/**
+ * Refuse the Query inputs this simulation does not model.
+ *
+ * Each of these changes which items a query answers with, or which parts of
+ * them, so a query that quietly ignored one would answer with more than the
+ * request asked for. That is the failure that passes here and surprises an
+ * application reading the page.
+ */
+export function refuseUnsimulatedQueryInput(input: SimQueryCommandInput): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("Query");
+
+  unsimulated.refuse(
+    input.IndexName !== undefined,
+    "IndexName",
+    "reading the table where a secondary index was asked for",
+  );
+  unsimulated.refuse(
+    input.FilterExpression !== undefined,
+    "FilterExpression",
+    "answering with the items a filter would have dropped",
+  );
+  unsimulated.refuse(
+    input.ProjectionExpression !== undefined,
+    "ProjectionExpression",
+    "answering with whole items where part of them was asked for",
+  );
+  unsimulated.refuse(
+    input.Select !== undefined && input.Select !== simulatedSelect,
+    "Select",
+    `counting or projecting rather than answering with whole items, which is ` +
+      `what ${simulatedSelect} asks for`,
+  );
+  unsimulated.refuse(
+    (input.AttributesToGet ?? []).length > 0,
+    "AttributesToGet",
+    "answering with whole items where part of them was asked for",
+  );
+  unsimulated.refuseNamed(
+    input.KeyConditions,
+    "KeyConditions",
+    "reading a key condition written the way KeyConditionExpression replaced",
+  );
+  unsimulated.refuseNamed(
+    input.QueryFilter,
+    "QueryFilter",
+    "answering with the items a legacy filter would have dropped",
+  );
+  unsimulated.refuse(
+    input.ConditionalOperator !== undefined,
+    "ConditionalOperator",
+    "joining the legacy conditions it applies to",
+  );
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+}

--- a/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
@@ -9,6 +9,7 @@ import { SimDynamoDbDeleteItem } from "./item/sim-dynamodb-delete-item.js";
 import { SimDynamoDbGetItem } from "./item/sim-dynamodb-get-item.js";
 import { SimDynamoDbPutItem } from "./item/sim-dynamodb-put-item.js";
 import { SimDynamoDbUpdateItem } from "./item/sim-dynamodb-update-item.js";
+import { SimDynamoDbQuery } from "./query/sim-dynamodb-query.js";
 import { SimDynamoDbTagCommands } from "./tag/sim-dynamodb-tag-commands.js";
 import { SimDynamoDbTimeToLiveCommands } from "./time-to-live/sim-dynamodb-time-to-live-commands.js";
 import { SimDynamoDbCreateTable } from "./table/sim-dynamodb-create-table.js";
@@ -40,6 +41,7 @@ export class SimDynamoDbCommandHandlers {
   public readonly itemReads: SimDynamoDbGetItem;
   public readonly itemDeletions: SimDynamoDbDeleteItem;
   public readonly itemUpdates: SimDynamoDbUpdateItem;
+  public readonly itemQueries: SimDynamoDbQuery;
   public readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
   public readonly itemBatchReads: SimDynamoDbBatchGetItem;
   public readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
@@ -71,6 +73,7 @@ export class SimDynamoDbCommandHandlers {
     this.itemReads = new SimDynamoDbGetItem({ access });
     this.itemDeletions = new SimDynamoDbDeleteItem({ access });
     this.itemUpdates = new SimDynamoDbUpdateItem({ access });
+    this.itemQueries = new SimDynamoDbQuery({ access });
     this.itemBatchWrites = new SimDynamoDbBatchWriteItem({ access });
     this.itemBatchReads = new SimDynamoDbBatchGetItem({ access });
     this.itemTransactWrites = new SimDynamoDbTransactWriteItems({

--- a/src/service/dynamodb/command/sim-dynamodb-command.types.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command.types.ts
@@ -30,6 +30,11 @@ export type {
   SimUpdateItemCommandOutput,
 } from "./item/item.command.js";
 export type {
+  SimQueryCommand,
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "./query/query.command.js";
+export type {
   SimBatchGetItemCommand,
   SimBatchGetItemCommandInput,
   SimBatchGetItemCommandOutput,

--- a/src/service/dynamodb/document/sim-dynamodb-document-command.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-command.ts
@@ -1,0 +1,47 @@
+import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
+
+/**
+ * The properties `@aws-sdk/lib-dynamodb` declares on every one of its Commands.
+ *
+ * They are TypeScript `protected`, which means nothing at runtime, so a
+ * document Command carries them where the client Command of the same name does
+ * not.
+ */
+const documentCommandProperties: readonly string[] = [
+  "inputKeyNodes",
+  "outputKeyNodes",
+  "clientCommand",
+];
+
+/**
+ * Whether an intercepted Command came from the document client.
+ */
+function isSimDynamoDbDocumentCommand(command: object): boolean {
+  return documentCommandProperties.every((property) =>
+    Object.hasOwn(command, property),
+  );
+}
+
+/**
+ * Refuse a document Command that shares its name with a client Command.
+ *
+ * The SDK router keys on the Command's class name, and `QueryCommand` and
+ * `ScanCommand` are named the same in `@aws-sdk/client-dynamodb` and in
+ * `@aws-sdk/lib-dynamodb`, unlike `PutCommand` and `PutItemCommand`. A document
+ * Command reaching the client operation would have its native JavaScript values
+ * read as AttributeValues, so it is refused by name instead.
+ */
+export function refuseSimDynamoDbDocumentCommand(
+  command: object,
+  commandName: string,
+): void {
+  if (!isSimDynamoDbDocumentCommand(command)) {
+    return;
+  }
+
+  throw new SimDynamoDbUnsupportedOperation(
+    `The document client's ${commandName} is not simulated. It shares its ` +
+      `name with the ${commandName} of @aws-sdk/client-dynamodb, which is, so ` +
+      `it is refused rather than read as though it carried AttributeValues.`,
+  );
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
@@ -7,6 +7,7 @@ import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
+  QueryCommand,
   TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
@@ -21,6 +22,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimSdk, SimSdkUnsupportedCommandError } from "../../../sdk/index.js";
+import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 
 /**
@@ -135,6 +137,34 @@ describe("simulated DynamoDB document client interception", () => {
     assertInstanceOf(error, SimSdkUnsupportedCommandError);
     assertStringIncludes(error.message, "TransactWriteCommand");
     assertStringIncludes(error.message, "PutCommand");
+  });
+
+  it("refuses a document Command sharing its name with a client Command", async () => {
+    // Given an intercepted document client.
+    using simSdk = new SimSdk();
+    const documents = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: "eu-west-2" }),
+    );
+    simSdk.intercept(documents);
+    await createTable(simSdk, documents);
+
+    // When a document Query is sent, which is named the same as the client
+    // Query the simulator does route.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new QueryCommand({
+          TableName: "OrdersTable",
+          KeyConditionExpression: "orderId = :order",
+          ExpressionAttributeValues: { ":order": "order-1" },
+        }),
+      );
+    });
+
+    // Then it is refused rather than read as though it carried
+    // AttributeValues, which is what the client Query would have done with its
+    // native values.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "document client's QueryCommand");
   });
 
   it("authorizes a document Command as the caller sending it", async () => {

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
@@ -106,7 +106,7 @@ function scalar(value: unknown, path: string): SimDynamoDbAttributeValue {
 function listMembers(
   values: readonly unknown[],
   path: string,
-): readonly SimDynamoDbAttributeValue[] {
+): SimDynamoDbAttributeValue[] {
   return values
     .filter((member) => typeof member !== "function")
     .map((member, index) =>

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-comparison.ts
@@ -1,5 +1,8 @@
 import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
-import { compareSimDynamoDbValues } from "../../item/sim-dynamodb-value-order.js";
+import {
+  compareSimDynamoDbValues,
+  simDynamoDbOrderHolds,
+} from "../../item/sim-dynamodb-value-order.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
 import type { SimDynamoDbConditionOperand } from "./sim-dynamodb-condition-operand.js";
@@ -16,29 +19,6 @@ export const simDynamoDbComparators: ReadonlySet<string> = new Set([
   ">",
   ">=",
 ]);
-
-/**
- * Whether an ordering satisfies a comparator.
- *
- * Only the four ordering comparators reach here, so the last of them is the
- * remaining case. `=` and `<>` are answered by equality before this is asked.
- */
-function ordered(comparator: string, order: number): boolean {
-  switch (comparator) {
-    case "<": {
-      return order < 0;
-    }
-    case "<=": {
-      return order <= 0;
-    }
-    case ">": {
-      return order > 0;
-    }
-    default: {
-      return order >= 0;
-    }
-  }
-}
 
 /**
  * Two operands compared against each other.
@@ -96,7 +76,7 @@ export class SimDynamoDbComparisonCondition implements SimDynamoDbCondition {
       return false;
     }
 
-    return ordered(this.comparator, order);
+    return simDynamoDbOrderHolds(this.comparator, order);
   }
 }
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.ts
@@ -1,4 +1,5 @@
 import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
+import { simDynamoDbValueBeginsWith } from "../../item/sim-dynamodb-value-prefix.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
 import type {
@@ -82,27 +83,8 @@ export class SimDynamoDbBeginsWithCondition implements SimDynamoDbCondition {
       return false;
     }
 
-    if (value.kind === "S" && prefix.kind === "S") {
-      return value.text.startsWith(prefix.text);
-    }
-
-    if (value.kind === "B" && prefix.kind === "B") {
-      return beginsWithBytes(value.bytes, prefix.bytes);
-    }
-
-    return false;
+    return simDynamoDbValueBeginsWith(value, prefix);
   }
-}
-
-/**
- * Whether some bytes start with some other bytes.
- */
-function beginsWithBytes(bytes: Uint8Array, prefix: Uint8Array): boolean {
-  if (prefix.length > bytes.length) {
-    return false;
-  }
-
-  return prefix.every((byte, at) => bytes.at(at) === byte);
 }
 
 /**

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
@@ -189,7 +189,7 @@ describe("DynamoDB condition expressions", () => {
       orderId: { S: "order-1" },
       address: { M: { city: { S: "Leeds" } } },
       lines: { L: [{ S: "widget" }] },
-    } as const;
+    };
 
     // When a condition reaches into both, then it reads what is there.
     const condition = readSimDynamoDbCondition({

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-begins-with-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-begins-with-key-term.ts
@@ -1,0 +1,86 @@
+import type { SimDynamoDbScalarAttributeType } from "../../command/table/table.types.js";
+import { simDynamoDbValueBeginsWith } from "../../item/sim-dynamodb-value-prefix.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+import type { SimDynamoDbKeyConditionOperands } from "./sim-dynamodb-key-condition-operands.js";
+import { simDynamoDbBeginsWithName } from "./sim-dynamodb-key-condition-refusals.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+interface SimDynamoDbBeginsWithKeyTermProperties {
+  readonly attributeName: string;
+  readonly prefix: SimDynamoDbValue;
+}
+
+interface SimDynamoDbBeginsWithKeyTermSource {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly operands: SimDynamoDbKeyConditionOperands;
+}
+
+/**
+ * A sort key that starts with a value.
+ */
+export class SimDynamoDbBeginsWithKeyTerm implements SimDynamoDbKeyConditionTerm {
+  public readonly attributeName: string;
+  public readonly operator = "begins_with";
+
+  private readonly prefix: SimDynamoDbValue;
+
+  constructor(properties: SimDynamoDbBeginsWithKeyTermProperties) {
+    this.attributeName = properties.attributeName;
+    this.prefix = properties.prefix;
+  }
+
+  /**
+   * Read `begins_with(sortKey, :prefix)` out of an expression.
+   *
+   * The call is read here rather than in the parser, since the shape of a call
+   * belongs with the term it makes.
+   */
+  static read(
+    source: SimDynamoDbBeginsWithKeyTermSource,
+  ): SimDynamoDbBeginsWithKeyTerm {
+    const { tokens, operands } = source;
+
+    tokens.next(simDynamoDbBeginsWithName);
+    tokens.next("(");
+
+    const attributeName = operands.attributeName();
+    tokens.expectSymbol(
+      ",",
+      `syntax error; ${simDynamoDbBeginsWithName} takes a key attribute and ` +
+        `a value, separated by a comma`,
+    );
+
+    const prefix = operands.value();
+    tokens.expectSymbol(
+      ")",
+      `syntax error; ${simDynamoDbBeginsWithName} is not closed`,
+    );
+
+    return new this({ attributeName, prefix });
+  }
+
+  /**
+   * Whether a key value starts with the prefix.
+   */
+  holdsFor(value: SimDynamoDbValue): boolean {
+    return simDynamoDbValueBeginsWith(value, this.prefix);
+  }
+
+  /**
+   * Refuse a prefix against a Number sort key.
+   *
+   * A number is stored as a value rather than as the digits it was written
+   * with, so `1E2` and `100` are one key and a prefix of either is meaningless.
+   * Real DynamoDB refuses this too.
+   */
+  assertUsableOn(type: SimDynamoDbScalarAttributeType): void {
+    if (type === "N") {
+      throw simDynamoDbKeyConditionError(
+        `begins_with reads a prefix of a String or Binary sort key, and ` +
+          `${this.attributeName} is a Number`,
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-begins-with-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-begins-with-key-term.ts
@@ -3,6 +3,7 @@ import { simDynamoDbValueBeginsWith } from "../../item/sim-dynamodb-value-prefix
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+import { assertSimDynamoDbKeyValueType } from "./sim-dynamodb-key-condition-term.js";
 import type { SimDynamoDbKeyConditionOperands } from "./sim-dynamodb-key-condition-operands.js";
 import { simDynamoDbBeginsWithName } from "./sim-dynamodb-key-condition-refusals.js";
 import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
@@ -82,5 +83,7 @@ export class SimDynamoDbBeginsWithKeyTerm implements SimDynamoDbKeyConditionTerm
           `${this.attributeName} is a Number`,
       );
     }
+
+    assertSimDynamoDbKeyValueType(this.attributeName, this.prefix, type);
   }
 }

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-between-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-between-key-term.ts
@@ -1,0 +1,75 @@
+import { compareSimDynamoDbValues } from "../../item/sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+interface SimDynamoDbBetweenKeyTermProperties {
+  readonly attributeName: string;
+  readonly lower: SimDynamoDbValue;
+  readonly upper: SimDynamoDbValue;
+}
+
+/**
+ * A sort key between two bounds, both of which count as inside.
+ */
+export class SimDynamoDbBetweenKeyTerm implements SimDynamoDbKeyConditionTerm {
+  public readonly attributeName: string;
+  public readonly operator = "BETWEEN";
+
+  private readonly lower: SimDynamoDbValue;
+  private readonly upper: SimDynamoDbValue;
+
+  constructor(properties: SimDynamoDbBetweenKeyTermProperties) {
+    this.attributeName = properties.attributeName;
+    this.lower = properties.lower;
+    this.upper = properties.upper;
+
+    this.assertBoundsOrdered();
+  }
+
+  /**
+   * Whether a key value is at or between the two bounds.
+   */
+  holdsFor(value: SimDynamoDbValue): boolean {
+    const aboveLower = compareSimDynamoDbValues(value, this.lower);
+    const belowUpper = compareSimDynamoDbValues(value, this.upper);
+
+    if (aboveLower === undefined || belowUpper === undefined) {
+      return false;
+    }
+
+    return aboveLower >= 0 && belowUpper <= 0;
+  }
+
+  /**
+   * Both bounds are ordinary key values, so there is nothing to refuse.
+   */
+  assertUsableOn(): void {
+    return;
+  }
+
+  /**
+   * Refuse a range that runs backwards, or whose bounds are different types.
+   *
+   * Real DynamoDB refuses both. A backwards range names no items at all, and
+   * bounds of two types have no order to sit between, so either one is a
+   * request that cannot mean what it says.
+   */
+  private assertBoundsOrdered(): void {
+    const order = compareSimDynamoDbValues(this.lower, this.upper);
+
+    if (order === undefined) {
+      throw simDynamoDbKeyConditionError(
+        `the BETWEEN bounds on ${this.attributeName} are not the same type, ` +
+          `so nothing can sit between them`,
+      );
+    }
+
+    if (order > 0) {
+      throw simDynamoDbKeyConditionError(
+        `the BETWEEN operator on ${this.attributeName} requires an upper ` +
+          `bound at or above its lower bound`,
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-between-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-between-key-term.ts
@@ -1,7 +1,12 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimDynamoDbScalarAttributeType } from "../../command/table/table.types.js";
 import { compareSimDynamoDbValues } from "../../item/sim-dynamodb-value-order.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
-import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+import {
+  assertSimDynamoDbKeyValueType,
+  type SimDynamoDbKeyConditionTerm,
+} from "./sim-dynamodb-key-condition-term.js";
 
 interface SimDynamoDbBetweenKeyTermProperties {
   readonly attributeName: string;
@@ -29,23 +34,35 @@ export class SimDynamoDbBetweenKeyTerm implements SimDynamoDbKeyConditionTerm {
 
   /**
    * Whether a key value is at or between the two bounds.
+   *
+   * All three always order. Every one of them is the type the table declared
+   * for the key attribute, which `assertUsableOn` checked before the query ran.
    */
   holdsFor(value: SimDynamoDbValue): boolean {
     const aboveLower = compareSimDynamoDbValues(value, this.lower);
     const belowUpper = compareSimDynamoDbValues(value, this.upper);
 
-    if (aboveLower === undefined || belowUpper === undefined) {
-      return false;
-    }
+    assertDefined(
+      aboveLower,
+      `order against the ${this.attributeName} lower bound`,
+    );
+    assertDefined(
+      belowUpper,
+      `order against the ${this.attributeName} upper bound`,
+    );
 
     return aboveLower >= 0 && belowUpper <= 0;
   }
 
   /**
-   * Both bounds are ordinary key values, so there is nothing to refuse.
+   * Refuse bounds of a type the key attribute was not declared as.
+   *
+   * The two bounds already agree with each other, which is checked when the
+   * term is built, so this is what ties them to the table.
    */
-  assertUsableOn(): void {
-    return;
+  assertUsableOn(type: SimDynamoDbScalarAttributeType): void {
+    assertSimDynamoDbKeyValueType(this.attributeName, this.lower, type);
+    assertSimDynamoDbKeyValueType(this.attributeName, this.upper, type);
   }
 
   /**

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-comparison-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-comparison-key-term.ts
@@ -3,8 +3,13 @@ import {
   compareSimDynamoDbValues,
   simDynamoDbOrderHolds,
 } from "../../item/sim-dynamodb-value-order.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimDynamoDbScalarAttributeType } from "../../command/table/table.types.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
-import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+import {
+  assertSimDynamoDbKeyValueType,
+  type SimDynamoDbKeyConditionTerm,
+} from "./sim-dynamodb-key-condition-term.js";
 
 interface SimDynamoDbComparisonKeyTermProperties {
   readonly attributeName: string;
@@ -33,6 +38,10 @@ export class SimDynamoDbComparisonKeyTerm implements SimDynamoDbKeyConditionTerm
 
   /**
    * Whether a key value stands in the relation the operator asked for.
+   *
+   * The two sides always order. Both are the type the table declared for the
+   * key attribute: the stored one because a write that broke that was refused,
+   * and the supplied one because `assertUsableOn` refused the query.
    */
   holdsFor(value: SimDynamoDbValue): boolean {
     if (this.operator === "=") {
@@ -41,17 +50,18 @@ export class SimDynamoDbComparisonKeyTerm implements SimDynamoDbKeyConditionTerm
 
     const order = compareSimDynamoDbValues(value, this.value);
 
-    if (order === undefined) {
-      return false;
-    }
+    assertDefined(order, `order of two ${this.attributeName} key values`);
 
     return simDynamoDbOrderHolds(this.operator, order);
   }
 
   /**
-   * Every scalar key type compares and orders, so there is nothing to refuse.
+   * Refuse a value of a type the key attribute was not declared as.
+   *
+   * Every scalar key type compares and orders, so the operator is always fine.
+   * What has to match is the value it compares against.
    */
-  assertUsableOn(): void {
-    return;
+  assertUsableOn(type: SimDynamoDbScalarAttributeType): void {
+    assertSimDynamoDbKeyValueType(this.attributeName, this.value, type);
   }
 }

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-comparison-key-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-comparison-key-term.ts
@@ -1,0 +1,57 @@
+import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
+import {
+  compareSimDynamoDbValues,
+  simDynamoDbOrderHolds,
+} from "../../item/sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+interface SimDynamoDbComparisonKeyTermProperties {
+  readonly attributeName: string;
+  readonly operator: string;
+  readonly value: SimDynamoDbValue;
+}
+
+/**
+ * A key attribute compared against one value.
+ *
+ * This is the only term the partition key can carry, and only with `=`, since a
+ * query reads one item collection and a range of partition keys would be
+ * several. The value it holds is therefore also the value a collection is found
+ * by.
+ */
+export class SimDynamoDbComparisonKeyTerm implements SimDynamoDbKeyConditionTerm {
+  public readonly attributeName: string;
+  public readonly operator: string;
+  public readonly value: SimDynamoDbValue;
+
+  constructor(properties: SimDynamoDbComparisonKeyTermProperties) {
+    this.attributeName = properties.attributeName;
+    this.operator = properties.operator;
+    this.value = properties.value;
+  }
+
+  /**
+   * Whether a key value stands in the relation the operator asked for.
+   */
+  holdsFor(value: SimDynamoDbValue): boolean {
+    if (this.operator === "=") {
+      return simDynamoDbValuesEqual(value, this.value);
+    }
+
+    const order = compareSimDynamoDbValues(value, this.value);
+
+    if (order === undefined) {
+      return false;
+    }
+
+    return simDynamoDbOrderHolds(this.operator, order);
+  }
+
+  /**
+   * Every scalar key type compares and orders, so there is nothing to refuse.
+   */
+  assertUsableOn(): void {
+    return;
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-error.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-error.ts
@@ -1,0 +1,21 @@
+import type { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
+
+/**
+ * The request parameter every refusal here names.
+ */
+export const keyConditionExpressionName = "KeyConditionExpression";
+
+/**
+ * Build the error a key condition is refused with.
+ *
+ * A key condition is refused in two places: while it is being read, and again
+ * once the table it names has been reached and its key schema is known. Both go
+ * through this, so a caller reading the failure sees the same wording either
+ * way.
+ */
+export function simDynamoDbKeyConditionError(
+  reason: string,
+): SimDynamoDbValidationException {
+  return simDynamoDbExpressionError(keyConditionExpressionName, reason);
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
@@ -1,0 +1,46 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { keyConditionExpressionName } from "./sim-dynamodb-key-condition-error.js";
+import { SimDynamoDbKeyConditionParser } from "./sim-dynamodb-key-condition-parser.js";
+import { SimDynamoDbKeyConditionTerms } from "./sim-dynamodb-key-condition-terms.js";
+
+interface SimDynamoDbKeyConditionRequest extends SimDynamoDbExpressionParameterInput {
+  readonly KeyConditionExpression?: string | undefined;
+}
+
+/**
+ * Read the key condition a query walks its item collection by.
+ *
+ * A query names one item collection, so unlike every other expression parameter
+ * this one is required rather than optional: a request without it is asking for
+ * a scan.
+ */
+export function readSimDynamoDbKeyCondition(
+  request: SimDynamoDbKeyConditionRequest,
+): SimDynamoDbKeyConditionTerms {
+  const expression = request.KeyConditionExpression;
+
+  if (expression === undefined) {
+    throw new SimDynamoDbValidationException(
+      "A KeyConditionExpression is required, since a query reads the items " +
+        "under one partition key",
+    );
+  }
+
+  const parameters = new SimDynamoDbExpressionParameters(request);
+  const terms = new SimDynamoDbKeyConditionParser({
+    tokens: SimDynamoDbExpressionTokens.of(
+      keyConditionExpressionName,
+      expression,
+      "the expression says nothing, and an expression cannot be empty",
+    ),
+    names: parameters.names,
+    values: parameters.values,
+  }).parse();
+
+  parameters.assertAllUsed();
+
+  return new SimDynamoDbKeyConditionTerms(terms);
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-operands.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-operands.ts
@@ -1,0 +1,120 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+import {
+  simDynamoDbBeginsWithName,
+  type SimDynamoDbKeyConditionRefusals,
+} from "./sim-dynamodb-key-condition-refusals.js";
+
+/**
+ * The comparators a key condition puts between a key attribute and a value.
+ *
+ * `<>` is not among them. A query reads a contiguous run of the sort key, and
+ * "everything except this one" is not one.
+ */
+const keyComparators: ReadonlySet<string> = new Set([
+  "=",
+  "<",
+  "<=",
+  ">",
+  ">=",
+]);
+
+interface SimDynamoDbKeyConditionOperandsProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+  readonly refusals: SimDynamoDbKeyConditionRefusals;
+}
+
+/**
+ * The three pieces every key condition term is built from: the key attribute,
+ * the comparator, and the value.
+ *
+ * They are read here rather than in the parser, so the parser stays the shape a
+ * key condition is allowed to take.
+ */
+export class SimDynamoDbKeyConditionOperands {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+  private readonly refusals: SimDynamoDbKeyConditionRefusals;
+
+  constructor(properties: SimDynamoDbKeyConditionOperandsProperties) {
+    this.tokens = properties.tokens;
+    this.names = properties.names;
+    this.values = properties.values;
+    this.refusals = properties.refusals;
+  }
+
+  /**
+   * Read the name of the key attribute a term names.
+   *
+   * A key attribute is a top-level attribute, so this reads one token rather
+   * than a document path: a key is scalar, and nothing in the closed grammar
+   * dereferences one.
+   */
+  attributeName(): string {
+    const token = this.tokens.next("a key attribute name");
+
+    if (token.kind !== "name" && token.kind !== "namePlaceholder") {
+      throw simDynamoDbKeyConditionError(
+        `syntax error; a key attribute name was expected, but ` +
+          `'${token.text}' was given`,
+      );
+    }
+
+    const attributeName = this.nameOf(token.kind, token.text);
+
+    this.refusals.assertNotNested(attributeName);
+
+    return attributeName;
+  }
+
+  /**
+   * Read the value a term compares against, which is always supplied.
+   *
+   * Key conditions have no literals, so every value arrives through
+   * `ExpressionAttributeValues`.
+   */
+  value(): SimDynamoDbValue {
+    const token = this.tokens.next("a value placeholder");
+
+    if (token.kind !== "valuePlaceholder") {
+      throw simDynamoDbKeyConditionError(
+        `a key condition compares a key attribute against a value from ` +
+          `ExpressionAttributeValues, and '${token.text}' is not one`,
+      );
+    }
+
+    return this.values.required(token.text);
+  }
+
+  /**
+   * Read the comparator between a key attribute and a value.
+   */
+  comparator(): string {
+    const token = this.tokens.next("a comparator");
+
+    if (token.kind !== "symbol" || !keyComparators.has(token.text)) {
+      throw simDynamoDbKeyConditionError(
+        `'${token.text}' is not a key condition operator. A key condition ` +
+          `uses =, <, <=, >, >=, BETWEEN or ${simDynamoDbBeginsWithName}.`,
+      );
+    }
+
+    return token.text;
+  }
+
+  /**
+   * The attribute a name token stands for, which may be a placeholder.
+   */
+  private nameOf(kind: string, text: string): string {
+    if (kind === "name") {
+      return text;
+    }
+
+    return this.names.required(text);
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-parser.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-parser.ts
@@ -1,0 +1,115 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { SimDynamoDbBeginsWithKeyTerm } from "./sim-dynamodb-begins-with-key-term.js";
+import { SimDynamoDbBetweenKeyTerm } from "./sim-dynamodb-between-key-term.js";
+import { SimDynamoDbComparisonKeyTerm } from "./sim-dynamodb-comparison-key-term.js";
+import { SimDynamoDbKeyConditionOperands } from "./sim-dynamodb-key-condition-operands.js";
+import { SimDynamoDbKeyConditionRefusals } from "./sim-dynamodb-key-condition-refusals.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+interface SimDynamoDbKeyConditionParserProperties {
+  readonly tokens: SimDynamoDbExpressionTokens;
+  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+}
+
+/**
+ * Reads a KeyConditionExpression into the terms it is made of.
+ *
+ * This is deliberately not the general condition grammar. A key condition is
+ * one equality on the partition key, optionally joined by AND to one sort key
+ * condition, and nothing else. Sharing the condition parser would let a query
+ * accept `OR`, which real DynamoDB refuses, and that is the kind of divergence
+ * that passes here and fails on deploy.
+ *
+ * Which attribute is the partition key and which is the sort key is not known
+ * here, since that is a property of the table rather than of the expression.
+ * This reads the terms, and `SimDynamoDbKeyConditionTerms` holds them to the
+ * key schema once the table has been reached.
+ */
+export class SimDynamoDbKeyConditionParser {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly refusals: SimDynamoDbKeyConditionRefusals;
+  private readonly operands: SimDynamoDbKeyConditionOperands;
+
+  constructor(properties: SimDynamoDbKeyConditionParserProperties) {
+    const refusals = new SimDynamoDbKeyConditionRefusals(properties.tokens);
+
+    this.tokens = properties.tokens;
+    this.refusals = refusals;
+    this.operands = new SimDynamoDbKeyConditionOperands({
+      tokens: properties.tokens,
+      names: properties.names,
+      values: properties.values,
+      refusals,
+    });
+  }
+
+  /**
+   * Read the whole expression, refusing anything left over after it.
+   */
+  parse(): readonly SimDynamoDbKeyConditionTerm[] {
+    const terms: SimDynamoDbKeyConditionTerm[] = [this.term()];
+
+    while (this.tokens.takeKeyword("AND")) {
+      terms.push(this.term());
+    }
+
+    this.refusals.assertNothingFollows();
+
+    return terms;
+  }
+
+  /**
+   * Read one term, which is either a prefix call or a key attribute put
+   * against one or two values.
+   */
+  private term(): SimDynamoDbKeyConditionTerm {
+    this.refusals.assertNoLogicalOperator();
+    this.refusals.assertNoBracket();
+
+    if (this.refusals.takesBeginsWith()) {
+      return SimDynamoDbBeginsWithKeyTerm.read({
+        tokens: this.tokens,
+        operands: this.operands,
+      });
+    }
+
+    return this.comparison();
+  }
+
+  /**
+   * Read a key attribute put against one value, or between two of them.
+   */
+  private comparison(): SimDynamoDbKeyConditionTerm {
+    const attributeName = this.operands.attributeName();
+
+    if (this.tokens.takeKeyword("BETWEEN")) {
+      return this.between(attributeName);
+    }
+
+    return new SimDynamoDbComparisonKeyTerm({
+      attributeName,
+      operator: this.operands.comparator(),
+      value: this.operands.value(),
+    });
+  }
+
+  /**
+   * Read `sortKey BETWEEN :lower AND :upper`.
+   *
+   * The AND here belongs to BETWEEN rather than joining two terms, which is why
+   * the range is read inside a term rather than beside one.
+   */
+  private between(attributeName: string): SimDynamoDbKeyConditionTerm {
+    const lower = this.operands.value();
+    this.tokens.expectKeyword("AND");
+
+    return new SimDynamoDbBetweenKeyTerm({
+      attributeName,
+      lower,
+      upper: this.operands.value(),
+    });
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-refusals.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-refusals.ts
@@ -1,0 +1,152 @@
+import type { SimDynamoDbExpressionToken } from "../sim-dynamodb-expression-token.js";
+import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+
+/**
+ * The one function a key condition takes, read in lower case as real DynamoDB
+ * reads it.
+ */
+export const simDynamoDbBeginsWithName = "begins_with";
+
+/**
+ * The boolean operators a key condition has no place for.
+ */
+const refusedKeywords: ReadonlySet<string> = new Set(["OR", "NOT"]);
+
+/**
+ * The symbols that dereference the attribute before them.
+ */
+const dereferenceSymbols: ReadonlySet<string> = new Set([".", "["]);
+
+/**
+ * What a key condition is refused for being, rather than for what it says.
+ *
+ * These are the shapes the general condition grammar takes and a key condition
+ * does not. They are a group of their own because each is about telling a
+ * caller which part of that grammar has no place here, rather than about
+ * building anything.
+ */
+export class SimDynamoDbKeyConditionRefusals {
+  private readonly tokens: SimDynamoDbExpressionTokens;
+
+  constructor(tokens: SimDynamoDbExpressionTokens) {
+    this.tokens = tokens;
+  }
+
+  /**
+   * Refuse the boolean operators a key condition has no place for.
+   *
+   * `OR` and `NOT` are reserved words in an expression, so an attribute of
+   * either name is written as a placeholder and never arrives here.
+   */
+  assertNoLogicalOperator(): void {
+    const token = this.tokens.peek();
+
+    if (token?.kind !== "name") {
+      return;
+    }
+
+    const word = token.text.toUpperCase();
+
+    if (!refusedKeywords.has(word)) {
+      return;
+    }
+
+    throw simDynamoDbKeyConditionError(
+      `${word} is not part of a key condition. A key condition tests the ` +
+        `partition key for equality, and may add one sort key condition ` +
+        `after AND.`,
+    );
+  }
+
+  /**
+   * Refuse a bracketed term.
+   *
+   * Brackets group a condition, and there is nothing here to group: the shape
+   * of a key condition is fixed. Refusing them is stricter than real DynamoDB,
+   * and is recorded in the Limitations section of the usage docs.
+   */
+  assertNoBracket(): void {
+    const token = this.tokens.peek();
+
+    if (token?.kind === "symbol" && token.text === "(") {
+      throw simDynamoDbKeyConditionError(
+        `a key condition takes no brackets: it is one partition key ` +
+          `equality, optionally with one sort key condition after AND`,
+      );
+    }
+  }
+
+  /**
+   * Whether the next term is a `begins_with` call, refusing any other function.
+   *
+   * A function name followed by anything but an opening bracket is an ordinary
+   * attribute name, since none of these words is reserved.
+   */
+  takesBeginsWith(): boolean {
+    const called = this.calledFunction();
+
+    if (called === undefined) {
+      return false;
+    }
+
+    if (called !== simDynamoDbBeginsWithName) {
+      throw simDynamoDbKeyConditionError(
+        `${called} is not a key condition function. ` +
+          `${simDynamoDbBeginsWithName} is the only one a sort key condition ` +
+          `uses.`,
+      );
+    }
+
+    return true;
+  }
+
+  /**
+   * Refuse a term dereferencing the attribute it names.
+   */
+  assertNotNested(attributeName: string): void {
+    const token = this.tokens.peek();
+
+    if (token?.kind === "symbol" && dereferenceSymbols.has(token.text)) {
+      throw simDynamoDbKeyConditionError(
+        `${attributeName} is followed by '${token.text}', and a key condition ` +
+          `names a top-level attribute: a key is scalar and cannot be nested`,
+      );
+    }
+  }
+
+  /**
+   * Refuse anything left over after the last term of an expression.
+   */
+  assertNothingFollows(): void {
+    this.assertNoLogicalOperator();
+
+    const remaining = this.tokens.peek();
+
+    if (remaining !== undefined) {
+      throw simDynamoDbKeyConditionError(
+        `syntax error; '${remaining.text}' follows a complete key condition`,
+      );
+    }
+  }
+
+  /**
+   * The name of the function the next term calls, if it calls one.
+   */
+  private calledFunction(): string | undefined {
+    const token = this.tokens.peek();
+
+    if (token?.kind !== "name" || !opensBracket(this.tokens.peek(1))) {
+      return undefined;
+    }
+
+    return token.text;
+  }
+}
+
+/**
+ * Whether a token is the bracket that makes the name before it a call.
+ */
+function opensBracket(token: SimDynamoDbExpressionToken | undefined): boolean {
+  return token?.kind === "symbol" && token.text === "(";
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-term.ts
@@ -1,0 +1,26 @@
+import type { SimDynamoDbScalarAttributeType } from "../../command/table/table.types.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+
+/**
+ * One test a key condition makes against one key attribute.
+ *
+ * A key condition is a closed grammar rather than a general condition, so there
+ * are only three of these: a comparison, a range, and a prefix. Each is its own
+ * class, since what they refuse and how they read a value differ.
+ */
+export interface SimDynamoDbKeyConditionTerm {
+  /** The attribute this term names, before anything knows if it is a key. */
+  readonly attributeName: string;
+  /** How the term was written, for a refusal to name it. */
+  readonly operator: string;
+
+  /**
+   * Whether a key value is inside what this term asks for.
+   */
+  holdsFor(value: SimDynamoDbValue): boolean;
+
+  /**
+   * Refuse a term that cannot be applied to the key attribute it names.
+   */
+  assertUsableOn(type: SimDynamoDbScalarAttributeType): void;
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-term.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-term.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbScalarAttributeType } from "../../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 
 /**
@@ -23,4 +24,27 @@ export interface SimDynamoDbKeyConditionTerm {
    * Refuse a term that cannot be applied to the key attribute it names.
    */
   assertUsableOn(type: SimDynamoDbScalarAttributeType): void;
+}
+
+/**
+ * Refuse a value of a type the table did not declare for a key attribute.
+ *
+ * A key attribute has exactly one type, so a condition comparing it against
+ * another type can never hold for any item. Real DynamoDB refuses the request,
+ * and so does this: answering with nothing instead would read as an item
+ * collection that happens to be empty, which is a test passing here on a query
+ * that fails on deploy.
+ */
+export function assertSimDynamoDbKeyValueType(
+  attributeName: string,
+  value: SimDynamoDbValue,
+  type: SimDynamoDbScalarAttributeType,
+): void {
+  if (value.kind !== type) {
+    throw new SimDynamoDbValidationException(
+      `One or more parameter values were invalid: Condition parameter type ` +
+        `does not match schema type. The key attribute ${attributeName} is ` +
+        `${type}, and the key condition compares it against ${value.kind}.`,
+    );
+  }
 }

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-terms.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-terms.ts
@@ -38,7 +38,10 @@ export class SimDynamoDbKeyConditionTerms {
     this.assertNameKeyAttributes(keySchema);
 
     return new SimDynamoDbKeyCondition({
-      partitionKeyValue: this.partitionKeyValue(keySchema),
+      partitionKeyValue: this.partitionKeyValue(
+        keySchema,
+        attributeDefinitions,
+      ),
       sortKeyTerm: this.sortKeyTerm(keySchema, attributeDefinitions),
     });
   }
@@ -66,7 +69,10 @@ export class SimDynamoDbKeyConditionTerms {
   /**
    * The one partition key value this condition names an item collection by.
    */
-  private partitionKeyValue(keySchema: SimDynamoDbKeySchema): SimDynamoDbValue {
+  private partitionKeyValue(
+    keySchema: SimDynamoDbKeySchema,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): SimDynamoDbValue {
     const attributeName = keySchema.hashKeyAttributeName;
     const term = this.single(attributeName);
 
@@ -84,6 +90,10 @@ export class SimDynamoDbKeyConditionTerms {
     if (term.operator !== "=") {
       throw this.partitionKeyOperatorError(attributeName, term.operator);
     }
+
+    // The partition key is held to its declared type the same way the sort key
+    // is. A value of another type names an item collection that cannot exist.
+    term.assertUsableOn(attributeDefinitions.typeOf(attributeName));
 
     return term.value;
   }

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-terms.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-terms.ts
@@ -1,0 +1,144 @@
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbAttributeDefinitions } from "../../table/sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
+import { SimDynamoDbKeyCondition } from "./sim-dynamodb-key-condition.js";
+import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
+import { SimDynamoDbComparisonKeyTerm } from "./sim-dynamodb-comparison-key-term.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+/**
+ * What a key condition needs to know about the table it names.
+ */
+export interface SimDynamoDbKeyConditionTable {
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+}
+
+/**
+ * The terms one KeyConditionExpression was written as.
+ *
+ * The expression is read before the table is reached, so that a request real
+ * DynamoDB would refuse is refused whether or not the table exists. Which
+ * attribute is the partition key is a property of the table, so the rules that
+ * need it are applied here rather than in the parser, once the table is known.
+ */
+export class SimDynamoDbKeyConditionTerms {
+  private readonly terms: readonly SimDynamoDbKeyConditionTerm[];
+
+  constructor(terms: readonly SimDynamoDbKeyConditionTerm[]) {
+    this.terms = terms;
+  }
+
+  /**
+   * Read these terms against the key schema of the table the request names.
+   */
+  forTable(table: SimDynamoDbKeyConditionTable): SimDynamoDbKeyCondition {
+    const { keySchema, attributeDefinitions } = table;
+
+    this.assertNameKeyAttributes(keySchema);
+
+    return new SimDynamoDbKeyCondition({
+      partitionKeyValue: this.partitionKeyValue(keySchema),
+      sortKeyTerm: this.sortKeyTerm(keySchema, attributeDefinitions),
+    });
+  }
+
+  /**
+   * Refuse a term naming anything but a key attribute.
+   *
+   * A query walks the primary key, so an attribute outside it has nothing to
+   * walk. Real DynamoDB refuses it rather than filtering by it, which is what
+   * `FilterExpression` is for.
+   */
+  private assertNameKeyAttributes(keySchema: SimDynamoDbKeySchema): void {
+    const keyNames = keySchema.attributeNames();
+
+    for (const term of this.terms) {
+      if (!keyNames.includes(term.attributeName)) {
+        throw simDynamoDbKeyConditionError(
+          `${term.attributeName} is not part of the table's primary key, and ` +
+            `a key condition names only key attributes`,
+        );
+      }
+    }
+  }
+
+  /**
+   * The one partition key value this condition names an item collection by.
+   */
+  private partitionKeyValue(keySchema: SimDynamoDbKeySchema): SimDynamoDbValue {
+    const attributeName = keySchema.hashKeyAttributeName;
+    const term = this.single(attributeName);
+
+    if (term === undefined) {
+      throw simDynamoDbKeyConditionError(
+        `the key condition does not name the partition key ${attributeName}, ` +
+          `and a query reads one item collection`,
+      );
+    }
+
+    if (!(term instanceof SimDynamoDbComparisonKeyTerm)) {
+      throw this.partitionKeyOperatorError(attributeName, term.operator);
+    }
+
+    if (term.operator !== "=") {
+      throw this.partitionKeyOperatorError(attributeName, term.operator);
+    }
+
+    return term.value;
+  }
+
+  /**
+   * The sort key condition, when the table has a sort key and one was written.
+   */
+  private sortKeyTerm(
+    keySchema: SimDynamoDbKeySchema,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): SimDynamoDbKeyConditionTerm | undefined {
+    const attributeName = keySchema.rangeKeyAttributeName;
+
+    // A table with no sort key has no other key attribute for a term to name,
+    // which the key attribute check has already refused.
+    if (attributeName === undefined) {
+      return undefined;
+    }
+
+    const term = this.single(attributeName);
+
+    term?.assertUsableOn(attributeDefinitions.typeOf(attributeName));
+
+    return term;
+  }
+
+  /**
+   * The one term naming an attribute, refusing an expression naming it twice.
+   */
+  private single(
+    attributeName: string,
+  ): SimDynamoDbKeyConditionTerm | undefined {
+    const found = this.terms.filter(
+      (term) => term.attributeName === attributeName,
+    );
+
+    if (found.length > 1) {
+      throw simDynamoDbKeyConditionError(
+        `the key condition tests ${attributeName} more than once`,
+      );
+    }
+
+    return found.at(0);
+  }
+
+  /**
+   * Build the refusal for a range operator applied to the partition key.
+   */
+  private partitionKeyOperatorError(
+    attributeName: string,
+    operator: string,
+  ): Error {
+    return simDynamoDbKeyConditionError(
+      `the partition key ${attributeName} takes only =, and ${operator} was ` +
+        `given: a query reads one item collection rather than a range of them`,
+    );
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition.ts
@@ -1,0 +1,45 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-term.js";
+
+interface SimDynamoDbKeyConditionProperties {
+  readonly partitionKeyValue: SimDynamoDbValue;
+  readonly sortKeyTerm?: SimDynamoDbKeyConditionTerm | undefined;
+}
+
+/**
+ * A key condition that has been read against the key schema of the table it
+ * names.
+ *
+ * It is two things: the one partition key value whose item collection the query
+ * reads, and the run of that collection the sort key condition asks for. A
+ * query with no sort key condition reads the whole collection.
+ */
+export class SimDynamoDbKeyCondition {
+  public readonly partitionKeyValue: SimDynamoDbValue;
+
+  private readonly sortKeyTerm: SimDynamoDbKeyConditionTerm | undefined;
+
+  constructor(properties: SimDynamoDbKeyConditionProperties) {
+    this.partitionKeyValue = properties.partitionKeyValue;
+    this.sortKeyTerm = properties.sortKeyTerm;
+  }
+
+  /**
+   * Whether an item's sort key is inside the run this condition asks for.
+   *
+   * The value is only absent for a table with no sort key, and such a table
+   * carries no sort key condition either, so the term is already gone by then.
+   */
+  holdsForSortKey(value: SimDynamoDbValue | undefined): boolean {
+    const term = this.sortKeyTerm;
+
+    if (term === undefined) {
+      return true;
+    }
+
+    assertDefined(value, `sort key ${term.attributeName} of a stored item`);
+
+    return term.holdsFor(value);
+  }
+}

--- a/src/service/dynamodb/item/sim-dynamodb-value-order.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-order.ts
@@ -28,6 +28,34 @@ function compareTexts(first: string, second: string): number {
 }
 
 /**
+ * Whether an ordering satisfies one of the four ordering comparators.
+ *
+ * Only those four reach here: `=` and `<>` are answered by equality rather than
+ * by an order, so the last of the four is the remaining case. Condition
+ * expressions and key conditions both read a comparator this way, which is why
+ * it sits with the item model.
+ */
+export function simDynamoDbOrderHolds(
+  comparator: string,
+  order: number,
+): boolean {
+  switch (comparator) {
+    case "<": {
+      return order < 0;
+    }
+    case "<=": {
+      return order <= 0;
+    }
+    case ">": {
+      return order > 0;
+    }
+    default: {
+      return order >= 0;
+    }
+  }
+}
+
+/**
  * Order two stored values, or nothing when they cannot be ordered.
  *
  * DynamoDB orders strings, numbers and binary, and only against a value of the

--- a/src/service/dynamodb/item/sim-dynamodb-value-prefix.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-prefix.ts
@@ -1,0 +1,39 @@
+import type { SimDynamoDbValue } from "./sim-dynamodb-value.js";
+
+/**
+ * Whether one stored value starts with another.
+ *
+ * DynamoDB reads a prefix over strings and over binary, and only against a
+ * value of the same type, so a string never begins with binary however the
+ * bytes line up. Anything else has no prefix at all, which makes the answer
+ * false rather than an error.
+ *
+ * `begins_with` in a condition expression and `begins_with` in a key condition
+ * both ask this, which is why it sits with the item model rather than with
+ * either of them.
+ */
+export function simDynamoDbValueBeginsWith(
+  value: SimDynamoDbValue,
+  prefix: SimDynamoDbValue,
+): boolean {
+  if (value.kind === "S" && prefix.kind === "S") {
+    return value.text.startsWith(prefix.text);
+  }
+
+  if (value.kind === "B" && prefix.kind === "B") {
+    return beginsWithBytes(value.bytes, prefix.bytes);
+  }
+
+  return false;
+}
+
+/**
+ * Whether some bytes start with some other bytes.
+ */
+function beginsWithBytes(bytes: Uint8Array, prefix: Uint8Array): boolean {
+  if (prefix.length > bytes.length) {
+    return false;
+  }
+
+  return prefix.every((byte, at) => bytes.at(at) === byte);
+}

--- a/src/service/dynamodb/item/sim-dynamodb-value-set.iso.test.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-set.iso.test.ts
@@ -31,7 +31,7 @@ describe("SimDynamoDbItem sets", () => {
     // When a string set carries something that is not a string.
     const error = assertThrowsError(() =>
       roundTrip({
-        colours: { SS: ["purple", 7] as unknown as readonly string[] },
+        colours: { SS: ["purple", 7] as unknown as string[] },
       }),
     );
 

--- a/src/service/dynamodb/item/sim-dynamodb-value-set.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-set.ts
@@ -49,7 +49,7 @@ function membersOf(
     );
   }
 
-  return members as readonly unknown[];
+  return members;
 }
 
 /**

--- a/src/service/dynamodb/item/sim-dynamodb-value-writer.ts
+++ b/src/service/dynamodb/item/sim-dynamodb-value-writer.ts
@@ -28,7 +28,7 @@ export function writeSimDynamoDbValue(
       return { NULL: true };
     }
     case "SS": {
-      return { SS: value.texts };
+      return { SS: [...value.texts] };
     }
     case "NS": {
       return { NS: value.numbers.map((number) => number.text) };

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -12,7 +12,7 @@ import {
   ListTablesCommand,
   PutItemCommand,
   ListTagsOfResourceCommand,
-  QueryCommand,
+  ScanCommand,
   TagResourceCommand,
   TransactGetItemsCommand,
   TransactWriteItemsCommand,
@@ -355,16 +355,10 @@ describe("simulated DynamoDB SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(
-        new QueryCommand({
-          TableName: "InterceptTable",
-          KeyConditionExpression: "id = :id",
-          ExpressionAttributeValues: { ":id": { S: "item-1" } },
-        }),
-      );
+      await client.send(new ScanCommand({ TableName: "InterceptTable" }));
     });
 
-    assertStringIncludes(error.message, "QueryCommand");
+    assertStringIncludes(error.message, "ScanCommand");
     assertStringIncludes(error.message, "PutItemCommand");
   });
 });

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -15,6 +15,7 @@ import type {
   SimPutItemCommand,
   SimUpdateItemCommand,
 } from "../command/item/item.command.js";
+import type { SimQueryCommand } from "../command/query/query.command.js";
 import type {
   SimBatchGetItemCommand,
   SimBatchWriteItemCommand,
@@ -32,6 +33,7 @@ import type {
   SimDescribeTimeToLiveCommand,
   SimUpdateTimeToLiveCommand,
 } from "../command/time-to-live/time-to-live.command.js";
+import { refuseSimDynamoDbDocumentCommand } from "../document/sim-dynamodb-document-command.js";
 import { simDynamoDbDocumentRoutes } from "../document/sim-dynamodb-document-routes.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../sim-dynamodb.js";
 
@@ -106,6 +108,19 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
             command as SimDeleteItemCommand,
             simSdkCallerOptions(context),
           ),
+      ],
+      [
+        "QueryCommand",
+        async (command, context): Promise<unknown> => {
+          // The document client names its Query the same as this one, so the
+          // Command name alone cannot tell them apart.
+          refuseSimDynamoDbDocumentCommand(command, "QueryCommand");
+
+          return await simDynamoDatabase.query(
+            command as SimQueryCommand,
+            simSdkCallerOptions(context),
+          );
+        },
       ],
       [
         "BatchWriteItemCommand",

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-query-routing.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-query-routing.iso.test.ts
@@ -1,0 +1,56 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("simulated DynamoDB Query SDK Command routing", () => {
+  it("round-trips a Query through an intercepted client", async () => {
+    // Given an intercepted client with a collection written to a table.
+    using simSdk = new SimSdk();
+    const client = new DynamoDBClient({ region: "eu-west-2" });
+    simSdk.intercept(client);
+
+    await client.send(
+      new CreateTableCommand({
+        TableName: "CollectionTable",
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "orderId", KeyType: "RANGE" },
+        ],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+          { AttributeName: "orderId", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    await client.send(
+      new PutItemCommand({
+        TableName: "CollectionTable",
+        Item: { customerId: { S: "c-1" }, orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When the collection is queried through the client.
+    const output = await client.send(
+      new QueryCommand({
+        TableName: "CollectionTable",
+        KeyConditionExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      }),
+    );
+
+    // Then the page comes back the way the SDK's own types expect it.
+    assertArrayLength(output.Items ?? [], 1);
+    assertIdentical(output.Items?.at(0)?.["orderId"]?.S, "order-1");
+    assertIdentical(output.Count, 1);
+    assertIdentical(output.ScannedCount, 1);
+  });
+});

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -145,6 +145,17 @@ export class SimDynamoDb {
   }
 
   /**
+   * Handle a Query Command from the SDK.
+   */
+  async query(
+    command: simDynamoDbCommands.SimQueryCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simDynamoDbCommands.SimQueryCommandOutput> {
+    await this.background.sequence();
+    return this.commands.itemQueries.handle(command, options);
+  }
+
+  /**
    * Handle a Batch Write Item Command from the SDK.
    */
   async batchWriteItem(

--- a/src/service/dynamodb/table/sim-dynamodb-collection-table.factory.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-collection-table.factory.ts
@@ -1,0 +1,77 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbScalarAttributeType } from "../command/table/table.types.js";
+import type { SimDynamoDbTable } from "./sim-dynamodb-table.js";
+
+/**
+ * What a test asks for when it wants a table whose items form collections.
+ */
+export interface SimDynamoDbCollectionTableInput {
+  readonly tableName: string;
+  readonly partitionKeyName: string;
+  readonly sortKeyName: string;
+  readonly sortKeyType: SimDynamoDbScalarAttributeType;
+}
+
+/**
+ * Creates a table with both a partition key and a sort key, through CreateTable.
+ *
+ * A sort key is what makes several items one item collection, so this is the
+ * table a Query reads. Use `simDynamoDbCreatedTableFactory` for a table keyed
+ * by partition key alone, which holds at most one item under each key.
+ *
+ * The table is ACTIVE by the time this answers, the same way it is there.
+ *
+ * ```typescript
+ * const table = await simDynamoDbCollectionTableFactory.make(
+ *   { tableName: "OrdersTable", partitionKeyName: "customerId" },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbCollectionTableFactory = new AsyncMappedFactory<
+  SimDynamoDbCollectionTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "OrdersTable",
+    partitionKeyName: "customerId",
+    sortKeyName: "orderId",
+    sortKeyType: "S",
+  }),
+  async (input, simAws) => {
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable({
+      input: {
+        TableName: input.tableName,
+        KeySchema: [
+          { AttributeName: input.partitionKeyName, KeyType: "HASH" },
+          { AttributeName: input.sortKeyName, KeyType: "RANGE" },
+        ],
+        AttributeDefinitions: [
+          { AttributeName: input.partitionKeyName, AttributeType: "S" },
+          {
+            AttributeName: input.sortKeyName,
+            AttributeType: input.sortKeyType,
+          },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // A name CreateTable accepted is a table the store holds, so this is only
+    // missing if something is wrong with the simulator itself.
+    const table = simDynamoDb.findTable(input.tableName);
+    assertDefined(
+      table,
+      `Simulated DynamoDB created the table ${input.tableName} and then did ` +
+        `not hold it`,
+    );
+
+    return table;
+  },
+);

--- a/src/service/dynamodb/table/sim-dynamodb-item-collection.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-item-collection.ts
@@ -1,0 +1,88 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { simDynamoDbValuesEqual } from "../item/sim-dynamodb-value-comparison.js";
+import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
+import { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+
+interface SimDynamoDbItemCollectionProperties {
+  readonly items: Iterable<SimDynamoDbItem>;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly keyCondition: SimDynamoDbKeyCondition;
+}
+
+interface SimDynamoDbItemCollectionWalk {
+  readonly forward: boolean;
+  readonly after?: SimDynamoDbItem | undefined;
+}
+
+/**
+ * The items one key condition names, in sort key order.
+ *
+ * A table holds its items in a map keyed by the marshalled primary key, which
+ * carries no order at all, so an item collection is gathered and ordered when
+ * it is read rather than kept that way. Real DynamoDB keeps a collection in
+ * sort key order, and a query reads the same items in the same order either
+ * way.
+ */
+export class SimDynamoDbItemCollection {
+  private readonly order: SimDynamoDbSortKeyOrder;
+  private readonly ascending: readonly SimDynamoDbItem[];
+
+  constructor(properties: SimDynamoDbItemCollectionProperties) {
+    const { keySchema, keyCondition } = properties;
+    const order = new SimDynamoDbSortKeyOrder(keySchema.rangeKeyAttributeName);
+
+    this.order = order;
+    this.ascending = order.ascending(
+      [...properties.items].filter((item) =>
+        this.named(item, keySchema, keyCondition),
+      ),
+    );
+  }
+
+  /**
+   * The collection in the order a query walks it, from the key it resumes
+   * after.
+   */
+  walk(properties: SimDynamoDbItemCollectionWalk): readonly SimDynamoDbItem[] {
+    const inOrder = this.inOrder(properties.forward);
+    const after = properties.after;
+
+    if (after === undefined) {
+      return inOrder;
+    }
+
+    return this.order.beyond(inOrder, after, properties.forward);
+  }
+
+  /**
+   * Whether a key condition names an item: it belongs to the item collection,
+   * and its sort key is inside the run the condition asks for.
+   */
+  private named(
+    item: SimDynamoDbItem,
+    keySchema: SimDynamoDbKeySchema,
+    keyCondition: SimDynamoDbKeyCondition,
+  ): boolean {
+    const partitionKey = item.attribute(keySchema.hashKeyAttributeName);
+
+    assertDefined(partitionKey, "partition key of a stored item");
+
+    return (
+      simDynamoDbValuesEqual(partitionKey, keyCondition.partitionKeyValue) &&
+      keyCondition.holdsForSortKey(this.order.valueOf(item))
+    );
+  }
+
+  /**
+   * The collection in the direction `ScanIndexForward` asked for.
+   */
+  private inOrder(forward: boolean): readonly SimDynamoDbItem[] {
+    if (forward) {
+      return this.ascending;
+    }
+
+    return this.ascending.toReversed();
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-primary-key.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-primary-key.ts
@@ -1,0 +1,31 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { writeSimDynamoDbValue } from "../item/sim-dynamodb-value-writer.js";
+import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
+
+/**
+ * The primary key of a stored item, as the attribute values a pagination token
+ * carries.
+ *
+ * `LastEvaluatedKey` is the primary key of the item a walk stopped on, and the
+ * `ExclusiveStartKey` of the next request is the same thing read back, so it is
+ * written here once for whatever hands out a page.
+ *
+ * Every item in a table carries its key attributes. A write that left one out
+ * was refused, so the value is there by the time an item is stored.
+ */
+export function simDynamoDbPrimaryKeyAttributes(
+  item: SimDynamoDbItem,
+  keySchema: SimDynamoDbKeySchema,
+): Record<string, SimDynamoDbAttributeValue> {
+  return Object.fromEntries(
+    keySchema.attributeNames().map((attributeName) => {
+      const value = item.attribute(attributeName);
+
+      assertDefined(value, `key attribute ${attributeName} of a stored item`);
+
+      return [attributeName, writeSimDynamoDbValue(value)];
+    }),
+  );
+}

--- a/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
@@ -1,0 +1,125 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { compareSimDynamoDbValues } from "../item/sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+
+/**
+ * The order a table's sort key puts an item collection in.
+ *
+ * A table with no sort key holds at most one item under a partition key, so
+ * every question here has a trivial answer for one. That is why the attribute
+ * name is optional rather than each caller asking whether there is one.
+ *
+ * The order is DynamoDB's rather than JavaScript's, through
+ * `compareSimDynamoDbValues`: numbers order by value however they were written,
+ * strings by their UTF-8 bytes, and binary as unsigned bytes.
+ */
+export class SimDynamoDbSortKeyOrder {
+  private readonly attributeName: string | undefined;
+
+  constructor(attributeName: string | undefined) {
+    this.attributeName = attributeName;
+  }
+
+  /**
+   * The sort key of an item, or nothing when the table has no sort key.
+   */
+  valueOf(item: SimDynamoDbItem): SimDynamoDbValue | undefined {
+    const attributeName = this.attributeName;
+
+    if (attributeName === undefined) {
+      return undefined;
+    }
+
+    return sortKeyValue(item, attributeName);
+  }
+
+  /**
+   * Items in ascending sort key order.
+   */
+  ascending(items: readonly SimDynamoDbItem[]): readonly SimDynamoDbItem[] {
+    const attributeName = this.attributeName;
+
+    if (attributeName === undefined) {
+      return items;
+    }
+
+    return items.toSorted((first, second) =>
+      this.compare(first, second, attributeName),
+    );
+  }
+
+  /**
+   * The items past the one a request resumes after, in the walk direction.
+   *
+   * With no sort key a collection holds one item, and that is the item the
+   * token names, so nothing comes after it.
+   */
+  beyond(
+    items: readonly SimDynamoDbItem[],
+    after: SimDynamoDbItem,
+    forward: boolean,
+  ): readonly SimDynamoDbItem[] {
+    const attributeName = this.attributeName;
+
+    if (attributeName === undefined) {
+      return [];
+    }
+
+    const direction = this.direction(forward);
+
+    return items.filter(
+      (item) => this.compare(item, after, attributeName) * direction > 0,
+    );
+  }
+
+  /**
+   * Which way along the sort key the walk is going.
+   */
+  private direction(forward: boolean): number {
+    if (forward) {
+      return 1;
+    }
+
+    return -1;
+  }
+
+  /**
+   * Order two items by their sort keys.
+   *
+   * Two items in one table always order: the table checks the type of every key
+   * attribute on the way in, so no collection holds two sort keys of different
+   * types.
+   */
+  private compare(
+    first: SimDynamoDbItem,
+    second: SimDynamoDbItem,
+    attributeName: string,
+  ): number {
+    const order = compareSimDynamoDbValues(
+      sortKeyValue(first, attributeName),
+      sortKeyValue(second, attributeName),
+    );
+
+    assertDefined(order, `order of two ${attributeName} sort keys`);
+
+    return order;
+  }
+}
+
+/**
+ * The sort key a stored item holds.
+ *
+ * Every item in a table carries its key attributes: a write that left one out
+ * was refused, so the value is there by the time an item is stored.
+ */
+function sortKeyValue(
+  item: SimDynamoDbItem,
+  attributeName: string,
+): SimDynamoDbValue {
+  const value = item.attribute(attributeName);
+
+  assertDefined(value, `sort key ${attributeName} of a stored item`);
+
+  return value;
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -14,6 +14,8 @@ import type { SimDynamoDbTimeToLiveDescription } from "../command/time-to-live/t
 import { SimDynamoDbTableExpiry } from "../time-to-live/sim-dynamodb-table-expiry.js";
 import { SimDynamoDbTimeToLive } from "../time-to-live/sim-dynamodb-time-to-live.js";
 import type { SimDynamoDbTimeToLiveSpecification } from "../time-to-live/sim-dynamodb-time-to-live-specification.js";
+import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import { SimDynamoDbItemCollection } from "./sim-dynamodb-item-collection.js";
 import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
@@ -236,5 +238,22 @@ export class SimDynamoDbTable {
    */
   public deleteItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
     return this.items.remove(this.itemKey.ofKey(key));
+  }
+
+  /**
+   * The items a key condition names, in sort key order.
+   *
+   * A Query reads a whole item collection rather than one key, so the items are
+   * reachable together as well as one at a time. The ordering belongs to the
+   * collection rather than to the command that reads it.
+   */
+  public itemCollection(
+    keyCondition: SimDynamoDbKeyCondition,
+  ): SimDynamoDbItemCollection {
+    return new SimDynamoDbItemCollection({
+      items: this.items.entries().values(),
+      keySchema: this.keySchema,
+      keyCondition,
+    });
   }
 }


### PR DESCRIPTION
Query reads one item collection: the items under one partition key, in sort key order. KeyConditionExpression is a closed grammar of its own rather than the general condition grammar, so a query cannot accept OR the way a condition can.

Limit counts items evaluated, LastEvaluatedKey is present whenever the walk stopped at that limit, and ExclusiveStartKey resumes exclusively by comparing sort keys.

IndexName, FilterExpression, ProjectionExpression and Select are refused by name. The document client's QueryCommand is refused too, since it shares its name with the client Command the interception routes by.

Resolves https://github.com/KensioSoftware/yulin/issues/266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DynamoDB `Query` operations, including partition and sort-key conditions, ascending or descending results, counts, and pagination.
  * Added support for continuation keys to resume queries and validate query boundaries.
  * Added SDK client routing and authorization coverage for Query requests.
* **Documentation**
  * Added Query usage examples, paging examples, supported functionality, syntax guidance, and limitations.
* **Bug Fixes**
  * Improved validation and handling of unsupported query options and document-client Query requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->