### PR TITLE
feat: create simulated DynamoDB global secondary indexes

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -157,7 +157,8 @@ console.log(index?.IndexArn); // ".../table/OrdersTable/index/byStatus"
 
 await simAws.backgroundTasksComplete();
 
-// An item with no status is simply absent from the index, rather than refused.
+// This order carries neither index key attribute, so it is absent from
+// byStatus rather than refused. Missing either one is enough.
 await dynamoDb.putItem(
   new PutItemCommand({
     TableName: "OrdersTable",
@@ -180,6 +181,9 @@ index keys plus the table keys, and `INCLUDE` adds 1 to 20 `NonKeyAttributes` to
 with no attributes named is refused, since it would add nothing to `KEYS_ONLY`, and attributes named
 under either of the other two types are refused as well.
 
+A table projects at most 100 `NonKeyAttributes` across all of its indexes, as well as 20 in any one
+of them. An attribute projected into two indexes counts twice.
+
 A provisioned table needs a `ProvisionedThroughput` per index as well as its own. `PAY_PER_REQUEST`
 refuses one, since an on-demand index has no capacity to provision.
 
@@ -189,10 +193,10 @@ under it. An index status follows its table's, so it is `CREATING` on the `Creat
 `ACTIVE` once the table is. A table that declared no index leaves `GlobalSecondaryIndexes` out of its
 description altogether.
 
-An index is sparse, so an item missing an index key attribute is absent from the index rather than
-refused on the write. The one thing a write is held to on account of an index is the type: an item
-carrying an index key attribute as a type the index did not declare is a `ValidationException`, since
-the index could never hold it.
+An index is sparse, so an item missing any one of an index's key attributes is absent from that index
+rather than refused on the write. An index keyed on two attributes needs both. The one thing a write
+is held to on account of an index is the type: an item carrying an index key attribute as a type the
+index did not declare is a `ValidationException`, since the index could never hold it.
 
 ## Describing a table
 

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -109,6 +109,91 @@ DynamoDB reports for one.
 `TableClass` is stored and reported, and changes nothing else: nothing bills a table here.
 `DeletionProtectionEnabled` does change what the table does, and is covered under deleting a table.
 
+## Global secondary indexes
+
+`GlobalSecondaryIndexes` on `CreateTable` declares indexes with a key of their own over the same
+items. Each index needs an `IndexName`, a `KeySchema` and a `Projection`.
+
+```typescript sim-dynamodb-global-secondary-index
+/**
+ * Declaring a global secondary index on a simulated table.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+const creation = await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    // Every index key attribute needs a definition, alongside the table's own.
+    AttributeDefinitions: [
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "status", AttributeType: "S" },
+      { AttributeName: "orderedAt", AttributeType: "N" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "byStatus",
+        KeySchema: [
+          { AttributeName: "status", KeyType: "HASH" },
+          { AttributeName: "orderedAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "ALL" },
+      },
+    ],
+  }),
+);
+
+const index = creation.TableDescription?.GlobalSecondaryIndexes?.[0];
+console.log(index?.IndexName); // "byStatus"
+console.log(index?.IndexStatus); // "CREATING"
+console.log(index?.IndexArn); // ".../table/OrdersTable/index/byStatus"
+
+await simAws.backgroundTasksComplete();
+
+// An item with no status is simply absent from the index, rather than refused.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);
+```
+
+`AttributeDefinitions` has to match the table key schema and every index key schema exactly, in both
+directions. Declaring an index without adding its key attribute definitions is a
+`ValidationException`, and so is defining an attribute no key uses. This is where `CreateTable` input
+most often goes wrong.
+
+An index key schema takes the same shape the table's does: one `HASH` element, optionally followed by
+one `RANGE` element, with key attributes of `S`, `N` or `B`. Index names are unique within a table,
+and a table holds at most 20 indexes.
+
+`Projection` says which attributes the index carries. `ALL` is the whole item, `KEYS_ONLY` is the
+index keys plus the table keys, and `INCLUDE` adds 1 to 20 `NonKeyAttributes` to those. `INCLUDE`
+with no attributes named is refused, since it would add nothing to `KEYS_ONLY`, and attributes named
+under either of the other two types are refused as well.
+
+A provisioned table needs a `ProvisionedThroughput` per index as well as its own. `PAY_PER_REQUEST`
+refuses one, since an on-demand index has no capacity to provision.
+
+The description reports each index with its `IndexName`, `IndexArn`, `KeySchema`, `Projection`,
+`ProvisionedThroughput` and `IndexStatus`. The index ARN is the table's own with the index named
+under it. An index status follows its table's, so it is `CREATING` on the `CreateTable` response and
+`ACTIVE` once the table is. A table that declared no index leaves `GlobalSecondaryIndexes` out of its
+description altogether.
+
+An index is sparse, so an item missing an index key attribute is absent from the index rather than
+refused on the write. The one thing a write is held to on account of an index is the type: an item
+carrying an index key attribute as a type the index did not declare is a `ValidationException`, since
+the index could never hold it.
+
 ## Describing a table
 
 `DescribeTable` answers with the same description `CreateTable` did, read off the table itself. A
@@ -2317,6 +2402,9 @@ property, and the rest of the stack still deploys: `GlobalSecondaryIndexes`, `Lo
 `AWS::DynamoDB::Table` does not have fails the resource instead, since that is a template real
 CloudFormation would refuse too.
 
+`GlobalSecondaryIndexes` is among those, even though `CreateTable` takes it. The template property is
+not read yet, so a stack declaring one skips the table rather than deploying it without its index.
+
 `AWS::DynamoDB::GlobalTable` is skipped rather than deployed, since replication across regions is
 not simulated.
 
@@ -2344,6 +2432,9 @@ nothing is written.
 
 - `CreateTable`, with table name, key schema, attribute definition, billing mode and throughput
   validation.
+- `GlobalSecondaryIndexes` on `CreateTable`, with index name, key schema, projection and per-index
+  throughput validation, `AttributeDefinitions` matched against every key schema in the request, and
+  each index reported in the table description.
 - `DescribeTable`, answering with the full table description, by table name or ARN.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
@@ -2405,10 +2496,19 @@ nothing is written.
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
   client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
   the operation rather than by the conversion.
-- Global and local secondary indexes are not simulated. `GlobalSecondaryIndexes` and
-  `LocalSecondaryIndexes` are refused rather than dropped, since a table missing an index it was
-  asked for would answer queries differently to the real one, and a `Query` naming an `IndexName` is
-  refused for the same reason. An empty list asks for no index, so it is accepted.
+- Reading a global secondary index is not simulated yet. An index is declared, validated and
+  reported, and the write path is held to its key attribute types, but `IndexName` on `Query` and
+  `Scan` is still refused rather than reading the table instead.
+- Local secondary indexes are not simulated. `LocalSecondaryIndexes` is refused rather than dropped,
+  since a table missing an index it was asked for would answer queries differently to the real one.
+  An empty list asks for no index, so it is accepted.
+- An index key is one attribute, or two. Real DynamoDB now takes more than that, and a key schema of
+  more than two elements is refused here.
+- `ItemCount` and `IndexSizeBytes` are 0 for every index, the same way the table's own figures are.
+- Per-index `ProvisionedThroughput` is read, validated and reported, and enforces nothing. No read or
+  write against an index is throttled, since none against the table is either.
+- `UpdateTable` is not simulated, so an index cannot be added to or removed from a table after it has
+  been created.
 - Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent, so
   a real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
   with none. Here the change is there by the time the call returns, so a test cannot observe the

--- a/docs/services/dynamodb/sim-dynamodb-global-secondary-index.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-global-secondary-index.example.ts
@@ -40,7 +40,8 @@ console.log(index?.IndexArn); // ".../table/OrdersTable/index/byStatus"
 
 await simAws.backgroundTasksComplete();
 
-// An item with no status is simply absent from the index, rather than refused.
+// This order carries neither index key attribute, so it is absent from
+// byStatus rather than refused. Missing either one is enough.
 await dynamoDb.putItem(
   new PutItemCommand({
     TableName: "OrdersTable",

--- a/docs/services/dynamodb/sim-dynamodb-global-secondary-index.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-global-secondary-index.example.ts
@@ -1,0 +1,49 @@
+/**
+ * Declaring a global secondary index on a simulated table.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+const creation = await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    // Every index key attribute needs a definition, alongside the table's own.
+    AttributeDefinitions: [
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "status", AttributeType: "S" },
+      { AttributeName: "orderedAt", AttributeType: "N" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "byStatus",
+        KeySchema: [
+          { AttributeName: "status", KeyType: "HASH" },
+          { AttributeName: "orderedAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "ALL" },
+      },
+    ],
+  }),
+);
+
+const index = creation.TableDescription?.GlobalSecondaryIndexes?.[0];
+console.log(index?.IndexName); // "byStatus"
+console.log(index?.IndexStatus); // "CREATING"
+console.log(index?.IndexArn); // ".../table/OrdersTable/index/byStatus"
+
+await simAws.backgroundTasksComplete();
+
+// An item with no status is simply absent from the index, rather than refused.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -91,6 +91,7 @@ Table state lives under `table/`.
 - creation time
 - current table status
 - key schema and attribute definitions
+- global secondary indexes
 - billing mode, provisioned throughput, table class and deletion protection
 - tags
 - in-memory items
@@ -111,13 +112,13 @@ naming what was wrong:
 
 - `SimDynamoDbTableName` for the name pattern and length
 - `SimDynamoDbKeySchema` for key element order, position and attribute names
-- `SimDynamoDbAttributeDefinitions` for attribute types, duplicates, and matching the key schema in
+- `SimDynamoDbAttributeDefinitions` for attribute types, duplicates, and matching every key schema in
   both directions
 - `SimDynamoDbTableBilling` for the billing mode and the throughput that goes with it
 
 ## Key schema handling
 
-`SimDynamoDbKeySchema` holds the table primary key.
+`SimDynamoDbKeySchema` holds the key of a table or of one of its secondary indexes.
 
 Supported key schema behavior:
 
@@ -126,6 +127,11 @@ Supported key schema behavior:
 - key attributes are `S`, `N` or `B`, and must have a matching attribute definition
 - item partition and sort key values must be strings or numbers
 - item keys are serialized as JSON and used as the internal item map key
+
+A request carries several key schemas: the table's own, and one per index. `SimDynamoDbKeySchemaSubject`
+is which of them a key schema is, and it travels with the key schema so a refusal names the one that
+was wrong. That is also what lets `SimDynamoDbAttributeDefinitions.assertMatches` take every key
+schema at once and report an undefined index key attribute against the index that declared it.
 
 For a table with only a partition key named `id`, an item with `{ id: { S: "abc" } }` is stored
 under an internal key equivalent to:
@@ -142,6 +148,35 @@ For a table with partition key `pk` and sort key `sk`, the internal key includes
 
 This is an implementation detail, but it is important when changing item storage because `putItem()`
 uses the key schema to overwrite items with the same primary key.
+
+## Secondary index model
+
+Index state lives under `secondary-index/`.
+
+`SimDynamoDbGlobalSecondaryIndex` is one index, as the name, key schema, projection and throughput a
+read of it needs. `SimDynamoDbGlobalSecondaryIndexes` is the indexes one table carries, and owns what
+is about how many there are: the 20 index cap and the uniqueness of a name. That is the same split
+the table tags follow.
+
+The parts an index is made of are a file each, since each has rules of its own:
+
+- `sim-dynamodb-index-name.ts` is the name pattern and length, which is the table name rule.
+- `sim-dynamodb-index-projection.ts` is `SimDynamoDbIndexProjection`: the three projection types, and
+  the two directions `INCLUDE` and `NonKeyAttributes` have to agree in.
+- `sim-dynamodb-index-throughput.ts` is the capacity an index is provisioned with, which contradicts
+  the billing mode in both directions the way the table's own does.
+- `sim-dynamodb-index-status.ts` maps a table status to the index status. Nothing here adds an index
+  to an existing table, so the index status follows the table's rather than being tracked apart from
+  it: `CREATING` on the CreateTable response, `ACTIVE` once the table is.
+
+Which items an index holds is worked out when the index is read rather than maintained on every
+write, following the precedent `SimSqsQueue.applyLifecycle` sets. So PutItem, UpdateItem and
+DeleteItem stay unaware of indexes apart from one check.
+
+That check is `assertItemKeyTypes`, applied in `SimDynamoDbTable.putItem`, which every write in the
+service goes through. An item missing an index key attribute is fine, since a global secondary index
+is sparse and simply does not hold it. An item carrying one as a type the index did not declare is a
+`ValidationException`, since the index could never hold it.
 
 ## Tagging behavior
 
@@ -231,7 +266,9 @@ The order it works in matters:
 2. The table name is read and checked, because the ARN is built from it.
 3. IAM authorizes `dynamodb:CreateTable` against that ARN. This runs before the table map is looked
    at, so an unauthorized caller cannot find out which names are taken.
-4. The key schema, attribute definitions, billing and table class are read and checked.
+4. The key schema, billing, secondary indexes, attribute definitions and table class are read and
+   checked. The indexes come before the attribute definitions, since the definitions have to match
+   every key schema the request carries and the indexes are where the rest of those are.
 5. Only then is the name checked against the table map and taken.
 
 `SimDynamoDb.createTable()` awaits `background.sequence()` and then calls `handle()`, which is
@@ -241,7 +278,8 @@ the same name cannot both get it. The second gets `SimDynamoDbResourceInUseExcep
 The returned `TableDescription` reports the table back: `TableName`, `TableArn`, `TableId`,
 `KeySchema`, `AttributeDefinitions`, `TableStatus`, `CreationDateTime`, `ProvisionedThroughput`,
 `DeletionProtectionEnabled`, and `BillingModeSummary` or `TableClassSummary` when the request named
-a billing mode or a table class. `ItemCount` and `TableSizeBytes` stay at 0.
+a billing mode or a table class. `GlobalSecondaryIndexes` is there when the table has any, and left
+out altogether when it has none. `ItemCount` and `TableSizeBytes` stay at 0.
 
 Unsimulated inputs are refused with `SimDynamoDbUnsupportedOperation` rather than dropped. Each one
 is listed in the Limitations section of
@@ -549,8 +587,9 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Indexes and streams are not implemented. Billing mode and provisioned capacity are read and
-stored by CreateTable, but nothing enforces them: no write is ever throttled.
+Streams are not implemented, and neither is reading a secondary index. Billing mode and provisioned
+capacity are read and stored by CreateTable, for the table and for each index, but nothing enforces
+them: no write is ever throttled.
 
 ## TransactWriteItems and TransactGetItems behavior
 

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.ts
@@ -16,7 +16,7 @@ type SimDynamoDbSelectKind = (typeof selectKinds)[number];
  * What a table read defaults to when the request says nothing.
  *
  * A read of an index defaults to `ALL_PROJECTED_ATTRIBUTES` instead, which does
- * not arise here: indexes are not simulated, so `IndexName` is refused.
+ * not arise here: reading an index is not simulated, so `IndexName` is refused.
  */
 const tableDefault: SimDynamoDbSelectKind = "ALL_ATTRIBUTES";
 

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table-index-validation.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table-index-validation.iso.test.ts
@@ -1,0 +1,276 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimCreateTableCommandInput } from "./table.command.js";
+import type { SimDynamoDbSecondaryIndexInput } from "./table.types.js";
+
+/**
+ * An index the request is otherwise happy with, for a test changing one part.
+ */
+const byStatus: SimDynamoDbSecondaryIndexInput = {
+  IndexName: "byStatus",
+  KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+  Projection: { ProjectionType: "KEYS_ONLY" },
+};
+
+/**
+ * Create a table with index input real DynamoDB would refuse.
+ */
+async function refusedIndexes(
+  indexes: readonly SimDynamoDbSecondaryIndexInput[],
+  overrides: Partial<SimCreateTableCommandInput> = {},
+): Promise<Error> {
+  const simDynamoDb = new SimAws().dynamoDb();
+
+  return await assertThrowsErrorAsync(async () =>
+    simDynamoDb.createTable({
+      input: {
+        TableName: "FoobarTable",
+        KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "pk", AttributeType: "S" },
+          { AttributeName: "status", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        ...overrides,
+        GlobalSecondaryIndexes: indexes,
+      },
+    }),
+  );
+}
+
+describe("DynamoDB CreateTableCommand index validation", () => {
+  it("requires an index name", async () => {
+    // When an index is declared with no name.
+    const error = await refusedIndexes([{ ...byStatus, IndexName: undefined }]);
+
+    // Then the missing name is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "A secondary index has no IndexName");
+  });
+
+  it("refuses an index name real DynamoDB would refuse", async () => {
+    // When an index is declared with a name holding a character AWS disallows.
+    const error = await refusedIndexes([
+      { ...byStatus, IndexName: "by Status" },
+    ]);
+
+    // Then the name is reported as invalid.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "IndexName 'by Status' is invalid");
+  });
+
+  it("refuses two indexes sharing a name", async () => {
+    // When a table is created with the same index name twice.
+    const error = await refusedIndexes([
+      byStatus,
+      { ...byStatus, Projection: { ProjectionType: "ALL" } },
+    ]);
+
+    // Then the repeated name is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "names an index more than once");
+  });
+
+  it("refuses more than twenty indexes", async () => {
+    // When a table is created with twenty one indexes.
+    const error = await refusedIndexes(
+      Array.from({ length: 21 }, (_unused, position) => ({
+        ...byStatus,
+        IndexName: `byStatus${position.toString()}`,
+      })),
+    );
+
+    // Then the count is reported rather than the twenty first index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "21 GlobalSecondaryIndexes were given");
+  });
+
+  it("requires an index key schema", async () => {
+    // When an index is declared with no key schema.
+    const error = await refusedIndexes([{ ...byStatus, KeySchema: undefined }]);
+
+    // Then the missing key schema names the index it belongs to.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "A KeySchema with a HASH key element is required for index byStatus",
+    );
+  });
+
+  it("refuses an index key schema with a RANGE key first", async () => {
+    // When an index is declared with its sort key ahead of its partition key.
+    const error = await refusedIndexes([
+      {
+        ...byStatus,
+        KeySchema: [
+          { AttributeName: "updatedAt", KeyType: "RANGE" },
+          { AttributeName: "status", KeyType: "HASH" },
+        ],
+      },
+    ]);
+
+    // Then the element in the wrong position is reported, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Invalid KeySchema for index byStatus: KeySchema element 1 is not a " +
+        "HASH key type",
+    );
+  });
+
+  it("refuses an index key schema with more than two elements", async () => {
+    // When an index is declared with three key schema elements.
+    const error = await refusedIndexes([
+      {
+        ...byStatus,
+        KeySchema: [
+          { AttributeName: "status", KeyType: "HASH" },
+          { AttributeName: "updatedAt", KeyType: "RANGE" },
+          { AttributeName: "extra", KeyType: "RANGE" },
+        ],
+      },
+    ]);
+
+    // Then the extra element is reported, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Invalid KeySchema for index byStatus: a key schema holds a HASH " +
+        "element and at most one RANGE element, but 3 elements were given",
+    );
+  });
+
+  it("refuses an index whose two keys name one attribute", async () => {
+    // When an index is declared with the same attribute as both its keys.
+    const error = await refusedIndexes([
+      {
+        ...byStatus,
+        KeySchema: [
+          { AttributeName: "status", KeyType: "HASH" },
+          { AttributeName: "status", KeyType: "RANGE" },
+        ],
+      },
+    ]);
+
+    // Then the repeated attribute is reported, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Invalid KeySchema for index byStatus: the HASH and RANGE elements " +
+        "both name the attribute status",
+    );
+  });
+
+  it("refuses an index key attribute with no definition", async () => {
+    // When an index is keyed on an attribute nothing defines.
+    const error = await refusedIndexes([
+      {
+        ...byStatus,
+        KeySchema: [{ AttributeName: "owner", KeyType: "HASH" }],
+      },
+    ]);
+
+    // Then the undefined key attribute is reported, naming the index. This is
+    // the rule CreateTable input goes wrong on most often.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The KeySchema for index byStatus names the attribute owner, which has " +
+        "no AttributeDefinition",
+    );
+  });
+
+  it("refuses an attribute defined for no key at all", async () => {
+    // When a table declares an attribute neither it nor its index is keyed on.
+    const error = await refusedIndexes([byStatus], {
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "status", AttributeType: "S" },
+        { AttributeName: "owner", AttributeType: "S" },
+      ],
+    });
+
+    // Then the unused definition is reported. An index key counts as a use, so
+    // the check runs against every key schema the request carries.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "defines the attribute owner, which no key uses",
+    );
+  });
+
+  it("refuses an index key attribute type that is not S, N or B", async () => {
+    // When an index is keyed on a boolean attribute.
+    const error = await refusedIndexes([byStatus], {
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "status", AttributeType: "BOOL" },
+      ],
+    });
+
+    // Then the attribute type is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "AttributeType 'BOOL'");
+  });
+
+  it("requires an index throughput on a provisioned table", async () => {
+    // When a provisioned table declares an index with no capacity of its own.
+    const error = await refusedIndexes([byStatus], {
+      BillingMode: "PROVISIONED",
+      ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 3 },
+    });
+
+    // Then the missing capacity is reported, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ProvisionedThroughput must be specified for index: byStatus",
+    );
+  });
+
+  it("refuses an index throughput on an on-demand table", async () => {
+    // When an on-demand table declares an index with capacity of its own.
+    const error = await refusedIndexes([
+      {
+        ...byStatus,
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 5,
+          WriteCapacityUnits: 3,
+        },
+      },
+    ]);
+
+    // Then the capacity is refused, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ProvisionedThroughput cannot be specified for index: byStatus",
+    );
+  });
+
+  it("refuses index capacity real DynamoDB would refuse", async () => {
+    // When a provisioned index asks for no read capacity at all.
+    const error = await refusedIndexes(
+      [
+        {
+          ...byStatus,
+          ProvisionedThroughput: { WriteCapacityUnits: 3 },
+        },
+      ],
+      {
+        BillingMode: "PROVISIONED",
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 3 },
+      },
+    );
+
+    // Then the capacity is held to the same rule the table's own is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "ReadCapacityUnits must be at least 1");
+  });
+});

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table-index-validation.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table-index-validation.iso.test.ts
@@ -91,6 +91,41 @@ describe("DynamoDB CreateTableCommand index validation", () => {
     assertStringIncludes(error.message, "21 GlobalSecondaryIndexes were given");
   });
 
+  it("refuses more than a hundred projected attributes in total", async () => {
+    // Given six indexes, each keyed on an attribute of its own and each
+    // projecting seventeen attributes, which is inside the twenty per index.
+    const keyed = ["a", "b", "c", "d", "e", "f"];
+    const indexes = keyed.map((attributeName) => ({
+      IndexName: `by${attributeName}`,
+      KeySchema: [{ AttributeName: attributeName, KeyType: "HASH" }],
+      Projection: {
+        ProjectionType: "INCLUDE",
+        NonKeyAttributes: Array.from(
+          { length: 17 },
+          (_unused, position) => `${attributeName}${position.toString()}`,
+        ),
+      },
+    }));
+
+    // When the table is created with all six.
+    const error = await refusedIndexes(indexes, {
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        ...keyed.map((attributeName) => ({
+          AttributeName: attributeName,
+          AttributeType: "S",
+        })),
+      ],
+    });
+
+    // Then the total is reported rather than each index passing on its own.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "102 NonKeyAttributes are projected across the table's indexes",
+    );
+  });
+
   it("requires an index key schema", async () => {
     // When an index is declared with no key schema.
     const error = await refusedIndexes([{ ...byStatus, KeySchema: undefined }]);

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table-indexes.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table-indexes.iso.test.ts
@@ -1,0 +1,280 @@
+import {
+  CreateTableCommand,
+  DescribeTableCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCreateTableCommandInput } from "./table.command.js";
+import type {
+  SimDynamoDbGlobalSecondaryIndexDescription,
+  SimDynamoDbSecondaryIndexInput,
+} from "./table.types.js";
+
+/**
+ * What a test asks for beyond the index itself.
+ *
+ * `AttributeDefinitions` names exactly the key attributes, index keys included,
+ * so an index keyed on a sort key of its own needs that attribute defined and
+ * one keyed on a partition key alone must not carry it.
+ */
+type SimDynamoDbIndexedTableInput = Pick<
+  SimCreateTableCommandInput,
+  "AttributeDefinitions" | "BillingMode" | "ProvisionedThroughput"
+>;
+
+const onDemand: SimDynamoDbIndexedTableInput = {
+  BillingMode: "PAY_PER_REQUEST",
+  AttributeDefinitions: [
+    { AttributeName: "pk", AttributeType: "S" },
+    { AttributeName: "status", AttributeType: "S" },
+  ],
+};
+
+/**
+ * Create a table carrying one global secondary index, and read the index back.
+ */
+async function createdIndex(
+  simAws: SimAws,
+  index: SimDynamoDbSecondaryIndexInput,
+  table: SimDynamoDbIndexedTableInput = onDemand,
+): Promise<SimDynamoDbGlobalSecondaryIndexDescription> {
+  const creation = await simAws.dynamoDb().createTable({
+    input: {
+      TableName: "FoobarTable",
+      KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+      ...table,
+      GlobalSecondaryIndexes: [index],
+    },
+  });
+
+  const described = creation.TableDescription?.GlobalSecondaryIndexes?.[0];
+  assertDefined(described, "the created index");
+
+  return described;
+}
+
+describe("DynamoDB CreateTableCommand global secondary indexes", () => {
+  it("reports an index the request declared", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with an index on a partition key of its own.
+    const index = await createdIndex(simAws, {
+      IndexName: "byStatus",
+      KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+      Projection: { ProjectionType: "KEYS_ONLY" },
+    });
+
+    // Then the index is reported as the request described it.
+    const [hashKey] = index.KeySchema ?? [];
+    assertDefined(hashKey, "the index HASH key element");
+    assertIdentical(index.IndexName, "byStatus");
+    assertIdentical(hashKey.AttributeName, "status");
+    assertIdentical(hashKey.KeyType, "HASH");
+    assertIdentical(index.Projection?.ProjectionType, "KEYS_ONLY");
+    assertIdentical(index.ItemCount, 0);
+    assertIdentical(index.IndexSizeBytes, 0);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("gives an index an ARN under its table", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with an index.
+    const index = await createdIndex(simAws, {
+      IndexName: "byStatus",
+      KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+      Projection: { ProjectionType: "ALL" },
+    });
+
+    // Then the index ARN names the index under the table ARN.
+    assertIdentical(
+      index.IndexArn,
+      `arn:aws:dynamodb:${simAws.defaultRegionName}:` +
+        `${simAws.defaultAccountId}:table/FoobarTable/index/byStatus`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("takes an index with a sort key of its own", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with an index keyed on two attributes.
+    const index = await createdIndex(
+      simAws,
+      {
+        IndexName: "byStatusUpdatedAt",
+        KeySchema: [
+          { AttributeName: "status", KeyType: "HASH" },
+          { AttributeName: "updatedAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "ALL" },
+      },
+      {
+        ...onDemand,
+        AttributeDefinitions: [
+          { AttributeName: "pk", AttributeType: "S" },
+          { AttributeName: "status", AttributeType: "S" },
+          { AttributeName: "updatedAt", AttributeType: "N" },
+        ],
+      },
+    );
+
+    // Then both key elements are reported, in the order they were given.
+    const elements = index.KeySchema ?? [];
+    assertArrayLength(elements, 2);
+    assertIdentical(elements[1].AttributeName, "updatedAt");
+    assertIdentical(elements[1].KeyType, "RANGE");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports the attributes an INCLUDE projection adds", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with an index projecting named attributes.
+    const index = await createdIndex(simAws, {
+      IndexName: "byStatus",
+      KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+      Projection: {
+        ProjectionType: "INCLUDE",
+        NonKeyAttributes: ["title", "owner"],
+      },
+    });
+
+    // Then the projection is reported with the attributes it names.
+    const included = index.Projection?.NonKeyAttributes ?? [];
+    assertIdentical(index.Projection?.ProjectionType, "INCLUDE");
+    assertIdentical(included[0], "title");
+    assertIdentical(included[1], "owner");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("leaves NonKeyAttributes out of a projection that names none", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with an index projecting the whole item.
+    const index = await createdIndex(simAws, {
+      IndexName: "byStatus",
+      KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+      Projection: { ProjectionType: "ALL" },
+    });
+
+    // Then the projection reports no NonKeyAttributes rather than an empty
+    // list, since ALL names no attributes to add.
+    assertUndefined(index.Projection?.NonKeyAttributes);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports the capacity a provisioned index was created with", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a provisioned table is created with a provisioned index.
+    const index = await createdIndex(
+      simAws,
+      {
+        IndexName: "byStatus",
+        KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+        Projection: { ProjectionType: "KEYS_ONLY" },
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 7,
+          WriteCapacityUnits: 2,
+        },
+      },
+      {
+        AttributeDefinitions: onDemand.AttributeDefinitions,
+        BillingMode: "PROVISIONED",
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 5,
+          WriteCapacityUnits: 3,
+        },
+      },
+    );
+
+    // Then the index reports its own capacity rather than the table's.
+    const throughput = index.ProvisionedThroughput;
+    assertDefined(throughput, "the index ProvisionedThroughput");
+    assertIdentical(throughput.ReadCapacityUnits, 7);
+    assertIdentical(throughput.WriteCapacityUnits, 2);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("moves an index from CREATING to ACTIVE with its table", async () => {
+    // Given a table created with an index, through the SDK Command.
+    const simAws = new SimAws();
+    const dynamoDb = simAws.dynamoDb();
+    const creation = await dynamoDb.createTable(
+      new CreateTableCommand({
+        TableName: "FoobarTable",
+        KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "pk", AttributeType: "S" },
+          { AttributeName: "status", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+            Projection: { ProjectionType: "KEYS_ONLY" },
+          },
+        ],
+      }),
+    );
+
+    // Then the index is CREATING while the table is.
+    assertIdentical(
+      creation.TableDescription?.GlobalSecondaryIndexes?.[0]?.IndexStatus,
+      "CREATING",
+    );
+
+    // When the scheduled activation has run.
+    await simAws.backgroundTasksComplete();
+    const described = await dynamoDb.describeTable(
+      new DescribeTableCommand({ TableName: "FoobarTable" }),
+    );
+
+    // Then DescribeTable reports the index as ACTIVE.
+    assertIdentical(
+      described.Table?.GlobalSecondaryIndexes?.[0]?.IndexStatus,
+      "ACTIVE",
+    );
+  });
+
+  it("leaves the indexes out of a table that declared none", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with no index at all.
+    const creation = await simAws.dynamoDb().createTable({
+      input: {
+        TableName: "FoobarTable",
+        KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+        AttributeDefinitions: [{ AttributeName: "pk", AttributeType: "S" }],
+        BillingMode: "PAY_PER_REQUEST",
+      },
+    });
+
+    // Then the description leaves GlobalSecondaryIndexes out rather than
+    // reporting an empty list, which is what real DynamoDB does.
+    assertUndefined(creation.TableDescription?.GlobalSecondaryIndexes);
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
@@ -2,6 +2,7 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimDynamoDbResourceInUseException } from "../../error/dynamodb.error.js";
+import { SimDynamoDbGlobalSecondaryIndexes } from "../../secondary-index/sim-dynamodb-global-secondary-indexes.js";
 import { SimDynamoDbAttributeDefinitions } from "../../table/sim-dynamodb-attribute-definitions.js";
 import { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
 import { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
@@ -107,23 +108,34 @@ export class SimDynamoDbCreateTable {
 
   /**
    * Build the table a request describes, checking what it describes.
+   *
+   * The indexes are read before the attribute definitions, since the
+   * definitions have to match every key schema the request carries and the
+   * indexes are where the rest of those are.
    */
   private tableFrom(
     name: SimDynamoDbTableName,
     input: SimCreateTableCommandInput,
   ): SimDynamoDbTable {
+    const arn = simDynamoDbTableArn(this.accountRegionScope, name.value);
     const keySchema = SimDynamoDbKeySchema.fromInput(input.KeySchema);
+    const billing = SimDynamoDbTableBilling.fromInput(input);
+    const indexes = SimDynamoDbGlobalSecondaryIndexes.fromInput(
+      input.GlobalSecondaryIndexes,
+      { tableArn: arn, billing },
+    );
     const attributeDefinitions = SimDynamoDbAttributeDefinitions.fromInput(
       input.AttributeDefinitions,
     );
-    attributeDefinitions.assertMatches(keySchema);
+    attributeDefinitions.assertMatches([keySchema, ...indexes.keySchemas()]);
 
     return new SimDynamoDbTable({
       name,
-      arn: simDynamoDbTableArn(this.accountRegionScope, name.value),
+      arn,
       keySchema,
       attributeDefinitions,
-      billing: SimDynamoDbTableBilling.fromInput(input),
+      billing,
+      indexes,
       tableClass: readSimDynamoDbTableClass(input.TableClass),
       deletionProtectionEnabled: input.DeletionProtectionEnabled,
       tags: SimDynamoDbTableTags.fromInput(input.Tags),

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
@@ -158,25 +158,35 @@ describe("DynamoDB CreateTableCommand unsimulated input", () => {
       ],
     });
 
-    // Then the limits are refused, the same as the table's own.
+    // Then the limits are refused, naming the index carrying them.
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "OnDemandThroughput maximums");
+    assertStringIncludes(
+      error.message,
+      "OnDemandThroughput maximums are not simulated, so CreateTable refuses " +
+        "them on index byStatus",
+    );
   });
 
   it("refuses warm throughput on an index", async () => {
-    // When an index is created pre-warmed for a level of traffic.
+    // When an index with no name yet is created pre-warmed for traffic.
     const error = await refusedCreateTable({
       ...indexedTableInput,
       GlobalSecondaryIndexes: [
         {
           ...indexedTableInput.GlobalSecondaryIndexes[0],
+          IndexName: undefined,
           WarmThroughput: { ReadUnitsPerSecond: 12_000 },
         },
       ],
     });
 
-    // Then the warm throughput is refused, the same as the table's own.
+    // Then the warm throughput is refused, naming the entry by its position.
+    // Unsimulated input is refused before any name is read, so the position is
+    // what an unnamed index can be pointed at by.
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "WarmThroughput");
+    assertStringIncludes(
+      error.message,
+      "refuses it on GlobalSecondaryIndexes entry 1",
+    );
   });
 });

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
@@ -17,6 +17,24 @@ const tableInput = {
 } as const satisfies SimCreateTableCommandInput;
 
 /**
+ * A table carrying one index, for the settings an index has of its own.
+ */
+const indexedTableInput = {
+  ...tableInput,
+  AttributeDefinitions: [
+    { AttributeName: "id", AttributeType: "S" },
+    { AttributeName: "status", AttributeType: "S" },
+  ],
+  GlobalSecondaryIndexes: [
+    {
+      IndexName: "byStatus",
+      KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+      Projection: { ProjectionType: "KEYS_ONLY" },
+    },
+  ],
+} as const satisfies SimCreateTableCommandInput;
+
+/**
  * Create a table asking for something the simulation does not model.
  */
 async function refusedCreateTable(
@@ -30,18 +48,6 @@ async function refusedCreateTable(
 }
 
 describe("DynamoDB CreateTableCommand unsimulated input", () => {
-  it("refuses global secondary indexes", async () => {
-    // When a table is created with a global secondary index.
-    const error = await refusedCreateTable({
-      ...tableInput,
-      GlobalSecondaryIndexes: [{ IndexName: "byEmail" }],
-    });
-
-    // Then the index is refused rather than quietly left out.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "Global secondary indexes");
-  });
-
   it("refuses local secondary indexes", async () => {
     // When a table is created with a local secondary index.
     const error = await refusedCreateTable({
@@ -136,6 +142,40 @@ describe("DynamoDB CreateTableCommand unsimulated input", () => {
     });
 
     // Then the warm throughput is refused.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "WarmThroughput");
+  });
+
+  it("refuses on-demand throughput maximums on an index", async () => {
+    // When an index is created with on-demand throughput limits of its own.
+    const error = await refusedCreateTable({
+      ...indexedTableInput,
+      GlobalSecondaryIndexes: [
+        {
+          ...indexedTableInput.GlobalSecondaryIndexes[0],
+          OnDemandThroughput: { MaxReadRequestUnits: 100 },
+        },
+      ],
+    });
+
+    // Then the limits are refused, the same as the table's own.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+    assertStringIncludes(error.message, "OnDemandThroughput maximums");
+  });
+
+  it("refuses warm throughput on an index", async () => {
+    // When an index is created pre-warmed for a level of traffic.
+    const error = await refusedCreateTable({
+      ...indexedTableInput,
+      GlobalSecondaryIndexes: [
+        {
+          ...indexedTableInput.GlobalSecondaryIndexes[0],
+          WarmThroughput: { ReadUnitsPerSecond: 12_000 },
+        },
+      ],
+    });
+
+    // Then the warm throughput is refused, the same as the table's own.
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
     assertStringIncludes(error.message, "WarmThroughput");
   });

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
@@ -1,5 +1,6 @@
 import { SimDynamoDbUnsupportedOperation } from "../../error/dynamodb.error.js";
 import type { SimCreateTableCommandInput } from "./table.command.js";
+import type { SimDynamoDbSecondaryIndexInput } from "./table.types.js";
 
 /**
  * Refuse the CreateTable inputs this simulation does not model.
@@ -84,25 +85,67 @@ function refuseEncryption(input: SimCreateTableCommandInput): void {
  * with settings nothing applies.
  */
 function refuseThroughputExtras(input: SimCreateTableCommandInput): void {
-  const indexes = input.GlobalSecondaryIndexes ?? [];
-
-  if (
-    input.OnDemandThroughput !== undefined ||
-    indexes.some((index) => index.OnDemandThroughput !== undefined)
-  ) {
+  if (input.OnDemandThroughput !== undefined) {
     throw new SimDynamoDbUnsupportedOperation(
       "OnDemandThroughput maximums are not simulated, so CreateTable refuses " +
         "them rather than reporting limits nothing here applies",
     );
   }
 
-  if (
-    input.WarmThroughput !== undefined ||
-    indexes.some((index) => index.WarmThroughput !== undefined)
-  ) {
+  if (input.WarmThroughput !== undefined) {
     throw new SimDynamoDbUnsupportedOperation(
       "WarmThroughput is not simulated, so CreateTable refuses it rather " +
         "than reporting a pre-warmed capacity nothing here applies",
     );
+  }
+
+  refuseIndexThroughputExtras(input.GlobalSecondaryIndexes ?? []);
+}
+
+/**
+ * How a refusal names the index carrying a setting nothing here applies.
+ *
+ * The name is what a reader recognises an index by. A request that left it out
+ * is refused for that once the indexes are read, so until then the position in
+ * the list stands in for it.
+ */
+function indexDescription(
+  index: SimDynamoDbSecondaryIndexInput,
+  position: number,
+): string {
+  if (index.IndexName === undefined) {
+    return `GlobalSecondaryIndexes entry ${(position + 1).toString()}`;
+  }
+
+  return `index ${index.IndexName}`;
+}
+
+/**
+ * Refuse the throughput settings an index carries of its own.
+ *
+ * A request can declare twenty indexes, so the refusal says which one was
+ * carrying the setting rather than leaving the reader to find it.
+ */
+function refuseIndexThroughputExtras(
+  indexes: readonly SimDynamoDbSecondaryIndexInput[],
+): void {
+  for (const [position, index] of indexes.entries()) {
+    const described = indexDescription(index, position);
+
+    if (index.OnDemandThroughput !== undefined) {
+      throw new SimDynamoDbUnsupportedOperation(
+        `OnDemandThroughput maximums are not simulated, so CreateTable ` +
+          `refuses them on ${described} rather than reporting limits nothing ` +
+          `here applies`,
+      );
+    }
+
+    if (index.WarmThroughput !== undefined) {
+      throw new SimDynamoDbUnsupportedOperation(
+        `WarmThroughput is not simulated, so CreateTable refuses it on ` +
+          `${described} rather than reporting a pre-warmed capacity nothing ` +
+          `here applies`,
+      );
+    }
   }
 }

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
@@ -32,16 +32,12 @@ export function refuseUnsimulatedTableInput(
 }
 
 /**
- * Refuse the secondary indexes a table would answer queries from.
+ * Refuse the local secondary indexes a table would answer queries from.
+ *
+ * Global secondary indexes are simulated, so they go through CreateTable's
+ * ordinary validation rather than being refused here.
  */
 function refuseSecondaryIndexes(input: SimCreateTableCommandInput): void {
-  if ((input.GlobalSecondaryIndexes ?? []).length > 0) {
-    throw new SimDynamoDbUnsupportedOperation(
-      "Global secondary indexes are not simulated, so CreateTable refuses " +
-        "them rather than creating a table that is missing them",
-    );
-  }
-
   if ((input.LocalSecondaryIndexes ?? []).length > 0) {
     throw new SimDynamoDbUnsupportedOperation(
       "Local secondary indexes are not simulated, so CreateTable refuses " +
@@ -82,16 +78,28 @@ function refuseEncryption(input: SimCreateTableCommandInput): void {
 
 /**
  * Refuse the throughput settings that go beyond provisioned capacity.
+ *
+ * A global secondary index carries its own copy of each of these, so the
+ * indexes are read alongside the table itself rather than being let through
+ * with settings nothing applies.
  */
 function refuseThroughputExtras(input: SimCreateTableCommandInput): void {
-  if (input.OnDemandThroughput !== undefined) {
+  const indexes = input.GlobalSecondaryIndexes ?? [];
+
+  if (
+    input.OnDemandThroughput !== undefined ||
+    indexes.some((index) => index.OnDemandThroughput !== undefined)
+  ) {
     throw new SimDynamoDbUnsupportedOperation(
       "OnDemandThroughput maximums are not simulated, so CreateTable refuses " +
         "them rather than reporting limits nothing here applies",
     );
   }
 
-  if (input.WarmThroughput !== undefined) {
+  if (
+    input.WarmThroughput !== undefined ||
+    indexes.some((index) => index.WarmThroughput !== undefined)
+  ) {
     throw new SimDynamoDbUnsupportedOperation(
       "WarmThroughput is not simulated, so CreateTable refuses it rather " +
         "than reporting a pre-warmed capacity nothing here applies",

--- a/src/service/dynamodb/command/table/table.types.ts
+++ b/src/service/dynamodb/command/table/table.types.ts
@@ -106,9 +106,26 @@ export interface SimDynamoDbTag {
 
 /**
  * Minimal structural sim DynamoDB secondary index, global or local.
+ *
+ * The throughput settings this simulation does not model are declared as well
+ * as the ones it does, so an index asking for one of them is refused by name
+ * rather than created without it.
  */
 export interface SimDynamoDbSecondaryIndexInput {
   readonly IndexName?: string | undefined;
+  readonly KeySchema?: readonly SimDynamoDbKeySchemaElementInput[] | undefined;
+  readonly Projection?: SimDynamoDbProjectionInput | undefined;
+  readonly ProvisionedThroughput?: SimDynamoDbProvisionedThroughput | undefined;
+  readonly OnDemandThroughput?: SimDynamoDbOnDemandThroughput | undefined;
+  readonly WarmThroughput?: SimDynamoDbWarmThroughput | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB projection, as a request carries it.
+ */
+export interface SimDynamoDbProjectionInput {
+  readonly ProjectionType?: string | undefined;
+  readonly NonKeyAttributes?: readonly string[] | undefined;
 }
 
 /**
@@ -185,6 +202,8 @@ export interface SimDynamoDbGlobalSecondaryIndexDescription {
   readonly Projection?: SimDynamoDbProjection | undefined;
   readonly IndexStatus?: SimDynamoDbIndexStatus | undefined;
   readonly IndexArn?: SimArn | undefined;
+  readonly ProvisionedThroughput?:
+    SimDynamoDbProvisionedThroughputDescription | undefined;
   readonly ItemCount?: number | undefined;
   readonly IndexSizeBytes?: number | undefined;
 }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-index.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-index.ts
@@ -1,0 +1,117 @@
+import type { SimArn } from "../../aws/arn.js";
+import type {
+  SimDynamoDbGlobalSecondaryIndexDescription,
+  SimDynamoDbIndexStatus,
+  SimDynamoDbSecondaryIndexInput,
+} from "../command/table/table.types.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import { SimDynamoDbKeySchemaSubject } from "../table/sim-dynamodb-key-schema-subject.js";
+import type { SimDynamoDbTableBilling } from "../table/sim-dynamodb-table-billing.js";
+import type { SimDynamoDbTableThroughput } from "../table/sim-dynamodb-table-throughput.js";
+import { assertSimDynamoDbIndexKeyTypes } from "./sim-dynamodb-index-key-types.js";
+import { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+import { readSimDynamoDbIndexName } from "./sim-dynamodb-index-name.js";
+import { readSimDynamoDbIndexThroughput } from "./sim-dynamodb-index-throughput.js";
+
+/**
+ * What a secondary index needs from the table it is declared on.
+ */
+export interface SimDynamoDbSecondaryIndexTable {
+  readonly tableArn: SimArn;
+  readonly billing: SimDynamoDbTableBilling;
+}
+
+interface SimDynamoDbGlobalSecondaryIndexProperties {
+  readonly name: string;
+  readonly tableArn: SimArn;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly projection: SimDynamoDbIndexProjection;
+  readonly throughput: SimDynamoDbTableThroughput;
+}
+
+/**
+ * One simulated global secondary index.
+ *
+ * An index is a key schema of its own over the same items, so it is held as
+ * what a read of it needs to know rather than as a copy of anything. The items
+ * it holds are worked out when it is read, which is why nothing here is
+ * maintained on the write path.
+ */
+export class SimDynamoDbGlobalSecondaryIndex {
+  public readonly name: string;
+  public readonly arn: SimArn;
+  public readonly keySchema: SimDynamoDbKeySchema;
+  public readonly projection: SimDynamoDbIndexProjection;
+
+  private readonly throughput: SimDynamoDbTableThroughput;
+
+  private constructor(properties: SimDynamoDbGlobalSecondaryIndexProperties) {
+    this.name = properties.name;
+    // An index ARN is the table's own with the index named under it, which is
+    // the resource an IAM policy naming one index is written against.
+    this.arn = `${properties.tableArn}/index/${properties.name}`;
+    this.keySchema = properties.keySchema;
+    this.projection = properties.projection;
+    this.throughput = properties.throughput;
+  }
+
+  /**
+   * Read one `GlobalSecondaryIndexes` entry a CreateTable request carries.
+   *
+   * The name is read first, since every other refusal names the index it is
+   * about.
+   */
+  static fromInput(
+    input: SimDynamoDbSecondaryIndexInput,
+    table: SimDynamoDbSecondaryIndexTable,
+  ): SimDynamoDbGlobalSecondaryIndex {
+    const name = readSimDynamoDbIndexName(input.IndexName);
+
+    return new this({
+      name,
+      tableArn: table.tableArn,
+      keySchema: SimDynamoDbKeySchema.fromInput(
+        input.KeySchema,
+        SimDynamoDbKeySchemaSubject.index(name),
+      ),
+      projection: SimDynamoDbIndexProjection.fromInput(input.Projection, name),
+      throughput: readSimDynamoDbIndexThroughput(input, name, table.billing),
+    });
+  }
+
+  /**
+   * Refuse an item carrying one of this index's key attributes as another type.
+   */
+  assertItemKeyTypes(
+    item: SimDynamoDbItem,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): void {
+    assertSimDynamoDbIndexKeyTypes({
+      indexName: this.name,
+      keySchema: this.keySchema,
+      item,
+      attributeDefinitions,
+    });
+  }
+
+  /**
+   * Describe this index the way DynamoDB reports it.
+   */
+  toDescription(
+    status: SimDynamoDbIndexStatus,
+  ): SimDynamoDbGlobalSecondaryIndexDescription {
+    return {
+      IndexName: this.name,
+      IndexArn: this.arn,
+      KeySchema: this.keySchema.elements,
+      Projection: this.projection.toDescription(),
+      IndexStatus: status,
+      ProvisionedThroughput: this.throughput.toDescription(),
+      // Neither figure is tracked, the same way the table's are not.
+      ItemCount: 0,
+      IndexSizeBytes: 0,
+    };
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
@@ -18,6 +18,11 @@ import {
 const maxIndexes = 20;
 
 /**
+ * The most NonKeyAttributes one table projects across all of its indexes.
+ */
+const maxProjectedAttributes = 100;
+
+/**
  * Refuse a request declaring one index name twice.
  *
  * An index is reached by name, so two indexes sharing one leave a read with no
@@ -32,6 +37,32 @@ function assertDistinctNames(
     throw new SimDynamoDbValidationException(
       "GlobalSecondaryIndexes names an index more than once, and an index " +
         "name is unique within a table",
+    );
+  }
+}
+
+/**
+ * Refuse a table projecting more attributes than DynamoDB lets it.
+ *
+ * The 20 an index projects is not the whole rule: a table is capped at 100
+ * across all of its indexes too, which six fully projecting indexes reach. An
+ * attribute projected into two indexes counts twice, so this is a plain sum
+ * rather than a count of distinct names, as it is on AWS.
+ */
+function assertProjectedAttributeCount(
+  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+): void {
+  const projected = elements.reduce(
+    (total, index) => total + index.projection.nonKeyAttributeCount,
+    0,
+  );
+
+  if (projected > maxProjectedAttributes) {
+    const most = maxProjectedAttributes.toString();
+
+    throw new SimDynamoDbValidationException(
+      `${projected.toString()} NonKeyAttributes are projected across the ` +
+        `table's indexes, and a table projects at most ${most}`,
     );
   }
 }
@@ -79,6 +110,7 @@ export class SimDynamoDbGlobalSecondaryIndexes {
     );
 
     assertDistinctNames(elements);
+    assertProjectedAttributeCount(elements);
 
     return new this(elements);
   }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
@@ -1,0 +1,123 @@
+import type {
+  SimDynamoDbGlobalSecondaryIndexDescription,
+  SimDynamoDbIndexStatus,
+  SimDynamoDbSecondaryIndexInput,
+} from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import {
+  SimDynamoDbGlobalSecondaryIndex,
+  type SimDynamoDbSecondaryIndexTable,
+} from "./sim-dynamodb-global-secondary-index.js";
+
+/**
+ * The most global secondary indexes one table holds.
+ */
+const maxIndexes = 20;
+
+/**
+ * Refuse a request declaring one index name twice.
+ *
+ * An index is reached by name, so two indexes sharing one leave a read with no
+ * way of saying which it meant.
+ */
+function assertDistinctNames(
+  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+): void {
+  const names = new Set(elements.map((index) => index.name));
+
+  if (names.size !== elements.length) {
+    throw new SimDynamoDbValidationException(
+      "GlobalSecondaryIndexes names an index more than once, and an index " +
+        "name is unique within a table",
+    );
+  }
+}
+
+/**
+ * The global secondary indexes one table carries.
+ *
+ * The collection owns what is about how many there are, and each index owns
+ * what is about itself, the same split the table tags follow.
+ */
+export class SimDynamoDbGlobalSecondaryIndexes {
+  public readonly elements: readonly SimDynamoDbGlobalSecondaryIndex[];
+
+  private constructor(elements: readonly SimDynamoDbGlobalSecondaryIndex[]) {
+    this.elements = elements;
+  }
+
+  /**
+   * The indexes of a table declaring none.
+   */
+  static none(): SimDynamoDbGlobalSecondaryIndexes {
+    return new this([]);
+  }
+
+  /**
+   * Read the `GlobalSecondaryIndexes` a CreateTable request carries.
+   */
+  static fromInput(
+    input: readonly SimDynamoDbSecondaryIndexInput[] | undefined,
+    table: SimDynamoDbSecondaryIndexTable,
+  ): SimDynamoDbGlobalSecondaryIndexes {
+    if (input === undefined || input.length === 0) {
+      return this.none();
+    }
+
+    if (input.length > maxIndexes) {
+      throw new SimDynamoDbValidationException(
+        `${input.length.toString()} GlobalSecondaryIndexes were given, and a ` +
+          `table holds at most ${maxIndexes.toString()}`,
+      );
+    }
+
+    const elements = input.map((index) =>
+      SimDynamoDbGlobalSecondaryIndex.fromInput(index, table),
+    );
+
+    assertDistinctNames(elements);
+
+    return new this(elements);
+  }
+
+  /**
+   * The key schemas these indexes are read by.
+   *
+   * `AttributeDefinitions` has to name every key attribute of every index as
+   * well as the table's own, so the schemas are reachable together.
+   */
+  keySchemas(): readonly SimDynamoDbKeySchema[] {
+    return this.elements.map((index) => index.keySchema);
+  }
+
+  /**
+   * Refuse an item carrying an index key attribute as the wrong type.
+   */
+  assertItemKeyTypes(
+    item: SimDynamoDbItem,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): void {
+    for (const index of this.elements) {
+      index.assertItemKeyTypes(item, attributeDefinitions);
+    }
+  }
+
+  /**
+   * How a table reports its indexes, which is not at all when it has none.
+   *
+   * Real DynamoDB leaves `GlobalSecondaryIndexes` out of the description of a
+   * table with no index, rather than reporting an empty list.
+   */
+  descriptions(
+    status: SimDynamoDbIndexStatus,
+  ): readonly SimDynamoDbGlobalSecondaryIndexDescription[] | undefined {
+    if (this.elements.length === 0) {
+      return undefined;
+    }
+
+    return this.elements.map((index) => index.toDescription(status));
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-item-keys.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-item-keys.iso.test.ts
@@ -1,0 +1,174 @@
+import { PutItemCommand, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../sim-dynamodb.js";
+
+/**
+ * A table with a partition key of its own and an index keyed on two others.
+ */
+async function indexedTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable({
+    input: {
+      TableName: "FoobarTable",
+      KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "status", AttributeType: "S" },
+        { AttributeName: "updatedAt", AttributeType: "N" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byStatus",
+          KeySchema: [
+            { AttributeName: "status", KeyType: "HASH" },
+            { AttributeName: "updatedAt", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+    },
+  });
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+describe("DynamoDB index key attributes on the write path", () => {
+  it("writes an item carrying no index key attribute at all", async () => {
+    // Given a table with an index on two attributes.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    // When an item is written with neither of them.
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+      }),
+    );
+
+    // Then the write succeeds. A global secondary index is sparse, so the item
+    // is simply absent from it rather than being refused.
+    const stored = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertIdentical(stored.Item?.["title"]?.S, "A hat");
+  });
+
+  it("writes an item carrying part of an index key", async () => {
+    // Given a table with an index on two attributes.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    // When an item is written with the index partition key and no sort key.
+    await simDynamoDb.putItem(
+      new PutItemCommand({
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, status: { S: "OPEN" } },
+      }),
+    );
+
+    // Then the write succeeds. The item is absent from the index, since an
+    // index entry needs the whole of the index key.
+    const stored = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertIdentical(stored.Item?.["status"]?.S, "OPEN");
+  });
+
+  it("refuses an index key attribute of another type", async () => {
+    // Given a table with an index whose sort key is a number.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    // When an item is written carrying that attribute as a string.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem(
+        new PutItemCommand({
+          TableName: "FoobarTable",
+          Item: {
+            pk: { S: "order-1" },
+            status: { S: "OPEN" },
+            updatedAt: { S: "2026-08-01" },
+          },
+        }),
+      ),
+    );
+
+    // Then the write is refused naming the index it could not be held by.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Type mismatch for Index Key updatedAt Expected: N Actual: S " +
+        "IndexName: byStatus",
+    );
+  });
+
+  it("leaves nothing written when an index key type is refused", async () => {
+    // Given a table with an index, holding an item already.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+      },
+    });
+
+    // When a write replacing it carries an index key of the wrong type.
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDb.putItem({
+        input: {
+          TableName: "FoobarTable",
+          Item: { pk: { S: "order-1" }, status: { N: "1" } },
+        },
+      }),
+    );
+
+    // Then the item is exactly as it was.
+    const stored = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertIdentical(stored.Item?.["title"]?.S, "A hat");
+  });
+
+  it("refuses an update giving an index key attribute another type", async () => {
+    // Given a table with an index, holding an item outside it.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+      },
+    });
+
+    // When an update sets an index key attribute as the wrong type.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.updateItem(
+        new UpdateItemCommand({
+          TableName: "FoobarTable",
+          Key: { pk: { S: "order-1" } },
+          UpdateExpression: "SET #status = :status",
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: { ":status": { N: "1" } },
+        }),
+      ),
+    );
+
+    // Then it is refused too. Every write reaches the table the same way, so
+    // the check needs writing once.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Type mismatch for Index Key status");
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-key-types.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-key-types.ts
@@ -1,0 +1,38 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+
+interface SimDynamoDbIndexKeyTypesProperties {
+  readonly indexName: string;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly item: SimDynamoDbItem;
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+}
+
+/**
+ * Refuse an item carrying an index key attribute as another type.
+ *
+ * This is the one thing a write is held to on account of an index. An item
+ * missing an index key attribute is simply absent from the index, since a
+ * global secondary index is sparse, but one carrying the attribute as a type
+ * the index did not declare could never be held by it at all.
+ */
+export function assertSimDynamoDbIndexKeyTypes(
+  properties: SimDynamoDbIndexKeyTypesProperties,
+): void {
+  const { indexName, item, attributeDefinitions } = properties;
+
+  for (const attributeName of properties.keySchema.attributeNames()) {
+    const value = item.attribute(attributeName);
+    const declared = attributeDefinitions.typeOf(attributeName);
+
+    if (value !== undefined && value.kind !== declared) {
+      throw new SimDynamoDbValidationException(
+        `One or more parameter values were invalid: Type mismatch for Index ` +
+          `Key ${attributeName} Expected: ${declared} Actual: ${value.kind} ` +
+          `IndexName: ${indexName}`,
+      );
+    }
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-name.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-name.ts
@@ -1,0 +1,32 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * Real DynamoDB allows letters, numbers, underscores, hyphens and periods in an
+ * index name, and between 3 and 255 of them, which is the table name rule.
+ */
+const indexNamePattern = /^[\w.-]{3,255}$/;
+
+/**
+ * Read the name a secondary index declares.
+ *
+ * The name is how a Query or a Scan reaches the index, so a name real DynamoDB
+ * would refuse is refused here rather than becoming an index nothing on AWS
+ * could name.
+ */
+export function readSimDynamoDbIndexName(name: string | undefined): string {
+  if (name === undefined || name === "") {
+    throw new SimDynamoDbValidationException(
+      "A secondary index has no IndexName",
+    );
+  }
+
+  if (!indexNamePattern.test(name)) {
+    throw new SimDynamoDbValidationException(
+      `IndexName '${name}' is invalid. It can only include letters, numbers, ` +
+        `underscores, hyphens and periods, and must be 3 to 255 characters ` +
+        `long.`,
+    );
+  }
+
+  return name;
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.iso.test.ts
@@ -1,0 +1,129 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimDynamoDbProjectionInput } from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+
+/**
+ * Read a projection an index would be refused for, and read the refusal.
+ */
+function refusedProjection(
+  input: SimDynamoDbProjectionInput | undefined,
+): Error {
+  return assertThrowsError(() =>
+    SimDynamoDbIndexProjection.fromInput(input, "byStatus"),
+  );
+}
+
+describe("SimDynamoDbIndexProjection", () => {
+  it("requires a projection", () => {
+    // When an index is declared with no projection at all.
+    const error = refusedProjection(undefined);
+
+    // Then the missing projection is reported, naming the index.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Index byStatus has no Projection");
+  });
+
+  it("requires a projection type", () => {
+    // When a projection names no type.
+    const error = refusedProjection({ NonKeyAttributes: ["title"] });
+
+    // Then the missing type is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The Projection of index byStatus has no ProjectionType",
+    );
+  });
+
+  it("refuses a projection type that is not one of the three", () => {
+    // When a projection names a type DynamoDB does not have.
+    const error = refusedProjection({ ProjectionType: "SOME" });
+
+    // Then the type is reported with the three it could have been.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "ProjectionType 'SOME'");
+    assertStringIncludes(error.message, "ALL, KEYS_ONLY, INCLUDE");
+  });
+
+  it("refuses INCLUDE naming no attributes", () => {
+    // When a projection includes attributes and names none.
+    const error = refusedProjection({
+      ProjectionType: "INCLUDE",
+      NonKeyAttributes: [],
+    });
+
+    // Then it is refused rather than read as KEYS_ONLY written the long way.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "adds nothing to KEYS_ONLY");
+  });
+
+  it("refuses INCLUDE with the attributes left out altogether", () => {
+    // When a projection is INCLUDE with no NonKeyAttributes property.
+    const error = refusedProjection({ ProjectionType: "INCLUDE" });
+
+    // Then the missing attributes are reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "adds nothing to KEYS_ONLY");
+  });
+
+  it("refuses more than twenty included attributes", () => {
+    // When a projection includes twenty one attributes.
+    const error = refusedProjection({
+      ProjectionType: "INCLUDE",
+      NonKeyAttributes: Array.from({ length: 21 }, (_unused, position) =>
+        position.toString(),
+      ),
+    });
+
+    // Then the count is reported.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "names 21 NonKeyAttributes");
+  });
+
+  it("refuses attributes named under a projection that adds none", () => {
+    // When a KEYS_ONLY projection names attributes to include.
+    const error = refusedProjection({
+      ProjectionType: "KEYS_ONLY",
+      NonKeyAttributes: ["title"],
+    });
+
+    // Then the contradiction is reported rather than the attributes dropped.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "names NonKeyAttributes with a ProjectionType of KEYS_ONLY",
+    );
+  });
+
+  it("takes a projection of the whole item", () => {
+    // When an index projects everything.
+    const projection = SimDynamoDbIndexProjection.fromInput(
+      { ProjectionType: "ALL" },
+      "byStatus",
+    );
+
+    // Then the type is what it reports, with no attributes to add.
+    assertIdentical(projection.type, "ALL");
+    assertUndefined(projection.toDescription().NonKeyAttributes);
+  });
+
+  it("takes a projection of the keys and named attributes", () => {
+    // When an index projects its keys plus two attributes.
+    const projection = SimDynamoDbIndexProjection.fromInput(
+      { ProjectionType: "INCLUDE", NonKeyAttributes: ["title", "owner"] },
+      "byStatus",
+    );
+
+    // Then the attributes are reported in the order they were given.
+    assertIdentical(projection.toDescription().NonKeyAttributes?.[0], "title");
+    assertIdentical(projection.toDescription().NonKeyAttributes?.[1], "owner");
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
@@ -127,6 +127,16 @@ export class SimDynamoDbIndexProjection {
   }
 
   /**
+   * How many attributes this projection adds to the index keys.
+   *
+   * A table is capped on the total across all of its indexes as well as on each
+   * one, so the count is readable rather than only the projection being.
+   */
+  get nonKeyAttributeCount(): number {
+    return this.nonKeyAttributes.length;
+  }
+
+  /**
    * How an index reports its projection.
    *
    * `NonKeyAttributes` is left out altogether unless the projection is INCLUDE,

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
@@ -1,0 +1,145 @@
+import type {
+  SimDynamoDbProjection,
+  SimDynamoDbProjectionInput,
+  SimDynamoDbProjectionType,
+} from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * The three things an index projection can be.
+ */
+const projectionTypes = ["ALL", "KEYS_ONLY", "INCLUDE"] as const;
+
+/**
+ * The most `NonKeyAttributes` one index adds to its keys.
+ */
+const maxNonKeyAttributes = 20;
+
+/**
+ * Read the projection type an index declares.
+ */
+function readProjectionType(
+  type: string | undefined,
+  indexName: string,
+): SimDynamoDbProjectionType {
+  if (type === undefined) {
+    throw new SimDynamoDbValidationException(
+      `The Projection of index ${indexName} has no ProjectionType. It is one ` +
+        `of ${projectionTypes.join(", ")}.`,
+    );
+  }
+
+  const found = projectionTypes.find((candidate) => candidate === type);
+
+  if (found === undefined) {
+    throw new SimDynamoDbValidationException(
+      `ProjectionType '${type}' of index ${indexName} is invalid. It is one ` +
+        `of ${projectionTypes.join(", ")}.`,
+    );
+  }
+
+  return found;
+}
+
+/**
+ * Read the attributes an INCLUDE projection adds to the index keys.
+ *
+ * The two halves have to agree in both directions. INCLUDE with nothing to
+ * include is KEYS_ONLY written the long way round, and attributes named under
+ * any other projection type have nothing to be added to.
+ */
+function readNonKeyAttributes(
+  attributeNames: readonly string[] | undefined,
+  type: SimDynamoDbProjectionType,
+  indexName: string,
+): readonly string[] {
+  if (type !== "INCLUDE") {
+    if (attributeNames !== undefined) {
+      throw new SimDynamoDbValidationException(
+        `The Projection of index ${indexName} names NonKeyAttributes with a ` +
+          `ProjectionType of ${type}. INCLUDE is the projection type that ` +
+          `names the attributes it adds.`,
+      );
+    }
+
+    return [];
+  }
+
+  if (attributeNames === undefined || attributeNames.length === 0) {
+    throw new SimDynamoDbValidationException(
+      `The Projection of index ${indexName} is INCLUDE and names no ` +
+        `NonKeyAttributes, so it adds nothing to KEYS_ONLY`,
+    );
+  }
+
+  if (attributeNames.length > maxNonKeyAttributes) {
+    throw new SimDynamoDbValidationException(
+      `The Projection of index ${indexName} names ` +
+        `${attributeNames.length.toString()} NonKeyAttributes, and an index ` +
+        `projects at most ${maxNonKeyAttributes.toString()}`,
+    );
+  }
+
+  return attributeNames;
+}
+
+/**
+ * Which attributes one secondary index carries.
+ *
+ * An index is a copy of the table holding the attributes it projects, so what
+ * it projects is what a read of it can answer with. KEYS_ONLY carries the index
+ * keys and the table keys, INCLUDE adds named attributes to those, and ALL
+ * carries the whole item.
+ */
+export class SimDynamoDbIndexProjection {
+  public readonly type: SimDynamoDbProjectionType;
+
+  private readonly nonKeyAttributes: readonly string[];
+
+  private constructor(
+    type: SimDynamoDbProjectionType,
+    nonKeyAttributes: readonly string[],
+  ) {
+    this.type = type;
+    this.nonKeyAttributes = nonKeyAttributes;
+  }
+
+  /**
+   * Read the Projection a secondary index has to carry.
+   */
+  static fromInput(
+    input: SimDynamoDbProjectionInput | undefined,
+    indexName: string,
+  ): SimDynamoDbIndexProjection {
+    if (input === undefined) {
+      throw new SimDynamoDbValidationException(
+        `Index ${indexName} has no Projection, and an index says which ` +
+          `attributes it carries`,
+      );
+    }
+
+    const type = readProjectionType(input.ProjectionType, indexName);
+
+    return new this(
+      type,
+      readNonKeyAttributes(input.NonKeyAttributes, type, indexName),
+    );
+  }
+
+  /**
+   * How an index reports its projection.
+   *
+   * `NonKeyAttributes` is left out altogether unless the projection is INCLUDE,
+   * since the other two types have none to report.
+   */
+  toDescription(): SimDynamoDbProjection {
+    if (this.type !== "INCLUDE") {
+      return { ProjectionType: this.type };
+    }
+
+    return {
+      ProjectionType: this.type,
+      NonKeyAttributes: this.nonKeyAttributes,
+    };
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-status.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-status.ts
@@ -1,0 +1,27 @@
+import type {
+  SimDynamoDbIndexStatus,
+  SimDynamoDbTableStatus,
+} from "../command/table/table.types.js";
+
+/**
+ * The status an index has while its table is in a status of its own.
+ *
+ * An index declared on CreateTable is built with the table that carries it, so
+ * real DynamoDB reports a CREATING index on the CreateTable response and an
+ * ACTIVE one once the table is ACTIVE. Nothing here adds an index to a table
+ * later, so the index status follows the table's rather than being tracked
+ * apart from it.
+ */
+export function simDynamoDbIndexStatus(
+  tableStatus: SimDynamoDbTableStatus,
+): SimDynamoDbIndexStatus {
+  if (tableStatus === "CREATING") {
+    return "CREATING";
+  }
+
+  if (tableStatus === "DELETING") {
+    return "DELETING";
+  }
+
+  return "ACTIVE";
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-throughput.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-throughput.ts
@@ -1,0 +1,40 @@
+import type { SimDynamoDbSecondaryIndexInput } from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbTableBilling } from "../table/sim-dynamodb-table-billing.js";
+import { SimDynamoDbTableThroughput } from "../table/sim-dynamodb-table-throughput.js";
+
+/**
+ * Read the capacity a secondary index is provisioned with.
+ *
+ * A global secondary index is provisioned separately from the table it belongs
+ * to, so a provisioned table needs a throughput per index as well as its own.
+ * An on-demand table has nothing to provision, and the two contradict each
+ * other in both directions the same way the table's own do.
+ */
+export function readSimDynamoDbIndexThroughput(
+  input: SimDynamoDbSecondaryIndexInput,
+  indexName: string,
+  billing: SimDynamoDbTableBilling,
+): SimDynamoDbTableThroughput {
+  if (billing.mode === "PROVISIONED") {
+    if (input.ProvisionedThroughput === undefined) {
+      throw new SimDynamoDbValidationException(
+        `One or more parameter values were invalid: ProvisionedThroughput ` +
+          `must be specified for index: ${indexName} when BillingMode is ` +
+          `PROVISIONED`,
+      );
+    }
+
+    return SimDynamoDbTableThroughput.required(input.ProvisionedThroughput);
+  }
+
+  if (input.ProvisionedThroughput !== undefined) {
+    throw new SimDynamoDbValidationException(
+      `One or more parameter values were invalid: ProvisionedThroughput ` +
+        `cannot be specified for index: ${indexName} when BillingMode is ` +
+        `PAY_PER_REQUEST`,
+    );
+  }
+
+  return SimDynamoDbTableThroughput.none();
+}

--- a/src/service/dynamodb/table/sim-dynamodb-attribute-definitions.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-attribute-definitions.ts
@@ -91,20 +91,30 @@ export class SimDynamoDbAttributeDefinitions {
   }
 
   /**
-   * Check these definitions and a key schema name exactly the same attributes.
+   * Check these definitions and the key schemas using them name exactly the
+   * same attributes.
+   *
+   * Every key schema a request carries takes part: the table's own, and one for
+   * each secondary index. Declaring an index whose key attribute has no
+   * definition is the mistake this catches, and it is where CreateTable input
+   * most often goes wrong.
    */
-  assertMatches(keySchema: SimDynamoDbKeySchema): void {
+  assertMatches(keySchemas: readonly SimDynamoDbKeySchema[]): void {
     const definedNames = new Set(
       this.elements.map((element) => element.AttributeName),
     );
-    const keyNames = new Set(keySchema.attributeNames());
+    const keyNames = new Set<string>();
 
-    for (const keyName of keyNames) {
-      if (!definedNames.has(keyName)) {
-        throw new SimDynamoDbValidationException(
-          `The KeySchema names the attribute ${keyName}, which has no ` +
-            `AttributeDefinition`,
-        );
+    for (const keySchema of keySchemas) {
+      for (const keyName of keySchema.attributeNames()) {
+        keyNames.add(keyName);
+
+        if (!definedNames.has(keyName)) {
+          throw new SimDynamoDbValidationException(
+            `The KeySchema${keySchema.subject.owner} names the attribute ` +
+              `${keyName}, which has no AttributeDefinition`,
+          );
+        }
       }
     }
 

--- a/src/service/dynamodb/table/sim-dynamodb-key-schema-element.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-key-schema-element.ts
@@ -3,10 +3,10 @@ import type {
   SimDynamoDbKeySchemaElementInput,
   SimDynamoDbKeyType,
 } from "../command/table/table.types.js";
-import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbKeySchemaSubject } from "./sim-dynamodb-key-schema-subject.js";
 
 /**
- * The key type belonging at a position in a table key schema.
+ * The key type belonging at a position in a key schema.
  */
 function keyTypeAt(index: number): SimDynamoDbKeyType {
   if (index === 0) {
@@ -22,24 +22,27 @@ function keyTypeAt(index: number): SimDynamoDbKeyType {
  * DynamoDB takes the key schema in order: a partition key first, then a sort
  * key when there is one. Position is the whole of it, so an element of the
  * wrong type for where it is gets refused rather than quietly sorted out.
+ *
+ * A secondary index key schema takes the same shape the table's does, so the
+ * subject is what a refusal names rather than the rules being written twice.
  */
 export function readSimDynamoDbKeySchemaElement(
   element: SimDynamoDbKeySchemaElementInput,
   index: number,
+  subject: SimDynamoDbKeySchemaSubject,
 ): SimDynamoDbKeySchemaElement {
   const expectedKeyType = keyTypeAt(index);
 
   if (element.KeyType !== expectedKeyType) {
-    throw new SimDynamoDbValidationException(
-      `Invalid KeySchema: KeySchema element ${(index + 1).toString()} is not ` +
-        `a ${expectedKeyType} key type`,
+    throw subject.refuse(
+      `KeySchema element ${(index + 1).toString()} is not a ` +
+        `${expectedKeyType} key type`,
     );
   }
 
   if (element.AttributeName === undefined || element.AttributeName === "") {
-    throw new SimDynamoDbValidationException(
-      `Invalid KeySchema: the ${expectedKeyType} key element has no ` +
-        `AttributeName`,
+    throw subject.refuse(
+      `the ${expectedKeyType} key element has no AttributeName`,
     );
   }
 

--- a/src/service/dynamodb/table/sim-dynamodb-key-schema-subject.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-key-schema-subject.ts
@@ -1,0 +1,45 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * Which KeySchema of a request a refusal is about.
+ *
+ * A CreateTable request carries one key schema for the table and one for every
+ * secondary index it declares, and all of them are read the same way. A refusal
+ * saying only "KeySchema" would leave the reader working out which of them was
+ * meant, so the subject travels with the key schema and names it.
+ */
+export class SimDynamoDbKeySchemaSubject {
+  /**
+   * How a message says where this key schema belongs, such as
+   * " for index byStatus". The table's own key schema needs no such words,
+   * since a request that names no index has only the one.
+   */
+  public readonly owner: string;
+
+  private constructor(owner: string) {
+    this.owner = owner;
+  }
+
+  /**
+   * The key schema of the table itself.
+   */
+  static table(): SimDynamoDbKeySchemaSubject {
+    return new this("");
+  }
+
+  /**
+   * The key schema of one secondary index.
+   */
+  static index(indexName: string): SimDynamoDbKeySchemaSubject {
+    return new this(` for index ${indexName}`);
+  }
+
+  /**
+   * Refuse this key schema for what it says, naming which one it is.
+   */
+  refuse(reason: string): SimDynamoDbValidationException {
+    return new SimDynamoDbValidationException(
+      `Invalid KeySchema${this.owner}: ${reason}`,
+    );
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-key-schema.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-key-schema.ts
@@ -5,58 +5,70 @@ import type {
 } from "../command/table/table.types.js";
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import { readSimDynamoDbKeySchemaElement } from "./sim-dynamodb-key-schema-element.js";
+import { SimDynamoDbKeySchemaSubject } from "./sim-dynamodb-key-schema-subject.js";
 
 /**
- * The primary key of one simulated table.
+ * The key of one simulated table or one of its secondary indexes.
  *
  * A key schema is one HASH element, optionally followed by one RANGE element,
- * in that order. Anything else is refused here as it is on AWS.
+ * in that order. Anything else is refused here as it is on AWS. The subject is
+ * what the key schema belongs to, so a request carrying several of them is
+ * refused naming the one that was wrong.
  */
 export class SimDynamoDbKeySchema {
   public readonly elements: readonly SimDynamoDbKeySchemaElement[];
+  public readonly subject: SimDynamoDbKeySchemaSubject;
   public readonly hashKeyAttributeName: string;
   public readonly rangeKeyAttributeName: string | undefined;
 
-  private constructor(elements: readonly SimDynamoDbKeySchemaElement[]) {
+  private constructor(
+    elements: readonly SimDynamoDbKeySchemaElement[],
+    subject: SimDynamoDbKeySchemaSubject,
+  ) {
     const [hashKey, rangeKey] = elements;
-    assertDefined(hashKey, "DynamoDB Table HASH key schema element");
+    assertDefined(hashKey, "DynamoDB HASH key schema element");
+    const hashKeyName = hashKey.AttributeName;
 
-    if (rangeKey?.AttributeName === hashKey.AttributeName) {
-      throw new SimDynamoDbValidationException(
-        `Invalid KeySchema: the HASH and RANGE key elements both name the ` +
-          `attribute ${hashKey.AttributeName}`,
+    if (rangeKey?.AttributeName === hashKeyName) {
+      throw subject.refuse(
+        `the HASH and RANGE elements both name the attribute ${hashKeyName}`,
       );
     }
 
     this.elements = elements;
+    this.subject = subject;
     this.hashKeyAttributeName = hashKey.AttributeName;
     this.rangeKeyAttributeName = rangeKey?.AttributeName;
   }
 
   /**
-   * Read the key schema a CreateTable request carries.
+   * Read a key schema a CreateTable request carries.
+   *
+   * The subject defaults to the table's own key schema, which is the one a
+   * request always has.
    */
   static fromInput(
     input: readonly SimDynamoDbKeySchemaElementInput[] | undefined,
+    subject: SimDynamoDbKeySchemaSubject = SimDynamoDbKeySchemaSubject.table(),
   ): SimDynamoDbKeySchema {
     if (input === undefined || input.length === 0) {
       throw new SimDynamoDbValidationException(
-        "A KeySchema with a HASH key element is required",
+        `A KeySchema with a HASH key element is required${subject.owner}`,
       );
     }
 
     if (input.length > 2) {
-      throw new SimDynamoDbValidationException(
-        `Invalid KeySchema: a table key schema holds a HASH element and at ` +
-          `most one RANGE element, but ${input.length.toString()} elements ` +
-          `were given`,
+      throw subject.refuse(
+        `a key schema holds a HASH element and at most one RANGE element, ` +
+          `but ${input.length.toString()} elements were given`,
       );
     }
 
     return new this(
       input.map((element, index) =>
-        readSimDynamoDbKeySchemaElement(element, index),
+        readSimDynamoDbKeySchemaElement(element, index, subject),
       ),
+      subject,
     );
   }
 

--- a/src/service/dynamodb/table/sim-dynamodb-table-description.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-description.ts
@@ -3,6 +3,7 @@ import type {
   SimDynamoDbTableClassSummary,
   SimDynamoDbTableDescription,
 } from "../command/table/table.types.js";
+import { simDynamoDbIndexStatus } from "../secondary-index/sim-dynamodb-index-status.js";
 import type { SimDynamoDbTable } from "./sim-dynamodb-table.js";
 
 /**
@@ -39,6 +40,9 @@ export function describeSimDynamoDbTable(
     BillingModeSummary: table.billing.summary(),
     ProvisionedThroughput: table.billing.throughputDescription(),
     TableClassSummary: tableClassSummary(table.tableClass),
+    GlobalSecondaryIndexes: table.indexes.descriptions(
+      simDynamoDbIndexStatus(table.status),
+    ),
     DeletionProtectionEnabled: table.deletionProtectionEnabled,
     // Neither figure is tracked yet. Real DynamoDB updates both about every
     // six hours, so they lag behind the items anyway.

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -15,6 +15,7 @@ import { SimDynamoDbTableExpiry } from "../time-to-live/sim-dynamodb-table-expir
 import { SimDynamoDbTimeToLive } from "../time-to-live/sim-dynamodb-time-to-live.js";
 import type { SimDynamoDbTimeToLiveSpecification } from "../time-to-live/sim-dynamodb-time-to-live-specification.js";
 import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import { SimDynamoDbGlobalSecondaryIndexes } from "../secondary-index/sim-dynamodb-global-secondary-indexes.js";
 import { SimDynamoDbItemCollection } from "./sim-dynamodb-item-collection.js";
 import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
@@ -36,6 +37,7 @@ interface SimDynamoDbTableProperties {
   readonly keySchema: SimDynamoDbKeySchema;
   readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
   readonly billing: SimDynamoDbTableBilling;
+  readonly indexes?: SimDynamoDbGlobalSecondaryIndexes;
   readonly tableClass?: SimDynamoDbTableClass | undefined;
   readonly deletionProtectionEnabled?: boolean | undefined;
   readonly tags?: SimDynamoDbTableTags;
@@ -58,6 +60,16 @@ export class SimDynamoDbTable {
   public readonly keySchema: SimDynamoDbKeySchema;
   public readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
   public readonly billing: SimDynamoDbTableBilling;
+
+  /**
+   * The global secondary indexes this table carries.
+   *
+   * Which items an index holds is worked out when it is read rather than kept
+   * up to date on every write, so nothing here is more than what the index was
+   * declared as.
+   */
+  public readonly indexes: SimDynamoDbGlobalSecondaryIndexes;
+
   public readonly tableClass: SimDynamoDbTableClass | undefined;
   public readonly deletionProtectionEnabled: boolean;
 
@@ -81,6 +93,7 @@ export class SimDynamoDbTable {
       keySchema,
       attributeDefinitions,
       billing,
+      indexes = SimDynamoDbGlobalSecondaryIndexes.none(),
       deletionProtectionEnabled = false,
       tags = SimDynamoDbTableTags.fromInput([]),
       background = new BackgroundTasks(),
@@ -92,6 +105,7 @@ export class SimDynamoDbTable {
     this.keySchema = keySchema;
     this.attributeDefinitions = attributeDefinitions;
     this.billing = billing;
+    this.indexes = indexes;
     this.tableClass = properties.tableClass;
     this.deletionProtectionEnabled = deletionProtectionEnabled;
     this.tags = tags;
@@ -156,6 +170,12 @@ export class SimDynamoDbTable {
    */
   public putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
     const key = this.itemKey.of(item);
+
+    // An item need not carry an index's key attributes, since a global
+    // secondary index is sparse. Carrying one as a type the index did not
+    // declare is refused, since the index could never hold it.
+    this.indexes.assertItemKeyTypes(item, this.attributeDefinitions);
+
     const replaced = this.items.put(key, item);
 
     this.expiry.scheduleFor(key, item);


### PR DESCRIPTION
Declare global secondary indexes on CreateTable, with index name, key schema, projection and per-index throughput validation. AttributeDefinitions is matched against the table key schema and every index key schema, in both directions. Each index is reported in the CreateTable and DescribeTable description with its ARN, key schema, projection and status.

An index is sparse, so an item missing an index key attribute is absent from the index rather than refused. An item carrying one as a type the index did not declare is refused on the write.

Reading an index is not included: IndexName on Query and Scan is still refused by name.

Part of https://github.com/KensioSoftware/yulin/issues/269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and describing DynamoDB global secondary indexes.
  * Added index key schemas, projections, provisioned throughput, lifecycle statuses, ARNs, and sparse-item behavior.
  * Added validation for index names, schemas, projections, attributes, throughput, and item key types.
  * Added an example demonstrating global secondary index creation and usage.

* **Limitations**
  * Reads using `IndexName` and local secondary indexes remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->