### PR TITLE
feat: query and scan simulated DynamoDB global secondary indexes

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2608,11 +2608,12 @@ nothing is written.
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
   client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
   the operation rather than by the conversion.
-- An index read answers with the attributes the index projects, and there is no way to ask for more.
-  Real DynamoDB fetches the rest from the table when a `ProjectionExpression` names an attribute an
-  index does not project, at the cost of a read per item. `ProjectionExpression` is not simulated on
-  `Query` or `Scan` at all, so the case does not arise, and `Select: ALL_ATTRIBUTES` is refused
-  rather than served that way.
+- An index read answers with the attributes the index projects, and nothing fills in the rest. Real
+  DynamoDB does not either: a global secondary index never reads the base table for an attribute it
+  does not project, which is why `Select: ALL_ATTRIBUTES` against a partial projection is refused
+  rather than served. Fetching from the base table is a local secondary index behaviour, and those
+  are not simulated. `ProjectionExpression` is not simulated on `Query` or `Scan`, so naming a
+  non-projected attribute that way does not arise.
 - Local secondary indexes are not simulated. `LocalSecondaryIndexes` is refused rather than dropped,
   since a table missing an index it was asked for would answer queries differently to the real one.
   An empty list asks for no index, so it is accepted.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1181,6 +1181,111 @@ A token still works when the item it names has since been deleted: it says where
 than which position to return to. A token from a different partition key is refused, since it names
 a collection this query is not reading.
 
+## Reading a global secondary index
+
+`IndexName` on `Query` and `Scan` reads an index instead of the table. The key condition is held to
+the index key schema rather than the table's, which is the point: the index is how an access pattern
+the table key cannot serve gets served.
+
+```typescript sim-dynamodb-query-index
+/**
+ * Querying a global secondary index.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "status", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "byStatus",
+        KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+        Projection: { ProjectionType: "INCLUDE", NonKeyAttributes: ["total"] },
+      },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: { S: "order-1" },
+      status: { S: "OPEN" },
+      total: { N: "42" },
+      note: { S: "Gift wrap" },
+    },
+  }),
+);
+
+// A draft carries no status, so the index does not hold it.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-2" }, total: { N: "7" } },
+  }),
+);
+
+const open = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    IndexName: "byStatus",
+    KeyConditionExpression: "#status = :status",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+  }),
+);
+
+console.log(open.Count); // 1
+console.log(open.Items?.[0]?.["orderId"]?.S); // "order-1"
+console.log(open.Items?.[0]?.["total"]?.N); // "42"
+
+// `note` is not projected, so it is not on the item the index answers with.
+console.log(open.Items?.[0]?.["note"]); // undefined
+```
+
+The index is sparse. An item missing any of the index key attributes is not in the index, so a read
+of it simply does not find that item. Nothing about the write said so at the time.
+
+An index key is not unique, so several items can share one. Items sharing an index key come back in
+no particular order, and `LastEvaluatedKey` carries the index key attributes together with the table
+key attributes, which is what names one of them exactly enough to resume after. An
+`ExclusiveStartKey` carrying only part of that is refused.
+
+A read answers with the attributes the index projects, so `Select` defaults to
+`ALL_PROJECTED_ATTRIBUTES` rather than `ALL_ATTRIBUTES`. Asking for more than the index carries is
+refused rather than quietly answered with less:
+
+- `Select: ALL_ATTRIBUTES` against an index whose projection is not `ALL` is a `ValidationException`.
+- A `FilterExpression` naming an attribute the index does not project is refused too. The attribute
+  is not on the items the index holds, so the filter would drop all of them and the empty page would
+  read as a collection that happens to hold nothing.
+
+An `IndexName` the table does not have gives `ResourceNotFoundException` rather than reading the
+table. `ConsistentRead: true` against a global secondary index is a `ValidationException`, because a
+global secondary index is maintained asynchronously on AWS and cannot answer a strongly consistent
+read at all.
+
+`Scan` takes `IndexName` the same way, including in parallel segments, which divide by the index
+partition key rather than the table's.
+
 ## Scanning a table
 
 `Scan` reads every item in a table. It needs no key knowledge at all, which is what makes it the
@@ -2439,6 +2544,9 @@ nothing is written.
 - `GlobalSecondaryIndexes` on `CreateTable`, with index name, key schema, projection and per-index
   throughput validation, `AttributeDefinitions` matched against every key schema in the request, and
   each index reported in the table description.
+- `IndexName` on `Query` and `Scan`, reading a sparse index by its own key schema, answering with the
+  attributes it projects, and paging with a `LastEvaluatedKey` carrying the index key and the table
+  key together.
 - `DescribeTable`, answering with the full table description, by table name or ARN.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
@@ -2500,9 +2608,11 @@ nothing is written.
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
   client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
   the operation rather than by the conversion.
-- Reading a global secondary index is not simulated yet. An index is declared, validated and
-  reported, and the write path is held to its key attribute types, but `IndexName` on `Query` and
-  `Scan` is still refused rather than reading the table instead.
+- An index read answers with the attributes the index projects, and there is no way to ask for more.
+  Real DynamoDB fetches the rest from the table when a `ProjectionExpression` names an attribute an
+  index does not project, at the cost of a read per item. `ProjectionExpression` is not simulated on
+  `Query` or `Scan` at all, so the case does not arise, and `Select: ALL_ATTRIBUTES` is refused
+  rather than served that way.
 - Local secondary indexes are not simulated. `LocalSecondaryIndexes` is refused rather than dropped,
   since a table missing an index it was asked for would answer queries differently to the real one.
   An empty list asks for no index, so it is accepted.
@@ -2586,11 +2696,8 @@ nothing is written.
   DynamoDB accepts it. The shape of a key condition is fixed, so there is nothing for brackets to
   group, and being stricter is the direction that fails safely: it is a puzzling refusal here rather
   than a query that means something different on AWS.
-- `IndexName` and `ProjectionExpression` are refused on `Query` and on `Scan`, since each of them
-  changes which items the operation answers with or which parts of them. Reading a secondary index
-  goes with the indexes themselves, which are not simulated.
-- A `Query` filter is held to the table's key schema, since indexes are not simulated. Which
-  attributes a filter may name on an index read is settled when index reads land.
+- `ProjectionExpression` is refused on `Query` and on `Scan`, since it changes which parts of an item
+  the operation answers with. `Select` covers the counted and the projected read in the meantime.
 - `UnprocessedItems` and `UnprocessedKeys` are always empty. Nothing here is throttled and no
   response stops at a size, so the branch of a batch retry loop that resends what did not go through
   is never taken against the simulator.

--- a/docs/services/dynamodb/sim-dynamodb-query-index.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-query-index.example.ts
@@ -1,0 +1,71 @@
+/**
+ * Querying a global secondary index.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "status", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: "byStatus",
+        KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+        Projection: { ProjectionType: "INCLUDE", NonKeyAttributes: ["total"] },
+      },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: {
+      orderId: { S: "order-1" },
+      status: { S: "OPEN" },
+      total: { N: "42" },
+      note: { S: "Gift wrap" },
+    },
+  }),
+);
+
+// A draft carries no status, so the index does not hold it.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-2" }, total: { N: "7" } },
+  }),
+);
+
+const open = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "OrdersTable",
+    IndexName: "byStatus",
+    KeyConditionExpression: "#status = :status",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+  }),
+);
+
+console.log(open.Count); // 1
+console.log(open.Items?.[0]?.["orderId"]?.S); // "order-1"
+console.log(open.Items?.[0]?.["total"]?.N); // "42"
+
+// `note` is not projected, so it is not on the item the index answers with.
+console.log(open.Items?.[0]?.["note"]); // undefined

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -173,6 +173,38 @@ Which items an index holds is worked out when the index is read rather than main
 write, following the precedent `SimSqsQueue.applyLifecycle` sets. So PutItem, UpdateItem and
 DeleteItem stay unaware of indexes apart from one check.
 
+## Read views
+
+`SimDynamoDbReadView` under `table/` is what a Query or a Scan reads: `SimDynamoDbTableView` for the
+table itself, or `SimDynamoDbIndexView` for one of its indexes. `SimDynamoDbTable.view` is where the
+choice is made, and it is the only place `IndexName` is looked at. Everything after it asks the view,
+so a read of an index is the same read against a narrower thing rather than a second code path.
+
+The two differ in four answers, which is the whole of what `IndexName` does:
+
+- which items there are. An index is sparse, so the view keeps only the items carrying every index
+  key attribute. That filter is the derivation, and it happens per read.
+- which key a walk follows. The index key schema rather than the table's, so the key condition, the
+  sort order and the parallel scan segments all follow the index.
+- which attributes come back. `project` cuts an item to what the index carries, so a read of a
+  KEYS_ONLY index answers with keys. A table view cuts nothing.
+- what a token carries. An index key is not unique, so `tokenKey` carries the index key and the
+  table key together, and `SimDynamoDbSortKeyOrder` takes the table's `SimDynamoDbItemKey` as an
+  identity to separate two items sharing an index key. Without it a walk could not resume after
+  either of them, and paging would repeat one or skip one.
+
+`SimDynamoDbIndexView` splits those two ways, and what is left in the view is the walking, which is
+the same walking a table gets:
+
+- `SimDynamoDbIndexKeys` is which items the index holds and how an entry is named: `holds` is the
+  sparseness, `tokenKey` is both keys together, and `assertStartKey` refuses a token missing either
+  of them or carrying anything else.
+- `SimDynamoDbIndexAttributes` is which parts of an item come back. `assertCarriesWholeItem` and
+  `assertCarriesPaths` are the two refusals only an index makes: a `Select` of `ALL_ATTRIBUTES`
+  against a projection that is not ALL, and a filter naming an attribute the index does not project.
+  Both fail closed. The alternative to the second is an empty page, which reads as a collection that
+  happens to hold nothing.
+
 That check is `assertItemKeyTypes`, applied in `SimDynamoDbTable.putItem`, which every write in the
 service goes through. An item missing an index key attribute is fine, since a global secondary index
 is sparse and simply does not hold it. An item carrying one as a type the index did not declare is a
@@ -485,8 +517,10 @@ Important behavior:
 - `ExclusiveStartKey` resumes exclusively, by comparing sort keys rather than by looking the item up,
   so a token still works when the item it names has since been deleted. That is the same choice
   `ListTables` and `ListTagsOfResource` make.
-- `IndexName` and `ProjectionExpression` are refused by name, since each changes which items a query
-  answers with or which parts of them.
+- `ProjectionExpression` is refused by name, since it changes which parts of an item a query answers
+  with.
+- `IndexName` chooses what is read, through `SimDynamoDbTable.view`. Everything after that asks the
+  view rather than the table, so a query of an index is the same query against a narrower thing.
 
 ## Scan behavior
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-item-page.ts
@@ -1,7 +1,6 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
-import type { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
-import { simDynamoDbPrimaryKeyAttributes } from "../../table/sim-dynamodb-primary-key.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbAttributeValue } from "./item.types.js";
 
 /**
@@ -30,7 +29,7 @@ interface SimDynamoDbItemPageProperties {
   /** The items the walk reached, already in the order they are read in. */
   readonly items: readonly SimDynamoDbItem[];
   readonly limit: number | undefined;
-  readonly keySchema: SimDynamoDbKeySchema;
+  readonly view: SimDynamoDbReadView;
 }
 
 /**
@@ -46,8 +45,10 @@ interface SimDynamoDbItemPageProperties {
  * is absent therefore reads one empty page at the end. That is what real
  * DynamoDB does: it cannot know the range is exhausted without looking past it.
  *
- * Scan pages the same way, so this takes items and a key schema rather than a
- * query.
+ * Scan pages the same way, so this takes items and the view they came from
+ * rather than a query. The view is also what decides which key attributes the
+ * token carries: a read of an index names the item it stopped on by the index
+ * key and the table key together, since an index key is not unique.
  */
 export class SimDynamoDbItemPage {
   public readonly items: readonly SimDynamoDbItem[];
@@ -58,7 +59,7 @@ export class SimDynamoDbItemPage {
     const limit = readLimit(properties.limit);
 
     this.items = properties.items.slice(0, limit);
-    this.lastEvaluatedKey = this.tokenFor(properties.keySchema, limit);
+    this.lastEvaluatedKey = this.tokenFor(properties.view, limit);
   }
 
   /**
@@ -66,7 +67,7 @@ export class SimDynamoDbItemPage {
    * the end of the range.
    */
   private tokenFor(
-    keySchema: SimDynamoDbKeySchema,
+    view: SimDynamoDbReadView,
     limit: number,
   ): Record<string, SimDynamoDbAttributeValue> | undefined {
     const last = this.items.at(-1);
@@ -75,6 +76,6 @@ export class SimDynamoDbItemPage {
       return undefined;
     }
 
-    return simDynamoDbPrimaryKeyAttributes(last, keySchema);
+    return view.tokenKey(last);
   }
 }

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-start-key.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-start-key.ts
@@ -3,11 +3,11 @@ import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import { simDynamoDbValuesEqual } from "../../item/sim-dynamodb-value-comparison.js";
-import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
 
 interface SimDynamoDbQueryStartKeyProperties {
-  readonly table: SimDynamoDbTable;
+  readonly view: SimDynamoDbReadView;
   readonly keyCondition: SimDynamoDbKeyCondition;
   readonly exclusiveStartKey:
     Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
@@ -28,7 +28,7 @@ interface SimDynamoDbQueryStartKeyProperties {
 export function readSimDynamoDbQueryStartKey(
   properties: SimDynamoDbQueryStartKeyProperties,
 ): SimDynamoDbItem | undefined {
-  const { table, keyCondition } = properties;
+  const { view, keyCondition } = properties;
   const attributeValues = properties.exclusiveStartKey;
 
   if (attributeValues === undefined) {
@@ -44,11 +44,12 @@ export function readSimDynamoDbQueryStartKey(
 
   const startKey = SimDynamoDbItem.fromAttributeValues(attributeValues);
 
-  // Reading the key through the table checks it against the key schema, which
-  // is what makes a token DynamoDB would refuse refused here too.
-  table.keyOfKey(startKey);
+  // Reading the key through the view checks it against the key schema, which
+  // is what makes a token DynamoDB would refuse refused here too. A read of an
+  // index takes a token carrying the index key and the table key together.
+  view.assertStartKey(startKey);
 
-  assertSamePartition(startKey, table, keyCondition);
+  assertSamePartition(startKey, view, keyCondition);
 
   return startKey;
 }
@@ -58,10 +59,10 @@ export function readSimDynamoDbQueryStartKey(
  */
 function assertSamePartition(
   startKey: SimDynamoDbItem,
-  table: SimDynamoDbTable,
+  view: SimDynamoDbReadView,
   keyCondition: SimDynamoDbKeyCondition,
 ): void {
-  const attributeName = table.keySchema.hashKeyAttributeName;
+  const attributeName = view.keySchema.hashKeyAttributeName;
   const value = startKey.attribute(attributeName);
 
   assertDefined(

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
+import { refuseSimDynamoDbConsistentIndexRead } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type {
@@ -51,34 +52,45 @@ export class SimDynamoDbQuery {
     refuseUnsimulatedQueryInput(input);
     refuseSimDynamoDbQuerySegment(input);
 
+    refuseSimDynamoDbConsistentIndexRead(input);
+
     const expressions = readSimDynamoDbQueryExpressions(input);
     const table = this.access.required(
       "dynamodb:Query",
       input.TableName,
       options?.caller,
     );
-    const keyCondition = expressions.terms.forTable(table);
+
+    // What is being read is settled here: the table, or one of its indexes. An
+    // IndexName the table does not have is refused rather than read as the
+    // table. Everything after this asks the view rather than the table, so a
+    // query of an index is the same query against a narrower thing.
+    const view = table.view(input.IndexName);
+    const keyCondition = expressions.terms.forTable(view);
+
+    select.assertAnswerableBy(view);
 
     // A query has narrowed the read by its key condition already, so a filter
     // naming a key attribute is refused. That needs the key schema, so it
-    // waits for the table the same way the key condition does.
-    expressions.filter?.assertNamesNoKeyAttribute(table.keySchema);
+    // waits for the view the same way the key condition does.
+    expressions.filter?.assertNamesNoKeyAttribute(view.keySchema);
+    expressions.filter?.assertNamesOnlyCarried(view);
 
     // The token names an item of the collection being read, so it can only be
     // checked once that collection is known.
     const after = readSimDynamoDbQueryStartKey({
-      table,
+      view,
       keyCondition,
       exclusiveStartKey: input.ExclusiveStartKey,
     });
 
     const page = new SimDynamoDbItemPage({
-      items: table.itemCollection(keyCondition).walk({
+      items: view.itemCollection(keyCondition).walk({
         forward: input.ScanIndexForward ?? true,
         after,
       }),
       limit: input.Limit,
-      keySchema: table.keySchema,
+      view,
     });
 
     return {
@@ -86,6 +98,7 @@ export class SimDynamoDbQuery {
         page,
         filter: expressions.filter,
         select,
+        view,
       }).fields(),
       $metadata: {},
     };

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
@@ -36,7 +36,6 @@ const keyCondition = {
 
 describe("DynamoDB QueryCommand unsimulated input", () => {
   it.each([
-    { name: "IndexName", input: { IndexName: "ByStatus" } },
     {
       name: "ProjectionExpression",
       input: { ProjectionExpression: "orderId" },

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
@@ -13,11 +13,6 @@ export function refuseUnsimulatedQueryInput(input: SimQueryCommandInput): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("Query");
 
   unsimulated.refuse(
-    input.IndexName !== undefined,
-    "IndexName",
-    "reading the table where a secondary index was asked for",
-  );
-  unsimulated.refuse(
     input.ProjectionExpression !== undefined,
     "ProjectionExpression",
     "answering with whole items where part of them was asked for",

--- a/src/service/dynamodb/command/read/sim-dynamodb-consistent-read.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-consistent-read.ts
@@ -1,0 +1,30 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+
+interface SimDynamoDbConsistentReadInput {
+  readonly ConsistentRead?: boolean | undefined;
+  readonly IndexName?: string | undefined;
+}
+
+/**
+ * Refuse a strongly consistent read of a global secondary index.
+ *
+ * A global secondary index is maintained asynchronously on AWS, so it cannot
+ * answer a strongly consistent read at all, whatever the index is. Local
+ * secondary indexes can, and are not simulated, so an `IndexName` here always
+ * names a global one.
+ *
+ * Every read here is strongly consistent, so accepting this and ignoring it
+ * would leave a test passing on a request real DynamoDB refuses outright.
+ */
+export function refuseSimDynamoDbConsistentIndexRead(
+  input: SimDynamoDbConsistentReadInput,
+): void {
+  if (input.ConsistentRead !== true || input.IndexName === undefined) {
+    return;
+  }
+
+  throw new SimDynamoDbValidationException(
+    `Consistent reads are not supported on global secondary indexes, and ` +
+      `this request asks for one on ${input.IndexName}`,
+  );
+}

--- a/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
@@ -1,5 +1,6 @@
 import type { SimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
 import type { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import type { SimDynamoDbSelect } from "./sim-dynamodb-select.js";
@@ -20,6 +21,7 @@ interface SimDynamoDbReadAnswerProperties {
   readonly page: SimDynamoDbItemPage;
   readonly filter: SimDynamoDbFilter | undefined;
   readonly select: SimDynamoDbSelect;
+  readonly view: SimDynamoDbReadView;
 }
 
 /**
@@ -41,6 +43,7 @@ export class SimDynamoDbReadAnswer {
   private readonly lastEvaluatedKey:
     Record<string, SimDynamoDbAttributeValue> | undefined;
   private readonly select: SimDynamoDbSelect;
+  private readonly view: SimDynamoDbReadView;
 
   constructor(properties: SimDynamoDbReadAnswerProperties) {
     const evaluated = properties.page.items;
@@ -49,6 +52,7 @@ export class SimDynamoDbReadAnswer {
     this.kept = properties.filter?.applyTo(evaluated) ?? evaluated;
     this.lastEvaluatedKey = properties.page.lastEvaluatedKey;
     this.select = properties.select;
+    this.view = properties.view;
   }
 
   /**
@@ -65,12 +69,20 @@ export class SimDynamoDbReadAnswer {
 
   /**
    * The items answered with, which a counted read leaves out altogether.
+   *
+   * Each is cut to what the view carries, so a read of an index answers with
+   * the attributes that index projects rather than with the whole item. A read
+   * of the table cuts nothing.
    */
   private items(): Pick<SimDynamoDbReadFields, "Items"> {
     if (this.select.countsOnly) {
       return {};
     }
 
-    return { Items: this.kept.map((item) => item.toAttributeValues()) };
+    return {
+      Items: this.kept.map((item) =>
+        this.view.project(item).toAttributeValues(),
+      ),
+    };
   }
 }

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.ts
@@ -1,4 +1,5 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 
 /**
  * The four things `Select` can ask a read for.
@@ -15,8 +16,8 @@ type SimDynamoDbSelectKind = (typeof selectKinds)[number];
 /**
  * What a table read defaults to when the request says nothing.
  *
- * A read of an index defaults to `ALL_PROJECTED_ATTRIBUTES` instead, which does
- * not arise here: reading an index is not simulated, so `IndexName` is refused.
+ * A read of an index defaults to `ALL_PROJECTED_ATTRIBUTES` instead, since an
+ * index carries only what it projects and cannot answer with more.
  */
 const tableDefault: SimDynamoDbSelectKind = "ALL_ATTRIBUTES";
 
@@ -53,12 +54,24 @@ export class SimDynamoDbSelect {
    * rest of the request.
    */
   static from(input: SimDynamoDbSelectInput): SimDynamoDbSelect {
-    const kind = readSelectKind(input.Select);
+    const kind = readSelectKind(input);
 
     assertIndexToProjectFrom(kind, input);
     assertProjectionAgrees(kind, input);
 
     return new this(kind);
+  }
+
+  /**
+   * Refuse a `Select` the view being read cannot answer.
+   *
+   * Only the view knows which attributes it carries, so this waits for it where
+   * the rest of the `Select` rules are about the request on its own.
+   */
+  assertAnswerableBy(view: SimDynamoDbReadView): void {
+    if (this.kind === "ALL_ATTRIBUTES") {
+      view.assertCarriesWholeItem();
+    }
   }
 
   /**
@@ -74,10 +87,19 @@ export class SimDynamoDbSelect {
 
 /**
  * Read the `Select` a request wrote, refusing a word that is not one.
+ *
+ * A request that wrote none defaults by what it is reading: whole items from a
+ * table, and what the index projects from an index.
  */
-function readSelectKind(select: string | undefined): SimDynamoDbSelectKind {
+function readSelectKind(input: SimDynamoDbSelectInput): SimDynamoDbSelectKind {
+  const select = input.Select;
+
   if (select === undefined) {
-    return tableDefault;
+    if (input.IndexName === undefined) {
+      return tableDefault;
+    }
+
+    return "ALL_PROJECTED_ATTRIBUTES";
   }
 
   const kind = selectKinds.find((candidate) => candidate === select);

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-start-key.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-start-key.ts
@@ -1,12 +1,12 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbScanSegment } from "../../table/sim-dynamodb-scan-segment.js";
-import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import type { SimDynamoDbTableScan } from "../../table/sim-dynamodb-table-scan.js";
 import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
 
 interface SimDynamoDbScanStartKeyProperties {
-  readonly table: SimDynamoDbTable;
+  readonly view: SimDynamoDbReadView;
   readonly scan: SimDynamoDbTableScan;
   readonly segment: SimDynamoDbScanSegment;
   readonly exclusiveStartKey:
@@ -29,7 +29,7 @@ interface SimDynamoDbScanStartKeyProperties {
 export function readSimDynamoDbScanStartKey(
   properties: SimDynamoDbScanStartKeyProperties,
 ): SimDynamoDbItem | undefined {
-  const { table, scan, segment } = properties;
+  const { view, scan, segment } = properties;
   const attributeValues = properties.exclusiveStartKey;
 
   if (attributeValues === undefined) {
@@ -45,9 +45,9 @@ export function readSimDynamoDbScanStartKey(
 
   const startKey = SimDynamoDbItem.fromAttributeValues(attributeValues);
 
-  // Reading the key through the table checks it against the key schema, which
+  // Reading the key through the view checks it against the key schema, which
   // is what makes a token DynamoDB would refuse refused here too.
-  table.keyOfKey(startKey);
+  view.assertStartKey(startKey);
 
   if (!scan.positionOf(startKey).inSegment(segment)) {
     throw new SimDynamoDbValidationException(

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -2,6 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { readSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
+import { refuseSimDynamoDbConsistentIndexRead } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type { SimScanCommand, SimScanCommandOutput } from "./scan.command.js";
@@ -51,6 +52,7 @@ export class SimDynamoDbScan {
     const select = SimDynamoDbSelect.from(input);
 
     refuseUnsimulatedScanInput(input);
+    refuseSimDynamoDbConsistentIndexRead(input);
 
     // The segment and the filter are read before the table is reached, so
     // input DynamoDB would refuse is refused whether or not the table is
@@ -63,12 +65,18 @@ export class SimDynamoDbScan {
       input.TableName,
       options?.caller,
     );
-    const scan = table.scan();
 
-    // The token names a place in this table's scan order, so it can only be
+    // What is being read is settled here: the table, or one of its indexes.
+    const view = table.view(input.IndexName);
+    const scan = view.scan();
+
+    select.assertAnswerableBy(view);
+    filter?.assertNamesOnlyCarried(view);
+
+    // The token names a place in this view's scan order, so it can only be
     // checked once that order is known.
     const after = readSimDynamoDbScanStartKey({
-      table,
+      view,
       scan,
       segment,
       exclusiveStartKey: input.ExclusiveStartKey,
@@ -77,11 +85,11 @@ export class SimDynamoDbScan {
     const page = new SimDynamoDbItemPage({
       items: scan.walk({ segment, after }),
       limit: input.Limit,
-      keySchema: table.keySchema,
+      view,
     });
 
     return {
-      ...new SimDynamoDbReadAnswer({ page, filter, select }).fields(),
+      ...new SimDynamoDbReadAnswer({ page, filter, select, view }).fields(),
       $metadata: {},
     };
   }

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
@@ -27,7 +27,6 @@ async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
 
 describe("DynamoDB ScanCommand unsimulated input", () => {
   it.each([
-    { name: "IndexName", input: { IndexName: "ByStatus" } },
     {
       name: "ProjectionExpression",
       input: { ProjectionExpression: "orderId" },

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
@@ -18,11 +18,6 @@ export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("Scan");
 
   unsimulated.refuse(
-    input.IndexName !== undefined,
-    "IndexName",
-    "reading the table where a secondary index was asked for",
-  );
-  unsimulated.refuse(
     input.ProjectionExpression !== undefined,
     "ProjectionExpression",
     "answering with whole items where part of them was asked for",

--- a/src/service/dynamodb/expression/filter/sim-dynamodb-filter.ts
+++ b/src/service/dynamodb/expression/filter/sim-dynamodb-filter.ts
@@ -1,6 +1,7 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbCondition } from "../condition/sim-dynamodb-condition.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { SimDynamoDbItemSnapshot } from "../sim-dynamodb-item-snapshot.js";
@@ -41,7 +42,19 @@ export class SimDynamoDbFilter {
   }
 
   /**
-   * Refuse a filter naming a key attribute of the table being read.
+   * Refuse a filter naming an attribute the view being read does not carry.
+   *
+   * An index holds only what it projects, so a filter on an attribute outside
+   * that would drop every item rather than the ones it meant. An empty page is
+   * the worst way to fail: it reads as a collection that happens to hold
+   * nothing. Real DynamoDB refuses it, so this does too.
+   */
+  assertNamesOnlyCarried(view: SimDynamoDbReadView): void {
+    view.assertCarriesPaths(this.paths);
+  }
+
+  /**
+   * Refuse a filter naming a key attribute of what is being read.
    *
    * Real DynamoDB refuses this on a query and allows it on a scan. A query has
    * already narrowed the read to the keys its key condition names, so a filter

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
@@ -3,7 +3,7 @@ import type {
   SimDynamoDbIndexStatus,
   SimDynamoDbSecondaryIndexInput,
 } from "../command/table/table.types.js";
-import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbResourceNotFoundException } from "../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
@@ -11,61 +11,11 @@ import {
   SimDynamoDbGlobalSecondaryIndex,
   type SimDynamoDbSecondaryIndexTable,
 } from "./sim-dynamodb-global-secondary-index.js";
-
-/**
- * The most global secondary indexes one table holds.
- */
-const maxIndexes = 20;
-
-/**
- * The most NonKeyAttributes one table projects across all of its indexes.
- */
-const maxProjectedAttributes = 100;
-
-/**
- * Refuse a request declaring one index name twice.
- *
- * An index is reached by name, so two indexes sharing one leave a read with no
- * way of saying which it meant.
- */
-function assertDistinctNames(
-  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
-): void {
-  const names = new Set(elements.map((index) => index.name));
-
-  if (names.size !== elements.length) {
-    throw new SimDynamoDbValidationException(
-      "GlobalSecondaryIndexes names an index more than once, and an index " +
-        "name is unique within a table",
-    );
-  }
-}
-
-/**
- * Refuse a table projecting more attributes than DynamoDB lets it.
- *
- * The 20 an index projects is not the whole rule: a table is capped at 100
- * across all of its indexes too, which six fully projecting indexes reach. An
- * attribute projected into two indexes counts twice, so this is a plain sum
- * rather than a count of distinct names, as it is on AWS.
- */
-function assertProjectedAttributeCount(
-  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
-): void {
-  const projected = elements.reduce(
-    (total, index) => total + index.projection.nonKeyAttributeCount,
-    0,
-  );
-
-  if (projected > maxProjectedAttributes) {
-    const most = maxProjectedAttributes.toString();
-
-    throw new SimDynamoDbValidationException(
-      `${projected.toString()} NonKeyAttributes are projected across the ` +
-        `table's indexes, and a table projects at most ${most}`,
-    );
-  }
-}
+import {
+  assertSimDynamoDbIndexCount,
+  assertSimDynamoDbIndexNamesDistinct,
+  assertSimDynamoDbProjectedAttributeCount,
+} from "./sim-dynamodb-index-limits.js";
 
 /**
  * The global secondary indexes one table carries.
@@ -98,21 +48,42 @@ export class SimDynamoDbGlobalSecondaryIndexes {
       return this.none();
     }
 
-    if (input.length > maxIndexes) {
-      throw new SimDynamoDbValidationException(
-        `${input.length.toString()} GlobalSecondaryIndexes were given, and a ` +
-          `table holds at most ${maxIndexes.toString()}`,
-      );
-    }
+    assertSimDynamoDbIndexCount(input.length);
 
     const elements = input.map((index) =>
       SimDynamoDbGlobalSecondaryIndex.fromInput(index, table),
     );
 
-    assertDistinctNames(elements);
-    assertProjectedAttributeCount(elements);
+    assertSimDynamoDbIndexNamesDistinct(elements);
+    assertSimDynamoDbProjectedAttributeCount(elements);
 
     return new this(elements);
+  }
+
+  /**
+   * The index a read names, refusing a name this table does not have.
+   *
+   * Real DynamoDB answers a name it does not have with
+   * `ResourceNotFoundException` rather than reading the table instead, since a
+   * read of an index that is not there is a read of nothing.
+   */
+  required(
+    indexName: string,
+    tableName: string,
+  ): SimDynamoDbGlobalSecondaryIndex {
+    const index = this.elements.find(
+      (candidate) => candidate.name === indexName,
+    );
+
+    if (index === undefined) {
+      throw new SimDynamoDbResourceNotFoundException(
+        `The table ${tableName} does not have the specified index: ${
+          indexName
+        }`,
+      );
+    }
+
+    return index;
   }
 
   /**

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-attributes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-attributes.ts
@@ -1,0 +1,103 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbDocumentPath } from "../expression/sim-dynamodb-document-path.js";
+import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+
+interface SimDynamoDbIndexAttributesProperties {
+  readonly indexName: string;
+  readonly projection: SimDynamoDbIndexProjection;
+  readonly keyAttributeNames: ReadonlySet<string>;
+}
+
+/**
+ * Which attributes one index carries, and what it refuses for not carrying.
+ *
+ * An index entry is keyed by the index key and identified by the table key, so
+ * both are in every item it holds and both come back whatever it projects. The
+ * projection says what else does.
+ *
+ * This is separate from the index view because it is about attributes rather
+ * than items: nothing here knows which items the index holds, or in what order.
+ */
+export class SimDynamoDbIndexAttributes {
+  private readonly indexName: string;
+  private readonly projection: SimDynamoDbIndexProjection;
+  private readonly keyAttributeNames: ReadonlySet<string>;
+
+  constructor(properties: SimDynamoDbIndexAttributesProperties) {
+    this.indexName = properties.indexName;
+    this.projection = properties.projection;
+    this.keyAttributeNames = properties.keyAttributeNames;
+  }
+
+  /**
+   * Cut an item down to the attributes the index carries.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem {
+    if (this.projection.carriesWholeItem) {
+      return item;
+    }
+
+    return SimDynamoDbItem.ofAttributes(
+      new Map(
+        item
+          .entries()
+          .entries()
+          .filter(([name]) => this.carries(name)),
+      ),
+    );
+  }
+
+  /**
+   * Refuse a read asking for whole items from a projection holding part of one.
+   *
+   * Real DynamoDB reads the table for each item to answer this, at a cost the
+   * request did not ask for, so it refuses it on an index that projects less
+   * than everything.
+   */
+  assertCarriesWholeItem(): void {
+    if (this.projection.carriesWholeItem) {
+      return;
+    }
+
+    throw new SimDynamoDbValidationException(
+      `One or more parameter values were invalid: Select type ALL_ATTRIBUTES ` +
+        `is not supported for global secondary index ${this.indexName} ` +
+        `because its projection type is not ALL`,
+    );
+  }
+
+  /**
+   * Refuse an expression naming an attribute the index does not project.
+   */
+  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void {
+    if (this.projection.carriesWholeItem) {
+      return;
+    }
+
+    const carried = [
+      ...this.keyAttributeNames,
+      ...this.projection.addedAttributeNames,
+    ];
+
+    for (const path of paths) {
+      if (carried.every((name) => !path.startsAt(name))) {
+        throw new SimDynamoDbValidationException(
+          `${path.text} is not projected into the global secondary index ` +
+            `${this.indexName}, and a read of an index names only the ` +
+            `attributes it projects`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Whether the index carries one attribute of the items it holds.
+   */
+  private carries(attributeName: string): boolean {
+    return (
+      this.keyAttributeNames.has(attributeName) ||
+      this.projection.adds(attributeName)
+    );
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-keys.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-keys.ts
@@ -1,0 +1,101 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import { SimDynamoDbItemKey } from "../table/sim-dynamodb-item-key.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import { simDynamoDbPrimaryKeyAttributes } from "../table/sim-dynamodb-primary-key.js";
+
+interface SimDynamoDbIndexKeysProperties {
+  readonly indexName: string;
+  readonly indexKeySchema: SimDynamoDbKeySchema;
+  readonly tableKeySchema: SimDynamoDbKeySchema;
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+  readonly tableItemKey: SimDynamoDbItemKey;
+}
+
+/**
+ * How one index entry is keyed and identified.
+ *
+ * An entry is keyed by the index key, which says where it sits, and identified
+ * by the table key, which says which item it is. An index key is not unique, so
+ * neither half names an entry on its own.
+ *
+ * That is why the entry has to carry both, why a pagination token carries both,
+ * and why a token missing either is refused rather than resumed from.
+ */
+export class SimDynamoDbIndexKeys {
+  /**
+   * The index key and the table key together.
+   */
+  public readonly attributeNames: ReadonlySet<string>;
+
+  /**
+   * The index key as the entries are marshalled by, which a scan orders on.
+   */
+  public readonly indexItemKey: SimDynamoDbItemKey;
+
+  private readonly indexName: string;
+  private readonly indexKeySchema: SimDynamoDbKeySchema;
+  private readonly tableKeySchema: SimDynamoDbKeySchema;
+  private readonly tableItemKey: SimDynamoDbItemKey;
+
+  constructor(properties: SimDynamoDbIndexKeysProperties) {
+    this.indexName = properties.indexName;
+    this.indexKeySchema = properties.indexKeySchema;
+    this.tableKeySchema = properties.tableKeySchema;
+    this.tableItemKey = properties.tableItemKey;
+    this.indexItemKey = new SimDynamoDbItemKey(
+      properties.indexKeySchema,
+      properties.attributeDefinitions,
+    );
+    this.attributeNames = new Set([
+      ...properties.indexKeySchema.attributeNames(),
+      ...properties.tableKeySchema.attributeNames(),
+    ]);
+  }
+
+  /**
+   * Whether the index holds an item, which needs the whole of the index key.
+   *
+   * This is what makes an index sparse. Nothing said so when the item was
+   * written: it is worked out here, when the index is read.
+   */
+  holds(item: SimDynamoDbItem): boolean {
+    return this.indexKeySchema
+      .attributeNames()
+      .every((attributeName) => item.attribute(attributeName) !== undefined);
+  }
+
+  /**
+   * The token naming the entry a walk stopped on, by both of its keys.
+   */
+  tokenKey(item: SimDynamoDbItem): Record<string, SimDynamoDbAttributeValue> {
+    return {
+      ...simDynamoDbPrimaryKeyAttributes(item, this.indexKeySchema),
+      ...simDynamoDbPrimaryKeyAttributes(item, this.tableKeySchema),
+    };
+  }
+
+  /**
+   * Refuse an `ExclusiveStartKey` this index could not have handed out.
+   *
+   * Both keys are required and nothing else is allowed alongside them. Without
+   * the table key the token names several entries, so resuming from it would
+   * repeat one or skip one.
+   */
+  assertStartKey(key: SimDynamoDbItem): void {
+    for (const attributeName of key.attributeNames()) {
+      if (!this.attributeNames.has(attributeName)) {
+        throw new SimDynamoDbValidationException(
+          `The provided starting key is invalid: the Key names the attribute ` +
+            `${attributeName}, which is part of neither the index ` +
+            `${this.indexName} key nor the table's primary key`,
+        );
+      }
+    }
+
+    this.indexItemKey.of(key);
+    this.tableItemKey.of(key);
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-limits.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-limits.ts
@@ -1,0 +1,73 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-secondary-index.js";
+
+/**
+ * The most global secondary indexes one table holds.
+ */
+export const maxSimDynamoDbIndexes = 20;
+
+/**
+ * The most NonKeyAttributes one table projects across all of its indexes.
+ */
+const maxProjectedAttributes = 100;
+
+/**
+ * Refuse a request declaring more indexes than a table holds.
+ *
+ * This is checked before the indexes are read, so a request well over the cap
+ * is refused for being over it rather than for whatever is wrong with its
+ * twenty first index.
+ */
+export function assertSimDynamoDbIndexCount(count: number): void {
+  if (count > maxSimDynamoDbIndexes) {
+    throw new SimDynamoDbValidationException(
+      `${count.toString()} GlobalSecondaryIndexes were given, and a table ` +
+        `holds at most ${maxSimDynamoDbIndexes.toString()}`,
+    );
+  }
+}
+
+/**
+ * Refuse a request declaring one index name twice.
+ *
+ * An index is reached by name, so two indexes sharing one leave a read with no
+ * way of saying which it meant.
+ */
+export function assertSimDynamoDbIndexNamesDistinct(
+  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+): void {
+  const names = new Set(elements.map((index) => index.name));
+
+  if (names.size !== elements.length) {
+    throw new SimDynamoDbValidationException(
+      "GlobalSecondaryIndexes names an index more than once, and an index " +
+        "name is unique within a table",
+    );
+  }
+}
+
+/**
+ * Refuse a table projecting more attributes than DynamoDB lets it.
+ *
+ * The 20 an index projects is not the whole rule: a table is capped at 100
+ * across all of its indexes too, which six fully projecting indexes reach. An
+ * attribute projected into two indexes counts twice, so this is a plain sum
+ * rather than a count of distinct names, as it is on AWS.
+ */
+export function assertSimDynamoDbProjectedAttributeCount(
+  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+): void {
+  const projected = elements.reduce(
+    (total, index) => total + index.projection.nonKeyAttributeCount,
+    0,
+  );
+
+  if (projected > maxProjectedAttributes) {
+    const most = maxProjectedAttributes.toString();
+
+    throw new SimDynamoDbValidationException(
+      `${projected.toString()} NonKeyAttributes are projected across the ` +
+        `table's indexes, and a table projects at most ${most}`,
+    );
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-paging.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-paging.iso.test.ts
@@ -1,0 +1,165 @@
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type {
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "../command/query/query.command.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../sim-dynamodb.js";
+import { simDynamoDbIndexedTableFactory } from "./sim-dynamodb-indexed-table.factory.js";
+
+/**
+ * The two shipped orders share a whole index key, so only the table key
+ * separates them. That is the case a token carrying the index key alone could
+ * not resume.
+ */
+const shippedOrders = {
+  TableName: "OrdersTable",
+  IndexName: "byStatus",
+  KeyConditionExpression: "#status = :status",
+  ExpressionAttributeNames: { "#status": "status" },
+  ExpressionAttributeValues: { ":status": { S: "SHIPPED" } },
+} as const satisfies SimQueryCommandInput;
+
+/**
+ * Read one page of the shipped orders, resuming after a token when given one.
+ */
+async function shippedPage(
+  simDynamoDb: SimDynamoDb,
+  after?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): Promise<SimQueryCommandOutput> {
+  return await simDynamoDb.query({
+    input: { ...shippedOrders, Limit: 1, ExclusiveStartKey: after },
+  });
+}
+
+/**
+ * The order ids a page came back with.
+ */
+function orderIds(page: SimQueryCommandOutput): readonly string[] {
+  return (page.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB paging a global secondary index", () => {
+  it("hands out a token carrying the index key and the table key", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When one item of the index is read.
+    const page = await simAws
+      .dynamoDb()
+      .query({ input: { ...shippedOrders, Limit: 1 } });
+
+    // Then the token names the item by both keys. The index key alone would
+    // not, since two entries can share one.
+    const token = page.LastEvaluatedKey;
+    assertDefined(token, "the LastEvaluatedKey of an index page");
+    assertIdentical(token["status"]?.S, "SHIPPED");
+    assertDefined(token["shippedAt"], "the index sort key of the token");
+    assertDefined(token["orderId"], "the table key of the token");
+  });
+
+  it("resumes exactly when two entries share an index key", async () => {
+    // Given a table whose two shipped orders share a whole index key.
+    const simAws = new SimAws();
+    const simDynamoDb = simAws.dynamoDb();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When the collection is paged one item at a time.
+    const first = await shippedPage(simDynamoDb);
+    const second = await shippedPage(simDynamoDb, first.LastEvaluatedKey);
+    const third = await shippedPage(simDynamoDb, second.LastEvaluatedKey);
+    const found = [...orderIds(first), ...orderIds(second), ...orderIds(third)];
+
+    // Then each order comes back once, in whichever order the index put them.
+    // Index key values are not unique, so nothing here promises which is first,
+    // only that paging neither repeats nor skips one. A token carrying the
+    // index key alone could not have told the two apart.
+    assertArrayLength(found, 2);
+    assertArrayIncludesAll(found, ["order-02", "order-04"]);
+    assertUndefined(third.LastEvaluatedKey);
+  });
+
+  it("stops handing out a token once the collection runs out", async () => {
+    // Given a table with two shipped orders in its index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When both are read in one page.
+    const page = await simAws
+      .dynamoDb()
+      .query({ input: { ...shippedOrders, Limit: 5 } });
+
+    // Then no token comes back, since the walk stopped inside the limit.
+    assertIdentical(page.Count, 2);
+    assertUndefined(page.LastEvaluatedKey);
+  });
+
+  it("refuses a start key naming an attribute outside both keys", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a query resumes from a token carrying an attribute neither key has.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          ...shippedOrders,
+          ExclusiveStartKey: {
+            status: { S: "SHIPPED" },
+            shippedAt: { S: "2026-01" },
+            orderId: { S: "order-02" },
+            title: { S: "Order order-02" },
+          },
+        },
+      }),
+    );
+
+    // Then it is refused rather than resumed from.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "the Key names the attribute title, which is part of neither the index " +
+        "byStatus key nor the table's primary key",
+    );
+  });
+
+  it("refuses a start key missing the table key", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a query resumes from a token carrying only the index key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          ...shippedOrders,
+          ExclusiveStartKey: {
+            status: { S: "SHIPPED" },
+            shippedAt: { S: "2026-01" },
+          },
+        },
+      }),
+    );
+
+    // Then it is refused. Without the table key the token names two items, so
+    // resuming from it would either repeat one or skip one.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "One of the required keys was not given a value: orderId",
+    );
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projected-read.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projected-read.iso.test.ts
@@ -1,0 +1,190 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimQueryCommandInput } from "../command/query/query.command.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbIndexedTableInput } from "./sim-dynamodb-indexed-table.factory.js";
+import { simDynamoDbIndexedTableFactory } from "./sim-dynamodb-indexed-table.factory.js";
+
+const openOrders = {
+  TableName: "OrdersTable",
+  IndexName: "byStatus",
+  KeyConditionExpression: "#status = :status",
+  ExpressionAttributeNames: { "#status": "status" },
+  ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+} as const satisfies SimQueryCommandInput;
+
+/**
+ * Read one item off an index projecting what a test asked it to.
+ */
+async function firstOpenOrder(
+  table: Partial<SimDynamoDbIndexedTableInput>,
+  overrides: Partial<SimQueryCommandInput> = {},
+): Promise<Readonly<Record<string, { S?: string }>>> {
+  const simAws = new SimAws();
+  await simDynamoDbIndexedTableFactory.make(table, simAws);
+
+  const page = await simAws
+    .dynamoDb()
+    .query({ input: { ...openOrders, ...overrides } });
+
+  return page.Items?.[0] ?? {};
+}
+
+describe("DynamoDB reads of what an index projects", () => {
+  it("answers a KEYS_ONLY index with the index and table keys", async () => {
+    // When an index projecting only keys is read.
+    const item = await firstOpenOrder({ projectionType: "KEYS_ONLY" });
+
+    // Then the index key and the table key come back, and nothing else. That
+    // is what the index carries, so answering with the whole item would be a
+    // page real DynamoDB never hands out.
+    assertIdentical(item["status"]?.S, "OPEN");
+    assertIdentical(item["shippedAt"]?.S, "2026-01");
+    assertIdentical(item["orderId"]?.S, "order-01");
+    assertUndefined(item["title"]);
+  });
+
+  it("answers an INCLUDE index with the attributes it adds", async () => {
+    // When an index including one attribute is read.
+    const item = await firstOpenOrder({
+      projectionType: "INCLUDE",
+      nonKeyAttributes: ["title"],
+    });
+
+    // Then the keys come back with the included attribute alongside them.
+    assertIdentical(item["orderId"]?.S, "order-01");
+    assertIdentical(item["title"]?.S, "Order order-01");
+  });
+
+  it("answers an ALL index with the whole item", async () => {
+    // When an index projecting everything is read.
+    const item = await firstOpenOrder({ projectionType: "ALL" });
+
+    // Then nothing is cut out of the item.
+    assertIdentical(item["title"]?.S, "Order order-01");
+  });
+
+  it("defaults to the attributes the index projects", async () => {
+    // When an index is read with no Select at all.
+    const item = await firstOpenOrder({ projectionType: "KEYS_ONLY" });
+
+    // Then the read answers with what the index projects rather than with the
+    // whole item, which is what ALL_PROJECTED_ATTRIBUTES means and what a read
+    // of an index defaults to.
+    assertUndefined(item["title"]);
+  });
+
+  it("takes ALL_PROJECTED_ATTRIBUTES written out", async () => {
+    // When an index is read asking for what it projects by name.
+    const item = await firstOpenOrder(
+      { projectionType: "KEYS_ONLY" },
+      { Select: "ALL_PROJECTED_ATTRIBUTES" },
+    );
+
+    // Then it answers the same way the default does.
+    assertIdentical(item["orderId"]?.S, "order-01");
+    assertUndefined(item["title"]);
+  });
+
+  it("refuses ALL_ATTRIBUTES on an index that projects less", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When a read of it asks for whole items.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDb()
+        .query({ input: { ...openOrders, Select: "ALL_ATTRIBUTES" } }),
+    );
+
+    // Then it is refused rather than answered with what the index has. Real
+    // DynamoDB would have to read the table for each item to answer it.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Select type ALL_ATTRIBUTES is not supported for global secondary " +
+        "index byStatus because its projection type is not ALL",
+    );
+  });
+
+  it("takes ALL_ATTRIBUTES on an index that projects everything", async () => {
+    // When an index projecting the whole item is asked for whole items.
+    const item = await firstOpenOrder(
+      { projectionType: "ALL" },
+      { Select: "ALL_ATTRIBUTES" },
+    );
+
+    // Then it answers, since the index carries what was asked for.
+    assertIdentical(item["title"]?.S, "Order order-01");
+  });
+
+  it("refuses a filter naming an attribute the index does not project", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When a read of it filters on an attribute outside the projection.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          ...openOrders,
+          FilterExpression: "title = :title",
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: {
+            ":status": { S: "OPEN" },
+            ":title": { S: "Order order-01" },
+          },
+        },
+      }),
+    );
+
+    // Then it is refused. The attribute is not on the items the index holds,
+    // so the filter would drop every one of them and the page would read as a
+    // collection that happens to be empty.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "title is not projected into the global secondary index byStatus",
+    );
+  });
+
+  it("takes a filter naming an attribute the index does project", async () => {
+    // Given a table whose index includes one attribute beyond its keys.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make(
+      { projectionType: "INCLUDE", nonKeyAttributes: ["title"] },
+      simAws,
+    );
+
+    // When a read of it filters on that attribute.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        ...openOrders,
+        FilterExpression: "title = :title",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":status": { S: "OPEN" },
+          ":title": { S: "Order order-01" },
+        },
+      },
+    });
+
+    // Then the filter runs, keeping the one item it names.
+    assertIdentical(page.Count, 1);
+    assertIdentical(page.ScannedCount, 2);
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection.ts
@@ -127,6 +127,30 @@ export class SimDynamoDbIndexProjection {
   }
 
   /**
+   * Whether the index carries every attribute of an item.
+   *
+   * A read of an index that does is the same read as one of the table, as far
+   * as which attributes come back goes.
+   */
+  get carriesWholeItem(): boolean {
+    return this.type === "ALL";
+  }
+
+  /**
+   * The attributes this projection adds to the index keys.
+   */
+  get addedAttributeNames(): readonly string[] {
+    return this.nonKeyAttributes;
+  }
+
+  /**
+   * Whether this projection adds a named attribute to the index keys.
+   */
+  adds(attributeName: string): boolean {
+    return this.nonKeyAttributes.includes(attributeName);
+  }
+
+  /**
    * How many attributes this projection adds to the index keys.
    *
    * A table is capped on the total across all of its indexes as well as on each

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-query.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-query.iso.test.ts
@@ -1,0 +1,227 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../error/dynamodb.error.js";
+import { simDynamoDbIndexedTableFactory } from "./sim-dynamodb-indexed-table.factory.js";
+
+/**
+ * The order ids a page came back with, so a test names items rather than places.
+ */
+function orderIds(
+  items: readonly Readonly<Record<string, { S?: string }>>[] | undefined,
+): readonly string[] {
+  return (items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB Query on a global secondary index", () => {
+  it("reads an item collection of the index rather than the table", async () => {
+    // Given a table with an index keyed on status and shipping month.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When the index is queried by its own partition key.
+    const page = await simAws.dynamoDb().query(
+      new QueryCommand({
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+      }),
+    );
+
+    // Then the open orders come back, which the table's own key could not have
+    // named: the table is keyed by orderId alone.
+    assertArrayLength(orderIds(page.Items), 2);
+    assertArrayIncludesAll(orderIds(page.Items), ["order-01", "order-05"]);
+  });
+
+  it("leaves out an item missing an index key attribute", async () => {
+    // Given a table whose orders do not all carry a status.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+    const dynamoDb = simAws.dynamoDb();
+
+    // When both statuses are read off the index.
+    const open = await dynamoDb.query({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+      },
+    });
+    const shipped = await dynamoDb.query({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "SHIPPED" } },
+      },
+    });
+
+    // Then the index holds four of the six orders. The other two carry no
+    // status, so the index is simply missing them rather than the write having
+    // been refused.
+    assertIdentical((open.Count ?? 0) + (shipped.Count ?? 0), 4);
+  });
+
+  it("orders a collection by the index sort key", async () => {
+    // Given a table with an index sorted by shipping month.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When the open orders are read backwards.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+        ScanIndexForward: false,
+      },
+    });
+
+    // Then the later shipping month comes first, by the index sort key rather
+    // than by anything the table is keyed on.
+    assertIdentical(orderIds(page.Items)[0], "order-05");
+    assertIdentical(orderIds(page.Items)[1], "order-01");
+  });
+
+  it("takes a sort key condition on the index sort key", async () => {
+    // Given a table with an index sorted by shipping month.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When the open orders are narrowed to the first month.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        KeyConditionExpression:
+          "#status = :status AND begins_with(shippedAt, :month)",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: {
+          ":status": { S: "OPEN" },
+          ":month": { S: "2026-01" },
+        },
+      },
+    });
+
+    // Then only the order shipped that month comes back.
+    assertArrayLength(orderIds(page.Items), 1);
+    assertIdentical(orderIds(page.Items)[0], "order-01");
+  });
+
+  it("refuses a key condition on an attribute outside the index key", async () => {
+    // Given a table with an index keyed on something other than its own key.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When the index is queried by the table's partition key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          TableName: "OrdersTable",
+          IndexName: "byStatus",
+          KeyConditionExpression: "orderId = :orderId",
+          ExpressionAttributeValues: { ":orderId": { S: "order-01" } },
+        },
+      }),
+    );
+
+    // Then it is refused: a key condition is held to the key being read, which
+    // for a read of an index is the index's own.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "orderId is not part of");
+  });
+
+  it("refuses an index name the table does not have", async () => {
+    // Given a table with one index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a query names an index that is not there.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          TableName: "OrdersTable",
+          IndexName: "byOwner",
+          KeyConditionExpression: "#status = :status",
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+        },
+      }),
+    );
+
+    // Then it is refused rather than read as the table.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+    assertStringIncludes(
+      error.message,
+      "The table OrdersTable does not have the specified index: byOwner",
+    );
+  });
+
+  it("refuses a consistent read of a global secondary index", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a query asks for a strongly consistent read of it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          TableName: "OrdersTable",
+          IndexName: "byStatus",
+          ConsistentRead: true,
+          KeyConditionExpression: "#status = :status",
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+        },
+      }),
+    );
+
+    // Then it is refused. A global secondary index is maintained
+    // asynchronously on AWS, so it cannot answer one whatever the simulation
+    // does.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Consistent reads are not supported on global secondary indexes",
+    );
+  });
+
+  it("still reads the table for a request naming no index", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a query names no IndexName and asks for a consistent read.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        TableName: "OrdersTable",
+        ConsistentRead: true,
+        KeyConditionExpression: "orderId = :orderId",
+        ExpressionAttributeValues: { ":orderId": { S: "order-03" } },
+      },
+    });
+
+    // Then the table answers, including the order the index does not hold.
+    assertArrayLength(orderIds(page.Items), 1);
+    assertIdentical(orderIds(page.Items)[0], "order-03");
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-scan.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-scan.iso.test.ts
@@ -1,0 +1,158 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertSetSize,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimScanCommandOutput } from "../command/scan/scan.command.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../error/dynamodb.error.js";
+import { simDynamoDbIndexedTableFactory } from "./sim-dynamodb-indexed-table.factory.js";
+
+/**
+ * The order ids a scanned page came back with.
+ */
+function scannedIds(page: SimScanCommandOutput): readonly string[] {
+  return (page.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB Scan of a global secondary index", () => {
+  it("reads the items the index holds rather than the whole table", async () => {
+    // Given a table of six orders, two of which carry no status.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+    const dynamoDb = simAws.dynamoDb();
+
+    // When the index and the table are each scanned.
+    const index = await dynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable", IndexName: "byStatus" }),
+    );
+    const table = await dynamoDb.scan(
+      new ScanCommand({ TableName: "OrdersTable" }),
+    );
+
+    // Then the index scan is short by the orders it does not hold.
+    assertIdentical(table.Count, 6);
+    assertIdentical(index.Count, 4);
+  });
+
+  it("answers with what the index projects", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When the index is scanned.
+    const page = await simAws
+      .dynamoDb()
+      .scan({ input: { TableName: "OrdersTable", IndexName: "byStatus" } });
+
+    // Then each item is cut to the keys, the same way a query of it is.
+    const item = page.Items?.[0] ?? {};
+    assertUndefined(item["title"]);
+    assertNonNullable(item["status"]);
+  });
+
+  it("pages an index scan by both keys", async () => {
+    // Given a table with an index holding four orders.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+    const dynamoDb = simAws.dynamoDb();
+
+    // When three are scanned off the index and the rest resumed after them.
+    const first = await dynamoDb.scan({
+      input: { TableName: "OrdersTable", IndexName: "byStatus", Limit: 3 },
+    });
+    const second = await dynamoDb.scan({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byStatus",
+        Limit: 3,
+        ExclusiveStartKey: first.LastEvaluatedKey,
+      },
+    });
+
+    // Then every item the index holds comes back once. The token carries the
+    // index key and the table key, so it names one entry rather than several.
+    const found = new Set([...scannedIds(first), ...scannedIds(second)]);
+    assertSetSize(found, 4);
+  });
+
+  it("refuses an index name the table does not have", async () => {
+    // Given a table with one index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a scan names an index that is not there.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDb()
+        .scan({ input: { TableName: "OrdersTable", IndexName: "byOwner" } }),
+    );
+
+    // Then it is refused rather than read as the table.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+    assertStringIncludes(error.message, "does not have the specified index");
+  });
+
+  it("refuses a consistent scan of a global secondary index", async () => {
+    // Given a table with an index.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+
+    // When a scan asks for a strongly consistent read of it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().scan({
+        input: {
+          TableName: "OrdersTable",
+          IndexName: "byStatus",
+          ConsistentRead: true,
+        },
+      }),
+    );
+
+    // Then it is refused, the same way a query of it is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Consistent reads are not supported on global secondary indexes",
+    );
+  });
+
+  it("divides an index scan into parallel segments", async () => {
+    // Given a table with an index holding two status values.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make({}, simAws);
+    const dynamoDb = simAws.dynamoDb();
+
+    // When the index is scanned in two segments.
+    const segments = await Promise.all(
+      [0, 1].map(async (index) =>
+        dynamoDb.scan({
+          input: {
+            TableName: "OrdersTable",
+            IndexName: "byStatus",
+            Segment: index,
+            TotalSegments: 2,
+          },
+        }),
+      ),
+    );
+
+    // Then between them they cover the index once. The segments divide by the
+    // index partition key rather than the table's, so an item collection of
+    // the index stays together.
+    const found = new Set(segments.flatMap((segment) => scannedIds(segment)));
+    assertSetSize(found, 4);
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-view.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-view.ts
@@ -1,0 +1,135 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import type { SimDynamoDbDocumentPath } from "../expression/sim-dynamodb-document-path.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import { SimDynamoDbItemCollection } from "../table/sim-dynamodb-item-collection.js";
+import type { SimDynamoDbItemKey } from "../table/sim-dynamodb-item-key.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbReadView } from "../table/sim-dynamodb-read-view.js";
+import { SimDynamoDbTableScan } from "../table/sim-dynamodb-table-scan.js";
+import { SimDynamoDbSortKeyOrder } from "../table/sim-dynamodb-sort-key-order.js";
+import type { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-secondary-index.js";
+import { SimDynamoDbIndexAttributes } from "./sim-dynamodb-index-attributes.js";
+import { SimDynamoDbIndexKeys } from "./sim-dynamodb-index-keys.js";
+
+interface SimDynamoDbIndexViewProperties {
+  readonly index: SimDynamoDbGlobalSecondaryIndex;
+  readonly items: readonly SimDynamoDbItem[];
+  readonly tableKeySchema: SimDynamoDbKeySchema;
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+  readonly tableItemKey: SimDynamoDbItemKey;
+}
+
+/**
+ * Reading one global secondary index.
+ *
+ * The index is worked out here rather than maintained on the write path, which
+ * is what makes an index added to a table have nothing to backfill and every
+ * item write unaware of it.
+ *
+ * The two things that make an index narrower than the table are answered by a
+ * collaborator each. `SimDynamoDbIndexKeys` is which items it holds and how
+ * they are named, and `SimDynamoDbIndexAttributes` is which parts of them come
+ * back. What is left here is the walking, which is the same walking a table
+ * gets.
+ */
+export class SimDynamoDbIndexView implements SimDynamoDbReadView {
+  public readonly description: string;
+  public readonly keySchema: SimDynamoDbKeySchema;
+  public readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+
+  private readonly items: readonly SimDynamoDbItem[];
+  private readonly keys: SimDynamoDbIndexKeys;
+  private readonly attributes: SimDynamoDbIndexAttributes;
+  private readonly order: SimDynamoDbSortKeyOrder;
+
+  constructor(properties: SimDynamoDbIndexViewProperties) {
+    const { index } = properties;
+
+    this.description = `index ${index.name}`;
+    this.keySchema = index.keySchema;
+    this.attributeDefinitions = properties.attributeDefinitions;
+    this.keys = new SimDynamoDbIndexKeys({
+      indexName: index.name,
+      indexKeySchema: index.keySchema,
+      tableKeySchema: properties.tableKeySchema,
+      attributeDefinitions: properties.attributeDefinitions,
+      tableItemKey: properties.tableItemKey,
+    });
+    this.attributes = new SimDynamoDbIndexAttributes({
+      indexName: index.name,
+      projection: index.projection,
+      keyAttributeNames: this.keys.attributeNames,
+    });
+
+    // Index key values are not unique, so the table key is what separates two
+    // entries sharing one and lets a walk resume after either.
+    this.order = new SimDynamoDbSortKeyOrder({
+      attributeName: index.keySchema.rangeKeyAttributeName,
+      identity: properties.tableItemKey,
+    });
+
+    this.items = properties.items.filter((item) => this.keys.holds(item));
+  }
+
+  /**
+   * The entries of the index one key condition names, by the index key.
+   */
+  itemCollection(
+    keyCondition: SimDynamoDbKeyCondition,
+  ): SimDynamoDbItemCollection {
+    return new SimDynamoDbItemCollection({
+      items: this.items,
+      keySchema: this.keySchema,
+      order: this.order,
+      keyCondition,
+    });
+  }
+
+  /**
+   * Every entry the index holds, in the order a Scan reads them.
+   */
+  scan(): SimDynamoDbTableScan {
+    return new SimDynamoDbTableScan({
+      items: this.items,
+      order: this.order,
+      itemKey: this.keys.indexItemKey,
+    });
+  }
+
+  /**
+   * Refuse an `ExclusiveStartKey` this index could not have handed out.
+   */
+  assertStartKey(key: SimDynamoDbItem): void {
+    this.keys.assertStartKey(key);
+  }
+
+  /**
+   * The index key and the table key of the entry a walk stopped on.
+   */
+  tokenKey(item: SimDynamoDbItem): Record<string, SimDynamoDbAttributeValue> {
+    return this.keys.tokenKey(item);
+  }
+
+  /**
+   * Cut an item down to the attributes this index carries.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem {
+    return this.attributes.project(item);
+  }
+
+  /**
+   * Refuse a read asking for whole items from a partial projection.
+   */
+  assertCarriesWholeItem(): void {
+    this.attributes.assertCarriesWholeItem();
+  }
+
+  /**
+   * Refuse an expression naming an attribute this index does not project.
+   */
+  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void {
+    this.attributes.assertCarriesPaths(paths);
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-orders.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-orders.ts
@@ -1,0 +1,49 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+
+/**
+ * The status the order in one place of the table carries.
+ */
+function statusAt(position: number): string {
+  if (position % 2 === 0) {
+    return "OPEN";
+  }
+
+  return "SHIPPED";
+}
+
+/**
+ * Whether the order in one place of the table is written without a status.
+ */
+function isDraft(position: number): boolean {
+  return position % 3 === 2;
+}
+
+/**
+ * The orders an indexed table holds, as the items they are written as.
+ *
+ * Every third order carries no `status`, so the index is missing it and a test
+ * has something the table holds and the index does not. The statuses that are
+ * there repeat, so the index holds several items under one partition key, and
+ * `shippedAt` repeats within a status so two index entries share a whole index
+ * key and only the table key separates them.
+ */
+export function simDynamoDbIndexedOrders(
+  orderCount: number,
+): readonly Readonly<Record<string, SimDynamoDbAttributeValue>>[] {
+  return Array.from({ length: orderCount }, (_unused, position) => {
+    const orderId = `order-${(position + 1).toString().padStart(2, "0")}`;
+    const order = { orderId: { S: orderId }, title: { S: `Order ${orderId}` } };
+
+    if (isDraft(position)) {
+      return order;
+    }
+
+    const shippedMonth = (Math.floor(position / 4) + 1).toString();
+
+    return {
+      ...order,
+      status: { S: statusAt(position) },
+      shippedAt: { S: `2026-0${shippedMonth}` },
+    };
+  });
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-orders.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-orders.ts
@@ -38,12 +38,14 @@ export function simDynamoDbIndexedOrders(
       return order;
     }
 
-    const shippedMonth = (Math.floor(position / 4) + 1).toString();
+    const shippedMonth = (Math.floor(position / 4) + 1)
+      .toString()
+      .padStart(2, "0");
 
     return {
       ...order,
       status: { S: statusAt(position) },
-      shippedAt: { S: `2026-0${shippedMonth}` },
+      shippedAt: { S: `2026-${shippedMonth}` },
     };
   });
 }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-table.factory.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-indexed-table.factory.ts
@@ -1,0 +1,112 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbProjectionType } from "../command/table/table.types.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+import { simDynamoDbIndexedOrders } from "./sim-dynamodb-indexed-orders.js";
+
+/**
+ * What a test asks for when it wants a table with an index to read.
+ *
+ * The projection is the input because it is what makes reads of one index
+ * differ from another: which attributes come back, and which `Select` values
+ * and filters the index can answer.
+ */
+export interface SimDynamoDbIndexedTableInput {
+  readonly tableName: string;
+  readonly indexName: string;
+  readonly projectionType: SimDynamoDbProjectionType;
+  readonly nonKeyAttributes: readonly string[];
+  readonly orderCount: number;
+}
+
+/**
+ * Creates a table with one global secondary index, holding orders to read.
+ *
+ * The table is keyed by `orderId` and the index by `status` and `shippedAt`, so
+ * a read of the index walks a key the table does not have. Every third order is
+ * written without a `status`, which is what makes the index sparse rather than
+ * a second copy of the table.
+ *
+ * ```typescript
+ * const table = await simDynamoDbIndexedTableFactory.make(
+ *   { projectionType: "KEYS_ONLY" },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbIndexedTableFactory = new AsyncMappedFactory<
+  SimDynamoDbIndexedTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "OrdersTable",
+    indexName: "byStatus",
+    projectionType: "ALL",
+    nonKeyAttributes: [],
+    orderCount: 6,
+  }),
+  async (input, simAws) => {
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable({
+      input: {
+        TableName: input.tableName,
+        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+          { AttributeName: "status", AttributeType: "S" },
+          { AttributeName: "shippedAt", AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: input.indexName,
+            KeySchema: [
+              { AttributeName: "status", KeyType: "HASH" },
+              { AttributeName: "shippedAt", KeyType: "RANGE" },
+            ],
+            Projection: projection(input),
+          },
+        ],
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    await Promise.all(
+      simDynamoDbIndexedOrders(input.orderCount).map(async (order) =>
+        simDynamoDb.putItem({
+          input: { TableName: input.tableName, Item: order },
+        }),
+      ),
+    );
+
+    const table = simDynamoDb.findTable(input.tableName);
+    assertDefined(
+      table,
+      `Simulated DynamoDB created the table ${input.tableName} and then did ` +
+        `not hold it`,
+    );
+
+    return table;
+  },
+);
+
+/**
+ * The Projection the index is created with, which INCLUDE alone names
+ * attributes for.
+ */
+function projection(input: SimDynamoDbIndexedTableInput): {
+  readonly ProjectionType: SimDynamoDbProjectionType;
+  readonly NonKeyAttributes?: readonly string[];
+} {
+  if (input.projectionType !== "INCLUDE") {
+    return { ProjectionType: input.projectionType };
+  }
+
+  return {
+    ProjectionType: input.projectionType,
+    NonKeyAttributes: input.nonKeyAttributes,
+  };
+}

--- a/src/service/dynamodb/table/sim-dynamodb-item-collection.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-item-collection.ts
@@ -3,11 +3,12 @@ import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dy
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import { simDynamoDbValuesEqual } from "../item/sim-dynamodb-value-comparison.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
-import { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+import type { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
 
 interface SimDynamoDbItemCollectionProperties {
   readonly items: Iterable<SimDynamoDbItem>;
   readonly keySchema: SimDynamoDbKeySchema;
+  readonly order: SimDynamoDbSortKeyOrder;
   readonly keyCondition: SimDynamoDbKeyCondition;
 }
 
@@ -24,14 +25,18 @@ interface SimDynamoDbItemCollectionWalk {
  * it is read rather than kept that way. Real DynamoDB keeps a collection in
  * sort key order, and a query reads the same items in the same order either
  * way.
+ *
+ * The key schema is the one being read by, which for a query on an index is the
+ * index's own rather than the table's. The order comes in alongside it, since
+ * what separates two items sharing a sort key is the view's business rather
+ * than the collection's.
  */
 export class SimDynamoDbItemCollection {
   private readonly order: SimDynamoDbSortKeyOrder;
   private readonly ascending: readonly SimDynamoDbItem[];
 
   constructor(properties: SimDynamoDbItemCollectionProperties) {
-    const { keySchema, keyCondition } = properties;
-    const order = new SimDynamoDbSortKeyOrder(keySchema.rangeKeyAttributeName);
+    const { keySchema, keyCondition, order } = properties;
 
     this.order = order;
     this.ascending = order.ascending(

--- a/src/service/dynamodb/table/sim-dynamodb-read-view.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-read-view.ts
@@ -1,0 +1,79 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import type { SimDynamoDbDocumentPath } from "../expression/sim-dynamodb-document-path.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbItemCollection } from "./sim-dynamodb-item-collection.js";
+import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
+import type { SimDynamoDbTableScan } from "./sim-dynamodb-table-scan.js";
+
+/**
+ * What a Query or a Scan reads: a table, or one of its secondary indexes.
+ *
+ * The two answer the same questions and answer them differently, which is the
+ * whole of what `IndexName` does to a read. A table view holds every item and
+ * every attribute of it. An index view holds the items carrying the index key,
+ * keyed by that key, and only the attributes the index projects.
+ *
+ * A view is built per read rather than kept, since an index is derived when it
+ * is looked at rather than maintained on the write path.
+ */
+export interface SimDynamoDbReadView {
+  /**
+   * How a refusal names what is being read.
+   */
+  readonly description: string;
+
+  /**
+   * The key a read of this walks by, which for an index is its own.
+   */
+  readonly keySchema: SimDynamoDbKeySchema;
+
+  /**
+   * The types the key attributes were declared with, which the table owns
+   * whichever view uses them.
+   */
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+
+  /**
+   * The items one key condition names, in sort key order.
+   */
+  itemCollection(
+    keyCondition: SimDynamoDbKeyCondition,
+  ): SimDynamoDbItemCollection;
+
+  /**
+   * Every item this view holds, in the order a Scan reads them.
+   */
+  scan(): SimDynamoDbTableScan;
+
+  /**
+   * Refuse an `ExclusiveStartKey` this view could not have handed out.
+   */
+  assertStartKey(key: SimDynamoDbItem): void;
+
+  /**
+   * The key attributes a pagination token carries for this view.
+   */
+  tokenKey(item: SimDynamoDbItem): Record<string, SimDynamoDbAttributeValue>;
+
+  /**
+   * Cut an item down to what this view carries.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem;
+
+  /**
+   * Refuse a read asking for whole items where this view holds part of them.
+   */
+  assertCarriesWholeItem(): void;
+
+  /**
+   * Refuse an expression naming an attribute this view does not carry.
+   *
+   * A path into an attribute an index does not project would match nothing
+   * here, which reads as a collection that happens to be empty. Real DynamoDB
+   * refuses it, so this does too rather than answering with a page that means
+   * something else.
+   */
+  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void;
+}

--- a/src/service/dynamodb/table/sim-dynamodb-sort-key-compare.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-sort-key-compare.ts
@@ -1,0 +1,68 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import {
+  compareSimDynamoDbBytes,
+  compareSimDynamoDbValues,
+} from "../item/sim-dynamodb-value-order.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+import type { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
+
+/**
+ * The sort key a stored item holds.
+ *
+ * Every item of a collection carries the key attributes it is walked by. A
+ * write that left a table key attribute out was refused, and an index holds
+ * only the items carrying the whole of its key, so the value is there either
+ * way.
+ */
+export function simDynamoDbSortKeyValue(
+  item: SimDynamoDbItem,
+  attributeName: string,
+): SimDynamoDbValue {
+  const value = item.attribute(attributeName);
+
+  assertDefined(value, `sort key ${attributeName} of a stored item`);
+
+  return value;
+}
+
+/**
+ * Order two items by their sort keys.
+ *
+ * Two items of one collection always order: every key attribute is checked
+ * against its declared type on the way in, so no collection holds two sort keys
+ * of different types.
+ */
+export function compareSimDynamoDbSortKeys(
+  first: SimDynamoDbItem,
+  second: SimDynamoDbItem,
+  attributeName: string,
+): number {
+  const order = compareSimDynamoDbValues(
+    simDynamoDbSortKeyValue(first, attributeName),
+    simDynamoDbSortKeyValue(second, attributeName),
+  );
+
+  assertDefined(order, `order of two ${attributeName} sort keys`);
+
+  return order;
+}
+
+/**
+ * Separate two items their sort keys did not, by the key that identifies them.
+ *
+ * The marshalled key is compared as UTF-8 bytes, which is the order the rest of
+ * the simulation compares text in. Nothing depends on which of two items comes
+ * first, only that the answer is the same every time, since an
+ * `ExclusiveStartKey` could not resume a walk otherwise.
+ */
+export function compareSimDynamoDbItemIdentities(
+  first: SimDynamoDbItem,
+  second: SimDynamoDbItem,
+  identity: SimDynamoDbItemKey,
+): number {
+  return compareSimDynamoDbBytes(
+    Buffer.from(identity.of(first), "utf8"),
+    Buffer.from(identity.of(second), "utf8"),
+  );
+}

--- a/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-sort-key-order.ts
@@ -1,28 +1,45 @@
-import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
-import { compareSimDynamoDbValues } from "../item/sim-dynamodb-value-order.js";
 import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+import type { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
+import {
+  compareSimDynamoDbItemIdentities,
+  compareSimDynamoDbSortKeys,
+  simDynamoDbSortKeyValue,
+} from "./sim-dynamodb-sort-key-compare.js";
+
+interface SimDynamoDbSortKeyOrderProperties {
+  readonly attributeName: string | undefined;
+  readonly identity?: SimDynamoDbItemKey | undefined;
+}
 
 /**
- * The order a table's sort key puts an item collection in.
+ * The order a sort key puts an item collection in.
  *
  * A table with no sort key holds at most one item under a partition key, so
  * every question here has a trivial answer for one. That is why the attribute
  * name is optional rather than each caller asking whether there is one.
  *
- * The order is DynamoDB's rather than JavaScript's, through
- * `compareSimDynamoDbValues`: numbers order by value however they were written,
- * strings by their UTF-8 bytes, and binary as unsigned bytes.
+ * The order is DynamoDB's rather than JavaScript's: numbers order by value
+ * however they were written, strings by their UTF-8 bytes, and binary as
+ * unsigned bytes.
+ *
+ * An index needs one thing more. Index key values are not unique, so a sort key
+ * settles nothing between two items sharing one, and a walk that could not tell
+ * them apart could not resume after either. The identity is what separates
+ * them: the table primary key, which is unique by definition. That is why a
+ * read of an index hands out a token carrying both.
  */
 export class SimDynamoDbSortKeyOrder {
   private readonly attributeName: string | undefined;
+  private readonly identity: SimDynamoDbItemKey | undefined;
 
-  constructor(attributeName: string | undefined) {
-    this.attributeName = attributeName;
+  constructor(properties: SimDynamoDbSortKeyOrderProperties) {
+    this.attributeName = properties.attributeName;
+    this.identity = properties.identity;
   }
 
   /**
-   * The sort key of an item, or nothing when the table has no sort key.
+   * The sort key of an item, or nothing when the collection has no sort key.
    */
   valueOf(item: SimDynamoDbItem): SimDynamoDbValue | undefined {
     const attributeName = this.attributeName;
@@ -31,63 +48,82 @@ export class SimDynamoDbSortKeyOrder {
       return undefined;
     }
 
-    return sortKeyValue(item, attributeName);
+    return simDynamoDbSortKeyValue(item, attributeName);
   }
 
   /**
    * Items in ascending sort key order.
    */
   ascending(items: readonly SimDynamoDbItem[]): readonly SimDynamoDbItem[] {
-    const attributeName = this.attributeName;
-
-    if (attributeName === undefined) {
-      return items;
-    }
-
-    return items.toSorted((first, second) =>
-      this.compare(first, second, attributeName),
-    );
+    return items.toSorted((first, second) => this.compareItems(first, second));
   }
 
   /**
    * The items past the one a request resumes after, in the walk direction.
    *
-   * With no sort key a collection holds one item, and that is the item the
-   * token names, so nothing comes after it.
+   * With nothing to order a collection by, it holds one item, and that is the
+   * item the token names, so nothing comes after it.
    */
   beyond(
     items: readonly SimDynamoDbItem[],
     after: SimDynamoDbItem,
     forward: boolean,
   ): readonly SimDynamoDbItem[] {
-    const attributeName = this.attributeName;
-
-    if (attributeName === undefined) {
-      return [];
-    }
-
     const direction = this.direction(forward);
 
     return items.filter(
-      (item) => this.compare(item, after, attributeName) * direction > 0,
+      (item) => this.compareItems(item, after) * direction > 0,
     );
   }
 
   /**
-   * Order two items of one table by their sort keys.
+   * Order two items of one collection, by sort key and then by identity.
    *
-   * With no sort key a partition key value names at most one item, so two items
-   * that reach here are the same item and nothing separates them. A scan orders
-   * a whole table this way once it has ordered by partition key.
+   * With neither a sort key nor an identity, a partition key value names at
+   * most one item, so two items that reach here are the same item and nothing
+   * separates them. A scan orders a whole table this way once it has ordered by
+   * partition key.
    */
   compareItems(first: SimDynamoDbItem, second: SimDynamoDbItem): number {
+    const bySortKey = this.compareSortKeys(first, second);
+
+    if (bySortKey !== 0) {
+      return bySortKey;
+    }
+
+    return this.compareIdentities(first, second);
+  }
+
+  /**
+   * Order two items by their sort keys, if the collection has one.
+   */
+  private compareSortKeys(
+    first: SimDynamoDbItem,
+    second: SimDynamoDbItem,
+  ): number {
     const attributeName = this.attributeName;
 
     if (attributeName === undefined) {
       return 0;
     }
 
-    return this.compare(first, second, attributeName);
+    return compareSimDynamoDbSortKeys(first, second, attributeName);
+  }
+
+  /**
+   * Separate two items their sort keys did not, where something can.
+   */
+  private compareIdentities(
+    first: SimDynamoDbItem,
+    second: SimDynamoDbItem,
+  ): number {
+    const identity = this.identity;
+
+    if (identity === undefined) {
+      return 0;
+    }
+
+    return compareSimDynamoDbItemIdentities(first, second, identity);
   }
 
   /**
@@ -100,43 +136,4 @@ export class SimDynamoDbSortKeyOrder {
 
     return -1;
   }
-
-  /**
-   * Order two items by their sort keys.
-   *
-   * Two items in one table always order: the table checks the type of every key
-   * attribute on the way in, so no collection holds two sort keys of different
-   * types.
-   */
-  private compare(
-    first: SimDynamoDbItem,
-    second: SimDynamoDbItem,
-    attributeName: string,
-  ): number {
-    const order = compareSimDynamoDbValues(
-      sortKeyValue(first, attributeName),
-      sortKeyValue(second, attributeName),
-    );
-
-    assertDefined(order, `order of two ${attributeName} sort keys`);
-
-    return order;
-  }
-}
-
-/**
- * The sort key a stored item holds.
- *
- * Every item in a table carries its key attributes: a write that left one out
- * was refused, so the value is there by the time an item is stored.
- */
-function sortKeyValue(
-  item: SimDynamoDbItem,
-  attributeName: string,
-): SimDynamoDbValue {
-  const value = item.attribute(attributeName);
-
-  assertDefined(value, `sort key ${attributeName} of a stored item`);
-
-  return value;
 }

--- a/src/service/dynamodb/table/sim-dynamodb-table-scan.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-scan.ts
@@ -1,13 +1,12 @@
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
-import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import { SimDynamoDbScanPosition } from "./sim-dynamodb-scan-position.js";
 import type { SimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment.js";
-import { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+import type { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
 
 interface SimDynamoDbTableScanProperties {
   readonly items: Iterable<SimDynamoDbItem>;
-  readonly keySchema: SimDynamoDbKeySchema;
+  readonly order: SimDynamoDbSortKeyOrder;
   readonly itemKey: SimDynamoDbItemKey;
 }
 
@@ -31,9 +30,7 @@ export class SimDynamoDbTableScan {
 
   constructor(properties: SimDynamoDbTableScanProperties) {
     this.itemKey = properties.itemKey;
-    this.sortKeyOrder = new SimDynamoDbSortKeyOrder(
-      properties.keySchema.rangeKeyAttributeName,
-    );
+    this.sortKeyOrder = properties.order;
     this.positions = [...properties.items]
       .map((item) => this.positionOf(item))
       .toSorted((first, second) => first.compareTo(second));

--- a/src/service/dynamodb/table/sim-dynamodb-table-view.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-view.ts
@@ -95,8 +95,7 @@ export class SimDynamoDbTableView implements SimDynamoDbReadView {
   }
 
   /**
-   * A table carries every attribute of every item, so neither of these refuses
-   * anything. They are questions only an index has a narrow answer to.
+   * A table read already answers with whole items, so nothing is refused.
    */
   assertCarriesWholeItem(): void {
     return;

--- a/src/service/dynamodb/table/sim-dynamodb-table-view.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-view.ts
@@ -1,0 +1,111 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
+import { SimDynamoDbItemCollection } from "./sim-dynamodb-item-collection.js";
+import type { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
+import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
+import { simDynamoDbPrimaryKeyAttributes } from "./sim-dynamodb-primary-key.js";
+import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
+import { SimDynamoDbTableScan } from "./sim-dynamodb-table-scan.js";
+import { SimDynamoDbSortKeyOrder } from "./sim-dynamodb-sort-key-order.js";
+
+interface SimDynamoDbTableViewProperties {
+  readonly tableName: string;
+  readonly items: readonly SimDynamoDbItem[];
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+  readonly itemKey: SimDynamoDbItemKey;
+}
+
+/**
+ * Reading the table itself, rather than one of its indexes.
+ *
+ * This is the view a request naming no `IndexName` gets, and it holds
+ * everything: every item the table has, keyed by the table's own primary key,
+ * with every attribute of each. So the questions an index answers narrowly all
+ * have the wide answer here.
+ */
+export class SimDynamoDbTableView implements SimDynamoDbReadView {
+  public readonly description: string;
+  public readonly keySchema: SimDynamoDbKeySchema;
+  public readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
+
+  private readonly items: readonly SimDynamoDbItem[];
+  private readonly itemKey: SimDynamoDbItemKey;
+  private readonly order: SimDynamoDbSortKeyOrder;
+
+  constructor(properties: SimDynamoDbTableViewProperties) {
+    this.description = `table ${properties.tableName}`;
+    this.keySchema = properties.keySchema;
+    this.attributeDefinitions = properties.attributeDefinitions;
+    this.items = properties.items;
+    this.itemKey = properties.itemKey;
+    // A table primary key is unique, so the sort key settles every order
+    // question and nothing has to separate two items sharing one.
+    this.order = new SimDynamoDbSortKeyOrder({
+      attributeName: properties.keySchema.rangeKeyAttributeName,
+    });
+  }
+
+  /**
+   * The items of the table one key condition names.
+   */
+  itemCollection(
+    keyCondition: SimDynamoDbKeyCondition,
+  ): SimDynamoDbItemCollection {
+    return new SimDynamoDbItemCollection({
+      items: this.items,
+      keySchema: this.keySchema,
+      order: this.order,
+      keyCondition,
+    });
+  }
+
+  /**
+   * Every item the table holds, in the order a Scan reads them.
+   */
+  scan(): SimDynamoDbTableScan {
+    return new SimDynamoDbTableScan({
+      items: this.items,
+      order: this.order,
+      itemKey: this.itemKey,
+    });
+  }
+
+  /**
+   * Refuse a token that is not a whole primary key of this table.
+   */
+  assertStartKey(key: SimDynamoDbItem): void {
+    this.itemKey.ofKey(key);
+  }
+
+  /**
+   * The primary key of the item a walk stopped on.
+   */
+  tokenKey(item: SimDynamoDbItem): Record<string, SimDynamoDbAttributeValue> {
+    return simDynamoDbPrimaryKeyAttributes(item, this.keySchema);
+  }
+
+  /**
+   * A table read answers with the whole item, so there is nothing to cut.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem {
+    return item;
+  }
+
+  /**
+   * A table carries every attribute of every item, so neither of these refuses
+   * anything. They are questions only an index has a narrow answer to.
+   */
+  assertCarriesWholeItem(): void {
+    return;
+  }
+
+  /**
+   * A filter may name any attribute of a table, so nothing is refused.
+   */
+  assertCarriesPaths(): void {
+    return;
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -14,15 +14,15 @@ import type { SimDynamoDbTimeToLiveDescription } from "../command/time-to-live/t
 import { SimDynamoDbTableExpiry } from "../time-to-live/sim-dynamodb-table-expiry.js";
 import { SimDynamoDbTimeToLive } from "../time-to-live/sim-dynamodb-time-to-live.js";
 import type { SimDynamoDbTimeToLiveSpecification } from "../time-to-live/sim-dynamodb-time-to-live-specification.js";
-import type { SimDynamoDbKeyCondition } from "../expression/key-condition/sim-dynamodb-key-condition.js";
 import { SimDynamoDbGlobalSecondaryIndexes } from "../secondary-index/sim-dynamodb-global-secondary-indexes.js";
-import { SimDynamoDbItemCollection } from "./sim-dynamodb-item-collection.js";
+import { SimDynamoDbIndexView } from "../secondary-index/sim-dynamodb-index-view.js";
 import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
+import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
 import { SimDynamoDbTableLifecycle } from "./sim-dynamodb-table-lifecycle.js";
-import { SimDynamoDbTableScan } from "./sim-dynamodb-table-scan.js";
 import { SimDynamoDbTableTags } from "./sim-dynamodb-table-tags.js";
+import { SimDynamoDbTableView } from "./sim-dynamodb-table-view.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -262,34 +262,31 @@ export class SimDynamoDbTable {
   }
 
   /**
-   * The items a key condition names, in sort key order.
+   * What a Query or a Scan reads: this table, or one of its indexes.
    *
-   * A Query reads a whole item collection rather than one key, so the items are
-   * reachable together as well as one at a time. The ordering belongs to the
-   * collection rather than to the command that reads it.
+   * An index is worked out here rather than kept up to date on the write path,
+   * so a view is built per read from the items as they stand. An `IndexName`
+   * this table does not have is refused rather than read as the table.
    */
-  public itemCollection(
-    keyCondition: SimDynamoDbKeyCondition,
-  ): SimDynamoDbItemCollection {
-    return new SimDynamoDbItemCollection({
-      items: this.items.entries().values(),
-      keySchema: this.keySchema,
-      keyCondition,
-    });
-  }
+  public view(indexName: string | undefined): SimDynamoDbReadView {
+    const items = this.items.entries().values().toArray();
 
-  /**
-   * Every item this table holds, in the order a Scan reads them.
-   *
-   * A Scan needs no key knowledge, so unlike an item collection this is the
-   * whole table. The order and the parallel scan segments both belong to the
-   * scan rather than to the command that reads it.
-   */
-  public scan(): SimDynamoDbTableScan {
-    return new SimDynamoDbTableScan({
-      items: this.items.entries().values(),
-      keySchema: this.keySchema,
-      itemKey: this.itemKey,
+    if (indexName === undefined) {
+      return new SimDynamoDbTableView({
+        tableName: this.tableName,
+        items,
+        keySchema: this.keySchema,
+        attributeDefinitions: this.attributeDefinitions,
+        itemKey: this.itemKey,
+      });
+    }
+
+    return new SimDynamoDbIndexView({
+      index: this.indexes.required(indexName, this.tableName),
+      items,
+      tableKeySchema: this.keySchema,
+      attributeDefinitions: this.attributeDefinitions,
+      tableItemKey: this.itemKey,
     });
   }
 }


### PR DESCRIPTION
IndexName on Query and Scan reads an index rather than the table, through a read view the table hands out. The index is derived when it is read, so it is sparse: an item missing any index key attribute is not in it.

Key conditions and filters are held to the index key schema, reads answer with the attributes the index projects, and Select defaults to ALL_PROJECTED_ATTRIBUTES. Asking for more than the index carries is refused rather than quietly answered with less.

Index keys are not unique, so LastEvaluatedKey carries the index key and the table key together and the table key breaks ties in the walk order. Without that, paging a collection whose entries share an index key would repeat an item or skip one.

An unknown IndexName gives ResourceNotFoundException, and ConsistentRead against a global secondary index is a ValidationException.

Resolves https://github.com/KensioSoftware/yulin/issues/269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying and scanning global secondary indexes.
  * Added sparse-index behavior, projected attributes, index-specific pagination, and validation.
  * Added support for `IndexName` in read operations.
  * Added examples demonstrating indexed queries and projected results.

* **Bug Fixes**
  * Improved validation for invalid indexes, unsupported attributes, pagination keys, and consistency settings.

* **Documentation**
  * Expanded DynamoDB documentation with index usage, projection behavior, pagination, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->