### PR TITLE
feat: match simulated HTTP API requests by route key, path parameter …

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -134,6 +134,183 @@ The `$default` route matches any method and path, so every request to the endpoi
 function. The integration URI is the function's ARN, and the function may be in another Account or
 Region: it is looked up where its ARN says it is.
 
+## Route keys
+
+A route key is either the literal `$default` or an upper-case HTTP method and a path separated by one
+space:
+
+```text
+GET /pets
+GET /pets/{petId}
+ANY /admin/{proxy+}
+$default
+```
+
+The method is one of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` or `ANY`, where `ANY`
+matches whatever method the request used.
+
+A path is made of three kinds of segment:
+
+- A literal, such as `pets`, matching that one segment.
+- A parameter, such as `{petId}`, matching exactly one segment, whatever is in it.
+- A greedy parameter, such as `{proxy+}`, matching everything left of the path. It is only ever the
+  last segment, and it needs at least one segment to match, so `GET /pets/{proxy+}` matches
+  `/pets/cat/1` but not `/pets`.
+
+A route key that cannot be read is refused by `CreateRoute` with a `BadRequestException`, which is
+where real API Gateway refuses it too. That covers a lower-case method, an unbalanced brace, and a
+greedy parameter anywhere but the end.
+
+A parameter name is not part of a route's identity, so `GET /pets/{id}` and `GET /pets/{petId}` are
+the same route key and creating the second gives a `ConflictException`.
+
+## Which route serves a request
+
+More than one route may match a request, and the most specific one takes it. In order:
+
+1. A route matching the whole path beats a route ending in a greedy parameter, which beats
+   `$default`.
+2. An exact method beats `ANY`.
+3. The path decides, segment by segment from the left, with a literal beating a `{name}` parameter
+   and a `{name}` beating a `{name+}`. Comparing left to right is also what makes the longest literal
+   prefix win between two greedy routes, so `GET /pets/dog/{proxy+}` takes `/pets/dog/collars/1`
+   ahead of `GET /pets/{proxy+}`.
+
+AWS's worked example, which is encoded as a test here:
+
+| Request           | Route selected       |
+| ----------------- | -------------------- |
+| `GET /pets/dog/1` | `GET /pets/dog/1`    |
+| `GET /pets/dog/2` | `GET /pets/dog/{id}` |
+| `GET /pets/cat/1` | `GET /pets/{proxy+}` |
+| `POST /test/5`    | `ANY /{proxy+}`      |
+
+from the routes `GET /pets/dog/1`, `GET /pets/dog/{id}`, `GET /pets/{proxy+}`, `ANY /{proxy+}` and
+`$default`.
+
+Rule 1 is documented by AWS, as is the literal-beating-parameter part of rule 3. Rule 2, the
+longest-literal-prefix part of rule 3, and the place of the method comparison above the path
+comparison rather than below it, are observed rather than documented. Each is marked in the code next
+to the rule it governs.
+
+A request whose path matches a route but whose method does not simply matches nothing. An API with no
+`ANY` route, no greedy route and no `$default` route to catch it answers 404, not 405.
+
+## Path parameters and named stages
+
+What a route captured reaches the handler as `event.pathParameters`. A named stage is served under
+its own path segment, and stage selection runs before route selection, so the routes never see the
+stage name.
+
+```typescript sim-apigatewayv2-routes
+/**
+ * Matching a simulated HTTP API request by route key, path parameter and stage.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          routeKey: event.routeKey,
+          rawPath: event.rawPath,
+          stage: event.requestContext.stage,
+          petId: event.pathParameters?.["petId"],
+        }),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "pets", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+for (const RouteKey of [
+  "GET /pets",
+  "GET /pets/{petId}",
+  "ANY /admin/{proxy+}",
+  "$default",
+]) {
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId,
+      RouteKey,
+      Target: `integrations/${IntegrationId}`,
+    }),
+  );
+}
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${ApiEndpoint}/dev/pets/6`));
+
+console.log(await response.json());
+
+srv.close();
+```
+
+The handler sees the route it matched, the parameter it captured, the path as the client sent it, and
+the stage that served it:
+
+```json
+{
+  "routeKey": "GET /pets/{petId}",
+  "rawPath": "/dev/pets/6",
+  "stage": "dev",
+  "petId": "6"
+}
+```
+
+`rawPath` and `requestContext.http.path` keep the stage segment, while `routeKey` and
+`pathParameters` come from the path the routes matched, which is `/pets/6`. The stage prefix in the
+path is corroborated by the documented `$context.path` access log variable, "the request path, for
+example `/{stage}/root/child`", rather than by the payload format page.
+
+A stage name is `$default`, or up to 128 alphanumerics, hyphens and underscores. The `$default` stage
+is served at the root of the endpoint instead of under a name, and both kinds can exist on one API at
+once. An explicit stage match wins over any route match: with a `$default` stage and a stage named
+`pets`, a request for `/pets/dog` is served by the stage `pets` on the route path `/dog`. A request
+reaching an API with no stage for it, and no `$default` stage, is a 404.
+
+`pathParameters` is left out of the event entirely when the matched route captured nothing, including
+on a `$default` match. `StageVariables` set on the stage arrive as `event.stageVariables`, and are
+left out the same way when the stage has none.
+
 ## The event the handler receives
 
 The handler is invoked with the API Gateway HTTP API payload format 2.0 event, exported as
@@ -271,8 +448,12 @@ the simulation without being given one. See the
 - `CreateApi`, `GetApi`, `GetApis` and `DeleteApi`, with the API id, the generated endpoint, and the
   Account and Region scoping a real API has
 - `CreateIntegration` and `GetIntegrations` for an `AWS_PROXY` integration naming a Lambda function
-- `CreateRoute` and `GetRoutes` for the `$default` catch-all route
-- `CreateStage` and `GetStages` for the `$default` stage, including stage variables
+- `CreateRoute` and `GetRoutes`, with route keys parsed and validated at creation, and requests
+  matched to a route by method, literal segment, `{name}` parameter, `{proxy+}` parameter and
+  `$default`
+- Path parameters captured by the matched route, reaching the handler as `event.pathParameters`
+- `CreateStage` and `GetStages` for the `$default` stage and for named stages served under their own
+  path segment, including stage variables
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
   payload format 2.0 event and turning its result back into an HTTP response
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
@@ -285,12 +466,12 @@ the simulation without being given one. See the
 Current documented limitations:
 
 - HTTP APIs only. `ProtocolType: "WEBSOCKET"` is refused.
-- `$default` is the only route key, so route matching by method and path is not simulated and every
-  request reaches the one route. A route key such as `GET /orders` is refused rather than accepted
-  and never matched. `pathParameters` therefore never has anything in it.
-- `$default` is the only stage name, so a stage served under a stage path segment is not simulated.
+- Two of the route selection rules, and the place of the method comparison in the order, are observed
+  rather than published by AWS. See [Which route serves a request](#which-route-serves-a-request).
 - Deployments are not simulated, so `CreateStage` requires `AutoDeploy: true`. A stage without it
   serves whichever Deployment it was given, which on real AWS is nothing until one is created.
+- `RouteSettings`, `DefaultRouteSettings` and `AccessLogSettings` on a stage are refused, as is any
+  other option `CreateStage` takes and this one does not.
 - `AWS_PROXY` is the only integration type, and its URI must be an unqualified Lambda function ARN.
   A version or alias qualifier is refused, since simulated Lambda has no versions. HTTP proxy
   integrations and AWS service integrations are not simulated.
@@ -305,13 +486,14 @@ Current documented limitations:
 - No `Update*` commands, and no per-resource `Delete*`. A route, integration or stage is changed by
   deleting its API and creating it again. `DeleteApi` deletes everything under the API, as it does on
   AWS.
+- Custom domain names and API mappings are not simulated. They change what `rawPath` holds, so an API
+  reached through one behaves differently on AWS from what is served here.
 - No paging. `MaxResults` and `NextToken` are refused rather than ignored, and every list command
   answers in full.
 - `CorsConfiguration` and `Tags` are refused, as is the `RouteKey`/`Target` quick-create shorthand on
   `CreateApi`. Anything else the real commands accept and this one does not is refused by name rather
   than dropped.
-- Custom domain names, access logging, route settings, throttling, usage plans and API keys are not
-  simulated.
+- Access logging, throttling, usage plans and API keys are not simulated.
 - No CloudFormation resource types yet, so an `AWS::ApiGatewayV2::Api` in a template is not created.
 - The response an API Gateway endpoint returns itself uses a lower-case `message` field, as a real
   HTTP API does. A Lambda Function URL uses `Message` for the same thing, so the two are not

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -164,6 +164,10 @@ greedy parameter anywhere but the end.
 A parameter name is not part of a route's identity, so `GET /pets/{id}` and `GET /pets/{petId}` are
 the same route key and creating the second gives a `ConflictException`.
 
+One path may not name the same parameter twice, so `GET /pets/{id}/toys/{id}` is refused. A handler
+reads path parameters off one object, so only one of the two captures could arrive. Whether real API
+Gateway refuses it is not established, so this is stricter than AWS rather than known to match it.
+
 ## Which route serves a request
 
 More than one route may match a request, and the most specific one takes it. In order:
@@ -284,8 +288,7 @@ console.log(await response.json());
 srv.close();
 ```
 
-The handler sees the route it matched, the parameter it captured, the path as the client sent it, and
-the stage that served it:
+That handler reports four fields of its event, so the response body it produces is:
 
 ```json
 {
@@ -468,6 +471,9 @@ Current documented limitations:
 - HTTP APIs only. `ProtocolType: "WEBSOCKET"` is refused.
 - Two of the route selection rules, and the place of the method comparison in the order, are observed
   rather than published by AWS. See [Which route serves a request](#which-route-serves-a-request).
+- A route path naming the same parameter twice, such as `GET /pets/{id}/toys/{id}`, is refused. This
+  is stricter than AWS is known to be: it was refused because only one of the two captures could
+  reach the handler, not because real API Gateway was seen to refuse it.
 - Deployments are not simulated, so `CreateStage` requires `AutoDeploy: true`. A stage without it
   serves whichever Deployment it was given, which on real AWS is nothing until one is created.
 - `RouteSettings`, `DefaultRouteSettings` and `AccessLogSettings` on a stage are refused, as is any

--- a/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Matching a simulated HTTP API request by route key, path parameter and stage.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          routeKey: event.routeKey,
+          rawPath: event.rawPath,
+          stage: event.requestContext.stage,
+          petId: event.pathParameters?.["petId"],
+        }),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "pets", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+for (const RouteKey of [
+  "GET /pets",
+  "GET /pets/{petId}",
+  "ANY /admin/{proxy+}",
+  "$default",
+]) {
+  await apiGateway.createRoute(
+    new CreateRouteCommand({
+      ApiId,
+      RouteKey,
+      Target: `integrations/${IntegrationId}`,
+    }),
+  );
+}
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${ApiEndpoint}/dev/pets/6`));
+
+console.log(await response.json());
+
+srv.close();

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -30,6 +30,45 @@ Routes, integrations and stages are all addressed by `ApiId` on real AWS and non
 the API, so they live on the API rather than in service-level maps that would have to carry the
 `ApiId` alongside them. Deleting an API therefore deletes everything under it by construction.
 
+## Matching a request
+
+`api/sim-http-api-match.ts` is the entry point: the stage first, then the route, then the integration
+behind that route.
+
+The stage goes first because a named stage is a path segment the routes know nothing about, so
+`/dev/pets/6` served from stage `dev` reaches route selection as the path `/pets/6`.
+`api/stage/sim-http-api-stage-selector.ts` takes that segment off, or falls back to the `$default`
+stage, which is served at the root and keeps the whole path.
+
+Routes are then matched by `api/route/`:
+
+```text
+SimHttpApiRouteKey            $default, or a method and a path
+├── SimHttpApiRouteMethod     GET, ANY and friends, and how specific each is
+├── SimHttpApiRoutePath       the segments, and matching a request path against them
+│   ├── SimHttpApiLiteralSegment    pets
+│   ├── SimHttpApiVariableSegment   {petId}
+│   └── SimHttpApiGreedySegment     {proxy+}
+└── SimHttpApiRouteRank       which of two matching routes wins
+```
+
+Three things are worth knowing here:
+
+- Segments are matched one at a time rather than compiled to a regex. Selection has to compare two
+  routes at the segment where they first differ, and a character count gives the wrong answer:
+  `GET /a/{b}/ccccc` has more literal characters than `GET /a/b/{c}` and is less specific where it
+  matters. `SimCloudFrontPathPattern` counts characters for the same reason CloudFront can, which is
+  that it has no segments and no captures.
+- Each kind of segment is its own small class answering the same questions, so matching is a loop
+  rather than a switch. This is also what keeps the code inside the repo's complexity and file-size
+  limits, and what absorbs `noUncheckedIndexedAccess` on the segment arrays.
+- The whole precedence rule is in `SimHttpApiRouteRank.compareTo`, in one place, with the parts AWS
+  documents and the parts that are only observed marked separately.
+
+A route is stored under its route key signature, which is the key with parameter names erased. That
+is the identity real API Gateway gives a route: `GET /pets/{id}` and `GET /pets/{petId}` are one
+route, and creating the second is a conflict.
+
 `registry/sim-http-api-registry.ts` is the one thing outside that tree. A served request carries the
 API id and the region in its hostname, but not the Account, so the registry maps an id to the
 Account that owns it. Ids are allocated there, which is what makes them unique across every Account
@@ -63,8 +102,8 @@ lives.
 1. `sim-api-gateway-v2-router.ts` finds the API from the request hostname, through the registry, and
    the integrated function from the integration's ARN. The function is looked up in the Account and
    Region its own ARN names, which need not be the API's.
-2. `sim-http-api-endpoint.ts` describes the API and the matched route as a
-   `SimPayload2Endpoint`.
+2. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
+   `SimPayload2Endpoint`, including what the route captured from the path.
 3. `src/serve/payload-2/` builds the payload format 2.0 event and turns the handler's result back
    into an HTTP response. That machinery is shared with Lambda Function URLs, which speak the same
    format.
@@ -83,9 +122,11 @@ simulation exists to avoid:
 - payload format `1.0`, which builds a different event
 - an integration type other than `AWS_PROXY`, and an integration URI that is not an unqualified
   Lambda function ARN
-- a route key other than `$default`, and an authorization type other than `NONE`
-- a stage name other than `$default`, and a stage without `AutoDeploy: true`, since Deployments are
-  not simulated and such a stage serves nothing on real AWS
+- a malformed route key, refused at `CreateRoute`, which is where real API Gateway refuses it
+- an authorization type other than `NONE`
+- a stage name that is neither `$default` nor something a URL path segment could hold, and a stage
+  without `AutoDeploy: true`, since Deployments are not simulated and such a stage serves nothing on
+  real AWS
 - `MaxResults`/`NextToken`, since every list command answers in full
 
 The function's resource policy is not evaluated when the integration invokes it. See

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-default-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-default-route-key.ts
@@ -1,0 +1,40 @@
+import { SimHttpApiPathParameters } from "../path/sim-http-api-path-parameters.js";
+import {
+  defaultRouteTier,
+  SimHttpApiRouteRank,
+} from "../sim-http-api-route-rank.js";
+import { exactMethodRank } from "./sim-http-api-route-method.js";
+import type { SimHttpApiRouteKey } from "./sim-http-api-route-key.js";
+
+/**
+ * The catch-all route key, which serves any method and path the API has no
+ * more specific route for.
+ */
+export const simHttpApiDefaultRouteKey = "$default";
+
+/**
+ * The `$default` route.
+ *
+ * It matches everything and captures nothing, and it loses to every other
+ * matching route, which is the tier AWS documents it in.
+ */
+export class SimHttpApiDefaultRouteKey implements SimHttpApiRouteKey {
+  public readonly text = simHttpApiDefaultRouteKey;
+  public readonly signature = simHttpApiDefaultRouteKey;
+  public readonly rank = new SimHttpApiRouteRank({
+    tier: defaultRouteTier,
+    methodRank: exactMethodRank,
+    segmentRanks: [],
+  });
+
+  /**
+   * Match any request, capturing nothing.
+   *
+   * The empty capture is what keeps `pathParameters` out of the event for a
+   * `$default` match, which is what real API Gateway does with it. That is
+   * observed rather than documented.
+   */
+  match(): SimHttpApiPathParameters {
+    return new SimHttpApiPathParameters();
+  }
+}

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-method-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-method-route-key.ts
@@ -1,0 +1,73 @@
+import type { SimHttpApiPathParameters } from "../path/sim-http-api-path-parameters.js";
+import type { SimHttpApiRoutePath } from "../path/sim-http-api-route-path.js";
+import {
+  fullMatchTier,
+  greedyMatchTier,
+  SimHttpApiRouteRank,
+} from "../sim-http-api-route-rank.js";
+import type { SimHttpApiRouteRequest } from "../sim-http-api-route-request.js";
+import type { SimHttpApiRouteMethod } from "./sim-http-api-route-method.js";
+import type { SimHttpApiRouteKey } from "./sim-http-api-route-key.js";
+
+interface SimHttpApiMethodRouteKeyProperties {
+  readonly method: SimHttpApiRouteMethod;
+  readonly path: SimHttpApiRoutePath;
+}
+
+/**
+ * A route key naming a method and a path, such as `GET /pets/{petId}`.
+ */
+export class SimHttpApiMethodRouteKey implements SimHttpApiRouteKey {
+  public readonly method: SimHttpApiRouteMethod;
+  public readonly path: SimHttpApiRoutePath;
+  public readonly rank: SimHttpApiRouteRank;
+
+  constructor(properties: SimHttpApiMethodRouteKeyProperties) {
+    this.method = properties.method;
+    this.path = properties.path;
+    this.rank = new SimHttpApiRouteRank({
+      tier: this.tier,
+      methodRank: this.method.rank,
+      segmentRanks: this.path.segmentRanks,
+    });
+  }
+
+  /**
+   * The route key as it was written.
+   */
+  get text(): string {
+    return `${this.method.token} ${this.path.text}`;
+  }
+
+  /**
+   * The route key with its parameter names erased, which is the identity real
+   * API Gateway gives the route.
+   */
+  get signature(): string {
+    return `${this.method.token} ${this.path.signature}`;
+  }
+
+  /**
+   * Match a request of the right method against this route's path.
+   *
+   * A request whose path matches and whose method does not simply misses this
+   * route, rather than being told it used the wrong method. An HTTP API with
+   * nothing else to catch it answers 404 rather than 405, which is observed
+   * rather than documented.
+   */
+  match(request: SimHttpApiRouteRequest): SimHttpApiPathParameters | undefined {
+    if (!this.method.matches(request.method)) {
+      return undefined;
+    }
+
+    return this.path.match(request.segments);
+  }
+
+  private get tier(): number {
+    if (this.path.hasGreedySegment) {
+      return greedyMatchTier;
+    }
+
+    return fullMatchTier;
+  }
+}

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.iso.test.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.iso.test.ts
@@ -113,6 +113,19 @@ describe("Reading a sim HTTP API route key", () => {
     );
   });
 
+  it("refuses a path naming the same parameter twice", () => {
+    // Given a route key using one parameter name at two segments
+    // When it is read
+    // Then it is refused, because a handler reads path parameters off one
+    // object and only one of the two captures could arrive
+    expect(() => parser.parse("GET /pets/{id}/toys/{id}")).toThrow(
+      /names the path parameter 'id' more than once/,
+    );
+    expect(() => parser.parse("GET /pets/{id}/{id+}")).toThrow(
+      /names the path parameter 'id' more than once/,
+    );
+  });
+
   it("refuses an empty path segment", () => {
     // Given a route key with a doubled slash in its path
     // When it is read

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.iso.test.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.iso.test.ts
@@ -1,0 +1,131 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimApiGatewayV2BadRequest } from "../../../error/sim-api-gateway-v2.error.js";
+import { SimHttpApiDefaultRouteKey } from "./sim-http-api-default-route-key.js";
+import { SimHttpApiMethodRouteKey } from "./sim-http-api-method-route-key.js";
+import { SimHttpApiRouteKeyParser } from "./sim-http-api-route-key-parser.js";
+
+const parser = new SimHttpApiRouteKeyParser();
+
+describe("Reading a sim HTTP API route key", () => {
+  it("reads the catch-all route key", () => {
+    // Given the catch-all route key
+    // When it is read
+    const routeKey = parser.parse("$default");
+
+    // Then it is the catch-all, which matches everything and captures nothing
+    assertInstanceOf(routeKey, SimHttpApiDefaultRouteKey);
+    assertIdentical(routeKey.text, "$default");
+    assertIdentical(routeKey.signature, "$default");
+  });
+
+  it("reads a method and a path", () => {
+    // Given a route key naming a method and a parameterised path
+    // When it is read
+    const routeKey = parser.parse("GET /pets/{petId}");
+
+    // Then it keeps the text it was written with
+    assertInstanceOf(routeKey, SimHttpApiMethodRouteKey);
+    assertIdentical(routeKey.text, "GET /pets/{petId}");
+  });
+
+  it("erases parameter names from the signature", () => {
+    // Given two route keys differing only in their parameter names
+    // When both are read
+    const first = parser.parse("GET /pets/{id}/toys/{toy+}");
+    const second = parser.parse("GET /pets/{petId}/toys/{proxy+}");
+
+    // Then they share a signature, because a parameter name is not part of a
+    // route's identity on real AWS
+    assertIdentical(first.signature, second.signature);
+    assertIdentical(first.signature, "GET /pets/{}/toys/{+}");
+  });
+
+  it("reads a path of only literals", () => {
+    // Given a route key with no parameters in it
+    // When it is read
+    const routeKey = parser.parse("ANY /admin/reports");
+
+    // Then its signature is the key itself, since there is nothing to erase
+    assertIdentical(routeKey.signature, "ANY /admin/reports");
+  });
+
+  it("refuses a lower-case method", () => {
+    // Given a route key whose method is not upper-case
+    // When it is read
+    // Then it is refused, because it would be a route that never matched
+    expect(() => parser.parse("get /pets")).toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses a method the API does not have", () => {
+    // Given a route key naming something that is not an HTTP method
+    // When it is read
+    // Then it is refused by name
+    expect(() => parser.parse("FETCH /pets")).toThrow(
+      /does not name an HTTP method/,
+    );
+  });
+
+  it("refuses a route key that is not a method and a path", () => {
+    // Given route keys with the wrong number of parts
+    // When each is read
+    // Then each is refused
+    expect(() => parser.parse("/pets")).toThrow(/is not a route key/);
+    expect(() => parser.parse("GET /pets extra")).toThrow(/is not a route key/);
+    expect(() => parser.parse("")).toThrow(/is not a route key/);
+  });
+
+  it("refuses a path that does not start with a slash", () => {
+    // Given a route key whose path is relative
+    // When it is read
+    // Then it is refused
+    expect(() => parser.parse("GET pets")).toThrow(
+      /does not start with a slash/,
+    );
+  });
+
+  it("refuses an unbalanced brace", () => {
+    // Given route keys with a brace that does not close, or one that closes
+    // in the middle of a literal
+    // When each is read
+    // Then each is refused as a malformed segment
+    expect(() => parser.parse("GET /pets/{petId")).toThrow(
+      /malformed path segment/,
+    );
+    expect(() => parser.parse("GET /pets/petId}")).toThrow(
+      /malformed path segment/,
+    );
+    expect(() => parser.parse("GET /pets/pet{id}")).toThrow(
+      /malformed path segment/,
+    );
+    expect(() => parser.parse("GET /pets/{}")).toThrow(
+      /malformed path segment/,
+    );
+  });
+
+  it("refuses a greedy parameter before the end of the path", () => {
+    // Given a route key with a greedy parameter that is not the last segment
+    // When it is read
+    // Then it is refused, because nothing after it could ever match
+    expect(() => parser.parse("ANY /admin/{proxy+}/reports")).toThrow(
+      /greedy path parameter before the end/,
+    );
+  });
+
+  it("refuses an empty path segment", () => {
+    // Given a route key with a doubled slash in its path
+    // When it is read
+    // Then it is refused
+    expect(() => parser.parse("GET /pets//dog")).toThrow(/empty path segment/);
+  });
+
+  it("reads the root path", () => {
+    // Given a route key for the root of the API
+    // When it is read
+    const routeKey = parser.parse("GET /");
+
+    // Then it has no segments to match, which is the empty request path
+    assertIdentical(routeKey.signature, "GET /");
+  });
+});

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-key-parser.ts
@@ -1,0 +1,48 @@
+import { SimApiGatewayV2BadRequest } from "../../../error/sim-api-gateway-v2.error.js";
+import { SimHttpApiRoutePathParser } from "../path/sim-http-api-route-path-parser.js";
+import {
+  SimHttpApiDefaultRouteKey,
+  simHttpApiDefaultRouteKey,
+} from "./sim-http-api-default-route-key.js";
+import { SimHttpApiMethodRouteKey } from "./sim-http-api-method-route-key.js";
+import { SimHttpApiRouteMethod } from "./sim-http-api-route-method.js";
+import type { SimHttpApiRouteKey } from "./sim-http-api-route-key.js";
+
+/**
+ * Reads the `RouteKey` a `CreateRoute` request carries.
+ *
+ * A route key is either the literal `$default` or a method and a path
+ * separated by one space. Everything else is refused here, which is where real
+ * API Gateway refuses it too: a route key that cannot be read is a route that
+ * would never match a request, and finding that out at request time rather
+ * than at creation time is the failure worth avoiding.
+ */
+export class SimHttpApiRouteKeyParser {
+  private readonly pathParser = new SimHttpApiRoutePathParser();
+
+  /**
+   * Read a route key, or refuse it.
+   */
+  parse(routeKey: string): SimHttpApiRouteKey {
+    if (routeKey === simHttpApiDefaultRouteKey) {
+      return new SimHttpApiDefaultRouteKey();
+    }
+
+    const parts = routeKey.split(" ");
+
+    if (parts.length !== 2) {
+      throw new SimApiGatewayV2BadRequest(
+        `Route key '${routeKey}' is not a route key: a route key is either ` +
+          `$default or a method and a path separated by one space, such as ` +
+          `'GET /pets'`,
+      );
+    }
+
+    const [method = "", path = ""] = parts;
+
+    return new SimHttpApiMethodRouteKey({
+      method: SimHttpApiRouteMethod.parse(method, routeKey),
+      path: this.pathParser.parse(path, routeKey),
+    });
+  }
+}

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-key.ts
@@ -1,0 +1,29 @@
+import type { SimHttpApiPathParameters } from "../path/sim-http-api-path-parameters.js";
+import type { SimHttpApiRouteRank } from "../sim-http-api-route-rank.js";
+import type { SimHttpApiRouteRequest } from "../sim-http-api-route-request.js";
+
+/**
+ * A parsed route key: what decides whether a route serves a request, and what
+ * it captures from the path when it does.
+ *
+ * There are two of these, the `$default` catch-all and a method with a path,
+ * and they answer the same questions differently rather than the caller asking
+ * which one it has.
+ */
+export interface SimHttpApiRouteKey {
+  /** The route key as it was written, which is what `RouteKey` reports. */
+  readonly text: string;
+  /**
+   * The route key with parameter names erased, which is the identity real API
+   * Gateway gives a route: `GET /pets/{id}` and `GET /pets/{petId}` are one
+   * route and the second is a conflict.
+   */
+  readonly signature: string;
+  /** How specific this route is, for choosing between matching routes. */
+  readonly rank: SimHttpApiRouteRank;
+  /**
+   * The path parameters this route captures from a request it matches, or
+   * nothing when it does not match.
+   */
+  match(request: SimHttpApiRouteRequest): SimHttpApiPathParameters | undefined;
+}

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-method.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-method.ts
@@ -1,0 +1,77 @@
+import { SimApiGatewayV2BadRequest } from "../../../error/sim-api-gateway-v2.error.js";
+
+/**
+ * The method token matching any method, which is what makes a route the one
+ * for a path whatever the request did to it.
+ */
+export const simHttpApiAnyMethod = "ANY";
+
+/**
+ * The method tokens an HTTP API route key may name.
+ */
+const routeMethods = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+  simHttpApiAnyMethod,
+]);
+
+export const exactMethodRank = 0;
+export const anyMethodRank = 1;
+
+/**
+ * The method half of a route key, such as the `GET` of `GET /pets`.
+ */
+export class SimHttpApiRouteMethod {
+  public readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  /**
+   * Read a method token, naming the whole route key in anything refused.
+   *
+   * The token is upper-case or nothing, so `get /pets` is refused. That real
+   * API Gateway refuses it at `CreateRoute` is observed rather than
+   * documented, but a lower-case method here would be a route that never
+   * matched a request, which is worse than being told about it early.
+   */
+  static parse(token: string, routeKey: string): SimHttpApiRouteMethod {
+    if (!routeMethods.has(token)) {
+      throw new SimApiGatewayV2BadRequest(
+        `Route key '${routeKey}' does not name an HTTP method: a route key is ` +
+          `either $default or an upper-case method and a path, such as ` +
+          `'GET /pets'`,
+      );
+    }
+
+    return new SimHttpApiRouteMethod(token);
+  }
+
+  /**
+   * How specific this method is. An exact method beats `ANY`.
+   */
+  get rank(): number {
+    if (this.token === simHttpApiAnyMethod) {
+      return anyMethodRank;
+    }
+
+    return exactMethodRank;
+  }
+
+  /**
+   * Whether a request of this method reaches this route.
+   */
+  matches(requestMethod: string): boolean {
+    if (this.token === simHttpApiAnyMethod) {
+      return true;
+    }
+
+    return this.token === requestMethod;
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-greedy-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-greedy-segment.ts
@@ -18,10 +18,10 @@ export class SimHttpApiGreedySegment implements SimHttpApiPathSegment {
    * Every greedy segment has the same signature, whatever the name is.
    */
   public readonly signature = "{+}";
-  public readonly name: string;
+  public readonly parameterName: string;
 
-  constructor(name: string) {
-    this.name = name;
+  constructor(parameterName: string) {
+    this.parameterName = parameterName;
   }
 
   /**
@@ -39,7 +39,7 @@ export class SimHttpApiGreedySegment implements SimHttpApiPathSegment {
 
     return new SimHttpApiSegmentMatch(
       remaining.length,
-      new SimHttpApiPathParameter(this.name, remaining.join("/")),
+      new SimHttpApiPathParameter(this.parameterName, remaining.join("/")),
     );
   }
 }

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-greedy-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-greedy-segment.ts
@@ -1,0 +1,45 @@
+import { SimHttpApiPathParameter } from "./sim-http-api-path-parameters.js";
+import {
+  greedySegmentRank,
+  type SimHttpApiPathSegment,
+  SimHttpApiSegmentMatch,
+} from "./sim-http-api-path-segment.js";
+
+/**
+ * A route path segment capturing everything left of the path, such as
+ * `{proxy+}`.
+ *
+ * It is only ever the last segment of a route path, which is what makes
+ * "everything left" well defined.
+ */
+export class SimHttpApiGreedySegment implements SimHttpApiPathSegment {
+  public readonly rank = greedySegmentRank;
+  /**
+   * Every greedy segment has the same signature, whatever the name is.
+   */
+  public readonly signature = "{+}";
+  public readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  /**
+   * Take everything left of the request path.
+   *
+   * Two things here are observed rather than documented. A greedy segment
+   * needs at least one segment to match, so `GET /pets/{proxy+}` does not
+   * match `/pets`. And the captured value has no leading slash, so `/pets` and
+   * `cat/1` produce `cat/1` rather than `/cat/1`.
+   */
+  consume(remaining: readonly string[]): SimHttpApiSegmentMatch | undefined {
+    if (remaining.length === 0) {
+      return undefined;
+    }
+
+    return new SimHttpApiSegmentMatch(
+      remaining.length,
+      new SimHttpApiPathParameter(this.name, remaining.join("/")),
+    );
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-literal-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-literal-segment.ts
@@ -1,0 +1,38 @@
+import {
+  literalSegmentRank,
+  type SimHttpApiPathSegment,
+  SimHttpApiSegmentMatch,
+} from "./sim-http-api-path-segment.js";
+
+/**
+ * A route path segment naming one exact path segment, such as `pets`.
+ *
+ * It captures nothing, and it is the most specific kind of segment: a request
+ * matching a literal here matches nothing more general at the same position.
+ */
+export class SimHttpApiLiteralSegment implements SimHttpApiPathSegment {
+  public readonly rank = literalSegmentRank;
+  public readonly text: string;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+
+  /**
+   * A literal has no parameter name to erase, so it is its own signature.
+   */
+  get signature(): string {
+    return this.text;
+  }
+
+  /**
+   * Take the one request segment this literal names, when it is there.
+   */
+  consume(remaining: readonly string[]): SimHttpApiSegmentMatch | undefined {
+    if (remaining[0] !== this.text) {
+      return undefined;
+    }
+
+    return new SimHttpApiSegmentMatch(1);
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-literal-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-literal-segment.ts
@@ -12,6 +12,8 @@ import {
  */
 export class SimHttpApiLiteralSegment implements SimHttpApiPathSegment {
   public readonly rank = literalSegmentRank;
+  /** A literal captures nothing, so it has no parameter to capture into. */
+  public readonly parameterName = undefined;
   public readonly text: string;
 
   constructor(text: string) {

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-parameters.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-parameters.ts
@@ -1,0 +1,53 @@
+/**
+ * One value a parameterised route path captured from a request path.
+ */
+export class SimHttpApiPathParameter {
+  public readonly name: string;
+  public readonly value: string;
+
+  constructor(name: string, value: string) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
+/**
+ * The values the matched route captured from the request path.
+ *
+ * This is a class rather than a record because matching builds it up one
+ * segment at a time, and because an empty one has to stay tellable from one
+ * with values in it. It becomes a record only at the event boundary, which is
+ * the one place a handler reads it.
+ */
+export class SimHttpApiPathParameters {
+  private readonly captured = new Map<string, string>();
+
+  /**
+   * Whether nothing was captured, which is what a route of only literal
+   * segments produces.
+   */
+  get isEmpty(): boolean {
+    return this.captured.size === 0;
+  }
+
+  /**
+   * Take a captured value, if the segment that offered it captured one.
+   *
+   * A literal segment captures nothing, so it is allowed to offer nothing
+   * rather than every caller having to ask whether there is anything to add.
+   */
+  add(parameter: SimHttpApiPathParameter | undefined): void {
+    if (parameter === undefined) {
+      return;
+    }
+
+    this.captured.set(parameter.name, parameter.value);
+  }
+
+  /**
+   * The captured values as the event's `pathParameters` field holds them.
+   */
+  toRecord(): Record<string, string> {
+    return Object.fromEntries(this.captured);
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment-parser.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment-parser.ts
@@ -1,0 +1,59 @@
+import { SimApiGatewayV2BadRequest } from "../../../error/sim-api-gateway-v2.error.js";
+import { SimHttpApiGreedySegment } from "./sim-http-api-greedy-segment.js";
+import { SimHttpApiLiteralSegment } from "./sim-http-api-literal-segment.js";
+import type { SimHttpApiPathSegment } from "./sim-http-api-path-segment.js";
+import { SimHttpApiVariableSegment } from "./sim-http-api-variable-segment.js";
+
+/**
+ * A `{name}` or `{name+}` segment. The name is what reaches the handler as a
+ * path parameter, so it is the character set a JavaScript property name can
+ * hold without quoting.
+ */
+const parameterSegment = /^\{(?<name>[\w.-]+)(?<greedy>\+)?\}$/;
+
+/**
+ * Reads one segment of a route key path.
+ *
+ * A segment is either a literal or a parameter, and anything in between, such
+ * as `{petId` or `pets{id}`, is refused at `CreateRoute`. Real API Gateway
+ * refuses it there too, which is the point of parsing this early rather than
+ * discovering it when a request fails to match.
+ */
+export class SimHttpApiPathSegmentParser {
+  /**
+   * Read one path segment, naming the whole route key in anything refused so
+   * the caller can see which route it came from.
+   */
+  parse(text: string, routeKey: string): SimHttpApiPathSegment {
+    if (!text.includes("{") && !text.includes("}")) {
+      return this.literal(text, routeKey);
+    }
+
+    const groups = parameterSegment.exec(text)?.groups;
+    const name = groups?.["name"];
+
+    if (name === undefined) {
+      throw new SimApiGatewayV2BadRequest(
+        `Route key '${routeKey}' has the malformed path segment '${text}': ` +
+          "a segment is either a literal, a {name} parameter, or a {name+} " +
+          "greedy parameter",
+      );
+    }
+
+    if (groups?.["greedy"] === undefined) {
+      return new SimHttpApiVariableSegment(name);
+    }
+
+    return new SimHttpApiGreedySegment(name);
+  }
+
+  private literal(text: string, routeKey: string): SimHttpApiLiteralSegment {
+    if (text.length === 0) {
+      throw new SimApiGatewayV2BadRequest(
+        `Route key '${routeKey}' has an empty path segment`,
+      );
+    }
+
+    return new SimHttpApiLiteralSegment(text);
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment.ts
@@ -1,0 +1,49 @@
+import type { SimHttpApiPathParameter } from "./sim-http-api-path-parameters.js";
+
+/**
+ * How specific each kind of path segment is, lower being more specific.
+ *
+ * A literal segment names one path, a `{name}` segment names any one segment,
+ * and a `{proxy+}` segment names everything left. Route selection compares
+ * these segment by segment, rather than counting characters, because it is the
+ * segment where two routes first differ that decides between them.
+ */
+export const literalSegmentRank = 0;
+export const variableSegmentRank = 1;
+export const greedySegmentRank = 2;
+
+/**
+ * What one route path segment took from the front of a request path.
+ */
+export class SimHttpApiSegmentMatch {
+  public readonly consumed: number;
+  public readonly parameter?: SimHttpApiPathParameter | undefined;
+
+  constructor(consumed: number, parameter?: SimHttpApiPathParameter) {
+    this.consumed = consumed;
+    this.parameter = parameter;
+  }
+}
+
+/**
+ * One segment of a route path.
+ *
+ * Each kind of segment answers the same questions, so matching a route is a
+ * loop over its segments rather than a switch over segment kinds.
+ */
+export interface SimHttpApiPathSegment {
+  /** How specific this kind of segment is. Lower is more specific. */
+  readonly rank: number;
+  /**
+   * The segment with any parameter name erased.
+   *
+   * Two route keys differing only in a parameter name are the same route to
+   * real API Gateway, so this is what a route is stored under.
+   */
+  readonly signature: string;
+  /**
+   * Take what this segment matches from the front of the request path segments
+   * it is offered, or nothing when it does not match them.
+   */
+  consume(remaining: readonly string[]): SimHttpApiSegmentMatch | undefined;
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-segment.ts
@@ -35,6 +35,11 @@ export interface SimHttpApiPathSegment {
   /** How specific this kind of segment is. Lower is more specific. */
   readonly rank: number;
   /**
+   * The path parameter this segment captures into, or nothing for a literal,
+   * which captures into none.
+   */
+  readonly parameterName: string | undefined;
+  /**
    * The segment with any parameter name erased.
    *
    * Two route keys differing only in a parameter name are the same route to

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-segments.iso.test.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-segments.iso.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { simHttpApiPathSegments } from "./sim-http-api-path-segments.js";
+
+describe("Splitting a request path into sim HTTP API route segments", () => {
+  it("splits a path on its slashes", () => {
+    // Given a request path
+    // When it is split
+    // Then the leading slash produces no segment
+    expect(simHttpApiPathSegments("/pets/dog/1")).toStrictEqual([
+      "pets",
+      "dog",
+      "1",
+    ]);
+  });
+
+  it("reads the root as no segments at all", () => {
+    // Given the root path
+    // When it is split
+    // Then there is nothing for a route to match, which is what makes
+    // `GET /` the route for it
+    expect(simHttpApiPathSegments("/")).toStrictEqual([]);
+  });
+
+  it("ignores one trailing slash", () => {
+    // Given the same path with and without a trailing slash
+    // When each is split
+    // Then they are the same path, so both reach the same route
+    expect(simHttpApiPathSegments("/pets/")).toStrictEqual(["pets"]);
+  });
+
+  it("keeps an empty segment inside the path", () => {
+    // Given a path with a doubled slash in the middle
+    // When it is split
+    // Then the empty segment is kept, so it matches neither a literal nor a
+    // parameter and the request falls through to whatever catches it
+    expect(simHttpApiPathSegments("/pets//dog")).toStrictEqual([
+      "pets",
+      "",
+      "dog",
+    ]);
+  });
+});

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-path-segments.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-path-segments.ts
@@ -1,0 +1,20 @@
+/**
+ * Split a URL path into the segments route matching works through.
+ *
+ * A leading slash produces no segment, so `/pets/dog` is `pets` then `dog`,
+ * and `/` is no segments at all. One trailing slash is dropped, so `/pets/`
+ * and `/pets` are the same path. That last part is observed rather than
+ * documented: real API Gateway matches both to the same route.
+ */
+export function simHttpApiPathSegments(path: string): string[] {
+  // The leading slash is taken off rather than tested for: a URL pathname
+  // always has one, and a route key path without one is refused before this
+  // is reached.
+  const segments = path.slice(1).split("/");
+
+  if (segments.at(-1) === "") {
+    segments.pop();
+  }
+
+  return segments;
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-route-path-parser.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-route-path-parser.ts
@@ -1,0 +1,57 @@
+import { SimApiGatewayV2BadRequest } from "../../../error/sim-api-gateway-v2.error.js";
+import { SimHttpApiPathSegmentParser } from "./sim-http-api-path-segment-parser.js";
+import { greedySegmentRank } from "./sim-http-api-path-segment.js";
+import type { SimHttpApiPathSegment } from "./sim-http-api-path-segment.js";
+import { simHttpApiPathSegments } from "./sim-http-api-path-segments.js";
+import { SimHttpApiRoutePath } from "./sim-http-api-route-path.js";
+
+/**
+ * Reads the path half of a route key into the segments it is made of.
+ */
+export class SimHttpApiRoutePathParser {
+  private readonly segmentParser = new SimHttpApiPathSegmentParser();
+
+  /**
+   * Read a route key path, naming the whole route key in anything refused.
+   */
+  parse(path: string, routeKey: string): SimHttpApiRoutePath {
+    if (!path.startsWith("/")) {
+      throw new SimApiGatewayV2BadRequest(
+        `Route key '${routeKey}' has the path '${path}', which does not ` +
+          `start with a slash`,
+      );
+    }
+
+    const segments = simHttpApiPathSegments(path).map((text) =>
+      this.segmentParser.parse(text, routeKey),
+    );
+    this.requireGreedyLast(segments, routeKey);
+
+    return new SimHttpApiRoutePath({ text: path, segments });
+  }
+
+  /**
+   * Refuse a greedy segment anywhere but the end.
+   *
+   * A `{proxy+}` takes everything left of the path, so a segment after it
+   * could never match anything.
+   */
+  private requireGreedyLast(
+    segments: readonly SimHttpApiPathSegment[],
+    routeKey: string,
+  ): void {
+    const greedyAt = segments.findIndex(
+      (segment) => segment.rank === greedySegmentRank,
+    );
+
+    if (greedyAt === -1 || greedyAt === segments.length - 1) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `Route key '${routeKey}' has a greedy path parameter before the end of ` +
+        `the path: a {name+} parameter takes the rest of the path, so nothing ` +
+        `can follow it`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-route-path-parser.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-route-path-parser.ts
@@ -26,8 +26,41 @@ export class SimHttpApiRoutePathParser {
       this.segmentParser.parse(text, routeKey),
     );
     this.requireGreedyLast(segments, routeKey);
+    this.requireDistinctParameterNames(segments, routeKey);
 
     return new SimHttpApiRoutePath({ text: path, segments });
+  }
+
+  /**
+   * Refuse a path naming the same parameter twice.
+   *
+   * A handler reads path parameters off one object, so `GET /pets/{id}/toys/{id}`
+   * has one `id` to put two captures in. Accepting it would silently keep one
+   * segment and lose the other, which is the kind of quietly wrong behaviour
+   * refusing exists to avoid. Whether real API Gateway refuses it is not
+   * established, so this is stricter than AWS rather than known to match it.
+   */
+  private requireDistinctParameterNames(
+    segments: readonly SimHttpApiPathSegment[],
+    routeKey: string,
+  ): void {
+    const named = new Set<string>();
+
+    for (const { parameterName } of segments) {
+      if (parameterName === undefined) {
+        continue;
+      }
+
+      if (named.has(parameterName)) {
+        throw new SimApiGatewayV2BadRequest(
+          `Route key '${routeKey}' names the path parameter ` +
+            `'${parameterName}' more than once: a handler reads path ` +
+            `parameters off one object, so only one of them could arrive`,
+        );
+      }
+
+      named.add(parameterName);
+    }
   }
 
   /**

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-route-path.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-route-path.ts
@@ -1,0 +1,81 @@
+import { SimHttpApiPathParameters } from "./sim-http-api-path-parameters.js";
+import {
+  greedySegmentRank,
+  type SimHttpApiPathSegment,
+} from "./sim-http-api-path-segment.js";
+
+interface SimHttpApiRoutePathProperties {
+  readonly text: string;
+  readonly segments: readonly SimHttpApiPathSegment[];
+}
+
+/**
+ * The path half of a route key, such as `/pets/{petId}`.
+ *
+ * The text is kept as the route key gave it, since that is what `RouteKey`
+ * reports back and what reaches the handler as `event.routeKey`.
+ */
+export class SimHttpApiRoutePath {
+  public readonly text: string;
+  public readonly segments: readonly SimHttpApiPathSegment[];
+
+  constructor(properties: SimHttpApiRoutePathProperties) {
+    this.text = properties.text;
+    this.segments = properties.segments;
+  }
+
+  /**
+   * This path with every parameter name erased, which is what makes two route
+   * keys differing only in parameter name the same route.
+   */
+  get signature(): string {
+    return `/${this.segments.map((segment) => segment.signature).join("/")}`;
+  }
+
+  /**
+   * How specific each segment is, in order, for route selection to compare.
+   */
+  get segmentRanks(): readonly number[] {
+    return this.segments.map((segment) => segment.rank);
+  }
+
+  /**
+   * Whether this path ends in a greedy segment, which puts it behind every
+   * fully matching route.
+   */
+  get hasGreedySegment(): boolean {
+    return this.segments.some((segment) => segment.rank === greedySegmentRank);
+  }
+
+  /**
+   * Match this path against the segments of one request path, capturing
+   * whatever its parameters name.
+   *
+   * The request has to be used up exactly: a path with segments left over
+   * matches nothing, which is what keeps `GET /pets` from matching
+   * `/pets/dog`.
+   */
+  match(
+    requestSegments: readonly string[],
+  ): SimHttpApiPathParameters | undefined {
+    const parameters = new SimHttpApiPathParameters();
+    let taken = 0;
+
+    for (const segment of this.segments) {
+      const matched = segment.consume(requestSegments.slice(taken));
+
+      if (matched === undefined) {
+        return undefined;
+      }
+
+      parameters.add(matched.parameter);
+      taken += matched.consumed;
+    }
+
+    if (taken !== requestSegments.length) {
+      return undefined;
+    }
+
+    return parameters;
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-variable-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-variable-segment.ts
@@ -1,0 +1,43 @@
+import { SimHttpApiPathParameter } from "./sim-http-api-path-parameters.js";
+import {
+  type SimHttpApiPathSegment,
+  SimHttpApiSegmentMatch,
+  variableSegmentRank,
+} from "./sim-http-api-path-segment.js";
+
+/**
+ * A route path segment capturing one path segment, such as `{petId}`.
+ *
+ * It matches exactly one segment, whatever is in it, and the value reaches the
+ * handler as `event.pathParameters.petId`.
+ */
+export class SimHttpApiVariableSegment implements SimHttpApiPathSegment {
+  public readonly rank = variableSegmentRank;
+  /**
+   * Every parameter segment has the same signature, whatever the name is, so
+   * `GET /pets/{id}` and `GET /pets/{petId}` are one route.
+   */
+  public readonly signature = "{}";
+  public readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  /**
+   * Take the one request segment this parameter names, when there is one with
+   * something in it.
+   */
+  consume(remaining: readonly string[]): SimHttpApiSegmentMatch | undefined {
+    const [value] = remaining;
+
+    if (value === undefined || value.length === 0) {
+      return undefined;
+    }
+
+    return new SimHttpApiSegmentMatch(
+      1,
+      new SimHttpApiPathParameter(this.name, value),
+    );
+  }
+}

--- a/src/service/apigatewayv2/api/route/path/sim-http-api-variable-segment.ts
+++ b/src/service/apigatewayv2/api/route/path/sim-http-api-variable-segment.ts
@@ -18,10 +18,10 @@ export class SimHttpApiVariableSegment implements SimHttpApiPathSegment {
    * `GET /pets/{id}` and `GET /pets/{petId}` are one route.
    */
   public readonly signature = "{}";
-  public readonly name: string;
+  public readonly parameterName: string;
 
-  constructor(name: string) {
-    this.name = name;
+  constructor(parameterName: string) {
+    this.parameterName = parameterName;
   }
 
   /**
@@ -37,7 +37,7 @@ export class SimHttpApiVariableSegment implements SimHttpApiPathSegment {
 
     return new SimHttpApiSegmentMatch(
       1,
-      new SimHttpApiPathParameter(this.name, value),
+      new SimHttpApiPathParameter(this.parameterName, value),
     );
   }
 }

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-rank.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-rank.ts
@@ -1,0 +1,83 @@
+/**
+ * The three tiers AWS documents for route selection, most specific first: a
+ * route matching the whole path, a route ending in a greedy parameter, then
+ * the `$default` catch-all.
+ */
+export const fullMatchTier = 0;
+export const greedyMatchTier = 1;
+export const defaultRouteTier = 2;
+
+interface SimHttpApiRouteRankProperties {
+  readonly tier: number;
+  readonly methodRank: number;
+  readonly segmentRanks: readonly number[];
+}
+
+/**
+ * How specific one route is, and therefore which of two matching routes serves
+ * a request.
+ *
+ * The whole precedence rule lives in `compareTo`, in the order it is applied:
+ *
+ * 1. The tier. AWS documents this one: a full match beats a greedy match,
+ *    which beats `$default`.
+ * 2. The method. An exact method beats `ANY`. Observed rather than documented,
+ *    as is its place above the path comparison rather than below it.
+ * 3. The path, segment by segment from the left, with a literal beating a
+ *    `{name}` parameter and a `{name}` beating a `{name+}`. The first two rows
+ *    of AWS's worked example give the literal-beats-parameter part. Comparing
+ *    left to right rather than counting characters is what makes
+ *    `GET /a/b/{c}` beat `GET /a/{b}/ccccc`, which has more literal characters
+ *    and is less specific where it counts. It is also what gives the observed
+ *    rule that the longest literal prefix wins between two greedy routes:
+ *    `GET /pets/dog/{proxy+}` and `GET /pets/{proxy+}` differ at the second
+ *    segment, where one has a literal and the other has taken everything.
+ */
+export class SimHttpApiRouteRank {
+  public readonly tier: number;
+  public readonly methodRank: number;
+  public readonly segmentRanks: readonly number[];
+
+  constructor(properties: SimHttpApiRouteRankProperties) {
+    this.tier = properties.tier;
+    this.methodRank = properties.methodRank;
+    this.segmentRanks = properties.segmentRanks;
+  }
+
+  /**
+   * Compare this rank with another, negative meaning this one is more specific
+   * and therefore wins.
+   */
+  compareTo(other: SimHttpApiRouteRank): number {
+    if (this.tier !== other.tier) {
+      return this.tier - other.tier;
+    }
+
+    if (this.methodRank !== other.methodRank) {
+      return this.methodRank - other.methodRank;
+    }
+
+    return this.compareSegments(other);
+  }
+
+  private compareSegments(other: SimHttpApiRouteRank): number {
+    const shared = Math.min(
+      this.segmentRanks.length,
+      other.segmentRanks.length,
+    );
+
+    for (let index = 0; index < shared; index++) {
+      const mine = this.segmentRanks.at(index) ?? 0;
+      const theirs = other.segmentRanks.at(index) ?? 0;
+
+      if (mine !== theirs) {
+        return mine - theirs;
+      }
+    }
+
+    /* v8 ignore next -- two routes matching one request always differ
+       somewhere in the segments they share: if they did not, they would be the
+       same route key, and the second is refused as a conflict */
+    return 0;
+  }
+}

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-request.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-request.ts
@@ -1,0 +1,21 @@
+interface SimHttpApiRouteRequestProperties {
+  readonly method: string;
+  readonly segments: readonly string[];
+}
+
+/**
+ * One request as route selection sees it: the HTTP method, and the path
+ * segments left once the stage has taken its own.
+ *
+ * A named stage is a path segment the routes know nothing about, so
+ * `/dev/pets/6` on stage `dev` reaches route selection as `pets` then `6`.
+ */
+export class SimHttpApiRouteRequest {
+  public readonly method: string;
+  public readonly segments: readonly string[];
+
+  constructor(properties: SimHttpApiRouteRequestProperties) {
+    this.method = properties.method;
+    this.segments = properties.segments;
+  }
+}

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-selector.iso.test.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-selector.iso.test.ts
@@ -1,0 +1,283 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import type { SimHttpApiIntegrationId } from "../integration/sim-http-api-integration.js";
+import { SimHttpApiRouteKeyParser } from "./key/sim-http-api-route-key-parser.js";
+import { simHttpApiPathSegments } from "./path/sim-http-api-path-segments.js";
+import { SimHttpApiRouteRequest } from "./sim-http-api-route-request.js";
+import { SimHttpApiRouteSelector } from "./sim-http-api-route-selector.js";
+import {
+  makeSimHttpApiRouteId,
+  SimHttpApiRoute,
+} from "./sim-http-api-route.js";
+
+const parser = new SimHttpApiRouteKeyParser();
+const selector = new SimHttpApiRouteSelector();
+
+/**
+ * Build the routes of an API from their route keys, all onto one integration.
+ */
+function routesFor(routeKeys: readonly string[]): SimHttpApiRoute[] {
+  return routeKeys.map(
+    (routeKey) =>
+      new SimHttpApiRoute({
+        routeId: makeSimHttpApiRouteId(),
+        key: parser.parse(routeKey),
+        integrationId: "abcdefgh" as SimHttpApiIntegrationId,
+        authorizationType: "NONE",
+      }),
+  );
+}
+
+/**
+ * The route key selected for one request, or undefined when nothing matched.
+ */
+function selectedKey(
+  routeKeys: readonly string[],
+  method: string,
+  path: string,
+): string | undefined {
+  return selector.select(
+    routesFor(routeKeys),
+    new SimHttpApiRouteRequest({
+      method,
+      segments: simHttpApiPathSegments(path),
+    }),
+  )?.route.routeKey;
+}
+
+/**
+ * AWS's published worked example of route selection, verbatim.
+ */
+const publishedExample = [
+  "GET /pets/dog/1",
+  "GET /pets/dog/{id}",
+  "GET /pets/{proxy+}",
+  "ANY /{proxy+}",
+  "$default",
+];
+
+describe("Choosing the sim HTTP API route that serves a request", () => {
+  it("selects the routes of AWS's worked example", () => {
+    // Given the five routes AWS documents the selection order with
+    // When each of its example requests arrives
+    // Then each reaches the route AWS says it does
+    assertIdentical(
+      selectedKey(publishedExample, "GET", "/pets/dog/1"),
+      "GET /pets/dog/1",
+    );
+    assertIdentical(
+      selectedKey(publishedExample, "GET", "/pets/dog/2"),
+      "GET /pets/dog/{id}",
+    );
+    assertIdentical(
+      selectedKey(publishedExample, "GET", "/pets/cat/1"),
+      "GET /pets/{proxy+}",
+    );
+    assertIdentical(
+      selectedKey(publishedExample, "POST", "/test/5"),
+      "ANY /{proxy+}",
+    );
+  });
+
+  it("falls back to the catch-all when nothing else matches", () => {
+    // Given an API with a specific route and a catch-all
+    const routeKeys = ["GET /pets", "$default"];
+
+    // When a request matches neither the method nor the path of the specific
+    // route
+    // Then the catch-all serves it, since it is behind everything else
+    assertIdentical(selectedKey(routeKeys, "GET", "/orders"), "$default");
+    assertIdentical(selectedKey(routeKeys, "POST", "/pets"), "$default");
+  });
+
+  it("prefers a literal segment to a parameter", () => {
+    // Given two routes differing only at the segment the request fills
+    const routeKeys = ["GET /pets/dog", "GET /pets/{petId}"];
+
+    // When a request could match either
+    // When the literal is what the request has there
+    // Then the literal wins, and otherwise the parameter takes it
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/dog"),
+      "GET /pets/dog",
+    );
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/cat"),
+      "GET /pets/{petId}",
+    );
+  });
+
+  it("prefers a full match to a greedy one", () => {
+    // Given a route of two parameters and a more literal greedy route
+    const routeKeys = ["GET /{owner}/{petId}", "GET /pets/{proxy+}"];
+
+    // When a request matches both
+    // Then the fully matching route wins, which is the tier AWS documents,
+    // even though the greedy one starts with a literal
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/dog"),
+      "GET /{owner}/{petId}",
+    );
+  });
+
+  it("prefers an exact method to ANY", () => {
+    // Given the same path routed for one method and for any method
+    const routeKeys = ["GET /pets/{petId}", "ANY /pets/{petId}"];
+
+    // When a GET arrives
+    // Then the exact method wins, and another method falls to ANY
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/6"),
+      "GET /pets/{petId}",
+    );
+    assertIdentical(
+      selectedKey(routeKeys, "DELETE", "/pets/6"),
+      "ANY /pets/{petId}",
+    );
+  });
+
+  it("prefers the longest literal prefix between greedy routes", () => {
+    // Given two greedy routes, one reaching further into the path
+    const routeKeys = ["GET /pets/dog/{proxy+}", "GET /pets/{proxy+}"];
+
+    // When a request matches both
+    // Then the one with more literal segments before the greedy one wins
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/dog/collars/1"),
+      "GET /pets/dog/{proxy+}",
+    );
+    assertIdentical(
+      selectedKey(routeKeys, "GET", "/pets/cat/1"),
+      "GET /pets/{proxy+}",
+    );
+  });
+
+  it("matches no route when the method is wrong and nothing catches it", () => {
+    // Given an API routing one method of one path, with no ANY route, no
+    // greedy route and no catch-all
+    const routeKeys = ["GET /pets"];
+
+    // When another method of that path is requested
+    const selected = selector.select(
+      routesFor(routeKeys),
+      new SimHttpApiRouteRequest({ method: "POST", segments: ["pets"] }),
+    );
+
+    // Then nothing serves it, which an HTTP API answers as a 404 rather than
+    // the 405 a method mismatch might suggest
+    assertUndefined(selected);
+  });
+
+  it("captures a path parameter from the segment it matched", () => {
+    // Given a parameterised route
+    const routes = routesFor(["GET /pets/{petId}/toys/{toyId}"]);
+
+    // When a request matches it
+    const selected = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({
+        method: "GET",
+        segments: ["pets", "6", "toys", "9"],
+      }),
+    );
+
+    // Then each parameter carries what was in its segment
+    expect(selected?.pathParameters.toRecord()).toStrictEqual({
+      petId: "6",
+      toyId: "9",
+    });
+  });
+
+  it("captures the rest of the path into a greedy parameter", () => {
+    // Given a greedy route
+    const routes = routesFor(["GET /pets/{proxy+}"]);
+
+    // When a request reaches past its literal segment
+    const selected = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({
+        method: "GET",
+        segments: ["pets", "cat", "1"],
+      }),
+    );
+
+    // Then the remainder is captured with no leading slash
+    expect(selected?.pathParameters.toRecord()).toStrictEqual({
+      proxy: "cat/1",
+    });
+  });
+
+  it("does not match a greedy route with nothing left to take", () => {
+    // Given a greedy route
+    const routes = routesFor(["GET /pets/{proxy+}"]);
+
+    // When the request path stops where the greedy segment starts
+    const selected = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({ method: "GET", segments: ["pets"] }),
+    );
+
+    // Then it does not match, because a greedy parameter needs at least one
+    // segment
+    assertUndefined(selected);
+  });
+
+  it("needs a segment for a parameter to match", () => {
+    // Given a route ending in a parameter
+    const routes = routesFor(["GET /pets/{petId}"]);
+
+    // When the request path stops before it, or has nothing in that segment
+    const short = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({ method: "GET", segments: ["pets"] }),
+    );
+    const empty = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({ method: "GET", segments: ["pets", ""] }),
+    );
+
+    // Then neither matches, because {petId} needs one segment with something
+    // in it
+    assertUndefined(short);
+    assertUndefined(empty);
+  });
+
+  it("captures nothing for a route of only literals", () => {
+    // Given a route with no parameters in it
+    const routes = routesFor(["GET /pets"]);
+
+    // When it matches a request
+    const selected = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({ method: "GET", segments: ["pets"] }),
+    );
+
+    // Then there are no path parameters, which keeps the field out of the
+    // event entirely
+    assertNonNullable(selected);
+    assertTrue(selected.pathParameters.isEmpty);
+  });
+
+  it("matches one segment per parameter, not several", () => {
+    // Given a route with one parameter at the end
+    const routes = routesFor(["GET /pets/{petId}"]);
+
+    // When a request has more path than that
+    const selected = selector.select(
+      routes,
+      new SimHttpApiRouteRequest({
+        method: "GET",
+        segments: ["pets", "dog", "1"],
+      }),
+    );
+
+    // Then it does not match, because {petId} takes exactly one segment
+    assertUndefined(selected);
+  });
+});

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-selector.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-selector.ts
@@ -1,0 +1,68 @@
+import type { SimHttpApiPathParameters } from "./path/sim-http-api-path-parameters.js";
+import type { SimHttpApiRouteRequest } from "./sim-http-api-route-request.js";
+import type { SimHttpApiRoute } from "./sim-http-api-route.js";
+
+interface SimHttpApiRouteSelectionProperties {
+  readonly route: SimHttpApiRoute;
+  readonly pathParameters: SimHttpApiPathParameters;
+}
+
+/**
+ * One route that matched a request, with what it captured from the path.
+ */
+export class SimHttpApiRouteSelection {
+  public readonly route: SimHttpApiRoute;
+  public readonly pathParameters: SimHttpApiPathParameters;
+
+  constructor(properties: SimHttpApiRouteSelectionProperties) {
+    this.route = properties.route;
+    this.pathParameters = properties.pathParameters;
+  }
+
+  /**
+   * Whether this route is the more specific of the two, and so the one that
+   * serves the request.
+   */
+  beats(other: SimHttpApiRouteSelection): boolean {
+    return this.route.key.rank.compareTo(other.route.key.rank) < 0;
+  }
+}
+
+/**
+ * Picks the route that serves one request.
+ *
+ * Every route is asked whether it matches, and the most specific of the ones
+ * that do wins. Two routes of an API cannot rank the same for one request,
+ * because two route keys that would are the same route key and the second is
+ * refused as a conflict when it is created.
+ */
+export class SimHttpApiRouteSelector {
+  /**
+   * Find the route serving this request, if the API has one.
+   */
+  select(
+    routes: readonly SimHttpApiRoute[],
+    request: SimHttpApiRouteRequest,
+  ): SimHttpApiRouteSelection | undefined {
+    let selected: SimHttpApiRouteSelection | undefined;
+
+    for (const route of routes) {
+      const pathParameters = route.key.match(request);
+
+      if (pathParameters === undefined) {
+        continue;
+      }
+
+      const candidate = new SimHttpApiRouteSelection({
+        route,
+        pathParameters,
+      });
+
+      if (selected === undefined || candidate.beats(selected)) {
+        selected = candidate;
+      }
+    }
+
+    return selected;
+  }
+}

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-selector.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-selector.ts
@@ -32,8 +32,8 @@ export class SimHttpApiRouteSelection {
  * Picks the route that serves one request.
  *
  * Every route is asked whether it matches, and the most specific of the ones
- * that do wins. Two routes of an API cannot rank the same for one request,
- * because two route keys that would are the same route key and the second is
+ * that do wins. There is always one winner: two route keys that would rank the
+ * same for a request are the same route key, and the second of those is
  * refused as a conflict when it is created.
  */
 export class SimHttpApiRouteSelector {

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-store.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-store.ts
@@ -7,11 +7,13 @@ import {
 /**
  * The routes of one API.
  *
- * Routes are keyed by route key rather than by id, because the route key is
- * what makes a route unique on real AWS: an API cannot have two routes for the
- * same method and path, and the id is only how a route is addressed
- * afterwards. The ids in use are tracked alongside, so allocating one can
- * avoid them.
+ * Routes are keyed by route key signature rather than by id, because the route
+ * key is what makes a route unique on real AWS: an API cannot have two routes
+ * for the same method and path, and the id is only how a route is addressed
+ * afterwards. The signature rather than the text, because a parameter name is
+ * not part of a route's identity, so `GET /pets/{id}` and `GET /pets/{petId}`
+ * are the same route. The ids in use are tracked alongside, so allocating one
+ * can avoid them.
  */
 export class SimHttpApiRouteStore {
   private readonly routes = new Map<string, SimHttpApiRoute>();
@@ -35,15 +37,16 @@ export class SimHttpApiRouteStore {
    * Add a route to this API.
    */
   add(route: SimHttpApiRoute): void {
-    this.routes.set(route.routeKey, route);
+    this.routes.set(route.key.signature, route);
     this.routeIds.add(route.routeId);
   }
 
   /**
-   * Find the route for a route key.
+   * Find the route holding a route key signature, which is what tells whether
+   * the API is already routing a route key.
    */
-  findByKey(routeKey: string): SimHttpApiRoute | undefined {
-    return this.routes.get(routeKey);
+  findBySignature(signature: string): SimHttpApiRoute | undefined {
+    return this.routes.get(signature);
   }
 
   /**

--- a/src/service/apigatewayv2/api/route/sim-http-api-route.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route.ts
@@ -2,17 +2,12 @@ import { faker } from "@faker-js/faker";
 
 import type { Brand } from "../../../../util/brand.type.js";
 import type { SimHttpApiIntegrationId } from "../integration/sim-http-api-integration.js";
+import type { SimHttpApiRouteKey } from "./key/sim-http-api-route-key.js";
 
 /**
  * The id API Gateway allocates for one route.
  */
 export type SimHttpApiRouteId = Brand<string, "SimHttpApiRouteId">;
-
-/**
- * The catch-all route key, which matches any method and path the API has no
- * more specific route for. It is the only route key simulated so far.
- */
-export const simHttpApiDefaultRouteKey = "$default";
 
 /**
  * The only authorization type simulated: none, so anyone may call the route.
@@ -28,7 +23,7 @@ export function makeSimHttpApiRouteId(): SimHttpApiRouteId {
 
 interface SimHttpApiRouteProperties {
   readonly routeId: SimHttpApiRouteId;
-  readonly routeKey: string;
+  readonly key: SimHttpApiRouteKey;
   readonly integrationId: SimHttpApiIntegrationId;
   readonly authorizationType: SimHttpApiAuthorizationType;
 }
@@ -48,15 +43,23 @@ export interface SimHttpApiRouteView {
  */
 export class SimHttpApiRoute {
   public readonly routeId: SimHttpApiRouteId;
-  public readonly routeKey: string;
+  public readonly key: SimHttpApiRouteKey;
   public readonly integrationId: SimHttpApiIntegrationId;
   public readonly authorizationType: SimHttpApiAuthorizationType;
 
   constructor(properties: SimHttpApiRouteProperties) {
     this.routeId = properties.routeId;
-    this.routeKey = properties.routeKey;
+    this.key = properties.key;
     this.integrationId = properties.integrationId;
     this.authorizationType = properties.authorizationType;
+  }
+
+  /**
+   * The route key as it was written, which is what the API reports back and
+   * what reaches the handler as `event.routeKey`.
+   */
+  get routeKey(): string {
+    return this.key.text;
   }
 
   /**

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -13,9 +13,14 @@ export interface SimHttpApiLambdaProxyInput {
   readonly apiName: string;
   readonly functionName: string;
   readonly roleArn: string;
-  /** The function code the API's one route hands every request to. */
+  /** The function code every route of the API hands its requests to. */
   readonly handler: (event: SimPayload2Event) => unknown;
   readonly disableExecuteApiEndpoint: boolean;
+  /** The route keys the API routes, all onto the one integration. */
+  readonly routeKeys: readonly string[];
+  /** The stages the API serves from. */
+  readonly stageNames: readonly string[];
+  /** The variables every one of those stages carries. */
   readonly stageVariables: Readonly<Record<string, string>>;
 }
 
@@ -51,6 +56,8 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     roleArn: "arn:aws:iam::111111111111:role/OrdersRole",
     handler: (): string => "hello",
     disableExecuteApiEndpoint: false,
+    routeKeys: ["$default"],
+    stageNames: ["$default"],
     stageVariables: {},
   }),
   async (input, simAws) => {
@@ -81,22 +88,30 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
         },
       });
 
-    await simApiGatewayV2.createRoute({
-      input: {
-        ApiId: apiId,
-        RouteKey: "$default",
-        Target: `integrations/${integrationId}`,
-      },
-    });
+    await Promise.all(
+      input.routeKeys.map(async (routeKey) =>
+        simApiGatewayV2.createRoute({
+          input: {
+            ApiId: apiId,
+            RouteKey: routeKey,
+            Target: `integrations/${integrationId}`,
+          },
+        }),
+      ),
+    );
 
-    await simApiGatewayV2.createStage({
-      input: {
-        ApiId: apiId,
-        StageName: "$default",
-        AutoDeploy: true,
-        StageVariables: input.stageVariables,
-      },
-    });
+    await Promise.all(
+      input.stageNames.map(async (stageName) =>
+        simApiGatewayV2.createStage({
+          input: {
+            ApiId: apiId,
+            StageName: stageName,
+            AutoDeploy: true,
+            StageVariables: input.stageVariables,
+          },
+        }),
+      ),
+    );
 
     // An id CreateApi allocated is an API the store holds, so this is only
     // missing if something is wrong with the simulator itself.

--- a/src/service/apigatewayv2/api/sim-http-api-match.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-match.ts
@@ -1,24 +1,25 @@
 import type { SimHttpApiIntegrationStore } from "./integration/sim-http-api-integration-store.js";
 import type { SimHttpApiIntegration } from "./integration/sim-http-api-integration.js";
+import type { SimHttpApiPathParameters } from "./route/path/sim-http-api-path-parameters.js";
 import type { SimHttpApiRouteStore } from "./route/sim-http-api-route-store.js";
-import {
-  simHttpApiDefaultRouteKey,
-  type SimHttpApiRoute,
-} from "./route/sim-http-api-route.js";
+import { SimHttpApiRouteRequest } from "./route/sim-http-api-route-request.js";
+import { SimHttpApiRouteSelector } from "./route/sim-http-api-route-selector.js";
+import type { SimHttpApiRoute } from "./route/sim-http-api-route.js";
 import type { SimHttpApiStageStore } from "./stage/sim-http-api-stage-store.js";
-import {
-  simHttpApiDefaultStageName,
-  type SimHttpApiStage,
-} from "./stage/sim-http-api-stage.js";
+import { SimHttpApiStageSelector } from "./stage/sim-http-api-stage-selector.js";
+import type { SimHttpApiStage } from "./stage/sim-http-api-stage.js";
+import type { SimHttpApiRequest } from "./sim-http-api-request.js";
 
 /**
- * What an API found for one request: the route that matched it, the
- * integration behind that route, and the stage serving it.
+ * What an API found for one request: the stage serving it, the route that
+ * matched it, the integration behind that route, and whatever the route
+ * captured from the path.
  */
 export interface SimHttpApiMatch {
   readonly route: SimHttpApiRoute;
   readonly integration: SimHttpApiIntegration;
   readonly stage: SimHttpApiStage;
+  readonly pathParameters: SimHttpApiPathParameters;
 }
 
 /**
@@ -31,29 +32,56 @@ interface SimHttpApiStores {
 }
 
 /**
- * Find what should handle one request to an API.
+ * Finds what should handle one request to an API.
  *
- * Only the `$default` route is simulated, so every request an API is asked
- * about matches it if it exists, whatever the method and path. A request
- * reaching an API with no route, or no stage to serve it from, matches
+ * The stage goes first, because a named stage is a path segment the routes
+ * know nothing about: `/dev/pets/6` served from stage `dev` is the route path
+ * `/pets/6`. The routes then compete for what is left.
+ *
+ * A request reaching an API with no stage for it, or no route for it, matches
  * nothing, which is a 404 on real AWS.
  */
-export function simHttpApiMatch(
-  stores: SimHttpApiStores,
-): SimHttpApiMatch | undefined {
-  const route = stores.routes.findByKey(simHttpApiDefaultRouteKey);
-  const stage = stores.stages.find(simHttpApiDefaultStageName);
+export class SimHttpApiMatcher {
+  private readonly stageSelector = new SimHttpApiStageSelector();
+  private readonly routeSelector = new SimHttpApiRouteSelector();
 
-  if (route === undefined || stage === undefined) {
-    return undefined;
+  /**
+   * Find what serves one request to an API.
+   */
+  match(
+    stores: SimHttpApiStores,
+    request: SimHttpApiRequest,
+  ): SimHttpApiMatch | undefined {
+    const stage = this.stageSelector.select(stores.stages, request.segments);
+
+    if (stage === undefined) {
+      return undefined;
+    }
+
+    const selected = this.routeSelector.select(
+      stores.routes.list(),
+      new SimHttpApiRouteRequest({
+        method: request.method,
+        segments: stage.segments,
+      }),
+    );
+
+    if (selected === undefined) {
+      return undefined;
+    }
+
+    const integration = stores.integrations.find(selected.route.integrationId);
+
+    /* v8 ignore if -- a route cannot name an integration the API never had */
+    if (integration === undefined) {
+      return undefined;
+    }
+
+    return {
+      route: selected.route,
+      integration,
+      stage: stage.stage,
+      pathParameters: selected.pathParameters,
+    };
   }
-
-  const integration = stores.integrations.find(route.integrationId);
-
-  /* v8 ignore if -- a route cannot name an integration the API never had */
-  if (integration === undefined) {
-    return undefined;
-  }
-
-  return { route, integration, stage };
 }

--- a/src/service/apigatewayv2/api/sim-http-api-request.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-request.ts
@@ -1,0 +1,30 @@
+import { simHttpApiPathSegments } from "./route/path/sim-http-api-path-segments.js";
+
+interface SimHttpApiRequestProperties {
+  readonly method: string;
+  readonly path: string;
+}
+
+/**
+ * One request arriving at an API's endpoint.
+ *
+ * The path is the whole request path, stage segment and all, which is what the
+ * event reports as `rawPath`. Stage selection takes its own segment off before
+ * route selection sees the rest.
+ */
+export class SimHttpApiRequest {
+  public readonly method: string;
+  public readonly path: string;
+
+  constructor(properties: SimHttpApiRequestProperties) {
+    this.method = properties.method;
+    this.path = properties.path;
+  }
+
+  /**
+   * The path split into the segments matching works through.
+   */
+  get segments(): readonly string[] {
+    return simHttpApiPathSegments(this.path);
+  }
+}

--- a/src/service/apigatewayv2/api/sim-http-api.ts
+++ b/src/service/apigatewayv2/api/sim-http-api.ts
@@ -3,8 +3,12 @@ import { SimHttpApiIntegrationStore } from "./integration/sim-http-api-integrati
 import { SimHttpApiRouteStore } from "./route/sim-http-api-route-store.js";
 import { SimHttpApiStageStore } from "./stage/sim-http-api-stage-store.js";
 import { simHttpApiHost } from "./sim-http-api-host.js";
-import { type SimHttpApiMatch, simHttpApiMatch } from "./sim-http-api-match.js";
+import {
+  type SimHttpApiMatch,
+  SimHttpApiMatcher,
+} from "./sim-http-api-match.js";
 import type { SimHttpApiId } from "./sim-http-api-id.js";
+import type { SimHttpApiRequest } from "./sim-http-api-request.js";
 import {
   type SimHttpApiProtocolType,
   simHttpApiView,
@@ -42,6 +46,8 @@ export class SimHttpApi {
   public readonly routes = new SimHttpApiRouteStore();
   public readonly stages = new SimHttpApiStageStore();
 
+  private readonly matcher = new SimHttpApiMatcher();
+
   constructor(properties: SimHttpApiProperties) {
     this.apiId = properties.apiId;
     this.name = properties.name;
@@ -76,8 +82,8 @@ export class SimHttpApi {
   /**
    * Find what should handle one request to this API.
    */
-  match(): SimHttpApiMatch | undefined {
-    return simHttpApiMatch(this);
+  match(request: SimHttpApiRequest): SimHttpApiMatch | undefined {
+    return this.matcher.match(this, request);
   }
 
   /**

--- a/src/service/apigatewayv2/api/stage/sim-http-api-stage-selector.iso.test.ts
+++ b/src/service/apigatewayv2/api/stage/sim-http-api-stage-selector.iso.test.ts
@@ -1,0 +1,123 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimHttpApiStageStore } from "./sim-http-api-stage-store.js";
+import { SimHttpApiStageSelector } from "./sim-http-api-stage-selector.js";
+import { SimHttpApiStage } from "./sim-http-api-stage.js";
+
+const selector = new SimHttpApiStageSelector();
+
+/**
+ * Build the stages of an API from their names.
+ */
+function stagesFor(stageNames: readonly string[]): SimHttpApiStageStore {
+  const stages = new SimHttpApiStageStore();
+
+  for (const stageName of stageNames) {
+    stages.add(
+      new SimHttpApiStage({
+        stageName,
+        autoDeploy: true,
+        createdDate: new Date(0),
+      }),
+    );
+  }
+
+  return stages;
+}
+
+describe("Choosing the sim HTTP API stage that serves a request", () => {
+  it("takes a named stage off the front of the path", () => {
+    // Given an API with a named stage
+    const stages = stagesFor(["dev"]);
+
+    // When a request arrives under that name
+    const selected = selector.select(stages, ["dev", "pets", "6"]);
+
+    // Then the stage serves it, and the routes see the rest of the path
+    assertNonNullable(selected);
+    assertIdentical(selected.stage.stageName, "dev");
+    expect(selected.segments).toStrictEqual(["pets", "6"]);
+  });
+
+  it("gives the whole path to the default stage", () => {
+    // Given an API with only the default stage
+    const stages = stagesFor(["$default"]);
+
+    // When a request arrives
+    const selected = selector.select(stages, ["pets", "6"]);
+
+    // Then the default stage serves it with nothing taken off the path, since
+    // it is served at the root of the endpoint
+    assertNonNullable(selected);
+    assertIdentical(selected.stage.stageName, "$default");
+    expect(selected.segments).toStrictEqual(["pets", "6"]);
+  });
+
+  it("prefers a named stage to the default stage", () => {
+    // Given an API with both a default stage and a stage named pets
+    const stages = stagesFor(["$default", "pets"]);
+
+    // When a request whose first segment is that name arrives
+    const selected = selector.select(stages, ["pets", "dog"]);
+
+    // Then the named stage takes it, because stage selection runs before the
+    // routes see anything, whatever a route would have made of /pets/dog
+    assertNonNullable(selected);
+    assertIdentical(selected.stage.stageName, "pets");
+    expect(selected.segments).toStrictEqual(["dog"]);
+  });
+
+  it("falls back to the default stage for an unknown first segment", () => {
+    // Given an API with a default stage and a named one
+    const stages = stagesFor(["$default", "dev"]);
+
+    // When a request names neither
+    const selected = selector.select(stages, ["pets", "6"]);
+
+    // Then the default stage serves it with the path intact
+    assertNonNullable(selected);
+    assertIdentical(selected.stage.stageName, "$default");
+    expect(selected.segments).toStrictEqual(["pets", "6"]);
+  });
+
+  it("serves the root of the endpoint from the default stage", () => {
+    // Given an API with a default stage
+    const stages = stagesFor(["$default"]);
+
+    // When the root is requested, which has no segments at all
+    const selected = selector.select(stages, []);
+
+    // Then the default stage takes it
+    assertIdentical(selected?.stage.stageName, "$default");
+  });
+
+  it("does not read $default in a path as a stage name", () => {
+    // Given an API with a default stage
+    const stages = stagesFor(["$default"]);
+
+    // When a request happens to start with that literal path segment
+    const selected = selector.select(stages, ["$default", "pets"]);
+
+    // Then it is a path, not a stage name: the default stage is served at the
+    // root of the endpoint and is not addressable by name
+    assertNonNullable(selected);
+    assertIdentical(selected.stage.stageName, "$default");
+    expect(selected.segments).toStrictEqual(["$default", "pets"]);
+  });
+
+  it("matches no stage when the API has none for the request", () => {
+    // Given an API whose only stage is a named one
+    const stages = stagesFor(["dev"]);
+
+    // When a request arrives outside it, with no default stage to catch it
+    const selected = selector.select(stages, ["pets", "6"]);
+
+    // Then nothing serves it, which is a 404 on real AWS
+    assertUndefined(selected);
+  });
+});

--- a/src/service/apigatewayv2/api/stage/sim-http-api-stage-selector.ts
+++ b/src/service/apigatewayv2/api/stage/sim-http-api-stage-selector.ts
@@ -1,0 +1,79 @@
+import type { SimHttpApiStageStore } from "./sim-http-api-stage-store.js";
+import {
+  simHttpApiDefaultStageName,
+  type SimHttpApiStage,
+} from "./sim-http-api-stage.js";
+
+interface SimHttpApiStageSelectionProperties {
+  readonly stage: SimHttpApiStage;
+  readonly segments: readonly string[];
+}
+
+/**
+ * The stage serving a request, and the path segments left for the routes.
+ */
+export class SimHttpApiStageSelection {
+  public readonly stage: SimHttpApiStage;
+  public readonly segments: readonly string[];
+
+  constructor(properties: SimHttpApiStageSelectionProperties) {
+    this.stage = properties.stage;
+    this.segments = properties.segments;
+  }
+}
+
+/**
+ * Picks the stage serving one request.
+ *
+ * A named stage is served under its own name, so the first path segment of
+ * `/dev/pets/6` names the stage and the routes never see it. The `$default`
+ * stage is served at the root instead, and keeps the whole path.
+ *
+ * This runs before route selection, and a named stage wins outright: an API
+ * with a stage named `pets` serves `/pets/dog` from that stage, whatever its
+ * routes would have made of the path.
+ */
+export class SimHttpApiStageSelector {
+  /**
+   * Find the stage serving this request, if the API has one for it.
+   */
+  select(
+    stages: SimHttpApiStageStore,
+    segments: readonly string[],
+  ): SimHttpApiStageSelection | undefined {
+    const named = this.namedStage(stages, segments);
+
+    if (named !== undefined) {
+      return named;
+    }
+
+    const fallback = stages.find(simHttpApiDefaultStageName);
+
+    if (fallback === undefined) {
+      return undefined;
+    }
+
+    return new SimHttpApiStageSelection({ stage: fallback, segments });
+  }
+
+  private namedStage(
+    stages: SimHttpApiStageStore,
+    segments: readonly string[],
+  ): SimHttpApiStageSelection | undefined {
+    const [first, ...rest] = segments;
+
+    // A `$default` stage is not addressable by name, so a request path saying
+    // so is a path, not a stage.
+    if (first === undefined || first === simHttpApiDefaultStageName) {
+      return undefined;
+    }
+
+    const stage = stages.find(first);
+
+    if (stage === undefined) {
+      return undefined;
+    }
+
+    return new SimHttpApiStageSelection({ stage, segments: rest });
+  }
+}

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-commands.iso.test.ts
@@ -81,6 +81,25 @@ describe("Sim API Gateway v2 route commands", () => {
     expect(items.map((route) => route.RouteId)).toStrictEqual([routeId]);
   });
 
+  it("creates a route for a method and a path", async () => {
+    // Given an API with an integration
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+
+    // When a route names a method and a parameterised path
+    const created = await simAws.apiGatewayV2().createRoute(
+      new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: "GET /pets/{petId}",
+        Target: target,
+      }),
+    );
+
+    // Then the route key comes back as it was written
+    assertIdentical(created.RouteKey, "GET /pets/{petId}");
+    assertIdentical(created.Target, target);
+  });
+
   it("refuses a second route for a route key the API already has", async () => {
     // Given an API that already routes $default
     const simAws = new SimAws();
@@ -104,6 +123,67 @@ describe("Sim API Gateway v2 route commands", () => {
         }),
       ),
     ).rejects.toThrow(SimApiGatewayV2Conflict);
+  });
+
+  it("refuses two route keys differing only in parameter name", async () => {
+    // Given an API already routing a parameterised path
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+    await simAws.apiGatewayV2().createRoute(
+      new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: "GET /pets/{id}",
+        Target: target,
+      }),
+    );
+
+    // When the same path is routed again under another parameter name
+    // Then it conflicts, because a parameter name is not part of a route's
+    // identity: both keys match exactly the same requests
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /pets/{petId}",
+          Target: target,
+        }),
+      ),
+    ).rejects.toThrow(/already has a route for GET \/pets\/\{id\}/);
+  });
+
+  it("refuses a malformed route key", async () => {
+    // Given an API with an integration
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+
+    // When a route key cannot be read
+    // Then it is refused here, which is where real API Gateway refuses it too
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "get /pets",
+          Target: target,
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses a route on an API that does not exist", async () => {
+    // Given a simulated AWS with no APIs in it
+    const simAws = new SimAws();
+
+    // When a route is created on an API id nothing holds
+    // Then it is reported as not found
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: "abcdefghij",
+          RouteKey: "$default",
+          Target: "integrations/abcdefgh",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
   });
 
   it("refuses a route targeting an integration the API does not have", async () => {

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
@@ -1,7 +1,5 @@
-import {
-  simHttpApiDefaultRouteKey,
-  SimHttpApiRoute,
-} from "../../api/route/sim-http-api-route.js";
+import { SimHttpApiRouteKeyParser } from "../../api/route/key/sim-http-api-route-key-parser.js";
+import { SimHttpApiRoute } from "../../api/route/sim-http-api-route.js";
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
 import type { SimHttpApiAccess } from "../sim-http-api-access.js";
@@ -32,6 +30,7 @@ interface SimHttpApiRouteCommandsProperties {
 export class SimHttpApiRouteCommands {
   private readonly access: SimHttpApiAccess;
   private readonly routeTarget = new SimHttpApiRouteTarget();
+  private readonly routeKeyParser = new SimHttpApiRouteKeyParser();
 
   constructor(properties: SimHttpApiRouteCommandsProperties) {
     this.access = properties.access;
@@ -48,13 +47,10 @@ export class SimHttpApiRouteCommands {
     const unsimulated = new SimApiGatewayV2UnsimulatedInput("CreateRoute");
     unsimulated.refuseUnaccepted(input, acceptedCreateRouteOptions);
     const apiId = unsimulated.require("ApiId", input.ApiId);
-    unsimulated.require("RouteKey", input.RouteKey);
-    unsimulated.refuseUnless(
-      "RouteKey",
-      input.RouteKey,
-      simHttpApiDefaultRouteKey,
-      "matching a route by method and path is not simulated, so every " +
-        "request reaches the catch-all route",
+    // Parsed before the API is looked up, because a malformed route key is a
+    // bad request whether or not the API it names exists.
+    const routeKey = this.routeKeyParser.parse(
+      unsimulated.require("RouteKey", input.RouteKey),
     );
     unsimulated.refuseUnless(
       "AuthorizationType",
@@ -70,11 +66,11 @@ export class SimHttpApiRouteCommands {
       childPath: routesPath,
       caller: options?.caller,
     });
-    this.routeTarget.requireUnusedRouteKey(httpApi, simHttpApiDefaultRouteKey);
+    this.routeTarget.requireUnusedRouteKey(httpApi, routeKey);
 
     const route = new SimHttpApiRoute({
       routeId: httpApi.routes.allocateId(),
-      routeKey: simHttpApiDefaultRouteKey,
+      key: routeKey,
       integrationId: this.routeTarget.integrationId(httpApi, target),
       authorizationType: "NONE",
     });

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-target.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-target.ts
@@ -1,4 +1,5 @@
 import type { SimHttpApiIntegrationId } from "../../api/integration/sim-http-api-integration.js";
+import type { SimHttpApiRouteKey } from "../../api/route/key/sim-http-api-route-key.js";
 import type { SimHttpApi } from "../../api/sim-http-api.js";
 import {
   SimApiGatewayV2BadRequest,
@@ -45,12 +46,24 @@ export class SimHttpApiRouteTarget {
   /**
    * Ensure the API is not already routing this route key, which real API
    * Gateway answers with a conflict.
+   *
+   * Two route keys differing only in a parameter name are one route key, so
+   * `GET /pets/{petId}` conflicts with an existing `GET /pets/{id}`. The
+   * existing key is named in the conflict rather than the new one, since that
+   * is the part the caller cannot see.
    */
-  requireUnusedRouteKey(httpApi: SimHttpApi, routeKey: string): void {
-    if (httpApi.routes.findByKey(routeKey) !== undefined) {
-      throw new SimApiGatewayV2Conflict(
-        `API ${httpApi.apiId} already has a route for ${routeKey}`,
-      );
+  requireUnusedRouteKey(
+    httpApi: SimHttpApi,
+    routeKey: SimHttpApiRouteKey,
+  ): void {
+    const existing = httpApi.routes.findBySignature(routeKey.signature);
+
+    if (existing === undefined) {
+      return;
     }
+
+    throw new SimApiGatewayV2Conflict(
+      `API ${httpApi.apiId} already has a route for ${existing.routeKey}`,
+    );
   }
 }

--- a/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
+++ b/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
@@ -124,25 +124,6 @@ describe("What sim API Gateway v2 refuses rather than ignores", () => {
     ).rejects.toThrow(/IntegrationType 'HTTP_PROXY' is not simulated/);
   });
 
-  it("refuses a route key that names a method and path", async () => {
-    // Given an API
-    const simAws = new SimAws();
-    const apiId = await createdApiId(simAws);
-
-    // When a route matches one method and path
-    // Then it is refused, because route matching is not simulated and every
-    // request reaches the catch-all route
-    await expect(
-      simAws.apiGatewayV2().createRoute(
-        new CreateRouteCommand({
-          ApiId: apiId,
-          RouteKey: "GET /orders",
-          Target: "integrations/abcdefgh",
-        }),
-      ),
-    ).rejects.toThrow(/RouteKey 'GET \/orders' is not simulated/);
-  });
-
   it("refuses a route with an authorizer", async () => {
     // Given an API
     const simAws = new SimAws();

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.iso.test.ts
@@ -10,6 +10,7 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import {
   SimApiGatewayV2BadRequest,
   SimApiGatewayV2Conflict,
+  SimApiGatewayV2NotFound,
 } from "../../error/sim-api-gateway-v2.error.js";
 
 describe("Sim API Gateway v2 stage commands", () => {
@@ -38,6 +39,93 @@ describe("Sim API Gateway v2 stage commands", () => {
     assertTrue(created.AutoDeploy);
     expect(created.StageVariables).toStrictEqual({ catalogue: "v2" });
     assertIdentical(created.Description, "The live stage");
+  });
+
+  it("creates a named stage alongside the default one", async () => {
+    // Given an API with its default stage
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+    await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: apiId,
+        StageName: "$default",
+        AutoDeploy: true,
+      }),
+    );
+
+    // When a second stage is created under a name
+    const created = await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: apiId,
+        StageName: "dev",
+        AutoDeploy: true,
+      }),
+    );
+
+    // Then the API has both, since a named stage is served under its own path
+    // segment rather than replacing the default one
+    assertIdentical(created.StageName, "dev");
+    const { Items: items } = await simAws
+      .apiGatewayV2()
+      .getStages(new GetStagesCommand({ ApiId: apiId }));
+    expect(items.map((stage) => stage.StageName)).toStrictEqual([
+      "$default",
+      "dev",
+    ]);
+  });
+
+  it("refuses a stage name that could not appear in a URL", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When a stage is named with something outside the alphanumerics, hyphens
+    // and underscores AWS accepts
+    // Then it is refused rather than becoming a stage nothing could reach
+    await expect(
+      simAws.apiGatewayV2().createStage(
+        new CreateStageCommand({
+          ApiId: apiId,
+          StageName: "dev/two",
+          AutoDeploy: true,
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+
+    const tooLong = new CreateStageCommand({
+      ApiId: apiId,
+      StageName: "d".repeat(129),
+      AutoDeploy: true,
+    });
+
+    await expect(simAws.apiGatewayV2().createStage(tooLong)).rejects.toThrow(
+      /is not a stage name/,
+    );
+  });
+
+  it("refuses a stage on an API that does not exist", async () => {
+    // Given a simulated AWS with no APIs in it
+    const simAws = new SimAws();
+
+    // When a stage is created on an API id nothing holds
+    // Then it is reported as not found
+    await expect(
+      simAws.apiGatewayV2().createStage(
+        new CreateStageCommand({
+          ApiId: "abcdefghij",
+          StageName: "dev",
+          AutoDeploy: true,
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
   });
 
   it("lists the stages of an API", async () => {

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
@@ -1,8 +1,5 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
-import {
-  simHttpApiDefaultStageName,
-  SimHttpApiStage,
-} from "../../api/stage/sim-http-api-stage.js";
+import { SimHttpApiStage } from "../../api/stage/sim-http-api-stage.js";
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
 import type { SimHttpApiAccess } from "../sim-http-api-access.js";
@@ -53,13 +50,8 @@ export class SimHttpApiStageCommands {
     const unsimulated = new SimApiGatewayV2UnsimulatedInput("CreateStage");
     unsimulated.refuseUnaccepted(input, acceptedCreateStageOptions);
     const apiId = unsimulated.require("ApiId", input.ApiId);
-    unsimulated.require("StageName", input.StageName);
-    unsimulated.refuseUnless(
-      "StageName",
-      input.StageName,
-      simHttpApiDefaultStageName,
-      "a named stage is served under a stage path segment, and that is not " +
-        "simulated",
+    const stageName = this.rules.requireStageName(
+      unsimulated.require("StageName", input.StageName),
     );
     this.rules.requireAutoDeploy(input.AutoDeploy);
 
@@ -69,10 +61,10 @@ export class SimHttpApiStageCommands {
       childPath: stagesPath,
       caller: options?.caller,
     });
-    this.rules.requireUnusedStageName(httpApi, simHttpApiDefaultStageName);
+    this.rules.requireUnusedStageName(httpApi, stageName);
 
     const stage = new SimHttpApiStage({
-      stageName: simHttpApiDefaultStageName,
+      stageName,
       autoDeploy: true,
       stageVariables: input.StageVariables,
       description: input.Description,

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-rules.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-rules.ts
@@ -1,3 +1,4 @@
+import { simHttpApiDefaultStageName } from "../../api/stage/sim-http-api-stage.js";
 import type { SimHttpApi } from "../../api/sim-http-api.js";
 import {
   SimApiGatewayV2BadRequest,
@@ -5,9 +6,33 @@ import {
 } from "../../error/sim-api-gateway-v2.error.js";
 
 /**
+ * A stage name other than `$default`: alphanumerics, hyphens and underscores,
+ * up to 128 characters, which is what real API Gateway accepts.
+ */
+const stageName = /^[\w-]{1,128}$/;
+
+/**
  * The rules a stage has to satisfy before an API will hold it.
  */
 export class SimHttpApiStageRules {
+  /**
+   * Read a stage name, or refuse it.
+   *
+   * A stage name reaches the URL of every request the stage serves, so a name
+   * that could not appear in a path is refused here rather than becoming a
+   * stage nothing can reach.
+   */
+  requireStageName(name: string): string {
+    if (name === simHttpApiDefaultStageName || stageName.test(name)) {
+      return name;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `Stage name '${name}' is not a stage name: a stage is either $default ` +
+        `or up to 128 alphanumerics, hyphens and underscores`,
+    );
+  }
+
   /**
    * Refuse a stage that does not deploy itself.
    *

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -2,6 +2,7 @@ export { SimApiGatewayV2 } from "./sim-api-gateway-v2.js";
 export type { SimApiGatewayV2RequestOptions } from "./command/sim-api-gateway-v2-request-options.js";
 export { SimHttpApi } from "./api/sim-http-api.js";
 export type { SimHttpApiMatch } from "./api/sim-http-api-match.js";
+export { SimHttpApiRequest } from "./api/sim-http-api-request.js";
 export type {
   SimHttpApiProtocolType,
   SimHttpApiView,
@@ -23,11 +24,27 @@ export {
 export { SimHttpApiLambdaUri } from "./api/integration/sim-http-api-lambda-uri.js";
 export {
   type SimHttpApiAuthorizationType,
-  simHttpApiDefaultRouteKey,
   SimHttpApiRoute,
   type SimHttpApiRouteId,
   type SimHttpApiRouteView,
 } from "./api/route/sim-http-api-route.js";
+export type { SimHttpApiRouteKey } from "./api/route/key/sim-http-api-route-key.js";
+export {
+  SimHttpApiDefaultRouteKey,
+  simHttpApiDefaultRouteKey,
+} from "./api/route/key/sim-http-api-default-route-key.js";
+export { SimHttpApiMethodRouteKey } from "./api/route/key/sim-http-api-method-route-key.js";
+export {
+  simHttpApiAnyMethod,
+  SimHttpApiRouteMethod,
+} from "./api/route/key/sim-http-api-route-method.js";
+export { SimHttpApiRouteKeyParser } from "./api/route/key/sim-http-api-route-key-parser.js";
+export {
+  SimHttpApiPathParameter,
+  SimHttpApiPathParameters,
+} from "./api/route/path/sim-http-api-path-parameters.js";
+export { SimHttpApiRoutePath } from "./api/route/path/sim-http-api-route-path.js";
+export { SimHttpApiRouteRank } from "./api/route/sim-http-api-route-rank.js";
 export {
   simHttpApiDefaultStageName,
   SimHttpApiStage,

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -5,6 +5,7 @@ import type {
 import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-event-builder.js";
 import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimHttpApiRequest } from "../api/sim-http-api-request.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
@@ -62,7 +63,14 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
   }
 
   private async invoke(api: SimHttpApi, request: Request): Promise<Response> {
-    const match = api.match();
+    // The whole request path, stage segment and all: the stage takes its own
+    // segment off, and `rawPath` reports the path as the client sent it.
+    const match = api.match(
+      new SimHttpApiRequest({
+        method: request.method,
+        path: new URL(request.url).pathname,
+      }),
+    );
 
     if (match === undefined) {
       return this.errorResponse.notFound();

--- a/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
@@ -6,9 +6,10 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
  * Describe an API and the route that matched as the endpoint a payload format
  * 2.0 event names.
  *
- * There are no path parameters here, because the only simulated route key is
- * the catch-all `$default`, which captures nothing. Stage variables come from
- * the stage that served the request.
+ * The path parameters come from the matched route and the stage variables from
+ * the stage that served the request. Either may be empty, and the event
+ * builder leaves an empty one out of the event, which is what real API Gateway
+ * does with them.
  */
 export function simHttpApiEndpoint(
   api: SimHttpApi,
@@ -20,6 +21,7 @@ export function simHttpApiEndpoint(
     domainPrefix: api.apiId,
     routeKey: match.route.routeKey,
     stage: match.stage.stageName,
+    pathParameters: match.pathParameters.toRecord(),
     stageVariables: match.stage.stageVariables,
   };
 }

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-routes.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-routes.iso.test.ts
@@ -1,0 +1,160 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+
+function localUrl(apiEndpoint: string, path: string): string {
+  return new SimAwsLocalUrl({ input: `${apiEndpoint}${path}` }).toString();
+}
+
+/** A handler echoing its invocation event back, so a test can assert on it. */
+const echoEvent = (event: SimPayload2Event): SimPayload2Event => event;
+
+describe("Matching a served sim HTTP API request to a route", () => {
+  it("gives the handler the route it matched and what it captured", async () => {
+    // Given an API routing several keys onto one function
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["GET /pets", "GET /pets/{petId}", "ANY /admin/{proxy+}"],
+      },
+      simAws,
+    );
+
+    // When a request matches the parameterised route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/pets/6"),
+    );
+
+    // Then the handler is told which route took it, and the segment the
+    // parameter matched reaches it as a path parameter
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.routeKey, "GET /pets/{petId}");
+    assertIdentical(event.requestContext.routeKey, "GET /pets/{petId}");
+    expect(event.pathParameters).toStrictEqual({ petId: "6" });
+  });
+
+  it("captures the rest of the path into a greedy parameter", async () => {
+    // Given an API with a greedy route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["ANY /admin/{proxy+}"] },
+      simAws,
+    );
+
+    // When a request reaches past the literal part of it
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/admin/reports/2026/07"),
+      { method: "POST" },
+    );
+
+    // Then the remainder is captured with no leading slash, and ANY took a
+    // method no exact route named
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.routeKey, "ANY /admin/{proxy+}");
+    expect(event.pathParameters).toStrictEqual({ proxy: "reports/2026/07" });
+  });
+
+  it("leaves path parameters out of the event when a route captures none", async () => {
+    // Given an API with a literal route and a catch-all
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets", "$default"] },
+      simAws,
+    );
+    const http = new SimAwsHttp({ simAws });
+
+    // When each of them serves a request
+    const literal = await http.fetch(localUrl(api.apiEndpoint, "/pets"));
+    const catchAll = await http.fetch(localUrl(api.apiEndpoint, "/orders"));
+
+    // Then neither event carries the field, rather than carrying an empty one
+    const literalEvent = (await literal.json()) as SimPayload2Event;
+    const catchAllEvent = (await catchAll.json()) as SimPayload2Event;
+    assertIdentical(literalEvent.routeKey, "GET /pets");
+    assertUndefined(literalEvent.pathParameters);
+    assertIdentical(catchAllEvent.routeKey, "$default");
+    assertUndefined(catchAllEvent.pathParameters);
+  });
+
+  it("answers 404 for a method no route of the path has", async () => {
+    // Given an API routing one method of one path, with no ANY route, no
+    // greedy route and no catch-all to pick the request up
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets"] },
+      simAws,
+    );
+
+    // When that path is requested with another method
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/pets"),
+      { method: "DELETE" },
+    );
+
+    // Then it is a 404 rather than a 405: an HTTP API matches a route or it
+    // does not, and a method that matches no route is no match
+    assertIdentical(response.status, 404);
+    expect(await response.json()).toStrictEqual({ message: "Not Found" });
+  });
+
+  it("answers 404 for a path no route matches", async () => {
+    // Given an API with one route and no catch-all
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets/{petId}"] },
+      simAws,
+    );
+
+    // When a request goes deeper than that route's one parameter
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/pets/6/toys"),
+    );
+
+    // Then nothing serves it
+    assertIdentical(response.status, 404);
+  });
+
+  it("routes AWS's worked example through a served endpoint", async () => {
+    // Given the five routes AWS documents the selection order with
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: [
+          "GET /pets/dog/1",
+          "GET /pets/dog/{id}",
+          "GET /pets/{proxy+}",
+          "ANY /{proxy+}",
+          "$default",
+        ],
+      },
+      simAws,
+    );
+    const http = new SimAwsHttp({ simAws });
+
+    // When each of AWS's example requests is served
+    const responses = await Promise.all([
+      http.fetch(localUrl(api.apiEndpoint, "/pets/dog/1")),
+      http.fetch(localUrl(api.apiEndpoint, "/pets/dog/2")),
+      http.fetch(localUrl(api.apiEndpoint, "/pets/cat/1")),
+      http.fetch(localUrl(api.apiEndpoint, "/test/5"), { method: "POST" }),
+    ]);
+    const events = (await Promise.all(
+      responses.map(async (response) => response.json()),
+    )) as SimPayload2Event[];
+
+    // Then each reaches the route AWS says it does
+    expect(events.map((event) => event.routeKey)).toStrictEqual([
+      "GET /pets/dog/1",
+      "GET /pets/dog/{id}",
+      "GET /pets/{proxy+}",
+      "ANY /{proxy+}",
+    ]);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-stages.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-stages.iso.test.ts
@@ -1,0 +1,162 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+
+function localUrl(apiEndpoint: string, path: string): string {
+  return new SimAwsLocalUrl({ input: `${apiEndpoint}${path}` }).toString();
+}
+
+/** A handler echoing its invocation event back, so a test can assert on it. */
+const echoEvent = (event: SimPayload2Event): SimPayload2Event => event;
+
+describe("Serving a sim HTTP API from a named stage", () => {
+  it("serves a named stage under its own path segment", async () => {
+    // Given an API with a named stage and a parameterised route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["GET /pets/{petId}"],
+        stageNames: ["dev"],
+      },
+      simAws,
+    );
+
+    // When a request arrives under the stage name
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/dev/pets/6"),
+    );
+
+    // Then the stage segment is not part of what the route matched, but it is
+    // part of the path the event reports. The stage prefix in rawPath is
+    // corroborated by the documented $context.path access log variable, "the
+    // request path, for example /{stage}/root/child", rather than by the
+    // payload format page.
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.rawPath, "/dev/pets/6");
+    assertIdentical(event.requestContext.http.path, "/dev/pets/6");
+    assertIdentical(event.requestContext.stage, "dev");
+    assertIdentical(event.routeKey, "GET /pets/{petId}");
+    expect(event.pathParameters).toStrictEqual({ petId: "6" });
+  });
+
+  it("selects the stage before it selects the route", async () => {
+    // Given an API whose stage name is also the first segment of one of its
+    // routes
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["GET /dog", "GET /pets/dog"],
+        stageNames: ["$default", "pets"],
+      },
+      simAws,
+    );
+
+    // When a request could be read either way
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/pets/dog"),
+    );
+
+    // Then the stage takes the first segment and the routes only see what is
+    // left, so an explicit stage match beats any route match
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.requestContext.stage, "pets");
+    assertIdentical(event.routeKey, "GET /dog");
+  });
+
+  it("serves the default stage at the root of the endpoint", async () => {
+    // Given an API with both a default stage and a named one
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["GET /pets"],
+        stageNames: ["$default", "dev"],
+      },
+      simAws,
+    );
+    const http = new SimAwsHttp({ simAws });
+
+    // When the same route is requested with and without the stage name
+    const root = await http.fetch(localUrl(api.apiEndpoint, "/pets"));
+    const named = await http.fetch(localUrl(api.apiEndpoint, "/dev/pets"));
+
+    // Then both reach the route, from the stage their path named
+    const rootEvent = (await root.json()) as SimPayload2Event;
+    const namedEvent = (await named.json()) as SimPayload2Event;
+    assertIdentical(rootEvent.requestContext.stage, "$default");
+    assertIdentical(namedEvent.requestContext.stage, "dev");
+    assertIdentical(namedEvent.rawPath, "/dev/pets");
+  });
+
+  it("answers 404 when no stage serves the request", async () => {
+    // Given an API with only a named stage
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["$default"],
+        stageNames: ["dev"],
+      },
+      simAws,
+    );
+
+    // When a request arrives outside that stage, with no default stage to
+    // catch it
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/pets"),
+    );
+
+    // Then there is nothing to serve it, even though the API has a catch-all
+    // route
+    assertIdentical(response.status, 404);
+    expect(await response.json()).toStrictEqual({ message: "Not Found" });
+  });
+
+  it("gives the handler the variables of the stage that served it", async () => {
+    // Given an API with a named stage carrying stage variables
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: echoEvent,
+        routeKeys: ["$default"],
+        stageNames: ["dev"],
+        stageVariables: { catalogue: "v2" },
+      },
+      simAws,
+    );
+
+    // When it serves a request
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/dev/pets"),
+    );
+
+    // Then the variables reach the handler
+    const event = (await response.json()) as SimPayload2Event;
+    expect(event.stageVariables).toStrictEqual({ catalogue: "v2" });
+  });
+
+  it("leaves stage variables out of the event for a stage with none", async () => {
+    // Given an API whose stage carries no variables
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, stageNames: ["dev"] },
+      simAws,
+    );
+
+    // When it serves a request
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/dev"),
+    );
+
+    // Then the field is absent rather than empty
+    const event = (await response.json()) as SimPayload2Event;
+    assertUndefined(event.stageVariables);
+  });
+});


### PR DESCRIPTION
…and stage

Route keys are parsed and validated at CreateRoute, one class per segment kind. A served request selects the route real API Gateway would, with the precedence rule in SimHttpApiRouteRank.compareTo. Named stages work alongside $default, and stage selection runs before route selection.

Resolves https://github.com/KensioSoftware/yulin/issues/299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom HTTP API routes, including literal, parameterized, greedy, `ANY`, and `$default` routes.
  - Added named-stage routing and stage-name validation.
  - Requests now capture route path parameters and include them in responses.
  - Route matching follows AWS precedence rules for methods, paths, and stages.
  - Added an executable API Gateway v2 routing example.

- **Documentation**
  - Expanded routing, stage behavior, path parameters, precedence, and known limitations.

- **Tests**
  - Added broad coverage for route parsing, matching, stages, validation, and served responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->