### PR TITLE
feat: scan a simulated DynamoDB table, including parallel segments

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1225,7 +1225,9 @@ for (const customerId of ["c-1", "c-2", "c-3", "c-4"]) {
 }
 
 const totalSegments = 4;
-const read: string[] = [];
+
+// Which segment each of a customer's orders came back in.
+const segmentsByCustomer = new Map<string, number[]>();
 
 for (let segment = 0; segment < totalSegments; segment++) {
   const segmentPage = await dynamoDb.scan(
@@ -1236,16 +1238,29 @@ for (let segment = 0; segment < totalSegments; segment++) {
     }),
   );
 
-  read.push(
-    ...(segmentPage.Items ?? []).map((item) => item["customerId"]?.S ?? ""),
-  );
+  const items = segmentPage.Items ?? [];
+
+  for (const item of items) {
+    const customerId = item["customerId"]?.S ?? "";
+    const segments = segmentsByCustomer.get(customerId) ?? [];
+
+    segmentsByCustomer.set(customerId, [...segments, segment]);
+  }
 }
 
 // The segments together are the whole table, with nothing read twice.
-console.log(read.length); // 8
+console.log(segmentsByCustomer.values().toArray().flat().length); // 8
+console.log(segmentsByCustomer.size); // 4
 
-// And each customer's orders arrived in one segment, both of them together.
-console.log(new Set(read).size); // 4
+// And each customer's two orders came back in one segment rather than split
+// between two.
+console.log(
+  segmentsByCustomer
+    .values()
+    .map((segments) => new Set(segments).size)
+    .toArray(),
+);
+// [ 1, 1, 1, 1 ]
 ```
 
 An item belongs to a segment by its partition key value, so every item of one item collection lands

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1092,6 +1092,188 @@ A token still works when the item it names has since been deleted: it says where
 than which position to return to. A token from a different partition key is refused, since it names
 a collection this query is not reading.
 
+## Scanning a table
+
+`Scan` reads every item in a table. It needs no key knowledge at all, which is what makes it the
+operation test setup and assertions reach for, and the wrong operation for most application access
+patterns: it reads the whole table however few items the caller wanted.
+
+```typescript sim-dynamodb-scan
+/**
+ * Reading a whole table back, whatever partition keys it holds.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const written = [
+  { customerId: "c-1", orderId: "2026-03" },
+  { customerId: "c-1", orderId: "2026-01" },
+  { customerId: "c-1", orderId: "2026-02" },
+  { customerId: "c-2", orderId: "2026-04" },
+  { customerId: "c-3", orderId: "2026-05" },
+];
+
+for (const order of written) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: {
+        customerId: { S: order.customerId },
+        orderId: { S: order.orderId },
+      },
+    }),
+  );
+}
+
+const page = await dynamoDb.scan(new ScanCommand({ TableName: "OrdersTable" }));
+
+console.log(page.Count); // 5
+console.log(page.ScannedCount); // 5
+
+// The items under one partition key come back together, ascending by sort key.
+console.log(
+  page.Items?.filter((item) => item["customerId"]?.S === "c-1").map(
+    (item) => item["orderId"]?.S,
+  ),
+);
+// [ "2026-01", "2026-02", "2026-03" ]
+```
+
+The partition key values themselves come back in an arbitrary order. It is not the sorted order and
+not the order the items were written in. Real DynamoDB walks a table by the hash of the partition
+key, so a scan that came back globally sorted would be something no real table gives you, and a test
+leaning on one would pass here and fail against the service.
+
+The order is arbitrary rather than varying. Two scans of an unchanged table read it the same way,
+which is what lets a token resume one.
+
+`Limit`, `LastEvaluatedKey` and `ExclusiveStartKey` page a scan the way they page a query, and the
+loop is the same one. `ConsistentRead` is accepted and changes nothing, since every simulated read is
+already the strongly consistent one.
+
+### Scanning in parallel
+
+`Segment` and `TotalSegments` divide a table between workers. `TotalSegments` is how many shares the
+table is divided into, and `Segment` is the zero based number of the share this request reads.
+
+```typescript sim-dynamodb-parallel-scan
+/**
+ * Reading a table in four segments.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const customerId of ["c-1", "c-2", "c-3", "c-4"]) {
+  for (const orderId of ["2026-01", "2026-02"]) {
+    await dynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { customerId: { S: customerId }, orderId: { S: orderId } },
+      }),
+    );
+  }
+}
+
+const totalSegments = 4;
+const read: string[] = [];
+
+for (let segment = 0; segment < totalSegments; segment++) {
+  const segmentPage = await dynamoDb.scan(
+    new ScanCommand({
+      TableName: "OrdersTable",
+      Segment: segment,
+      TotalSegments: totalSegments,
+    }),
+  );
+
+  read.push(
+    ...(segmentPage.Items ?? []).map((item) => item["customerId"]?.S ?? ""),
+  );
+}
+
+// The segments together are the whole table, with nothing read twice.
+console.log(read.length); // 8
+
+// And each customer's orders arrived in one segment, both of them together.
+console.log(new Set(read).size); // 4
+```
+
+An item belongs to a segment by its partition key value, so every item of one item collection lands
+in the same segment. That is what makes a segment a share of the table's partition keys rather than
+a share of its items, and it is why segments come out uneven. A segment holding nothing is ordinary,
+and dividing a table into more segments than it has partition key values leaves most of them empty.
+
+There is nothing to gain in speed here, since a simulated scan walks a map in memory. What a parallel
+scan gives a test is the caller's side of one: code that divides a table between workers can be run
+without a real table.
+
+Each segment pages on its own. `Limit` and `LastEvaluatedKey` work per segment, and the next request
+passes that segment's token back with the same `Segment` and `TotalSegments`. A token from another
+segment is refused, since it names a place that segment's walk never reaches.
+
+These are the rules a request is held to, each a `ValidationException`:
+
+- `Segment` without `TotalSegments`, or `TotalSegments` without `Segment`. They are supplied together
+  or not at all, and a request naming neither reads the whole table.
+- a `Segment` at or above `TotalSegments`, or below zero. It is zero based, so the last segment of
+  four is `3`.
+- a `TotalSegments` outside 1 to 1000000. A `TotalSegments` of 1 is a sequential scan.
+- an `ExclusiveStartKey` belonging to another segment.
+
+`Segment` and `TotalSegments` are refused on `Query`, which is not a parallel operation and never had
+them. A query reads one item collection, which sits under one partition key and so inside one
+segment.
+
 ## Reading and writing items in batches
 
 `BatchWriteItem` puts and deletes items across tables in one call, and `BatchGetItem` reads them by
@@ -2013,6 +2195,8 @@ nothing is written.
   all five `ReturnValues` modes. Every action reads the item as it stood before the update.
 - `Query`, reading one item collection in sort key order, with the seven sort key conditions,
   `ScanIndexForward`, and `Limit`, `LastEvaluatedKey` and `ExclusiveStartKey` paging.
+- `Scan`, reading every item in a table with the same paging, and `Segment` and `TotalSegments`
+  dividing a table between parallel workers.
 - `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
   `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
   `begins_with`, `contains` and `size` functions.
@@ -2040,12 +2224,12 @@ nothing is written.
 
 ## Limitations
 
-- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted. `Scan`
-  and PartiQL are operations this simulation does not have yet. `Query`, `TransactWriteCommand` and
-  `TransactGetCommand` are simulated as operations, so only the document form is missing: for the
-  transaction Commands that is simply not written yet, and for `Query` it is because
-  `@aws-sdk/lib-dynamodb` and `@aws-sdk/client-dynamodb` both name their Command `QueryCommand`,
-  which the interception routes by. All of them are refused by name rather than half converted.
+- The document client's `Query`, `Scan`, transaction and PartiQL Commands are not converted. PartiQL
+  is an operation this simulation does not have yet. The rest are simulated as operations, so only
+  the document form is missing: for the transaction Commands that is simply not written yet, and for
+  `Query` and `Scan` it is because `@aws-sdk/lib-dynamodb` and `@aws-sdk/client-dynamodb` both name
+  their Commands `QueryCommand` and `ScanCommand`, which the interception routes by. All of them are
+  refused by name rather than half converted.
 - A document client's translate config is not read, so the marshalling options it was built with do
   not apply. See [the SDK docs](../../sdk/README.md#limitations).
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
@@ -2107,27 +2291,37 @@ nothing is written.
 - Deletion happens as soon as the background work runs, where real DynamoDB may take a while over a
   large table. Nothing waits for a `DELETING` table to go, so a test that needs it gone calls
   `simAws.backgroundTasksComplete()`.
+- The segment a parallel scan puts an item in is not the segment real DynamoDB would put it in.
+  DynamoDB's partition key hash is unpublished, so a different one is used here. What matches is the
+  shape: whole item collections move together, and the segments come out uneven. A test asserting
+  which segment a given key lands in is asserting something about this simulator rather than about
+  DynamoDB.
 - A table ARN naming another Account or Region is refused rather than resolved to the local table of
   that name. Cross-account table access needs a resource policy, which is not simulated.
 - `UpdateTable` is not implemented, so a table never reaches `UPDATING` on its own. `DeleteTable`
   refuses that status anyway, for when it can.
 - Nothing enforces capacity. A provisioned table's throughput is stored and reported, and no request
   is ever throttled with `ProvisionedThroughputExceededException`.
-- `UpdateTable` and `Scan` are not implemented yet.
-- A query page is never cut short by size. Real DynamoDB stops a page at 1 MB and hands out a
-  `LastEvaluatedKey`, which is not modelled here, so a page breaks only on a `Limit`. A test reading
-  a large collection with no `Limit` gets all of it in one page where a real one would page.
-- Nothing here throttles or measures a query, so `ReturnConsumedCapacity` is refused unless it names
-  `NONE`, and a `Limit` is the only thing that ends a page early.
+- A query or scan page is never cut short by size. Real DynamoDB stops a page at 1 MB and hands out
+  a `LastEvaluatedKey`, which is not modelled here, so a page breaks only on a `Limit`. A test
+  reading a large collection or a large table with no `Limit` gets all of it in one page where a real
+  one would page.
+- Nothing here throttles or measures a query or a scan, so `ReturnConsumedCapacity` is refused unless
+  it names `NONE`, and a `Limit` is the only thing that ends a page early.
 - A key condition takes no brackets. `(customerId = :c) AND orderId > :o` is refused here, where real
   DynamoDB accepts it. The shape of a key condition is fixed, so there is nothing for brackets to
   group, and being stricter is the direction that fails safely: it is a puzzling refusal here rather
   than a query that means something different on AWS.
-- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused on `Query`, since
-  each of them changes which items a query answers with or which parts of them. `Select` naming
-  `ALL_ATTRIBUTES` is the default a table query already behaves as, so it is accepted.
+- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused on `Query` and on
+  `Scan`, since each of them changes which items the operation answers with or which parts of them.
+  `Select` naming `ALL_ATTRIBUTES` is the default a table read already behaves as, so it is accepted.
+  Scanning a secondary index goes with the indexes themselves, which are not simulated.
+- `ExpressionAttributeNames` and `ExpressionAttributeValues` on a `Scan` are refused as unsimulated
+  input, where real DynamoDB calls placeholders with no expression to use them a
+  `ValidationException`. Every expression a scan can carry is refused already, so the request fails
+  either way, and naming the parameter is more use than matching the error class.
 - `Count` and `ScannedCount` are always the same number. They differ only when a `FilterExpression`
-  drops items a query evaluated, and filters are not simulated.
+  drops items a query or scan evaluated, and filters are not simulated.
 - `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
   response stops at a size, so the branch of a batch retry loop that resends what did not go through
   is never taken against the simulator.
@@ -2155,7 +2349,7 @@ nothing is written.
 - CloudFormation stack updates and deletes are not simulated, so neither is table replacement or the
   `DeletionPolicy` a template sets on a table.
 - `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. On `Query`
-  it is refused rather than ignored, and `Scan` is not implemented yet.
+  and `Scan` it is refused rather than ignored.
 - The legacy `AttributesToGet` is refused rather than ignored, since an item that came back whole
   where part of it was asked for would hide an application reading an attribute it never requested.
   `ProjectionExpression` replaced it, and real DynamoDB has built nothing on it since.

--- a/docs/services/dynamodb/sim-dynamodb-parallel-scan.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-parallel-scan.example.ts
@@ -1,0 +1,64 @@
+/**
+ * Reading a table in four segments.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+for (const customerId of ["c-1", "c-2", "c-3", "c-4"]) {
+  for (const orderId of ["2026-01", "2026-02"]) {
+    await dynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { customerId: { S: customerId }, orderId: { S: orderId } },
+      }),
+    );
+  }
+}
+
+const totalSegments = 4;
+const read: string[] = [];
+
+for (let segment = 0; segment < totalSegments; segment++) {
+  const segmentPage = await dynamoDb.scan(
+    new ScanCommand({
+      TableName: "OrdersTable",
+      Segment: segment,
+      TotalSegments: totalSegments,
+    }),
+  );
+
+  read.push(
+    ...(segmentPage.Items ?? []).map((item) => item["customerId"]?.S ?? ""),
+  );
+}
+
+// The segments together are the whole table, with nothing read twice.
+console.log(read.length); // 8
+
+// And each customer's orders arrived in one segment, both of them together.
+console.log(new Set(read).size); // 4

--- a/docs/services/dynamodb/sim-dynamodb-parallel-scan.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-parallel-scan.example.ts
@@ -41,7 +41,9 @@ for (const customerId of ["c-1", "c-2", "c-3", "c-4"]) {
 }
 
 const totalSegments = 4;
-const read: string[] = [];
+
+// Which segment each of a customer's orders came back in.
+const segmentsByCustomer = new Map<string, number[]>();
 
 for (let segment = 0; segment < totalSegments; segment++) {
   const segmentPage = await dynamoDb.scan(
@@ -52,13 +54,26 @@ for (let segment = 0; segment < totalSegments; segment++) {
     }),
   );
 
-  read.push(
-    ...(segmentPage.Items ?? []).map((item) => item["customerId"]?.S ?? ""),
-  );
+  const items = segmentPage.Items ?? [];
+
+  for (const item of items) {
+    const customerId = item["customerId"]?.S ?? "";
+    const segments = segmentsByCustomer.get(customerId) ?? [];
+
+    segmentsByCustomer.set(customerId, [...segments, segment]);
+  }
 }
 
 // The segments together are the whole table, with nothing read twice.
-console.log(read.length); // 8
+console.log(segmentsByCustomer.values().toArray().flat().length); // 8
+console.log(segmentsByCustomer.size); // 4
 
-// And each customer's orders arrived in one segment, both of them together.
-console.log(new Set(read).size); // 4
+// And each customer's two orders came back in one segment rather than split
+// between two.
+console.log(
+  segmentsByCustomer
+    .values()
+    .map((segments) => new Set(segments).size)
+    .toArray(),
+);
+// [ 1, 1, 1, 1 ]

--- a/docs/services/dynamodb/sim-dynamodb-scan.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-scan.example.ts
@@ -1,0 +1,63 @@
+/**
+ * Reading a whole table back, whatever partition keys it holds.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const written = [
+  { customerId: "c-1", orderId: "2026-03" },
+  { customerId: "c-1", orderId: "2026-01" },
+  { customerId: "c-1", orderId: "2026-02" },
+  { customerId: "c-2", orderId: "2026-04" },
+  { customerId: "c-3", orderId: "2026-05" },
+];
+
+for (const order of written) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: {
+        customerId: { S: order.customerId },
+        orderId: { S: order.orderId },
+      },
+    }),
+  );
+}
+
+const page = await dynamoDb.scan(new ScanCommand({ TableName: "OrdersTable" }));
+
+console.log(page.Count); // 5
+console.log(page.ScannedCount); // 5
+
+// The items under one partition key come back together, ascending by sort key.
+console.log(
+  page.Items?.filter((item) => item["customerId"]?.S === "c-1").map(
+    (item) => item["orderId"]?.S,
+  ),
+);
+// [ "2026-01", "2026-02", "2026-03" ]

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -50,6 +50,7 @@ Current command areas include:
 - `table/` (CreateTable, DescribeTable, ListTables and DeleteTable)
 - `item/` (PutItem, GetItem, DeleteItem, UpdateItem, and the structural types for the item commands)
 - `query/` (Query)
+- `scan/` (Scan, including parallel scan segments)
 - `batch/` (BatchWriteItem and BatchGetItem)
 - `transact/` (TransactWriteItems and TransactGetItems)
 - `tag/` (TagResource, UntagResource and ListTagsOfResource)
@@ -412,7 +413,7 @@ The parts a query is made of split by what they know:
   order itself, and is where a table with no sort key stops mattering: such a table holds at most one
   item under a partition key, so every question about ordering has a trivial answer.
 - `SimDynamoDbItemPage` under `command/item/` is `Limit` and `LastEvaluatedKey`. It takes items and a
-  key schema rather than a query, so `Scan` can use it unchanged.
+  key schema rather than a query, which is what lets `Scan` use it unchanged.
 - `readSimDynamoDbQueryStartKey` reads the `ExclusiveStartKey`. It goes through the table's own key
   reading, so a token that is not a whole primary key is refused the way any Key is, and then checks
   that it names the collection being read.
@@ -433,6 +434,54 @@ Important behavior:
 - `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused by name, since each
   changes which items a query answers with or which parts of them. `Select: ALL_ATTRIBUTES` is the
   default a table query already behaves as, so it is let through.
+
+## Scan behavior
+
+`SimDynamoDbScan` reads a whole table rather than one item collection, so it needs no key condition
+and no key knowledge. It takes the same steps a query does, minus the expression:
+
+1. `refuseUnsimulatedScanInput` refuses the inputs this simulation does not model.
+2. `readSimDynamoDbScanSegment` reads `Segment` and `TotalSegments`, before the table is reached, so
+   a division DynamoDB would refuse is refused whether or not the table is there.
+3. The table is found and the caller authorized.
+4. The table is put in scan order, walked from the `ExclusiveStartKey`, and cut to a page by the same
+   `SimDynamoDbItemPage` a query uses.
+
+The parts a scan is made of sit under `table/`, since the order and the segments belong to the table
+rather than to the command reading it:
+
+- `SimDynamoDbTableScan` is every item the table holds, in the order a scan reads them. As with an
+  item collection the order is worked out when the table is read, because the item map carries none.
+- `SimDynamoDbScanPosition` is where one item sits in that order: by the hash of its partition key
+  first, then by sort key through `SimDynamoDbSortKeyOrder`. Partition keys that hash alike are
+  separated by their marshalled bytes, which is what makes the order total rather than merely
+  arbitrary. A position is worked out for the `ExclusiveStartKey` too, so a token names a place
+  rather than an item and still resumes a scan after the item it named has been deleted.
+- `SimDynamoDbScanSegment` is one share of a parallel scan, and holds a partition key when its hash
+  modulo `TotalSegments` is the segment's own number. It validates the division it was built from, so
+  a segment that exists is one a request could ask for.
+- `simDynamoDbPartitionKeyHash` is the hash both of those read. It is FNV-1a rather than DynamoDB's
+  own, which is unpublished, so the segment an item lands in here is not the segment it lands in on
+  AWS. What is reproduced is the shape: whole item collections move together and segments come out
+  uneven.
+
+Important behavior:
+
+- Partition key values come back in hash order, which is deliberately not the sorted order. Real
+  DynamoDB sorts nothing across partitions, so a scan that came back sorted would let a test lean on
+  an ordering the service does not give. It is stable within a process all the same, since an
+  `ExclusiveStartKey` could not resume a scan otherwise.
+- Items under one partition key come back together and ascending by sort key.
+- `Segment` and `TotalSegments` are supplied together or not at all, and neither is defaulted from
+  the other. A request naming neither reads `SimDynamoDbScanSegment.whole()`, which is one segment out
+  of one.
+- An `ExclusiveStartKey` from another segment is refused. Resuming the wrong segment is the mistake
+  parallel scan code makes, so it fails rather than reading that segment from the start.
+- `ConsistentRead` is accepted and changes nothing, since every simulated read is strongly
+  consistent.
+- `Segment` and `TotalSegments` are declared on the Query input as well, and refused there by
+  `refuseSimDynamoDbQuerySegment`. They are not Query parameters on AWS, and a query carrying one is
+  code that meant to scan.
 
 ## BatchWriteItem and BatchGetItem behavior
 
@@ -478,7 +527,7 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Scans, indexes and streams are not implemented. Billing mode and provisioned capacity are read and
+Indexes and streams are not implemented. Billing mode and provisioned capacity are read and
 stored by CreateTable, but nothing enforces them: no write is ever throttled.
 
 ## TransactWriteItems and TransactGetItems behavior
@@ -582,7 +631,7 @@ attribute named `size` is a different job from deciding whether an OR binds loos
 
 The comparison rules live in `item/sim-dynamodb-value-comparison.ts` and
 `item/sim-dynamodb-value-order.ts` rather than inside the evaluator, because a sort key condition
-compares the same way a condition expression does, and a filter expression will when `Scan` arrives.
+compares the same way a condition expression does, and a filter expression will when filters arrive.
 Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare through
 `SimDynamoDbNumber.compareTo` so digits past what a JavaScript number holds still order correctly,
 and binary compares as unsigned bytes. Two values of different types have no order at all, which is

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-segment.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-segment.ts
@@ -1,0 +1,24 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimQueryCommandInput } from "./query.command.js";
+
+/**
+ * Refuse the parallel scan inputs on a Query.
+ *
+ * `Segment` and `TotalSegments` divide a Scan. They are not Query parameters at
+ * all, and a query has nothing to divide: it reads one item collection, which
+ * sits under one partition key and so inside one segment. A request carrying
+ * one is code that meant to scan, so it is refused rather than ignored.
+ */
+export function refuseSimDynamoDbQuerySegment(
+  input: SimQueryCommandInput,
+): void {
+  if (input.Segment === undefined && input.TotalSegments === undefined) {
+    return;
+  }
+
+  throw new SimDynamoDbValidationException(
+    "Segment and TotalSegments divide a parallel Scan, and Query does not " +
+      "take them: a query reads one item collection, which sits under one " +
+      "partition key",
+  );
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-validation.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-validation.iso.test.ts
@@ -266,4 +266,34 @@ describe("DynamoDB QueryCommand key condition validation", () => {
     assertInstanceOf(error, SimDynamoDbValidationException);
     assertStringIncludes(error.message, ":spare");
   });
+
+  it.each([
+    { name: "Segment", input: { Segment: 0 } },
+    { name: "TotalSegments", input: { TotalSegments: 4 } },
+    { name: "both", input: { Segment: 0, TotalSegments: 4 } },
+  ])(
+    "refuses a Query dividing itself into segments, given $name",
+    async (example) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a query carries the parallel scan parameters.
+      const error = await assertThrowsErrorAsync(async () =>
+        simDynamoDb.query({
+          input: {
+            TableName: "OrdersTable",
+            KeyConditionExpression: "customerId = :customer",
+            ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+            ...example.input,
+          },
+        }),
+      );
+
+      // Then it is refused. Segment and TotalSegments divide a Scan, and a query
+      // reads one item collection, which sits inside one segment.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "Scan");
+    },
+  );
 });

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -6,6 +6,7 @@ import type {
   SimQueryCommand,
   SimQueryCommandOutput,
 } from "./query.command.js";
+import { refuseSimDynamoDbQuerySegment } from "./sim-dynamodb-query-segment.js";
 import { readSimDynamoDbQueryStartKey } from "./sim-dynamodb-query-start-key.js";
 import { refuseUnsimulatedQueryInput } from "./sim-dynamodb-unsimulated-query-input.js";
 
@@ -41,6 +42,7 @@ export class SimDynamoDbQuery {
     const input = command.input;
 
     refuseUnsimulatedQueryInput(input);
+    refuseSimDynamoDbQuerySegment(input);
 
     // The key condition is read before the table is reached, so an expression
     // DynamoDB would refuse is refused whether or not the table is there. What

--- a/src/service/dynamodb/command/scan/scan.command.ts
+++ b/src/service/dynamodb/command/scan/scan.command.ts
@@ -5,61 +5,53 @@ import type {
 } from "../item/item.types.js";
 
 /**
- * Minimal structural sim DynamoDB Query command.
+ * Minimal structural sim DynamoDB Scan command.
  */
-export interface SimQueryCommand {
-  readonly input: SimQueryCommandInput;
+export interface SimScanCommand {
+  readonly input: SimScanCommandInput;
 }
 
 /**
- * Minimal structural sim DynamoDB Query input.
+ * Minimal structural sim DynamoDB Scan input.
  *
  * The inputs this simulation does not model are declared as well as the ones it
  * does, so a request that asks for one of them is refused by name rather than
  * given a page that means something else.
  */
-export interface SimQueryCommandInput {
+export interface SimScanCommandInput {
   readonly TableName?: string | undefined;
-  readonly KeyConditionExpression?: string | undefined;
-  readonly ExpressionAttributeNames?:
-    Readonly<Record<string, string>> | undefined;
-  readonly ExpressionAttributeValues?:
-    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
-  readonly ScanIndexForward?: boolean | undefined;
   readonly Limit?: number | undefined;
   readonly ExclusiveStartKey?:
     Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
   readonly ConsistentRead?: boolean | undefined;
+  readonly Segment?: number | undefined;
+  readonly TotalSegments?: number | undefined;
   readonly IndexName?: string | undefined;
   readonly FilterExpression?: string | undefined;
   readonly ProjectionExpression?: string | undefined;
+  readonly ExpressionAttributeNames?:
+    Readonly<Record<string, string>> | undefined;
+  readonly ExpressionAttributeValues?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
   readonly Select?: string | undefined;
   readonly ReturnConsumedCapacity?: string | undefined;
   readonly AttributesToGet?: readonly string[] | undefined;
-  readonly KeyConditions?:
-    Readonly<Record<string, SimDynamoDbLegacyCondition>> | undefined;
-  readonly QueryFilter?:
+  readonly ScanFilter?:
     Readonly<Record<string, SimDynamoDbLegacyCondition>> | undefined;
   readonly ConditionalOperator?: string | undefined;
-
-  // Scan parameters, which a Query never had. They are declared so a request
-  // that meant to scan is refused by name rather than answered with one item
-  // collection.
-  readonly Segment?: number | undefined;
-  readonly TotalSegments?: number | undefined;
 }
 
 /**
- * Minimal structural sim DynamoDB Query output.
+ * Minimal structural sim DynamoDB Scan output.
  *
  * `Count` and `ScannedCount` are the same number here, since nothing filters a
- * query yet: every item the walk evaluated is an item it answers with.
+ * scan yet: every item the walk evaluated is an item it answers with.
  *
- * `LastEvaluatedKey` is absent only when the key range ran out inside the
- * `Limit`, so a caller loops until it is gone rather than until the page is
- * short.
+ * `LastEvaluatedKey` is absent only when the table, or the segment of it being
+ * read, ran out inside the `Limit`, so a caller loops until it is gone rather
+ * than until the page is short.
  */
-export interface SimQueryCommandOutput {
+export interface SimScanCommandOutput {
   readonly Items?:
     readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] | undefined;
   readonly Count?: number | undefined;

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-iam.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-iam.iso.test.ts
@@ -1,0 +1,167 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * One simulated Account and Region, with a table holding one item.
+ */
+interface ScanScope {
+  readonly accountId: string;
+  readonly region: string;
+  readonly simAws: SimAws;
+  readonly simDynamoDb: SimDynamoDb;
+}
+
+/**
+ * A scope with a table to scan.
+ */
+async function scanScope(): Promise<ScanScope> {
+  const accountId = makeSimAwsAccountId();
+  const region = makeAwsRegionName();
+  const simAws = new SimAws();
+  const simDynamoDb = simAws.account(accountId).region(region).dynamoDb();
+
+  await simDynamoDb.createTable({
+    input: {
+      TableName: "OrdersTable",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    },
+  });
+  await simAws.backgroundTasksComplete();
+
+  await simDynamoDb.putItem({
+    input: {
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-1" }, orderId: { S: "order-1" } },
+    },
+  });
+
+  return { accountId, region, simAws, simDynamoDb };
+}
+
+/**
+ * A Role that may assume itself from the Account root, and nothing else.
+ */
+async function roleArnFor(scope: ScanScope, roleName: string): Promise<string> {
+  const creation = await scope.simAws
+    .account(scope.accountId)
+    .iam()
+    .createRole(
+      new CreateRoleCommand({
+        RoleName: roleName,
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${scope.accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+  return creation.Role.Arn;
+}
+
+/**
+ * Allow one DynamoDB action on the table this scope holds.
+ */
+async function allow(
+  scope: ScanScope,
+  roleName: string,
+  action: string,
+): Promise<void> {
+  await scope.simAws
+    .account(scope.accountId)
+    .iam()
+    .putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: roleName,
+        PolicyName: `${action.replace(":", "")}Policy`,
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: action,
+            Resource: `arn:aws:dynamodb:${scope.region}:${scope.accountId}:table/OrdersTable`,
+          },
+        }),
+      }),
+    );
+}
+
+describe("DynamoDB ScanCommand IAM authorization", () => {
+  it("allows a Role its policy permits dynamodb:Scan", async () => {
+    // Given a Role allowed to scan the table.
+    const scope = await scanScope();
+    const roleArn = await roleArnFor(scope, "TableReader");
+    await allow(scope, "TableReader", "dynamodb:Scan");
+
+    // When the Role scans it.
+    const output = await scope.simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then IAM allows the request.
+    assertArrayLength(output.Items ?? [], 1);
+  });
+
+  it("implicitly denies a Role with no matching policy", async () => {
+    // Given a Role with no DynamoDB permissions.
+    const scope = await scanScope();
+    const roleArn = await roleArnFor(scope, "NoScanRole");
+
+    // When the Role attempts to scan the table.
+    const error = await assertThrowsErrorAsync(async () =>
+      scope.simDynamoDb.scan(new ScanCommand({ TableName: "OrdersTable" }), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then IAM denies the request, naming the action and the table ARN.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:Scan");
+    assertIdentical(
+      error.resource,
+      `arn:aws:dynamodb:${scope.region}:${scope.accountId}:table/OrdersTable`,
+    );
+  });
+
+  it("does not let permission to query read the whole table", async () => {
+    // Given a Role allowed only to read one item collection at a time.
+    const scope = await scanScope();
+    const roleArn = await roleArnFor(scope, "QueryOnlyRole");
+    await allow(scope, "QueryOnlyRole", "dynamodb:Query");
+
+    // When the Role attempts to scan.
+    const error = await assertThrowsErrorAsync(async () =>
+      scope.simDynamoDb.scan(new ScanCommand({ TableName: "OrdersTable" }), {
+        caller: { kind: "arn", arn: roleArn },
+      }),
+    );
+
+    // Then each DynamoDB operation is its own IAM action.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:Scan");
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-paging.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-paging.iso.test.ts
@@ -1,0 +1,228 @@
+import {
+  DeleteItemCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * A table keyed by customer and order, holding two orders for each of three
+ * customers.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  await Promise.all(
+    ["c-1", "c-2", "c-3"].flatMap((customerId) =>
+      ["2026-02", "2026-01"].map(async (orderId) =>
+        simDynamoDb.putItem(
+          new PutItemCommand({
+            TableName: "OrdersTable",
+            Item: { customerId: { S: customerId }, orderId: { S: orderId } },
+          }),
+        ),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * Each item of a page, as the pair of key values that names it.
+ */
+function keysOf(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? []).map(
+    (item) => `${item["customerId"]?.S ?? ""}/${item["orderId"]?.S ?? ""}`,
+  );
+}
+
+/**
+ * Read a whole table by looping until the token runs out.
+ */
+async function pagedScan(
+  simDynamoDb: SimDynamoDb,
+  limit: number,
+): Promise<readonly string[]> {
+  const read: string[] = [];
+  let exclusiveStartKey: Record<string, SimDynamoDbAttributeValue> | undefined;
+
+  do {
+    // eslint-disable-next-line no-await-in-loop -- a page at a time is the point.
+    const page = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        Limit: limit,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    read.push(...keysOf(page));
+    exclusiveStartKey = page.LastEvaluatedKey;
+  } while (exclusiveStartKey !== undefined);
+
+  return read;
+}
+
+describe("DynamoDB ScanCommand paging", () => {
+  it("stops a page at the Limit and says where to resume", async () => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan asks for two of them.
+    const page = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", Limit: 2 }),
+    );
+
+    // Then the page holds two items and hands out the primary key of the one
+    // the walk stopped on.
+    assertArrayLength(page.Items ?? [], 2);
+    assertIdentical(page.Count, 2);
+
+    const token = page.LastEvaluatedKey;
+    assertNonNullable(token);
+    assertArrayEquals(
+      Object.keys(token).toSorted((one, other) => one.localeCompare(other)),
+      ["customerId", "orderId"],
+    );
+  });
+
+  it("reads the whole table by looping until the token runs out", async () => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When it is read a page at a time, and read again in one go.
+    const paged = await pagedScan(simDynamoDb, 2);
+    const whole = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then the pages together are the scan, in the same order, with nothing
+    // read twice and nothing missed.
+    assertArrayEquals(paged, keysOf(whole));
+  });
+
+  it("hands out a token on the last item, then an empty page", async () => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan reaches its Limit on the last item of the table.
+    const page = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", Limit: 6 }),
+    );
+
+    const token = page.LastEvaluatedKey;
+    assertNonNullable(token);
+
+    const next = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", ExclusiveStartKey: token }),
+    );
+
+    // Then it still hands out a token, and the next page is empty with no
+    // token of its own. Real DynamoDB cannot know the table is exhausted
+    // without looking past the last item.
+    assertArrayLength(next.Items ?? [], 0);
+    assertUndefined(next.LastEvaluatedKey);
+  });
+
+  it("resumes after an item that has since been deleted", async () => {
+    // Given a table holding six items, and the token of a page of one.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    const first = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", Limit: 1 }),
+    );
+    const token = first.LastEvaluatedKey;
+    assertNonNullable(token);
+
+    // When the item the token names is deleted before the scan resumes.
+    await simDynamoDb.deleteItem(
+      new DeleteItemCommand({ TableName: "OrdersTable", Key: token }),
+    );
+
+    const next = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", ExclusiveStartKey: token }),
+    );
+
+    // Then the rest of the table still comes back. A token says where to
+    // resume rather than which item to return to.
+    assertArrayLength(next.Items ?? [], 5);
+  });
+
+  it("refuses an ExclusiveStartKey naming no attribute", async () => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan resumes from a token with nothing in it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({ TableName: "OrdersTable", ExclusiveStartKey: {} }),
+      ),
+    );
+
+    // Then it is refused, since it names no item to resume after.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("refuses an ExclusiveStartKey that is not a primary key", async () => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan resumes from a token naming an attribute the key schema does
+    // not have.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({
+          TableName: "OrdersTable",
+          ExclusiveStartKey: {
+            customerId: { S: "c-1" },
+            orderId: { S: "2026-01" },
+            status: { S: "shipped" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused the same way the Key of a GetItem would be.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it.each([0, -1, 1.5])("refuses a Limit of %s", async (limit) => {
+    // Given a table holding six items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan asks for a page size that is not a whole number of items.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({ TableName: "OrdersTable", Limit: limit }),
+      ),
+    );
+
+    // Then it is refused rather than read as no limit at all.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-parallel.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-parallel.iso.test.ts
@@ -1,0 +1,137 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertSetSize,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import {
+  simDynamoDbStockedCustomerIds,
+  simDynamoDbStockedTableFactory,
+} from "../../table/sim-dynamodb-stocked-table.factory.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * The customers the table these tests scan holds orders for.
+ */
+const customerIds = simDynamoDbStockedCustomerIds(20);
+
+/**
+ * A table holding two orders for each of twenty customers.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  await simDynamoDbStockedTableFactory.make(
+    { customerCount: customerIds.length },
+    simAws,
+  );
+
+  return simAws.dynamoDb();
+}
+
+/**
+ * Each item of a page, as the pair of key values that names it.
+ */
+function keysOf(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? []).map(
+    (item) => `${item["customerId"]?.S ?? ""}/${item["orderId"]?.S ?? ""}`,
+  );
+}
+
+/**
+ * Read every segment of a division, in segment order.
+ */
+async function everySegment(
+  simDynamoDb: SimDynamoDb,
+  totalSegments: number,
+): Promise<readonly (readonly string[])[]> {
+  const pages: (readonly string[])[] = [];
+
+  for (let segment = 0; segment < totalSegments; segment++) {
+    const command = new ScanCommand({
+      TableName: "OrdersTable",
+      Segment: segment,
+      TotalSegments: totalSegments,
+    });
+
+    // eslint-disable-next-line no-await-in-loop -- one segment at a time, as a worker reads it.
+    pages.push(keysOf(await simDynamoDb.scan(command)));
+  }
+
+  return pages;
+}
+
+describe("DynamoDB ScanCommand parallel segments", () => {
+  it("covers the whole table across the segments", async () => {
+    // Given a table holding forty items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When each of four segments is scanned.
+    const pages = await everySegment(simDynamoDb, 4);
+    const read = pages.flat();
+
+    // Then the segments together hold every item, and no item is in two of
+    // them.
+    assertArrayLength(read, customerIds.length * 2);
+    assertSetSize(new Set(read), customerIds.length * 2);
+  });
+
+  it("puts every item of one partition key in one segment", async () => {
+    // Given a table holding two orders for each customer.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When each of four segments is scanned.
+    const pages = await everySegment(simDynamoDb, 4);
+
+    // Then each customer's orders are in one of them, both together, since a
+    // segment is a share of the partition keys rather than of the items.
+    const holders = customerIds.map(
+      (customerId) =>
+        pages.filter((page) =>
+          page.some((key) => key.startsWith(`${customerId}/`)),
+        ).length,
+    );
+
+    assertArrayEquals(
+      holders,
+      customerIds.map(() => 1),
+    );
+  });
+
+  it("reads the whole table as one segment out of one", async () => {
+    // Given a table holding forty items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan divides it into one segment, which is what a sequential scan
+    // reads.
+    const [single] = await everySegment(simDynamoDb, 1);
+    const whole = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then it reads the same items in the same order as a scan naming no
+    // segment at all.
+    assertArrayEquals(single ?? [], keysOf(whole));
+  });
+
+  it("answers with an empty page for a segment holding nothing", async () => {
+    // Given a table holding one customer's orders.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDbStockedTableFactory.make({ customerCount: 1 }, simAws);
+
+    // When it is divided into more segments than it has partition keys.
+    const pages = await everySegment(simDynamoDb, 8);
+
+    // Then most segments hold nothing, which is ordinary rather than a
+    // failure.
+    assertArrayLength(
+      pages.filter((page) => page.length === 0),
+      7,
+    );
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-segment-input.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-segment-input.ts
@@ -1,0 +1,41 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbScanSegment } from "../../table/sim-dynamodb-scan-segment.js";
+import type { SimScanCommandInput } from "./scan.command.js";
+
+/**
+ * Read the segment of the table a scan request reads.
+ *
+ * `Segment` and `TotalSegments` are supplied together or not at all. One
+ * without the other is refused rather than defaulted, since either default
+ * would answer with items the request did not ask for: a missing
+ * `TotalSegments` cannot be guessed, and a missing `Segment` would read a share
+ * of the table the caller never named.
+ *
+ * A request naming neither reads the whole table, which is a scan of one
+ * segment out of one.
+ */
+export function readSimDynamoDbScanSegment(
+  input: SimScanCommandInput,
+): SimDynamoDbScanSegment {
+  const { Segment: index, TotalSegments: totalSegments } = input;
+
+  if (index === undefined && totalSegments === undefined) {
+    return SimDynamoDbScanSegment.whole();
+  }
+
+  if (totalSegments === undefined) {
+    throw new SimDynamoDbValidationException(
+      "The TotalSegments parameter is required but was not present in the " +
+        "request when Segment parameter is present",
+    );
+  }
+
+  if (index === undefined) {
+    throw new SimDynamoDbValidationException(
+      "The Segment parameter is required but was not present in the request " +
+        "when parameter TotalSegments is present",
+    );
+  }
+
+  return new SimDynamoDbScanSegment({ index, totalSegments });
+}

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-segment-paging.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-segment-paging.iso.test.ts
@@ -1,0 +1,120 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * A table holding two orders for each of twenty customers.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  await simDynamoDbStockedTableFactory.make({ customerCount: 20 }, simAws);
+
+  return simAws.dynamoDb();
+}
+
+/**
+ * Each item of a page, as the pair of key values that names it.
+ */
+function keysOf(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? []).map(
+    (item) => `${item["customerId"]?.S ?? ""}/${item["orderId"]?.S ?? ""}`,
+  );
+}
+
+/**
+ * Read one segment of a table, a page at a time.
+ */
+async function pagedSegment(
+  simDynamoDb: SimDynamoDb,
+  segment: number,
+  totalSegments: number,
+  limit: number,
+): Promise<readonly string[]> {
+  const read: string[] = [];
+  let exclusiveStartKey: Record<string, SimDynamoDbAttributeValue> | undefined;
+
+  do {
+    // eslint-disable-next-line no-await-in-loop -- a page at a time is the point.
+    const page = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        Segment: segment,
+        TotalSegments: totalSegments,
+        Limit: limit,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    read.push(...keysOf(page));
+    exclusiveStartKey = page.LastEvaluatedKey;
+  } while (exclusiveStartKey !== undefined);
+
+  return read;
+}
+
+describe("DynamoDB ScanCommand segment paging", () => {
+  it("resumes a page on the same segment", async () => {
+    // Given a table holding forty items.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When one segment is read a page at a time, and again in one go.
+    const paged = await pagedSegment(simDynamoDb, 1, 4, 3);
+    const whole = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        Segment: 1,
+        TotalSegments: 4,
+      }),
+    );
+
+    // Then the pages together are that segment, and nothing from another
+    // segment came back with them.
+    assertArrayEquals(paged, keysOf(whole));
+  });
+
+  it("refuses an ExclusiveStartKey from another segment", async () => {
+    // Given the token one segment of a division handed out.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    const page = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        Segment: 0,
+        TotalSegments: 4,
+        Limit: 1,
+      }),
+    );
+    const token = page.LastEvaluatedKey;
+    assertNonNullable(token);
+
+    // When another segment of the same division resumes from it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({
+          TableName: "OrdersTable",
+          Segment: 1,
+          TotalSegments: 4,
+          ExclusiveStartKey: token,
+        }),
+      ),
+    );
+
+    // Then it is refused, since the token names a place that segment's walk
+    // never reaches.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Segment 1 of 4");
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-start-key.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-start-key.ts
@@ -1,0 +1,62 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbScanSegment } from "../../table/sim-dynamodb-scan-segment.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableScan } from "../../table/sim-dynamodb-table-scan.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+
+interface SimDynamoDbScanStartKeyProperties {
+  readonly table: SimDynamoDbTable;
+  readonly scan: SimDynamoDbTableScan;
+  readonly segment: SimDynamoDbScanSegment;
+  readonly exclusiveStartKey:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+/**
+ * Read the key a scan resumes after, if the request carries one.
+ *
+ * The token a page hands out is the primary key of the item the walk stopped
+ * on, so it is read back as a Key: the same rules apply as to the Key of a
+ * GetItem, and an attribute that is not part of the primary key, a missing key
+ * element or a type mismatch are refused the same way.
+ *
+ * A parallel scan adds one rule. The token has to name an item of the segment
+ * being read, since a token from another segment names a place this walk never
+ * reaches. Resuming a page on the wrong segment is the mistake parallel scan
+ * code makes, so it is refused rather than quietly reading from the start.
+ */
+export function readSimDynamoDbScanStartKey(
+  properties: SimDynamoDbScanStartKeyProperties,
+): SimDynamoDbItem | undefined {
+  const { table, scan, segment } = properties;
+  const attributeValues = properties.exclusiveStartKey;
+
+  if (attributeValues === undefined) {
+    return undefined;
+  }
+
+  if (Object.keys(attributeValues).length === 0) {
+    throw new SimDynamoDbValidationException(
+      "An ExclusiveStartKey names the item to resume after, and this one " +
+        "names no attribute at all",
+    );
+  }
+
+  const startKey = SimDynamoDbItem.fromAttributeValues(attributeValues);
+
+  // Reading the key through the table checks it against the key schema, which
+  // is what makes a token DynamoDB would refuse refused here too.
+  table.keyOfKey(startKey);
+
+  if (!scan.positionOf(startKey).inSegment(segment)) {
+    throw new SimDynamoDbValidationException(
+      `The ExclusiveStartKey names an item of another segment than Segment ` +
+        `${segment.index.toString()} of ` +
+        `${segment.totalSegments.toString()}. A parallel scan resumes each ` +
+        `segment with the token that segment handed out.`,
+    );
+  }
+
+  return startKey;
+}

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-validation.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-validation.iso.test.ts
@@ -1,0 +1,158 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+
+/**
+ * A table keyed by customer and order, holding nothing.
+ *
+ * These divisions are refused before the table is read, so there is nothing to
+ * write.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  return simDynamoDb;
+}
+
+describe("DynamoDB ScanCommand segment validation", () => {
+  it("refuses a Segment with no TotalSegments", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan names the segment to read but not the division it belongs
+    // to.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({ TableName: "OrdersTable", Segment: 0 }),
+      ),
+    );
+
+    // Then it is refused, since the share of the table it asks for cannot be
+    // worked out.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "TotalSegments");
+  });
+
+  it("refuses a TotalSegments with no Segment", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan names the division but not which segment of it to read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({ TableName: "OrdersTable", TotalSegments: 4 }),
+      ),
+    );
+
+    // Then it is refused rather than defaulted to a segment the caller never
+    // named.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Segment");
+  });
+
+  it.each([4, 5, -1])(
+    "refuses a Segment of %s out of four",
+    async (segment) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a scan names a segment the division does not have.
+      const error = await assertThrowsErrorAsync(async () =>
+        simDynamoDb.scan(
+          new ScanCommand({
+            TableName: "OrdersTable",
+            Segment: segment,
+            TotalSegments: 4,
+          }),
+        ),
+      );
+
+      // Then it is refused, since Segment is zero based and below
+      // TotalSegments.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "Segment");
+    },
+  );
+
+  it.each([0, 1_000_001])(
+    "refuses a TotalSegments of %s",
+    async (totalSegments) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a scan divides the table into a number of segments outside the
+      // range AWS takes.
+      const error = await assertThrowsErrorAsync(async () =>
+        simDynamoDb.scan(
+          new ScanCommand({
+            TableName: "OrdersTable",
+            Segment: 0,
+            TotalSegments: totalSegments,
+          }),
+        ),
+      );
+
+      // Then it is refused.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "TotalSegments");
+    },
+  );
+
+  it("refuses a division before it reads the table", async () => {
+    // Given a simulated DynamoDB holding no such table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    // When a scan of a table that is not there names a segment that is not
+    // there either.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({
+          TableName: "MissingTable",
+          Segment: 9,
+          TotalSegments: 4,
+        }),
+      ),
+    );
+
+    // Then the division is what it is refused for. A request DynamoDB would
+    // not take is refused whether or not the table is there.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it.each([1, 1_000_000])(
+    "takes a TotalSegments of %s",
+    async (totalSegments) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a scan divides it at either end of the range.
+      const output = await simDynamoDb.scan(
+        new ScanCommand({
+          TableName: "OrdersTable",
+          Segment: 0,
+          TotalSegments: totalSegments,
+        }),
+      );
+
+      // Then it is read, and holds nothing since the table does.
+      assertArrayLength(output.Items ?? [], 0);
+    },
+  );
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.iso.test.ts
@@ -1,0 +1,217 @@
+import { PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbResourceNotFoundException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * The customers a scan of the table below walks, and the orders each of them
+ * holds.
+ */
+const orders: Readonly<Record<string, readonly string[]>> = {
+  "c-1": ["2026-03", "2026-01", "2026-02"],
+  "c-2": ["2026-01"],
+  "c-3": ["2027-01", "2026-12"],
+  "c-4": ["2026-05"],
+  "c-5": ["2026-07", "2026-06"],
+};
+
+/**
+ * A table keyed by customer and order, holding several item collections.
+ *
+ * The orders are written out of sort key order, so the order a scan answers in
+ * is the table's rather than the order they arrived in.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  await Promise.all(
+    Object.entries(orders).flatMap(([customerId, orderIds]) =>
+      orderIds.map(async (orderId) =>
+        simDynamoDb.putItem(
+          new PutItemCommand({
+            TableName: "OrdersTable",
+            Item: { customerId: { S: customerId }, orderId: { S: orderId } },
+          }),
+        ),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The partition keys a page came back with, in the order they came back in.
+ */
+function customerIds(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["customerId"]?.S ?? "");
+}
+
+/**
+ * The orders one customer came back with, in the order they came back in.
+ */
+function orderIdsOf(
+  output: SimScanCommandOutput,
+  customerId: string,
+): readonly string[] {
+  return (output.Items ?? [])
+    .filter((item) => item["customerId"]?.S === customerId)
+    .map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB ScanCommand", () => {
+  it("answers with every item the table holds", async () => {
+    // Given a table holding several customers' orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then every item comes back, whatever partition key it sits under, and
+    // nothing is left to resume from.
+    assertArrayLength(output.Items ?? [], 9);
+    assertIdentical(output.Count, 9);
+    assertIdentical(output.ScannedCount, 9);
+    assertUndefined(output.LastEvaluatedKey);
+  });
+
+  it("answers with an empty page for a table holding nothing", async () => {
+    // Given a table with no items written to it.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+    // When the table is scanned.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then the page is empty rather than missing, and there is nothing to
+    // resume from.
+    assertArrayLength(output.Items ?? [], 0);
+    assertIdentical(output.Count, 0);
+    assertUndefined(output.LastEvaluatedKey);
+  });
+
+  it("answers with one partition key's items in sort key order", async () => {
+    // Given a table holding one customer's orders, written out of order.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then the items under one partition key are ascending by sort key, as
+    // DynamoDB keeps them.
+    assertArrayEquals(orderIdsOf(output, "c-1"), [
+      "2026-01",
+      "2026-02",
+      "2026-03",
+    ]);
+    assertArrayEquals(orderIdsOf(output, "c-3"), ["2026-12", "2027-01"]);
+  });
+
+  it("keeps each partition key's items together", async () => {
+    // Given a table holding several customers' orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then a partition key value appears in one run rather than scattered
+    // through the page, since a scan walks whole item collections.
+    const runs = customerIds(output).filter(
+      (customerId, index, all) => customerId !== all[index - 1],
+    );
+
+    assertArrayLength(runs, Object.keys(orders).length);
+  });
+
+  it("does not sort the partition keys it answers with", async () => {
+    // Given a table holding several customers' orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then the partition keys come back in an arbitrary order rather than a
+    // sorted one. A test that leaned on a global sort here would pass and then
+    // fail against the real service, which sorts nothing across partitions.
+    const answered = customerIds(output);
+    const sorted = answered.toSorted((one, other) => one.localeCompare(other));
+
+    assertFalse(answered.join(",") === sorted.join(","));
+  });
+
+  it("walks the table the same way every time", async () => {
+    // Given a table holding several customers' orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the same table is scanned twice.
+    const first = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+    const second = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then both scans read it in the same order. The order is arbitrary, not
+    // varying: an ExclusiveStartKey could not resume a scan otherwise.
+    assertArrayEquals(customerIds(second), customerIds(first));
+  });
+
+  it("takes a ConsistentRead, which it already is", async () => {
+    // Given a table holding several customers' orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan asks for a strongly consistent read.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", ConsistentRead: true }),
+    );
+
+    // Then it reads the same items. Every write has landed by the time the call
+    // that made it returned, so a simulated read is always the consistent one.
+    assertArrayLength(output.Items ?? [], 9);
+  });
+
+  it("refuses a scan of a table that is not there", async () => {
+    // Given a simulated DynamoDB holding no such table.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+
+    // When a table that was never created is scanned.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(new ScanCommand({ TableName: "MissingTable" })),
+    );
+
+    // Then it is refused rather than answered with an empty page.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -1,0 +1,82 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
+import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type { SimScanCommand, SimScanCommandOutput } from "./scan.command.js";
+import { readSimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment-input.js";
+import { readSimDynamoDbScanStartKey } from "./sim-dynamodb-scan-start-key.js";
+import { refuseUnsimulatedScanInput } from "./sim-dynamodb-unsimulated-scan-input.js";
+
+interface SimDynamoDbScanProperties {
+  readonly access: SimDynamoDbTableAccess;
+}
+
+interface SimDynamoDbScanOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The Scan command.
+ *
+ * A scan reads the whole table rather than one item collection, so it needs no
+ * key knowledge at all. That is what makes it the operation test setup and
+ * assertions reach for, and the wrong operation for most application access
+ * patterns.
+ *
+ * `ConsistentRead` is accepted and changes nothing. Every write here has landed
+ * before the call that made it returned, so a simulated scan is always the
+ * strongly consistent read.
+ */
+export class SimDynamoDbScan {
+  private readonly access: SimDynamoDbTableAccess;
+
+  constructor(properties: SimDynamoDbScanProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Read a page of the table, or of one segment of it.
+   */
+  handle(
+    command: SimScanCommand,
+    options?: SimDynamoDbScanOptions,
+  ): SimScanCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedScanInput(input);
+
+    // The segment is read before the table is reached, so a division DynamoDB
+    // would refuse is refused whether or not the table is there.
+    const segment = readSimDynamoDbScanSegment(input);
+    const table = this.access.required(
+      "dynamodb:Scan",
+      input.TableName,
+      options?.caller,
+    );
+    const scan = table.scan();
+
+    // The token names a place in this table's scan order, so it can only be
+    // checked once that order is known.
+    const after = readSimDynamoDbScanStartKey({
+      table,
+      scan,
+      segment,
+      exclusiveStartKey: input.ExclusiveStartKey,
+    });
+
+    const page = new SimDynamoDbItemPage({
+      items: scan.walk({ segment, after }),
+      limit: input.Limit,
+      keySchema: table.keySchema,
+    });
+
+    return {
+      Items: page.items.map((item) => item.toAttributeValues()),
+      // Nothing filters a scan yet, so every item the walk evaluated is an item
+      // the page carries.
+      Count: page.items.length,
+      ScannedCount: page.items.length,
+      LastEvaluatedKey: page.lastEvaluatedKey,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
@@ -1,0 +1,113 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbUnsupportedOperation } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+
+/**
+ * A table keyed by customer and order, holding nothing.
+ *
+ * These inputs are refused before the table is read, so there is nothing to
+ * write.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  return simDynamoDb;
+}
+
+describe("DynamoDB ScanCommand unsimulated input", () => {
+  it.each([
+    { name: "IndexName", input: { IndexName: "ByStatus" } },
+    { name: "FilterExpression", input: { FilterExpression: "status = :s" } },
+    {
+      name: "ProjectionExpression",
+      input: { ProjectionExpression: "orderId" },
+    },
+    { name: "Select", input: { Select: "COUNT" } },
+    { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
+    {
+      name: "ScanFilter",
+      input: {
+        ScanFilter: {
+          status: {
+            ComparisonOperator: "EQ",
+            AttributeValueList: [{ S: "shipped" }],
+          },
+        },
+      },
+    },
+    { name: "ConditionalOperator", input: { ConditionalOperator: "AND" } },
+    {
+      name: "ExpressionAttributeNames",
+      input: { ExpressionAttributeNames: { "#status": "status" } },
+    },
+    {
+      name: "ExpressionAttributeValues",
+      input: { ExpressionAttributeValues: { ":s": { S: "shipped" } } },
+    },
+    {
+      name: "ReturnConsumedCapacity",
+      input: { ReturnConsumedCapacity: "TOTAL" },
+    },
+  ])("refuses $name by name", async (example) => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan asks for something this simulation does not model.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan({
+        input: { TableName: "OrdersTable", ...example.input },
+      }),
+    );
+
+    // Then it is refused by name rather than answered with a page that means
+    // something else.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, example.name);
+  });
+
+  it.each(["ALL_ATTRIBUTES", undefined])(
+    "takes a Select of %s, which asks for what it already does",
+    async (select) => {
+      // Given a table.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a scan names the Select a table scan already behaves as.
+      const output = await simDynamoDb.scan({
+        input: { TableName: "OrdersTable", Select: select },
+      });
+
+      // Then it is let through, since whole items are what it answers with.
+      assertArrayLength(output.Items ?? [], 0);
+    },
+  );
+
+  it("takes a ReturnConsumedCapacity of NONE", async () => {
+    // Given a table.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan asks for the capacity reporting it already does.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        ReturnConsumedCapacity: "NONE",
+      }),
+    );
+
+    // Then it is let through.
+    assertArrayLength(output.Items ?? [], 0);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
@@ -1,0 +1,81 @@
+import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-input.js";
+import type { SimScanCommandInput } from "./scan.command.js";
+
+/**
+ * The `Select` a scan already behaves as, which asks for whole items.
+ *
+ * Real DynamoDB defaults to this for a scan of a table rather than an index, so
+ * a request naming it asks for what this simulation already does.
+ */
+const simulatedSelect = "ALL_ATTRIBUTES";
+
+/**
+ * Refuse the Scan inputs this simulation does not model.
+ *
+ * Each of these changes which items a scan answers with, or which parts of
+ * them, so a scan that quietly ignored one would answer with more than the
+ * request asked for. That is the failure that passes here and surprises an
+ * application reading the page.
+ *
+ * `ExpressionAttributeNames` and `ExpressionAttributeValues` are the
+ * placeholders of an expression, and every expression a scan can carry is
+ * refused above, so a request naming them is asking for one of those. Real
+ * DynamoDB calls that a ValidationException rather than an unsupported
+ * operation. The refusal is the same either way, and naming what is missing is
+ * more use than matching the error class.
+ */
+export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
+  const unsimulated = new SimDynamoDbUnsimulatedInput("Scan");
+
+  unsimulated.refuse(
+    input.IndexName !== undefined,
+    "IndexName",
+    "reading the table where a secondary index was asked for",
+  );
+  unsimulated.refuse(
+    input.FilterExpression !== undefined,
+    "FilterExpression",
+    "answering with the items a filter would have dropped",
+  );
+  unsimulated.refuse(
+    input.ProjectionExpression !== undefined,
+    "ProjectionExpression",
+    "answering with whole items where part of them was asked for",
+  );
+  unsimulated.refuse(
+    input.Select !== undefined && input.Select !== simulatedSelect,
+    "Select",
+    `counting or projecting rather than answering with whole items, which is ` +
+      `what ${simulatedSelect} asks for`,
+  );
+  unsimulated.refuse(
+    (input.AttributesToGet ?? []).length > 0,
+    "AttributesToGet",
+    "answering with whole items where part of them was asked for",
+  );
+  unsimulated.refuseNamed(
+    input.ScanFilter,
+    "ScanFilter",
+    "answering with the items a legacy filter would have dropped",
+  );
+  unsimulated.refuse(
+    input.ConditionalOperator !== undefined,
+    "ConditionalOperator",
+    "joining the legacy conditions it applies to",
+  );
+  unsimulated.refuseNamed(
+    input.ExpressionAttributeNames,
+    "ExpressionAttributeNames",
+    "reading placeholders for an expression Scan does not take",
+  );
+  unsimulated.refuseNamed(
+    input.ExpressionAttributeValues,
+    "ExpressionAttributeValues",
+    "reading placeholders for an expression Scan does not take",
+  );
+  unsimulated.refuseReporting(
+    input.ReturnConsumedCapacity,
+    "ReturnConsumedCapacity",
+    "reporting a capacity cost nothing here measures",
+  );
+}

--- a/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
@@ -10,6 +10,7 @@ import { SimDynamoDbGetItem } from "./item/sim-dynamodb-get-item.js";
 import { SimDynamoDbPutItem } from "./item/sim-dynamodb-put-item.js";
 import { SimDynamoDbUpdateItem } from "./item/sim-dynamodb-update-item.js";
 import { SimDynamoDbQuery } from "./query/sim-dynamodb-query.js";
+import { SimDynamoDbScan } from "./scan/sim-dynamodb-scan.js";
 import { SimDynamoDbTagCommands } from "./tag/sim-dynamodb-tag-commands.js";
 import { SimDynamoDbTimeToLiveCommands } from "./time-to-live/sim-dynamodb-time-to-live-commands.js";
 import { SimDynamoDbCreateTable } from "./table/sim-dynamodb-create-table.js";
@@ -42,6 +43,7 @@ export class SimDynamoDbCommandHandlers {
   public readonly itemDeletions: SimDynamoDbDeleteItem;
   public readonly itemUpdates: SimDynamoDbUpdateItem;
   public readonly itemQueries: SimDynamoDbQuery;
+  public readonly itemScans: SimDynamoDbScan;
   public readonly itemBatchWrites: SimDynamoDbBatchWriteItem;
   public readonly itemBatchReads: SimDynamoDbBatchGetItem;
   public readonly itemTransactWrites: SimDynamoDbTransactWriteItems;
@@ -74,6 +76,7 @@ export class SimDynamoDbCommandHandlers {
     this.itemDeletions = new SimDynamoDbDeleteItem({ access });
     this.itemUpdates = new SimDynamoDbUpdateItem({ access });
     this.itemQueries = new SimDynamoDbQuery({ access });
+    this.itemScans = new SimDynamoDbScan({ access });
     this.itemBatchWrites = new SimDynamoDbBatchWriteItem({ access });
     this.itemBatchReads = new SimDynamoDbBatchGetItem({ access });
     this.itemTransactWrites = new SimDynamoDbTransactWriteItems({

--- a/src/service/dynamodb/command/sim-dynamodb-command.types.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command.types.ts
@@ -35,6 +35,11 @@ export type {
   SimQueryCommandOutput,
 } from "./query/query.command.js";
 export type {
+  SimScanCommand,
+  SimScanCommandInput,
+  SimScanCommandOutput,
+} from "./scan/scan.command.js";
+export type {
   SimBatchGetItemCommand,
   SimBatchGetItemCommandInput,
   SimBatchGetItemCommandOutput,

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.iso.test.ts
@@ -12,7 +12,7 @@ import {
   ListTablesCommand,
   PutItemCommand,
   ListTagsOfResourceCommand,
-  ScanCommand,
+  ExecuteStatementCommand,
   TagResourceCommand,
   TransactGetItemsCommand,
   TransactWriteItemsCommand,
@@ -355,10 +355,14 @@ describe("simulated DynamoDB SDK Command routing", () => {
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(new ScanCommand({ TableName: "InterceptTable" }));
+      await client.send(
+        new ExecuteStatementCommand({
+          Statement: `SELECT * FROM "InterceptTable"`,
+        }),
+      );
     });
 
-    assertStringIncludes(error.message, "ScanCommand");
+    assertStringIncludes(error.message, "ExecuteStatementCommand");
     assertStringIncludes(error.message, "PutItemCommand");
   });
 });

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-command-router.ts
@@ -16,6 +16,7 @@ import type {
   SimUpdateItemCommand,
 } from "../command/item/item.command.js";
 import type { SimQueryCommand } from "../command/query/query.command.js";
+import type { SimScanCommand } from "../command/scan/scan.command.js";
 import type {
   SimBatchGetItemCommand,
   SimBatchWriteItemCommand,
@@ -118,6 +119,19 @@ export class SimDynamoDatabaseSdkCommandRouter implements SimSdkCommandRouter {
 
           return await simDynamoDatabase.query(
             command as SimQueryCommand,
+            simSdkCallerOptions(context),
+          );
+        },
+      ],
+      [
+        "ScanCommand",
+        async (command, context): Promise<unknown> => {
+          // The document client names its Scan the same as this one, so the
+          // Command name alone cannot tell them apart.
+          refuseSimDynamoDbDocumentCommand(command, "ScanCommand");
+
+          return await simDynamoDatabase.scan(
+            command as SimScanCommand,
             simSdkCallerOptions(context),
           );
         },

--- a/src/service/dynamodb/sdk/sim-dynamodb-sdk-scan-routing.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-sdk-scan-routing.iso.test.ts
@@ -1,0 +1,97 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand as DocumentScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbUnsupportedOperation } from "../error/dynamodb.error.js";
+
+/**
+ * An intercepted client with two items written to a table.
+ */
+async function tableClient(simSdk: SimSdk): Promise<DynamoDBClient> {
+  const client = new DynamoDBClient({ region: "eu-west-2" });
+  simSdk.intercept(client);
+
+  await client.send(
+    new CreateTableCommand({
+      TableName: "CollectionTable",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  await Promise.all(
+    ["order-1", "order-2"].map(async (orderId) =>
+      client.send(
+        new PutItemCommand({
+          TableName: "CollectionTable",
+          Item: { customerId: { S: "c-1" }, orderId: { S: orderId } },
+        }),
+      ),
+    ),
+  );
+
+  return client;
+}
+
+describe("simulated DynamoDB Scan SDK Command routing", () => {
+  it("round-trips a Scan through an intercepted client", async () => {
+    // Given an intercepted client with items written to a table.
+    using simSdk = new SimSdk();
+    const client = await tableClient(simSdk);
+
+    // When the table is scanned through the client.
+    const output = await client.send(
+      new ScanCommand({ TableName: "CollectionTable" }),
+    );
+
+    // Then the page comes back the way the SDK's own types expect it.
+    assertArrayLength(output.Items ?? [], 2);
+    assertIdentical(output.Count, 2);
+    assertIdentical(output.ScannedCount, 2);
+  });
+
+  it("refuses the document client's Scan, which shares its name", async () => {
+    // Given an intercepted document client. It is the document client that is
+    // intercepted, since it has a send of its own.
+    using simSdk = new SimSdk();
+    const client = await tableClient(simSdk);
+    const documentClient = DynamoDBDocumentClient.from(client);
+    simSdk.intercept(documentClient);
+
+    // When a document Scan is sent through it.
+    const error = await assertThrowsErrorAsync(async () =>
+      documentClient.send(
+        new DocumentScanCommand({ TableName: "CollectionTable" }),
+      ),
+    );
+
+    // Then it is refused by name rather than read as though it carried
+    // AttributeValues, since @aws-sdk/lib-dynamodb names its Command the same
+    // as @aws-sdk/client-dynamodb does.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "ScanCommand");
+  });
+});

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -156,6 +156,17 @@ export class SimDynamoDb {
   }
 
   /**
+   * Handle a Scan Command from the SDK.
+   */
+  async scan(
+    command: simDynamoDbCommands.SimScanCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simDynamoDbCommands.SimScanCommandOutput> {
+    await this.background.sequence();
+    return this.commands.itemScans.handle(command, options);
+  }
+
+  /**
    * Handle a Batch Write Item Command from the SDK.
    */
   async batchWriteItem(

--- a/src/service/dynamodb/table/sim-dynamodb-item-key.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-item-key.ts
@@ -115,6 +115,16 @@ export class SimDynamoDbItemKey {
   }
 
   /**
+   * The marshalled partition key of an item, on its own.
+   *
+   * A Scan orders a table by this and a parallel Scan divides one by it, since
+   * the items sharing a partition key are the items DynamoDB keeps together.
+   */
+  partitionOf(item: SimDynamoDbItem): string {
+    return this.keyValue(item, this.keySchema.hashKeyAttributeName);
+  }
+
+  /**
    * Read one key attribute of an item, checking it against the key schema.
    */
   private keyValue(item: SimDynamoDbItem, attributeName: string): string {

--- a/src/service/dynamodb/table/sim-dynamodb-partition-key-hash.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-partition-key-hash.ts
@@ -1,0 +1,28 @@
+/**
+ * The offset basis and prime of 32 bit FNV-1a.
+ */
+const offsetBasis = 2_166_136_261;
+const prime = 16_777_619;
+
+/**
+ * The hash of a marshalled partition key value.
+ *
+ * Two things read this. A scan walks partition key values in hash order, which
+ * is an order that is stable within a process and is not the sorted one. A
+ * parallel scan puts a partition key value in a segment by the same hash, so
+ * every item sharing a partition key lands in the same segment.
+ *
+ * Real DynamoDB hashes the partition key to decide which physical partition an
+ * item lives on, and both of those follow from that. The hash itself is not
+ * DynamoDB's, which is unpublished, so the segment an item lands in here is not
+ * the segment it lands in on AWS. What matches is the shape: whole item
+ * collections move together, and segments come out uneven.
+ */
+export function simDynamoDbPartitionKeyHash(partitionKey: string): number {
+  return (
+    Buffer.from(partitionKey, "utf8").reduce(
+      (hash, byte) => Math.imul(hash ^ byte, prime),
+      offsetBasis,
+    ) >>> 0
+  );
+}

--- a/src/service/dynamodb/table/sim-dynamodb-scan-position.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-scan-position.ts
@@ -1,0 +1,77 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { compareSimDynamoDbBytes } from "../item/sim-dynamodb-value-order.js";
+import { simDynamoDbPartitionKeyHash } from "./sim-dynamodb-partition-key-hash.js";
+import type { SimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment.js";
+import type { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+
+interface SimDynamoDbScanPositionProperties {
+  readonly item: SimDynamoDbItem;
+  readonly partitionKey: string;
+  readonly sortKeyOrder: SimDynamoDbSortKeyOrder;
+}
+
+/**
+ * Where one item sits in the order a scan walks a table in.
+ *
+ * The order is by the hash of the partition key first, then by sort key inside
+ * one partition key value. That gives two things a scan needs. Items under one
+ * partition key come back together and ascending, as they do on AWS. Partition
+ * key values come back in an order that is not the sorted one, so a test cannot
+ * quietly come to depend on a global ordering that real DynamoDB does not give.
+ *
+ * The order has to be a total order all the same, otherwise an
+ * `ExclusiveStartKey` could not say where to resume from. Partition key values
+ * that hash alike are ordered by their marshalled bytes to settle that.
+ *
+ * A position is also worked out for the Key a request resumes after, which is
+ * why it is built from a key and a sort key order rather than read off a stored
+ * item: the item the token names may since have been deleted.
+ */
+export class SimDynamoDbScanPosition {
+  public readonly item: SimDynamoDbItem;
+
+  private readonly partitionKey: string;
+  private readonly hash: number;
+  private readonly sortKeyOrder: SimDynamoDbSortKeyOrder;
+
+  constructor(properties: SimDynamoDbScanPositionProperties) {
+    this.item = properties.item;
+    this.partitionKey = properties.partitionKey;
+    this.hash = simDynamoDbPartitionKeyHash(properties.partitionKey);
+    this.sortKeyOrder = properties.sortKeyOrder;
+  }
+
+  /**
+   * Whether a parallel scan segment holds this item.
+   */
+  inSegment(segment: SimDynamoDbScanSegment): boolean {
+    return segment.holds(this.partitionKey);
+  }
+
+  /**
+   * Order this position against another position in the same table.
+   */
+  compareTo(other: SimDynamoDbScanPosition): number {
+    const partitions = this.comparePartitions(other);
+
+    if (partitions !== 0) {
+      return partitions;
+    }
+
+    return this.sortKeyOrder.compareItems(this.item, other.item);
+  }
+
+  /**
+   * Order two partition key values, by their hash and then by their bytes.
+   */
+  private comparePartitions(other: SimDynamoDbScanPosition): number {
+    if (this.hash !== other.hash) {
+      return this.hash - other.hash;
+    }
+
+    return compareSimDynamoDbBytes(
+      Buffer.from(this.partitionKey, "utf8"),
+      Buffer.from(other.partitionKey, "utf8"),
+    );
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-scan-segment.iso.test.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-scan-segment.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  assertArrayIncludes,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringStartsWith,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment.js";
+
+/**
+ * A run of marshalled partition key values, as an item key makes them.
+ */
+function partitionKeys(count: number): readonly string[] {
+  return Array.from({ length: count }, (_, index) => `S:c-${index.toString()}`);
+}
+
+/**
+ * The segments of a division, as a caller of a parallel scan makes them.
+ */
+function segments(totalSegments: number): readonly SimDynamoDbScanSegment[] {
+  return Array.from(
+    { length: totalSegments },
+    (_, index) => new SimDynamoDbScanSegment({ index, totalSegments }),
+  );
+}
+
+describe("SimDynamoDbScanSegment", () => {
+  it("holds every partition key in one segment of a division", () => {
+    // Given a table divided into four segments.
+    const division = segments(4);
+
+    // When each partition key value is offered to every segment.
+    const holders = partitionKeys(50).map(
+      (partitionKey) =>
+        division.filter((segment) => segment.holds(partitionKey)).length,
+    );
+
+    // Then exactly one segment holds it, so the segments together cover the
+    // whole table and none of them overlap.
+    assertArrayLength(
+      holders.filter((count) => count !== 1),
+      0,
+    );
+  });
+
+  it("holds one partition key in the same segment every time", () => {
+    // Given one segment of a division.
+    const segment = new SimDynamoDbScanSegment({ index: 2, totalSegments: 7 });
+
+    // When the same partition key value is offered to it twice.
+    const first = segment.holds("S:c-1");
+    const second = segment.holds("S:c-1");
+
+    // Then it answers the same way, since the segment follows from the
+    // partition key rather than from when it was asked.
+    assertIdentical(second, first);
+  });
+
+  it("holds everything in a whole table segment", () => {
+    // Given the segment a sequential scan reads.
+    const segment = SimDynamoDbScanSegment.whole();
+
+    // When partition key values are offered to it.
+    const held = partitionKeys(20).every((partitionKey) =>
+      segment.holds(partitionKey),
+    );
+
+    // Then it holds all of them, since one segment out of one is the table.
+    assertTrue(held);
+    assertIdentical(segment.index, 0);
+    assertIdentical(segment.totalSegments, 1);
+  });
+
+  it("leaves a partition key out of the segments that do not hold it", () => {
+    // Given a division into two segments.
+    const [first, second] = segments(2);
+    assertInstanceOf(first, SimDynamoDbScanSegment);
+    assertInstanceOf(second, SimDynamoDbScanSegment);
+
+    // When a partition key value is offered to both.
+    const held = [first.holds("S:c-1"), second.holds("S:c-1")];
+
+    // Then one holds it and the other does not.
+    assertArrayIncludes(held, true);
+    assertFalse(held.every(Boolean));
+  });
+
+  it.each([0, -1, 1.5, 1_000_001, NaN])(
+    "refuses a TotalSegments of %s",
+    (totalSegments) => {
+      // Given nothing but the division a request asked for.
+      // When a segment is made of a TotalSegments outside the range.
+      const error = assertThrowsError(
+        () => new SimDynamoDbScanSegment({ index: 0, totalSegments }),
+      );
+
+      // Then it is refused, naming the parameter that was wrong.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringStartsWith(error.message, "TotalSegments");
+    },
+  );
+
+  it.each([-1, 4, 5, 0.5, NaN])(
+    "refuses a Segment of %s out of four",
+    (index) => {
+      // Given a division into four segments.
+      // When a segment names a share that division does not have.
+      const error = assertThrowsError(
+        () => new SimDynamoDbScanSegment({ index, totalSegments: 4 }),
+      );
+
+      // Then it is refused, since a Segment is zero based and below
+      // TotalSegments.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringStartsWith(error.message, "Segment");
+    },
+  );
+
+  it("takes the last segment of a division", () => {
+    // Given a division into four segments.
+    // When the last of them is named, which is one below TotalSegments.
+    const segment = new SimDynamoDbScanSegment({ index: 3, totalSegments: 4 });
+
+    // Then it is a segment, since Segment is zero based.
+    assertIdentical(segment.index, 3);
+  });
+});

--- a/src/service/dynamodb/table/sim-dynamodb-scan-segment.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-scan-segment.ts
@@ -1,0 +1,90 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { simDynamoDbPartitionKeyHash } from "./sim-dynamodb-partition-key-hash.js";
+
+/**
+ * The most segments a parallel scan can be divided into, as on AWS.
+ */
+const greatestTotalSegments = 1_000_000;
+
+interface SimDynamoDbScanSegmentProperties {
+  readonly index: number;
+  readonly totalSegments: number;
+}
+
+/**
+ * One segment of a parallel scan.
+ *
+ * A segment is a share of the table's partition key values rather than a share
+ * of its items. Every item under one partition key belongs to one segment, so a
+ * segment holds whole item collections, and two segments of the same table can
+ * hold very different numbers of items. A segment holding nothing at all is
+ * ordinary rather than a failure.
+ *
+ * There is no concurrency to gain here, since a simulated scan walks a map in
+ * memory. What a segment models is the caller's side of a parallel scan: code
+ * that divides a table between workers can be run against a simulated table.
+ */
+export class SimDynamoDbScanSegment {
+  /** The zero based number of this segment. */
+  public readonly index: number;
+
+  /** How many segments the table is divided into. */
+  public readonly totalSegments: number;
+
+  constructor(properties: SimDynamoDbScanSegmentProperties) {
+    assertTotalSegments(properties.totalSegments);
+    assertIndex(properties.index, properties.totalSegments);
+
+    this.index = properties.index;
+    this.totalSegments = properties.totalSegments;
+  }
+
+  /**
+   * The whole table as one segment, which is what a sequential scan reads.
+   */
+  static whole(): SimDynamoDbScanSegment {
+    return new this({ index: 0, totalSegments: 1 });
+  }
+
+  /**
+   * Whether this segment holds the items under a marshalled partition key.
+   *
+   * A `TotalSegments` of 1 holds everything, which is what makes a parallel
+   * scan of one segment the same read as a sequential scan.
+   */
+  holds(partitionKey: string): boolean {
+    return (
+      simDynamoDbPartitionKeyHash(partitionKey) % this.totalSegments ===
+      this.index
+    );
+  }
+}
+
+/**
+ * Refuse a `TotalSegments` outside the range a parallel scan takes.
+ */
+function assertTotalSegments(totalSegments: number): void {
+  if (
+    !Number.isSafeInteger(totalSegments) ||
+    totalSegments < 1 ||
+    totalSegments > greatestTotalSegments
+  ) {
+    throw new SimDynamoDbValidationException(
+      `TotalSegments ${totalSegments.toString()} is invalid. It is a whole ` +
+        `number between 1 and ${greatestTotalSegments.toString()}.`,
+    );
+  }
+}
+
+/**
+ * Refuse a `Segment` that names no segment of the division asked for.
+ */
+function assertIndex(index: number, totalSegments: number): void {
+  if (!Number.isSafeInteger(index) || index < 0 || index >= totalSegments) {
+    throw new SimDynamoDbValidationException(
+      `Segment ${index.toString()} is invalid. It is zero based, so it is a ` +
+        `whole number between 0 and ${(totalSegments - 1).toString()} for a ` +
+        `TotalSegments of ${totalSegments.toString()}.`,
+    );
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
@@ -74,6 +74,23 @@ export class SimDynamoDbSortKeyOrder {
   }
 
   /**
+   * Order two items of one table by their sort keys.
+   *
+   * With no sort key a partition key value names at most one item, so two items
+   * that reach here are the same item and nothing separates them. A scan orders
+   * a whole table this way once it has ordered by partition key.
+   */
+  compareItems(first: SimDynamoDbItem, second: SimDynamoDbItem): number {
+    const attributeName = this.attributeName;
+
+    if (attributeName === undefined) {
+      return 0;
+    }
+
+    return this.compare(first, second, attributeName);
+  }
+
+  /**
    * Which way along the sort key the walk is going.
    */
   private direction(forward: boolean): number {

--- a/src/service/dynamodb/table/sim-dynamodb-stocked-table.factory.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-stocked-table.factory.ts
@@ -1,0 +1,94 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simDynamoDbCollectionTableFactory } from "./sim-dynamodb-collection-table.factory.js";
+import type { SimDynamoDbTable } from "./sim-dynamodb-table.js";
+
+/**
+ * What a test asks for when it wants a table with items already in it.
+ *
+ * The customers and orders are counts rather than the values themselves, so a
+ * test asking for fewer than the default gets fewer rather than the first few
+ * defaults with its own in place of them.
+ */
+export interface SimDynamoDbStockedTableInput {
+  readonly tableName: string;
+  readonly customerCount: number;
+  readonly orderCount: number;
+}
+
+/**
+ * The customers a stocked table holds orders for, so a test can name them.
+ */
+export function simDynamoDbStockedCustomerIds(
+  customerCount: number,
+): readonly string[] {
+  return Array.from(
+    { length: customerCount },
+    (_, customer) => `c-${(customer + 1).toString()}`,
+  );
+}
+
+/**
+ * The orders a stocked table holds for each customer.
+ */
+function orderIds(orderCount: number): readonly string[] {
+  return Array.from(
+    { length: orderCount },
+    (_, order) => `2026-${(order + 1).toString().padStart(2, "0")}`,
+  );
+}
+
+/**
+ * Creates a table keyed by customer and order, holding one item per pair.
+ *
+ * This is the table a Scan reads: several item collections rather than one, so
+ * a walk of the whole table has more than one partition key value to put in
+ * order. Use `simDynamoDbCollectionTableFactory` for the same table with
+ * nothing written to it.
+ *
+ * The orders are written together rather than in order, so the order a scan
+ * answers in is the table's rather than the order they arrived in.
+ *
+ * ```typescript
+ * const table = await simDynamoDbStockedTableFactory.make(
+ *   { customerCount: 20 },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbStockedTableFactory = new AsyncMappedFactory<
+  SimDynamoDbStockedTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "OrdersTable",
+    customerCount: 3,
+    orderCount: 2,
+  }),
+  async (input, simAws) => {
+    const table = await simDynamoDbCollectionTableFactory.make(
+      { tableName: input.tableName },
+      simAws,
+    );
+    const simDynamoDb = simAws.dynamoDb();
+
+    await Promise.all(
+      simDynamoDbStockedCustomerIds(input.customerCount).flatMap((customerId) =>
+        orderIds(input.orderCount).map(async (orderId) =>
+          simDynamoDb.putItem({
+            input: {
+              TableName: input.tableName,
+              Item: {
+                customerId: { S: customerId },
+                orderId: { S: orderId },
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    return table;
+  },
+);

--- a/src/service/dynamodb/table/sim-dynamodb-table-scan.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-scan.ts
@@ -1,0 +1,83 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
+import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
+import { SimDynamoDbScanPosition } from "./sim-dynamodb-scan-position.js";
+import type { SimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment.js";
+import { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+
+interface SimDynamoDbTableScanProperties {
+  readonly items: Iterable<SimDynamoDbItem>;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly itemKey: SimDynamoDbItemKey;
+}
+
+interface SimDynamoDbTableScanWalk {
+  readonly segment: SimDynamoDbScanSegment;
+  readonly after?: SimDynamoDbItem | undefined;
+}
+
+/**
+ * Every item one table holds, in the order a Scan reads them.
+ *
+ * A table holds its items in a map keyed by the marshalled primary key, which
+ * carries no order at all, so the scan order is worked out when the table is
+ * read rather than kept. Two scans of an unchanged table walk it the same way,
+ * which is what lets an `ExclusiveStartKey` resume one.
+ */
+export class SimDynamoDbTableScan {
+  private readonly itemKey: SimDynamoDbItemKey;
+  private readonly sortKeyOrder: SimDynamoDbSortKeyOrder;
+  private readonly positions: readonly SimDynamoDbScanPosition[];
+
+  constructor(properties: SimDynamoDbTableScanProperties) {
+    this.itemKey = properties.itemKey;
+    this.sortKeyOrder = new SimDynamoDbSortKeyOrder(
+      properties.keySchema.rangeKeyAttributeName,
+    );
+    this.positions = [...properties.items]
+      .map((item) => this.positionOf(item))
+      .toSorted((first, second) => first.compareTo(second));
+  }
+
+  /**
+   * Where an item or a request's Key sits in this table's scan order.
+   */
+  positionOf(item: SimDynamoDbItem): SimDynamoDbScanPosition {
+    return new SimDynamoDbScanPosition({
+      item,
+      partitionKey: this.itemKey.partitionOf(item),
+      sortKeyOrder: this.sortKeyOrder,
+    });
+  }
+
+  /**
+   * The items one segment holds, from the key the request resumes after.
+   */
+  walk(properties: SimDynamoDbTableScanWalk): readonly SimDynamoDbItem[] {
+    const held = this.positions.filter((position) =>
+      position.inSegment(properties.segment),
+    );
+
+    return this.beyond(held, properties.after).map((position) => position.item);
+  }
+
+  /**
+   * The positions past the one a request resumes after.
+   *
+   * The token says where to resume rather than which item to return to, so this
+   * compares positions rather than looking the item up. An item that has since
+   * been deleted still names a place in the order.
+   */
+  private beyond(
+    positions: readonly SimDynamoDbScanPosition[],
+    after: SimDynamoDbItem | undefined,
+  ): readonly SimDynamoDbScanPosition[] {
+    if (after === undefined) {
+      return positions;
+    }
+
+    const from = this.positionOf(after);
+
+    return positions.filter((position) => position.compareTo(from) > 0);
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -20,6 +20,7 @@ import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
 import { SimDynamoDbTableLifecycle } from "./sim-dynamodb-table-lifecycle.js";
+import { SimDynamoDbTableScan } from "./sim-dynamodb-table-scan.js";
 import { SimDynamoDbTableTags } from "./sim-dynamodb-table-tags.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
@@ -254,6 +255,21 @@ export class SimDynamoDbTable {
       items: this.items.entries().values(),
       keySchema: this.keySchema,
       keyCondition,
+    });
+  }
+
+  /**
+   * Every item this table holds, in the order a Scan reads them.
+   *
+   * A Scan needs no key knowledge, so unlike an item collection this is the
+   * whole table. The order and the parallel scan segments both belong to the
+   * scan rather than to the command that reads it.
+   */
+  public scan(): SimDynamoDbTableScan {
+    return new SimDynamoDbTableScan({
+      items: this.items.entries().values(),
+      keySchema: this.keySchema,
+      itemKey: this.itemKey,
     });
   }
 }


### PR DESCRIPTION
Scan walks the whole table, ordering partition key values by a hash so they come back arbitrarily rather than sorted, and items under one partition key ascending by sort key. Paging reuses the collaborator Query pages with.

Segment and TotalSegments divide a table by the same hash, so whole item collections move together. They are supplied together, and are refused on Query, which never had them.

Resolves https://github.com/KensioSoftware/yulin/issues/267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DynamoDB `ScanCommand` support, including full-table reads, deterministic ordering, pagination, continuation keys, and strong-read handling.
  * Added parallel scans using configurable segments.
  * Added native SDK routing and authorization for scan operations.
  * Added examples demonstrating standard and parallel scans.

* **Bug Fixes**
  * Query now explicitly rejects scan-only segment parameters.
  * Document-client scan commands are clearly reported as unsupported.

* **Documentation**
  * Updated DynamoDB feature lists, limitations, command references, and scan behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->