### PR TITLE
feat: filter and count simulated DynamoDB query and scan results

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1289,6 +1289,157 @@ These are the rules a request is held to, each a `ValidationException`:
 them. A query reads one item collection, which sits under one partition key and so inside one
 segment.
 
+## Filtering a read
+
+`FilterExpression` drops items a `Query` or a `Scan` read. It is the same grammar a
+[conditional write](#conditional-writes) is guarded by, evaluated against each item the read
+reached.
+
+It runs after the read rather than during it, and that order is what the counts report. The walk is
+cut at the `Limit` first, and the filter then drops items from the page that came back.
+`ScannedCount` is how many items the read evaluated, and `Count` how many of those survived.
+
+```typescript sim-dynamodb-query-filter
+/**
+ * Reading a customer's open orders, and counting what that cost.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const orders = [
+  { orderId: "2026-01", status: "OPEN" },
+  { orderId: "2026-02", status: "SHIPPED" },
+  { orderId: "2026-03", status: "OPEN" },
+  { orderId: "2026-04", status: "SHIPPED" },
+];
+
+for (const order of orders) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: {
+        customerId: { S: "c-1" },
+        orderId: { S: order.orderId },
+        status: { S: order.status },
+      },
+    }),
+  );
+}
+
+const page = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    FilterExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":open": { S: "OPEN" },
+    },
+    Limit: 3,
+  }),
+);
+
+console.log(page.Items?.map((item) => item["orderId"]?.S));
+// [ "2026-01", "2026-03" ]
+
+// Three items were read, and two of them survived the filter.
+console.log(page.ScannedCount); // 3
+console.log(page.Count); // 2
+
+// There is more to read, even though the page came back shorter than the Limit.
+console.log(page.LastEvaluatedKey?.["orderId"]?.S); // "2026-03"
+
+// Select COUNT counts the same read and answers with no items at all.
+const counted = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    FilterExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":open": { S: "OPEN" },
+    },
+    Select: "COUNT",
+  }),
+);
+
+console.log(counted.Count); // 2
+console.log(counted.ScannedCount); // 4
+console.log(counted.Items); // undefined
+```
+
+A filter saves nothing. Every item it drops was read, so a filtered query is charged for what it
+threw away on AWS.
+
+A `Count` below the `Limit` therefore says nothing about whether the collection is exhausted. A page
+can even come back with no items at all and a `LastEvaluatedKey`, when the filter dropped every item
+on it. Loop until the token is gone rather than until a page looks short or empty.
+
+An item that does not have what the filter points at fails it. `status = :open` drops an item with no
+`status`, the same way a condition on a write does not hold for an attribute that is not there.
+
+### What a filter may name
+
+A `Query` filter may not name a key attribute, and a `Scan` filter may name any attribute at all. A
+query has already narrowed the read by its `KeyConditionExpression`, so a filter on the partition key
+or the sort key is either that condition written twice or a condition the key condition should have
+carried. Real DynamoDB refuses it as a `ValidationException`, and so does this. A scan narrows
+nothing, so there a key attribute is an attribute like any other.
+
+The rule is about where a path starts, so `details.customerId` is allowed on a query with a
+`customerId` partition key: it names an attribute of a map rather than the key. Writing the key
+attribute as an `ExpressionAttributeNames` placeholder does not get past it either.
+
+The key condition and the filter share one set of placeholders. A `#name` or `:value` either of them
+uses counts as used, and one neither uses is refused the way an unused placeholder always is.
+
+### Counting and projecting with Select
+
+`Select` says which attributes a read answers with. A table read defaults to `ALL_ATTRIBUTES`, which
+is whole items.
+
+`COUNT` answers with `Count` and `ScannedCount` and no `Items` at all, as at the end of the example
+above. It reads and filters the same items, and leaves them out of the response. `Limit` and
+`LastEvaluatedKey` page a counted read the same way.
+
+The other two values are held to the rules AWS holds them to, each a `ValidationException`:
+
+- `SPECIFIC_ATTRIBUTES` needs a `ProjectionExpression` to name what to answer with.
+- a `ProjectionExpression` alongside any `Select` other than `SPECIFIC_ATTRIBUTES`. That one is the
+  `Select` that projects. Writing a `ProjectionExpression` and no `Select` at all is fine.
+- `ALL_PROJECTED_ATTRIBUTES` without an `IndexName`. It asks for the attributes an index projects,
+  and a table read has no index to project from.
+
+Projecting a `Query` or a `Scan` is not simulated, so `SPECIFIC_ATTRIBUTES` gets as far as the
+`ProjectionExpression` refusal rather than being accepted with nothing to project.
+
 ## Reading and writing items in batches
 
 `BatchWriteItem` puts and deletes items across tables in one call, and `BatchGetItem` reads them by
@@ -2212,6 +2363,10 @@ nothing is written.
   `ScanIndexForward`, and `Limit`, `LastEvaluatedKey` and `ExclusiveStartKey` paging.
 - `Scan`, reading every item in a table with the same paging, and `Segment` and `TotalSegments`
   dividing a table between parallel workers.
+- `FilterExpression` on `Query` and `Scan`, applied after the `Limit` so that `ScannedCount` counts
+  what was read and `Count` what survived, and refused on a `Query` when it names a key attribute.
+- `Select` on `Query` and `Scan`, with `COUNT` answering with counts alone and the rules tying
+  `SPECIFIC_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES` and a projection together.
 - `ConditionExpression` on `PutItem`, `DeleteItem` and `UpdateItem`, with the six comparators, `BETWEEN`, `IN`,
   `AND`, `OR`, `NOT`, brackets, and the `attribute_exists`, `attribute_not_exists`, `attribute_type`,
   `begins_with`, `contains` and `size` functions.
@@ -2327,16 +2482,11 @@ nothing is written.
   DynamoDB accepts it. The shape of a key condition is fixed, so there is nothing for brackets to
   group, and being stricter is the direction that fails safely: it is a puzzling refusal here rather
   than a query that means something different on AWS.
-- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused on `Query` and on
-  `Scan`, since each of them changes which items the operation answers with or which parts of them.
-  `Select` naming `ALL_ATTRIBUTES` is the default a table read already behaves as, so it is accepted.
-  Scanning a secondary index goes with the indexes themselves, which are not simulated.
-- `ExpressionAttributeNames` and `ExpressionAttributeValues` on a `Scan` are refused as unsimulated
-  input, where real DynamoDB calls placeholders with no expression to use them a
-  `ValidationException`. Every expression a scan can carry is refused already, so the request fails
-  either way, and naming the parameter is more use than matching the error class.
-- `Count` and `ScannedCount` are always the same number. They differ only when a `FilterExpression`
-  drops items a query or scan evaluated, and filters are not simulated.
+- `IndexName` and `ProjectionExpression` are refused on `Query` and on `Scan`, since each of them
+  changes which items the operation answers with or which parts of them. Reading a secondary index
+  goes with the indexes themselves, which are not simulated.
+- A `Query` filter is held to the table's key schema, since indexes are not simulated. Which
+  attributes a filter may name on an index read is settled when index reads land.
 - `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
   response stops at a size, so the branch of a batch retry loop that resends what did not go through
   is never taken against the simulator.
@@ -2375,8 +2525,7 @@ nothing is written.
   whether a request sets it once for a read or per table for a batch read, so a test cannot observe a
   stale read here the way it might against a real table.
 - Condition expressions are simulated on `PutItem`, `DeleteItem`, `UpdateItem` and the actions of
-  `TransactWriteItems`, and key conditions on `Query`. Filter expressions are not implemented yet, on
-  either `Query` or `Scan`.
+  `TransactWriteItems`, key conditions on `Query`, and filters on `Query` and `Scan`.
 - Two update actions cannot write to overlapping paths, so `ADD tags :added DELETE tags :gone` in one
   expression is refused as it is on AWS. Taking members out of a set an expression also adds to is a
   second update.

--- a/docs/services/dynamodb/sim-dynamodb-query-filter.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-query-filter.example.ts
@@ -1,0 +1,93 @@
+/**
+ * Reading a customer's open orders, and counting what that cost.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const orders = [
+  { orderId: "2026-01", status: "OPEN" },
+  { orderId: "2026-02", status: "SHIPPED" },
+  { orderId: "2026-03", status: "OPEN" },
+  { orderId: "2026-04", status: "SHIPPED" },
+];
+
+for (const order of orders) {
+  await dynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: {
+        customerId: { S: "c-1" },
+        orderId: { S: order.orderId },
+        status: { S: order.status },
+      },
+    }),
+  );
+}
+
+const page = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    FilterExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":open": { S: "OPEN" },
+    },
+    Limit: 3,
+  }),
+);
+
+console.log(page.Items?.map((item) => item["orderId"]?.S));
+// [ "2026-01", "2026-03" ]
+
+// Three items were read, and two of them survived the filter.
+console.log(page.ScannedCount); // 3
+console.log(page.Count); // 2
+
+// There is more to read, even though the page came back shorter than the Limit.
+console.log(page.LastEvaluatedKey?.["orderId"]?.S); // "2026-03"
+
+// Select COUNT counts the same read and answers with no items at all.
+const counted = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    KeyConditionExpression: "customerId = :customer",
+    FilterExpression: "#status = :open",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: {
+      ":customer": { S: "c-1" },
+      ":open": { S: "OPEN" },
+    },
+    Select: "COUNT",
+  }),
+);
+
+console.log(counted.Count); // 2
+console.log(counted.ScannedCount); // 4
+console.log(counted.Items); // undefined

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -394,14 +394,18 @@ lookup.
 
 The order it works in is the order the other commands follow, with one addition:
 
-1. `refuseUnsimulatedQueryInput` refuses the inputs this simulation does not model.
-2. `readSimDynamoDbKeyCondition` reads the `KeyConditionExpression`, before the table is reached, so
-   an expression DynamoDB would refuse is refused whether or not the table is there.
-3. The table is found and the caller authorized.
-4. `SimDynamoDbKeyConditionTerms.forTable` reads the terms against the table's key schema, which is
+1. `SimDynamoDbSelect.from` reads which attributes the request asks for. It comes first because it
+   decides whether the projection the request carries is one it could have asked for at all.
+2. `refuseUnsimulatedQueryInput` refuses the inputs this simulation does not model.
+3. `readSimDynamoDbQueryExpressions` reads the `KeyConditionExpression` and the `FilterExpression`,
+   before the table is reached, so an expression DynamoDB would refuse is refused whether or not the
+   table is there. Both draw on one `SimDynamoDbExpressionParameters`, the way UpdateItem's two
+   expressions do.
+4. The table is found and the caller authorized.
+5. `SimDynamoDbKeyConditionTerms.forTable` reads the terms against the table's key schema, which is
    the part that could not be checked without it: which attribute is the partition key, and what type
-   the sort key is.
-5. The collection is gathered, walked, and cut to a page.
+   the sort key is. `SimDynamoDbFilter.assertNamesNoKeyAttribute` is held to the same schema.
+6. The collection is gathered, walked, and cut to a page, which is then filtered.
 
 The parts a query is made of split by what they know:
 
@@ -414,6 +418,14 @@ The parts a query is made of split by what they know:
   item under a partition key, so every question about ordering has a trivial answer.
 - `SimDynamoDbItemPage` under `command/item/` is `Limit` and `LastEvaluatedKey`. It takes items and a
   key schema rather than a query, which is what lets `Scan` use it unchanged.
+- `command/read/` is what a query and a scan answer with, since both answer the same way.
+  `SimDynamoDbReadAnswer` holds the order the counts depend on: a page cut at the `Limit`, then
+  filtered, so `ScannedCount` is what was evaluated and `Count` what survived. `SimDynamoDbSelect` is
+  the `Select` matrix, and is what leaves `Items` out of a counted read.
+- `expression/filter/` reads the `FilterExpression`. It is the ordinary condition grammar rather than
+  one of its own, so it goes through `SimDynamoDbConditionParser` under a different expression name.
+  `SimDynamoDbFilter` is the condition plus the paths it named, which is what the key attribute rule
+  needs.
 - `readSimDynamoDbQueryStartKey` reads the `ExclusiveStartKey`. It goes through the table's own key
   reading, so a token that is not a whole primary key is refused the way any Key is, and then checks
   that it names the collection being read.
@@ -422,8 +434,12 @@ Important behavior:
 
 - `ScanIndexForward` defaults to true. Setting it to false reads the collection backwards, and
   resumes backwards too.
-- `Limit` counts the items a walk evaluated. Nothing filters a query yet, so that is also the number
-  it answers with, and `Count` and `ScannedCount` are the same.
+- `Limit` counts the items a walk evaluated rather than the items it answers with. The filter runs
+  over the page after the cut, so `ScannedCount` is the walk's own count and `Count` is what the
+  filter kept. A page can come back empty with a `LastEvaluatedKey` on it.
+- a filter naming a key attribute is refused, since a query has narrowed by its key condition
+  already. `SimDynamoDbDocumentPath.startsAt` is the check, so a path into a map named after a key
+  attribute is not caught by it.
 - `LastEvaluatedKey` is there whenever the walk stopped at the limit, including when it stopped on
   the last matching item. A caller looping until the token is absent therefore reads one empty page
   at the end, which is what real DynamoDB does: it cannot know the range is exhausted without looking
@@ -431,21 +447,22 @@ Important behavior:
 - `ExclusiveStartKey` resumes exclusively, by comparing sort keys rather than by looking the item up,
   so a token still works when the item it names has since been deleted. That is the same choice
   `ListTables` and `ListTagsOfResource` make.
-- `IndexName`, `FilterExpression`, `ProjectionExpression` and `Select` are refused by name, since each
-  changes which items a query answers with or which parts of them. `Select: ALL_ATTRIBUTES` is the
-  default a table query already behaves as, so it is let through.
+- `IndexName` and `ProjectionExpression` are refused by name, since each changes which items a query
+  answers with or which parts of them.
 
 ## Scan behavior
 
 `SimDynamoDbScan` reads a whole table rather than one item collection, so it needs no key condition
-and no key knowledge. It takes the same steps a query does, minus the expression:
+and no key knowledge. It takes the same steps a query does, minus the key condition:
 
-1. `refuseUnsimulatedScanInput` refuses the inputs this simulation does not model.
-2. `readSimDynamoDbScanSegment` reads `Segment` and `TotalSegments`, before the table is reached, so
-   a division DynamoDB would refuse is refused whether or not the table is there.
-3. The table is found and the caller authorized.
-4. The table is put in scan order, walked from the `ExclusiveStartKey`, and cut to a page by the same
-   `SimDynamoDbItemPage` a query uses.
+1. `SimDynamoDbSelect.from` reads which attributes the request asks for.
+2. `refuseUnsimulatedScanInput` refuses the inputs this simulation does not model.
+3. `readSimDynamoDbScanSegment` reads `Segment` and `TotalSegments`, and `readSimDynamoDbFilter` the
+   `FilterExpression`, before the table is reached, so input DynamoDB would refuse is refused whether
+   or not the table is there. A scan filter needs nothing from the table, unlike a query's.
+4. The table is found and the caller authorized.
+5. The table is put in scan order, walked from the `ExclusiveStartKey`, and cut to a page by the same
+   `SimDynamoDbItemPage` a query uses, then filtered by the same `SimDynamoDbReadAnswer`.
 
 The parts a scan is made of sit under `table/`, since the order and the segments belong to the table
 rather than to the command reading it:
@@ -479,6 +496,11 @@ Important behavior:
   parallel scan code makes, so it fails rather than reading that segment from the start.
 - `ConsistentRead` is accepted and changes nothing, since every simulated read is strongly
   consistent.
+- a scan filter may name any attribute, key attributes included, where a query's may not. A scan has
+  narrowed nothing, so there is no key condition for a filter to contradict.
+- `ExpressionAttributeNames` and `ExpressionAttributeValues` with no `FilterExpression` to use them
+  in are a `ValidationException` through `SimDynamoDbExpressionParameters.assertNoneWithout`, rather
+  than unsimulated input, because that is what real DynamoDB calls them.
 - `Segment` and `TotalSegments` are declared on the Query input as well, and refused there by
   `refuseSimDynamoDbQuerySegment`. They are not Query parameters on AWS, and a query carrying one is
   code that meant to scan.
@@ -629,10 +651,16 @@ precedence DynamoDB documents is the shape of the class rather than a table some
 and the function calls have parsers of their own, because deciding whether `size` is a call or an
 attribute named `size` is a different job from deciding whether an OR binds looser than an AND.
 
+`expression/filter/` is the same grammar under another name. A FilterExpression is a
+ConditionExpression evaluated against each item a read reached, so `parseSimDynamoDbFilter` builds
+the same parser through `SimDynamoDbConditionParser.of` and only the expression name a refusal
+carries differs. What it adds is `SimDynamoDbFilter`, which holds the paths the expression named
+alongside the condition. Nothing checking a write needs those, since the request already named the
+item; a query does, to be refused for naming a key attribute.
+
 The comparison rules live in `item/sim-dynamodb-value-comparison.ts` and
 `item/sim-dynamodb-value-order.ts` rather than inside the evaluator, because a sort key condition
-compares the same way a condition expression does, and a filter expression will when filters arrive.
-Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare through
+compares the same way a condition expression and a filter expression do. Strings compare by UTF-8 bytes rather than by UTF-16 code units, numbers compare through
 `SimDynamoDbNumber.compareTo` so digits past what a JavaScript number holds still order correctly,
 and binary compares as unsigned bytes. Two values of different types have no order at all, which is
 what makes a comparison between them false rather than an error. `simDynamoDbValueBeginsWith` in

--- a/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
@@ -37,9 +37,9 @@ interface SimDynamoDbItemPageProperties {
  * One page of items, as a Query hands them out.
  *
  * `Limit` counts the items a walk evaluated rather than the items it answers
- * with, which is the same number here because nothing filters a query yet. The
- * distinction matters once `FilterExpression` arrives, and the walk is written
- * around evaluation so it keeps meaning the same thing.
+ * with. A page is cut here and filtered afterwards, which is what makes
+ * `ScannedCount` the items the read evaluated and lets a filtered page come
+ * back shorter than the limit, or empty.
  *
  * `LastEvaluatedKey` is there whenever the walk stopped at the limit, including
  * when it stopped on the last matching item. A caller looping until the token

--- a/src/service/dynamodb/command/query/query.command.ts
+++ b/src/service/dynamodb/command/query/query.command.ts
@@ -52,8 +52,11 @@ export interface SimQueryCommandInput {
 /**
  * Minimal structural sim DynamoDB Query output.
  *
- * `Count` and `ScannedCount` are the same number here, since nothing filters a
- * query yet: every item the walk evaluated is an item it answers with.
+ * `ScannedCount` is how many items the walk evaluated and `Count` how many of
+ * them the filter kept, so the two are the same number for a query carrying no
+ * `FilterExpression`.
+ *
+ * `Items` is absent altogether for a `Select` of `COUNT`, rather than empty.
  *
  * `LastEvaluatedKey` is absent only when the key range ran out inside the
  * `Limit`, so a caller loops until it is gone rather than until the page is

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-expressions.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-expressions.ts
@@ -1,0 +1,52 @@
+import { parseSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
+import type { SimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter.js";
+import { readSimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition-expression.js";
+import type { SimDynamoDbKeyConditionTerms } from "../../expression/key-condition/sim-dynamodb-key-condition-terms.js";
+import { SimDynamoDbExpressionParameters } from "../../expression/sim-dynamodb-expression-parameters.js";
+import type { SimQueryCommandInput } from "./query.command.js";
+
+/**
+ * What a query's expressions say, once both have been read.
+ */
+export interface SimDynamoDbQueryExpressions {
+  readonly terms: SimDynamoDbKeyConditionTerms;
+  readonly filter: SimDynamoDbFilter | undefined;
+}
+
+/**
+ * Read both expressions of a query against one set of placeholders.
+ *
+ * `ExpressionAttributeNames` and `ExpressionAttributeValues` are shared between
+ * them, so they are checked once both have been read. A placeholder used by
+ * either counts as used, and one used by neither is refused.
+ *
+ * Both are read before the table is reached, so an expression DynamoDB would
+ * refuse is refused whether or not the table is there. What is left is the part
+ * that needs the key schema, which each of them is held to once the table has
+ * been found.
+ */
+export function readSimDynamoDbQueryExpressions(
+  input: SimQueryCommandInput,
+): SimDynamoDbQueryExpressions {
+  const parameters = new SimDynamoDbExpressionParameters(input);
+  const terms = readSimDynamoDbKeyCondition(input, parameters);
+  const filter = filterIn(input.FilterExpression, parameters);
+
+  parameters.assertAllUsed();
+
+  return { terms, filter };
+}
+
+/**
+ * Read the filter a query drops read items by, if it names one.
+ */
+function filterIn(
+  expression: string | undefined,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbFilter | undefined {
+  if (expression === undefined) {
+    return undefined;
+  }
+
+  return parseSimDynamoDbFilter(expression, parameters);
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-filter-validation.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-filter-validation.iso.test.ts
@@ -1,0 +1,142 @@
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+
+/**
+ * A table keyed by customer and order, holding one order.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+  await simDynamoDb.putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: {
+        customerId: { S: "c-1" },
+        orderId: { S: "2026-01" },
+        details: { M: { customerId: { S: "c-1" } } },
+      },
+    }),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The key condition every one of these queries carries.
+ */
+const keyCondition = {
+  TableName: "OrdersTable",
+  KeyConditionExpression: "customerId = :customer",
+};
+
+describe("DynamoDB QueryCommand FilterExpression validation", () => {
+  it.each([
+    {
+      name: "the partition key",
+      filter: "customerId = :customer",
+      names: undefined,
+      refused: "customerId",
+    },
+    {
+      name: "the sort key",
+      filter: "orderId > :customer",
+      names: undefined,
+      refused: "orderId",
+    },
+    {
+      name: "a key attribute written as a placeholder",
+      filter: "#order > :customer",
+      names: { "#order": "orderId" },
+      refused: "orderId",
+    },
+    {
+      name: "a key attribute measured by size",
+      filter: "size(orderId) > :customer",
+      names: undefined,
+      refused: "orderId",
+    },
+    {
+      name: "a path into a key attribute",
+      filter: "customerId.name = :customer",
+      names: undefined,
+      refused: "customerId",
+    },
+  ])("refuses a query filter naming $name", async (example) => {
+    // Given a table keyed by customer and order.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query filters by a key attribute.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          ...keyCondition,
+          FilterExpression: example.filter,
+          ExpressionAttributeNames: example.names,
+          ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+        }),
+      ),
+    );
+
+    // Then it is refused naming the key attribute, since a query narrows by
+    // its key condition rather than by a filter.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, example.refused);
+  });
+
+  it("takes a filter naming an attribute inside a key attribute name", async () => {
+    // Given a table holding an order carrying a map with a key attribute name
+    // inside it.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query filters by that nested path.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        ...keyCondition,
+        FilterExpression: "details.customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+      }),
+    );
+
+    // Then it is read rather than refused: the path starts at an attribute
+    // outside the primary key.
+    assertArrayLength(output.Items ?? [], 1);
+  });
+
+  it.each([
+    { name: "an empty expression", filter: " " },
+    { name: "a syntax error", filter: "status =" },
+    { name: "a condition left incomplete", filter: "status = :customer AND" },
+  ])("refuses $name in a query filter", async (example) => {
+    // Given a table keyed by customer and order.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a query carries a filter DynamoDB would not read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          ...keyCondition,
+          FilterExpression: example.filter,
+          ExpressionAttributeValues: { ":customer": { S: "c-1" } },
+        }),
+      ),
+    );
+
+    // Then the refusal names the parameter the expression arrived as.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "FilterExpression");
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-filter-validation.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-filter-validation.iso.test.ts
@@ -8,29 +8,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
 import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
-
-/**
- * A table keyed by customer and order, holding one order.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-  await simDynamoDb.putItem(
-    new PutItemCommand({
-      TableName: "OrdersTable",
-      Item: {
-        customerId: { S: "c-1" },
-        orderId: { S: "2026-01" },
-        details: { M: { customerId: { S: "c-1" } } },
-      },
-    }),
-  );
-
-  return simDynamoDb;
-}
 
 /**
  * The key condition every one of these queries carries.
@@ -75,7 +53,9 @@ describe("DynamoDB QueryCommand FilterExpression validation", () => {
   ])("refuses a query filter naming $name", async (example) => {
     // Given a table keyed by customer and order.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
 
     // When a query filters by a key attribute.
     const error = await assertThrowsErrorAsync(async () =>
@@ -99,7 +79,19 @@ describe("DynamoDB QueryCommand FilterExpression validation", () => {
     // Given a table holding an order carrying a map with a key attribute name
     // inside it.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: {
+          customerId: { S: "c-1" },
+          orderId: { S: "2026-01" },
+          details: { M: { customerId: { S: "c-1" } } },
+        },
+      }),
+    );
 
     // When a query filters by that nested path.
     const output = await simDynamoDb.query(
@@ -122,7 +114,9 @@ describe("DynamoDB QueryCommand FilterExpression validation", () => {
   ])("refuses $name in a query filter", async (example) => {
     // Given a table keyed by customer and order.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
 
     // When a query carries a filter DynamoDB would not read.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
@@ -8,43 +8,8 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
 import type { SimQueryCommandOutput } from "./query.command.js";
-
-/**
- * A table holding one customer's orders, every other one of them open.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-
-  const orders = [
-    { orderId: "2026-01", status: "OPEN", total: "1" },
-    { orderId: "2026-02", status: "SHIPPED", total: "2" },
-    { orderId: "2026-03", status: "OPEN", total: "3" },
-    { orderId: "2026-04", status: "SHIPPED", total: "4" },
-  ];
-
-  await Promise.all(
-    orders.map(async (order) =>
-      simDynamoDb.putItem(
-        new PutItemCommand({
-          TableName: "OrdersTable",
-          Item: {
-            customerId: { S: "c-1" },
-            orderId: { S: order.orderId },
-            status: { S: order.status },
-            total: { N: order.total },
-          },
-        }),
-      ),
-    ),
-  );
-
-  return simDynamoDb;
-}
 
 /**
  * The sort keys a page came back with, in the order they came back in.
@@ -57,7 +22,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("drops the items the filter does not hold for", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When the collection is read with a filter on an attribute outside the
     // key.
@@ -81,7 +51,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("counts what it evaluated apart from what it answered with", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When the collection is read with a filter.
     const output = await simDynamoDb.query(
@@ -106,7 +81,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("applies the filter after the Limit rather than before it", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When a page of two items is read with a filter.
     const output = await simDynamoDb.query(
@@ -135,7 +115,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("answers with an empty page it can still be resumed from", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When a page is read whose every item the filter drops.
     const output = await simDynamoDb.query(
@@ -164,7 +149,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("reads the whole condition grammar", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When the filter uses functions, comparisons and the words joining them.
     const output = await simDynamoDb.query(
@@ -188,10 +178,16 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   });
 
   it("drops an item that does not have what the filter points at", async () => {
-    // Given a table holding an order with no status at all.
+    // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
 
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
+
+    // And an order with no status at all.
     await simDynamoDb.putItem(
       new PutItemCommand({
         TableName: "OrdersTable",
@@ -221,7 +217,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("counts a placeholder the filter alone uses as used", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When a value only the filter names is supplied.
     const output = await simDynamoDb.query(
@@ -244,7 +245,12 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
   it("refuses a placeholder neither expression uses", async () => {
     // Given a table holding one customer's open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 1, orderCount: 4 },
+      simAws,
+    );
 
     // When a value no expression names is supplied.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
@@ -144,6 +144,27 @@ describe("DynamoDB QueryCommand FilterExpression", () => {
     assertIdentical(output.Count, 0);
     assertIdentical(output.ScannedCount, 1);
     assertNonNullable(output.LastEvaluatedKey);
+
+    // And that token resumes after the item the filter dropped, so a caller
+    // looping on it reads the rest of the collection rather than stopping at
+    // the empty page.
+    const resumed = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer AND orderId > :after",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":after": { S: "2026-01" },
+          ":open": { S: "OPEN" },
+        },
+        ExclusiveStartKey: output.LastEvaluatedKey,
+      }),
+    );
+
+    assertArrayEquals(orderIds(resumed), ["2026-03"]);
+    assertIdentical(resumed.ScannedCount, 2);
   });
 
   it("reads the whole condition grammar", async () => {

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-filter.iso.test.ts
@@ -1,0 +1,268 @@
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimQueryCommandOutput } from "./query.command.js";
+
+/**
+ * A table holding one customer's orders, every other one of them open.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  const orders = [
+    { orderId: "2026-01", status: "OPEN", total: "1" },
+    { orderId: "2026-02", status: "SHIPPED", total: "2" },
+    { orderId: "2026-03", status: "OPEN", total: "3" },
+    { orderId: "2026-04", status: "SHIPPED", total: "4" },
+  ];
+
+  await Promise.all(
+    orders.map(async (order) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "OrdersTable",
+          Item: {
+            customerId: { S: "c-1" },
+            orderId: { S: order.orderId },
+            status: { S: order.status },
+            total: { N: order.total },
+          },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The sort keys a page came back with, in the order they came back in.
+ */
+function orderIds(output: SimQueryCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB QueryCommand FilterExpression", () => {
+  it("drops the items the filter does not hold for", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read with a filter on an attribute outside the
+    // key.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":open": { S: "OPEN" },
+        },
+      }),
+    );
+
+    // Then only the items the filter kept come back.
+    assertArrayEquals(orderIds(output), ["2026-01", "2026-03"]);
+  });
+
+  it("counts what it evaluated apart from what it answered with", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the collection is read with a filter.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":open": { S: "OPEN" },
+        },
+      }),
+    );
+
+    // Then ScannedCount is what the read evaluated and Count what survived the
+    // filter. A filter saves nothing: every item it dropped was read.
+    assertIdentical(output.ScannedCount, 4);
+    assertIdentical(output.Count, 2);
+  });
+
+  it("applies the filter after the Limit rather than before it", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a page of two items is read with a filter.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":open": { S: "OPEN" },
+        },
+        Limit: 2,
+      }),
+    );
+
+    // Then the limit cut the read at two items and the filter dropped one of
+    // them, so a Count below the Limit says nothing about there being more to
+    // read.
+    assertIdentical(output.ScannedCount, 2);
+    assertIdentical(output.Count, 1);
+    assertArrayEquals(orderIds(output), ["2026-01"]);
+    assertNonNullable(output.LastEvaluatedKey);
+  });
+
+  it("answers with an empty page it can still be resumed from", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a page is read whose every item the filter drops.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer AND orderId > :after",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":after": { S: "2026-01" },
+          ":open": { S: "OPEN" },
+        },
+        Limit: 1,
+      }),
+    );
+
+    // Then the page carries no items and a token to carry on from, since the
+    // read reached the limit rather than the end of the collection.
+    assertArrayLength(output.Items ?? [], 0);
+    assertIdentical(output.Count, 0);
+    assertIdentical(output.ScannedCount, 1);
+    assertNonNullable(output.LastEvaluatedKey);
+  });
+
+  it("reads the whole condition grammar", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the filter uses functions, comparisons and the words joining them.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression:
+          "attribute_exists(#status) AND (total > :least OR " +
+          "begins_with(#status, :prefix))",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":least": { N: "3" },
+          ":prefix": { S: "OP" },
+        },
+      }),
+    );
+
+    // Then the items it holds for are the ones that come back.
+    assertArrayEquals(orderIds(output), ["2026-01", "2026-03", "2026-04"]);
+  });
+
+  it("drops an item that does not have what the filter points at", async () => {
+    // Given a table holding an order with no status at all.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "OrdersTable",
+        Item: { customerId: { S: "c-1" }, orderId: { S: "2026-05" } },
+      }),
+    );
+
+    // When the collection is read with a filter naming that attribute.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression: "#status <> :shipped",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":shipped": { S: "SHIPPED" },
+        },
+      }),
+    );
+
+    // Then the item without it is dropped rather than kept: an attribute that
+    // is not there compares to nothing, so the filter does not hold.
+    assertArrayEquals(orderIds(output), ["2026-01", "2026-03"]);
+  });
+
+  it("counts a placeholder the filter alone uses as used", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a value only the filter names is supplied.
+    const output = await simDynamoDb.query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customer",
+        FilterExpression: "total >= :least",
+        ExpressionAttributeValues: {
+          ":customer": { S: "c-1" },
+          ":least": { N: "3" },
+        },
+      }),
+    );
+
+    // Then it is read rather than refused as unused: the key condition and the
+    // filter share the placeholders the request defines.
+    assertArrayEquals(orderIds(output), ["2026-03", "2026-04"]);
+  });
+
+  it("refuses a placeholder neither expression uses", async () => {
+    // Given a table holding one customer's open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a value no expression names is supplied.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.query(
+        new QueryCommand({
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :customer",
+          FilterExpression: "total >= :least",
+          ExpressionAttributeValues: {
+            ":customer": { S: "c-1" },
+            ":least": { N: "3" },
+            ":unused": { S: "nothing" },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused by name.
+    assertIdentical(error.name, "ValidationException");
+  });
+});

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -1,11 +1,13 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import { readSimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition-expression.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
+import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
+import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type {
   SimQueryCommand,
   SimQueryCommandOutput,
 } from "./query.command.js";
+import { readSimDynamoDbQueryExpressions } from "./sim-dynamodb-query-expressions.js";
 import { refuseSimDynamoDbQuerySegment } from "./sim-dynamodb-query-segment.js";
 import { readSimDynamoDbQueryStartKey } from "./sim-dynamodb-query-start-key.js";
 import { refuseUnsimulatedQueryInput } from "./sim-dynamodb-unsimulated-query-input.js";
@@ -41,20 +43,26 @@ export class SimDynamoDbQuery {
   ): SimQueryCommandOutput {
     const input = command.input;
 
+    // Which attributes the request asks for is read first, since it decides
+    // whether the projection the request carries is one it could have asked
+    // for at all.
+    const select = SimDynamoDbSelect.from(input);
+
     refuseUnsimulatedQueryInput(input);
     refuseSimDynamoDbQuerySegment(input);
 
-    // The key condition is read before the table is reached, so an expression
-    // DynamoDB would refuse is refused whether or not the table is there. What
-    // is left is the part that needs the key schema, which is read once the
-    // table has been found.
-    const terms = readSimDynamoDbKeyCondition(input);
+    const expressions = readSimDynamoDbQueryExpressions(input);
     const table = this.access.required(
       "dynamodb:Query",
       input.TableName,
       options?.caller,
     );
-    const keyCondition = terms.forTable(table);
+    const keyCondition = expressions.terms.forTable(table);
+
+    // A query has narrowed the read by its key condition already, so a filter
+    // naming a key attribute is refused. That needs the key schema, so it
+    // waits for the table the same way the key condition does.
+    expressions.filter?.assertNamesNoKeyAttribute(table.keySchema);
 
     // The token names an item of the collection being read, so it can only be
     // checked once that collection is known.
@@ -74,12 +82,11 @@ export class SimDynamoDbQuery {
     });
 
     return {
-      Items: page.items.map((item) => item.toAttributeValues()),
-      // Nothing filters a query yet, so every item the walk evaluated is an
-      // item the page carries.
-      Count: page.items.length,
-      ScannedCount: page.items.length,
-      LastEvaluatedKey: page.lastEvaluatedKey,
+      ...new SimDynamoDbReadAnswer({
+        page,
+        filter: expressions.filter,
+        select,
+      }).fields(),
       $metadata: {},
     };
   }

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
@@ -37,12 +37,10 @@ const keyCondition = {
 describe("DynamoDB QueryCommand unsimulated input", () => {
   it.each([
     { name: "IndexName", input: { IndexName: "ByStatus" } },
-    { name: "FilterExpression", input: { FilterExpression: "status = :s" } },
     {
       name: "ProjectionExpression",
       input: { ProjectionExpression: "orderId" },
     },
-    { name: "Select", input: { Select: "COUNT" } },
     { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
     {
       name: "KeyConditions",
@@ -86,23 +84,6 @@ describe("DynamoDB QueryCommand unsimulated input", () => {
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
     assertStringIncludes(error.message, example.name);
   });
-
-  it.each(["ALL_ATTRIBUTES", undefined])(
-    "takes a Select of %s, which asks for what it already does",
-    async (select) => {
-      // Given a table.
-      const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
-
-      // When a query names the Select a table query already behaves as.
-      const output = await simDynamoDb.query({
-        input: { ...keyCondition, Select: select },
-      });
-
-      // Then it is let through, since whole items are what it answers with.
-      assertArrayLength(output.Items ?? [], 0);
-    },
-  );
 
   it("takes a ReturnConsumedCapacity of NONE", async () => {
     // Given a table.

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
@@ -2,14 +2,6 @@ import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-in
 import type { SimQueryCommandInput } from "./query.command.js";
 
 /**
- * The `Select` a query already behaves as, which asks for whole items.
- *
- * Real DynamoDB defaults to this for a query against a table rather than an
- * index, so a request naming it asks for what this simulation already does.
- */
-const simulatedSelect = "ALL_ATTRIBUTES";
-
-/**
  * Refuse the Query inputs this simulation does not model.
  *
  * Each of these changes which items a query answers with, or which parts of
@@ -26,20 +18,9 @@ export function refuseUnsimulatedQueryInput(input: SimQueryCommandInput): void {
     "reading the table where a secondary index was asked for",
   );
   unsimulated.refuse(
-    input.FilterExpression !== undefined,
-    "FilterExpression",
-    "answering with the items a filter would have dropped",
-  );
-  unsimulated.refuse(
     input.ProjectionExpression !== undefined,
     "ProjectionExpression",
     "answering with whole items where part of them was asked for",
-  );
-  unsimulated.refuse(
-    input.Select !== undefined && input.Select !== simulatedSelect,
-    "Select",
-    `counting or projecting rather than answering with whole items, which is ` +
-      `what ${simulatedSelect} asks for`,
   );
   unsimulated.refuse(
     (input.AttributesToGet ?? []).length > 0,

--- a/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
@@ -1,0 +1,76 @@
+import type { SimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
+import type { SimDynamoDbSelect } from "./sim-dynamodb-select.js";
+
+/**
+ * What a query or a scan answers with, beyond its metadata.
+ */
+export interface SimDynamoDbReadFields {
+  readonly Items?:
+    readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] | undefined;
+  readonly Count: number;
+  readonly ScannedCount: number;
+  readonly LastEvaluatedKey?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+}
+
+interface SimDynamoDbReadAnswerProperties {
+  readonly page: SimDynamoDbItemPage;
+  readonly filter: SimDynamoDbFilter | undefined;
+  readonly select: SimDynamoDbSelect;
+}
+
+/**
+ * The page a query or a scan answers with, once its filter has been applied.
+ *
+ * The order the parts run in is the whole of the behaviour. The walk is cut to
+ * the `Limit` first, so `ScannedCount` is how many items the read evaluated.
+ * The filter then drops items from that page, so `Count` is how many of them
+ * survived. A `Count` below the `Limit` therefore says nothing about whether
+ * there is more to read, and a page whose items were all dropped answers with
+ * none and still hands out a `LastEvaluatedKey`.
+ *
+ * Query and Scan answer the same way, so this takes a page rather than either
+ * of them.
+ */
+export class SimDynamoDbReadAnswer {
+  private readonly kept: readonly SimDynamoDbItem[];
+  private readonly scannedCount: number;
+  private readonly lastEvaluatedKey:
+    Record<string, SimDynamoDbAttributeValue> | undefined;
+  private readonly select: SimDynamoDbSelect;
+
+  constructor(properties: SimDynamoDbReadAnswerProperties) {
+    const evaluated = properties.page.items;
+
+    this.scannedCount = evaluated.length;
+    this.kept = properties.filter?.applyTo(evaluated) ?? evaluated;
+    this.lastEvaluatedKey = properties.page.lastEvaluatedKey;
+    this.select = properties.select;
+  }
+
+  /**
+   * The fields the command output carries.
+   */
+  fields(): SimDynamoDbReadFields {
+    return {
+      ...this.items(),
+      Count: this.kept.length,
+      ScannedCount: this.scannedCount,
+      LastEvaluatedKey: this.lastEvaluatedKey,
+    };
+  }
+
+  /**
+   * The items answered with, which a counted read leaves out altogether.
+   */
+  private items(): Pick<SimDynamoDbReadFields, "Items"> {
+    if (this.select.countsOnly) {
+      return {};
+    }
+
+    return { Items: this.kept.map((item) => item.toAttributeValues()) };
+  }
+}

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
@@ -1,0 +1,273 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type {
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "../query/query.command.js";
+import type { SimScanCommandInput } from "../scan/scan.command.js";
+
+/**
+ * A table holding one customer's orders, every other one of them open.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  const orders = [
+    { orderId: "2026-01", status: "OPEN" },
+    { orderId: "2026-02", status: "SHIPPED" },
+  ];
+
+  await Promise.all(
+    orders.map(async (order) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "OrdersTable",
+          Item: {
+            customerId: { S: "c-1" },
+            orderId: { S: order.orderId },
+            status: { S: order.status },
+          },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The values a query's own key condition needs, whatever the test adds.
+ */
+const keyConditionValues = { ":customer": { S: "c-1" } };
+
+/**
+ * One way of reading a table, so a rule about `Select` is checked on both of
+ * the operations that take it.
+ *
+ * A query carries a key condition of its own, so what a test writes is added to
+ * that rather than replacing it.
+ */
+interface SimDynamoDbTableRead {
+  readonly operation: string;
+  readonly read: (
+    simDynamoDb: SimDynamoDb,
+    input: SimQueryCommandInput & SimScanCommandInput,
+  ) => Promise<SimQueryCommandOutput>;
+}
+
+const reads: readonly SimDynamoDbTableRead[] = [
+  {
+    operation: "Query",
+    read: async (simDynamoDb, input) =>
+      simDynamoDb.query({
+        input: {
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :customer",
+          ...input,
+          ExpressionAttributeValues: {
+            ...keyConditionValues,
+            ...input.ExpressionAttributeValues,
+          },
+        },
+      }),
+  },
+  {
+    operation: "Scan",
+    read: async (simDynamoDb, input) =>
+      simDynamoDb.scan({ input: { TableName: "OrdersTable", ...input } }),
+  },
+];
+
+describe("DynamoDB Select", () => {
+  it.each(reads)(
+    "counts without answering with items on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When the read asks only to be counted.
+      const output = await read(simDynamoDb, { Select: "COUNT" });
+
+      // Then the counts are there and the items are absent altogether, rather
+      // than an empty list.
+      assertIdentical(output.Count, 2);
+      assertIdentical(output.ScannedCount, 2);
+      assertUndefined(output.Items);
+    },
+  );
+
+  it.each(reads)(
+    "counts what a filter kept on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's open and shipped orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a counted read carries a filter.
+      const output = await read(simDynamoDb, {
+        Select: "COUNT",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":open": { S: "OPEN" } },
+      });
+
+      // Then Count is what survived the filter and ScannedCount what was read to
+      // find it.
+      assertIdentical(output.Count, 1);
+      assertIdentical(output.ScannedCount, 2);
+      assertUndefined(output.Items);
+    },
+  );
+
+  it.each(reads)(
+    "takes a Select of ALL_ATTRIBUTES on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When the read names the Select a table read already behaves as.
+      const output = await read(simDynamoDb, { Select: "ALL_ATTRIBUTES" });
+
+      // Then whole items are what it answers with.
+      assertArrayLength(output.Items ?? [], 2);
+    },
+  );
+
+  it.each(reads)(
+    "refuses SPECIFIC_ATTRIBUTES with nothing to project on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks for specific attributes and names none.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, { Select: "SPECIFIC_ATTRIBUTES" }),
+      );
+
+      // Then it is refused, since there is nothing for it to answer with.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "ProjectionExpression");
+    },
+  );
+
+  it.each(reads)(
+    "refuses a projection alongside another Select on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks to be counted and to project at the same time.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, {
+          Select: "COUNT",
+          ProjectionExpression: "orderId",
+        }),
+      );
+
+      // Then it is refused: SPECIFIC_ATTRIBUTES is the Select that projects.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "SPECIFIC_ATTRIBUTES");
+    },
+  );
+
+  it.each(reads)(
+    "refuses ALL_PROJECTED_ATTRIBUTES without an index on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks for what an index projects and names no index.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, { Select: "ALL_PROJECTED_ATTRIBUTES" }),
+      );
+
+      // Then it is refused, since a table read has no index to project from.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "IndexName");
+    },
+  );
+
+  it.each(reads)(
+    "refuses a Select that is not one on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks for something Select does not take.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, { Select: "EVERYTHING" }),
+      );
+
+      // Then it is refused naming what it could have said.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "ALL_ATTRIBUTES");
+    },
+  );
+
+  it.each(reads)(
+    "refuses SPECIFIC_ATTRIBUTES with a projection as unsimulated on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks for specific attributes and names them.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, {
+          Select: "SPECIFIC_ATTRIBUTES",
+          ProjectionExpression: "orderId",
+        }),
+      );
+
+      // Then the pair is allowed and the projection itself is what is refused,
+      // since projecting a query or a scan is not simulated yet.
+      assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+      assertStringIncludes(error.message, "ProjectionExpression");
+    },
+  );
+
+  it.each(reads)(
+    "refuses SPECIFIC_ATTRIBUTES with AttributesToGet by name on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = await ordersTable(simAws);
+
+      // When a read asks for specific attributes the legacy way.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, {
+          Select: "SPECIFIC_ATTRIBUTES",
+          AttributesToGet: ["orderId"],
+        }),
+      );
+
+      // Then AttributesToGet counts as the projection, so the refusal names it
+      // rather than a ProjectionExpression the request never meant to write.
+      assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+      assertStringIncludes(error.message, "AttributesToGet");
+    },
+  );
+});

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
@@ -1,4 +1,3 @@
-import { PutItemCommand } from "@aws-sdk/client-dynamodb";
 import {
   assertArrayLength,
   assertIdentical,
@@ -14,43 +13,12 @@ import {
   SimDynamoDbValidationException,
 } from "../../error/dynamodb.error.js";
 import type { SimDynamoDb } from "../../sim-dynamodb.js";
-import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
 import type {
   SimQueryCommandInput,
   SimQueryCommandOutput,
 } from "../query/query.command.js";
 import type { SimScanCommandInput } from "../scan/scan.command.js";
-
-/**
- * A table holding one customer's orders, every other one of them open.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-
-  const orders = [
-    { orderId: "2026-01", status: "OPEN" },
-    { orderId: "2026-02", status: "SHIPPED" },
-  ];
-
-  await Promise.all(
-    orders.map(async (order) =>
-      simDynamoDb.putItem(
-        new PutItemCommand({
-          TableName: "OrdersTable",
-          Item: {
-            customerId: { S: "c-1" },
-            orderId: { S: order.orderId },
-            status: { S: order.status },
-          },
-        }),
-      ),
-    ),
-  );
-
-  return simDynamoDb;
-}
 
 /**
  * The values a query's own key condition needs, whatever the test adds.
@@ -101,7 +69,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When the read asks only to be counted.
       const output = await read(simDynamoDb, { Select: "COUNT" });
@@ -119,7 +92,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's open and shipped orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a counted read carries a filter.
       const output = await read(simDynamoDb, {
@@ -142,7 +120,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When the read names the Select a table read already behaves as.
       const output = await read(simDynamoDb, { Select: "ALL_ATTRIBUTES" });
@@ -157,7 +140,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks for specific attributes and names none.
       const error = await assertThrowsErrorAsync(async () =>
@@ -175,7 +163,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks to be counted and to project at the same time.
       const error = await assertThrowsErrorAsync(async () =>
@@ -196,7 +189,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks for what an index projects and names no index.
       const error = await assertThrowsErrorAsync(async () =>
@@ -214,7 +212,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks for something Select does not take.
       const error = await assertThrowsErrorAsync(async () =>
@@ -232,7 +235,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks for specific attributes and names them.
       const error = await assertThrowsErrorAsync(async () =>
@@ -254,7 +262,12 @@ describe("DynamoDB Select", () => {
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(
+        { customerCount: 1, orderCount: 2 },
+        simAws,
+      );
 
       // When a read asks for specific attributes the legacy way.
       const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.ts
@@ -1,0 +1,152 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+
+/**
+ * The four things `Select` can ask a read for.
+ */
+const selectKinds = [
+  "ALL_ATTRIBUTES",
+  "ALL_PROJECTED_ATTRIBUTES",
+  "SPECIFIC_ATTRIBUTES",
+  "COUNT",
+] as const;
+
+type SimDynamoDbSelectKind = (typeof selectKinds)[number];
+
+/**
+ * What a table read defaults to when the request says nothing.
+ *
+ * A read of an index defaults to `ALL_PROJECTED_ATTRIBUTES` instead, which does
+ * not arise here: indexes are not simulated, so `IndexName` is refused.
+ */
+const tableDefault: SimDynamoDbSelectKind = "ALL_ATTRIBUTES";
+
+/**
+ * The parts of a request `Select` is read against.
+ *
+ * Which attributes come back is written in three places that have to agree, so
+ * the other two are read alongside it.
+ */
+export interface SimDynamoDbSelectInput {
+  readonly Select?: string | undefined;
+  readonly ProjectionExpression?: string | undefined;
+  readonly AttributesToGet?: readonly string[] | undefined;
+  readonly IndexName?: string | undefined;
+}
+
+/**
+ * Which attributes a query or a scan answers with.
+ *
+ * `Select` and the projection a request carries have to say the same thing, and
+ * DynamoDB refuses the pairs that do not. That check is worth making whether or
+ * not projecting a read is simulated, since a request the service would refuse
+ * should be refused here too.
+ */
+export class SimDynamoDbSelect {
+  private readonly kind: SimDynamoDbSelectKind;
+
+  private constructor(kind: SimDynamoDbSelectKind) {
+    this.kind = kind;
+  }
+
+  /**
+   * Read the `Select` a request asks for, refusing one that contradicts the
+   * rest of the request.
+   */
+  static from(input: SimDynamoDbSelectInput): SimDynamoDbSelect {
+    const kind = readSelectKind(input.Select);
+
+    assertIndexToProjectFrom(kind, input);
+    assertProjectionAgrees(kind, input);
+
+    return new this(kind);
+  }
+
+  /**
+   * Whether the read answers with counts alone.
+   *
+   * `COUNT` leaves out `Items` rather than answering with an empty list, so a
+   * caller reading the items of a counted page finds nothing there.
+   */
+  get countsOnly(): boolean {
+    return this.kind === "COUNT";
+  }
+}
+
+/**
+ * Read the `Select` a request wrote, refusing a word that is not one.
+ */
+function readSelectKind(select: string | undefined): SimDynamoDbSelectKind {
+  if (select === undefined) {
+    return tableDefault;
+  }
+
+  const kind = selectKinds.find((candidate) => candidate === select);
+
+  if (kind === undefined) {
+    throw new SimDynamoDbValidationException(
+      `Select ${select} is not one of ${selectKinds.join(", ")}`,
+    );
+  }
+
+  return kind;
+}
+
+/**
+ * Refuse a read asking for what an index projects when it reads no index.
+ */
+function assertIndexToProjectFrom(
+  kind: SimDynamoDbSelectKind,
+  input: SimDynamoDbSelectInput,
+): void {
+  if (kind === "ALL_PROJECTED_ATTRIBUTES" && input.IndexName === undefined) {
+    throw new SimDynamoDbValidationException(
+      `Select ALL_PROJECTED_ATTRIBUTES answers with the attributes an index ` +
+        `projects, and this request names no IndexName. A table read takes ` +
+        `${tableDefault}.`,
+    );
+  }
+}
+
+/**
+ * Refuse a `Select` and a projection that do not say the same thing.
+ *
+ * `SPECIFIC_ATTRIBUTES` is the one that projects, so it is the only one a
+ * projection goes with, and it needs one to have anything to answer with.
+ * `AttributesToGet` counts as a projection here as it does on AWS, which leaves
+ * a request using it refused by name rather than for a missing
+ * `ProjectionExpression` it never meant to write.
+ *
+ * A request that writes a projection and no `Select` at all is asking for
+ * exactly one thing, so there is nothing for it to contradict.
+ */
+function assertProjectionAgrees(
+  kind: SimDynamoDbSelectKind,
+  input: SimDynamoDbSelectInput,
+): void {
+  if (input.Select === undefined) {
+    return;
+  }
+
+  const projects =
+    input.ProjectionExpression !== undefined ||
+    (input.AttributesToGet ?? []).length > 0;
+
+  if (kind === "SPECIFIC_ATTRIBUTES" && !projects) {
+    throw new SimDynamoDbValidationException(
+      `Select SPECIFIC_ATTRIBUTES answers with the attributes a ` +
+        `ProjectionExpression names, and this request carries none`,
+    );
+  }
+
+  if (kind === "SPECIFIC_ATTRIBUTES") {
+    return;
+  }
+
+  if (input.ProjectionExpression !== undefined) {
+    throw new SimDynamoDbValidationException(
+      `Select ${kind} cannot be combined with a ProjectionExpression. ` +
+        `SPECIFIC_ATTRIBUTES is the Select that answers with the attributes ` +
+        `a projection names.`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/scan/scan.command.ts
+++ b/src/service/dynamodb/command/scan/scan.command.ts
@@ -44,8 +44,11 @@ export interface SimScanCommandInput {
 /**
  * Minimal structural sim DynamoDB Scan output.
  *
- * `Count` and `ScannedCount` are the same number here, since nothing filters a
- * scan yet: every item the walk evaluated is an item it answers with.
+ * `ScannedCount` is how many items the walk evaluated and `Count` how many of
+ * them the filter kept, so the two are the same number for a scan carrying no
+ * `FilterExpression`.
+ *
+ * `Items` is absent altogether for a `Select` of `COUNT`, rather than empty.
  *
  * `LastEvaluatedKey` is absent only when the table, or the segment of it being
  * read, ran out inside the `Limit`, so a caller loops until it is gone rather

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-paging.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-paging.iso.test.ts
@@ -2,7 +2,7 @@ import type {
   AttributeValue,
   ScanCommandInput,
 } from "@aws-sdk/client-dynamodb";
-import { PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
 import {
   assertArrayEquals,
   assertIdentical,
@@ -11,41 +11,8 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimDynamoDb } from "../../sim-dynamodb.js";
-import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
 import type { SimScanCommandOutput } from "./scan.command.js";
-
-/**
- * A table holding one order per customer, every other one of them open.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-
-  const orders = [
-    { customerId: "c-1", status: "OPEN" },
-    { customerId: "c-2", status: "SHIPPED" },
-    { customerId: "c-3", status: "OPEN" },
-    { customerId: "c-4", status: "SHIPPED" },
-  ];
-
-  await Promise.all(
-    orders.map(async (order) =>
-      simDynamoDb.putItem(
-        new PutItemCommand({
-          TableName: "OrdersTable",
-          Item: {
-            customerId: { S: order.customerId },
-            orderId: { S: "2026-01" },
-            status: { S: order.status },
-          },
-        }),
-      ),
-    ),
-  );
-
-  return simDynamoDb;
-}
 
 /**
  * The customers a page came back with.
@@ -86,7 +53,12 @@ describe("DynamoDB ScanCommand FilterExpression paging", () => {
   it("answers with an empty page it can still be resumed from", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When one item is read with a filter no item holds for.
     const page = await openOrders(simDynamoDb, {
@@ -106,7 +78,12 @@ describe("DynamoDB ScanCommand FilterExpression paging", () => {
   it("reads a whole table through a filtered paging loop", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When the table is read one item at a time until the token runs out.
     const read: string[] = [];
@@ -131,7 +108,12 @@ describe("DynamoDB ScanCommand FilterExpression paging", () => {
   it("filters a segment of a parallel scan", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When every segment of a parallel scan is read with a filter.
     const pages = await Promise.all(

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-paging.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-paging.iso.test.ts
@@ -1,0 +1,149 @@
+import type {
+  AttributeValue,
+  ScanCommandInput,
+} from "@aws-sdk/client-dynamodb";
+import { PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * A table holding one order per customer, every other one of them open.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  const orders = [
+    { customerId: "c-1", status: "OPEN" },
+    { customerId: "c-2", status: "SHIPPED" },
+    { customerId: "c-3", status: "OPEN" },
+    { customerId: "c-4", status: "SHIPPED" },
+  ];
+
+  await Promise.all(
+    orders.map(async (order) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "OrdersTable",
+          Item: {
+            customerId: { S: order.customerId },
+            orderId: { S: "2026-01" },
+            status: { S: order.status },
+          },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The customers a page came back with.
+ */
+function customerIds(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? []).map((item) => item["customerId"]?.S ?? "");
+}
+
+/**
+ * Customers put in order.
+ *
+ * A scan reads partition keys in hash order, which is deliberately arbitrary,
+ * so a test asserting which items came back sorts them first.
+ */
+function inOrder(customers: readonly string[]): readonly string[] {
+  return customers.toSorted((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Scan the table for open orders, however the test wants the read divided.
+ */
+async function openOrders(
+  simDynamoDb: SimDynamoDb,
+  input: Omit<ScanCommandInput, "TableName">,
+): Promise<SimScanCommandOutput> {
+  return simDynamoDb.scan(
+    new ScanCommand({
+      TableName: "OrdersTable",
+      FilterExpression: "#status = :open",
+      ExpressionAttributeNames: { "#status": "status" },
+      ExpressionAttributeValues: { ":open": { S: "OPEN" } },
+      ...input,
+    }),
+  );
+}
+
+describe("DynamoDB ScanCommand FilterExpression paging", () => {
+  it("answers with an empty page it can still be resumed from", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When one item is read with a filter no item holds for.
+    const page = await openOrders(simDynamoDb, {
+      FilterExpression: "#status = :gone",
+      ExpressionAttributeValues: { ":gone": { S: "CANCELLED" } },
+      Limit: 1,
+    });
+
+    // Then the page carries no items and a token to carry on from, since the
+    // read stopped at the limit rather than at the end of the table.
+    assertArrayEquals(customerIds(page), []);
+    assertIdentical(page.Count, 0);
+    assertIdentical(page.ScannedCount, 1);
+    assertNonNullable(page.LastEvaluatedKey);
+  });
+
+  it("reads a whole table through a filtered paging loop", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is read one item at a time until the token runs out.
+    const read: string[] = [];
+    let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+    do {
+      // eslint-disable-next-line no-await-in-loop -- a page at a time is the point.
+      const page = await openOrders(simDynamoDb, {
+        Limit: 1,
+        ExclusiveStartKey: exclusiveStartKey,
+      });
+
+      read.push(...customerIds(page));
+      exclusiveStartKey = page.LastEvaluatedKey;
+    } while (exclusiveStartKey !== undefined);
+
+    // Then every matching item is found. Most of those pages held nothing, so
+    // a loop stopping at the first empty page would have missed them.
+    assertArrayEquals(inOrder(read), ["c-1", "c-3"]);
+  });
+
+  it("filters a segment of a parallel scan", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When every segment of a parallel scan is read with a filter.
+    const pages = await Promise.all(
+      [0, 1].map(async (segment) =>
+        openOrders(simDynamoDb, { Segment: segment, TotalSegments: 2 }),
+      ),
+    );
+
+    // Then the segments together hold the matching items, with the filter
+    // applied to each segment's own page.
+    const found = pages.flatMap((page) => customerIds(page));
+
+    assertArrayEquals(inOrder(found), ["c-1", "c-3"]);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-validation.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-validation.iso.test.ts
@@ -1,0 +1,77 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+
+/**
+ * A table keyed by customer and order, holding nothing.
+ *
+ * A filter is read before the table is, so there is nothing to write.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  return simDynamoDb;
+}
+
+describe("DynamoDB ScanCommand FilterExpression validation", () => {
+  it.each([
+    {
+      parameter: "ExpressionAttributeNames",
+      input: { ExpressionAttributeNames: { "#status": "status" } },
+    },
+    {
+      parameter: "ExpressionAttributeValues",
+      input: { ExpressionAttributeValues: { ":open": { S: "OPEN" } } },
+    },
+  ])("refuses $parameter with no filter to use them", async (example) => {
+    // Given a table keyed by customer and order.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan defines placeholders and carries no expression.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({ TableName: "OrdersTable", ...example.input }),
+      ),
+    );
+
+    // Then it is refused by name, since nothing would ever read them.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, example.parameter);
+  });
+
+  it.each([
+    { name: "an empty expression", filter: " " },
+    { name: "a syntax error", filter: "#status =" },
+    { name: "an undefined placeholder", filter: "#missing = :open" },
+  ])("refuses $name in a scan filter", async (example) => {
+    // Given a table keyed by customer and order.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a scan carries a filter DynamoDB would not read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.scan(
+        new ScanCommand({
+          TableName: "OrdersTable",
+          FilterExpression: example.filter,
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: { ":open": { S: "OPEN" } },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than read as something else.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-validation.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter-validation.iso.test.ts
@@ -7,21 +7,7 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
 import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
-
-/**
- * A table keyed by customer and order, holding nothing.
- *
- * A filter is read before the table is, so there is nothing to write.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-
-  return simDynamoDb;
-}
 
 describe("DynamoDB ScanCommand FilterExpression validation", () => {
   it.each([
@@ -34,9 +20,12 @@ describe("DynamoDB ScanCommand FilterExpression validation", () => {
       input: { ExpressionAttributeValues: { ":open": { S: "OPEN" } } },
     },
   ])("refuses $parameter with no filter to use them", async (example) => {
-    // Given a table keyed by customer and order.
+    // Given a table keyed by customer and order. A filter is read before the
+    // table is, so there is nothing to write to it.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
 
     // When a scan defines placeholders and carries no expression.
     const error = await assertThrowsErrorAsync(async () =>
@@ -55,9 +44,12 @@ describe("DynamoDB ScanCommand FilterExpression validation", () => {
     { name: "a syntax error", filter: "#status =" },
     { name: "an undefined placeholder", filter: "#missing = :open" },
   ])("refuses $name in a scan filter", async (example) => {
-    // Given a table keyed by customer and order.
+    // Given a table keyed by customer and order. A filter is read before the
+    // table is, so there is nothing to write to it.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbCollectionTableFactory.make({}, simAws);
 
     // When a scan carries a filter DynamoDB would not read.
     const error = await assertThrowsErrorAsync(async () =>

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter.iso.test.ts
@@ -1,4 +1,4 @@
-import { PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
 import {
   assertArrayEquals,
   assertIdentical,
@@ -6,42 +6,8 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
-import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
 import type { SimScanCommandOutput } from "./scan.command.js";
-
-/**
- * A table holding one order per customer, every other one of them open.
- */
-async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
-  const simDynamoDb = simAws.dynamoDb();
-
-  await simDynamoDbCollectionTableFactory.make({}, simAws);
-
-  const orders = [
-    { customerId: "c-1", status: "OPEN" },
-    { customerId: "c-2", status: "SHIPPED" },
-    { customerId: "c-3", status: "OPEN" },
-    { customerId: "c-4", status: "SHIPPED" },
-  ];
-
-  await Promise.all(
-    orders.map(async (order) =>
-      simDynamoDb.putItem(
-        new PutItemCommand({
-          TableName: "OrdersTable",
-          Item: {
-            customerId: { S: order.customerId },
-            orderId: { S: "2026-01" },
-            status: { S: order.status },
-          },
-        }),
-      ),
-    ),
-  );
-
-  return simDynamoDb;
-}
 
 /**
  * The customers a page came back with, put in order.
@@ -59,7 +25,12 @@ describe("DynamoDB ScanCommand FilterExpression", () => {
   it("drops the items the filter does not hold for", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When the table is scanned with a filter.
     const output = await simDynamoDb.scan(
@@ -81,7 +52,12 @@ describe("DynamoDB ScanCommand FilterExpression", () => {
   it("takes a scan filter naming a key attribute", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When the table is scanned with a filter on the partition key, which the
     // same query would be refused for.
@@ -101,7 +77,12 @@ describe("DynamoDB ScanCommand FilterExpression", () => {
   it("applies the filter after the Limit rather than before it", async () => {
     // Given a table holding open and shipped orders.
     const simAws = new SimAws();
-    const simDynamoDb = await ordersTable(simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDbStockedTableFactory.make(
+      { customerCount: 4, orderCount: 1 },
+      simAws,
+    );
 
     // When a page of two items is scanned with a filter.
     const output = await simDynamoDb.scan(

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-filter.iso.test.ts
@@ -1,0 +1,123 @@
+import { PutItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import type { SimScanCommandOutput } from "./scan.command.js";
+
+/**
+ * A table holding one order per customer, every other one of them open.
+ */
+async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDbCollectionTableFactory.make({}, simAws);
+
+  const orders = [
+    { customerId: "c-1", status: "OPEN" },
+    { customerId: "c-2", status: "SHIPPED" },
+    { customerId: "c-3", status: "OPEN" },
+    { customerId: "c-4", status: "SHIPPED" },
+  ];
+
+  await Promise.all(
+    orders.map(async (order) =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "OrdersTable",
+          Item: {
+            customerId: { S: order.customerId },
+            orderId: { S: "2026-01" },
+            status: { S: order.status },
+          },
+        }),
+      ),
+    ),
+  );
+
+  return simDynamoDb;
+}
+
+/**
+ * The customers a page came back with, put in order.
+ *
+ * A scan reads partition keys in hash order, which is deliberately arbitrary,
+ * so a test asserting which items came back sorts them first.
+ */
+function customerIds(output: SimScanCommandOutput): readonly string[] {
+  return (output.Items ?? [])
+    .map((item) => item["customerId"]?.S ?? "")
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+describe("DynamoDB ScanCommand FilterExpression", () => {
+  it("drops the items the filter does not hold for", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned with a filter.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        FilterExpression: "#status = :open",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":open": { S: "OPEN" } },
+      }),
+    );
+
+    // Then only the items the filter kept come back, and the counts say how
+    // many were read to find them.
+    assertArrayEquals(customerIds(output), ["c-1", "c-3"]);
+    assertIdentical(output.Count, 2);
+    assertIdentical(output.ScannedCount, 4);
+  });
+
+  it("takes a scan filter naming a key attribute", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When the table is scanned with a filter on the partition key, which the
+    // same query would be refused for.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        FilterExpression: "customerId = :customer",
+        ExpressionAttributeValues: { ":customer": { S: "c-2" } },
+      }),
+    );
+
+    // Then it is read: a scan narrows nothing, so a key attribute is an
+    // attribute like any other.
+    assertArrayEquals(customerIds(output), ["c-2"]);
+  });
+
+  it("applies the filter after the Limit rather than before it", async () => {
+    // Given a table holding open and shipped orders.
+    const simAws = new SimAws();
+    const simDynamoDb = await ordersTable(simAws);
+
+    // When a page of two items is scanned with a filter.
+    const output = await simDynamoDb.scan(
+      new ScanCommand({
+        TableName: "OrdersTable",
+        FilterExpression: "#status = :shipped",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":shipped": { S: "SHIPPED" } },
+        Limit: 2,
+      }),
+    );
+
+    // Then the limit cut the read at two items before the filter saw them, so
+    // the page carries at most those two and a token to carry on from.
+    assertIdentical(output.ScannedCount, 2);
+    assertIdentical(output.Count, (output.Items ?? []).length);
+    assertNonNullable(output.LastEvaluatedKey);
+  });
+});

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -1,5 +1,8 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { readSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
+import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
+import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type { SimScanCommand, SimScanCommandOutput } from "./scan.command.js";
 import { readSimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment-input.js";
@@ -42,11 +45,19 @@ export class SimDynamoDbScan {
   ): SimScanCommandOutput {
     const input = command.input;
 
+    // Which attributes the request asks for is read first, since it decides
+    // whether the projection the request carries is one it could have asked
+    // for at all.
+    const select = SimDynamoDbSelect.from(input);
+
     refuseUnsimulatedScanInput(input);
 
-    // The segment is read before the table is reached, so a division DynamoDB
-    // would refuse is refused whether or not the table is there.
+    // The segment and the filter are read before the table is reached, so
+    // input DynamoDB would refuse is refused whether or not the table is
+    // there. A scan narrows nothing, so unlike a query its filter may name any
+    // attribute, including a key attribute, and needs no key schema to check.
     const segment = readSimDynamoDbScanSegment(input);
+    const filter = readSimDynamoDbFilter(input);
     const table = this.access.required(
       "dynamodb:Scan",
       input.TableName,
@@ -70,12 +81,7 @@ export class SimDynamoDbScan {
     });
 
     return {
-      Items: page.items.map((item) => item.toAttributeValues()),
-      // Nothing filters a scan yet, so every item the walk evaluated is an item
-      // the page carries.
-      Count: page.items.length,
-      ScannedCount: page.items.length,
-      LastEvaluatedKey: page.lastEvaluatedKey,
+      ...new SimDynamoDbReadAnswer({ page, filter, select }).fields(),
       $metadata: {},
     };
   }

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
@@ -28,12 +28,10 @@ async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
 describe("DynamoDB ScanCommand unsimulated input", () => {
   it.each([
     { name: "IndexName", input: { IndexName: "ByStatus" } },
-    { name: "FilterExpression", input: { FilterExpression: "status = :s" } },
     {
       name: "ProjectionExpression",
       input: { ProjectionExpression: "orderId" },
     },
-    { name: "Select", input: { Select: "COUNT" } },
     { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
     {
       name: "ScanFilter",
@@ -47,14 +45,6 @@ describe("DynamoDB ScanCommand unsimulated input", () => {
       },
     },
     { name: "ConditionalOperator", input: { ConditionalOperator: "AND" } },
-    {
-      name: "ExpressionAttributeNames",
-      input: { ExpressionAttributeNames: { "#status": "status" } },
-    },
-    {
-      name: "ExpressionAttributeValues",
-      input: { ExpressionAttributeValues: { ":s": { S: "shipped" } } },
-    },
     {
       name: "ReturnConsumedCapacity",
       input: { ReturnConsumedCapacity: "TOTAL" },
@@ -76,23 +66,6 @@ describe("DynamoDB ScanCommand unsimulated input", () => {
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
     assertStringIncludes(error.message, example.name);
   });
-
-  it.each(["ALL_ATTRIBUTES", undefined])(
-    "takes a Select of %s, which asks for what it already does",
-    async (select) => {
-      // Given a table.
-      const simAws = new SimAws();
-      const simDynamoDb = await ordersTable(simAws);
-
-      // When a scan names the Select a table scan already behaves as.
-      const output = await simDynamoDb.scan({
-        input: { TableName: "OrdersTable", Select: select },
-      });
-
-      // Then it is let through, since whole items are what it answers with.
-      assertArrayLength(output.Items ?? [], 0);
-    },
-  );
 
   it("takes a ReturnConsumedCapacity of NONE", async () => {
     // Given a table.

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
@@ -2,14 +2,6 @@ import { SimDynamoDbUnsimulatedInput } from "../item/sim-dynamodb-unsimulated-in
 import type { SimScanCommandInput } from "./scan.command.js";
 
 /**
- * The `Select` a scan already behaves as, which asks for whole items.
- *
- * Real DynamoDB defaults to this for a scan of a table rather than an index, so
- * a request naming it asks for what this simulation already does.
- */
-const simulatedSelect = "ALL_ATTRIBUTES";
-
-/**
  * Refuse the Scan inputs this simulation does not model.
  *
  * Each of these changes which items a scan answers with, or which parts of
@@ -17,12 +9,10 @@ const simulatedSelect = "ALL_ATTRIBUTES";
  * request asked for. That is the failure that passes here and surprises an
  * application reading the page.
  *
- * `ExpressionAttributeNames` and `ExpressionAttributeValues` are the
- * placeholders of an expression, and every expression a scan can carry is
- * refused above, so a request naming them is asking for one of those. Real
- * DynamoDB calls that a ValidationException rather than an unsupported
- * operation. The refusal is the same either way, and naming what is missing is
- * more use than matching the error class.
+ * `ExpressionAttributeNames` and `ExpressionAttributeValues` are not among
+ * them. They are the placeholders of the `FilterExpression`, and a request
+ * carrying them with no expression to use them in is a ValidationException the
+ * way it is on AWS.
  */
 export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("Scan");
@@ -33,20 +23,9 @@ export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
     "reading the table where a secondary index was asked for",
   );
   unsimulated.refuse(
-    input.FilterExpression !== undefined,
-    "FilterExpression",
-    "answering with the items a filter would have dropped",
-  );
-  unsimulated.refuse(
     input.ProjectionExpression !== undefined,
     "ProjectionExpression",
     "answering with whole items where part of them was asked for",
-  );
-  unsimulated.refuse(
-    input.Select !== undefined && input.Select !== simulatedSelect,
-    "Select",
-    `counting or projecting rather than answering with whole items, which is ` +
-      `what ${simulatedSelect} asks for`,
   );
   unsimulated.refuse(
     (input.AttributesToGet ?? []).length > 0,
@@ -62,16 +41,6 @@ export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
     input.ConditionalOperator !== undefined,
     "ConditionalOperator",
     "joining the legacy conditions it applies to",
-  );
-  unsimulated.refuseNamed(
-    input.ExpressionAttributeNames,
-    "ExpressionAttributeNames",
-    "reading placeholders for an expression Scan does not take",
-  );
-  unsimulated.refuseNamed(
-    input.ExpressionAttributeValues,
-    "ExpressionAttributeValues",
-    "reading placeholders for an expression Scan does not take",
   );
   unsimulated.refuseReporting(
     input.ReturnConsumedCapacity,

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
@@ -1,8 +1,7 @@
 import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
 import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
-import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import type { SimDynamoDbCondition } from "./sim-dynamodb-condition.js";
-import { SimDynamoDbConditionParser } from "./sim-dynamodb-condition-parser.js";
+import { simDynamoDbConditionParser } from "./sim-dynamodb-condition-grammar.js";
 
 const expressionName = "ConditionExpression";
 
@@ -49,13 +48,9 @@ export function parseSimDynamoDbCondition(
   expression: string,
   parameters: SimDynamoDbExpressionParameters,
 ): SimDynamoDbCondition {
-  return new SimDynamoDbConditionParser({
-    tokens: SimDynamoDbExpressionTokens.of(
-      expressionName,
-      expression,
-      "the expression says nothing, and an expression cannot be empty",
-    ),
-    names: parameters.names,
-    values: parameters.values,
-  }).parse();
+  return simDynamoDbConditionParser(
+    expressionName,
+    expression,
+    parameters,
+  ).parse();
 }

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-grammar.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-grammar.ts
@@ -1,0 +1,26 @@
+import type { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
+import { SimDynamoDbConditionParser } from "./sim-dynamodb-condition-parser.js";
+
+/**
+ * Build a parser for one expression written in the condition grammar.
+ *
+ * The same grammar arrives as a `ConditionExpression` on a write and as a
+ * `FilterExpression` on a read, so the name a refusal carries is passed in.
+ * Nothing else about them differs.
+ */
+export function simDynamoDbConditionParser(
+  expressionName: string,
+  expression: string,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbConditionParser {
+  return new SimDynamoDbConditionParser({
+    tokens: SimDynamoDbExpressionTokens.of(
+      expressionName,
+      expression,
+      "the expression says nothing, and an expression cannot be empty",
+    ),
+    names: parameters.names,
+    values: parameters.values,
+  });
+}

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
@@ -33,11 +34,23 @@ export class SimDynamoDbConditionOperandParser {
   private readonly tokens: SimDynamoDbExpressionTokens;
   private readonly names: SimDynamoDbExpressionPlaceholders<string>;
   private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
+  private readonly read: SimDynamoDbDocumentPath[] = [];
 
   constructor(properties: SimDynamoDbConditionOperandParserProperties) {
     this.tokens = properties.tokens;
     this.names = properties.names;
     this.values = properties.values;
+  }
+
+  /**
+   * Every place in the item the expression named, in the order it named them.
+   *
+   * A condition on a write has no use for these, since it is checked against
+   * one item the request already named. A filter does: which attributes it
+   * names is what a query is held to.
+   */
+  get paths(): readonly SimDynamoDbDocumentPath[] {
+    return this.read;
   }
 
   /**
@@ -115,11 +128,13 @@ export class SimDynamoDbConditionOperandParser {
    * Read a document path, which is what an operand is when it is nothing else.
    */
   private path(): SimDynamoDbPathOperand {
-    return new SimDynamoDbPathOperand(
-      new SimDynamoDbDocumentPathParser({
-        tokens: this.tokens,
-        names: this.names,
-      }).parse(),
-    );
+    const path = new SimDynamoDbDocumentPathParser({
+      tokens: this.tokens,
+      names: this.names,
+    }).parse();
+
+    this.read.push(path);
+
+    return new SimDynamoDbPathOperand(path);
   }
 }

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import {
@@ -30,6 +31,7 @@ interface SimDynamoDbConditionParserProperties {
  */
 export class SimDynamoDbConditionParser {
   private readonly tokens: SimDynamoDbExpressionTokens;
+  private readonly operands: SimDynamoDbConditionOperandParser;
   private readonly comparisons: SimDynamoDbConditionComparisonParser;
   private readonly functions: SimDynamoDbConditionFunctionParser;
 
@@ -41,6 +43,7 @@ export class SimDynamoDbConditionParser {
     });
 
     this.tokens = properties.tokens;
+    this.operands = operands;
     this.comparisons = new SimDynamoDbConditionComparisonParser({
       tokens: properties.tokens,
       operands,
@@ -49,6 +52,13 @@ export class SimDynamoDbConditionParser {
       tokens: properties.tokens,
       operands,
     });
+  }
+
+  /**
+   * Every place in the item the expression named.
+   */
+  get paths(): readonly SimDynamoDbDocumentPath[] {
+    return this.operands.paths;
   }
 
   /**

--- a/src/service/dynamodb/expression/filter/sim-dynamodb-filter-expression.ts
+++ b/src/service/dynamodb/expression/filter/sim-dynamodb-filter-expression.ts
@@ -1,0 +1,59 @@
+import { simDynamoDbConditionParser } from "../condition/sim-dynamodb-condition-grammar.js";
+import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import { SimDynamoDbFilter } from "./sim-dynamodb-filter.js";
+
+const expressionName = "FilterExpression";
+
+interface SimDynamoDbFilterRequest extends SimDynamoDbExpressionParameterInput {
+  readonly FilterExpression?: string | undefined;
+}
+
+/**
+ * Read the filter a read drops items by, if it names one.
+ *
+ * A request with no FilterExpression answers with every item it read, so there
+ * is nothing to drop by.
+ */
+export function readSimDynamoDbFilter(
+  request: SimDynamoDbFilterRequest,
+): SimDynamoDbFilter | undefined {
+  const expression = request.FilterExpression;
+
+  if (expression === undefined) {
+    SimDynamoDbExpressionParameters.assertNoneWithout(request);
+
+    return undefined;
+  }
+
+  const parameters = new SimDynamoDbExpressionParameters(request);
+  const filter = parseSimDynamoDbFilter(expression, parameters);
+
+  parameters.assertAllUsed();
+
+  return filter;
+}
+
+/**
+ * Read one FilterExpression against placeholders that have already been
+ * gathered.
+ *
+ * A query carries a key condition alongside its filter, and both draw on the
+ * same `ExpressionAttributeNames` and `ExpressionAttributeValues`, so the
+ * placeholders are checked once both expressions have been read.
+ */
+export function parseSimDynamoDbFilter(
+  expression: string,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbFilter {
+  const parser = simDynamoDbConditionParser(
+    expressionName,
+    expression,
+    parameters,
+  );
+
+  return new SimDynamoDbFilter({
+    condition: parser.parse(),
+    paths: parser.paths,
+  });
+}

--- a/src/service/dynamodb/expression/filter/sim-dynamodb-filter.ts
+++ b/src/service/dynamodb/expression/filter/sim-dynamodb-filter.ts
@@ -1,0 +1,63 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbCondition } from "../condition/sim-dynamodb-condition.js";
+import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
+
+interface SimDynamoDbFilterProperties {
+  readonly condition: SimDynamoDbCondition;
+  readonly paths: readonly SimDynamoDbDocumentPath[];
+}
+
+/**
+ * The filter a query or a scan drops items by.
+ *
+ * A filter runs after the read rather than during it. The walk is cut to the
+ * `Limit` first, and the filter then drops items from the page that came back,
+ * so a filtered page can be shorter than the limit or empty. It saves nothing:
+ * every item it drops was read.
+ *
+ * It is the ordinary condition grammar, evaluated against each item the way a
+ * conditional write is evaluated against the item it names. An item that does
+ * not have what the filter points at fails it, since there is no third answer.
+ */
+export class SimDynamoDbFilter {
+  private readonly condition: SimDynamoDbCondition;
+  private readonly paths: readonly SimDynamoDbDocumentPath[];
+
+  constructor(properties: SimDynamoDbFilterProperties) {
+    this.condition = properties.condition;
+    this.paths = properties.paths;
+  }
+
+  /**
+   * The items of a page this filter holds for.
+   */
+  applyTo(items: readonly SimDynamoDbItem[]): readonly SimDynamoDbItem[] {
+    return items.filter((item) =>
+      this.condition.holdsFor(new SimDynamoDbItemSnapshot(item)),
+    );
+  }
+
+  /**
+   * Refuse a filter naming a key attribute of the table being read.
+   *
+   * Real DynamoDB refuses this on a query and allows it on a scan. A query has
+   * already narrowed the read to the keys its key condition names, so a filter
+   * on a key attribute is either that condition written twice or a condition
+   * the key condition should have carried. A scan narrows nothing, so there a
+   * key attribute is an attribute like any other.
+   */
+  assertNamesNoKeyAttribute(keySchema: SimDynamoDbKeySchema): void {
+    for (const attributeName of keySchema.attributeNames()) {
+      if (this.paths.some((path) => path.startsAt(attributeName))) {
+        throw new SimDynamoDbValidationException(
+          `Filter Expression can not contain key attributes: ` +
+            `${attributeName} is part of the table's primary key, and a ` +
+            `query narrows by its KeyConditionExpression instead`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
@@ -1,6 +1,8 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
-import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
-import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import type {
+  SimDynamoDbExpressionParameterInput,
+  SimDynamoDbExpressionParameters,
+} from "../sim-dynamodb-expression-parameters.js";
 import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { keyConditionExpressionName } from "./sim-dynamodb-key-condition-error.js";
 import { SimDynamoDbKeyConditionParser } from "./sim-dynamodb-key-condition-parser.js";
@@ -16,9 +18,14 @@ interface SimDynamoDbKeyConditionRequest extends SimDynamoDbExpressionParameterI
  * A query names one item collection, so unlike every other expression parameter
  * this one is required rather than optional: a request without it is asking for
  * a scan.
+ *
+ * The placeholders are passed in rather than gathered here, since a query can
+ * carry a filter alongside its key condition and both draw on the same ones.
+ * They are checked once every expression on the request has been read.
  */
 export function readSimDynamoDbKeyCondition(
   request: SimDynamoDbKeyConditionRequest,
+  parameters: SimDynamoDbExpressionParameters,
 ): SimDynamoDbKeyConditionTerms {
   const expression = request.KeyConditionExpression;
 
@@ -29,7 +36,6 @@ export function readSimDynamoDbKeyCondition(
     );
   }
 
-  const parameters = new SimDynamoDbExpressionParameters(request);
   const terms = new SimDynamoDbKeyConditionParser({
     tokens: SimDynamoDbExpressionTokens.of(
       keyConditionExpressionName,
@@ -39,8 +45,6 @@ export function readSimDynamoDbKeyCondition(
     names: parameters.names,
     values: parameters.values,
   }).parse();
-
-  parameters.assertAllUsed();
 
   return new SimDynamoDbKeyConditionTerms(terms);
 }

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path.ts
@@ -57,6 +57,19 @@ export class SimDynamoDbDocumentPath {
   }
 
   /**
+   * Whether this path starts at one named attribute of the item.
+   *
+   * A path into a map or a list is still a path into the attribute it starts
+   * at, so `order.status` starts at `order`. That is what a rule about which
+   * attributes an expression may name is asking about.
+   */
+  startsAt(attributeName: string): boolean {
+    const first = this.segments.at(0);
+
+    return first?.kind === "attribute" && first.name === attributeName;
+  }
+
+  /**
    * The path written back out, for a refusal to name.
    *
    * Placeholders are gone by this point, so this is the path the request meant

--- a/src/service/dynamodb/table/sim-dynamodb-stocked-table.factory.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-stocked-table.factory.ts
@@ -1,5 +1,6 @@
 import { AsyncMappedFactory } from "@kensio/part-factory";
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { simDynamoDbCollectionTableFactory } from "./sim-dynamodb-collection-table.factory.js";
 import type { SimDynamoDbTable } from "./sim-dynamodb-table.js";
 
@@ -39,12 +40,47 @@ function orderIds(orderCount: number): readonly string[] {
 }
 
 /**
+ * The status the order in one place of the table carries.
+ *
+ * Statuses alternate over the table as a whole, so a read filtering by one has
+ * something to keep and something to drop however few orders a test asks for,
+ * and a table of one order per customer alternates by customer.
+ */
+function orderStatus(position: number): string {
+  if (position % 2 === 0) {
+    return "OPEN";
+  }
+
+  return "SHIPPED";
+}
+
+/**
+ * One order a stocked table holds, as the item it is written as.
+ */
+function orderItem(
+  customerId: string,
+  orderId: string,
+  position: number,
+): Readonly<Record<string, SimDynamoDbAttributeValue>> {
+  return {
+    customerId: { S: customerId },
+    orderId: { S: orderId },
+    status: { S: orderStatus(position) },
+    total: { N: (position + 1).toString() },
+  };
+}
+
+/**
  * Creates a table keyed by customer and order, holding one item per pair.
  *
  * This is the table a Scan reads: several item collections rather than one, so
  * a walk of the whole table has more than one partition key value to put in
  * order. Use `simDynamoDbCollectionTableFactory` for the same table with
  * nothing written to it.
+ *
+ * Each order carries a `status` of `OPEN` or `SHIPPED`, alternating over the
+ * table, and a `total` counting up from 1 in the same order. Both are there so
+ * a read can filter, project or compare by something outside the key.
  *
  * The orders are written together rather than in order, so the order a scan
  * answers in is the table's rather than the order they arrived in.
@@ -72,20 +108,23 @@ export const simDynamoDbStockedTableFactory = new AsyncMappedFactory<
       simAws,
     );
     const simDynamoDb = simAws.dynamoDb();
+    const orders = orderIds(input.orderCount);
 
     await Promise.all(
-      simDynamoDbStockedCustomerIds(input.customerCount).flatMap((customerId) =>
-        orderIds(input.orderCount).map(async (orderId) =>
-          simDynamoDb.putItem({
-            input: {
-              TableName: input.tableName,
-              Item: {
-                customerId: { S: customerId },
-                orderId: { S: orderId },
+      simDynamoDbStockedCustomerIds(input.customerCount).flatMap(
+        (customerId, customer) =>
+          orders.map(async (orderId, order) =>
+            simDynamoDb.putItem({
+              input: {
+                TableName: input.tableName,
+                Item: orderItem(
+                  customerId,
+                  orderId,
+                  customer * orders.length + order,
+                ),
               },
-            },
-          }),
-        ),
+            }),
+          ),
       ),
     );
 


### PR DESCRIPTION
FilterExpression on Query and Scan, applied after the Limit so ScannedCount counts the items a read evaluated and Count the ones that survived. A page whose items were all dropped comes back empty with a LastEvaluatedKey.

A Query filter naming a key attribute is refused, and the same expression on a Scan is accepted. Select takes COUNT, and the rules tying SPECIFIC_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES and a projection together are enforced.

Resolves https://github.com/KensioSoftware/yulin/issues/268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `FilterExpression` support for DynamoDB queries and scans, including filtering, validation, pagination, and accurate scanned/result counts.
  * Added `Select` support, including count-only responses and supported projection modes.
  * Added filtering and selection behavior for parallel scans and missing attributes.
* **Documentation**
  * Expanded DynamoDB documentation and examples covering filters, selections, projections, pagination, validation, and response semantics.
* **Tests**
  * Added comprehensive coverage for query, scan, filtering, selection, validation, and pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->