### PR TITLE
feat: create and query simulated DynamoDB local secondary indexes

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -198,6 +198,141 @@ rather than refused on the write. An index keyed on two attributes needs both. T
 is held to on account of an index is the type: an item carrying an index key attribute as a type the
 index did not declare is a `ValidationException`, since the index could never hold it.
 
+## Local secondary indexes
+
+`LocalSecondaryIndexes` on `CreateTable` gives an item collection a second sort key. The index shares
+the table's partition key, so an entry sits in the same partition as the item it indexes, and its
+sort key is some other attribute. That is what serves an access pattern such as "this customer's
+orders in date order" against a table keyed by customer and order id.
+
+`CreateTable` is the only place one can be declared. AWS has no call that adds, changes or removes a
+local secondary index afterwards, so a table created without one stays without it for the whole of
+its life.
+
+```typescript sim-dynamodb-local-secondary-index
+/**
+ * Declaring and querying a local secondary index.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "Orders",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "placedAt", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    LocalSecondaryIndexes: [
+      {
+        IndexName: "OrdersByDate",
+        // The partition key is the table's own. The sort key is the whole of
+        // what the index adds.
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "placedAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "KEYS_ONLY" },
+      },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "Orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-1" },
+      placedAt: { S: "2026-03-19" },
+      total: { N: "7" },
+    },
+  }),
+);
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "Orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-2" },
+      placedAt: { S: "2026-01-08" },
+      total: { N: "42" },
+    },
+  }),
+);
+
+const byDate = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "Orders",
+    IndexName: "OrdersByDate",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+    // The index sits in the same partition as the item it indexes, so it can
+    // answer a strongly consistent read.
+    ConsistentRead: true,
+  }),
+);
+
+// In date order, which is not the order the table's own sort key gives.
+console.log(byDate.Items?.[0]?.["orderId"]?.S); // "order-2"
+console.log(byDate.Items?.[1]?.["orderId"]?.S); // "order-1"
+
+// The index projects its keys alone, so `total` is not on what it answers with.
+console.log(byDate.Items?.[0]?.["total"]); // undefined
+
+const whole = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "Orders",
+    IndexName: "OrdersByDate",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+    // Asking for whole items fetches what the index does not project from the
+    // base table, which is the read AWS charges the extra capacity for.
+    Select: "ALL_ATTRIBUTES",
+  }),
+);
+
+console.log(whole.Items?.[0]?.["total"]?.N); // "42"
+```
+
+The key schema is what a declaration is held to. The `HASH` element is the table's own partition key,
+and a `RANGE` element is required and names some other attribute. An index sorted by the attribute
+the table is already sorted by is refused, since it would repeat the order the table is in, and so is
+one keyed on a partition key of its own. A table with no sort key at all takes no local secondary
+index, because it holds one item per partition key and there is no collection for a second sort key
+to reorder.
+
+A table holds at most 5 local secondary indexes. Index names are unique within a table across both
+kinds, so a local secondary index cannot take the name of a global one. `Projection` follows the same
+`ALL`, `KEYS_ONLY` and `INCLUDE` rules a global secondary index does, and the 100 `NonKeyAttributes`
+a table projects is counted across every index of both kinds.
+
+A per-index `ProvisionedThroughput` is refused. A local secondary index is read and written out of
+the table's own capacity, so there is nothing to provision for it, and real DynamoDB has no
+throughput field on a `LocalSecondaryIndex` at all.
+
+The description reports each index with its `IndexName`, `IndexArn`, `KeySchema` and `Projection`.
+There is no `IndexStatus` and no `ProvisionedThroughput`, since the index is built with the table and
+shares its capacity. A table that declared none leaves `LocalSecondaryIndexes` out of its description
+altogether.
+
 ## Describing a table
 
 `DescribeTable` answers with the same description `CreateTable` did, read off the table itself. A
@@ -1285,6 +1420,25 @@ read at all.
 
 `Scan` takes `IndexName` the same way, including in parallel segments, which divide by the index
 partition key rather than the table's.
+
+## Reading a local secondary index
+
+`IndexName` reaches a local secondary index the same way, and the walk is the same walk: the index is
+sparse, the key condition is held to the index key schema, and `Scan` takes the index too. Two things
+differ, and both follow from the index sitting in the same partition as the item it indexes.
+
+`ConsistentRead: true` is answered rather than refused. The index is written with the item, in the
+same partition, so there is no window in which it lags behind the table.
+
+An attribute the index does not project is fetched from the base table rather than refused. So
+`Select: ALL_ATTRIBUTES` against a `KEYS_ONLY` index answers with whole items, and a
+`FilterExpression` may name any attribute of the item rather than only a projected one. Real DynamoDB
+charges the extra read capacity for that fetch. A read that asks for neither still answers with what
+the index projects, since `Select` defaults to `ALL_PROJECTED_ATTRIBUTES` on any index.
+
+`LastEvaluatedKey` carries three attributes: the table partition key, the index sort key and the
+table sort key. Two entries can share a whole index key, so the table sort key is what names one of
+them exactly enough to resume after. An `ExclusiveStartKey` missing any of the three is refused.
 
 ## Scanning a table
 
@@ -2544,9 +2698,13 @@ nothing is written.
 - `GlobalSecondaryIndexes` on `CreateTable`, with index name, key schema, projection and per-index
   throughput validation, `AttributeDefinitions` matched against every key schema in the request, and
   each index reported in the table description.
-- `IndexName` on `Query` and `Scan`, reading a sparse index by its own key schema, answering with the
-  attributes it projects, and paging with a `LastEvaluatedKey` carrying the index key and the table
-  key together.
+- `LocalSecondaryIndexes` on `CreateTable`, with the key schema rules that make an index local, the
+  5 index cap, index names unique across both kinds, and each index reported in the table
+  description.
+- `IndexName` on `Query` and `Scan`, reading a sparse index of either kind by its own key schema,
+  answering with the attributes it projects, and paging with a `LastEvaluatedKey` carrying the index
+  key and the table key together. A local secondary index also answers a strongly consistent read,
+  and fetches an unprojected attribute from the base table.
 - `DescribeTable`, answering with the full table description, by table name or ARN.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
@@ -2608,22 +2766,25 @@ nothing is written.
 - `Expected`, `ConditionalOperator` and `AttributeUpdates` are not converted for the document
   client, because simulated DynamoDB refuses all three anyway. A request carrying one is refused by
   the operation rather than by the conversion.
-- An index read answers with the attributes the index projects, and nothing fills in the rest. Real
-  DynamoDB does not either: a global secondary index never reads the base table for an attribute it
-  does not project, which is why `Select: ALL_ATTRIBUTES` against a partial projection is refused
-  rather than served. Fetching from the base table is a local secondary index behaviour, and those
-  are not simulated. `ProjectionExpression` is not simulated on `Query` or `Scan`, so naming a
-  non-projected attribute that way does not arise.
-- Local secondary indexes are not simulated. `LocalSecondaryIndexes` is refused rather than dropped,
-  since a table missing an index it was asked for would answer queries differently to the real one.
-  An empty list asks for no index, so it is accepted.
+- A read of a global secondary index answers with the attributes the index projects, and nothing
+  fills in the rest. Real DynamoDB does not either: it never reads the base table for an attribute a
+  global secondary index does not project, which is why `Select: ALL_ATTRIBUTES` against a partial
+  projection is refused rather than served. A local secondary index does fetch from the base table,
+  and that is simulated. `ProjectionExpression` is not simulated on `Query` or `Scan` either way, so
+  naming a non-projected attribute that way does not arise.
+- The 10 GB limit on one item collection is not modelled, and neither is
+  `ItemCollectionSizeLimitExceededException`. A table with a local secondary index can hold as much
+  under one partition key here as memory allows, so a write real DynamoDB would refuse for the size
+  of the collection it lands in goes through. `ReturnItemCollectionMetrics` is refused by name, so a
+  write cannot ask how large the collection it touched has grown either.
 - An index key is one attribute, or two. Real DynamoDB now takes more than that, and a key schema of
   more than two elements is refused here.
 - `ItemCount` and `IndexSizeBytes` are 0 for every index, the same way the table's own figures are.
 - Per-index `ProvisionedThroughput` is read, validated and reported, and enforces nothing. No read or
   write against an index is throttled, since none against the table is either.
-- `UpdateTable` is not simulated, so an index cannot be added to or removed from a table after it has
-  been created.
+- `UpdateTable` is not simulated, so a global secondary index cannot be added to or removed from a
+  table after it has been created. A local secondary index cannot be either, which is AWS behaviour
+  rather than a limitation here: `CreateTable` is the only call that declares one.
 - Tagging is immediate. AWS documents `TagResource` and `UntagResource` as eventually consistent, so
   a real `ListTagsOfResource` issued straight after one of them may answer with the previous tags or
   with none. Here the change is there by the time the call returns, so a test cannot observe the

--- a/docs/services/dynamodb/sim-dynamodb-local-secondary-index.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-local-secondary-index.example.ts
@@ -1,0 +1,100 @@
+/**
+ * Declaring and querying a local secondary index.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "Orders",
+    KeySchema: [
+      { AttributeName: "customerId", KeyType: "HASH" },
+      { AttributeName: "orderId", KeyType: "RANGE" },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: "customerId", AttributeType: "S" },
+      { AttributeName: "orderId", AttributeType: "S" },
+      { AttributeName: "placedAt", AttributeType: "S" },
+    ],
+    BillingMode: "PAY_PER_REQUEST",
+    LocalSecondaryIndexes: [
+      {
+        IndexName: "OrdersByDate",
+        // The partition key is the table's own. The sort key is the whole of
+        // what the index adds.
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "placedAt", KeyType: "RANGE" },
+        ],
+        Projection: { ProjectionType: "KEYS_ONLY" },
+      },
+    ],
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "Orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-1" },
+      placedAt: { S: "2026-03-19" },
+      total: { N: "7" },
+    },
+  }),
+);
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "Orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-2" },
+      placedAt: { S: "2026-01-08" },
+      total: { N: "42" },
+    },
+  }),
+);
+
+const byDate = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "Orders",
+    IndexName: "OrdersByDate",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+    // The index sits in the same partition as the item it indexes, so it can
+    // answer a strongly consistent read.
+    ConsistentRead: true,
+  }),
+);
+
+// In date order, which is not the order the table's own sort key gives.
+console.log(byDate.Items?.[0]?.["orderId"]?.S); // "order-2"
+console.log(byDate.Items?.[1]?.["orderId"]?.S); // "order-1"
+
+// The index projects its keys alone, so `total` is not on what it answers with.
+console.log(byDate.Items?.[0]?.["total"]); // undefined
+
+const whole = await dynamoDb.query(
+  new QueryCommand({
+    TableName: "Orders",
+    IndexName: "OrdersByDate",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+    // Asking for whole items fetches what the index does not project from the
+    // base table, which is the read AWS charges the extra capacity for.
+    Select: "ALL_ATTRIBUTES",
+  }),
+);
+
+console.log(whole.Items?.[0]?.["total"]?.N); // "42"

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -91,7 +91,7 @@ Table state lives under `table/`.
 - creation time
 - current table status
 - key schema and attribute definitions
-- global secondary indexes
+- secondary indexes, global and local
 - billing mode, provisioned throughput, table class and deletion protection
 - tags
 - in-memory items
@@ -153,21 +153,36 @@ uses the key schema to overwrite items with the same primary key.
 
 Index state lives under `secondary-index/`.
 
-`SimDynamoDbGlobalSecondaryIndex` is one index, as the name, key schema, projection and throughput a
-read of it needs. `SimDynamoDbGlobalSecondaryIndexes` is the indexes one table carries, and owns what
-is about how many there are: the 20 index cap and the uniqueness of a name. That is the same split
-the table tags follow.
+`SimDynamoDbSecondaryIndex` is the interface a read reaches an index through, whichever kind it is.
+`SimDynamoDbGlobalSecondaryIndex` and `SimDynamoDbLocalSecondaryIndex` implement it, each as the name,
+key schema and projection a read of it needs, plus what only it has: a throughput on the global one.
+
+There is a collection per kind, since the two are declared apart and described apart.
+`SimDynamoDbGlobalSecondaryIndexes` owns the 20 index cap and `SimDynamoDbLocalSecondaryIndexes` owns
+the 5, along with the one rule about the table rather than an index: a table with no sort key has no
+collection for a local secondary index to reorder. `SimDynamoDbSecondaryIndexes` holds both and owns
+what they share, since neither collection can see the other:
+
+- one namespace for their names, so a local secondary index cannot take a global one's name
+- one cap of 100 `NonKeyAttributes` projected across every index of both kinds
+- one `IndexName` parameter reaching either of them, through `requiredSimDynamoDbIndex`
 
 The parts an index is made of are a file each, since each has rules of its own:
 
 - `sim-dynamodb-index-name.ts` is the name pattern and length, which is the table name rule.
 - `sim-dynamodb-index-projection.ts` is `SimDynamoDbIndexProjection`: the three projection types, and
-  the two directions `INCLUDE` and `NonKeyAttributes` have to agree in.
-- `sim-dynamodb-index-throughput.ts` is the capacity an index is provisioned with, which contradicts
-  the billing mode in both directions the way the table's own does.
+  the two directions `INCLUDE` and `NonKeyAttributes` have to agree in. Both kinds project the same
+  way, so both read it.
+- `sim-dynamodb-index-throughput.ts` is the capacity a global secondary index is provisioned with,
+  which contradicts the billing mode in both directions the way the table's own does.
+  `sim-dynamodb-local-index-throughput.ts` is the other half of that: a local secondary index shares
+  the table's throughput, so any capacity setting on one is refused.
+- `sim-dynamodb-local-index-key-schema.ts` is what makes an index local. The partition key is the
+  table's own, and the sort key is required and is anything the table is not already sorted by.
 - `sim-dynamodb-index-status.ts` maps a table status to the index status. Nothing here adds an index
   to an existing table, so the index status follows the table's rather than being tracked apart from
-  it: `CREATING` on the CreateTable response, `ACTIVE` once the table is.
+  it: `CREATING` on the CreateTable response, `ACTIVE` once the table is. A local secondary index
+  reports no status at all, since DynamoDB reports none for one.
 
 Which items an index holds is worked out when the index is read rather than maintained on every
 write, following the precedent `SimSqsQueue.applyLifecycle` sets. So PutItem, UpdateItem and
@@ -194,21 +209,39 @@ The two differ in four answers, which is the whole of what `IndexName` does:
   either of them, and paging would repeat one or skip one.
 
 `SimDynamoDbIndexView` splits those two ways, and what is left in the view is the walking, which is
-the same walking a table gets:
+the same walking a table gets and the same walking whichever kind of index it is:
 
 - `SimDynamoDbIndexKeys` is which items the index holds and how an entry is named: `holds` is the
   sparseness, `tokenKey` is both keys together, and `assertStartKey` refuses a token missing either
   of them or carrying anything else.
-- `SimDynamoDbIndexAttributes` is which parts of an item come back. `assertCarriesWholeItem` and
-  `assertCarriesPaths` are the two refusals only an index makes: a `Select` of `ALL_ATTRIBUTES`
-  against a projection that is not ALL, and a filter naming an attribute the index does not project.
-  Both fail closed. The alternative to the second is an empty page, which reads as a collection that
-  happens to hold nothing.
+- `SimDynamoDbIndexAttributes` is which parts of an item come back. It is an interface with an
+  implementation per index kind, since this is the only place a read of one kind differs from a read
+  of the other. The index builds its own through `attributesOf`, so the view asks rather than
+  decides.
 
-That check is `assertItemKeyTypes`, applied in `SimDynamoDbTable.putItem`, which every write in the
-service goes through. An item missing an index key attribute is fine, since a global secondary index
-is sparse and simply does not hold it. An item carrying one as a type the index did not declare is a
-`ValidationException`, since the index could never hold it.
+`SimDynamoDbProjectedIndexAttributes` is the global secondary index half. `assertCarriesWholeItem`
+and `assertCarriesPaths` refuse a `Select` of `ALL_ATTRIBUTES` against a projection that is not ALL,
+and a filter naming an attribute the index does not project. Both fail closed. The alternative to
+the second is an empty page, which reads as a collection that happens to hold nothing.
+
+`SimDynamoDbFetchedIndexAttributes` is the local secondary index half, and refuses neither. The index
+entry is in the same partition as the item, so DynamoDB reads the base table for what the index does
+not project and charges the extra capacity for it. Cutting an item down to the projection is still
+the same job, so it is delegated to the projected implementation rather than written twice. What the
+read then answers with is decided by `SimDynamoDbSelect.wholeItems` in `SimDynamoDbReadAnswer`: a
+read asking for whole items gets the item, and anything else gets the view's projection of it.
+
+The other place the kinds differ is `assertAnswersConsistentRead`, reached through
+`SimDynamoDbReadView.assertConsistentRead` and applied by
+`assertSimDynamoDbConsistentReadAnswerable`. A global secondary index is maintained asynchronously on
+AWS and refuses one; a local secondary index and the table both answer it. That is why the check runs
+after `IndexName` has been resolved to a view rather than off the request alone.
+
+The one thing a write is held to on account of an index is `assertItemKeyTypes`, applied in
+`SimDynamoDbTable.putItem`, which every write in the service goes through. An item missing an index
+key attribute is fine, since a secondary index of either kind is sparse and simply does not hold it.
+An item carrying one as a type the index did not declare is a `ValidationException`, since the index
+could never hold it.
 
 ## Tagging behavior
 
@@ -310,8 +343,8 @@ the same name cannot both get it. The second gets `SimDynamoDbResourceInUseExcep
 The returned `TableDescription` reports the table back: `TableName`, `TableArn`, `TableId`,
 `KeySchema`, `AttributeDefinitions`, `TableStatus`, `CreationDateTime`, `ProvisionedThroughput`,
 `DeletionProtectionEnabled`, and `BillingModeSummary` or `TableClassSummary` when the request named
-a billing mode or a table class. `GlobalSecondaryIndexes` is there when the table has any, and left
-out altogether when it has none. `ItemCount` and `TableSizeBytes` stay at 0.
+a billing mode or a table class. `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` are each
+there when the table has any of that kind, and left out altogether when it has none. `ItemCount` and `TableSizeBytes` stay at 0.
 
 Unsimulated inputs are refused with `SimDynamoDbUnsupportedOperation` rather than dropped. Each one
 is listed in the Limitations section of
@@ -621,7 +654,7 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Streams are not implemented, and neither is reading a secondary index. Billing mode and provisioned
+Streams are not implemented. Billing mode and provisioned
 capacity are read and stored by CreateTable, for the table and for each index, but nothing enforces
 them: no write is ever throttled.
 

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -654,9 +654,10 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Streams are not implemented. Billing mode and provisioned
-capacity are read and stored by CreateTable, for the table and for each index, but nothing enforces
-them: no write is ever throttled.
+Streams are not implemented. Billing mode and provisioned capacity are read and stored by
+CreateTable, for the table and for each global secondary index, but nothing enforces them: no write
+is ever throttled. A local secondary index has no capacity of its own to store, since it is read and
+written out of the table's.
 
 ## TransactWriteItems and TransactGetItems behavior
 

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -1,7 +1,7 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
-import { refuseSimDynamoDbConsistentIndexRead } from "../read/sim-dynamodb-consistent-read.js";
+import { assertSimDynamoDbConsistentReadAnswerable } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type {
@@ -52,8 +52,6 @@ export class SimDynamoDbQuery {
     refuseUnsimulatedQueryInput(input);
     refuseSimDynamoDbQuerySegment(input);
 
-    refuseSimDynamoDbConsistentIndexRead(input);
-
     const expressions = readSimDynamoDbQueryExpressions(input);
     const table = this.access.required(
       "dynamodb:Query",
@@ -66,6 +64,11 @@ export class SimDynamoDbQuery {
     // table. Everything after this asks the view rather than the table, so a
     // query of an index is the same query against a narrower thing.
     const view = table.view(input.IndexName);
+
+    // Whether a strongly consistent read is answerable depends on which of the
+    // two index kinds is being read, so it waits for the view as well.
+    assertSimDynamoDbConsistentReadAnswerable(input, view);
+
     const keyCondition = expressions.terms.forTable(view);
 
     select.assertAnswerableBy(view);

--- a/src/service/dynamodb/command/read/sim-dynamodb-consistent-read.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-consistent-read.ts
@@ -1,30 +1,29 @@
-import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 
 interface SimDynamoDbConsistentReadInput {
   readonly ConsistentRead?: boolean | undefined;
-  readonly IndexName?: string | undefined;
 }
 
 /**
- * Refuse a strongly consistent read of a global secondary index.
+ * Refuse a strongly consistent read the thing being read cannot answer.
  *
  * A global secondary index is maintained asynchronously on AWS, so it cannot
- * answer a strongly consistent read at all, whatever the index is. Local
- * secondary indexes can, and are not simulated, so an `IndexName` here always
- * names a global one.
+ * answer one at all. A local secondary index sits in the same partition as the
+ * item it indexes and is written with it, so it can, and so can the table.
+ * Which of those is being read is a question only the view can answer, so this
+ * runs after the `IndexName` has been resolved rather than off the request
+ * alone.
  *
- * Every read here is strongly consistent, so accepting this and ignoring it
+ * Every read here is strongly consistent, so accepting the flag and ignoring it
  * would leave a test passing on a request real DynamoDB refuses outright.
  */
-export function refuseSimDynamoDbConsistentIndexRead(
+export function assertSimDynamoDbConsistentReadAnswerable(
   input: SimDynamoDbConsistentReadInput,
+  view: SimDynamoDbReadView,
 ): void {
-  if (input.ConsistentRead !== true || input.IndexName === undefined) {
+  if (input.ConsistentRead !== true) {
     return;
   }
 
-  throw new SimDynamoDbValidationException(
-    `Consistent reads are not supported on global secondary indexes, and ` +
-      `this request asks for one on ${input.IndexName}`,
-  );
+  view.assertConsistentRead();
 }

--- a/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
@@ -69,10 +69,6 @@ export class SimDynamoDbReadAnswer {
 
   /**
    * The items answered with, which a counted read leaves out altogether.
-   *
-   * Each is cut to what the view carries, so a read of an index answers with
-   * the attributes that index projects rather than with the whole item. A read
-   * of the table cuts nothing.
    */
   private items(): Pick<SimDynamoDbReadFields, "Items"> {
     if (this.select.countsOnly) {
@@ -80,9 +76,23 @@ export class SimDynamoDbReadAnswer {
     }
 
     return {
-      Items: this.kept.map((item) =>
-        this.view.project(item).toAttributeValues(),
-      ),
+      Items: this.kept.map((item) => this.answered(item).toAttributeValues()),
     };
+  }
+
+  /**
+   * One item as the read answers with it.
+   *
+   * A read asking for whole items answers with the whole item. Anything else is
+   * cut to what the view carries, so a read of an index answers with the
+   * attributes that index projects rather than with everything. A read of the
+   * table cuts nothing either way.
+   */
+  private answered(item: SimDynamoDbItem): SimDynamoDbItem {
+    if (this.select.wholeItems) {
+      return item;
+    }
+
+    return this.view.project(item);
   }
 }

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.ts
@@ -75,6 +75,19 @@ export class SimDynamoDbSelect {
   }
 
   /**
+   * Whether the read answers with whole items rather than what the view holds.
+   *
+   * `ALL_ATTRIBUTES` is the one `Select` that can ask for more than an index
+   * carries. A view that cannot answer it has refused the read already in
+   * `assertAnswerableBy`, so by the time this is asked the whole item is there
+   * to answer with. On a local secondary index that is the base table fetch AWS
+   * charges the extra read capacity for; here the item was already to hand.
+   */
+  get wholeItems(): boolean {
+    return this.kind === "ALL_ATTRIBUTES";
+  }
+
+  /**
    * Whether the read answers with counts alone.
    *
    * `COUNT` leaves out `Items` rather than answering with an empty list, so a

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -2,7 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { readSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
-import { refuseSimDynamoDbConsistentIndexRead } from "../read/sim-dynamodb-consistent-read.js";
+import { assertSimDynamoDbConsistentReadAnswerable } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type { SimScanCommand, SimScanCommandOutput } from "./scan.command.js";
@@ -52,7 +52,6 @@ export class SimDynamoDbScan {
     const select = SimDynamoDbSelect.from(input);
 
     refuseUnsimulatedScanInput(input);
-    refuseSimDynamoDbConsistentIndexRead(input);
 
     // The segment and the filter are read before the table is reached, so
     // input DynamoDB would refuse is refused whether or not the table is
@@ -70,6 +69,9 @@ export class SimDynamoDbScan {
     const view = table.view(input.IndexName);
     const scan = view.scan();
 
+    // Whether a strongly consistent read is answerable depends on which of the
+    // two index kinds is being read, so it waits for the view.
+    assertSimDynamoDbConsistentReadAnswerable(input, view);
     select.assertAnswerableBy(view);
     filter?.assertNamesOnlyCarried(view);
 

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table-local-index-validation.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table-local-index-validation.iso.test.ts
@@ -1,0 +1,279 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbSecondaryIndexInput } from "./table.types.js";
+import type { SimCreateTableCommandInput } from "./table.command.js";
+
+const byPlacedAt = {
+  IndexName: "byPlacedAt",
+  KeySchema: [
+    { AttributeName: "customerId", KeyType: "HASH" },
+    { AttributeName: "placedAt", KeyType: "RANGE" },
+  ],
+  Projection: { ProjectionType: "KEYS_ONLY" },
+} as const satisfies SimDynamoDbSecondaryIndexInput;
+
+const ordersTable = {
+  TableName: "OrdersTable",
+  KeySchema: [
+    { AttributeName: "customerId", KeyType: "HASH" },
+    { AttributeName: "orderId", KeyType: "RANGE" },
+  ],
+  AttributeDefinitions: [
+    { AttributeName: "customerId", AttributeType: "S" },
+    { AttributeName: "orderId", AttributeType: "S" },
+    { AttributeName: "placedAt", AttributeType: "S" },
+  ],
+  BillingMode: "PAY_PER_REQUEST",
+  LocalSecondaryIndexes: [byPlacedAt],
+} as const satisfies SimCreateTableCommandInput;
+
+/**
+ * Create a table whose local secondary indexes a test has replaced.
+ */
+async function refusedIndexes(
+  indexes: readonly SimDynamoDbSecondaryIndexInput[],
+  overrides: Partial<SimCreateTableCommandInput> = {},
+): Promise<Error> {
+  const simDynamoDb = new SimAws().dynamoDb();
+
+  return await assertThrowsErrorAsync(async () =>
+    simDynamoDb.createTable({
+      input: { ...ordersTable, ...overrides, LocalSecondaryIndexes: indexes },
+    }),
+  );
+}
+
+describe("DynamoDB CreateTable local secondary index validation", () => {
+  it("refuses a partition key that is not the table's", async () => {
+    // When an index is keyed on some other attribute.
+    const error = await refusedIndexes([
+      {
+        ...byPlacedAt,
+        KeySchema: [
+          { AttributeName: "placedAt", KeyType: "HASH" },
+          { AttributeName: "orderId", KeyType: "RANGE" },
+        ],
+      },
+    ]);
+
+    // Then it is refused. A local secondary index sits in the same partition as
+    // the item it indexes, so it has no partition key of its own to choose.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Invalid KeySchema for index byPlacedAt: the HASH element names " +
+        "placedAt, and a local secondary index shares the table's partition " +
+        "key, which is customerId",
+    );
+  });
+
+  it("refuses an index with no sort key", async () => {
+    // When an index is declared with a partition key alone.
+    const error = await refusedIndexes([
+      {
+        ...byPlacedAt,
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+      },
+    ]);
+
+    // Then it is refused. The sort key is the whole of what the index adds.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "has no RANGE element");
+  });
+
+  it("refuses a sort key that is the table's own", async () => {
+    // When an index is sorted by the attribute the table is sorted by.
+    const error = await refusedIndexes([
+      {
+        ...byPlacedAt,
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "orderId", KeyType: "RANGE" },
+        ],
+      },
+    ]);
+
+    // Then it is refused, since the index would be the table written twice.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "the RANGE element names orderId, which is the table's own sort key",
+    );
+  });
+
+  it("refuses a sort key attribute that is not scalar", async () => {
+    // When the index sort key is defined as something other than S, N or B.
+    const error = await refusedIndexes([byPlacedAt], {
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+        { AttributeName: "placedAt", AttributeType: "BOOL" },
+      ],
+    });
+
+    // Then it is refused: a key attribute is one of the three scalar types.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "AttributeType 'BOOL'");
+  });
+
+  it("refuses a sort key attribute with no definition", async () => {
+    // When the index sort key is named nowhere in AttributeDefinitions.
+    const error = await refusedIndexes([byPlacedAt], {
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+    });
+
+    // Then it is refused, naming the index that declared the attribute.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The KeySchema for index byPlacedAt names the attribute placedAt, " +
+        "which has no AttributeDefinition",
+    );
+  });
+
+  it("refuses a throughput on the index", async () => {
+    // When an index asks for capacity of its own.
+    const error = await refusedIndexes([
+      {
+        ...byPlacedAt,
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      },
+    ]);
+
+    // Then it is refused. A local secondary index is read and written out of
+    // the table's own capacity, so there is nothing to provision for it.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "ProvisionedThroughput cannot be specified for index: byPlacedAt " +
+        "because it is a local secondary index",
+    );
+  });
+
+  it("refuses an on-demand throughput on the index", async () => {
+    // When an index asks for on-demand limits of its own.
+    const error = await refusedIndexes([
+      { ...byPlacedAt, OnDemandThroughput: { MaxReadRequestUnits: 100 } },
+    ]);
+
+    // Then it is refused for the same reason provisioned capacity is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "OnDemandThroughput cannot be specified for index: byPlacedAt",
+    );
+  });
+
+  it("refuses a warm throughput on the index", async () => {
+    // When an index asks to be pre-warmed on its own.
+    const error = await refusedIndexes([
+      { ...byPlacedAt, WarmThroughput: { ReadUnitsPerSecond: 100 } },
+    ]);
+
+    // Then it is refused for the same reason provisioned capacity is.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "WarmThroughput cannot be specified for index: byPlacedAt",
+    );
+  });
+
+  it("refuses more than five indexes", async () => {
+    // When a table declares six local secondary indexes.
+    const error = await refusedIndexes(
+      Array.from({ length: 6 }, (_unused, position) => ({
+        ...byPlacedAt,
+        IndexName: `byPlacedAt-${position.toString()}`,
+      })),
+    );
+
+    // Then the request is refused for being over the cap.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "6 LocalSecondaryIndexes were given, and a table holds at most 5",
+    );
+  });
+
+  it("refuses a name a global secondary index already has", async () => {
+    // When a local secondary index takes the name of a global one.
+    const error = await refusedIndexes(
+      [{ ...byPlacedAt, IndexName: "byDate" }],
+      {
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
+          { AttributeName: "orderId", AttributeType: "S" },
+          { AttributeName: "placedAt", AttributeType: "S" },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byDate",
+            KeySchema: [{ AttributeName: "placedAt", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      },
+    );
+
+    // Then it is refused. An index is reached by name, so the two kinds share
+    // one namespace and a read naming byDate would have two answers.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "names an index more than once");
+  });
+
+  it("refuses a local secondary index on a table with no sort key", async () => {
+    // When the table it is declared on is keyed by a partition key alone.
+    const error = await refusedIndexes([byPlacedAt], {
+      KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "placedAt", AttributeType: "S" },
+      ],
+    });
+
+    // Then the whole request is refused. Such a table holds one item per
+    // partition key, so there is no collection for a second sort key to
+    // reorder.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Table KeySchema does not have a range key",
+    );
+  });
+
+  it("refuses an index name real DynamoDB would refuse", async () => {
+    // When an index is named with characters DynamoDB does not allow.
+    const error = await refusedIndexes([
+      { ...byPlacedAt, IndexName: "by placed at" },
+    ]);
+
+    // Then it is refused by the same rule a table name is held to.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "IndexName 'by placed at' is invalid");
+  });
+
+  it("refuses an INCLUDE projection naming no attributes", async () => {
+    // When an index includes nothing beyond its keys.
+    const error = await refusedIndexes([
+      { ...byPlacedAt, Projection: { ProjectionType: "INCLUDE" } },
+    ]);
+
+    // Then it is refused, the same way a global secondary index would be: both
+    // kinds project by the same rules.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "The Projection of index byPlacedAt is INCLUDE and names no " +
+        "NonKeyAttributes",
+    );
+  });
+});

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table-local-indexes.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table-local-indexes.iso.test.ts
@@ -1,0 +1,195 @@
+import type { CreateTableCommandInput } from "@aws-sdk/client-dynamodb";
+import { CreateTableCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const ordersTable = {
+  TableName: "OrdersTable",
+  KeySchema: [
+    { AttributeName: "customerId", KeyType: "HASH" },
+    { AttributeName: "orderId", KeyType: "RANGE" },
+  ],
+  AttributeDefinitions: [
+    { AttributeName: "customerId", AttributeType: "S" },
+    { AttributeName: "orderId", AttributeType: "S" },
+    { AttributeName: "placedAt", AttributeType: "S" },
+  ],
+  BillingMode: "PAY_PER_REQUEST",
+  LocalSecondaryIndexes: [
+    {
+      IndexName: "byPlacedAt",
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "placedAt", KeyType: "RANGE" },
+      ],
+      Projection: { ProjectionType: "KEYS_ONLY" },
+    },
+  ],
+} satisfies CreateTableCommandInput;
+
+/**
+ * The table keyed the way the orders table is, with no index on it at all.
+ */
+const unindexedTable = {
+  TableName: ordersTable.TableName,
+  KeySchema: ordersTable.KeySchema,
+  AttributeDefinitions: ordersTable.AttributeDefinitions.slice(0, 2),
+  BillingMode: ordersTable.BillingMode,
+} satisfies CreateTableCommandInput;
+
+describe("DynamoDB CreateTable with local secondary indexes", () => {
+  it("reports the index it was declared with", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with a local secondary index.
+    const creation = await simAws
+      .dynamoDb()
+      .createTable(new CreateTableCommand(ordersTable));
+
+    // Then the description reports it the way DynamoDB does.
+    const index = creation.TableDescription?.LocalSecondaryIndexes?.[0];
+    assertDefined(index, "the created table's local secondary index");
+    assertIdentical(index.IndexName, "byPlacedAt");
+    assertIdentical(index.Projection?.ProjectionType, "KEYS_ONLY");
+    assertArrayLength(index.KeySchema ?? [], 2);
+    assertIdentical(index.KeySchema?.[0]?.AttributeName, "customerId");
+    assertIdentical(index.KeySchema[1]?.AttributeName, "placedAt");
+    assertIdentical(index.ItemCount, 0);
+    assertIdentical(index.IndexSizeBytes, 0);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names the index under the table's own ARN", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created with a local secondary index.
+    const creation = await simAws
+      .dynamoDb()
+      .createTable({ input: ordersTable });
+
+    // Then the index ARN is the table's with the index named under it, which is
+    // the resource an IAM policy naming one index is written against.
+    const index = creation.TableDescription?.LocalSecondaryIndexes?.[0];
+    assertIdentical(
+      index?.IndexArn,
+      `${creation.TableDescription?.TableArn ?? ""}/index/byPlacedAt`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("leaves the indexes out of a table that declared none", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table is created without any local secondary index.
+    const creation = await simAws.dynamoDb().createTable({
+      input: { ...unindexedTable, LocalSecondaryIndexes: [] },
+    });
+
+    // Then the description leaves the field out altogether rather than
+    // reporting an empty list, which is what real DynamoDB does.
+    assertUndefined(creation.TableDescription?.LocalSecondaryIndexes);
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("describes the indexes off the table afterwards", async () => {
+    // Given a table created with a local secondary index.
+    const simAws = new SimAws();
+    await simAws.dynamoDb().createTable({ input: ordersTable });
+    await simAws.backgroundTasksComplete();
+
+    // When the table is described.
+    const description = await simAws
+      .dynamoDb()
+      .describeTable({ input: { TableName: "OrdersTable" } });
+
+    // Then the index is reported the same way it was on creation.
+    assertIdentical(
+      description.Table?.LocalSecondaryIndexes?.[0]?.IndexName,
+      "byPlacedAt",
+    );
+  });
+
+  it("takes both kinds of index on one table", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+
+    // When a table declares an index of each kind.
+    const creation = await simAws.dynamoDb().createTable({
+      input: {
+        ...ordersTable,
+        AttributeDefinitions: [
+          ...ordersTable.AttributeDefinitions,
+          { AttributeName: "status", AttributeType: "S" },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      },
+    });
+
+    // Then both are reported, each under its own field.
+    assertArrayLength(
+      creation.TableDescription?.LocalSecondaryIndexes ?? [],
+      1,
+    );
+    assertArrayLength(
+      creation.TableDescription?.GlobalSecondaryIndexes ?? [],
+      1,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("takes the five indexes a table holds", async () => {
+    // Given a simulated DynamoDB.
+    const simAws = new SimAws();
+    const sortKeys = ["placedAt", "shippedAt", "paidAt", "packedAt", "sentAt"];
+
+    // When a table declares the most local secondary indexes it can.
+    const creation = await simAws.dynamoDb().createTable({
+      input: {
+        ...unindexedTable,
+        AttributeDefinitions: [
+          ...unindexedTable.AttributeDefinitions,
+          ...sortKeys.map((name) => ({
+            AttributeName: name,
+            AttributeType: "S",
+          })),
+        ],
+        LocalSecondaryIndexes: sortKeys.map((name) => ({
+          IndexName: `by-${name}`,
+          KeySchema: [
+            { AttributeName: "customerId", KeyType: "HASH" },
+            { AttributeName: name, KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "KEYS_ONLY" },
+        })),
+      },
+    });
+
+    // Then all five are created, each giving the collection a sort key of its
+    // own over the same items.
+    assertArrayLength(
+      creation.TableDescription?.LocalSecondaryIndexes ?? [],
+      5,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
@@ -2,7 +2,7 @@ import type { BackgroundScheduler } from "../../../../util/background/background
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimDynamoDbResourceInUseException } from "../../error/dynamodb.error.js";
-import { SimDynamoDbGlobalSecondaryIndexes } from "../../secondary-index/sim-dynamodb-global-secondary-indexes.js";
+import { SimDynamoDbSecondaryIndexes } from "../../secondary-index/sim-dynamodb-secondary-indexes.js";
 import { SimDynamoDbAttributeDefinitions } from "../../table/sim-dynamodb-attribute-definitions.js";
 import { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
 import { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
@@ -120,10 +120,11 @@ export class SimDynamoDbCreateTable {
     const arn = simDynamoDbTableArn(this.accountRegionScope, name.value);
     const keySchema = SimDynamoDbKeySchema.fromInput(input.KeySchema);
     const billing = SimDynamoDbTableBilling.fromInput(input);
-    const indexes = SimDynamoDbGlobalSecondaryIndexes.fromInput(
-      input.GlobalSecondaryIndexes,
-      { tableArn: arn, billing },
-    );
+    const indexes = SimDynamoDbSecondaryIndexes.fromInput(input, {
+      tableArn: arn,
+      keySchema,
+      billing,
+    });
     const attributeDefinitions = SimDynamoDbAttributeDefinitions.fromInput(
       input.AttributeDefinitions,
     );

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
@@ -48,18 +48,6 @@ async function refusedCreateTable(
 }
 
 describe("DynamoDB CreateTableCommand unsimulated input", () => {
-  it("refuses local secondary indexes", async () => {
-    // When a table is created with a local secondary index.
-    const error = await refusedCreateTable({
-      ...tableInput,
-      LocalSecondaryIndexes: [{ IndexName: "byCreatedAt" }],
-    });
-
-    // Then the index is refused rather than quietly left out.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "Local secondary indexes");
-  });
-
   it("refuses a stream specification", async () => {
     // When a table is created with a stream.
     const error = await refusedCreateTable({

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
@@ -7,18 +7,17 @@ import type { SimDynamoDbSecondaryIndexInput } from "./table.types.js";
  *
  * Each of these changes what the table does, so accepting one and ignoring it
  * would leave a test passing against a table that is not the table the request
- * asked for: queries would run against indexes that were never built, and items
- * would outlive a time to live that was never applied. Refusing is the louder
- * failure, and the one that happens here rather than in a deployment.
+ * asked for: items would outlive a time to live that was never applied, and
+ * changes would be published to a stream that was never made. Refusing is the
+ * louder failure, and the one that happens here rather than in a deployment.
  *
- * Only input that asks for something is refused. An empty index list, and a
- * stream or encryption specification that is switched off, describe the table
- * this simulation already makes, so they are let through.
+ * Only input that asks for something is refused. A stream or encryption
+ * specification that is switched off describes the table this simulation
+ * already makes, so it is let through.
  */
 export function refuseUnsimulatedTableInput(
   input: SimCreateTableCommandInput,
 ): void {
-  refuseSecondaryIndexes(input);
   refuseStreams(input);
   refuseEncryption(input);
   refuseThroughputExtras(input);
@@ -28,21 +27,6 @@ export function refuseUnsimulatedTableInput(
       "A table ResourcePolicy is not simulated, so CreateTable refuses one " +
         "rather than leaving the table open to callers the policy would have " +
         "kept out",
-    );
-  }
-}
-
-/**
- * Refuse the local secondary indexes a table would answer queries from.
- *
- * Global secondary indexes are simulated, so they go through CreateTable's
- * ordinary validation rather than being refused here.
- */
-function refuseSecondaryIndexes(input: SimCreateTableCommandInput): void {
-  if ((input.LocalSecondaryIndexes ?? []).length > 0) {
-    throw new SimDynamoDbUnsupportedOperation(
-      "Local secondary indexes are not simulated, so CreateTable refuses " +
-        "them rather than creating a table that is missing them",
     );
   }
 }

--- a/src/service/dynamodb/command/table/table.types.ts
+++ b/src/service/dynamodb/command/table/table.types.ts
@@ -21,6 +21,8 @@ export interface SimDynamoDbTableDescription {
   readonly TableSizeBytes?: number | undefined;
   readonly GlobalSecondaryIndexes?:
     readonly SimDynamoDbGlobalSecondaryIndexDescription[] | undefined;
+  readonly LocalSecondaryIndexes?:
+    readonly SimDynamoDbLocalSecondaryIndexDescription[] | undefined;
 }
 
 /**
@@ -204,6 +206,23 @@ export interface SimDynamoDbGlobalSecondaryIndexDescription {
   readonly IndexArn?: SimArn | undefined;
   readonly ProvisionedThroughput?:
     SimDynamoDbProvisionedThroughputDescription | undefined;
+  readonly ItemCount?: number | undefined;
+  readonly IndexSizeBytes?: number | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB local secondary index description.
+ *
+ * There is no `IndexStatus` and no `ProvisionedThroughput` here, unlike the
+ * global secondary index description. A local secondary index is built with the
+ * table that carries it and reads out of the table's own capacity, so DynamoDB
+ * reports neither.
+ */
+export interface SimDynamoDbLocalSecondaryIndexDescription {
+  readonly IndexName?: string | undefined;
+  readonly KeySchema?: readonly SimDynamoDbKeySchemaElement[] | undefined;
+  readonly Projection?: SimDynamoDbProjection | undefined;
+  readonly IndexArn?: SimArn | undefined;
   readonly ItemCount?: number | undefined;
   readonly IndexSizeBytes?: number | undefined;
 }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-fetched-index-attributes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-fetched-index-attributes.ts
@@ -1,0 +1,51 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type {
+  SimDynamoDbIndexAttributes,
+  SimDynamoDbIndexAttributesProperties,
+} from "./sim-dynamodb-index-attributes.js";
+import { SimDynamoDbProjectedIndexAttributes } from "./sim-dynamodb-projected-index-attributes.js";
+
+/**
+ * The attributes a local secondary index carries, plus the base table's.
+ *
+ * A local secondary index entry sits in the same partition as the item it
+ * indexes, so DynamoDB can read that item while it walks the index. An
+ * attribute the index does not project is therefore fetched rather than
+ * refused, which is the fetch the extra read capacity is charged for.
+ *
+ * The projection still decides what a read answers with by default, so cutting
+ * an item down is the same job it is on a global secondary index and is left to
+ * that class. What differs is that nothing here refuses a read for asking
+ * beyond the projection.
+ */
+export class SimDynamoDbFetchedIndexAttributes implements SimDynamoDbIndexAttributes {
+  private readonly projected: SimDynamoDbProjectedIndexAttributes;
+
+  constructor(properties: SimDynamoDbIndexAttributesProperties) {
+    this.projected = new SimDynamoDbProjectedIndexAttributes(properties);
+  }
+
+  /**
+   * Cut an item down to the attributes the index projects.
+   *
+   * This is what a read answers with unless it asked for whole items, since
+   * `ALL_PROJECTED_ATTRIBUTES` is what a read of any index defaults to.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem {
+    return this.projected.project(item);
+  }
+
+  /**
+   * Whole items are answerable from any projection, since the table is there.
+   */
+  assertCarriesWholeItem(): void {
+    return;
+  }
+
+  /**
+   * Any attribute is nameable, since one outside the projection is fetched.
+   */
+  assertCarriesPaths(): void {
+    return;
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-global-secondary-indexes.ts
@@ -3,25 +3,17 @@ import type {
   SimDynamoDbIndexStatus,
   SimDynamoDbSecondaryIndexInput,
 } from "../command/table/table.types.js";
-import { SimDynamoDbResourceNotFoundException } from "../error/dynamodb.error.js";
-import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
-import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
-import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
-import {
-  SimDynamoDbGlobalSecondaryIndex,
-  type SimDynamoDbSecondaryIndexTable,
-} from "./sim-dynamodb-global-secondary-index.js";
-import {
-  assertSimDynamoDbIndexCount,
-  assertSimDynamoDbIndexNamesDistinct,
-  assertSimDynamoDbProjectedAttributeCount,
-} from "./sim-dynamodb-index-limits.js";
+import { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-secondary-index.js";
+import { assertSimDynamoDbIndexCount } from "./sim-dynamodb-index-limits.js";
+import type { SimDynamoDbSecondaryIndexTable } from "./sim-dynamodb-secondary-index.js";
 
 /**
  * The global secondary indexes one table carries.
  *
  * The collection owns what is about how many there are, and each index owns
- * what is about itself, the same split the table tags follow.
+ * what is about itself, the same split the table tags follow. The rules that
+ * span both kinds of index, such as a name being unique across them, belong to
+ * `SimDynamoDbSecondaryIndexes` instead.
  */
 export class SimDynamoDbGlobalSecondaryIndexes {
   public readonly elements: readonly SimDynamoDbGlobalSecondaryIndex[];
@@ -50,62 +42,11 @@ export class SimDynamoDbGlobalSecondaryIndexes {
 
     assertSimDynamoDbIndexCount(input.length);
 
-    const elements = input.map((index) =>
-      SimDynamoDbGlobalSecondaryIndex.fromInput(index, table),
+    return new this(
+      input.map((index) =>
+        SimDynamoDbGlobalSecondaryIndex.fromInput(index, table),
+      ),
     );
-
-    assertSimDynamoDbIndexNamesDistinct(elements);
-    assertSimDynamoDbProjectedAttributeCount(elements);
-
-    return new this(elements);
-  }
-
-  /**
-   * The index a read names, refusing a name this table does not have.
-   *
-   * Real DynamoDB answers a name it does not have with
-   * `ResourceNotFoundException` rather than reading the table instead, since a
-   * read of an index that is not there is a read of nothing.
-   */
-  required(
-    indexName: string,
-    tableName: string,
-  ): SimDynamoDbGlobalSecondaryIndex {
-    const index = this.elements.find(
-      (candidate) => candidate.name === indexName,
-    );
-
-    if (index === undefined) {
-      throw new SimDynamoDbResourceNotFoundException(
-        `The table ${tableName} does not have the specified index: ${
-          indexName
-        }`,
-      );
-    }
-
-    return index;
-  }
-
-  /**
-   * The key schemas these indexes are read by.
-   *
-   * `AttributeDefinitions` has to name every key attribute of every index as
-   * well as the table's own, so the schemas are reachable together.
-   */
-  keySchemas(): readonly SimDynamoDbKeySchema[] {
-    return this.elements.map((index) => index.keySchema);
-  }
-
-  /**
-   * Refuse an item carrying an index key attribute as the wrong type.
-   */
-  assertItemKeyTypes(
-    item: SimDynamoDbItem,
-    attributeDefinitions: SimDynamoDbAttributeDefinitions,
-  ): void {
-    for (const index of this.elements) {
-      index.assertItemKeyTypes(item, attributeDefinitions);
-    }
   }
 
   /**

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-attributes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-attributes.ts
@@ -1,13 +1,6 @@
-import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import type { SimDynamoDbDocumentPath } from "../expression/sim-dynamodb-document-path.js";
-import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
-
-interface SimDynamoDbIndexAttributesProperties {
-  readonly indexName: string;
-  readonly projection: SimDynamoDbIndexProjection;
-  readonly keyAttributeNames: ReadonlySet<string>;
-}
 
 /**
  * Which attributes one index carries, and what it refuses for not carrying.
@@ -16,88 +9,39 @@ interface SimDynamoDbIndexAttributesProperties {
  * both are in every item it holds and both come back whatever it projects. The
  * projection says what else does.
  *
+ * This is where the two index kinds part company, and it is the only place a
+ * read of one differs from a read of the other. A global secondary index is a
+ * copy of the table held apart from it, so it can only answer with what it
+ * projects and a read asking for more is refused. A local secondary index sits
+ * in the same partition as the item it indexes, so DynamoDB reads the base
+ * table for an attribute the index does not project, and charges the extra
+ * read capacity for it.
+ *
  * This is separate from the index view because it is about attributes rather
  * than items: nothing here knows which items the index holds, or in what order.
  */
-export class SimDynamoDbIndexAttributes {
-  private readonly indexName: string;
-  private readonly projection: SimDynamoDbIndexProjection;
-  private readonly keyAttributeNames: ReadonlySet<string>;
-
-  constructor(properties: SimDynamoDbIndexAttributesProperties) {
-    this.indexName = properties.indexName;
-    this.projection = properties.projection;
-    this.keyAttributeNames = properties.keyAttributeNames;
-  }
-
+export interface SimDynamoDbIndexAttributes {
   /**
    * Cut an item down to the attributes the index carries.
    */
-  project(item: SimDynamoDbItem): SimDynamoDbItem {
-    if (this.projection.carriesWholeItem) {
-      return item;
-    }
-
-    return SimDynamoDbItem.ofAttributes(
-      new Map(
-        item
-          .entries()
-          .entries()
-          .filter(([name]) => this.carries(name)),
-      ),
-    );
-  }
+  project(item: SimDynamoDbItem): SimDynamoDbItem;
 
   /**
-   * Refuse a read asking for whole items from a projection holding part of one.
-   *
-   * Real DynamoDB reads the table for each item to answer this, at a cost the
-   * request did not ask for, so it refuses it on an index that projects less
-   * than everything.
+   * Refuse a read asking for whole items where the index holds part of one.
    */
-  assertCarriesWholeItem(): void {
-    if (this.projection.carriesWholeItem) {
-      return;
-    }
-
-    throw new SimDynamoDbValidationException(
-      `One or more parameter values were invalid: Select type ALL_ATTRIBUTES ` +
-        `is not supported for global secondary index ${this.indexName} ` +
-        `because its projection type is not ALL`,
-    );
-  }
+  assertCarriesWholeItem(): void;
 
   /**
    * Refuse an expression naming an attribute the index does not project.
    */
-  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void {
-    if (this.projection.carriesWholeItem) {
-      return;
-    }
+  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void;
+}
 
-    const carried = [
-      ...this.keyAttributeNames,
-      ...this.projection.addedAttributeNames,
-    ];
-
-    for (const path of paths) {
-      if (carried.every((name) => !path.startsAt(name))) {
-        throw new SimDynamoDbValidationException(
-          `${path.text} is not projected into the global secondary index ` +
-            `${this.indexName}, and a read of an index names only the ` +
-            `attributes it projects`,
-        );
-      }
-    }
-  }
-
-  /**
-   * Whether the index carries one attribute of the items it holds.
-   */
-  private carries(attributeName: string): boolean {
-    return (
-      this.keyAttributeNames.has(attributeName) ||
-      this.projection.adds(attributeName)
-    );
-  }
+/**
+ * What either kind of index attributes is built from.
+ */
+export interface SimDynamoDbIndexAttributesProperties {
+  readonly indexName: string;
+  readonly projection: SimDynamoDbIndexProjection;
+  readonly keyAttributeNames: ReadonlySet<string>;
 }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-limits.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-limits.ts
@@ -1,5 +1,5 @@
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
-import type { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-secondary-index.js";
+import type { SimDynamoDbSecondaryIndex } from "./sim-dynamodb-secondary-index.js";
 
 /**
  * The most global secondary indexes one table holds.
@@ -7,12 +7,20 @@ import type { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-seco
 export const maxSimDynamoDbIndexes = 20;
 
 /**
+ * The most local secondary indexes one table holds.
+ *
+ * There are fewer of these because they share the table's partitions rather
+ * than living apart from them.
+ */
+export const maxSimDynamoDbLocalIndexes = 5;
+
+/**
  * The most NonKeyAttributes one table projects across all of its indexes.
  */
 const maxProjectedAttributes = 100;
 
 /**
- * Refuse a request declaring more indexes than a table holds.
+ * Refuse a request declaring more global secondary indexes than a table holds.
  *
  * This is checked before the indexes are read, so a request well over the cap
  * is refused for being over it rather than for whatever is wrong with its
@@ -28,20 +36,33 @@ export function assertSimDynamoDbIndexCount(count: number): void {
 }
 
 /**
+ * Refuse a request declaring more local secondary indexes than a table holds.
+ */
+export function assertSimDynamoDbLocalIndexCount(count: number): void {
+  if (count > maxSimDynamoDbLocalIndexes) {
+    throw new SimDynamoDbValidationException(
+      `${count.toString()} LocalSecondaryIndexes were given, and a table ` +
+        `holds at most ${maxSimDynamoDbLocalIndexes.toString()}`,
+    );
+  }
+}
+
+/**
  * Refuse a request declaring one index name twice.
  *
  * An index is reached by name, so two indexes sharing one leave a read with no
- * way of saying which it meant.
+ * way of saying which it meant. The two kinds share the one namespace, so a
+ * local secondary index cannot take the name of a global one either.
  */
 export function assertSimDynamoDbIndexNamesDistinct(
-  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+  elements: readonly SimDynamoDbSecondaryIndex[],
 ): void {
   const names = new Set(elements.map((index) => index.name));
 
   if (names.size !== elements.length) {
     throw new SimDynamoDbValidationException(
-      "GlobalSecondaryIndexes names an index more than once, and an index " +
-        "name is unique within a table",
+      "The request names an index more than once, and an index name is " +
+        "unique within a table across both kinds of secondary index",
     );
   }
 }
@@ -55,7 +76,7 @@ export function assertSimDynamoDbIndexNamesDistinct(
  * rather than a count of distinct names, as it is on AWS.
  */
 export function assertSimDynamoDbProjectedAttributeCount(
-  elements: readonly SimDynamoDbGlobalSecondaryIndex[],
+  elements: readonly SimDynamoDbSecondaryIndex[],
 ): void {
   const projected = elements.reduce(
     (total, index) => total + index.projection.nonKeyAttributeCount,

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-lookup.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-lookup.ts
@@ -1,0 +1,28 @@
+import { SimDynamoDbResourceNotFoundException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbSecondaryIndex } from "./sim-dynamodb-secondary-index.js";
+
+/**
+ * The index an `IndexName` names, refusing a name the table does not have.
+ *
+ * Real DynamoDB answers a name it does not have with
+ * `ResourceNotFoundException` rather than reading the table instead, since a
+ * read of an index that is not there is a read of nothing.
+ *
+ * The two kinds share one namespace, so the lookup is over both of them at once
+ * rather than over either collection.
+ */
+export function requiredSimDynamoDbIndex(
+  elements: readonly SimDynamoDbSecondaryIndex[],
+  indexName: string,
+  tableName: string,
+): SimDynamoDbSecondaryIndex {
+  const index = elements.find((candidate) => candidate.name === indexName);
+
+  if (index === undefined) {
+    throw new SimDynamoDbResourceNotFoundException(
+      `The table ${tableName} does not have the specified index: ${indexName}`,
+    );
+  }
+
+  return index;
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection-input.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projection-input.ts
@@ -1,0 +1,32 @@
+import type {
+  SimDynamoDbProjectionInput,
+  SimDynamoDbProjectionType,
+} from "../command/table/table.types.js";
+
+/**
+ * What a test says when it asks for an index projecting one thing or another.
+ */
+export interface SimDynamoDbIndexedTableProjection {
+  readonly projectionType: SimDynamoDbProjectionType;
+  readonly nonKeyAttributes: readonly string[];
+}
+
+/**
+ * The `Projection` an index is created with, which INCLUDE alone names
+ * attributes for.
+ *
+ * The two index kinds project the same way, so their factories build this the
+ * same way rather than each having a copy of the rule.
+ */
+export function simDynamoDbIndexProjectionInput(
+  input: SimDynamoDbIndexedTableProjection,
+): SimDynamoDbProjectionInput {
+  if (input.projectionType !== "INCLUDE") {
+    return { ProjectionType: input.projectionType };
+  }
+
+  return {
+    ProjectionType: input.projectionType,
+    NonKeyAttributes: input.nonKeyAttributes,
+  };
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-view.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-view.ts
@@ -9,12 +9,12 @@ import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
 import type { SimDynamoDbReadView } from "../table/sim-dynamodb-read-view.js";
 import { SimDynamoDbTableScan } from "../table/sim-dynamodb-table-scan.js";
 import { SimDynamoDbSortKeyOrder } from "../table/sim-dynamodb-sort-key-order.js";
-import type { SimDynamoDbGlobalSecondaryIndex } from "./sim-dynamodb-global-secondary-index.js";
-import { SimDynamoDbIndexAttributes } from "./sim-dynamodb-index-attributes.js";
+import type { SimDynamoDbIndexAttributes } from "./sim-dynamodb-index-attributes.js";
 import { SimDynamoDbIndexKeys } from "./sim-dynamodb-index-keys.js";
+import type { SimDynamoDbSecondaryIndex } from "./sim-dynamodb-secondary-index.js";
 
 interface SimDynamoDbIndexViewProperties {
-  readonly index: SimDynamoDbGlobalSecondaryIndex;
+  readonly index: SimDynamoDbSecondaryIndex;
   readonly items: readonly SimDynamoDbItem[];
   readonly tableKeySchema: SimDynamoDbKeySchema;
   readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
@@ -22,7 +22,7 @@ interface SimDynamoDbIndexViewProperties {
 }
 
 /**
- * Reading one global secondary index.
+ * Reading one secondary index, of either kind.
  *
  * The index is worked out here rather than maintained on the write path, which
  * is what makes an index added to a table have nothing to backfill and every
@@ -32,13 +32,14 @@ interface SimDynamoDbIndexViewProperties {
  * collaborator each. `SimDynamoDbIndexKeys` is which items it holds and how
  * they are named, and `SimDynamoDbIndexAttributes` is which parts of them come
  * back. What is left here is the walking, which is the same walking a table
- * gets.
+ * gets, and the same walking whichever kind of index this is.
  */
 export class SimDynamoDbIndexView implements SimDynamoDbReadView {
   public readonly description: string;
   public readonly keySchema: SimDynamoDbKeySchema;
   public readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
 
+  private readonly index: SimDynamoDbSecondaryIndex;
   private readonly items: readonly SimDynamoDbItem[];
   private readonly keys: SimDynamoDbIndexKeys;
   private readonly attributes: SimDynamoDbIndexAttributes;
@@ -47,6 +48,7 @@ export class SimDynamoDbIndexView implements SimDynamoDbReadView {
   constructor(properties: SimDynamoDbIndexViewProperties) {
     const { index } = properties;
 
+    this.index = index;
     this.description = `index ${index.name}`;
     this.keySchema = index.keySchema;
     this.attributeDefinitions = properties.attributeDefinitions;
@@ -57,11 +59,7 @@ export class SimDynamoDbIndexView implements SimDynamoDbReadView {
       attributeDefinitions: properties.attributeDefinitions,
       tableItemKey: properties.tableItemKey,
     });
-    this.attributes = new SimDynamoDbIndexAttributes({
-      indexName: index.name,
-      projection: index.projection,
-      keyAttributeNames: this.keys.attributeNames,
-    });
+    this.attributes = index.attributesOf(this.keys.attributeNames);
 
     // Index key values are not unique, so the table key is what separates two
     // entries sharing one and lets a walk resume after either.
@@ -131,5 +129,12 @@ export class SimDynamoDbIndexView implements SimDynamoDbReadView {
    */
   assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void {
     this.attributes.assertCarriesPaths(paths);
+  }
+
+  /**
+   * Refuse a strongly consistent read this index cannot answer.
+   */
+  assertConsistentRead(): void {
+    this.index.assertAnswersConsistentRead();
   }
 }

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-fetched-read.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-fetched-read.iso.test.ts
@@ -1,0 +1,125 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimQueryCommandInput } from "../command/query/query.command.js";
+import type { SimDynamoDbLocallyIndexedTableInput } from "./sim-dynamodb-locally-indexed-table.factory.js";
+import { simDynamoDbLocallyIndexedTableFactory } from "./sim-dynamodb-locally-indexed-table.factory.js";
+
+const firstCustomer = {
+  TableName: "OrdersTable",
+  IndexName: "byPlacedAt",
+  KeyConditionExpression: "customerId = :customerId",
+  ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+} as const satisfies SimQueryCommandInput;
+
+/**
+ * Read one item off an index projecting what a test asked it to.
+ */
+async function firstOrder(
+  table: Partial<SimDynamoDbLocallyIndexedTableInput>,
+  overrides: Partial<SimQueryCommandInput> = {},
+): Promise<Readonly<Record<string, { S?: string }>>> {
+  const simAws = new SimAws();
+  await simDynamoDbLocallyIndexedTableFactory.make(table, simAws);
+
+  const page = await simAws
+    .dynamoDb()
+    .query({ input: { ...firstCustomer, ...overrides } });
+
+  return page.Items?.[0] ?? {};
+}
+
+describe("DynamoDB reads beyond what a local secondary index projects", () => {
+  it("answers a KEYS_ONLY index with the index and table keys", async () => {
+    // When an index projecting only keys is read.
+    const item = await firstOrder({ projectionType: "KEYS_ONLY" });
+
+    // Then the index key and the table key come back, and nothing else. The
+    // table sort key is in the entry whatever the projection asks for, since it
+    // is what names the item the entry stands for.
+    assertIdentical(item["customerId"]?.S, "customer-1");
+    assertIdentical(item["placedAt"]?.S, "2026-01");
+    assertIdentical(item["orderId"]?.S, "order-02");
+    assertUndefined(item["title"]);
+  });
+
+  it("answers an INCLUDE index with the attributes it adds", async () => {
+    // When an index including one attribute is read.
+    const item = await firstOrder({
+      projectionType: "INCLUDE",
+      nonKeyAttributes: ["title"],
+    });
+
+    // Then the keys come back with the included attribute alongside them.
+    assertIdentical(item["orderId"]?.S, "order-02");
+    assertIdentical(item["title"]?.S, "Order order-02");
+  });
+
+  it("fetches an unprojected attribute from the base table", async () => {
+    // When a read of a KEYS_ONLY index asks for whole items.
+    const item = await firstOrder(
+      { projectionType: "KEYS_ONLY" },
+      { Select: "ALL_ATTRIBUTES" },
+    );
+
+    // Then it is answered rather than refused. An index entry sits in the same
+    // partition as the item it indexes, so DynamoDB reads the item as it walks
+    // and charges the extra read capacity for it. A global secondary index
+    // refuses the same request.
+    assertIdentical(item["title"]?.S, "Order order-02");
+  });
+
+  it("still defaults to the attributes the index projects", async () => {
+    // When a KEYS_ONLY index is read with no Select at all.
+    const item = await firstOrder({ projectionType: "KEYS_ONLY" });
+
+    // Then only the keys come back. The base table fetch happens when a read
+    // asks for more, not on every read.
+    assertUndefined(item["title"]);
+  });
+
+  it("filters on an attribute the index does not project", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When a read of it filters on an attribute outside the projection.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        ...firstCustomer,
+        FilterExpression: "title = :title",
+        ExpressionAttributeValues: {
+          ":customerId": { S: "customer-1" },
+          ":title": { S: "Order order-04" },
+        },
+      },
+    });
+
+    // Then the filter runs against the item in the base table, keeping the one
+    // it names. Three index entries were evaluated to find it.
+    assertIdentical(page.Count, 1);
+    assertIdentical(page.ScannedCount, 3);
+    assertIdentical(page.Items?.[0]?.["orderId"]?.S, "order-04");
+  });
+
+  it("answers a counted read the same way", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When the index is counted rather than read.
+    const page = await simAws
+      .dynamoDb()
+      .query({ input: { ...firstCustomer, Select: "COUNT" } });
+
+    // Then the count is of the index entries, with no Items at all.
+    assertIdentical(page.Count, 3);
+    assertUndefined(page.Items);
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-key-schema.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-key-schema.ts
@@ -1,0 +1,71 @@
+import type { SimDynamoDbKeySchemaElementInput } from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import { SimDynamoDbKeySchemaSubject } from "../table/sim-dynamodb-key-schema-subject.js";
+
+/**
+ * Refuse a local secondary index on a table with no sort key of its own.
+ *
+ * The index adds a second sort key to an item collection, and a table keyed by
+ * a partition key alone holds one item per collection. There is nothing there
+ * to sort, which is why AWS refuses the whole request rather than the index.
+ */
+export function assertSimDynamoDbTableSortsForLocalIndexes(
+  tableKeySchema: SimDynamoDbKeySchema,
+): void {
+  if (tableKeySchema.rangeKeyAttributeName !== undefined) {
+    return;
+  }
+
+  throw new SimDynamoDbValidationException(
+    "One or more parameter values were invalid: Table KeySchema does not " +
+      "have a range key, which is required when specifying a " +
+      "LocalSecondaryIndex",
+  );
+}
+
+/**
+ * Read the KeySchema of one local secondary index.
+ *
+ * The key schema is what makes the index local. Its partition key is the
+ * table's own, so an entry sits in the same partition as the item it indexes,
+ * and its sort key is some other attribute, so the collection has a second
+ * order to be read in. An index sorted by the attribute the table is already
+ * sorted by would be the table written twice.
+ */
+export function readSimDynamoDbLocalIndexKeySchema(
+  input: readonly SimDynamoDbKeySchemaElementInput[] | undefined,
+  indexName: string,
+  tableKeySchema: SimDynamoDbKeySchema,
+): SimDynamoDbKeySchema {
+  const subject = SimDynamoDbKeySchemaSubject.index(indexName);
+  const keySchema = SimDynamoDbKeySchema.fromInput(input, subject);
+  const partitionKey = keySchema.hashKeyAttributeName;
+
+  if (partitionKey !== tableKeySchema.hashKeyAttributeName) {
+    throw subject.refuse(
+      `the HASH element names ${partitionKey}, and a local secondary index ` +
+        `shares the table's partition key, which is ${
+          tableKeySchema.hashKeyAttributeName
+        }`,
+    );
+  }
+
+  const sortKey = keySchema.rangeKeyAttributeName;
+
+  if (sortKey === undefined) {
+    throw subject.refuse(
+      "a local secondary index gives an item collection a second sort key, " +
+        "and this key schema has no RANGE element",
+    );
+  }
+
+  if (sortKey === tableKeySchema.rangeKeyAttributeName) {
+    throw subject.refuse(
+      `the RANGE element names ${sortKey}, which is the table's own sort ` +
+        `key, so the index would repeat the order the table is already in`,
+    );
+  }
+
+  return keySchema;
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-paging.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-paging.iso.test.ts
@@ -1,0 +1,196 @@
+import { ScanCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import type {
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "../command/query/query.command.js";
+import type { SimScanCommandOutput } from "../command/scan/scan.command.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../sim-dynamodb.js";
+import { simDynamoDbLocallyIndexedTableFactory } from "./sim-dynamodb-locally-indexed-table.factory.js";
+
+/**
+ * Two of this customer's orders were placed in the same month, so they share a
+ * whole index key and only the table sort key separates them. That is the case
+ * a token carrying the index key alone could not resume.
+ */
+const firstCustomer = {
+  TableName: "OrdersTable",
+  IndexName: "byPlacedAt",
+  KeyConditionExpression: "customerId = :customerId",
+  ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+} as const satisfies SimQueryCommandInput;
+
+/**
+ * Read one order off the index, resuming after a token when given one.
+ */
+async function orderPage(
+  simDynamoDb: SimDynamoDb,
+  after?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
+): Promise<SimQueryCommandOutput> {
+  return await simDynamoDb.query({
+    input: { ...firstCustomer, Limit: 1, ExclusiveStartKey: after },
+  });
+}
+
+/**
+ * The order ids a page came back with.
+ */
+function orderIds(
+  page: SimQueryCommandOutput | SimScanCommandOutput,
+): readonly string[] {
+  return (page.Items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+describe("DynamoDB paging a local secondary index", () => {
+  it("hands out a token carrying the partition key and both sort keys", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When one entry of the index is read.
+    const page = await orderPage(simAws.dynamoDb());
+
+    // Then the token names the entry by the table partition key, the index sort
+    // key and the table sort key. The index key alone would not, since two
+    // entries share one.
+    const token = page.LastEvaluatedKey;
+    assertDefined(token, "the LastEvaluatedKey of an index page");
+    assertArrayLength(Object.keys(token), 3);
+    assertIdentical(token["customerId"]?.S, "customer-1");
+    assertIdentical(token["placedAt"]?.S, "2026-01");
+    assertIdentical(token["orderId"]?.S, "order-02");
+  });
+
+  it("resumes exactly when two entries share an index key", async () => {
+    // Given a page that stopped on the first of two entries sharing a month.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+    const simDynamoDb = simAws.dynamoDb();
+    const first = await orderPage(simDynamoDb);
+
+    // When the walk resumes from that token.
+    const second = await orderPage(simDynamoDb, first.LastEvaluatedKey);
+
+    // Then the other entry of that index key comes next, rather than the walk
+    // repeating one or skipping past both.
+    assertIdentical(orderIds(first)[0], "order-02");
+    assertIdentical(orderIds(second)[0], "order-04");
+  });
+
+  it("walks a collection to the end", async () => {
+    // Given a table whose index holds three of one customer's orders.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    // When the collection is read an entry at a time.
+    const first = await orderPage(simDynamoDb);
+    const second = await orderPage(simDynamoDb, first.LastEvaluatedKey);
+    const third = await orderPage(simDynamoDb, second.LastEvaluatedKey);
+    const fourth = await orderPage(simDynamoDb, third.LastEvaluatedKey);
+
+    // Then every entry comes back once, in index order, and the walk then finds
+    // nothing past the end of the collection.
+    assertIdentical(
+      [first, second, third].flatMap((page) => orderIds(page)).join(","),
+      "order-02,order-04,order-01",
+    );
+    assertArrayLength(orderIds(fourth), 0);
+    assertUndefined(fourth.LastEvaluatedKey);
+  });
+
+  it("refuses a token missing the table sort key", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When a query resumes from the index key alone.
+    const error = await assertThrowsErrorAsync(async () =>
+      orderPage(simAws.dynamoDb(), {
+        customerId: { S: "customer-1" },
+        placedAt: { S: "2026-01" },
+      }),
+    );
+
+    // Then it is refused. The index key names two entries, so resuming from it
+    // would repeat one or skip one.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "orderId");
+  });
+
+  it("scans the index rather than the table", async () => {
+    // Given a table whose index does not hold every order.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the index is scanned.
+    const page = await simAws
+      .dynamoDb()
+      .scan(
+        new ScanCommand({ TableName: "OrdersTable", IndexName: "byPlacedAt" }),
+      );
+
+    // Then the four dated orders come back and the two undated ones do not.
+    assertArrayLength(orderIds(page), 4);
+    assertArrayIncludesAll(orderIds(page), [
+      "order-01",
+      "order-02",
+      "order-04",
+      "order-05",
+    ]);
+  });
+
+  it("scans the index consistently", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the index is scanned with a strongly consistent read.
+    const page = await simAws.dynamoDb().scan({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byPlacedAt",
+        ConsistentRead: true,
+      },
+    });
+
+    // Then it is answered rather than refused, as a query of it is.
+    assertArrayLength(orderIds(page), 4);
+  });
+
+  it("pages a scan of the index", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+    const simDynamoDb = simAws.dynamoDb();
+
+    // When a scan of it stops at a limit and resumes.
+    const first = await simDynamoDb.scan({
+      input: { TableName: "OrdersTable", IndexName: "byPlacedAt", Limit: 3 },
+    });
+    const second = await simDynamoDb.scan({
+      input: {
+        TableName: "OrdersTable",
+        IndexName: "byPlacedAt",
+        ExclusiveStartKey: first.LastEvaluatedKey,
+      },
+    });
+
+    // Then the two pages hold the index between them, each entry once.
+    assertArrayLength([...orderIds(first), ...orderIds(second)], 4);
+    assertUndefined(second.LastEvaluatedKey);
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-query.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-query.iso.test.ts
@@ -1,0 +1,181 @@
+import { QueryCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { simDynamoDbLocallyIndexedTableFactory } from "./sim-dynamodb-locally-indexed-table.factory.js";
+
+/**
+ * The order ids a page came back with, so a test names items rather than places.
+ */
+function orderIds(
+  items: readonly Readonly<Record<string, { S?: string }>>[] | undefined,
+): readonly string[] {
+  return (items ?? []).map((item) => item["orderId"]?.S ?? "");
+}
+
+const firstCustomer = {
+  TableName: "OrdersTable",
+  IndexName: "byPlacedAt",
+  KeyConditionExpression: "customerId = :customerId",
+  ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+} as const;
+
+describe("DynamoDB Query on a local secondary index", () => {
+  it("reads a collection in the index sort key order", async () => {
+    // Given a table whose index re-sorts each customer's orders by date.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the customer's orders are read off the index.
+    const page = await simAws
+      .dynamoDb()
+      .query(new QueryCommand({ ...firstCustomer }));
+
+    // Then they come back by placedAt rather than by orderId, which is the
+    // access pattern the table's own key could not serve. The two January
+    // orders share a whole index key, so only the table sort key separates
+    // them.
+    assertIdentical(
+      orderIds(page.Items).join(","),
+      "order-02,order-04,order-01",
+    );
+  });
+
+  it("leaves out an item missing the index sort key", async () => {
+    // Given a table whose orders do not all carry a date.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the customer's orders are read off the index.
+    const page = await simAws.dynamoDb().query({ input: { ...firstCustomer } });
+
+    // Then order-03 is absent. It has no placedAt, so the index simply does not
+    // hold it rather than the write having been refused.
+    assertArrayLength(orderIds(page.Items), 3);
+  });
+
+  it("still reads the whole collection off the table", async () => {
+    // Given a table whose index does not hold every order.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the same collection is read with no IndexName.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        TableName: "OrdersTable",
+        KeyConditionExpression: "customerId = :customerId",
+        ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+      },
+    });
+
+    // Then all four orders come back, in the table's own sort key order.
+    assertIdentical(
+      orderIds(page.Items).join(","),
+      "order-01,order-02,order-03,order-04",
+    );
+  });
+
+  it("answers a strongly consistent read", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When a query asks for a strongly consistent read of it.
+    const page = await simAws
+      .dynamoDb()
+      .query({ input: { ...firstCustomer, ConsistentRead: true } });
+
+    // Then it is answered rather than refused. The index sits in the same
+    // partition as the item it indexes and is written with it, so there is no
+    // window in which it lags behind the table.
+    assertArrayLength(orderIds(page.Items), 3);
+  });
+
+  it("takes a sort key condition on the index sort key", async () => {
+    // Given a table whose index is sorted by the month an order was placed.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the customer's orders are narrowed to January.
+    const page = await simAws.dynamoDb().query({
+      input: {
+        ...firstCustomer,
+        KeyConditionExpression:
+          "customerId = :customerId AND placedAt = :placedAt",
+        ExpressionAttributeValues: {
+          ":customerId": { S: "customer-1" },
+          ":placedAt": { S: "2026-01" },
+        },
+      },
+    });
+
+    // Then the two orders placed that month come back.
+    assertIdentical(orderIds(page.Items).join(","), "order-02,order-04");
+  });
+
+  it("reads the collection backwards", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the customer's orders are read backwards.
+    const page = await simAws
+      .dynamoDb()
+      .query({ input: { ...firstCustomer, ScanIndexForward: false } });
+
+    // Then the latest month comes first, by the index sort key.
+    assertIdentical(orderIds(page.Items)[0], "order-01");
+  });
+
+  it("refuses a key condition on the table sort key", async () => {
+    // Given a table with a local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When the index is queried by the attribute the table sorts on.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: {
+          ...firstCustomer,
+          KeyConditionExpression:
+            "customerId = :customerId AND orderId = :orderId",
+          ExpressionAttributeValues: {
+            ":customerId": { S: "customer-1" },
+            ":orderId": { S: "order-01" },
+          },
+        },
+      }),
+    );
+
+    // Then it is refused: a key condition is held to the key being read, and
+    // the index is sorted by placedAt.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "orderId is not part of");
+  });
+
+  it("refuses an index name the table does not have", async () => {
+    // Given a table with one local secondary index.
+    const simAws = new SimAws();
+    await simDynamoDbLocallyIndexedTableFactory.make({}, simAws);
+
+    // When a query names an index that is not there.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDb()
+        .query({ input: { ...firstCustomer, IndexName: "byShippedAt" } }),
+    );
+
+    // Then it is refused rather than read as the table.
+    assertStringIncludes(
+      error.message,
+      "The table OrdersTable does not have the specified index: byShippedAt",
+    );
+  });
+});

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-query.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-query.iso.test.ts
@@ -8,7 +8,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
-import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../error/dynamodb.error.js";
 import { simDynamoDbLocallyIndexedTableFactory } from "./sim-dynamodb-locally-indexed-table.factory.js";
 
 /**
@@ -173,6 +176,7 @@ describe("DynamoDB Query on a local secondary index", () => {
     );
 
     // Then it is refused rather than read as the table.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
     assertStringIncludes(
       error.message,
       "The table OrdersTable does not have the specified index: byShippedAt",

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-throughput.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-throughput.ts
@@ -1,0 +1,41 @@
+import type { SimDynamoDbSecondaryIndexInput } from "../command/table/table.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * How a refusal says a local secondary index has no capacity of its own.
+ */
+function refuseSetting(
+  setting: string,
+  indexName: string,
+): SimDynamoDbValidationException {
+  return new SimDynamoDbValidationException(
+    `One or more parameter values were invalid: ${setting} cannot be ` +
+      `specified for index: ${indexName} because it is a local secondary ` +
+      `index, which is read and written out of the table's own throughput`,
+  );
+}
+
+/**
+ * Refuse the capacity a local secondary index cannot be given.
+ *
+ * A local secondary index sits in the same partition as the items it indexes
+ * and shares the table's throughput, so there is nothing to provision for it.
+ * Real DynamoDB has no throughput field on a `LocalSecondaryIndex` at all, so a
+ * request carrying one is refused rather than stored and ignored.
+ */
+export function refuseSimDynamoDbLocalIndexThroughput(
+  input: SimDynamoDbSecondaryIndexInput,
+  indexName: string,
+): void {
+  if (input.ProvisionedThroughput !== undefined) {
+    throw refuseSetting("ProvisionedThroughput", indexName);
+  }
+
+  if (input.OnDemandThroughput !== undefined) {
+    throw refuseSetting("OnDemandThroughput", indexName);
+  }
+
+  if (input.WarmThroughput !== undefined) {
+    throw refuseSetting("WarmThroughput", indexName);
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-secondary-index.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-secondary-index.ts
@@ -1,62 +1,58 @@
 import type { SimArn } from "../../aws/arn.js";
 import type {
-  SimDynamoDbGlobalSecondaryIndexDescription,
-  SimDynamoDbIndexStatus,
+  SimDynamoDbLocalSecondaryIndexDescription,
   SimDynamoDbSecondaryIndexInput,
 } from "../command/table/table.types.js";
-import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
-import { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
-import { SimDynamoDbKeySchemaSubject } from "../table/sim-dynamodb-key-schema-subject.js";
-import type { SimDynamoDbTableThroughput } from "../table/sim-dynamodb-table-throughput.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import { SimDynamoDbFetchedIndexAttributes } from "./sim-dynamodb-fetched-index-attributes.js";
 import type { SimDynamoDbIndexAttributes } from "./sim-dynamodb-index-attributes.js";
 import { assertSimDynamoDbIndexKeyTypes } from "./sim-dynamodb-index-key-types.js";
-import { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
 import { readSimDynamoDbIndexName } from "./sim-dynamodb-index-name.js";
-import { readSimDynamoDbIndexThroughput } from "./sim-dynamodb-index-throughput.js";
-import { SimDynamoDbProjectedIndexAttributes } from "./sim-dynamodb-projected-index-attributes.js";
+import { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+import { readSimDynamoDbLocalIndexKeySchema } from "./sim-dynamodb-local-index-key-schema.js";
+import { refuseSimDynamoDbLocalIndexThroughput } from "./sim-dynamodb-local-index-throughput.js";
 import type {
   SimDynamoDbSecondaryIndex,
   SimDynamoDbSecondaryIndexTable,
 } from "./sim-dynamodb-secondary-index.js";
 
-interface SimDynamoDbGlobalSecondaryIndexProperties {
+interface SimDynamoDbLocalSecondaryIndexProperties {
   readonly name: string;
   readonly tableArn: SimArn;
   readonly keySchema: SimDynamoDbKeySchema;
   readonly projection: SimDynamoDbIndexProjection;
-  readonly throughput: SimDynamoDbTableThroughput;
 }
 
 /**
- * One simulated global secondary index.
+ * One simulated local secondary index.
  *
- * An index is a key schema of its own over the same items, so it is held as
- * what a read of it needs to know rather than as a copy of anything. The items
- * it holds are worked out when it is read, which is why nothing here is
- * maintained on the write path.
+ * A local secondary index gives an item collection a second sort key. It shares
+ * the table's partition key, so an entry sits in the same partition as the item
+ * it indexes, which is what lets it answer a strongly consistent read and lets a
+ * read of it reach the base table for an attribute it does not project.
+ *
+ * `CreateTable` is the only place one can be declared. AWS has no call that
+ * adds, changes or removes one afterwards, so neither does this.
  */
-export class SimDynamoDbGlobalSecondaryIndex implements SimDynamoDbSecondaryIndex {
+export class SimDynamoDbLocalSecondaryIndex implements SimDynamoDbSecondaryIndex {
   public readonly name: string;
   public readonly arn: SimArn;
   public readonly keySchema: SimDynamoDbKeySchema;
   public readonly projection: SimDynamoDbIndexProjection;
 
-  private readonly throughput: SimDynamoDbTableThroughput;
-
-  private constructor(properties: SimDynamoDbGlobalSecondaryIndexProperties) {
+  private constructor(properties: SimDynamoDbLocalSecondaryIndexProperties) {
     this.name = properties.name;
     // An index ARN is the table's own with the index named under it, which is
     // the resource an IAM policy naming one index is written against.
     this.arn = `${properties.tableArn}/index/${properties.name}`;
     this.keySchema = properties.keySchema;
     this.projection = properties.projection;
-    this.throughput = properties.throughput;
   }
 
   /**
-   * Read one `GlobalSecondaryIndexes` entry a CreateTable request carries.
+   * Read one `LocalSecondaryIndexes` entry a CreateTable request carries.
    *
    * The name is read first, since every other refusal names the index it is
    * about.
@@ -64,31 +60,30 @@ export class SimDynamoDbGlobalSecondaryIndex implements SimDynamoDbSecondaryInde
   static fromInput(
     input: SimDynamoDbSecondaryIndexInput,
     table: SimDynamoDbSecondaryIndexTable,
-  ): SimDynamoDbGlobalSecondaryIndex {
+  ): SimDynamoDbLocalSecondaryIndex {
     const name = readSimDynamoDbIndexName(input.IndexName);
+
+    refuseSimDynamoDbLocalIndexThroughput(input, name);
 
     return new this({
       name,
       tableArn: table.tableArn,
-      keySchema: SimDynamoDbKeySchema.fromInput(
+      keySchema: readSimDynamoDbLocalIndexKeySchema(
         input.KeySchema,
-        SimDynamoDbKeySchemaSubject.index(name),
+        name,
+        table.keySchema,
       ),
       projection: SimDynamoDbIndexProjection.fromInput(input.Projection, name),
-      throughput: readSimDynamoDbIndexThroughput(input, name, table.billing),
     });
   }
 
   /**
    * Which attributes a read of this index answers with.
-   *
-   * A global secondary index is held apart from the table, so what it projects
-   * is the whole of what a read of it can answer with.
    */
   attributesOf(
     keyAttributeNames: ReadonlySet<string>,
   ): SimDynamoDbIndexAttributes {
-    return new SimDynamoDbProjectedIndexAttributes({
+    return new SimDynamoDbFetchedIndexAttributes({
       indexName: this.name,
       projection: this.projection,
       keyAttributeNames,
@@ -96,18 +91,15 @@ export class SimDynamoDbGlobalSecondaryIndex implements SimDynamoDbSecondaryInde
   }
 
   /**
-   * Refuse a strongly consistent read of this index.
+   * A local secondary index answers a strongly consistent read.
    *
-   * A global secondary index is maintained asynchronously on AWS, so it cannot
-   * answer one at all. Every read here is strongly consistent, so accepting the
-   * request and ignoring the flag would leave a test passing on something real
-   * DynamoDB refuses outright.
+   * It is written in the same partition as the item it indexes, in the same
+   * operation, so there is no window in which it lags behind the table. That is
+   * the difference from a global secondary index, which is maintained
+   * asynchronously and refuses one.
    */
   assertAnswersConsistentRead(): void {
-    throw new SimDynamoDbValidationException(
-      `Consistent reads are not supported on global secondary indexes, and ` +
-        `this request asks for one on ${this.name}`,
-    );
+    return;
   }
 
   /**
@@ -127,17 +119,16 @@ export class SimDynamoDbGlobalSecondaryIndex implements SimDynamoDbSecondaryInde
 
   /**
    * Describe this index the way DynamoDB reports it.
+   *
+   * There is no `IndexStatus` and no `ProvisionedThroughput`, since a local
+   * secondary index is built with the table and shares its capacity.
    */
-  toDescription(
-    status: SimDynamoDbIndexStatus,
-  ): SimDynamoDbGlobalSecondaryIndexDescription {
+  toDescription(): SimDynamoDbLocalSecondaryIndexDescription {
     return {
       IndexName: this.name,
       IndexArn: this.arn,
       KeySchema: this.keySchema.elements,
       Projection: this.projection.toDescription(),
-      IndexStatus: status,
-      ProvisionedThroughput: this.throughput.toDescription(),
       // Neither figure is tracked, the same way the table's are not.
       ItemCount: 0,
       IndexSizeBytes: 0,

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-secondary-indexes.ts
@@ -1,0 +1,67 @@
+import type {
+  SimDynamoDbLocalSecondaryIndexDescription,
+  SimDynamoDbSecondaryIndexInput,
+} from "../command/table/table.types.js";
+import { assertSimDynamoDbLocalIndexCount } from "./sim-dynamodb-index-limits.js";
+import { assertSimDynamoDbTableSortsForLocalIndexes } from "./sim-dynamodb-local-index-key-schema.js";
+import { SimDynamoDbLocalSecondaryIndex } from "./sim-dynamodb-local-secondary-index.js";
+import type { SimDynamoDbSecondaryIndexTable } from "./sim-dynamodb-secondary-index.js";
+
+/**
+ * The local secondary indexes one table carries.
+ *
+ * As with the global ones, the collection owns what is about how many there
+ * are and each index owns what is about itself. What is added here is the one
+ * rule about the table rather than about any index: a table with no sort key
+ * has no collection for a second sort key to reorder.
+ */
+export class SimDynamoDbLocalSecondaryIndexes {
+  public readonly elements: readonly SimDynamoDbLocalSecondaryIndex[];
+
+  private constructor(elements: readonly SimDynamoDbLocalSecondaryIndex[]) {
+    this.elements = elements;
+  }
+
+  /**
+   * The indexes of a table declaring none.
+   */
+  static none(): SimDynamoDbLocalSecondaryIndexes {
+    return new this([]);
+  }
+
+  /**
+   * Read the `LocalSecondaryIndexes` a CreateTable request carries.
+   */
+  static fromInput(
+    input: readonly SimDynamoDbSecondaryIndexInput[] | undefined,
+    table: SimDynamoDbSecondaryIndexTable,
+  ): SimDynamoDbLocalSecondaryIndexes {
+    if (input === undefined || input.length === 0) {
+      return this.none();
+    }
+
+    assertSimDynamoDbLocalIndexCount(input.length);
+    assertSimDynamoDbTableSortsForLocalIndexes(table.keySchema);
+
+    return new this(
+      input.map((index) =>
+        SimDynamoDbLocalSecondaryIndex.fromInput(index, table),
+      ),
+    );
+  }
+
+  /**
+   * How a table reports its indexes, which is not at all when it has none.
+   *
+   * Real DynamoDB leaves `LocalSecondaryIndexes` out of the description of a
+   * table with no index, rather than reporting an empty list.
+   */
+  descriptions():
+    readonly SimDynamoDbLocalSecondaryIndexDescription[] | undefined {
+    if (this.elements.length === 0) {
+      return undefined;
+    }
+
+    return this.elements.map((index) => index.toDescription());
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-locally-indexed-orders.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-locally-indexed-orders.ts
@@ -1,0 +1,61 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+
+/**
+ * One order of a locally indexed table, before it is written as an item.
+ *
+ * An order with no `placedAt` is not in the index, which is what makes a local
+ * secondary index sparse the same way a global one is.
+ */
+interface SimDynamoDbLocallyIndexedOrder {
+  readonly customerId: string;
+  readonly orderId: string;
+  readonly placedAt?: string;
+}
+
+/**
+ * The orders a locally indexed table holds.
+ *
+ * The months run out of order against the order ids, so the index reads a
+ * customer's orders in an order the table's own sort key does not give. One
+ * month repeats within a customer, so two index entries share a whole index key
+ * and only the table sort key separates them.
+ */
+const orders: readonly SimDynamoDbLocallyIndexedOrder[] = [
+  { customerId: "customer-1", orderId: "order-01", placedAt: "2026-03" },
+  { customerId: "customer-1", orderId: "order-02", placedAt: "2026-01" },
+  { customerId: "customer-1", orderId: "order-03" },
+  { customerId: "customer-1", orderId: "order-04", placedAt: "2026-01" },
+  { customerId: "customer-2", orderId: "order-05", placedAt: "2026-03" },
+  { customerId: "customer-2", orderId: "order-06" },
+];
+
+/**
+ * The item one order is written as.
+ *
+ * `title` is on every order and in no key, so it is the attribute a test names
+ * to find out whether a read reached the base table.
+ */
+function orderItem(
+  order: SimDynamoDbLocallyIndexedOrder,
+): Readonly<Record<string, SimDynamoDbAttributeValue>> {
+  const item = {
+    customerId: { S: order.customerId },
+    orderId: { S: order.orderId },
+    title: { S: `Order ${order.orderId}` },
+  };
+
+  if (order.placedAt === undefined) {
+    return item;
+  }
+
+  return { ...item, placedAt: { S: order.placedAt } };
+}
+
+/**
+ * The orders a locally indexed table holds, as the items they are written as.
+ */
+export function simDynamoDbLocallyIndexedOrders(): readonly Readonly<
+  Record<string, SimDynamoDbAttributeValue>
+>[] {
+  return orders.map((order) => orderItem(order));
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-locally-indexed-table.factory.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-locally-indexed-table.factory.ts
@@ -4,49 +4,47 @@ import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimDynamoDbProjectionType } from "../command/table/table.types.js";
 import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
 import { simDynamoDbIndexProjectionInput } from "./sim-dynamodb-index-projection-input.js";
-import { simDynamoDbIndexedOrders } from "./sim-dynamodb-indexed-orders.js";
+import { simDynamoDbLocallyIndexedOrders } from "./sim-dynamodb-locally-indexed-orders.js";
 
 /**
- * What a test asks for when it wants a table with an index to read.
+ * What a test asks for when it wants a table with a local secondary index.
  *
- * The projection is the input because it is what makes reads of one index
- * differ from another: which attributes come back, and which `Select` values
- * and filters the index can answer.
+ * The projection is the input because it is what a read of a local secondary
+ * index turns on: which attributes come back by default, and which of them the
+ * read has to reach the base table for.
  */
-export interface SimDynamoDbIndexedTableInput {
+export interface SimDynamoDbLocallyIndexedTableInput {
   readonly tableName: string;
   readonly indexName: string;
   readonly projectionType: SimDynamoDbProjectionType;
   readonly nonKeyAttributes: readonly string[];
-  readonly orderCount: number;
 }
 
 /**
- * Creates a table with one global secondary index, holding orders to read.
+ * Creates a table with one local secondary index, holding orders to read.
  *
- * The table is keyed by `orderId` and the index by `status` and `shippedAt`, so
- * a read of the index walks a key the table does not have. Every third order is
- * written without a `status`, which is what makes the index sparse rather than
- * a second copy of the table.
+ * The table is keyed by `customerId` and `orderId`, and the index re-sorts each
+ * customer's orders by `placedAt`. One order per customer carries no
+ * `placedAt`, which is what makes the index sparse rather than a second copy of
+ * the table.
  *
  * ```typescript
- * const table = await simDynamoDbIndexedTableFactory.make(
+ * const table = await simDynamoDbLocallyIndexedTableFactory.make(
  *   { projectionType: "KEYS_ONLY" },
  *   simAws,
  * );
  * ```
  */
-export const simDynamoDbIndexedTableFactory = new AsyncMappedFactory<
-  SimDynamoDbIndexedTableInput,
+export const simDynamoDbLocallyIndexedTableFactory = new AsyncMappedFactory<
+  SimDynamoDbLocallyIndexedTableInput,
   SimDynamoDbTable,
   SimAws
 >(
   () => ({
     tableName: "OrdersTable",
-    indexName: "byStatus",
+    indexName: "byPlacedAt",
     projectionType: "ALL",
     nonKeyAttributes: [],
-    orderCount: 6,
   }),
   async (input, simAws) => {
     const simDynamoDb = simAws.dynamoDb();
@@ -54,19 +52,22 @@ export const simDynamoDbIndexedTableFactory = new AsyncMappedFactory<
     await simDynamoDb.createTable({
       input: {
         TableName: input.tableName,
-        KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+        KeySchema: [
+          { AttributeName: "customerId", KeyType: "HASH" },
+          { AttributeName: "orderId", KeyType: "RANGE" },
+        ],
         AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "S" },
           { AttributeName: "orderId", AttributeType: "S" },
-          { AttributeName: "status", AttributeType: "S" },
-          { AttributeName: "shippedAt", AttributeType: "S" },
+          { AttributeName: "placedAt", AttributeType: "S" },
         ],
         BillingMode: "PAY_PER_REQUEST",
-        GlobalSecondaryIndexes: [
+        LocalSecondaryIndexes: [
           {
             IndexName: input.indexName,
             KeySchema: [
-              { AttributeName: "status", KeyType: "HASH" },
-              { AttributeName: "shippedAt", KeyType: "RANGE" },
+              { AttributeName: "customerId", KeyType: "HASH" },
+              { AttributeName: "placedAt", KeyType: "RANGE" },
             ],
             Projection: simDynamoDbIndexProjectionInput(input),
           },
@@ -76,7 +77,7 @@ export const simDynamoDbIndexedTableFactory = new AsyncMappedFactory<
     await simAws.backgroundTasksComplete();
 
     await Promise.all(
-      simDynamoDbIndexedOrders(input.orderCount).map(async (order) =>
+      simDynamoDbLocallyIndexedOrders().map(async (order) =>
         simDynamoDb.putItem({
           input: { TableName: input.tableName, Item: order },
         }),

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-projected-index-attributes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-projected-index-attributes.ts
@@ -1,0 +1,99 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbDocumentPath } from "../expression/sim-dynamodb-document-path.js";
+import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type {
+  SimDynamoDbIndexAttributes,
+  SimDynamoDbIndexAttributesProperties,
+} from "./sim-dynamodb-index-attributes.js";
+import type { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+
+/**
+ * The attributes a global secondary index carries, and nothing else.
+ *
+ * A global secondary index is a copy of the table held apart from it, so a read
+ * of one never reaches the table. Anything the index does not project is not
+ * there to answer with, which is why asking for it is refused rather than
+ * served.
+ */
+export class SimDynamoDbProjectedIndexAttributes implements SimDynamoDbIndexAttributes {
+  private readonly indexName: string;
+  private readonly projection: SimDynamoDbIndexProjection;
+  private readonly keyAttributeNames: ReadonlySet<string>;
+
+  constructor(properties: SimDynamoDbIndexAttributesProperties) {
+    this.indexName = properties.indexName;
+    this.projection = properties.projection;
+    this.keyAttributeNames = properties.keyAttributeNames;
+  }
+
+  /**
+   * Cut an item down to the attributes the index carries.
+   */
+  project(item: SimDynamoDbItem): SimDynamoDbItem {
+    if (this.projection.carriesWholeItem) {
+      return item;
+    }
+
+    return SimDynamoDbItem.ofAttributes(
+      new Map(
+        item
+          .entries()
+          .entries()
+          .filter(([name]) => this.carries(name)),
+      ),
+    );
+  }
+
+  /**
+   * Refuse a read asking for whole items from a projection holding part of one.
+   *
+   * Real DynamoDB reads the table for each item to answer this, at a cost the
+   * request did not ask for, so it refuses it on an index that projects less
+   * than everything.
+   */
+  assertCarriesWholeItem(): void {
+    if (this.projection.carriesWholeItem) {
+      return;
+    }
+
+    throw new SimDynamoDbValidationException(
+      `One or more parameter values were invalid: Select type ALL_ATTRIBUTES ` +
+        `is not supported for global secondary index ${this.indexName} ` +
+        `because its projection type is not ALL`,
+    );
+  }
+
+  /**
+   * Refuse an expression naming an attribute the index does not project.
+   */
+  assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void {
+    if (this.projection.carriesWholeItem) {
+      return;
+    }
+
+    const carried = [
+      ...this.keyAttributeNames,
+      ...this.projection.addedAttributeNames,
+    ];
+
+    for (const path of paths) {
+      if (carried.every((name) => !path.startsAt(name))) {
+        throw new SimDynamoDbValidationException(
+          `${path.text} is not projected into the global secondary index ` +
+            `${this.indexName}, and a read of an index names only the ` +
+            `attributes it projects`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Whether the index carries one attribute of the items it holds.
+   */
+  private carries(attributeName: string): boolean {
+    return (
+      this.keyAttributeNames.has(attributeName) ||
+      this.projection.adds(attributeName)
+    );
+  }
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-secondary-index.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-secondary-index.ts
@@ -1,0 +1,59 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbTableBilling } from "../table/sim-dynamodb-table-billing.js";
+import type { SimDynamoDbIndexAttributes } from "./sim-dynamodb-index-attributes.js";
+import type { SimDynamoDbIndexProjection } from "./sim-dynamodb-index-projection.js";
+
+/**
+ * What a secondary index needs from the table it is declared on.
+ *
+ * The table key schema is here because a local secondary index is declared
+ * against it: its partition key is the table's, and its sort key is anything
+ * the table is not already sorted by.
+ */
+export interface SimDynamoDbSecondaryIndexTable {
+  readonly tableArn: SimArn;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly billing: SimDynamoDbTableBilling;
+}
+
+/**
+ * One secondary index of a table, whichever of the two kinds it is.
+ *
+ * A read reaches an index through this rather than through either class, since
+ * walking an index is the same walking whichever kind it is. The two kinds
+ * differ in two answers, and both are asked for here: which attributes a read
+ * of the index can answer with, and whether it can answer a strongly
+ * consistent read at all.
+ */
+export interface SimDynamoDbSecondaryIndex {
+  readonly name: string;
+  readonly arn: SimArn;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly projection: SimDynamoDbIndexProjection;
+
+  /**
+   * Which attributes a read of this index answers with.
+   *
+   * The key attributes are supplied rather than worked out here, since they
+   * are the index key and the table key together and only the read knows both.
+   */
+  attributesOf(
+    keyAttributeNames: ReadonlySet<string>,
+  ): SimDynamoDbIndexAttributes;
+
+  /**
+   * Refuse a strongly consistent read this index cannot answer.
+   */
+  assertAnswersConsistentRead(): void;
+
+  /**
+   * Refuse an item carrying one of this index's key attributes as another type.
+   */
+  assertItemKeyTypes(
+    item: SimDynamoDbItem,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): void;
+}

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-secondary-indexes.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-secondary-indexes.ts
@@ -1,0 +1,119 @@
+import type { SimDynamoDbSecondaryIndexInput } from "../command/table/table.types.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbAttributeDefinitions } from "../table/sim-dynamodb-attribute-definitions.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import { SimDynamoDbGlobalSecondaryIndexes } from "./sim-dynamodb-global-secondary-indexes.js";
+import {
+  assertSimDynamoDbIndexNamesDistinct,
+  assertSimDynamoDbProjectedAttributeCount,
+} from "./sim-dynamodb-index-limits.js";
+import { requiredSimDynamoDbIndex } from "./sim-dynamodb-index-lookup.js";
+import { SimDynamoDbLocalSecondaryIndexes } from "./sim-dynamodb-local-secondary-indexes.js";
+import type {
+  SimDynamoDbSecondaryIndex,
+  SimDynamoDbSecondaryIndexTable,
+} from "./sim-dynamodb-secondary-index.js";
+
+/**
+ * The parts of a CreateTable request that declare secondary indexes.
+ */
+export interface SimDynamoDbSecondaryIndexesInput {
+  readonly GlobalSecondaryIndexes?:
+    readonly SimDynamoDbSecondaryIndexInput[] | undefined;
+  readonly LocalSecondaryIndexes?:
+    readonly SimDynamoDbSecondaryIndexInput[] | undefined;
+}
+
+interface SimDynamoDbSecondaryIndexesProperties {
+  readonly global: SimDynamoDbGlobalSecondaryIndexes;
+  readonly local: SimDynamoDbLocalSecondaryIndexes;
+}
+
+/**
+ * Every secondary index one table carries, of both kinds.
+ *
+ * The two kinds are declared apart and described apart, so each has a
+ * collection of its own. What they share is a table: one namespace for their
+ * names, one cap on how many attributes they project between them, and one
+ * `IndexName` parameter reaching either of them. Those rules live here, since
+ * neither collection can see the other.
+ */
+export class SimDynamoDbSecondaryIndexes {
+  public readonly global: SimDynamoDbGlobalSecondaryIndexes;
+  public readonly local: SimDynamoDbLocalSecondaryIndexes;
+
+  private constructor(properties: SimDynamoDbSecondaryIndexesProperties) {
+    this.global = properties.global;
+    this.local = properties.local;
+  }
+
+  /**
+   * The indexes of a table declaring none of either kind.
+   */
+  static none(): SimDynamoDbSecondaryIndexes {
+    return new this({
+      global: SimDynamoDbGlobalSecondaryIndexes.none(),
+      local: SimDynamoDbLocalSecondaryIndexes.none(),
+    });
+  }
+
+  /**
+   * Read the secondary indexes a CreateTable request declares.
+   */
+  static fromInput(
+    input: SimDynamoDbSecondaryIndexesInput,
+    table: SimDynamoDbSecondaryIndexTable,
+  ): SimDynamoDbSecondaryIndexes {
+    const indexes = new this({
+      global: SimDynamoDbGlobalSecondaryIndexes.fromInput(
+        input.GlobalSecondaryIndexes,
+        table,
+      ),
+      local: SimDynamoDbLocalSecondaryIndexes.fromInput(
+        input.LocalSecondaryIndexes,
+        table,
+      ),
+    });
+
+    assertSimDynamoDbIndexNamesDistinct(indexes.elements);
+    assertSimDynamoDbProjectedAttributeCount(indexes.elements);
+
+    return indexes;
+  }
+
+  /**
+   * Every index the table carries, whichever kind it is.
+   */
+  get elements(): readonly SimDynamoDbSecondaryIndex[] {
+    return [...this.global.elements, ...this.local.elements];
+  }
+
+  /**
+   * The index a read names, refusing a name this table does not have.
+   */
+  required(indexName: string, tableName: string): SimDynamoDbSecondaryIndex {
+    return requiredSimDynamoDbIndex(this.elements, indexName, tableName);
+  }
+
+  /**
+   * The key schemas these indexes are read by.
+   *
+   * `AttributeDefinitions` has to name every key attribute of every index as
+   * well as the table's own, so the schemas are reachable together.
+   */
+  keySchemas(): readonly SimDynamoDbKeySchema[] {
+    return this.elements.map((index) => index.keySchema);
+  }
+
+  /**
+   * Refuse an item carrying an index key attribute as the wrong type.
+   */
+  assertItemKeyTypes(
+    item: SimDynamoDbItem,
+    attributeDefinitions: SimDynamoDbAttributeDefinitions,
+  ): void {
+    for (const index of this.elements) {
+      index.assertItemKeyTypes(item, attributeDefinitions);
+    }
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-read-view.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-read-view.ts
@@ -76,4 +76,13 @@ export interface SimDynamoDbReadView {
    * something else.
    */
   assertCarriesPaths(paths: readonly SimDynamoDbDocumentPath[]): void;
+
+  /**
+   * Refuse a strongly consistent read this view cannot answer.
+   *
+   * Only a global secondary index refuses one. It is maintained asynchronously
+   * on AWS, so it cannot answer a strongly consistent read whatever the
+   * simulation does. A table and a local secondary index both can.
+   */
+  assertConsistentRead(): void;
 }

--- a/src/service/dynamodb/table/sim-dynamodb-table-description.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-description.ts
@@ -40,9 +40,10 @@ export function describeSimDynamoDbTable(
     BillingModeSummary: table.billing.summary(),
     ProvisionedThroughput: table.billing.throughputDescription(),
     TableClassSummary: tableClassSummary(table.tableClass),
-    GlobalSecondaryIndexes: table.indexes.descriptions(
+    GlobalSecondaryIndexes: table.indexes.global.descriptions(
       simDynamoDbIndexStatus(table.status),
     ),
+    LocalSecondaryIndexes: table.indexes.local.descriptions(),
     DeletionProtectionEnabled: table.deletionProtectionEnabled,
     // Neither figure is tracked yet. Real DynamoDB updates both about every
     // six hours, so they lag behind the items anyway.

--- a/src/service/dynamodb/table/sim-dynamodb-table-view.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-view.ts
@@ -107,4 +107,11 @@ export class SimDynamoDbTableView implements SimDynamoDbReadView {
   assertCarriesPaths(): void {
     return;
   }
+
+  /**
+   * Every simulated read of a table is strongly consistent already.
+   */
+  assertConsistentRead(): void {
+    return;
+  }
 }

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -14,7 +14,7 @@ import type { SimDynamoDbTimeToLiveDescription } from "../command/time-to-live/t
 import { SimDynamoDbTableExpiry } from "../time-to-live/sim-dynamodb-table-expiry.js";
 import { SimDynamoDbTimeToLive } from "../time-to-live/sim-dynamodb-time-to-live.js";
 import type { SimDynamoDbTimeToLiveSpecification } from "../time-to-live/sim-dynamodb-time-to-live-specification.js";
-import { SimDynamoDbGlobalSecondaryIndexes } from "../secondary-index/sim-dynamodb-global-secondary-indexes.js";
+import { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
 import { SimDynamoDbIndexView } from "../secondary-index/sim-dynamodb-index-view.js";
 import { SimDynamoDbItemKey } from "./sim-dynamodb-item-key.js";
 import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
@@ -37,7 +37,7 @@ interface SimDynamoDbTableProperties {
   readonly keySchema: SimDynamoDbKeySchema;
   readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
   readonly billing: SimDynamoDbTableBilling;
-  readonly indexes?: SimDynamoDbGlobalSecondaryIndexes;
+  readonly indexes?: SimDynamoDbSecondaryIndexes;
   readonly tableClass?: SimDynamoDbTableClass | undefined;
   readonly deletionProtectionEnabled?: boolean | undefined;
   readonly tags?: SimDynamoDbTableTags;
@@ -62,13 +62,13 @@ export class SimDynamoDbTable {
   public readonly billing: SimDynamoDbTableBilling;
 
   /**
-   * The global secondary indexes this table carries.
+   * The secondary indexes this table carries, global and local.
    *
    * Which items an index holds is worked out when it is read rather than kept
    * up to date on every write, so nothing here is more than what the index was
    * declared as.
    */
-  public readonly indexes: SimDynamoDbGlobalSecondaryIndexes;
+  public readonly indexes: SimDynamoDbSecondaryIndexes;
 
   public readonly tableClass: SimDynamoDbTableClass | undefined;
   public readonly deletionProtectionEnabled: boolean;
@@ -93,7 +93,7 @@ export class SimDynamoDbTable {
       keySchema,
       attributeDefinitions,
       billing,
-      indexes = SimDynamoDbGlobalSecondaryIndexes.none(),
+      indexes = SimDynamoDbSecondaryIndexes.none(),
       deletionProtectionEnabled = false,
       tags = SimDynamoDbTableTags.fromInput([]),
       background = new BackgroundTasks(),
@@ -171,8 +171,8 @@ export class SimDynamoDbTable {
   public putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
     const key = this.itemKey.of(item);
 
-    // An item need not carry an index's key attributes, since a global
-    // secondary index is sparse. Carrying one as a type the index did not
+    // An item need not carry an index's key attributes, since a secondary
+    // index of either kind is sparse. Carrying one as a type the index did not
     // declare is refused, since the index could never hold it.
     this.indexes.assertItemKeyTypes(item, this.attributeDefinitions);
 


### PR DESCRIPTION
LocalSecondaryIndexes on CreateTable, with the key schema rules that make an index local, and Query and Scan reading one. A local secondary index answers a strongly consistent read and fetches an attribute it does not project from the base table, which is where a read of it differs from a read of a global secondary index.

Resolves https://github.com/KensioSoftware/yulin/issues/270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local secondary indexes when creating and describing DynamoDB tables.
  * Added querying and scanning through local secondary indexes, including sorting, filtering, pagination, and strongly consistent reads.
  * Added support for `KEYS_ONLY`, `INCLUDE`, and `ALL_ATTRIBUTES` projections, including fetching non-projected attributes from the base table.
  * Added validation for index keys, projections, naming, limits, and unsupported throughput settings.
  * Added documentation and a working local-index example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->