### PR TITLE
feat: deploy simulated DynamoDB secondary indexes from CloudFormation

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2644,9 +2644,15 @@ console.log(stack.outputs.get("OrdersTableArn")?.value);
 ```
 
 The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
-`ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled`, `Tags`, `TimeToLiveSpecification`,
-`GlobalSecondaryIndexes` and `LocalSecondaryIndexes`. Each one is passed to `CreateTable` rather than
-applied here, so a value the template gets wrong fails the same way it would for an SDK caller.
+`ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled`, `Tags`,
+`GlobalSecondaryIndexes`, `LocalSecondaryIndexes` and `TimeToLiveSpecification`. All but the last are
+passed to `CreateTable` rather than applied here, so a value the template gets wrong fails the same
+way it would for an SDK caller.
+
+`TimeToLiveSpecification` is applied after the table is created, through `UpdateTimeToLive`. Real
+`CreateTable` has no parameter for it either, so real CloudFormation makes the table and then
+updates it. A specification the template got wrong is refused in the words `UpdateTimeToLive` refuses
+it in.
 
 A table with no `TableName` is named after the stack and its logical ID, so the table above with its
 name left out would be `orders-stack-OrdersTable`. Real CloudFormation adds random characters to
@@ -2771,10 +2777,11 @@ const byTotal = await simAws.dynamoDb().query(
 console.log(byTotal.Count); // 1
 ```
 
-Nothing about an index is checked in the CloudFormation layer, so a template declaring an index whose
-key attributes are missing from `AttributeDefinitions` fails that resource with the error the API
-gives for the same input. The same goes for the projection rules, the per-index throughput a
-provisioned table needs, and the rule that a local secondary index shares the table's partition key.
+Which properties an index entry may carry is decided here, and nothing else about an index is. A
+template declaring an index whose key attributes are missing from `AttributeDefinitions` fails that
+resource with the error the API gives for the same input. The same goes for the projection rules, the
+per-index throughput a provisioned table needs, and the rule that a local secondary index shares the
+table's partition key.
 
 `ContributorInsightsSpecification`, `OnDemandThroughput` and `WarmThroughput` on a global secondary
 index are not simulated, so a table declaring one is skipped with a reason naming the index it was

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2644,9 +2644,9 @@ console.log(stack.outputs.get("OrdersTableArn")?.value);
 ```
 
 The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
-`ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled` and `Tags`. Each one is passed to
-`CreateTable` rather than applied here, so a value the template gets wrong fails the same way it
-would for an SDK caller.
+`ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled`, `Tags`, `TimeToLiveSpecification`,
+`GlobalSecondaryIndexes` and `LocalSecondaryIndexes`. Each one is passed to `CreateTable` rather than
+applied here, so a value the template gets wrong fails the same way it would for an SDK caller.
 
 A table with no `TableName` is named after the stack and its logical ID, so the table above with its
 name left out would be `orders-stack-OrdersTable`. Real CloudFormation adds random characters to
@@ -2658,15 +2658,11 @@ ending in a hash of the untrimmed name so two long names that start the same sta
 would read as a working stream to whatever the template handed it to.
 
 A property with behaviour that is not simulated skips the resource, with a reason naming the
-property, and the rest of the stack still deploys: `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`,
-`TimeToLiveSpecification`, `StreamSpecification`, `KinesisStreamSpecification`,
-`SSESpecification`, `PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`,
-`ImportSourceSpecification`, `ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property
-`AWS::DynamoDB::Table` does not have fails the resource instead, since that is a template real
-CloudFormation would refuse too.
-
-`GlobalSecondaryIndexes` is among those, even though `CreateTable` takes it. The template property is
-not read yet, so a stack declaring one skips the table rather than deploying it without its index.
+property, and the rest of the stack still deploys: `StreamSpecification`,
+`KinesisStreamSpecification`, `SSESpecification`, `PointInTimeRecoverySpecification`,
+`ContributorInsightsSpecification`, `ImportSourceSpecification`, `ResourcePolicy`,
+`OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` does not have fails the
+resource instead, since that is a template real CloudFormation would refuse too.
 
 `AWS::DynamoDB::GlobalTable` is skipped rather than deployed, since replication across regions is
 not simulated.
@@ -2674,6 +2670,119 @@ not simulated.
 CDK works without hand-editing. A `dynamodb.Table` synthesises a template that deploys here, with
 the table name reaching a function through its environment and a grant policy naming the table by
 the ARN `Fn::GetAtt` gives.
+
+## Deploying a table with secondary indexes
+
+`GlobalSecondaryIndexes` and `LocalSecondaryIndexes` are read off the resource and handed to
+`CreateTable` with the rest of the table. An index a template declared is the index an SDK caller
+would have got, so it is queried and scanned the same way.
+
+```typescript sim-dynamodb-cloudformation-indexes
+/**
+ * Deploying a table with secondary indexes from a CloudFormation template.
+ */
+
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [
+            { AttributeName: "customerId", KeyType: "HASH" },
+            { AttributeName: "orderId", KeyType: "RANGE" },
+          ],
+          AttributeDefinitions: [
+            { AttributeName: "customerId", AttributeType: "S" },
+            { AttributeName: "orderId", AttributeType: "S" },
+            { AttributeName: "status", AttributeType: "S" },
+            { AttributeName: "total", AttributeType: "N" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: "byStatus",
+              KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+              Projection: { ProjectionType: "ALL" },
+            },
+          ],
+          LocalSecondaryIndexes: [
+            {
+              IndexName: "byTotal",
+              KeySchema: [
+                { AttributeName: "customerId", KeyType: "HASH" },
+                { AttributeName: "total", KeyType: "RANGE" },
+              ],
+              Projection: { ProjectionType: "ALL" },
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-1" },
+      status: { S: "OPEN" },
+      total: { N: "42" },
+    },
+  }),
+);
+
+// The global index is keyed by a partition key the table does not have.
+const open = await simAws.dynamoDb().query(
+  new QueryCommand({
+    TableName: "orders",
+    IndexName: "byStatus",
+    KeyConditionExpression: "#status = :status",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+  }),
+);
+
+console.log(open.Items?.[0]?.["orderId"]?.S); // "order-1"
+
+// The local index sorts one customer's orders by total.
+const byTotal = await simAws.dynamoDb().query(
+  new QueryCommand({
+    TableName: "orders",
+    IndexName: "byTotal",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+  }),
+);
+
+console.log(byTotal.Count); // 1
+```
+
+Nothing about an index is checked in the CloudFormation layer, so a template declaring an index whose
+key attributes are missing from `AttributeDefinitions` fails that resource with the error the API
+gives for the same input. The same goes for the projection rules, the per-index throughput a
+provisioned table needs, and the rule that a local secondary index shares the table's partition key.
+
+`ContributorInsightsSpecification`, `OnDemandThroughput` and `WarmThroughput` on a global secondary
+index are not simulated, so a table declaring one is skipped with a reason naming the index it was
+on. `LocalSecondaryIndexes` entries have `IndexName`, `KeySchema` and `Projection` and nothing else,
+so anything further on one fails the resource, as it would on real CloudFormation.
+
+A CDK `Table` with `addGlobalSecondaryIndex` and `addLocalSecondaryIndex` synthesises a template that
+deploys here without hand-editing.
 
 ## IAM authorization
 
@@ -2747,7 +2856,8 @@ nothing is written.
   past their deletion window, with no sweep for a test to call.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
-  expires items, and `Tags` deploying a tagged table.
+  expires items, `Tags` deploying a tagged table, and `GlobalSecondaryIndexes` and
+  `LocalSecondaryIndexes` deploying a table whose indexes are then queried and scanned.
 - SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
   `UpdateCommand`, `BatchWriteCommand` and `BatchGetCommand` converting native JavaScript values on
@@ -2881,6 +2991,11 @@ nothing is written.
   retry that names the same actions in a different order reads as a different request and is refused
   rather than replayed. A retry of the same call sends the same JSON, so this shows up only in a
   test that rebuilds the request by hand.
+- AWS creates one table with secondary indexes at a time in an account and region, and refuses a
+  `CreateTable` that overlaps another one. Simulated CloudFormation creates each batch of resources
+  whose dependencies are met at once, so a template holding two indexed tables with no `DependsOn`
+  between them deploys here and may not on AWS. That is the exact template shape that diverges: one
+  indexed table, or several with `DependsOn` ordering them, behaves the same either way.
 - A CloudFormation stack reaches `CREATE_COMPLETE` while the table it created is still `CREATING`.
   Real CloudFormation waits for the table to be `ACTIVE`, so a test reading the status after the
   stack deployed calls `simAws.backgroundTasksComplete()` first.

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-indexes.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-indexes.example.ts
@@ -1,0 +1,91 @@
+/**
+ * Deploying a table with secondary indexes from a CloudFormation template.
+ */
+
+import { PutItemCommand, QueryCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [
+            { AttributeName: "customerId", KeyType: "HASH" },
+            { AttributeName: "orderId", KeyType: "RANGE" },
+          ],
+          AttributeDefinitions: [
+            { AttributeName: "customerId", AttributeType: "S" },
+            { AttributeName: "orderId", AttributeType: "S" },
+            { AttributeName: "status", AttributeType: "S" },
+            { AttributeName: "total", AttributeType: "N" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: "byStatus",
+              KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+              Projection: { ProjectionType: "ALL" },
+            },
+          ],
+          LocalSecondaryIndexes: [
+            {
+              IndexName: "byTotal",
+              KeySchema: [
+                { AttributeName: "customerId", KeyType: "HASH" },
+                { AttributeName: "total", KeyType: "RANGE" },
+              ],
+              Projection: { ProjectionType: "ALL" },
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: {
+      customerId: { S: "customer-1" },
+      orderId: { S: "order-1" },
+      status: { S: "OPEN" },
+      total: { N: "42" },
+    },
+  }),
+);
+
+// The global index is keyed by a partition key the table does not have.
+const open = await simAws.dynamoDb().query(
+  new QueryCommand({
+    TableName: "orders",
+    IndexName: "byStatus",
+    KeyConditionExpression: "#status = :status",
+    ExpressionAttributeNames: { "#status": "status" },
+    ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+  }),
+);
+
+console.log(open.Items?.[0]?.["orderId"]?.S); // "order-1"
+
+// The local index sorts one customer's orders by total.
+const byTotal = await simAws.dynamoDb().query(
+  new QueryCommand({
+    TableName: "orders",
+    IndexName: "byTotal",
+    KeyConditionExpression: "customerId = :customerId",
+    ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+  }),
+);
+
+console.log(byTotal.Count); // 1

--- a/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-indexes.loc.test.ts
+++ b/src/service/cloudformation/cdk/dynamodb/sim-cdk-dynamodb-indexes.loc.test.ts
@@ -1,0 +1,158 @@
+import {
+  DescribeTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+describe("Sim CDK DynamoDB secondary index deployment local integration", () => {
+  it("deploys a CDK table an SDK caller then queries both indexes of", async () => {
+    // Given a CDK stack with a table carrying one global and one local
+    // secondary index, added the way CDK adds them.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersTable = new dynamodb.Table(stack, "OrdersTable", {
+  partitionKey: { name: "customerId", type: dynamodb.AttributeType.STRING },
+  sortKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+});
+
+ordersTable.addGlobalSecondaryIndex({
+  indexName: "byStatus",
+  partitionKey: { name: "status", type: dynamodb.AttributeType.STRING },
+  sortKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+});
+
+ordersTable.addLocalSecondaryIndex({
+  indexName: "byTotal",
+  sortKey: { name: "total", type: dynamodb.AttributeType.NUMBER },
+});
+
+new cdk.CfnOutput(stack, "OrdersTableName", {
+  value: ordersTable.tableName,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template, with no hand-editing of the
+    // GlobalSecondaryIndexes and LocalSecondaryIndexes properties CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+
+    // Then the deployed table describes both indexes.
+    const described = await scoped
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: tableName }));
+
+    assertNonNullable(described.Table);
+    assertArrayLength(described.Table.GlobalSecondaryIndexes, 1);
+    assertArrayLength(described.Table.LocalSecondaryIndexes, 1);
+    assertIdentical(
+      described.Table.GlobalSecondaryIndexes[0].IndexName,
+      "byStatus",
+    );
+    assertIdentical(
+      described.Table.GlobalSecondaryIndexes[0].IndexStatus,
+      "ACTIVE",
+    );
+    assertIdentical(
+      described.Table.LocalSecondaryIndexes[0].IndexName,
+      "byTotal",
+    );
+
+    // And two orders written to it are found through both indexes.
+    await scoped.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-1" },
+          status: { S: "OPEN" },
+          total: { N: "42" },
+        },
+      }),
+    );
+    await scoped.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          customerId: { S: "customer-1" },
+          orderId: { S: "order-2" },
+          status: { S: "SHIPPED" },
+          total: { N: "7" },
+        },
+      }),
+    );
+
+    const shipped = await scoped.dynamoDb().query(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "SHIPPED" } },
+      }),
+    );
+
+    assertIdentical(shipped.Count, 1);
+    assertIdentical(shipped.Items?.[0]?.["orderId"]?.S, "order-2");
+
+    // The local index sorts the customer's orders by total rather than by
+    // order ID, so the cheaper order comes first.
+    const byTotal = await scoped.dynamoDb().query(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: "byTotal",
+        KeyConditionExpression: "customerId = :customerId",
+        ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+      }),
+    );
+
+    assertIdentical(byTotal.Count, 2);
+    assertIdentical(byTotal.Items?.[0]?.["orderId"]?.S, "order-2");
+    assertIdentical(byTotal.Items[1]?.["orderId"]?.S, "order-1");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -854,17 +854,31 @@ The parts under `cfn/table/` split by responsibility:
   on, a real property that is not simulated skips the resource with a reason naming it, and anything
   that is not an `AWS::DynamoDB::Table` property at all fails the resource, because that is a
   template real CloudFormation would refuse too.
+- `SimCfnDynamoDbTableIndexRules` applies the same rule a level down, to the entries of
+  `GlobalSecondaryIndexes` and `LocalSecondaryIndexes`. The two kinds have different property sets:
+  a local secondary index has no throughput or insights settings on AWS either, so anything of the
+  sort on one fails the resource rather than skipping it.
 - `SimCfnDynamoDbTableValues` reads the plain shapes a property can hold, naming the property path in
   each refusal. It takes a number from the string a template Parameter carries one as.
 - `SimCfnDynamoDbTableProperties` turns the template properties into `CreateTable` input, and
   generates a name for a table the template did not name, through the shared
-  `SimCfnGeneratedResourceName`.
+  `SimCfnGeneratedResourceName`. The parts several properties share are read by
+  `readSimCfnDynamoDbKeySchema`, `readSimCfnDynamoDbThroughput` and
+  `readSimCfnDynamoDbTableIndexes`, since a table and its indexes state their keys and their
+  capacity the same way.
 - `SimCfnDynamoDbTableCreator` calls `SimDynamoDb.createTable()` with that input and finds the
   created table through `SimDynamoDb.findTable()`.
 
-Nothing here decides what a key schema, a billing mode or a table class is allowed to be. Creating
-the table through the ordinary command is what keeps a template-created table the same thing an SDK
-caller would have got.
+Nothing here decides what a key schema, a billing mode, a table class or a secondary index is
+allowed to be. Creating the table through the ordinary command is what keeps a template-created
+table the same thing an SDK caller would have got.
+
+One divergence is deliberate, and commented where the indexes are read. AWS creates only one table
+with secondary indexes at a time in an account and region. Simulated CloudFormation creates each
+dependency-ready batch of resources at once, so a template with two indexed tables and no
+`DependsOn` between them deploys here and may not on AWS. It is documented under Limitations rather
+than serialised, since serialising would hold up stack timing over a template shape a test is
+unlikely to be about.
 
 `Ref` and `Fn::GetAtt` behaviour lives with the CloudFormation engine rather than on the table, in
 `SimDynamoDbTableCfn` under `cloudformation/resource/cfn/dynamodb/`. `Ref` answers with the table

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-index-validation.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-index-validation.iso.test.ts
@@ -1,0 +1,285 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnDynamoDbIndexedTableResourceFactory } from "./table/sim-cfn-dynamodb-indexed-table-resource.factory.js";
+
+/**
+ * Deploy an indexed table whose Resource carries the properties given, and give
+ * back the stack whatever came of it.
+ */
+async function deployIndexedTable(
+  simAws: SimAws,
+  properties: SimCfnTemplateValueRecord,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersTable: simCfnDynamoDbIndexedTableResourceFactory.make({
+          properties,
+        }),
+        OrdersBucket: { Type: "AWS::S3::Bucket" },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+}
+
+describe("DynamoDB CloudFormation Table secondary index validation", () => {
+  it("fails an index whose key attribute has no AttributeDefinition", async () => {
+    // Given a template whose index is keyed by an attribute the table never
+    // defines, which CreateTable refuses for an SDK caller too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byWarehouse",
+            KeySchema: [{ AttributeName: "warehouseId", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      });
+    });
+
+    // And the failure is the one CreateTable gives, because the Resource is
+    // created by calling it.
+    assertStringIncludes(
+      error.message,
+      "The KeySchema for index byWarehouse names the attribute warehouseId, " +
+        "which has no AttributeDefinition",
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    assertIdentical(stack?.getResource("OrdersTable")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a local index that does not share the table's partition key", async () => {
+    // Given a template whose local index is keyed by an attribute of its own
+    // rather than by the table's partition key.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails with the rule
+    // that makes an index local, rather than with anything read here.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        LocalSecondaryIndexes: [
+          {
+            IndexName: "byTotal",
+            KeySchema: [
+              { AttributeName: "status", KeyType: "HASH" },
+              { AttributeName: "total", KeyType: "RANGE" },
+            ],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "shares the table's partition key");
+  });
+
+  it("fails an index the template gives no Projection", async () => {
+    // Given a template whose index says nothing about which attributes it
+    // carries.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails in the words
+    // CreateTable refuses the same index in.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(error.message, "Index byStatus has no Projection");
+  });
+
+  it("skips a table whose index asks for something not simulated", async () => {
+    // Given a template asking for warm throughput on one index, which is not
+    // simulated, in a stack with another Resource in it.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await deployIndexedTable(simAws, {
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byStatus",
+          KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+          WarmThroughput: { ReadUnitsPerSecond: 12_000 },
+        },
+      ],
+    });
+
+    // Then the whole table is skipped, with a reason naming the index the
+    // setting was on, rather than deployed with an index that ignores it.
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    const resource = stack?.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "GlobalSecondaryIndexes.0.WarmThroughput is a real " +
+        "AWS::DynamoDB::Table property that simulated DynamoDB does not " +
+        "simulate",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+
+    // And the rest of the stack still deploys.
+    assertTrue(stack?.getResource("OrdersBucket")?.deployed);
+  });
+
+  it("fails an index carrying something that is not an index property", async () => {
+    // Given a template naming something on its index that AWS::DynamoDB::Table
+    // has no such property for.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails rather than
+    // skipping, since real CloudFormation would refuse this template too.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+            Sorted: true,
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "GlobalSecondaryIndexes.0.Sorted is not an AWS::DynamoDB::Table " +
+        "GlobalSecondaryIndex property",
+    );
+  });
+
+  it("fails a local index the template provisions capacity for", async () => {
+    // Given a template provisioning capacity for a local secondary index,
+    // which has no such property: it reads out of the table's own capacity.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails naming the
+    // property.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        LocalSecondaryIndexes: [
+          {
+            IndexName: "byTotal",
+            KeySchema: [
+              { AttributeName: "customerId", KeyType: "HASH" },
+              { AttributeName: "total", KeyType: "RANGE" },
+            ],
+            Projection: { ProjectionType: "ALL" },
+            ProvisionedThroughput: {
+              ReadCapacityUnits: 2,
+              WriteCapacityUnits: 1,
+            },
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "LocalSecondaryIndexes.0.ProvisionedThroughput is not an " +
+        "AWS::DynamoDB::Table LocalSecondaryIndex property",
+    );
+  });
+
+  it("fails an index property list the template did not write as a list", async () => {
+    // Given a template holding one index object where the list of them belongs.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails naming the
+    // property that was the wrong shape.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: {
+          IndexName: "byStatus",
+          KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "GlobalSecondaryIndexes must be a list",
+    );
+  });
+
+  it("fails a projection naming something other than attribute names", async () => {
+    // Given a template whose NonKeyAttributes holds a number.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails naming the
+    // entry that was not an attribute name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+            Projection: {
+              ProjectionType: "INCLUDE",
+              NonKeyAttributes: ["total", 7],
+            },
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "GlobalSecondaryIndexes.0.Projection.NonKeyAttributes.1 must be a string",
+    );
+  });
+
+  it("fails a projection whose NonKeyAttributes is not a list", async () => {
+    // Given a template naming one attribute where the list of them belongs.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails naming the
+    // property that was the wrong shape.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployIndexedTable(simAws, {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byStatus",
+            KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+            Projection: {
+              ProjectionType: "INCLUDE",
+              NonKeyAttributes: "total",
+            },
+          },
+        ],
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "GlobalSecondaryIndexes.0.Projection.NonKeyAttributes must be a list",
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
@@ -1,0 +1,239 @@
+import {
+  DescribeTableCommand,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simCfnDynamoDbIndexedTableResourceFactory } from "./table/sim-cfn-dynamodb-indexed-table-resource.factory.js";
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
+
+/**
+ * Deploy a table with one secondary index of each kind, and put two orders for
+ * one customer on it.
+ */
+async function deployIndexedOrders(simAws: SimAws): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersTable: simCfnDynamoDbIndexedTableResourceFactory.make({}),
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+  await simAws.backgroundTasksComplete();
+
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: {
+        customerId: { S: "customer-1" },
+        orderId: { S: "order-1" },
+        status: { S: "OPEN" },
+        total: { N: "42" },
+      },
+    }),
+  );
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: {
+        customerId: { S: "customer-1" },
+        orderId: { S: "order-2" },
+        status: { S: "SHIPPED" },
+        total: { N: "7" },
+      },
+    }),
+  );
+}
+
+describe("DynamoDB CloudFormation Table secondary indexes", () => {
+  it("describes the indexes a template declares", async () => {
+    // Given a template declaring a global and a local secondary index.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await deployIndexedOrders(simAws);
+
+    // Then the table describes both, the way an SDK caller's table does.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    assertNonNullable(described.Table);
+    assertArrayLength(described.Table.GlobalSecondaryIndexes, 1);
+    assertArrayLength(described.Table.LocalSecondaryIndexes, 1);
+
+    const global = described.Table.GlobalSecondaryIndexes[0];
+    assertIdentical(global.IndexName, "byStatus");
+    assertIdentical(global.IndexStatus, "ACTIVE");
+    assertIdentical(global.KeySchema?.at(0)?.AttributeName, "status");
+    assertIdentical(global.Projection?.ProjectionType, "ALL");
+    assertIdentical(
+      global.IndexArn,
+      `${described.Table.TableArn ?? ""}/index/byStatus`,
+    );
+
+    const local = described.Table.LocalSecondaryIndexes[0];
+    assertIdentical(local.IndexName, "byTotal");
+    assertIdentical(local.KeySchema?.at(1)?.AttributeName, "total");
+  });
+
+  it("queries the global secondary index a template declared", async () => {
+    // Given a deployed indexed table holding two orders.
+    const simAws = new SimAws();
+    await deployIndexedOrders(simAws);
+
+    // When the global index is queried by the partition key it has of its own.
+    const shipped = await simAws.dynamoDb().query(
+      new QueryCommand({
+        TableName: "orders",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "SHIPPED" } },
+      }),
+    );
+
+    // Then it answers with the order in that status alone.
+    assertIdentical(shipped.Count, 1);
+    assertIdentical(shipped.Items?.[0]?.["orderId"]?.S, "order-2");
+  });
+
+  it("queries the local secondary index a template declared", async () => {
+    // Given the same deployed table.
+    const simAws = new SimAws();
+    await deployIndexedOrders(simAws);
+
+    // When the local index is queried, which sorts the customer's orders by
+    // total rather than by order ID.
+    const byTotal = await simAws.dynamoDb().query(
+      new QueryCommand({
+        TableName: "orders",
+        IndexName: "byTotal",
+        KeyConditionExpression: "customerId = :customerId",
+        ExpressionAttributeValues: { ":customerId": { S: "customer-1" } },
+      }),
+    );
+
+    // Then both orders come back in total order, cheapest first.
+    assertIdentical(byTotal.Count, 2);
+    assertIdentical(byTotal.Items?.[0]?.["orderId"]?.S, "order-2");
+    assertIdentical(byTotal.Items[1]?.["orderId"]?.S, "order-1");
+  });
+
+  it("projects the attributes a template's index names", async () => {
+    // Given a template whose global index projects named attributes rather
+    // than the whole item.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+            tableName: "orders",
+            partitionKeyName: "orderId",
+            properties: {
+              AttributeDefinitions: [
+                { AttributeName: "orderId", AttributeType: "S" },
+                { AttributeName: "status", AttributeType: "S" },
+              ],
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: "byStatus",
+                  KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+                  Projection: {
+                    ProjectionType: "INCLUDE",
+                    NonKeyAttributes: ["total"],
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: {
+          orderId: { S: "order-1" },
+          status: { S: "OPEN" },
+          total: { N: "42" },
+          note: { S: "Gift wrap" },
+        },
+      }),
+    );
+
+    // When the index is read.
+    const open = await simAws.dynamoDb().query(
+      new QueryCommand({
+        TableName: "orders",
+        IndexName: "byStatus",
+        KeyConditionExpression: "#status = :status",
+        ExpressionAttributeNames: { "#status": "status" },
+        ExpressionAttributeValues: { ":status": { S: "OPEN" } },
+      }),
+    );
+
+    // Then it answers with the named attribute and not with the rest of the
+    // item, so the template's Projection reached the index.
+    assertIdentical(open.Items?.[0]?.["total"]?.N, "42");
+    assertUndefined(open.Items[0]["note"]);
+  });
+
+  it("provisions the capacity a template gives a global index", async () => {
+    // Given a provisioned table whose global index is provisioned separately,
+    // as a provisioned table's index has to be.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTable: simCfnDynamoDbIndexedTableResourceFactory.make({
+            properties: {
+              BillingMode: "PROVISIONED",
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 3,
+              },
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: "byStatus",
+                  KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+                  Projection: { ProjectionType: "KEYS_ONLY" },
+                  ProvisionedThroughput: {
+                    ReadCapacityUnits: 2,
+                    WriteCapacityUnits: 1,
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the index reports the capacity of its own that the template gave it.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+
+    const throughput =
+      described.Table?.GlobalSecondaryIndexes?.[0]?.ProvisionedThroughput;
+    assertIdentical(throughput?.ReadCapacityUnits, 2);
+    assertIdentical(throughput.WriteCapacityUnits, 1);
+  });
+});

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-indexed-table-resource.factory.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-indexed-table-resource.factory.ts
@@ -1,0 +1,87 @@
+import { MappedFactory } from "@kensio/part-factory";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * What a test asks for when it wants an `AWS::DynamoDB::Table` Resource
+ * carrying a secondary index of each kind.
+ *
+ * The keys are fixed, since what a test of the CloudFormation path is about is
+ * the properties reaching CreateTable rather than which attribute is the key.
+ * `properties` is what the template says beyond that, and it is applied last,
+ * so a test that needs one property of its own states that one.
+ */
+export interface SimCfnDynamoDbIndexedTableResourceInput {
+  readonly tableName: string;
+  readonly globalIndexName: string;
+  readonly localIndexName: string;
+  readonly projectionType: string;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Builds the `AWS::DynamoDB::Table` Resource of a table with one global and one
+ * local secondary index.
+ *
+ * The table is keyed by `customerId` and `orderId`. The global index is keyed
+ * by `status` and `orderId`, which is a partition key the table does not have.
+ * The local index is keyed by the table's own `customerId` and by `total`,
+ * which reorders one customer's orders.
+ *
+ * ```typescript
+ * template: {
+ *   Resources: {
+ *     OrdersTable: simCfnDynamoDbIndexedTableResourceFactory.make({}),
+ *   },
+ * }
+ * ```
+ */
+export const simCfnDynamoDbIndexedTableResourceFactory = new MappedFactory<
+  SimCfnDynamoDbIndexedTableResourceInput,
+  SimCfnTemplateValueRecord
+>(
+  () => ({
+    tableName: "orders",
+    globalIndexName: "byStatus",
+    localIndexName: "byTotal",
+    projectionType: "ALL",
+    properties: {},
+  }),
+  (input) => ({
+    Type: "AWS::DynamoDB::Table",
+    Properties: {
+      TableName: input.tableName,
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+        { AttributeName: "status", AttributeType: "S" },
+        { AttributeName: "total", AttributeType: "N" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: input.globalIndexName,
+          KeySchema: [
+            { AttributeName: "status", KeyType: "HASH" },
+            { AttributeName: "orderId", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: input.projectionType },
+        },
+      ],
+      LocalSecondaryIndexes: [
+        {
+          IndexName: input.localIndexName,
+          KeySchema: [
+            { AttributeName: "customerId", KeyType: "HASH" },
+            { AttributeName: "total", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: input.projectionType },
+        },
+      ],
+      ...input.properties,
+    },
+  }),
+);

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -47,6 +47,8 @@ export class SimCfnDynamoDbTableCreator {
         AttributeDefinitions: tableProperties.attributeDefinitions(),
         BillingMode: tableProperties.billingMode(),
         ProvisionedThroughput: tableProperties.provisionedThroughput(),
+        GlobalSecondaryIndexes: tableProperties.globalSecondaryIndexes(),
+        LocalSecondaryIndexes: tableProperties.localSecondaryIndexes(),
         TableClass: tableProperties.tableClass(),
         DeletionProtectionEnabled: tableProperties.deletionProtectionEnabled(),
         Tags: tableProperties.tags(),

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-index-rules.ts
@@ -1,0 +1,130 @@
+import {
+  dynamoDbTablePropertyError,
+  dynamoDbTableUnsimulatedPropertyError,
+} from "./sim-cfn-dynamodb-table-property-error.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * The GlobalSecondaryIndex properties this simulation acts on.
+ *
+ * Each one is handed to CreateTable rather than applied here, so what an index
+ * name, a key schema, a projection or a capacity is allowed to be stays with
+ * the rules simulated DynamoDB already applies to a CreateTable request.
+ */
+const simulatedGlobalIndexPropertyNames: ReadonlySet<string> = new Set([
+  "IndexName",
+  "KeySchema",
+  "Projection",
+  "ProvisionedThroughput",
+]);
+
+/**
+ * Real GlobalSecondaryIndex properties this simulation does not model.
+ */
+const unsimulatedGlobalIndexPropertyNames: ReadonlySet<string> = new Set([
+  "ContributorInsightsSpecification",
+  "OnDemandThroughput",
+  "WarmThroughput",
+]);
+
+/**
+ * The LocalSecondaryIndex properties, which this simulation models all of.
+ *
+ * A local secondary index is built with its table and reads out of the table's
+ * capacity, so AWS gives it no throughput or insights settings of its own.
+ * There is nothing here that is real and unmodelled, which is why there is no
+ * unsimulated set to go with this one.
+ */
+const simulatedLocalIndexPropertyNames: ReadonlySet<string> = new Set([
+  "IndexName",
+  "KeySchema",
+  "Projection",
+]);
+
+interface SimCfnDynamoDbTableIndexRulesProperties {
+  readonly logicalId: string;
+  readonly kind: string;
+  readonly simulated: ReadonlySet<string>;
+  readonly unsimulated: ReadonlySet<string>;
+}
+
+/**
+ * Which properties of one secondary index a template declares simulated
+ * DynamoDB can act on.
+ *
+ * This is the table's own property rule applied a level down. A real index
+ * property that is not simulated skips the whole table, since a table deployed
+ * without a setting its index asked for answers reads differently. Anything
+ * that is not an index property at all fails the Resource, because that is a
+ * template real CloudFormation would refuse too.
+ */
+export class SimCfnDynamoDbTableIndexRules {
+  private readonly logicalId: string;
+  private readonly kind: string;
+  private readonly simulated: ReadonlySet<string>;
+  private readonly unsimulated: ReadonlySet<string>;
+
+  private constructor(properties: SimCfnDynamoDbTableIndexRulesProperties) {
+    this.logicalId = properties.logicalId;
+    this.kind = properties.kind;
+    this.simulated = properties.simulated;
+    this.unsimulated = properties.unsimulated;
+  }
+
+  /**
+   * The rules a `GlobalSecondaryIndexes` entry is read under.
+   */
+  static global(logicalId: string): SimCfnDynamoDbTableIndexRules {
+    return new this({
+      logicalId,
+      kind: "GlobalSecondaryIndex",
+      simulated: simulatedGlobalIndexPropertyNames,
+      unsimulated: unsimulatedGlobalIndexPropertyNames,
+    });
+  }
+
+  /**
+   * The rules a `LocalSecondaryIndexes` entry is read under.
+   */
+  static local(logicalId: string): SimCfnDynamoDbTableIndexRules {
+    return new this({
+      logicalId,
+      kind: "LocalSecondaryIndex",
+      simulated: simulatedLocalIndexPropertyNames,
+      unsimulated: new Set<string>(),
+    });
+  }
+
+  /**
+   * Refuse everything about these index entries that is not simulated.
+   */
+  assertSimulated(entries: readonly SimCfnDynamoDbTableValues[]): void {
+    for (const entry of entries) {
+      for (const name of entry.names) {
+        this.assertSimulatedProperty(entry, name);
+      }
+    }
+  }
+
+  private assertSimulatedProperty(
+    entry: SimCfnDynamoDbTableValues,
+    name: string,
+  ): void {
+    if (this.simulated.has(name)) {
+      return;
+    }
+
+    if (this.unsimulated.has(name)) {
+      throw dynamoDbTableUnsimulatedPropertyError(
+        this.logicalId,
+        entry.pathTo(name),
+      );
+    }
+
+    throw dynamoDbTablePropertyError(
+      this.logicalId,
+      `${entry.pathTo(name)} is not an AWS::DynamoDB::Table ${this.kind} ` +
+        `property`,
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-indexes.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-indexes.ts
@@ -1,0 +1,71 @@
+import type {
+  SimDynamoDbProjectionInput,
+  SimDynamoDbSecondaryIndexInput,
+} from "../../command/table/table.types.js";
+import { readSimCfnDynamoDbKeySchema } from "./sim-cfn-dynamodb-table-key-schema.js";
+import { readSimCfnDynamoDbThroughput } from "./sim-cfn-dynamodb-table-throughput.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * Read the `GlobalSecondaryIndexes` or `LocalSecondaryIndexes` an
+ * AWS::DynamoDB::Table Resource declares.
+ *
+ * A template states both kinds the same way, so both are read here and handed
+ * to CreateTable in the shape it takes. What an index is allowed to be is
+ * decided there: the key schema rules, the projection rules, whether a local
+ * index shares the table's partition key, and whether every key attribute has
+ * an `AttributeDefinition`.
+ *
+ * One divergence is deliberate. AWS creates only one table with secondary
+ * indexes at a time in an account and region, and refuses a second CreateTable
+ * that overlaps it. Sim CloudFormation creates each dependency-ready batch of
+ * Resources at once, so a template with two indexed tables and no `DependsOn`
+ * between them deploys here. Serialising it would have meant holding up stack
+ * timing over a rule that only bites on a template shape a test is unlikely to
+ * be about, so the divergence is documented under Limitations instead.
+ */
+export function readSimCfnDynamoDbTableIndexes(
+  values: SimCfnDynamoDbTableValues,
+  propertyName: string,
+): readonly SimDynamoDbSecondaryIndexInput[] {
+  return values.list(propertyName).map((index) => readIndex(index));
+}
+
+/**
+ * Read one entry of either index property.
+ *
+ * A local secondary index has no `ProvisionedThroughput` in a template at all,
+ * so reading one that is not there leaves it out rather than inventing it.
+ */
+function readIndex(
+  index: SimCfnDynamoDbTableValues,
+): SimDynamoDbSecondaryIndexInput {
+  return {
+    IndexName: index.string("IndexName"),
+    KeySchema: readSimCfnDynamoDbKeySchema(index),
+    Projection: readProjection(index),
+    ProvisionedThroughput: readSimCfnDynamoDbThroughput(index),
+  };
+}
+
+/**
+ * Read the `Projection` an index entry carries.
+ *
+ * An index with no `Projection` at all is left as it was declared, since
+ * CreateTable is where an index says which attributes it carries and refuses
+ * one that does not.
+ */
+function readProjection(
+  index: SimCfnDynamoDbTableValues,
+): SimDynamoDbProjectionInput | undefined {
+  const projection = index.object("Projection");
+
+  if (projection === undefined) {
+    return undefined;
+  }
+
+  return {
+    ProjectionType: projection.string("ProjectionType"),
+    NonKeyAttributes: projection.strings("NonKeyAttributes"),
+  };
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-schema.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-key-schema.ts
@@ -1,0 +1,20 @@
+import type { SimDynamoDbKeySchemaElementInput } from "../../command/table/table.types.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * Read the `KeySchema` property of a table or one of its secondary indexes.
+ *
+ * A table and an index state their keys the same way, so both are read here.
+ * The elements are kept in the order the template lists them, since that is
+ * what says which is the partition key.
+ */
+export function readSimCfnDynamoDbKeySchema(
+  values: SimCfnDynamoDbTableValues,
+): readonly SimDynamoDbKeySchemaElementInput[] {
+  return values.list("KeySchema").map((element) => {
+    return {
+      AttributeName: element.string("AttributeName"),
+      KeyType: element.string("KeyType"),
+    };
+  });
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -5,10 +5,14 @@ import type {
   SimDynamoDbAttributeDefinitionInput,
   SimDynamoDbKeySchemaElementInput,
   SimDynamoDbProvisionedThroughput,
+  SimDynamoDbSecondaryIndexInput,
   SimDynamoDbTagInput,
 } from "../../command/table/table.types.js";
 import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
+import { readSimCfnDynamoDbTableIndexes } from "./sim-cfn-dynamodb-table-indexes.js";
+import { readSimCfnDynamoDbKeySchema } from "./sim-cfn-dynamodb-table-key-schema.js";
 import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
+import { readSimCfnDynamoDbThroughput } from "./sim-cfn-dynamodb-table-throughput.js";
 import { readSimCfnDynamoDbTableTimeToLive } from "./sim-cfn-dynamodb-table-time-to-live.js";
 import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
 
@@ -38,13 +42,13 @@ export class SimCfnDynamoDbTableProperties {
 
   constructor(properties: SimCfnDynamoDbTablePropertiesProperties) {
     this.resource = properties.resource;
-    this.rules = new SimCfnDynamoDbTablePropertyRules({
-      logicalId: properties.resource.logicalId,
-      properties: properties.properties,
-    });
     this.values = new SimCfnDynamoDbTableValues({
       logicalId: properties.resource.logicalId,
       properties: properties.properties,
+    });
+    this.rules = new SimCfnDynamoDbTablePropertyRules({
+      logicalId: properties.resource.logicalId,
+      values: this.values,
     });
   }
 
@@ -71,12 +75,7 @@ export class SimCfnDynamoDbTableProperties {
    * The table's primary key elements, in the order the template lists them.
    */
   keySchema(): readonly SimDynamoDbKeySchemaElementInput[] {
-    return this.values.list("KeySchema").map((element) => {
-      return {
-        AttributeName: element.string("AttributeName"),
-        KeyType: element.string("KeyType"),
-      };
-    });
+    return readSimCfnDynamoDbKeySchema(this.values);
   }
 
   /**
@@ -102,16 +101,24 @@ export class SimCfnDynamoDbTableProperties {
    * The capacity a provisioned table is created with.
    */
   provisionedThroughput(): SimDynamoDbProvisionedThroughput | undefined {
-    const throughput = this.values.object("ProvisionedThroughput");
+    return readSimCfnDynamoDbThroughput(this.values);
+  }
 
-    if (throughput === undefined) {
-      return undefined;
-    }
+  /**
+   * The global secondary indexes the template declares on the table.
+   */
+  globalSecondaryIndexes(): readonly SimDynamoDbSecondaryIndexInput[] {
+    return readSimCfnDynamoDbTableIndexes(
+      this.values,
+      "GlobalSecondaryIndexes",
+    );
+  }
 
-    return {
-      ReadCapacityUnits: throughput.number("ReadCapacityUnits"),
-      WriteCapacityUnits: throughput.number("WriteCapacityUnits"),
-    };
+  /**
+   * The local secondary indexes the template declares on the table.
+   */
+  localSecondaryIndexes(): readonly SimDynamoDbSecondaryIndexInput[] {
+    return readSimCfnDynamoDbTableIndexes(this.values, "LocalSecondaryIndexes");
   }
 
   /**

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-error.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Build the error a property of an AWS::DynamoDB::Table Resource is refused
+ * with.
+ *
+ * The wording matters. Sim CloudFormation skips a Resource whose error reads as
+ * an unsupported Resource type, and skipping is the wrong answer for a table
+ * the template described in a way it cannot be created: nothing is missing from
+ * the simulation, the template is wrong, and the same template would fail on
+ * real CloudFormation.
+ */
+export function dynamoDbTablePropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid AWS::DynamoDB::Table Resource ${logicalId}: ${reason}`,
+  );
+}
+
+/**
+ * Build the error that skips a Resource over a property that is not simulated.
+ *
+ * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
+ * as skipped rather than failing the stack, so the rest of the template still
+ * deploys and the skip reason names the property. The path is the whole way to
+ * the property, so a setting on one index of several says which one it was on.
+ */
+export function dynamoDbTableUnsimulatedPropertyError(
+  logicalId: string,
+  path: string,
+): Error {
+  return new Error(
+    `Unsupported sim DynamoDB CloudFormation Resource ${logicalId}: ` +
+      `${path} is a real AWS::DynamoDB::Table property that simulated ` +
+      `DynamoDB does not simulate, so the table is skipped rather than ` +
+      `created without it`,
+  );
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -1,4 +1,9 @@
-import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnDynamoDbTableIndexRules } from "./sim-cfn-dynamodb-table-index-rules.js";
+import {
+  dynamoDbTablePropertyError,
+  dynamoDbTableUnsimulatedPropertyError,
+} from "./sim-cfn-dynamodb-table-property-error.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
 
 /**
  * The AWS::DynamoDB::Table properties this simulation acts on.
@@ -11,7 +16,9 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "AttributeDefinitions",
   "BillingMode",
   "DeletionProtectionEnabled",
+  "GlobalSecondaryIndexes",
   "KeySchema",
+  "LocalSecondaryIndexes",
   "ProvisionedThroughput",
   "TableClass",
   "TableName",
@@ -22,16 +29,14 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
 /**
  * Real AWS::DynamoDB::Table properties this simulation does not model.
  *
- * Each one changes what the table does. A table deployed without its secondary
- * indexes would answer queries differently, so the Resource is skipped rather
- * than deployed as something else.
+ * Each one changes what the table does. A table deployed without the stream its
+ * changes were meant to be published to would leave whatever reads that stream
+ * waiting, so the Resource is skipped rather than deployed as something else.
  */
 const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ContributorInsightsSpecification",
-  "GlobalSecondaryIndexes",
   "ImportSourceSpecification",
   "KinesisStreamSpecification",
-  "LocalSecondaryIndexes",
   "OnDemandThroughput",
   "PointInTimeRecoverySpecification",
   "ResourcePolicy",
@@ -40,28 +45,9 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "WarmThroughput",
 ]);
 
-/**
- * Build the error a property of an AWS::DynamoDB::Table Resource is refused
- * with.
- *
- * The wording matters. Sim CloudFormation skips a Resource whose error reads as
- * an unsupported Resource type, and skipping is the wrong answer for a table
- * the template described in a way it cannot be created: nothing is missing from
- * the simulation, the template is wrong, and the same template would fail on
- * real CloudFormation.
- */
-export function dynamoDbTablePropertyError(
-  logicalId: string,
-  reason: string,
-): Error {
-  return new Error(
-    `Invalid AWS::DynamoDB::Table Resource ${logicalId}: ${reason}`,
-  );
-}
-
 interface SimCfnDynamoDbTablePropertyRulesProperties {
   readonly logicalId: string;
-  readonly properties: SimCfnTemplateValueRecord;
+  readonly values: SimCfnDynamoDbTableValues;
 }
 
 /**
@@ -72,23 +58,28 @@ interface SimCfnDynamoDbTablePropertyRulesProperties {
  * was left out. Anything that is not an AWS::DynamoDB::Table property at all
  * fails the Resource instead, because that is a template real CloudFormation
  * would refuse too.
+ *
+ * The two index properties carry properties of their own, which are held to the
+ * same rule a level down.
  */
 export class SimCfnDynamoDbTablePropertyRules {
   private readonly logicalId: string;
-  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly values: SimCfnDynamoDbTableValues;
 
   constructor(properties: SimCfnDynamoDbTablePropertyRulesProperties) {
     this.logicalId = properties.logicalId;
-    this.properties = properties.properties;
+    this.values = properties.values;
   }
 
   /**
    * Refuse everything about this Resource that is not simulated.
    */
   assertSimulated(): void {
-    for (const name of Object.keys(this.properties)) {
+    for (const name of this.values.names) {
       this.assertSimulatedProperty(name);
     }
+
+    this.assertSimulatedIndexes();
   }
 
   private assertSimulatedProperty(name: string): void {
@@ -97,7 +88,7 @@ export class SimCfnDynamoDbTablePropertyRules {
     }
 
     if (unsimulatedPropertyNames.has(name)) {
-      throw this.skipError(name);
+      throw dynamoDbTableUnsimulatedPropertyError(this.logicalId, name);
     }
 
     throw dynamoDbTablePropertyError(
@@ -107,18 +98,14 @@ export class SimCfnDynamoDbTablePropertyRules {
   }
 
   /**
-   * The error that skips this Resource over a property that is not simulated.
-   *
-   * The "Unsupported sim ... CloudFormation" wording is what marks the Resource
-   * as skipped rather than failing the stack, so the rest of the template still
-   * deploys and the skip reason names the property.
+   * Refuse what the entries of the two index properties ask for and cannot get.
    */
-  private skipError(name: string): Error {
-    return new Error(
-      `Unsupported sim DynamoDB CloudFormation Resource ${this.logicalId}: ` +
-        `${name} is a real AWS::DynamoDB::Table property that simulated ` +
-        `DynamoDB does not simulate, so the table is skipped rather than ` +
-        `created without it`,
+  private assertSimulatedIndexes(): void {
+    SimCfnDynamoDbTableIndexRules.global(this.logicalId).assertSimulated(
+      this.values.list("GlobalSecondaryIndexes"),
+    );
+    SimCfnDynamoDbTableIndexRules.local(this.logicalId).assertSimulated(
+      this.values.list("LocalSecondaryIndexes"),
     );
   }
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-throughput.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-throughput.ts
@@ -1,0 +1,24 @@
+import type { SimDynamoDbProvisionedThroughput } from "../../command/table/table.types.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * Read the capacity a `ProvisionedThroughput` property asks for.
+ *
+ * A table and each of its global secondary indexes are provisioned separately
+ * and state it the same way, so both are read here rather than each carrying a
+ * copy of the shape.
+ */
+export function readSimCfnDynamoDbThroughput(
+  values: SimCfnDynamoDbTableValues,
+): SimDynamoDbProvisionedThroughput | undefined {
+  const throughput = values.object("ProvisionedThroughput");
+
+  if (throughput === undefined) {
+    return undefined;
+  }
+
+  return {
+    ReadCapacityUnits: throughput.number("ReadCapacityUnits"),
+    WriteCapacityUnits: throughput.number("WriteCapacityUnits"),
+  };
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-values.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-values.ts
@@ -2,7 +2,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import { dynamoDbTablePropertyError } from "./sim-cfn-dynamodb-table-property-rules.js";
+import { dynamoDbTablePropertyError } from "./sim-cfn-dynamodb-table-property-error.js";
 
 interface SimCfnDynamoDbTableValuesProperties {
   readonly logicalId: string;
@@ -33,6 +33,13 @@ export class SimCfnDynamoDbTableValues {
   }
 
   /**
+   * The names of the properties this object holds.
+   */
+  get names(): readonly string[] {
+    return this.entries.keys().toArray();
+  }
+
+  /**
    * Read a property holding a list of objects, such as a key schema.
    *
    * A property the template leaves out reads as no entries, which is what
@@ -46,11 +53,41 @@ export class SimCfnDynamoDbTableValues {
     }
 
     if (!Array.isArray(value)) {
-      throw this.error(`${this.at(name)} must be a list`);
+      throw this.error(`${this.pathTo(name)} must be a list`);
     }
 
     return value.map((element, index) => {
-      return this.reader(element, `${this.at(name)}.${index.toString()}`);
+      return this.reader(element, `${this.pathTo(name)}.${index.toString()}`);
+    });
+  }
+
+  /**
+   * Read a property holding a list of strings, such as the attributes an index
+   * projection names.
+   *
+   * A property the template leaves out reads as nothing rather than as an empty
+   * list, since the two say different things: an index projecting no named
+   * attributes is not the same as one that named none.
+   */
+  strings(name: string): readonly string[] | undefined {
+    const value = this.entries.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.error(`${this.pathTo(name)} must be a list`);
+    }
+
+    return value.map((element, index) => {
+      if (typeof element !== "string") {
+        throw this.error(
+          `${this.pathTo(name)}.${index.toString()} must be a string`,
+        );
+      }
+
+      return element;
     });
   }
 
@@ -64,7 +101,7 @@ export class SimCfnDynamoDbTableValues {
       return undefined;
     }
 
-    return this.reader(value, this.at(name));
+    return this.reader(value, this.pathTo(name));
   }
 
   /**
@@ -78,7 +115,7 @@ export class SimCfnDynamoDbTableValues {
     }
 
     if (typeof value !== "string") {
-      throw this.error(`${this.at(name)} must be a string`);
+      throw this.error(`${this.pathTo(name)} must be a string`);
     }
 
     return value;
@@ -109,7 +146,7 @@ export class SimCfnDynamoDbTableValues {
       }
     }
 
-    throw this.error(`${this.at(name)} must be a number`);
+    throw this.error(`${this.pathTo(name)} must be a number`);
   }
 
   /**
@@ -134,7 +171,7 @@ export class SimCfnDynamoDbTableValues {
       return false;
     }
 
-    throw this.error(`${this.at(name)} must be true or false`);
+    throw this.error(`${this.pathTo(name)} must be true or false`);
   }
 
   /**
@@ -142,6 +179,17 @@ export class SimCfnDynamoDbTableValues {
    */
   error(reason: string): Error {
     return dynamoDbTablePropertyError(this.logicalId, reason);
+  }
+
+  /**
+   * The whole path a property sits at, for a refusal to name.
+   */
+  pathTo(name: string): string {
+    if (this.path === "") {
+      return name;
+    }
+
+    return `${this.path}.${name}`;
   }
 
   /**
@@ -160,16 +208,5 @@ export class SimCfnDynamoDbTableValues {
       properties: value,
       path,
     });
-  }
-
-  /**
-   * The whole path a property sits at, for a refusal to name.
-   */
-  private at(name: string): string {
-    if (this.path === "") {
-      return name;
-    }
-
-    return `${this.path}.${name}`;
   }
 }


### PR DESCRIPTION
GlobalSecondaryIndexes and LocalSecondaryIndexes are read off an AWS::DynamoDB::Table Resource and handed to CreateTable, so an index a template declared is the index an SDK caller would have got. The two property refusals are gone, and the index entries are held to the same simulated-property rule the table is: an unmodelled setting on a global index skips the table naming it, and a property neither index kind has fails the Resource.

AWS creates one indexed table at a time in an account and region, which sim CloudFormation does not, so that divergence is documented under Limitations rather than serialised.

Resolves https://github.com/KensioSoftware/yulin/issues/271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying DynamoDB tables with global and local secondary indexes through CloudFormation and CDK.
  * Added querying, projections, and independently provisioned capacity for supported indexes.
* **Bug Fixes**
  * Improved validation and clearer handling of invalid or unsupported index configurations.
  * Preserved key-schema ordering and optional projection settings during deployment.
* **Documentation**
  * Added indexed-table examples, supported functionality, validation guidance, CDK usage, and concurrency limitations.
* **Tests**
  * Added coverage for deployment, validation, index queries, projections, and resource status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->