### PR TITLE
feat: deploy CDK-defined simulated Cognito user pools and app clients…

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1051,12 +1051,15 @@ the secret with `DescribeUserPoolClient`, which reports it here as it does on re
 
 The properties each type reads are the ones this simulation models:
 
-- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `MfaConfiguration` and
-  `UserPoolTier`. The last two are accepted at their AWS defaults and refused otherwise, as
-  `CreateUserPool` refuses them.
+- `AWS::Cognito::UserPool`: `UserPoolName`, `Policies`, `DeletionProtection`, `MfaConfiguration`,
+  `UserPoolTier`, `AccountRecoverySetting`, `AdminCreateUserConfig`, `EmailVerificationMessage`,
+  `EmailVerificationSubject`, `SmsVerificationMessage` and `VerificationMessageTemplate`. All but
+  the first three are accepted at one value each and refused at any other, as `CreateUserPool`
+  refuses them.
 - `AWS::Cognito::UserPoolClient`: `UserPoolId`, `ClientName`, `GenerateSecret`, `ExplicitAuthFlows`,
-  `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity` and
-  `TokenValidityUnits`.
+  `PreventUserExistenceErrors`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`,
+  `TokenValidityUnits`, `AllowedOAuthFlowsUserPoolClient` and `SupportedIdentityProviders`. The last
+  two are accepted at the values that turn managed login off.
 - `AWS::Cognito::UserPoolGroup`: `UserPoolId`, `GroupName`, `Description`, `Precedence` and
   `RoleArn`.
 
@@ -1064,6 +1067,120 @@ Any other property is refused at deploy time, naming the logical id and the prop
 deploying a resource that would behave differently on AWS. A stack that forgets
 `ALLOW_ADMIN_USER_PASSWORD_AUTH` therefore fails at the sign-in here as it would in a deployment,
 which is the point of deploying the template rather than restating it.
+
+`UserPoolName` and `ClientName` are optional. A template that sets neither gets
+`<stack name>-<logical id>`, as real CloudFormation generates a name, trimmed to the 128 characters
+Cognito allows if the two are longer than that together. Real CloudFormation adds random characters
+on the end and this does not, so the name is the same on every deployment of the same template and a
+test can assert it.
+
+## Properties accepted without being simulated
+
+A CDK `UserPool` construct emits six properties on `AWS::Cognito::UserPool` before it has been asked
+for anything, and a client created with `disableOAuth` emits two on `AWS::Cognito::UserPoolClient`.
+None of the eight is simulated. They configure email and SMS delivery, verification message wording,
+account recovery, and whether users may sign themselves up, and none of those happens here.
+
+They are accepted anyway, at one value each and no other, so a CDK stack deploys as it stands.
+
+```typescript sim-cognito-cdk-defaults
+/**
+ * Deploying the Resources a CDK UserPool construct emits by default.
+ */
+
+import { DescribeUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      // What `new cognito.UserPool(stack, "Pool")` synthesizes, with no
+      // UserPoolName among it.
+      Pool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          AccountRecoverySetting: {
+            RecoveryMechanisms: [
+              { Name: "verified_phone_number", Priority: 1 },
+              { Name: "verified_email", Priority: 2 },
+            ],
+          },
+          AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+          EmailVerificationMessage: verificationMessage,
+          EmailVerificationSubject: "Verify your new account",
+          SmsVerificationMessage: verificationMessage,
+          VerificationMessageTemplate: {
+            DefaultEmailOption: "CONFIRM_WITH_CODE",
+            EmailMessage: verificationMessage,
+            EmailSubject: "Verify your new account",
+            SmsMessage: verificationMessage,
+          },
+        },
+      },
+      // What `pool.addClient("Client", { disableOAuth: true })` synthesizes.
+      PoolClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "Pool" },
+          AllowedOAuthFlowsUserPoolClient: false,
+          SupportedIdentityProviders: ["COGNITO"],
+        },
+      },
+    },
+    Outputs: { PoolId: { Value: { Ref: "Pool" } } },
+  },
+});
+await stack.waitForDeployComplete();
+
+const userPoolId = stack.outputs.get("PoolId")?.value as string;
+
+// The pool is named after the stack and the logical id, as the template named
+// neither it nor the client.
+const described = await simAws
+  .cognitoIdentityProvider()
+  .describeUserPool(new DescribeUserPoolCommand({ UserPoolId: userPoolId }));
+
+console.log(described.UserPool?.Name); // "app-stack-Pool"
+
+// What the template declared is reported back, though nothing here reads it.
+console.log(described.UserPool?.AdminCreateUserConfig);
+// { AllowAdminCreateUserOnly: true }
+```
+
+The accepted value of each is below. A pool or a client created without one of these reports it not
+at all, rather than reporting the value it would have had to use.
+
+| Property                          | Accepted value                                                             |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `AccountRecoverySetting`          | `verified_phone_number` at priority 1, then `verified_email` at priority 2 |
+| `AdminCreateUserConfig`           | `{ AllowAdminCreateUserOnly: true }`                                       |
+| `EmailVerificationMessage`        | `The verification code to your new account is {####}`                      |
+| `EmailVerificationSubject`        | `Verify your new account`                                                  |
+| `SmsVerificationMessage`          | `The verification code to your new account is {####}`                      |
+| `VerificationMessageTemplate`     | `CONFIRM_WITH_CODE`, with the three strings above                          |
+| `AllowedOAuthFlowsUserPoolClient` | `false`                                                                    |
+| `SupportedIdentityProviders`      | `["COGNITO"]`                                                              |
+
+Every key is compared, so an object carrying one the accepted value does not have is refused along
+with everything else that differs. The refusal names the property, the value asked for and the value
+that is simulated.
+
+Two of these are worth reading twice. `AllowAdminCreateUserOnly` is accepted at `true` and refused
+at `false`, which is the opposite way round from the AWS default: `false` says users may sign
+themselves up, and there is no `SignUp` command here to do that with, so accepting it would promise
+something this simulation cannot do. And the verification wording is accepted only at the wording
+CDK emits, because a request writing its own is asking for a message a user would read, and no
+message is ever delivered.
+
+These values are what `aws-cdk-lib` 2.262.1 synthesizes. Whether real Cognito defaults a bare pool
+to the same wording has not been checked against a live account.
 
 ## Serving a pool's JWKS on localhost
 
@@ -1354,11 +1471,20 @@ Current documented limitations:
   protection needs `UpdateUserPool`.
 - Unsimulated `CreateUserPool` inputs are refused rather than ignored: `UsernameAttributes`,
   `AliasAttributes`, `AutoVerifiedAttributes`, `Schema`, `LambdaConfig`, `UsernameConfiguration`,
-  `UserAttributeUpdateSettings`, `DeviceConfiguration`, `AccountRecoverySetting`,
-  `AdminCreateUserConfig`, `UserPoolAddOns`, `KeyConfiguration`, `IssuerConfiguration`,
-  `UserPoolTags`, the email and SMS configurations, the message templates, an `MfaConfiguration`
-  other than `OFF`, a `UserPoolTier` other than `ESSENTIALS`, a `SignInPolicy`, and a
-  `PasswordHistorySize`.
+  `UserAttributeUpdateSettings`, `DeviceConfiguration`, `UserPoolAddOns`, `KeyConfiguration`,
+  `IssuerConfiguration`, `UserPoolTags`, the email and SMS configurations, an
+  `SmsAuthenticationMessage`, an `MfaConfiguration` other than `OFF`, a `UserPoolTier` other than
+  `ESSENTIALS`, a `SignInPolicy`, and a `PasswordHistorySize`.
+- `AccountRecoverySetting`, `AdminCreateUserConfig`, `EmailVerificationMessage`,
+  `EmailVerificationSubject`, `SmsVerificationMessage` and `VerificationMessageTemplate` are
+  accepted at one value each and refused at any other. Nothing here reads any of them. They are
+  accepted so a CDK stack deploys, and reported back by `DescribeUserPool` so what the template
+  declared stays visible. The accepted values are in "Properties accepted without being simulated"
+  above.
+- `AdminCreateUserConfig` is accepted at `{ AllowAdminCreateUserOnly: true }` and refused at
+  `AllowAdminCreateUserOnly: false`, though `false` is what AWS itself defaults to. `false` says
+  users may sign themselves up, and there is no `SignUp` command here, so accepting it would let a
+  pool be created that claims something this simulation cannot do. This is stricter than AWS.
 - `UsernameAttributes` is worth calling out among those. A pool that signs users in by email or phone
   number stores a generated UUID as the username, so a pool created here without that would answer
   with the wrong username and the right one on real AWS.
@@ -1369,6 +1495,9 @@ Current documented limitations:
   `AnalyticsConfiguration`, `AuthSessionValidity`, `EnablePropagateAdditionalUserContextData`,
   `RefreshTokenRotation`, `ReadAttributes`, `WriteAttributes`, and an `EnableTokenRevocation` of
   `false`.
+- An `AllowedOAuthFlowsUserPoolClient` of `false`, and a `SupportedIdentityProviders` of
+  `["COGNITO"]`, are accepted and change nothing, because both say the client wants the pool's own
+  users and nothing else, which is all there is here. `DescribeUserPoolClient` reports them back.
 - Unsimulated authentication inputs are refused the same way: `ClientMetadata` and
   `AnalyticsMetadata` on all four operations, `ContextData` on the admin ones, `UserContextData` on
   the client ones, and a `Session` on `InitiateAuth` or `AdminInitiateAuth`, which continues a flow

--- a/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
+++ b/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Deploying the Resources a CDK UserPool construct emits by default.
+ */
+
+import { DescribeUserPoolCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "app-stack",
+  template: {
+    Resources: {
+      // What `new cognito.UserPool(stack, "Pool")` synthesizes, with no
+      // UserPoolName among it.
+      Pool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          AccountRecoverySetting: {
+            RecoveryMechanisms: [
+              { Name: "verified_phone_number", Priority: 1 },
+              { Name: "verified_email", Priority: 2 },
+            ],
+          },
+          AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+          EmailVerificationMessage: verificationMessage,
+          EmailVerificationSubject: "Verify your new account",
+          SmsVerificationMessage: verificationMessage,
+          VerificationMessageTemplate: {
+            DefaultEmailOption: "CONFIRM_WITH_CODE",
+            EmailMessage: verificationMessage,
+            EmailSubject: "Verify your new account",
+            SmsMessage: verificationMessage,
+          },
+        },
+      },
+      // What `pool.addClient("Client", { disableOAuth: true })` synthesizes.
+      PoolClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "Pool" },
+          AllowedOAuthFlowsUserPoolClient: false,
+          SupportedIdentityProviders: ["COGNITO"],
+        },
+      },
+    },
+    Outputs: { PoolId: { Value: { Ref: "Pool" } } },
+  },
+});
+await stack.waitForDeployComplete();
+
+const userPoolId = stack.outputs.get("PoolId")?.value as string;
+
+// The pool is named after the stack and the logical id, as the template named
+// neither it nor the client.
+const described = await simAws
+  .cognitoIdentityProvider()
+  .describeUserPool(new DescribeUserPoolCommand({ UserPoolId: userPoolId }));
+
+console.log(described.UserPool?.Name); // "app-stack-Pool"
+
+// What the template declared is reported back, though nothing here reads it.
+console.log(described.UserPool?.AdminCreateUserConfig);
+// { AllowAdminCreateUserOnly: true }

--- a/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
+++ b/src/service/cloudformation/cdk/cognito/sim-cdk-cognito-user-pool.loc.test.ts
@@ -1,0 +1,162 @@
+import {
+  AdminCreateUserCommand,
+  AdminInitiateAuthCommand,
+  AdminSetUserPasswordCommand,
+  DescribeUserPoolClientCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+describe("Sim CDK Cognito user pool deployment local integration", () => {
+  it("deploys a CDK user pool and app client a user signs in against", async () => {
+    // Given a CDK stack with a user pool and an app client asking for nothing
+    // but the admin password flow, so neither is named and both carry only
+    // the properties CDK emits by default.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const pool = new cognito.UserPool(stack, "Pool");
+const client = pool.addClient("Client", {
+  disableOAuth: true,
+  authFlows: { adminUserPassword: true },
+});
+
+new cdk.CfnOutput(stack, "PoolId", { value: pool.userPoolId });
+new cdk.CfnOutput(stack, "ClientId", { value: client.userPoolClientId });
+new cdk.CfnOutput(stack, "ProviderUrl", { value: pool.userPoolProviderUrl });
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the Cognito Resources CDK
+    // emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await stack.waitForDeployComplete();
+
+    // Then the pool id CDK output carries is the deployed pool.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    const cognito = scoped.cognitoIdentityProvider();
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertIdentical(described.UserPool?.Id, userPoolId);
+    assertIdentical(
+      stack.outputs.get("ProviderUrl")?.value,
+      `https://cognito-idp.eu-west-2.amazonaws.com/${userPoolId}`,
+    );
+
+    // And it is named after the stack and the logical ID, because the CDK
+    // construct emits no UserPoolName and CreateUserPool needs one.
+    assertNonNullable(described.UserPool.Name);
+    assertStringStartsWith(described.UserPool.Name, "TestStack-Pool");
+
+    // And the properties CDK emits for a pool nobody configured were kept as
+    // the template set them, rather than failing the stack or being dropped.
+    assertObjectEquals(described.UserPool.AdminCreateUserConfig, {
+      AllowAdminCreateUserOnly: true,
+    });
+    assertObjectEquals(described.UserPool.AccountRecoverySetting, {
+      RecoveryMechanisms: [
+        { Name: "verified_phone_number", Priority: 1 },
+        { Name: "verified_email", Priority: 2 },
+      ],
+    });
+    assertIdentical(
+      described.UserPool.EmailVerificationMessage,
+      verificationMessage,
+    );
+
+    // And the app client deployed with the two settings a disableOAuth client
+    // emits, which say it wants the pool's own users and no hosted UI.
+    const describedClient = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+    assertNonNullable(describedClient.UserPoolClient);
+    assertFalse(describedClient.UserPoolClient.AllowedOAuthFlowsUserPoolClient);
+    assertArrayEquals(
+      describedClient.UserPoolClient.SupportedIdentityProviders,
+      ["COGNITO"],
+    );
+
+    // And a user created in the deployed pool signs in through the deployed
+    // client, which is what deploying the template rather than restating it
+    // is for.
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "alice" }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: "alice",
+        Password: "Sup3rSecretPassw0rd!",
+        Permanent: true,
+      }),
+    );
+
+    const signedIn = await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: "alice",
+          PASSWORD: "Sup3rSecretPassw0rd!",
+        },
+      }),
+    );
+
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cognito/README.md
+++ b/src/service/cognito/README.md
@@ -161,6 +161,21 @@ to a Command that has nowhere to refuse them. Properties the API does know, such
 `MfaConfiguration`, are passed through instead, so the refusal that reaches the reader is the one
 that says why.
 
+A property whose only accepted value is one particular value counts as simulated at this layer and
+is judged by the Command that receives it, so the value is judged in one place rather than two.
+`SimCognitoUnsimulatedInput` compares a string or a boolean, and `SimCognitoUnsimulatedStructure`
+compares an object by its contents, through the canonical rendering in
+`SimCognitoCanonicalValue`. What each Command accepts and why is in the doc comments on
+`SimCognitoUnsimulatedUserPoolFeatures` and `SimCognitoUnsimulatedUserPoolMessaging`. The values
+each pool and client was created with are kept in `SimCognitoUnsimulatedPoolSettings` and
+`SimCognitoUnsimulatedClientSettings`, which exist only so a described resource reports back what
+its request set.
+
+`UserPoolName` and `ClientName` are both optional, and a CDK `UserPool` construct emits neither,
+while both creation Commands require a name. `SimCfnCognitoGeneratedName` generates one from the
+stack name and the logical ID. One class covers both because Cognito gives a pool and a client the
+same name rules.
+
 `Ref` and `Fn::GetAtt` live in `cloudformation/resource/cfn/cognito/`, one adapter per Resource
 type, rather than on the service objects.
 

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-properties.ts
@@ -4,15 +4,22 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateUserPoolClientCommandInput } from "../../command/client/user-pool-client.command.js";
-import type { SimCognitoTokenValidityUnitsType } from "../../user-pool/client/sim-cognito-token-validity.js";
+import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+import { SimCfnCognitoTokenValidityUnits } from "./sim-cfn-cognito-token-validity-units.js";
 
 /**
  * The AWS::Cognito::UserPoolClient properties this simulation deploys.
  *
- * The OAuth and managed login properties are absent because the hosted UI is
- * not simulated at all, so a client deployed with them would offer flows
- * nothing here can run.
+ * The OAuth and managed login properties that turn the hosted UI on are
+ * absent, because it is not simulated at all, so a client deployed with them
+ * would offer flows nothing here can run.
+ *
+ * The last two are the ones that turn it off, which is what a CDK client
+ * created with `disableOAuth` emits. CreateUserPoolClient accepts an
+ * `AllowedOAuthFlowsUserPoolClient` of `false`, and a
+ * `SupportedIdentityProviders` naming only `COGNITO`, because both ask for
+ * the pool's own users and nothing else. Any other value is refused there.
  */
 const simulatedProperties = [
   "UserPoolId",
@@ -24,12 +31,9 @@ const simulatedProperties = [
   "IdTokenValidity",
   "RefreshTokenValidity",
   "TokenValidityUnits",
+  "AllowedOAuthFlowsUserPoolClient",
+  "SupportedIdentityProviders",
 ];
-
-/**
- * The `TokenValidityUnits` fields, which are all of them.
- */
-const modelledValidityUnits = ["AccessToken", "IdToken", "RefreshToken"];
 
 interface SimCfnCognitoClientPropertiesProperties {
   readonly resource: SimCfnResource;
@@ -73,7 +77,7 @@ export class SimCfnCognitoClientProperties {
   createUserPoolClientInput(): SimCreateUserPoolClientCommandInput {
     return {
       UserPoolId: this.userPoolId(),
-      ClientName: this.string(this.properties["ClientName"], "ClientName"),
+      ClientName: this.clientName(),
       GenerateSecret: this.propertyParser.optionalBoolean(
         this.resource,
         this.properties["GenerateSecret"],
@@ -100,43 +104,38 @@ export class SimCfnCognitoClientProperties {
         this.properties["RefreshTokenValidity"],
         "RefreshTokenValidity",
       ),
-      TokenValidityUnits: this.tokenValidityUnits(),
+      TokenValidityUnits: new SimCfnCognitoTokenValidityUnits({
+        resource: this.resource,
+        propertyParser: this.propertyParser,
+      }).parse(this.properties["TokenValidityUnits"]),
+      AllowedOAuthFlowsUserPoolClient: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["AllowedOAuthFlowsUserPoolClient"],
+        "AllowedOAuthFlowsUserPoolClient",
+      ),
+      SupportedIdentityProviders: this.propertyParser.optionalStringArray(
+        this.resource,
+        this.properties["SupportedIdentityProviders"],
+        "SupportedIdentityProviders",
+      ),
     };
   }
 
   /**
-   * The units the three validity numbers are counted in.
+   * The client's name, generated from the stack and the logical ID when the
+   * template names none, as real CloudFormation generates one.
    */
-  private tokenValidityUnits(): SimCognitoTokenValidityUnitsType | undefined {
-    const units = this.propertyParser.optionalRecord(
-      this.resource,
-      this.properties["TokenValidityUnits"],
-      "TokenValidityUnits",
-    );
+  private clientName(): string {
+    const named = this.string(this.properties["ClientName"], "ClientName");
 
-    if (units === undefined) {
-      return undefined;
+    if (named !== undefined) {
+      return named;
     }
 
-    this.propertyParser.requireOnlyKeys(
-      this.resource,
-      units,
-      modelledValidityUnits,
-      "TokenValidityUnits ",
-    );
-
-    return {
-      AccessToken: this.unit(units["AccessToken"], "AccessToken"),
-      IdToken: this.unit(units["IdToken"], "IdToken"),
-      RefreshToken: this.unit(units["RefreshToken"], "RefreshToken"),
-    };
-  }
-
-  private unit(
-    value: SimCfnTemplateValue | undefined,
-    field: string,
-  ): string | undefined {
-    return this.string(value, `TokenValidityUnits ${field}`);
+    return new SimCfnCognitoGeneratedName({
+      stackName: this.resource.stackName,
+      logicalId: this.resource.logicalId,
+    }).value;
   }
 
   private string(

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-token-validity-units.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-token-validity-units.ts
@@ -1,0 +1,73 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCognitoTokenValidityUnitsType } from "../../user-pool/client/sim-cognito-token-validity.js";
+import type { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
+
+/**
+ * The `TokenValidityUnits` fields, which are all of them.
+ */
+const modelledFields = ["AccessToken", "IdToken", "RefreshToken"];
+
+interface SimCfnCognitoTokenValidityUnitsProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnCognitoPropertyParser;
+}
+
+/**
+ * Reads the `TokenValidityUnits` property of an AWS::Cognito::UserPoolClient
+ * Resource into the shape CreateUserPoolClient takes.
+ *
+ * What each unit may be is left to the client, which is where the same
+ * request from an SDK caller is checked.
+ */
+export class SimCfnCognitoTokenValidityUnits {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnCognitoPropertyParser;
+
+  constructor(properties: SimCfnCognitoTokenValidityUnitsProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The units the three validity numbers are counted in, or undefined when
+   * the template names none.
+   */
+  parse(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCognitoTokenValidityUnitsType | undefined {
+    const units = this.propertyParser.optionalRecord(
+      this.resource,
+      value,
+      "TokenValidityUnits",
+    );
+
+    if (units === undefined) {
+      return undefined;
+    }
+
+    this.propertyParser.requireOnlyKeys(
+      this.resource,
+      units,
+      modelledFields,
+      "TokenValidityUnits ",
+    );
+
+    return {
+      AccessToken: this.unit(units["AccessToken"], "AccessToken"),
+      IdToken: this.unit(units["IdToken"], "IdToken"),
+      RefreshToken: this.unit(units["RefreshToken"], "RefreshToken"),
+    };
+  }
+
+  private unit(
+    value: SimCfnTemplateValue | undefined,
+    field: string,
+  ): string | undefined {
+    return this.propertyParser.optionalString(
+      this.resource,
+      value,
+      `TokenValidityUnits ${field}`,
+    );
+  }
+}

--- a/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
@@ -1,0 +1,227 @@
+import {
+  DescribeUserPoolClientCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployFailure,
+  simAwsInEuWest2,
+} from "../../../../test/cognito/cfn-deploy.js";
+
+/**
+ * The AWS::Cognito::UserPool and AWS::Cognito::UserPoolClient Resources
+ * `aws-cdk-lib` 2.262.1 emits for `new cognito.UserPool(stack, "Pool")` and
+ * `pool.addClient("Client", { disableOAuth: true })`.
+ *
+ * They are written out here rather than synthesized, so this suite stays an
+ * isolated test. The CDK CLI runs the same template through in
+ * `src/service/cloudformation/cdk/cognito/`.
+ */
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+const cdkPoolProperties = {
+  AccountRecoverySetting: {
+    RecoveryMechanisms: [
+      { Name: "verified_phone_number", Priority: 1 },
+      { Name: "verified_email", Priority: 2 },
+    ],
+  },
+  AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+  EmailVerificationMessage: verificationMessage,
+  EmailVerificationSubject: "Verify your new account",
+  SmsVerificationMessage: verificationMessage,
+  VerificationMessageTemplate: {
+    DefaultEmailOption: "CONFIRM_WITH_CODE",
+    EmailMessage: verificationMessage,
+    EmailSubject: "Verify your new account",
+    SmsMessage: verificationMessage,
+  },
+};
+
+const cdkResources = {
+  PoolD3F588B8: {
+    Type: "AWS::Cognito::UserPool",
+    Properties: cdkPoolProperties,
+  },
+  PoolClient8A3E5EB7: {
+    Type: "AWS::Cognito::UserPoolClient",
+    Properties: {
+      AllowedOAuthFlowsUserPoolClient: false,
+      SupportedIdentityProviders: ["COGNITO"],
+      UserPoolId: { Ref: "PoolD3F588B8" },
+    },
+  },
+};
+
+const cdkOutputs = {
+  PoolId: { Value: { Ref: "PoolD3F588B8" } },
+  ClientId: { Value: { Ref: "PoolClient8A3E5EB7" } },
+};
+
+describe("Cognito CloudFormation defaults a CDK stack emits", () => {
+  it("deploys a pool and a client asking for nothing in particular", async () => {
+    // Given the template CDK synthesizes for a bare UserPool and a client
+    // created with disableOAuth, which names neither of them.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "app-stack",
+      template: { Resources: cdkResources, Outputs: cdkOutputs },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the pool deployed, rather than the six properties CDK emits
+    // failing the stack.
+    const userPoolId = stack.outputs.get("PoolId")?.value;
+    const clientId = stack.outputs.get("ClientId")?.value;
+    assertTypeString(userPoolId);
+    assertTypeString(clientId);
+
+    // And it is named after the stack and the logical ID, because the
+    // template set no UserPoolName and CreateUserPool needs one.
+    const cognito = simAws.cognitoIdentityProvider();
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertIdentical(described.UserPool?.Name, "app-stack-PoolD3F588B8");
+
+    // And the properties the template declared are reported back, so what the
+    // stack asked for stays visible even though nothing here reads any of it.
+    assertObjectEquals(
+      described.UserPool.AdminCreateUserConfig,
+      cdkPoolProperties.AdminCreateUserConfig,
+    );
+    assertObjectEquals(
+      described.UserPool.AccountRecoverySetting,
+      cdkPoolProperties.AccountRecoverySetting,
+    );
+    assertObjectEquals(
+      described.UserPool.VerificationMessageTemplate,
+      cdkPoolProperties.VerificationMessageTemplate,
+    );
+    assertIdentical(
+      described.UserPool.EmailVerificationSubject,
+      cdkPoolProperties.EmailVerificationSubject,
+    );
+
+    // And the client deployed with the two settings that say it wants the
+    // pool's own users and no hosted UI, under a name generated the same way
+    // because the template named it no more than it named the pool.
+    const describedClient = await cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+      }),
+    );
+    assertNonNullable(describedClient.UserPoolClient);
+    assertIdentical(
+      describedClient.UserPoolClient.ClientName,
+      "app-stack-PoolClient8A3E5EB7",
+    );
+    assertFalse(describedClient.UserPoolClient.AllowedOAuthFlowsUserPoolClient);
+    assertArrayEquals(
+      describedClient.UserPoolClient.SupportedIdentityProviders,
+      ["COGNITO"],
+    );
+  });
+
+  it("refuses a pool property at a value other than the one it accepts", async () => {
+    // Given a template asking for self-service sign-up, which no command here
+    // implements.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: {
+          UserPoolName: "myapp-users",
+          AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+        },
+      },
+    });
+
+    // Then the failure names the logical ID, the property, the value asked
+    // for and the one that is simulated.
+    assertStringIncludes(error.message, "AppPool");
+    assertStringIncludes(error.message, "CreateUserPool AdminCreateUserConfig");
+    assertStringIncludes(error.message, '{"AllowAdminCreateUserOnly":false}');
+    assertStringIncludes(error.message, "self-service sign-up");
+    assertStringIncludes(
+      error.message,
+      'Only {"AllowAdminCreateUserOnly":true} is supported',
+    );
+  });
+
+  it("refuses a client asking for the hosted UI flows", async () => {
+    // Given a template turning the managed login OAuth flows on, which the
+    // two accepted settings exist to turn off.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users" },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ClientName: "web",
+          AllowedOAuthFlowsUserPoolClient: true,
+        },
+      },
+    });
+
+    // Then it is refused in the words CreateUserPoolClient already uses,
+    // rather than deploying a client offering flows nothing here can run.
+    assertStringIncludes(error.message, "AppClient");
+    assertStringIncludes(
+      error.message,
+      "CreateUserPoolClient AllowedOAuthFlowsUserPoolClient 'true' is not " +
+        "simulated",
+    );
+  });
+
+  it("refuses a client federating to another identity provider", async () => {
+    // Given a template naming a provider outside the pool.
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed.
+    const error = await deployFailure(simAws, {
+      AppPool: {
+        Type: "AWS::Cognito::UserPool",
+        Properties: { UserPoolName: "myapp-users" },
+      },
+      AppClient: {
+        Type: "AWS::Cognito::UserPoolClient",
+        Properties: {
+          UserPoolId: { Ref: "AppPool" },
+          ClientName: "web",
+          SupportedIdentityProviders: ["COGNITO", "Google"],
+        },
+      },
+    });
+
+    // Then it is refused, because federated sign-in happens at the provider
+    // rather than anywhere this simulation could stand in for.
+    assertStringIncludes(error.message, "AppClient");
+    assertStringIncludes(
+      error.message,
+      "federated sign-in happens at the provider",
+    );
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-generated-name.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-generated-name.iso.test.ts
@@ -1,0 +1,108 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringLength,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCognitoName } from "../user-pool/sim-cognito-name.js";
+import { SimCfnCognitoGeneratedName } from "./sim-cfn-cognito-generated-name.js";
+
+describe("SimCfnCognitoGeneratedName", () => {
+  it("names a resource after the stack and the logical ID", () => {
+    // Given a Resource in a stack whose template named neither the pool nor
+    // the client.
+    const pool = new SimCfnCognitoGeneratedName({
+      stackName: "app-stack",
+      logicalId: "AppPool",
+    });
+    const client = new SimCfnCognitoGeneratedName({
+      stackName: "app-stack",
+      logicalId: "AppPoolClient",
+    });
+
+    // When each generated name is read, then it carries both parts, as a real
+    // CloudFormation generated name does.
+    assertIdentical(pool.value, "app-stack-AppPool");
+    assertIdentical(client.value, "app-stack-AppPoolClient");
+  });
+
+  it("falls back to the logical ID with no stack name", () => {
+    // Given a Resource created outside a stack, which has no stack name to
+    // derive a name from.
+    const noStack = new SimCfnCognitoGeneratedName({
+      stackName: undefined,
+      logicalId: "AppPool",
+    });
+    const emptyStackName = new SimCfnCognitoGeneratedName({
+      stackName: "",
+      logicalId: "AppPool",
+    });
+
+    // When the generated name is read, then it is the logical ID on its own
+    // rather than a name with an empty part in it.
+    assertIdentical(noStack.value, "AppPool");
+    assertIdentical(emptyStackName.value, "AppPool");
+  });
+
+  it("trims a generated name to the 128 characters Cognito allows", () => {
+    // Given a stack name and logical ID too long together for a Cognito name.
+    const stackName = "a".repeat(100);
+    const logicalId = "AppPoolWithARatherLongLogicalIdIndeed";
+    const name = new SimCfnCognitoGeneratedName({ stackName, logicalId });
+
+    // When the generated name is read, then it is trimmed to fit, keeping the
+    // start, so the stack name is still in it.
+    assertStringLength(name.value, 128);
+    assertStringStartsWith(name.value, `${stackName}-AppPoolWithARather`);
+
+    // And the same template generates the same name again, rather than a new
+    // one each deployment.
+    assertIdentical(
+      name.value,
+      new SimCfnCognitoGeneratedName({ stackName, logicalId }).value,
+    );
+  });
+
+  it("keeps two trimmed names apart where only the trimmed-off part differs", () => {
+    // Given two logical IDs that are the same up to the point a generated name
+    // is trimmed at. CDK puts its disambiguating hash at the end of a logical
+    // ID, which is the part trimming takes off.
+    const stackName = "a".repeat(90);
+    const sharedPrefix = "AppPool".repeat(6);
+    const first = new SimCfnCognitoGeneratedName({
+      stackName,
+      logicalId: `${sharedPrefix}D3F588B8`,
+    });
+    const second = new SimCfnCognitoGeneratedName({
+      stackName,
+      logicalId: `${sharedPrefix}8A3E5EB7`,
+    });
+
+    // When both names are read, then they are different names, so the two
+    // resources do not ask for one name.
+    assertStringLength(first.value, 128);
+    assertStringLength(second.value, 128);
+    assertFalse(first.value === second.value);
+  });
+
+  it("generates a name the Cognito name rules accept", () => {
+    // Given a trimmed name, whose hashed tail is the part most likely to
+    // carry a character a Cognito name does not allow.
+    const generated = new SimCfnCognitoGeneratedName({
+      stackName: "a".repeat(100),
+      logicalId: "AppPoolWithARatherLongLogicalIdIndeed",
+    });
+
+    // When it is put through the rules both creation commands apply.
+    const name = new SimCognitoName({
+      field: "PoolName",
+      value: generated.value,
+    });
+
+    // Then it is accepted, rather than a template without a name failing on
+    // the one this generated for it.
+    assertIdentical(name.value, generated.value);
+  });
+});

--- a/src/service/cognito/cfn/sim-cfn-cognito-generated-name.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-generated-name.ts
@@ -1,0 +1,49 @@
+import { SimCfnGeneratedResourceName } from "../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+
+/**
+ * How long a pool name or an app client name may be, which is the same
+ * length for both. `SimCognitoName` is where that rule is applied.
+ */
+const maximumNameLength = 128;
+
+interface SimCfnCognitoGeneratedNameProperties {
+  readonly stackName: string | undefined;
+  readonly logicalId: string;
+}
+
+/**
+ * The name CloudFormation gives a user pool or an app client whose template
+ * does not name it.
+ *
+ * `UserPoolName` and `ClientName` are both optional on their Resource types,
+ * and a CDK `UserPool` construct emits neither, so a template without them is
+ * ordinary rather than incomplete. `CreateUserPool` and
+ * `CreateUserPoolClient` both require a name, which is why one is generated
+ * here rather than passed on as undefined.
+ *
+ * One class covers both because Cognito gives a pool and a client the same
+ * name rules. A name is at most 128 characters, so a long stack name and
+ * logical ID together are trimmed to fit. How a generated name is put
+ * together and trimmed is the same for every service, and lives in
+ * `SimCfnGeneratedResourceName`. The characters a stack name and a
+ * logical ID are made of are all ones a Cognito name allows, so nothing here
+ * has to replace any of them.
+ */
+export class SimCfnCognitoGeneratedName {
+  private readonly generated: SimCfnGeneratedResourceName;
+
+  constructor(properties: SimCfnCognitoGeneratedNameProperties) {
+    this.generated = new SimCfnGeneratedResourceName({
+      stackName: properties.stackName,
+      logicalId: properties.logicalId,
+      maximumLength: maximumNameLength,
+    });
+  }
+
+  /**
+   * The generated name.
+   */
+  get value(): string {
+    return this.generated.value;
+  }
+}

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-properties.ts
@@ -4,6 +4,7 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateUserPoolCommandInput } from "../../command/user-pool/user-pool.command.js";
+import { SimCfnCognitoGeneratedName } from "../sim-cfn-cognito-generated-name.js";
 import { SimCfnCognitoPropertyParser } from "../sim-cfn-cognito-property-parser.js";
 import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
 
@@ -14,6 +15,13 @@ import { SimCfnCognitoPolicies } from "./sim-cfn-cognito-policies.js";
  * accepts each at its AWS default and refuses it otherwise, in words that say
  * why. A CDK stack states both routinely, so refusing them outright would
  * refuse templates that ask for nothing unsimulated.
+ *
+ * The six from `AccountRecoverySetting` down are here for the same reason,
+ * and are the six a CDK `UserPool` construct emits when it was asked for
+ * nothing in particular. Each configures message delivery, verification
+ * wording or account recovery, none of which is simulated, so CreateUserPool
+ * accepts each at the one value that asks for nothing this simulation does
+ * not already do and refuses it at every other.
  */
 const simulatedProperties = [
   "UserPoolName",
@@ -21,6 +29,12 @@ const simulatedProperties = [
   "DeletionProtection",
   "MfaConfiguration",
   "UserPoolTier",
+  "AccountRecoverySetting",
+  "AdminCreateUserConfig",
+  "EmailVerificationMessage",
+  "EmailVerificationSubject",
+  "SmsVerificationMessage",
+  "VerificationMessageTemplate",
 ];
 
 interface SimCfnCognitoUserPoolPropertiesProperties {
@@ -59,7 +73,7 @@ export class SimCfnCognitoUserPoolProperties {
    */
   createUserPoolInput(): SimCreateUserPoolCommandInput {
     return {
-      PoolName: this.string(this.properties["UserPoolName"], "UserPoolName"),
+      PoolName: this.poolName(),
       Policies: new SimCfnCognitoPolicies({
         resource: this.resource,
         propertyParser: this.propertyParser,
@@ -76,7 +90,62 @@ export class SimCfnCognitoUserPoolProperties {
         this.properties["UserPoolTier"],
         "UserPoolTier",
       ),
+      AccountRecoverySetting: this.record(
+        this.properties["AccountRecoverySetting"],
+        "AccountRecoverySetting",
+      ),
+      AdminCreateUserConfig: this.record(
+        this.properties["AdminCreateUserConfig"],
+        "AdminCreateUserConfig",
+      ),
+      VerificationMessageTemplate: this.record(
+        this.properties["VerificationMessageTemplate"],
+        "VerificationMessageTemplate",
+      ),
+      EmailVerificationMessage: this.string(
+        this.properties["EmailVerificationMessage"],
+        "EmailVerificationMessage",
+      ),
+      EmailVerificationSubject: this.string(
+        this.properties["EmailVerificationSubject"],
+        "EmailVerificationSubject",
+      ),
+      SmsVerificationMessage: this.string(
+        this.properties["SmsVerificationMessage"],
+        "SmsVerificationMessage",
+      ),
     };
+  }
+
+  /**
+   * The pool's name, generated from the stack and the logical ID when the
+   * template names none, as real CloudFormation generates one.
+   */
+  private poolName(): string {
+    const named = this.string(this.properties["UserPoolName"], "UserPoolName");
+
+    if (named !== undefined) {
+      return named;
+    }
+
+    return new SimCfnCognitoGeneratedName({
+      stackName: this.resource.stackName,
+      logicalId: this.resource.logicalId,
+    }).value;
+  }
+
+  /**
+   * A property carried as an object, passed on to CreateUserPool as written.
+   *
+   * The keys inside are not checked here. CreateUserPool compares the whole
+   * object against the one value it accepts, which refuses an unknown key
+   * along with everything else that differs.
+   */
+  private record(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): object | undefined {
+    return this.propertyParser.optionalRecord(this.resource, value, label);
   }
 
   private string(

--- a/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
+++ b/src/service/cognito/command/client/sim-cognito-client-unsimulated-options.iso.test.ts
@@ -3,13 +3,17 @@ import {
   type PreventUserExistenceErrorTypes,
   CreateUserPoolClientCommand,
   CreateUserPoolCommand,
+  DescribeUserPoolClientCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
+  assertArrayEquals,
+  assertFalse,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -170,6 +174,40 @@ describe("sim Cognito app client unsimulated options", () => {
 
     // Then it is created rather than refused.
     assertIdentical(created.UserPoolClient?.ClientName, "web");
+
+    // And the two managed login settings are reported back as the request set
+    // them, so what a template declared stays visible on the client.
+    const clientId = created.UserPoolClient.ClientId;
+    assertNonNullable(clientId);
+
+    const described = await withPool.cognito.describeUserPoolClient(
+      new DescribeUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientId: clientId,
+      }),
+    );
+    assertFalse(described.UserPoolClient?.AllowedOAuthFlowsUserPoolClient);
+    assertArrayEquals(described.UserPoolClient.SupportedIdentityProviders, [
+      "COGNITO",
+    ]);
+  });
+
+  it("reports neither of them for a client created without them", async () => {
+    // Given a user pool.
+    const withPool = await simCognitoWithPool();
+
+    // When a client is created without either managed login setting.
+    const created = await withPool.cognito.createUserPoolClient(
+      new CreateUserPoolClientCommand({
+        UserPoolId: withPool.userPoolId,
+        ClientName: "web",
+      }),
+    );
+
+    // Then neither appears, rather than the client reporting the value a
+    // request would have had to use to be accepted.
+    assertUndefined(created.UserPoolClient?.AllowedOAuthFlowsUserPoolClient);
+    assertUndefined(created.UserPoolClient?.SupportedIdentityProviders);
   });
 
   it("takes a PreventUserExistenceErrors of either value", async () => {

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-commands.ts
@@ -69,6 +69,7 @@ export class SimCognitoUserPoolClientCommands {
       explicitAuthFlows: input.ExplicitAuthFlows,
       preventUserExistenceErrors: input.PreventUserExistenceErrors,
       tokenValidity: input,
+      unsimulatedSettings: input,
     });
 
     pool.addClient(client);

--- a/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
+++ b/src/service/cognito/command/client/sim-cognito-user-pool-client-view.ts
@@ -14,6 +14,10 @@ export class SimCognitoUserPoolClientView {
    * `DescribeUserPoolClient` is how an application reads the secret it was
    * given, since nothing else ever shows it again.
    *
+   * The two managed login settings the client accepted without acting on
+   * are reported back as the request set them, and omitted where it set
+   * neither.
+   *
    * `AccessTokenValidity` and `IdTokenValidity` appear only when the request
    * set them, which is what real Cognito does. `RefreshTokenValidity` always
    * appears, defaulted to thirty days, and so does
@@ -35,6 +39,7 @@ export class SimCognitoUserPoolClientView {
       TokenValidityUnits: tokenValidity.unitsOutput(),
       CreationDate: client.creationDate,
       LastModifiedDate: client.lastModifiedDate,
+      ...client.unsimulatedSettings.toOutput(),
     };
   }
 

--- a/src/service/cognito/command/client/user-pool-client.command.ts
+++ b/src/service/cognito/command/client/user-pool-client.command.ts
@@ -1,15 +1,18 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimCognitoTokenValidityUnitsType } from "../../user-pool/client/sim-cognito-token-validity.js";
+import type { SimCognitoUnsimulatedClientSettingsType } from "../../user-pool/client/sim-cognito-unsimulated-client-settings.js";
 
 /**
  * An app client as sim Cognito reports it.
  *
- * Only the properties this simulation models appear. Real Cognito reports
- * more, including the OAuth and managed login settings.
+ * Only the properties this simulation models appear, alongside the two
+ * managed login settings it accepts without acting on and reports back so a
+ * request's intent stays visible. Real Cognito reports more, including the
+ * rest of the OAuth settings.
  *
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientType.html
  */
-export interface SimCognitoUserPoolClientType {
+export interface SimCognitoUserPoolClientType extends SimCognitoUnsimulatedClientSettingsType {
   readonly ClientId?: string | undefined;
   readonly ClientName?: string | undefined;
   readonly UserPoolId?: string | undefined;

--- a/src/service/cognito/command/sim-cognito-canonical-value.iso.test.ts
+++ b/src/service/cognito/command/sim-cognito-canonical-value.iso.test.ts
@@ -1,0 +1,82 @@
+import { assertArrayEquals, assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCognitoCanonicalValue } from "./sim-cognito-canonical-value.js";
+
+describe("sim Cognito canonical value", () => {
+  it("matches two objects whose keys were written in different orders", () => {
+    // Given a value whose keys are in the order CDK emits them.
+    const canonical = new SimCognitoCanonicalValue({
+      DefaultEmailOption: "CONFIRM_WITH_CODE",
+      EmailSubject: "Verify your new account",
+    });
+
+    // When it is compared with the same settings written the other way round.
+    const matches = canonical.matches({
+      EmailSubject: "Verify your new account",
+      DefaultEmailOption: "CONFIRM_WITH_CODE",
+    });
+
+    // Then they say the same thing, because the order keys are written in
+    // carries no meaning.
+    assertTrue(matches);
+  });
+
+  it("refuses an object carrying a key the other one does not", () => {
+    // Given a value with one key.
+    const canonical = new SimCognitoCanonicalValue({
+      AllowAdminCreateUserOnly: true,
+    });
+
+    // When it is compared with the same key plus another.
+    const matches = canonical.matches({
+      AllowAdminCreateUserOnly: true,
+      UnusedAccountValidityDays: 7,
+    });
+
+    // Then they do not match, so a request asking for more than the simulated
+    // value is refused rather than accepted for the part that agrees.
+    assertFalse(matches);
+  });
+
+  it("keeps the order of a list, where the order is part of what it says", () => {
+    // Given a recovery setting listing two mechanisms in priority order.
+    const canonical = new SimCognitoCanonicalValue({
+      RecoveryMechanisms: [
+        { Name: "verified_phone_number", Priority: 1 },
+        { Name: "verified_email", Priority: 2 },
+      ],
+    });
+
+    // When it is compared with the same two mechanisms the other way round.
+    const matches = canonical.matches({
+      RecoveryMechanisms: [
+        { Name: "verified_email", Priority: 2 },
+        { Name: "verified_phone_number", Priority: 1 },
+      ],
+    });
+
+    // Then they do not match, because a list saying its entries in a
+    // different order is saying something different.
+    assertFalse(matches);
+  });
+
+  it("renders the values a refusal prints back", () => {
+    // Given values of each kind a Cognito property carries.
+    const values = ["OFF", 7, false, null, { B: [1, 2], A: "x" }] as const;
+
+    // When each is rendered.
+    const rendered = values.map(
+      (value) => new SimCognitoCanonicalValue(value).text,
+    );
+
+    // Then the rendering is the JSON a refusal can print.
+    assertArrayEquals(rendered, [
+      '"OFF"',
+      "7",
+      "false",
+      "null",
+      '{"A":"x","B":[1,2]}',
+    ]);
+  });
+});

--- a/src/service/cognito/command/sim-cognito-canonical-value.ts
+++ b/src/service/cognito/command/sim-cognito-canonical-value.ts
@@ -1,0 +1,51 @@
+/**
+ * A request value rendered in a form two of them can be compared by.
+ *
+ * A structured input arrives as plain JSON, from a template or from an SDK
+ * call, and the order its keys were written in carries no meaning. Rendering
+ * it with the keys in a fixed order makes two values that say the same thing
+ * render the same, and gives a refusal something readable to print back.
+ */
+export class SimCognitoCanonicalValue {
+  private readonly value: unknown;
+
+  constructor(value: unknown) {
+    this.value = value;
+  }
+
+  /**
+   * The rendered value.
+   */
+  get text(): string {
+    return JSON.stringify(this.ordered(this.value));
+  }
+
+  /**
+   * Whether this value says the same thing as another.
+   */
+  matches(other: unknown): boolean {
+    return this.text === new SimCognitoCanonicalValue(other).text;
+  }
+
+  /**
+   * The value with every object's keys in a fixed order.
+   *
+   * A list keeps the order it arrived in, because the order of a list is part
+   * of what it says. An object's is not.
+   */
+  private ordered(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item: unknown) => this.ordered(item));
+    }
+
+    if (typeof value !== "object" || value === null) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, this.ordered(nested)]),
+    );
+  }
+}

--- a/src/service/cognito/command/sim-cognito-unsimulated-structure.ts
+++ b/src/service/cognito/command/sim-cognito-unsimulated-structure.ts
@@ -1,0 +1,50 @@
+import { SimCognitoInvalidParameterException } from "../error/sim-cognito.error.js";
+import { SimCognitoCanonicalValue } from "./sim-cognito-canonical-value.js";
+
+/**
+ * Refuses a structured request input set to anything but the one value this
+ * simulation models.
+ *
+ * This is what `SimCognitoUnsimulatedInput.refuseUnless` does for a string
+ * or a boolean. That one compares with `===`, which answers false for
+ * two objects saying the same thing, so a property arriving as an object
+ * needs comparing by its contents instead. The comparison is the whole of the
+ * difference, so it lives beside the existing refusals rather than inside
+ * them.
+ */
+export class SimCognitoUnsimulatedStructure {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse a structured input that is not the one this simulation models.
+   *
+   * Every key is compared, so an object carrying an extra one is refused even
+   * where the keys it shares with the simulated value all match.
+   */
+  refuseUnless(
+    option: string,
+    value: object | undefined,
+    simulated: object,
+    feature: string,
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+
+    const simulatedValue = new SimCognitoCanonicalValue(simulated);
+
+    if (simulatedValue.matches(value)) {
+      return;
+    }
+
+    throw new SimCognitoInvalidParameterException(
+      `${this.operation} ${option} ${new SimCognitoCanonicalValue(value).text}` +
+        ` is not simulated: ${feature} would be ignored here and applied on ` +
+        `real AWS. Only ${simulatedValue.text} is supported.`,
+    );
+  }
+}

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-features.ts
@@ -1,15 +1,53 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import { SimCognitoUnsimulatedStructure } from "../sim-cognito-unsimulated-structure.js";
 import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * The account recovery a pool is accepted with, which is what `aws-cdk-lib`
+ * 2.262.1 emits for a `UserPool` construct asking for nothing in particular.
+ *
+ * There is no `ForgotPassword` command here, so no mechanism is ever reached
+ * whichever ones are listed. A request listing its own is still refused,
+ * because choosing them is choosing behaviour, and a pool that ignored the
+ * choice would recover accounts differently on real AWS.
+ */
+const accountRecoverySetting = {
+  RecoveryMechanisms: [
+    { Name: "verified_phone_number", Priority: 1 },
+    { Name: "verified_email", Priority: 2 },
+  ],
+};
+
+/**
+ * The AdminCreateUser configuration a pool is accepted with.
+ *
+ * `AllowAdminCreateUserOnly: true` says only an administrator creates users,
+ * which is all `AdminCreateUser` does here, so accepting it promises nothing
+ * this simulation does not already do. `false` says users may sign themselves
+ * up, and there is no `SignUp` command to do that with, so it is refused.
+ *
+ * That asymmetry is deliberately stricter than AWS, whose own default for the
+ * field is `false`. CDK emits `true`, which is why the accepted value is the
+ * one that is safe rather than the one AWS defaults to.
+ */
+const adminCreateUserConfig = { AllowAdminCreateUserOnly: true };
 
 /**
  * Refuses the user pool features this simulation does not model.
  *
- * These are the settings that decide what a pool does with its users. None of
- * them can be honoured here, and a pool created as if they had been would
- * behave differently in a deployment.
+ * These are the settings that decide what a pool does with its users. Most of
+ * them cannot be honoured here at all, and a pool created as if they had been
+ * would behave differently in a deployment.
+ *
+ * Two are accepted at one value each, and refused at every other. Neither
+ * value asks for anything this simulation does not do, and both are what CDK
+ * emits, so a stack that only wanted a pool deploys.
  */
 export class SimCognitoUnsimulatedUserPoolFeatures {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+  private readonly structure = new SimCognitoUnsimulatedStructure(
     "CreateUserPool",
   );
 
@@ -48,15 +86,17 @@ export class SimCognitoUnsimulatedUserPoolFeatures {
       input.DeviceConfiguration,
       "device remembering",
     );
-    this.unsimulated.refuse(
+    this.structure.refuseUnless(
       "AccountRecoverySetting",
       input.AccountRecoverySetting,
+      accountRecoverySetting,
       "account recovery",
     );
-    this.unsimulated.refuse(
+    this.structure.refuseUnless(
       "AdminCreateUserConfig",
       input.AdminCreateUserConfig,
-      "the AdminCreateUser settings",
+      adminCreateUserConfig,
+      "self-service sign-up and the invitation an admin-created user is sent",
     );
     this.unsimulated.refuse(
       "UserPoolAddOns",

--- a/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-unsimulated-pool-messaging.ts
@@ -1,14 +1,48 @@
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
+import { SimCognitoUnsimulatedStructure } from "../sim-cognito-unsimulated-structure.js";
 import type { SimCreateUserPoolCommandInput } from "./user-pool.command.js";
+
+/**
+ * The verification wording a pool is accepted with.
+ *
+ * These are the values `aws-cdk-lib` 2.262.1 emits for a `UserPool` construct
+ * asking for nothing in particular, so a stack that only wants a pool
+ * deploys. Whether real Cognito defaults a bare pool to the same wording was
+ * not checked against a live account, so the CDK synth is the source here
+ * rather than the AWS default.
+ */
+const verificationMessage =
+  "The verification code to your new account is {####}";
+const verificationSubject = "Verify your new account";
+const verificationMessageTemplate = {
+  DefaultEmailOption: "CONFIRM_WITH_CODE",
+  EmailMessage: verificationMessage,
+  EmailSubject: verificationSubject,
+  SmsMessage: verificationMessage,
+};
+
+/**
+ * What a refusal of the verification wording says would be lost.
+ */
+const verificationWording = "the wording of a verification message";
 
 /**
  * Refuses the message delivery inputs this simulation does not model.
  *
- * Nothing here sends an email or a text message, so a template or a delivery
- * configuration would be stored and never used.
+ * Nothing here sends an email or a text message, so a delivery configuration
+ * would be stored and never used.
+ *
+ * The verification wording is a narrower case. No message is delivered, so
+ * the wording is never read either, and refusing the wording CDK emits would
+ * refuse every stack that only wanted a pool. It is accepted at that wording
+ * and refused at any other, because a request writing its own wording is
+ * asking for a message a user would read.
  */
 export class SimCognitoUnsimulatedUserPoolMessaging {
   private readonly unsimulated = new SimCognitoUnsimulatedInput(
+    "CreateUserPool",
+  );
+  private readonly structure = new SimCognitoUnsimulatedStructure(
     "CreateUserPool",
   );
 
@@ -28,29 +62,43 @@ export class SimCognitoUnsimulatedUserPoolMessaging {
       "SMS delivery",
     );
     this.unsimulated.refuse(
-      "VerificationMessageTemplate",
-      input.VerificationMessageTemplate,
-      "verification messages",
-    );
-    this.unsimulated.refuse(
-      "EmailVerificationMessage",
-      input.EmailVerificationMessage,
-      "verification messages",
-    );
-    this.unsimulated.refuse(
-      "EmailVerificationSubject",
-      input.EmailVerificationSubject,
-      "verification messages",
-    );
-    this.unsimulated.refuse(
-      "SmsVerificationMessage",
-      input.SmsVerificationMessage,
-      "verification messages",
-    );
-    this.unsimulated.refuse(
       "SmsAuthenticationMessage",
       input.SmsAuthenticationMessage,
       "multi-factor authentication messages",
+    );
+
+    this.refuseVerificationWording(input);
+  }
+
+  /**
+   * Refuse verification wording other than the one this simulation accepts.
+   */
+  private refuseVerificationWording(
+    input: SimCreateUserPoolCommandInput,
+  ): void {
+    this.unsimulated.refuseUnless(
+      "EmailVerificationMessage",
+      input.EmailVerificationMessage,
+      verificationMessage,
+      verificationWording,
+    );
+    this.unsimulated.refuseUnless(
+      "EmailVerificationSubject",
+      input.EmailVerificationSubject,
+      verificationSubject,
+      verificationWording,
+    );
+    this.unsimulated.refuseUnless(
+      "SmsVerificationMessage",
+      input.SmsVerificationMessage,
+      verificationMessage,
+      verificationWording,
+    );
+    this.structure.refuseUnless(
+      "VerificationMessageTemplate",
+      input.VerificationMessageTemplate,
+      verificationMessageTemplate,
+      verificationWording,
     );
   }
 }

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  CreateUserPoolCommand,
+  DescribeUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { CreateUserPoolCommandInput } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
+
+/**
+ * The pool settings `aws-cdk-lib` 2.262.1 emits for a `UserPool` construct
+ * asking for nothing in particular.
+ *
+ * Each configures message delivery, verification wording or account recovery.
+ * None of those is simulated, and none of these values asks for anything this
+ * simulation does not already do, so a pool is created with them rather than
+ * refused. They are recorded here as one block because a default CDK stack
+ * sends all six together.
+ */
+const verificationMessage =
+  "The verification code to your new account is {####}";
+
+const cdkDefaultSettings = {
+  AccountRecoverySetting: {
+    RecoveryMechanisms: [
+      { Name: "verified_phone_number", Priority: 1 },
+      { Name: "verified_email", Priority: 2 },
+    ],
+  },
+  AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
+  EmailVerificationMessage: verificationMessage,
+  EmailVerificationSubject: "Verify your new account",
+  SmsVerificationMessage: verificationMessage,
+  VerificationMessageTemplate: {
+    DefaultEmailOption: "CONFIRM_WITH_CODE",
+    EmailMessage: verificationMessage,
+    EmailSubject: "Verify your new account",
+    SmsMessage: verificationMessage,
+  },
+} satisfies Partial<CreateUserPoolCommandInput>;
+
+/**
+ * A value of each accepted setting that this simulation refuses, with what
+ * the refusal has to say about it.
+ */
+interface RefusedValue {
+  readonly label: string;
+  readonly input: Partial<CreateUserPoolCommandInput>;
+  readonly says: string;
+}
+
+const refusedValues: readonly RefusedValue[] = [
+  {
+    label: "AccountRecoverySetting",
+    input: {
+      AccountRecoverySetting: {
+        RecoveryMechanisms: [{ Name: "admin_only", Priority: 1 }],
+      },
+    },
+    says: "account recovery",
+  },
+  {
+    label: "AdminCreateUserConfig self sign-up",
+    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: false } },
+    says: "self-service sign-up",
+  },
+  {
+    label: "AdminCreateUserConfig extra key",
+    input: {
+      AdminCreateUserConfig: {
+        AllowAdminCreateUserOnly: true,
+        InviteMessageTemplate: { EmailSubject: "Welcome" },
+      },
+    },
+    says: "self-service sign-up",
+  },
+  {
+    label: "EmailVerificationMessage",
+    input: { EmailVerificationMessage: "Your code is {####}" },
+    says: "the wording of a verification message",
+  },
+  {
+    label: "EmailVerificationSubject",
+    input: { EmailVerificationSubject: "Confirm your address" },
+    says: "the wording of a verification message",
+  },
+  {
+    label: "SmsVerificationMessage",
+    input: { SmsVerificationMessage: "Your code is {####}" },
+    says: "the wording of a verification message",
+  },
+  {
+    label: "VerificationMessageTemplate",
+    input: {
+      VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_LINK" },
+    },
+    says: "the wording of a verification message",
+  },
+];
+
+function simCognito(): SimCognitoIdentityProvider {
+  return new SimAws().cognitoIdentityProvider();
+}
+
+async function createdPoolId(
+  cognito: SimCognitoIdentityProvider,
+  input: Partial<CreateUserPoolCommandInput>,
+): Promise<string> {
+  const created = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users", ...input }),
+  );
+  const userPoolId = created.UserPool?.Id;
+  assertTypeString(userPoolId);
+
+  return userPoolId;
+}
+
+describe("sim Cognito user pool settings accepted without being simulated", () => {
+  it("creates a pool with the settings a default CDK pool sends", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When a pool is created with all six settings at the values CDK emits.
+    const userPoolId = await createdPoolId(cognito, cdkDefaultSettings);
+
+    // Then the pool exists, rather than the request being refused for asking
+    // about message delivery this simulation does not do.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertNonNullable(described.UserPool);
+
+    // And each setting is reported back as the request set it, so what the
+    // pool was asked for stays visible even though nothing here reads it.
+    assertObjectEquals(
+      described.UserPool.AccountRecoverySetting,
+      cdkDefaultSettings.AccountRecoverySetting,
+    );
+    assertObjectEquals(
+      described.UserPool.AdminCreateUserConfig,
+      cdkDefaultSettings.AdminCreateUserConfig,
+    );
+    assertObjectEquals(
+      described.UserPool.VerificationMessageTemplate,
+      cdkDefaultSettings.VerificationMessageTemplate,
+    );
+    assertIdentical(
+      described.UserPool.EmailVerificationMessage,
+      cdkDefaultSettings.EmailVerificationMessage,
+    );
+    assertIdentical(
+      described.UserPool.EmailVerificationSubject,
+      cdkDefaultSettings.EmailVerificationSubject,
+    );
+    assertIdentical(
+      described.UserPool.SmsVerificationMessage,
+      cdkDefaultSettings.SmsVerificationMessage,
+    );
+  });
+
+  it("reports none of them for a pool created without them", async () => {
+    // Given a pool created with nothing but a name.
+    const cognito = simCognito();
+    const userPoolId = await createdPoolId(cognito, {});
+
+    // When it is described.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+
+    // Then none of the settings appears, rather than the pool reporting the
+    // value a request would have had to use to be accepted.
+    assertNonNullable(described.UserPool);
+    assertUndefined(described.UserPool.AccountRecoverySetting);
+    assertUndefined(described.UserPool.AdminCreateUserConfig);
+    assertUndefined(described.UserPool.VerificationMessageTemplate);
+    assertUndefined(described.UserPool.EmailVerificationMessage);
+    assertUndefined(described.UserPool.EmailVerificationSubject);
+    assertUndefined(described.UserPool.SmsVerificationMessage);
+  });
+
+  it("refuses each of them at any other value", async () => {
+    // Given simulated Cognito.
+    const cognito = simCognito();
+
+    // When each setting is used at a value this simulation does not model.
+    const outcomes = await Promise.all(
+      refusedValues.map(async (refused) => ({
+        refused,
+        error: await assertThrowsErrorAsync(async () => {
+          await createdPoolId(cognito, refused.input);
+        }, refused.label),
+      })),
+    );
+
+    // Then each refusal names the input, the value asked for, and what would
+    // have been ignored here and applied on real AWS.
+    for (const { refused, error } of outcomes) {
+      assertStringIncludes(error.message, "CreateUserPool");
+      assertStringIncludes(error.message, refused.says);
+      assertStringIncludes(error.message, "is not simulated");
+      assertStringIncludes(error.message, "Only");
+    }
+  });
+});

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-accepted-settings.iso.test.ts
@@ -189,6 +189,34 @@ describe("sim Cognito user pool settings accepted without being simulated", () =
     assertUndefined(described.UserPool.SmsVerificationMessage);
   });
 
+  it("keeps what the request said rather than the request object", async () => {
+    // Given a pool created from an input object the caller still holds.
+    const cognito = simCognito();
+    const input: Partial<CreateUserPoolCommandInput> =
+      structuredClone(cdkDefaultSettings);
+    const userPoolId = await createdPoolId(cognito, input);
+    assertNonNullable(input.AdminCreateUserConfig);
+
+    // When the caller edits that object afterwards, as it would to create a
+    // second pool from the same starting point.
+    input.AdminCreateUserConfig.AllowAdminCreateUserOnly = false;
+    input.EmailVerificationSubject = "Something else";
+
+    // Then the pool still reports what the request said when it was made,
+    // rather than following the object it was handed.
+    const described = await cognito.describeUserPool(
+      new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
+    );
+    assertNonNullable(described.UserPool);
+    assertObjectEquals(described.UserPool.AdminCreateUserConfig, {
+      AllowAdminCreateUserOnly: true,
+    });
+    assertIdentical(
+      described.UserPool.EmailVerificationSubject,
+      "Verify your new account",
+    );
+  });
+
   it("refuses each of them at any other value", async () => {
     // Given simulated Cognito.
     const cognito = simCognito();

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-commands.ts
@@ -61,6 +61,7 @@ export class SimCognitoUserPoolCommands {
       name: input.PoolName,
       policies: input.Policies,
       deletionProtection: input.DeletionProtection,
+      unsimulatedSettings: input,
     });
 
     this.pools.add(pool);

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-validation.iso.test.ts
@@ -107,8 +107,8 @@ const refusedInputs: readonly RefusedInput[] = [
   },
   {
     label: "AdminCreateUserConfig",
-    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: true } },
-    says: "the AdminCreateUser settings",
+    input: { AdminCreateUserConfig: { AllowAdminCreateUserOnly: false } },
+    says: "self-service sign-up",
   },
   {
     label: "UserPoolAddOns",
@@ -147,22 +147,22 @@ const refusedInputs: readonly RefusedInput[] = [
     input: {
       VerificationMessageTemplate: { DefaultEmailOption: "CONFIRM_WITH_CODE" },
     },
-    says: "verification messages",
+    says: "the wording of a verification message",
   },
   {
     label: "EmailVerificationMessage",
     input: { EmailVerificationMessage: "Your code is {####}" },
-    says: "verification messages",
+    says: "the wording of a verification message",
   },
   {
     label: "EmailVerificationSubject",
     input: { EmailVerificationSubject: "Verify your email" },
-    says: "verification messages",
+    says: "the wording of a verification message",
   },
   {
     label: "SmsVerificationMessage",
     input: { SmsVerificationMessage: "Your code is {####}" },
-    says: "verification messages",
+    says: "the wording of a verification message",
   },
   {
     label: "SmsAuthenticationMessage",

--- a/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
+++ b/src/service/cognito/command/user-pool/sim-cognito-user-pool-view.ts
@@ -12,6 +12,10 @@ export class SimCognitoUserPoolView {
   /**
    * A pool as `CreateUserPool` and `DescribeUserPool` report it.
    *
+   * The settings the pool accepted without acting on are reported back as
+   * the request set them, so a template's declaration stays visible. Nothing
+   * here reads any of them.
+   *
    * `MfaConfiguration` is always `OFF` because MFA is not simulated.
    * `EstimatedNumberOfUsers` is how many users the pool holds now. Real
    * Cognito refreshes that number periodically rather than on each write, so
@@ -28,6 +32,7 @@ export class SimCognitoUserPoolView {
       EstimatedNumberOfUsers: pool.userCount,
       CreationDate: pool.creationDate,
       LastModifiedDate: pool.lastModifiedDate,
+      ...pool.unsimulatedSettings.toOutput(),
     };
   }
 

--- a/src/service/cognito/command/user-pool/user-pool.command.ts
+++ b/src/service/cognito/command/user-pool/user-pool.command.ts
@@ -1,15 +1,17 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimCognitoUserPoolPoliciesType } from "../../user-pool/sim-cognito-password-policy.js";
+import type { SimCognitoUnsimulatedPoolSettingsType } from "../../user-pool/sim-cognito-unsimulated-pool-settings.js";
 
 /**
  * A user pool as sim Cognito reports it.
  *
- * Only the properties this simulation models appear. Real Cognito reports
- * more, including the pool's schema attributes and its message templates.
+ * Only the properties this simulation models appear, alongside the ones it
+ * accepts without acting on and reports back so a request's intent stays
+ * visible. Real Cognito reports more, including the pool's schema attributes.
  *
  * https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html
  */
-export interface SimCognitoUserPoolType {
+export interface SimCognitoUserPoolType extends SimCognitoUnsimulatedPoolSettingsType {
   readonly Id?: string | undefined;
   readonly Name?: string | undefined;
   readonly Arn?: string | undefined;

--- a/src/service/cognito/user-pool/client/sim-cognito-unsimulated-client-settings.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-unsimulated-client-settings.ts
@@ -23,19 +23,32 @@ export class SimCognitoUnsimulatedClientSettings {
   private readonly settings: SimCognitoUnsimulatedClientSettingsType;
 
   constructor(settings: SimCognitoUnsimulatedClientSettingsType) {
-    this.settings = settings;
+    this.settings = this.accepted(settings);
   }
 
   /**
    * These settings as a described app client reports them.
-   *
-   * Each one appears only where the request set it, so a described client
-   * carries what was asked for and nothing more.
    */
   toOutput(): SimCognitoUnsimulatedClientSettingsType {
-    const settings = this.settings;
+    return structuredClone(this.settings);
+  }
 
-    return {
+  /**
+   * The settings this holds, copied out of the request rather than kept by
+   * reference.
+   *
+   * A caller passes its whole `CreateUserPoolClient` input in, and may reuse
+   * or edit that object afterwards. Copying means a described client reports
+   * what the request said at the time it was made, as a real one does.
+   *
+   * Each setting is kept only where the request set it, so a client created
+   * without either reports neither rather than reporting the value it would
+   * have had to use.
+   */
+  private accepted(
+    settings: SimCognitoUnsimulatedClientSettingsType,
+  ): SimCognitoUnsimulatedClientSettingsType {
+    return structuredClone({
       ...(settings.AllowedOAuthFlowsUserPoolClient !== undefined && {
         AllowedOAuthFlowsUserPoolClient:
           settings.AllowedOAuthFlowsUserPoolClient,
@@ -43,6 +56,6 @@ export class SimCognitoUnsimulatedClientSettings {
       ...(settings.SupportedIdentityProviders !== undefined && {
         SupportedIdentityProviders: settings.SupportedIdentityProviders,
       }),
-    };
+    });
   }
 }

--- a/src/service/cognito/user-pool/client/sim-cognito-unsimulated-client-settings.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-unsimulated-client-settings.ts
@@ -1,0 +1,48 @@
+/**
+ * The app client settings a request may set that this simulation does not act
+ * on.
+ *
+ * These are the two managed login settings `CreateUserPoolClient` accepts at
+ * one value each, in the shape a described client reports them in.
+ */
+export interface SimCognitoUnsimulatedClientSettingsType {
+  readonly AllowedOAuthFlowsUserPoolClient?: boolean | undefined;
+  readonly SupportedIdentityProviders?: readonly string[] | undefined;
+}
+
+/**
+ * The settings an app client was created with and this simulation does not
+ * act on.
+ *
+ * Both say the client wants nothing outside the pool's own users: no hosted
+ * UI OAuth flows, and no federated identity provider. Neither reaches
+ * anything here, because there is nothing here to turn off, so they are kept
+ * only so `DescribeUserPoolClient` reports what the request set.
+ */
+export class SimCognitoUnsimulatedClientSettings {
+  private readonly settings: SimCognitoUnsimulatedClientSettingsType;
+
+  constructor(settings: SimCognitoUnsimulatedClientSettingsType) {
+    this.settings = settings;
+  }
+
+  /**
+   * These settings as a described app client reports them.
+   *
+   * Each one appears only where the request set it, so a described client
+   * carries what was asked for and nothing more.
+   */
+  toOutput(): SimCognitoUnsimulatedClientSettingsType {
+    const settings = this.settings;
+
+    return {
+      ...(settings.AllowedOAuthFlowsUserPoolClient !== undefined && {
+        AllowedOAuthFlowsUserPoolClient:
+          settings.AllowedOAuthFlowsUserPoolClient,
+      }),
+      ...(settings.SupportedIdentityProviders !== undefined && {
+        SupportedIdentityProviders: settings.SupportedIdentityProviders,
+      }),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client-factory.ts
@@ -8,6 +8,10 @@ import {
   SimCognitoTokenValidity,
   type SimCognitoTokenValidityInput,
 } from "./sim-cognito-token-validity.js";
+import {
+  SimCognitoUnsimulatedClientSettings,
+  type SimCognitoUnsimulatedClientSettingsType,
+} from "./sim-cognito-unsimulated-client-settings.js";
 import { SimCognitoUserPoolClient } from "./sim-cognito-user-pool-client.js";
 import { makeSimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
 
@@ -22,6 +26,13 @@ interface SimCognitoMakeUserPoolClientProperties {
   readonly explicitAuthFlows?: readonly string[] | undefined;
   readonly preventUserExistenceErrors?: string | undefined;
   readonly tokenValidity: SimCognitoTokenValidityInput;
+
+  /**
+   * The settings the request set that this simulation accepts without acting
+   * on, which a described client reports back.
+   */
+  readonly unsimulatedSettings?:
+    SimCognitoUnsimulatedClientSettingsType | undefined;
 }
 
 /**
@@ -61,6 +72,9 @@ export class SimCognitoUserPoolClientFactory {
         properties.preventUserExistenceErrors,
       ),
       tokenValidity: new SimCognitoTokenValidity(properties.tokenValidity),
+      unsimulatedSettings: new SimCognitoUnsimulatedClientSettings(
+        properties.unsimulatedSettings ?? {},
+      ),
       createdDate: this.clock.now(),
     });
   }

--- a/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
+++ b/src/service/cognito/user-pool/client/sim-cognito-user-pool-client.ts
@@ -3,6 +3,7 @@ import type { SimCognitoUserPoolId } from "../sim-cognito-user-pool-id.js";
 import type { SimCognitoExplicitAuthFlows } from "./sim-cognito-explicit-auth-flows.js";
 import type { SimCognitoPreventUserExistenceErrors } from "./sim-cognito-prevent-user-existence-errors.js";
 import type { SimCognitoTokenValidity } from "./sim-cognito-token-validity.js";
+import type { SimCognitoUnsimulatedClientSettings } from "./sim-cognito-unsimulated-client-settings.js";
 import type { SimCognitoUserPoolClientId } from "./sim-cognito-user-pool-client-id.js";
 
 interface SimCognitoUserPoolClientProperties {
@@ -13,6 +14,7 @@ interface SimCognitoUserPoolClientProperties {
   readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
   readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
   readonly tokenValidity: SimCognitoTokenValidity;
+  readonly unsimulatedSettings: SimCognitoUnsimulatedClientSettings;
   readonly createdDate: Date;
 }
 
@@ -31,6 +33,13 @@ export class SimCognitoUserPoolClient {
   public readonly explicitAuthFlows: SimCognitoExplicitAuthFlows;
   public readonly preventUserExistenceErrors: SimCognitoPreventUserExistenceErrors;
   public readonly tokenValidity: SimCognitoTokenValidity;
+
+  /**
+   * What the client was created with and nothing here acts on, kept so a
+   * described client reports it.
+   */
+  public readonly unsimulatedSettings: SimCognitoUnsimulatedClientSettings;
+
   public readonly creationDate: Date;
 
   /**
@@ -47,6 +56,7 @@ export class SimCognitoUserPoolClient {
     this.explicitAuthFlows = properties.explicitAuthFlows;
     this.preventUserExistenceErrors = properties.preventUserExistenceErrors;
     this.tokenValidity = properties.tokenValidity;
+    this.unsimulatedSettings = properties.unsimulatedSettings;
     this.creationDate = properties.createdDate;
   }
 

--- a/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
@@ -30,19 +30,33 @@ export class SimCognitoUnsimulatedPoolSettings {
   private readonly settings: SimCognitoUnsimulatedPoolSettingsType;
 
   constructor(settings: SimCognitoUnsimulatedPoolSettingsType) {
-    this.settings = settings;
+    this.settings = this.accepted(settings);
   }
 
   /**
    * These settings as a described pool reports them.
-   *
-   * Each one appears only where the request set it, so a described pool
-   * carries what was asked for and nothing more.
    */
   toOutput(): SimCognitoUnsimulatedPoolSettingsType {
-    const settings = this.settings;
+    return structuredClone(this.settings);
+  }
 
-    return {
+  /**
+   * The settings this holds, copied out of the request rather than kept by
+   * reference.
+   *
+   * A caller passes its whole `CreateUserPool` input in, and may reuse or
+   * edit that object afterwards. Three of these are nested objects, so the
+   * copy goes all the way down. Copying means a described pool reports what
+   * the request said at the time it was made, as a real one does.
+   *
+   * Each setting is kept only where the request set it, so a pool created
+   * without one describes without it rather than describing it as the value
+   * the request would have needed to use.
+   */
+  private accepted(
+    settings: SimCognitoUnsimulatedPoolSettingsType,
+  ): SimCognitoUnsimulatedPoolSettingsType {
+    return structuredClone({
       ...(settings.AccountRecoverySetting !== undefined && {
         AccountRecoverySetting: settings.AccountRecoverySetting,
       }),
@@ -61,6 +75,6 @@ export class SimCognitoUnsimulatedPoolSettings {
       ...(settings.VerificationMessageTemplate !== undefined && {
         VerificationMessageTemplate: settings.VerificationMessageTemplate,
       }),
-    };
+    });
   }
 }

--- a/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
+++ b/src/service/cognito/user-pool/sim-cognito-unsimulated-pool-settings.ts
@@ -1,0 +1,66 @@
+/**
+ * The pool settings a request may set that this simulation does not act on.
+ *
+ * These are the ones `CreateUserPool` accepts at one value each, in the shape
+ * a described pool reports them in.
+ */
+export interface SimCognitoUnsimulatedPoolSettingsType {
+  readonly AccountRecoverySetting?: object | undefined;
+  readonly AdminCreateUserConfig?: object | undefined;
+  readonly EmailVerificationMessage?: string | undefined;
+  readonly EmailVerificationSubject?: string | undefined;
+  readonly SmsVerificationMessage?: string | undefined;
+  readonly VerificationMessageTemplate?: object | undefined;
+}
+
+/**
+ * The settings a pool was created with and this simulation does not act on.
+ *
+ * Each one configures message delivery or account recovery, and neither is
+ * simulated, so nothing reads any of them back out. They are kept so
+ * `DescribeUserPool` reports what the request set, which is how a test can
+ * see that a template's declaration reached the pool rather than being
+ * dropped on the way.
+ *
+ * Only what the request set is reported. A pool created without one of these
+ * describes without it, rather than describing it as the value the request
+ * would have needed to use.
+ */
+export class SimCognitoUnsimulatedPoolSettings {
+  private readonly settings: SimCognitoUnsimulatedPoolSettingsType;
+
+  constructor(settings: SimCognitoUnsimulatedPoolSettingsType) {
+    this.settings = settings;
+  }
+
+  /**
+   * These settings as a described pool reports them.
+   *
+   * Each one appears only where the request set it, so a described pool
+   * carries what was asked for and nothing more.
+   */
+  toOutput(): SimCognitoUnsimulatedPoolSettingsType {
+    const settings = this.settings;
+
+    return {
+      ...(settings.AccountRecoverySetting !== undefined && {
+        AccountRecoverySetting: settings.AccountRecoverySetting,
+      }),
+      ...(settings.AdminCreateUserConfig !== undefined && {
+        AdminCreateUserConfig: settings.AdminCreateUserConfig,
+      }),
+      ...(settings.EmailVerificationMessage !== undefined && {
+        EmailVerificationMessage: settings.EmailVerificationMessage,
+      }),
+      ...(settings.EmailVerificationSubject !== undefined && {
+        EmailVerificationSubject: settings.EmailVerificationSubject,
+      }),
+      ...(settings.SmsVerificationMessage !== undefined && {
+        SmsVerificationMessage: settings.SmsVerificationMessage,
+      }),
+      ...(settings.VerificationMessageTemplate !== undefined && {
+        VerificationMessageTemplate: settings.VerificationMessageTemplate,
+      }),
+    };
+  }
+}

--- a/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool-factory.ts
@@ -9,6 +9,10 @@ import {
 import { SimCognitoUserPool } from "./sim-cognito-user-pool.js";
 import { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import { makeSimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import {
+  SimCognitoUnsimulatedPoolSettings,
+  type SimCognitoUnsimulatedPoolSettingsType,
+} from "./sim-cognito-unsimulated-pool-settings.js";
 import type { SimCognitoUserPoolStore } from "./sim-cognito-user-pool-store.js";
 
 interface SimCognitoUserPoolFactoryProperties {
@@ -21,6 +25,13 @@ interface SimCognitoMakeUserPoolProperties {
   readonly name: string | undefined;
   readonly policies?: SimCognitoUserPoolPoliciesType | undefined;
   readonly deletionProtection?: string | undefined;
+
+  /**
+   * The settings the request set that this simulation accepts without acting
+   * on, which a described pool reports back.
+   */
+  readonly unsimulatedSettings?:
+    SimCognitoUnsimulatedPoolSettingsType | undefined;
 }
 
 /**
@@ -65,6 +76,9 @@ export class SimCognitoUserPoolFactory {
       ),
       deletionProtection: new SimCognitoDeletionProtection(
         properties.deletionProtection,
+      ),
+      unsimulatedSettings: new SimCognitoUnsimulatedPoolSettings(
+        properties.unsimulatedSettings ?? {},
       ),
       createdDate: this.clock.now(),
     });

--- a/src/service/cognito/user-pool/sim-cognito-user-pool.ts
+++ b/src/service/cognito/user-pool/sim-cognito-user-pool.ts
@@ -10,6 +10,7 @@ import type { SimCognitoName } from "./sim-cognito-name.js";
 import type { SimCognitoPasswordPolicy } from "./sim-cognito-password-policy.js";
 import type { SimCognitoUserPoolArn } from "./sim-cognito-user-pool-arn.js";
 import type { SimCognitoUserPoolId } from "./sim-cognito-user-pool-id.js";
+import type { SimCognitoUnsimulatedPoolSettings } from "./sim-cognito-unsimulated-pool-settings.js";
 import {
   SimCognitoSigningKey,
   type SimCognitoJwks,
@@ -24,6 +25,7 @@ interface SimCognitoUserPoolProperties {
   readonly name: SimCognitoName;
   readonly passwordPolicy: SimCognitoPasswordPolicy;
   readonly deletionProtection: SimCognitoDeletionProtection;
+  readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
   readonly createdDate: Date;
 }
 
@@ -40,6 +42,13 @@ export class SimCognitoUserPool {
   public readonly name: string;
   public readonly passwordPolicy: SimCognitoPasswordPolicy;
   public readonly deletionProtection: SimCognitoDeletionProtection;
+
+  /**
+   * What the pool was created with and nothing here acts on, kept so a
+   * described pool reports it.
+   */
+  public readonly unsimulatedSettings: SimCognitoUnsimulatedPoolSettings;
+
   public readonly creationDate: Date;
 
   /**
@@ -59,6 +68,7 @@ export class SimCognitoUserPool {
     this.name = properties.name.value;
     this.passwordPolicy = properties.passwordPolicy;
     this.deletionProtection = properties.deletionProtection;
+    this.unsimulatedSettings = properties.unsimulatedSettings;
     this.creationDate = properties.createdDate;
   }
 


### PR DESCRIPTION
… from CloudFormation

Accept the six AWS::Cognito::UserPool properties and the two AWS::Cognito::UserPoolClient properties a default CDK stack emits, each at one value and refused at any other, and report them back from DescribeUserPool and DescribeUserPoolClient. Generate a pool or client name from the stack and logical ID where the template sets none, which CDK does for both.

Resolves https://github.com/KensioSoftware/yulin/issues/297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CDK-generated Cognito user pool and app client names.
  * Cognito now accepts and reports additional pool and client settings, including supported OAuth and identity-provider values.
  * Accepted settings are preserved in resource descriptions, even when they do not affect simulated behavior.
  * Added validation for supported default configurations and clearer errors for unsupported values.

* **Documentation**
  * Expanded Cognito documentation with accepted values, examples, generated naming behavior, and simulation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->