### PR TITLE
feat: require an invoke permission before a simulated HTTP API calls …

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -52,8 +52,11 @@ share a name, and only the id tells them apart.
 ## Routing requests to a Lambda function
 
 An API needs three more resources before it serves anything: an integration naming the function, a
-route pointing at that integration, and a stage to serve it from. Once they exist, `serveSimAws`
-answers requests to the generated endpoint by invoking the function.
+route pointing at that integration, and a stage to serve it from. The function also has to allow API
+Gateway to invoke it, which is a permission on the function rather than anything on the API. See
+[Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
+Once all of that exists, `serveSimAws` answers requests to the generated endpoint by invoking the
+function.
 
 Pass the API endpoint through `srv.localUrl(...)`, which keeps the endpoint's hostname but sends the
 request to the local server, in the same way it adapts simulated S3 website and Lambda Function URL
@@ -70,7 +73,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
 import { SimAws } from "@kensio/yulin";
 import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
@@ -120,6 +126,16 @@ await apiGateway.createStage(
   new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
 );
 
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
 const srv = await serveSimAws({ simAws });
 
 const response = await fetch(srv.localUrl(`${ApiEndpoint}/orders?limit=10`));
@@ -133,6 +149,45 @@ srv.close();
 The `$default` route matches any method and path, so every request to the endpoint reaches the
 function. The integration URI is the function's ARN, and the function may be in another Account or
 Region: it is looked up where its ARN says it is.
+
+## Granting the API permission to invoke the function
+
+A Lambda proxy integration does not work until the function's resource policy allows
+`apigateway.amazonaws.com` to invoke it. The console adds that permission for you; an integration
+created through CloudFormation, the CLI or an SDK does not, which is what `AddPermissionCommand` in
+the example above is for. Without it the request is answered with a 500 and
+`{"message":"Internal Server Error"}`, and the handler does not run. CDK's
+`HttpLambdaIntegration` emits the same grant as an `AWS::Lambda::Permission`.
+
+Each request is authorized as `lambda:InvokeFunction` on the function ARN, with the caller being the
+service principal `apigateway.amazonaws.com`. The function's own resource policy is what decides: a
+service principal has no identity policies of its own. The route that matched is supplied as
+`AWS:SourceArn`, so a permission may be granted for one route and not another:
+
+```text
+arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<route path>
+```
+
+- The Account and Region are the API's, not the function's.
+- The stage is the one that served the request, so `$default` for the default stage.
+- The method is the request's own, so a `GET` reaching a route keyed `ANY /orders` gives `GET`.
+- The path is the matched route key's template with its parameter braces intact, so a request to
+  `/orders/42` on the route `GET /orders/{orderId}` gives `orders/{orderId}`. A `SourceArn` is
+  written against route keys rather than against paths, and IAM treats a brace as an ordinary
+  character.
+- The `$default` route has no method and no path of its own, so both collapse into one `$default`
+  segment: `<apiId>/<stage>/$default`.
+
+A `SourceArn` may wildcard any part of that, which is what the usual grant does:
+`<apiId>/*/*` allows every route of the API on every stage.
+
+`AWS:SourceArn` is the only condition key supplied here. A permission that also carries
+`SourceAccount`, `PrincipalOrgID` or `InvokedViaFunctionUrl` never matches, since nothing gives those
+keys a value at request time, so the request is refused with the same 500.
+
+Neither the method nor the path is documented by AWS as the value API Gateway supplies. Both are
+inferred from the permission patterns AWS and CDK write, which is recorded next to the code that
+builds the ARN.
 
 ## Route keys
 
@@ -217,7 +272,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
 import { SimAws } from "@kensio/yulin";
 import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
@@ -277,6 +335,16 @@ for (const RouteKey of [
 
 await apiGateway.createStage(
   new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pets",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
 );
 
 const srv = await serveSimAws({ simAws });
@@ -459,6 +527,8 @@ the simulation without being given one. See the
   path segment, including stage variables
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
   payload format 2.0 event and turning its result back into an HTTP response
+- The integration's invoke permission, evaluated against the function's resource policy with the
+  matched route supplied as `AWS:SourceArn`
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - Authorization of every command by simulated IAM, against the HTTP method and resource path real
   API Gateway uses
@@ -486,9 +556,10 @@ Current documented limitations:
 - `AuthorizationType: "NONE"` only. JWT authorizers, `AWS_IAM` routes and Lambda authorizers are not
   simulated, so a route is open here that would be closed on AWS if it asked for one. The route is
   refused rather than created open.
-- The integrated function's resource policy is not evaluated. Real API Gateway needs
-  `lambda:InvokeFunction` granted to `apigateway.amazonaws.com`, and needs it explicitly for a
-  function in another Account, so an integration can work here that would return a 500 on AWS.
+- The method and path segments of the source ARN are inferred rather than documented. See
+  [Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
+- An integration `CredentialsArn`, the IAM Role alternative to a resource policy grant, is refused
+  by `CreateIntegration`. A permission on the function is the only way to admit the invocation.
 - No `Update*` commands, and no per-resource `Delete*`. A route, integration or stage is changed by
   deleting its API and creating it again. `DeleteApi` deletes everything under the API, as it does on
   AWS.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-proxy.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-proxy.example.ts
@@ -8,7 +8,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
 import { SimAws } from "@kensio/yulin";
 import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
@@ -56,6 +59,16 @@ await apiGateway.createRoute(
 
 await apiGateway.createStage(
   new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
 );
 
 const srv = await serveSimAws({ simAws });

--- a/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-routes.example.ts
@@ -8,7 +8,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
 import { SimAws } from "@kensio/yulin";
 import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
@@ -68,6 +71,16 @@ for (const RouteKey of [
 
 await apiGateway.createStage(
   new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pets",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
 );
 
 const srv = await serveSimAws({ simAws });

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -217,8 +217,13 @@ paths is allowed. Stored Policies can be inspected with `GetPolicyCommand` and
 ## Policy conditions
 
 Policy statements can carry `Condition` blocks. Sim IAM currently supports the `StringEquals`,
-`StringLike`, and `NumericLessThanEquals` operators, along with the `ForAllValues:` and
-`ForAnyValue:` set variants of `StringEquals` and `StringLike`.
+`StringLike`, `ArnLike`, `ArnEquals` and `NumericLessThanEquals` operators, along with the
+`ForAllValues:` and `ForAnyValue:` set variants of `StringEquals` and `StringLike`.
+
+`ArnLike` and `ArnEquals` behave identically, as AWS documents them doing. Both compare the six
+colon-delimited components of an ARN separately, and both accept `*` and `?` wildcards in any of
+them. A wildcard stays inside the component it is written in, so `arn:aws:s3:*` matches nothing: a
+pattern needs as many components as the ARN it is matched against.
 
 Condition context values are supplied by the service handling the simulated request, such as S3
 object tags. Sim IAM automatically derives global values it can work out itself, such as

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -868,6 +868,18 @@ else is read as a service principal, and `*` stays `*`.
 Function URL is invoked. That is what a Function URL grant conditions on in practice: a permission
 granted for `AWS_IAM` does not also open a URL later switched to `NONE`.
 
+`SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, which is evaluated when a simulated
+API Gateway HTTP API invokes the function through a Lambda proxy integration. That is the one
+request-time value supplied for the key, so a grant naming an API's routes decides whether those
+requests are served. See
+[Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function).
+A direct `Invoke`, a Function URL request and an SQS event source mapping supply no source ARN, so a
+statement carrying one does not match them.
+
+`SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so
+`GetPolicy` reports the grant that was made, but nothing supplies a value for them at request time,
+so a statement carrying one of those never matches.
+
 A function that has been granted nothing has no policy at all, which `GetPolicy` reports as a
 `ResourceNotFoundException` rather than as an empty document. Granting a `StatementId` that is
 already in use is a `ResourceConflictException`, and removing one that was never granted is a
@@ -1329,10 +1341,12 @@ Current documented limitations:
 - A cross-account grant is only half of what admits a call: the caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account the simulation knows nothing about is denied.
-- Only the `lambda:FunctionUrlAuthType` condition key is given a value at request time.
-  `SourceArn`, `SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the
-  statement so `GetPolicy` reports the grant that was made, but nothing supplies a value for them,
-  so a statement carrying one never matches.
+- `lambda:FunctionUrlAuthType` and `AWS:SourceArn` are the only condition keys given a value at
+  request time, the first when a Function URL is invoked and the second when a simulated API Gateway
+  HTTP API invokes the function. `SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are
+  written into the statement so `GetPolicy` reports the grant that was made, but nothing supplies a
+  value for them, so a statement carrying one never matches. Neither does a `SourceArn` statement on
+  a request from anything but an HTTP API integration.
 - `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are not simulated,
   as versions and aliases are not.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -101,13 +101,20 @@ lives.
 
 1. `sim-api-gateway-v2-router.ts` finds the API from the request hostname, through the registry, and
    the integrated function from the integration's ARN. The function is looked up in the Account and
-   Region its own ARN names, which need not be the API's.
-2. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
+   Region its own ARN names, which need not be the API's, and the router hands back that Account's
+   IAM alongside the function.
+2. `serve/auth/sim-http-api-integration-authorizer.ts` asks whether the API may invoke the function
+   at all. The caller is the service principal `apigateway.amazonaws.com`, the action is
+   `lambda:InvokeFunction`, and the request supplies `AWS:SourceArn` from
+   `api/sim-http-api-execute-api-arn.ts`. A function with no matching permission answers 500 and is
+   never invoked, as it is on real AWS. That ARN builder carries the reasoning for what the method
+   and path segments of the ARN hold, since neither is documented by AWS.
+3. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
    `SimPayload2Endpoint`, including what the route captured from the path.
-3. `src/serve/payload-2/` builds the payload format 2.0 event and turns the handler's result back
+4. `src/serve/payload-2/` builds the payload format 2.0 event and turns the handler's result back
    into an HTTP response. That machinery is shared with Lambda Function URLs, which speak the same
    format.
-4. `sim-api-gateway-v2-error-response.ts` answers the cases where there is nothing to proxy to. The
+5. `sim-api-gateway-v2-error-response.ts` answers the cases where there is nothing to proxy to. The
    field is lower-case `message`, which is what an HTTP API uses; a Function URL uses `Message` for
    the same thing.
 
@@ -129,6 +136,5 @@ simulation exists to avoid:
   real AWS
 - `MaxResults`/`NextToken`, since every list command answers in full
 
-The function's resource policy is not evaluated when the integration invokes it. See
-[docs/services/apigatewayv2/README.md](../../../docs/services/apigatewayv2/README.md) for the
+See [docs/services/apigatewayv2/README.md](../../../docs/services/apigatewayv2/README.md) for the
 user-facing limitations.

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-default-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-default-route-key.ts
@@ -37,4 +37,15 @@ export class SimHttpApiDefaultRouteKey implements SimHttpApiRouteKey {
   match(): SimHttpApiPathParameters {
     return new SimHttpApiPathParameters();
   }
+
+  /**
+   * Name this route in an `execute-api` ARN.
+   *
+   * The catch-all has no method and no path of its own, and both collapse into
+   * the single literal `$default`, so the ARN ends `<apiId>/<stage>/$default`.
+   * AWS gives that form as a CLI example for granting a `$default` route.
+   */
+  methodAndPath(): string {
+    return simHttpApiDefaultRouteKey;
+  }
 }

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-method-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-method-route-key.ts
@@ -63,6 +63,17 @@ export class SimHttpApiMethodRouteKey implements SimHttpApiRouteKey {
     return this.path.match(request.segments);
   }
 
+  /**
+   * Name this route in an `execute-api` ARN, as `GET/pets/{petId}`.
+   *
+   * The path is the route key's template, braces and all, rather than the path
+   * the request asked for. The method is the request's, since a route key of
+   * `ANY /pets` serves a request of any method and the ARN names one method.
+   */
+  methodAndPath(requestMethod: string): string {
+    return `${requestMethod}${this.path.text}`;
+  }
+
   private get tier(): number {
     if (this.path.hasGreedySegment) {
       return greedyMatchTier;

--- a/src/service/apigatewayv2/api/route/key/sim-http-api-route-key.ts
+++ b/src/service/apigatewayv2/api/route/key/sim-http-api-route-key.ts
@@ -26,4 +26,13 @@ export interface SimHttpApiRouteKey {
    * nothing when it does not match.
    */
   match(request: SimHttpApiRouteRequest): SimHttpApiPathParameters | undefined;
+  /**
+   * How this route names itself in an `execute-api` ARN, given the method of
+   * the request that matched it.
+   *
+   * The method is the request's rather than the route's, because a route key
+   * of `ANY /pets` is matched by a `GET` request and API Gateway puts a
+   * concrete verb in the ARN. `SimHttpApiExecuteApiArn` has the reasoning.
+   */
+  methodAndPath(requestMethod: string): string;
 }

--- a/src/service/apigatewayv2/api/sim-http-api-execute-api-arn.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-execute-api-arn.ts
@@ -1,0 +1,64 @@
+import type { SimHttpApi } from "./sim-http-api.js";
+
+interface SimHttpApiExecuteApiArnProperties {
+  readonly api: SimHttpApi;
+  readonly stageName: string;
+  /**
+   * The method and path part of the ARN, such as `GET/orders/{orderId}` or
+   * the literal `$default`.
+   */
+  readonly methodAndPath: string;
+}
+
+/**
+ * The `execute-api` ARN of one request to an API.
+ *
+ * ```text
+ * arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
+ * ```
+ *
+ * Two things want this ARN and they fill the last part differently:
+ *
+ * - the invoke permission a Lambda integration is authorized against, where
+ *   the path is the matched route key's template with its braces intact,
+ *   because that is the form a permission's `SourceArn` is written in;
+ * - `AWS_IAM` route authorization, where the path is the path the request
+ *   asked for, because that is the resource the caller is acting on.
+ *
+ * Neither part is documented by AWS as the value API Gateway supplies. The
+ * path is the better supported of the two: CDK synthesises a `SourceArn`
+ * whose stage and method segments are wildcards and whose path segments are
+ * the route key template, braces and all. IAM wildcard matching treats a brace
+ * as a literal, so a concrete request path could never match a permission
+ * written that way.
+ *
+ * The method is weaker. AWS's CLI example for granting an `ANY /test` route on
+ * the `prod` stage wildcards the method segment, which shows what a permission
+ * may say rather than what API Gateway puts there. A concrete verb matches
+ * such a pattern, while a permission written with a literal `ANY` would not
+ * match a concrete verb, so the concrete verb is the reading that keeps a
+ * CDK-deployed route working.
+ */
+export class SimHttpApiExecuteApiArn {
+  private readonly api: SimHttpApi;
+  private readonly stageName: string;
+  private readonly methodAndPath: string;
+
+  constructor(properties: SimHttpApiExecuteApiArnProperties) {
+    this.api = properties.api;
+    this.stageName = properties.stageName;
+    this.methodAndPath = properties.methodAndPath;
+  }
+
+  /**
+   * The ARN as a permission or a policy names it.
+   */
+  toString(): string {
+    const { accountId, regionName } = this.api.accountRegionScope;
+
+    return (
+      `arn:aws:execute-api:${regionName}:${accountId}:` +
+      `${this.api.apiId}/${this.stageName}/${this.methodAndPath}`
+    );
+  }
+}

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -2,8 +2,10 @@ import { AsyncMappedFactory } from "@kensio/part-factory";
 
 import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-integration-authorizer.js";
 import type { SimHttpApi } from "./sim-http-api.js";
 
 /**
@@ -12,6 +14,11 @@ import type { SimHttpApi } from "./sim-http-api.js";
 export interface SimHttpApiLambdaProxyInput {
   readonly apiName: string;
   readonly functionName: string;
+  /**
+   * The Account the function belongs to, which need not be the API's: an
+   * integration URI is free to name another one.
+   */
+  readonly functionAccountId: string;
   readonly roleArn: string;
   /** The function code every route of the API hands its requests to. */
   readonly handler: (event: SimPayload2Event) => unknown;
@@ -22,6 +29,15 @@ export interface SimHttpApiLambdaProxyInput {
   readonly stageNames: readonly string[];
   /** The variables every one of those stages carries. */
   readonly stageVariables: Readonly<Record<string, string>>;
+  /**
+   * Whether the function grants the API permission to invoke it, which it
+   * needs before any route serves anything.
+   *
+   * The grant is the one CDK writes: `apigateway.amazonaws.com` may
+   * `lambda:InvokeFunction` for any stage and route of this API. A test about
+   * the permission itself turns this off and grants what it means to test.
+   */
+  readonly invokePermission: boolean;
 }
 
 /**
@@ -42,8 +58,9 @@ export interface SimHttpApiLambdaProxyInput {
  * );
  * ```
  *
- * Everything is created in the default Account and Region of the simulated AWS
- * it is given. A test working in another scope sends the commands itself.
+ * The API is created in the default Account and Region of the simulated AWS it
+ * is given, and so is the function unless another Account is asked for. A test
+ * working in another scope sends the commands itself.
  */
 export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
   SimHttpApiLambdaProxyInput,
@@ -53,15 +70,18 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
   () => ({
     apiName: "orders",
     functionName: "orders",
+    functionAccountId: DEFAULT_SIM_AWS_ACCOUNT_ID,
     roleArn: "arn:aws:iam::111111111111:role/OrdersRole",
     handler: (): string => "hello",
     disableExecuteApiEndpoint: false,
     routeKeys: ["$default"],
     stageNames: ["$default"],
     stageVariables: {},
+    invokePermission: true,
   }),
   async (input, simAws) => {
-    const { FunctionArn: functionArn } = await simAws.lambda().createFunction({
+    const simLambda = simAws.account(input.functionAccountId).lambda();
+    const { FunctionArn: functionArn } = await simLambda.createFunction({
       input: {
         FunctionName: input.functionName,
         Role: input.roleArn,
@@ -99,6 +119,22 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
         }),
       ),
     );
+
+    if (input.invokePermission) {
+      // The ARN names the API's own Account and Region, which is where the
+      // request arrives, whatever Account the function belongs to.
+      const { accountId, regionName } =
+        simAws.accountRegionScope().accountRegionScope;
+      await simLambda.addPermission({
+        input: {
+          FunctionName: input.functionName,
+          StatementId: "api-gateway-invoke",
+          Action: "lambda:InvokeFunction",
+          Principal: simApiGatewayServicePrincipal,
+          SourceArn: `arn:aws:execute-api:${regionName}:${accountId}:${apiId}/*/*`,
+        },
+      });
+    }
 
     await Promise.all(
       input.stageNames.map(async (stageName) =>

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-integration-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-integration-authorizer.ts
@@ -1,0 +1,71 @@
+import type {
+  SimIamAuthorizationDecision,
+  SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simLambdaResourcePolicies } from "../../../lambda/command/authorize/sim-lambda-resource-policies.js";
+import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import type { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
+
+/**
+ * The service principal API Gateway invokes a Lambda integration as.
+ */
+export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
+
+/**
+ * The condition key the invoking API is supplied under, which is what an
+ * `AddPermission` `SourceArn` is written against.
+ */
+const sourceArnConditionKey = "AWS:SourceArn";
+
+interface SimHttpApiIntegrationAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+interface SimHttpApiIntegrationAuthorizationInput {
+  readonly simFunction: SimLambdaFunction;
+  readonly sourceArn: SimHttpApiExecuteApiArn;
+}
+
+/**
+ * Decides whether an API Gateway integration may invoke its Lambda function.
+ *
+ * A Lambda proxy integration created through CloudFormation, the CLI or an SDK
+ * does not work until the function's resource policy allows
+ * `apigateway.amazonaws.com` to invoke it. API Gateway is the caller, so the
+ * caller's own identity policies are not what admits the call: a service
+ * principal owns none, and the function's resource policy is the whole
+ * decision.
+ *
+ * The answer is a decision rather than a thrown error, because a refusal is an
+ * ordinary HTTP outcome: the endpoint answers 500 the way real API Gateway
+ * does, with nothing to propagate to a caller in process.
+ */
+export class SimHttpApiIntegrationAuthorizer {
+  private static readonly action = "lambda:InvokeFunction";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimHttpApiIntegrationAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Evaluate `lambda:InvokeFunction` for the API against the function.
+   *
+   * The route the request matched is supplied as `AWS:SourceArn`, so a
+   * permission granted for one route does not open another.
+   */
+  authorize(
+    input: SimHttpApiIntegrationAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    return this.iam.authorize({
+      action: SimHttpApiIntegrationAuthorizer.action,
+      resource: input.simFunction.arn,
+      caller: { kind: "service", service: simApiGatewayServicePrincipal },
+      resourcePolicies: simLambdaResourcePolicies(input.simFunction),
+      conditionContext: {
+        [sourceArnConditionKey]: input.sourceArn.toString(),
+      },
+    });
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -5,8 +5,10 @@ import type {
 import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-event-builder.js";
 import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js";
 import { SimHttpApiRequest } from "../api/sim-http-api-request.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
+import { SimHttpApiIntegrationAuthorizer } from "./auth/sim-http-api-integration-authorizer.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
 import { simHttpApiEndpoint } from "./sim-http-api-endpoint.js";
@@ -25,7 +27,8 @@ interface SimApiGatewayV2ServiceControllerProperties {
  * any other invocation.
  *
  * Every simulated route is `AuthorizationType: NONE`, so nothing here refuses
- * a caller. A request that reached the endpoint reaches the integration.
+ * the client. The integration still has to be allowed to invoke the function,
+ * which is a separate question and the API's own rather than the client's.
  */
 export class SimApiGatewayV2ServiceController implements SimAwsServiceController {
   private readonly router: SimApiGatewayV2Router;
@@ -76,11 +79,29 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       return this.errorResponse.notFound();
     }
 
-    const simFunction = this.router.functionFor(match.integration);
+    const target = this.router.targetFor(match.integration);
 
-    if (simFunction === undefined) {
+    if (target === undefined) {
       // The integration names a function that is not there, which real API
       // Gateway discovers the same way: only when it tries to invoke it.
+      return this.errorResponse.internalServerError();
+    }
+
+    const decision = new SimHttpApiIntegrationAuthorizer({
+      iam: target.iam,
+    }).authorize({
+      simFunction: target.simFunction,
+      sourceArn: new SimHttpApiExecuteApiArn({
+        api,
+        stageName: match.stage.stageName,
+        methodAndPath: match.route.key.methodAndPath(request.method),
+      }),
+    });
+
+    if (decision.isDenied) {
+      // Real API Gateway answers a missing invoke permission with a 500 and
+      // never invokes the function, which is the same answer as an integration
+      // that failed. The refusal is only visible in the API's own logs.
       return this.errorResponse.internalServerError();
     }
 
@@ -90,7 +111,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
         simHttpApiEndpoint(api, match),
       );
 
-      return this.responseBuilder.build(await simFunction.invoke(event));
+      return this.responseBuilder.build(await target.simFunction.invoke(event));
     } catch {
       // Real API Gateway reports an unhandled integration error as a 500, with
       // the error itself only visible in the function's logs. Reading the

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -6,9 +6,22 @@ import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-functio
 import type { SimHttpApiIntegration } from "../api/integration/sim-http-api-integration.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
 import type { SimHttpApiRegistry } from "../registry/sim-http-api-registry.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 
 interface SimApiGatewayV2RouterProperties {
   readonly simAws?: SimAws;
+}
+
+/**
+ * What an integration invokes, and what decides whether it may.
+ */
+export interface SimHttpApiIntegrationTarget {
+  readonly simFunction: SimLambdaFunction;
+  /**
+   * IAM of the Account that owns the function, which is what the integration's
+   * invoke permission is evaluated against. It need not be the API's Account.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
 }
 
 /**
@@ -54,22 +67,27 @@ export class SimApiGatewayV2Router {
   }
 
   /**
-   * Find the function an integration invokes.
+   * Find the function an integration invokes, and the IAM deciding whether it
+   * may be invoked.
    *
    * The function is looked up in the Account and Region its ARN names, not the
    * API's, because an integration ARN is free to name either.
    */
-  functionFor(
+  targetFor(
     integration: SimHttpApiIntegration,
-  ): SimLambdaFunction | undefined {
+  ): SimHttpApiIntegrationTarget | undefined {
     const { accountId, regionName, functionName } = integration.lambdaUri;
 
-    return this.simAws
-      .accountRegionScope(
-        accountId as SimAwsAccountId,
-        regionName as AwsRegionName,
-      )
-      .lambda()
-      .getSimFunctionByName(functionName);
+    const scope = this.simAws.accountRegionScope(
+      accountId as SimAwsAccountId,
+      regionName as AwsRegionName,
+    );
+    const simFunction = scope.lambda().getSimFunctionByName(functionName);
+
+    if (simFunction === undefined) {
+      return undefined;
+    }
+
+    return { simFunction, iam: scope.iam() };
   }
 }

--- a/src/service/apigatewayv2/serve/sim-http-api-invoke-permission.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-invoke-permission.iso.test.ts
@@ -1,0 +1,247 @@
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+function localUrl(api: SimHttpApi, path: string): string {
+  return new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString();
+}
+
+/**
+ * The `execute-api` ARN prefix a permission for this API is written with,
+ * without the stage and route part.
+ */
+function executeApiArn(api: SimHttpApi, suffix: string): string {
+  const { accountId, regionName } = api.accountRegionScope;
+
+  return `arn:aws:execute-api:${regionName}:${accountId}:${api.apiId}/${suffix}`;
+}
+
+/**
+ * Grant the API permission to invoke the function, for one source ARN.
+ */
+async function grantInvoke(simAws: SimAws, sourceArn?: string): Promise<void> {
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: "orders",
+      StatementId: "api-gateway-invoke",
+      Action: "lambda:InvokeFunction",
+      Principal: "apigateway.amazonaws.com",
+      ...(sourceArn !== undefined && { SourceArn: sourceArn }),
+    }),
+  );
+}
+
+describe("Invoking a sim HTTP API integration's function", () => {
+  it("refuses a route whose function granted it no permission", async () => {
+    // Given an API whose function has no resource policy at all
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        handler: (): string => {
+          invocations += 1;
+          return "orders";
+        },
+      },
+      simAws,
+    );
+
+    // When a request reaches the route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the API answers as real API Gateway does when the invoke
+    // permission is missing, and the handler never ran
+    assertIdentical(response.status, 500);
+    expect(await response.json()).toStrictEqual({
+      message: "Internal Server Error",
+    });
+    assertIdentical(invocations, 0);
+  });
+
+  it("allows a permission granted with no source ARN", async () => {
+    // Given a function granting the API Gateway service principal the invoke
+    // action for anything
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { invokePermission: false, handler: (): string => "orders" },
+      simAws,
+    );
+    await grantInvoke(simAws);
+
+    // When a request reaches the route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the unconditioned grant admits it
+    assertIdentical(response.status, 200);
+  });
+
+  it("refuses a permission naming a different route", async () => {
+    // Given a grant for one route of the API
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        routeKeys: ["GET /orders", "GET /refunds"],
+        handler: (): string => {
+          invocations += 1;
+          return "orders";
+        },
+      },
+      simAws,
+    );
+    await grantInvoke(simAws, executeApiArn(api, "$default/GET/orders"));
+
+    // When a request reaches the other route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/refunds"),
+    );
+
+    // Then the source ARN of the request does not match the grant
+    assertIdentical(response.status, 500);
+    assertIdentical(invocations, 0);
+  });
+
+  it("names the route key template in the source ARN", async () => {
+    // Given a grant written the way CDK writes one for a parameterised route,
+    // with the parameter braces intact
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        routeKeys: ["GET /orders/{orderId}"],
+        handler: (): string => "one order",
+      },
+      simAws,
+    );
+    await grantInvoke(simAws, executeApiArn(api, "*/*/orders/{orderId}"));
+
+    // When a request supplies a concrete path parameter
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders/42"),
+    );
+
+    // Then the source ARN is built from the route key rather than from the
+    // path asked for, so the grant matches
+    assertIdentical(response.status, 200);
+  });
+
+  it("names the request's own method in the source ARN", async () => {
+    // Given a grant naming a concrete method, on a route serving any method
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        routeKeys: ["ANY /orders"],
+        handler: (): string => "orders",
+      },
+      simAws,
+    );
+    await grantInvoke(simAws, executeApiArn(api, "$default/POST/orders"));
+
+    // When a POST reaches the route
+    const posted = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+      { method: "POST" },
+    );
+
+    // And when a GET reaches the same route
+    const fetched = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the method in the ARN is the request's, not the route key's `ANY`
+    assertIdentical(posted.status, 200);
+    assertIdentical(fetched.status, 500);
+  });
+
+  it("collapses the catch-all route to $default in the source ARN", async () => {
+    // Given a `$default` route and the grant CDK writes, which wildcards the
+    // stage and the route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { invokePermission: false, handler: (): string => "anything" },
+      simAws,
+    );
+    await grantInvoke(simAws, executeApiArn(api, "*/*"));
+
+    // When a request reaches it
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the ARN is `<apiId>/<stage>/$default`, which those two wildcards
+    // match
+    assertIdentical(response.status, 200);
+  });
+
+  it("asks the function's own Account, not the API's", async () => {
+    // Given an API whose integrated function belongs to another Account
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        functionAccountId: "222222222222",
+        roleArn: "arn:aws:iam::222222222222:role/OrdersRole",
+        handler: (): string => "orders",
+      },
+      simAws,
+    );
+    const otherAccount = simAws.account("222222222222");
+
+    // When the request is refused, and again once that Account's function
+    // grants the API the invoke action
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const ungranted = await simAwsHttp.fetch(localUrl(api, "/orders"));
+    await otherAccount.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceArn: executeApiArn(api, "*/*"),
+      }),
+    );
+    const granted = await simAwsHttp.fetch(localUrl(api, "/orders"));
+
+    // Then the grant on the function decides, and the source ARN still names
+    // the API's Account rather than the function's
+    assertIdentical(ungranted.status, 500);
+    assertIdentical(granted.status, 200);
+  });
+
+  it("names the stage that served the request", async () => {
+    // Given an API with a named stage, and a grant for that stage only
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        routeKeys: ["GET /orders"],
+        stageNames: ["dev", "prod"],
+        handler: (): string => "orders",
+      },
+      simAws,
+    );
+    await grantInvoke(simAws, executeApiArn(api, "dev/GET/orders"));
+
+    // When each stage serves the same route
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const development = await simAwsHttp.fetch(localUrl(api, "/dev/orders"));
+    const production = await simAwsHttp.fetch(localUrl(api, "/prod/orders"));
+
+    // Then only the stage the grant names may invoke the function
+    assertIdentical(development.status, 200);
+    assertIdentical(production.status, 500);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-serve.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve.iso.test.ts
@@ -4,7 +4,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -156,6 +159,17 @@ describe("Serving a request through a sim HTTP API", () => {
         ApiId: apiId,
         StageName: "$default",
         AutoDeploy: true,
+      }),
+    );
+
+    // And the function granting that API permission to invoke it
+    await scoped.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceArn: `arn:aws:execute-api:us-east-1:222222222222:${apiId}/*/*`,
       }),
     );
 

--- a/src/service/apigatewayv2/serve/sim-http-api-serve.loc.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve.loc.test.ts
@@ -4,7 +4,10 @@ import {
   CreateRouteCommand,
   CreateStageCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 import { assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -60,6 +63,17 @@ describe("Serving a sim HTTP API on localhost", () => {
         ApiId: apiId,
         StageName: "$default",
         AutoDeploy: true,
+      }),
+    );
+
+    // And the function allowing that API to invoke it
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${apiId}/*/*`,
       }),
     );
 

--- a/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.iso.test.ts
@@ -1,0 +1,116 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../../../aws/sim-aws.js";
+import type { SimIam } from "../../../../../sim-iam.js";
+
+const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+
+/**
+ * Create a Role whose inline policy allows sending to a queue only for
+ * requests whose `aws:SourceArn` matches the given pattern.
+ */
+async function senderRole(simIam: SimIam, pattern: string): Promise<string> {
+  const roleCreation = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderSender",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { AWS: `arn:aws:iam::${simIam.accountId}:root` },
+        },
+      }),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderSender",
+      PolicyName: "SendOrders",
+      PolicyDocument: JSON.stringify({
+        Statement: {
+          Effect: "Allow",
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnEquals: { "aws:SourceArn": pattern } },
+        },
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}
+
+describe("sim IAM ArnEquals authorization", () => {
+  it("allows a request whose source ARN the identity policy names", async () => {
+    // Given a Role allowed to send only on behalf of one topic
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+    const roleArn = await senderRole(
+      simIam,
+      "arn:aws:sns:eu-west-2:111111111111:orders-topic",
+    );
+
+    // When the request supplies that topic as its source
+    const decision = simIam.authorize({
+      action: "sqs:SendMessage",
+      resource: queueArn,
+      caller: { kind: "arn", arn: roleArn },
+      conditionContext: {
+        "aws:SourceArn": "arn:aws:sns:eu-west-2:111111111111:orders-topic",
+      },
+    });
+
+    // Then the identity policy allows it
+    assertTrue(decision.isAllowed);
+  });
+
+  it("accepts wildcards, as AWS documents ArnEquals doing", async () => {
+    // Given a Role whose grant wildcards the Account and the resource name,
+    // which ArnEquals allows: AWS documents it as behaving like ArnLike
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+    const roleArn = await senderRole(
+      simIam,
+      "arn:aws:sns:eu-west-2:*:orders-*",
+    );
+
+    // When the request supplies a source ARN fitting the pattern
+    const decision = simIam.authorize({
+      action: "sqs:SendMessage",
+      resource: queueArn,
+      caller: { kind: "arn", arn: roleArn },
+      conditionContext: {
+        "aws:SourceArn": "arn:aws:sns:eu-west-2:222222222222:orders-topic",
+      },
+    });
+
+    // Then it is allowed
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not allow a request from another source", async () => {
+    // Given a Role allowed to send only on behalf of one topic
+    const simAws = new SimAws();
+    const simIam = simAws.iam();
+    const roleArn = await senderRole(
+      simIam,
+      "arn:aws:sns:eu-west-2:111111111111:orders-topic",
+    );
+
+    // When the request names a different topic
+    const decision = simIam.authorize({
+      action: "sqs:SendMessage",
+      resource: queueArn,
+      caller: { kind: "arn", arn: roleArn },
+      conditionContext: {
+        "aws:SourceArn": "arn:aws:sns:eu-west-2:111111111111:refunds-topic",
+      },
+    });
+
+    // Then the condition does not match, so nothing allows the request
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.ts
+++ b/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.ts
@@ -1,0 +1,17 @@
+import { simIamArnMatch } from "../../../../sim-iam-arn-match.js";
+import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar-string-condition-operator.js";
+
+/**
+ * IAM `ArnEquals` condition operator.
+ *
+ * AWS documents `ArnEquals` and `ArnLike` as behaving identically: both
+ * compare the six components of an ARN separately, and both accept `*` and `?`
+ * wildcards in any of them. So a policy written with either operator is
+ * evaluated the same way here, rather than `ArnEquals` being the exact-string
+ * comparison its name suggests.
+ */
+export class SimIamArnEquals extends SimIamScalarStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return simIamArnMatch(expected, actual);
+  }
+}

--- a/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.iso.test.ts
@@ -1,0 +1,139 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIam } from "../../../../../sim-iam.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../../context/sim-iam-auth-z-context.factory.js";
+import type { SimIamConditionValue } from "../../../../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDecision } from "../../../../sim-iam-decision.js";
+
+const functionArn = "arn:aws:lambda:eu-west-2:111111111111:function:orders";
+const sourceArn =
+  "arn:aws:execute-api:eu-west-2:111111111111:a1b2c3d4e5/$default/GET/orders/{orderId}";
+
+/**
+ * Authorize an invocation against a resource policy granting it for one
+ * `AWS:SourceArn` pattern, with the source ARN supplied at request time.
+ */
+function decide(
+  pattern: SimIamConditionValue,
+  requestSourceArn = sourceArn,
+): SimIamPolicyDecision {
+  const simIam = new SimIam();
+
+  return simIam.authorize({
+    action: "lambda:InvokeFunction",
+    resource: functionArn,
+    caller: { kind: "service", service: "apigateway.amazonaws.com" },
+    conditionContext: { "AWS:SourceArn": requestSourceArn },
+    resourcePolicies: [
+      simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "apigateway.amazonaws.com" },
+            Action: "lambda:InvokeFunction",
+            Resource: functionArn,
+            Condition: { ArnLike: { "AWS:SourceArn": pattern } },
+          },
+        },
+      }),
+    ],
+  });
+}
+
+describe("sim IAM ArnLike authorization", () => {
+  it("allows a request whose source ARN matches the pattern exactly", () => {
+    // Given a grant naming the source ARN with no wildcards in it
+    // When the request supplies that source ARN
+    const decision = decide(sourceArn);
+
+    // Then the statement matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a wildcard in the region, Account and resource positions", () => {
+    // Given a grant wildcarding the stage and method, as CDK writes one, and
+    // wildcarding the region and Account too
+    // When the request supplies a concrete source ARN
+    const decision = decide(
+      "arn:aws:execute-api:*:*:a1b2c3d4e5/*/*/orders/{orderId}",
+    );
+
+    // Then each component matches its own pattern
+    assertTrue(decision.isAllowed);
+  });
+
+  it("allows a request matching any of several patterns", () => {
+    // Given a grant listing more than one source ARN
+    // When the request supplies the second of them
+    const decision = decide([
+      "arn:aws:execute-api:eu-west-2:111111111111:zzzzzzzzzz/*/*",
+      "arn:aws:execute-api:eu-west-2:111111111111:a1b2c3d4e5/*/*",
+    ]);
+
+    // Then the patterns are an OR, so one match is enough
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not allow a request from another resource", () => {
+    // Given a grant naming one API
+    // When a request from a different API supplies its own source ARN
+    const decision = decide(
+      "arn:aws:execute-api:eu-west-2:111111111111:a1b2c3d4e5/*/*",
+      "arn:aws:execute-api:eu-west-2:111111111111:zzzzzzzzzz/$default/GET/orders",
+    );
+
+    // Then the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("keeps a wildcard inside the component it is written in", () => {
+    // Given a pattern with fewer components than an ARN has, so its trailing
+    // wildcard would have to cover the Account and resource to match
+    // When a request supplies a full ARN
+    const decision = decide("arn:aws:execute-api:*");
+
+    // Then it does not match, because AWS compares the six components of an
+    // ARN separately
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches case-sensitively", () => {
+    // Given a grant naming a lower-case resource
+    // When the request supplies the same ARN in a different case
+    const decision = decide(
+      "arn:aws:execute-api:eu-west-2:111111111111:A1B2C3D4E5/*/*",
+    );
+
+    // Then the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("does not allow a request supplying no source ARN", () => {
+    // Given a grant conditioned on a source ARN
+    const simIam = new SimIam();
+
+    // When a request arrives with no value for the key
+    const decision = simIam.authorize({
+      action: "lambda:InvokeFunction",
+      resource: functionArn,
+      caller: { kind: "service", service: "apigateway.amazonaws.com" },
+      resourcePolicies: [
+        simIamAuthZResourcePolicySourceFactory.make({
+          document: {
+            Statement: {
+              Effect: "Allow",
+              Principal: { Service: "apigateway.amazonaws.com" },
+              Action: "lambda:InvokeFunction",
+              Resource: functionArn,
+              Condition: { ArnLike: { "AWS:SourceArn": sourceArn } },
+            },
+          },
+        }),
+      ],
+    });
+
+    // Then the condition fails closed rather than matching anything
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.ts
+++ b/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.ts
@@ -1,0 +1,16 @@
+import { simIamArnMatch } from "../../../../sim-iam-arn-match.js";
+import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar-string-condition-operator.js";
+
+/**
+ * IAM `ArnLike` condition operator.
+ *
+ * This is `StringLike` over an ARN, with the wildcards confined to the
+ * component they are written in. It is what `AddPermission` writes a
+ * `SourceArn` under, so it is the operator an invoking service's grant is
+ * evaluated with.
+ */
+export class SimIamArnLike extends SimIamScalarStringConditionOperator {
+  protected override valueMatches(actual: string, expected: string): boolean {
+    return simIamArnMatch(expected, actual);
+  }
+}

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
@@ -6,10 +6,14 @@ import { SimIamForAnyValueStringLike } from "./string/any-value/sim-iam-for-any-
 import { SimIamStringEquals } from "./string/equals/sim-iam-string-equals.js";
 import { SimIamStringLike } from "./string/like/sim-iam-string-like.js";
 import { SimIamNumericLessThanEquals } from "./numeric/less-than-equals/sim-iam-number-lte.js";
+import { SimIamArnEquals } from "./arn/equals/sim-iam-arn-equals.js";
+import { SimIamArnLike } from "./arn/like/sim-iam-arn-like.js";
 
 type SimIamConditionOperatorFactory = () => SimIamConditionOperator;
 
 const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
+  ["ArnEquals", (): SimIamConditionOperator => new SimIamArnEquals()],
+  ["ArnLike", (): SimIamConditionOperator => new SimIamArnLike()],
   [
     "NumericLessThanEquals",
     (): SimIamConditionOperator => new SimIamNumericLessThanEquals(),

--- a/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
@@ -89,7 +89,6 @@ export class SimIamPolicyPrincipalMatcher {
         );
       }
 
-      /* v8 ignore if -- service principals not yet fully supported */
       if (type === "Service") {
         return this.firstMatch(patterns, (pattern) =>
           this.servicePatternMatches(pattern),
@@ -144,12 +143,14 @@ export class SimIamPolicyPrincipalMatcher {
 
   /**
    * Compare a service principal pattern with the resolved caller.
+   *
+   * A service principal has no ARN and no Account, so this is a direct grant
+   * or nothing: there is no Account for a statement to delegate to. It is what
+   * admits an API Gateway integration invoking a Lambda function.
    */
   private servicePatternMatches(pattern: string): SimIamPrincipalMatch {
-    /* v8 ignore next -- service principals not yet fully supported */
     const service = this.context.caller.service;
 
-    /* v8 ignore next -- service principals not yet fully supported */
     return SimIamPrincipalMatch.direct().when(
       service !== undefined &&
         simIamWildcardMatch(pattern, service, {

--- a/src/service/iam/authorize/sim-iam-arn-match.ts
+++ b/src/service/iam/authorize/sim-iam-arn-match.ts
@@ -1,0 +1,53 @@
+import { simIamWildcardMatch } from "./sim-iam-wildcard.js";
+
+/**
+ * The number of colon-delimited components an ARN has.
+ *
+ * The last of them is the resource, which may itself contain colons, so
+ * anything past the fifth colon belongs to it.
+ */
+const arnComponentCount = 6;
+
+/**
+ * Match an ARN against an ARN pattern, as the `ArnLike` and `ArnEquals`
+ * condition operators do.
+ *
+ * AWS compares each of the six colon-delimited components separately, and a
+ * wildcard in one of them stays inside it: `arn:aws:s3:*` does not match an
+ * ARN whose Account or resource happen to make the rest of the string fit. A
+ * pattern with fewer components than an ARN has therefore matches nothing,
+ * which is stricter than comparing the two as plain strings would be.
+ */
+export function simIamArnMatch(pattern: string, value: string): boolean {
+  const patternComponents = arnComponents(pattern);
+  const valueComponents = arnComponents(value);
+
+  if (patternComponents.length !== valueComponents.length) {
+    return false;
+  }
+
+  // The two have the same number of components, so the fallback below stands
+  // in for a component that cannot be missing.
+  return patternComponents.every((component, index) =>
+    simIamWildcardMatch(component, valueComponents.at(index) ?? "", {
+      caseSensitive: true,
+    }),
+  );
+}
+
+/**
+ * Split an ARN into its six components, leaving any colons in the resource
+ * component where they are.
+ */
+function arnComponents(arn: string): readonly string[] {
+  const components = arn.split(":");
+
+  if (components.length <= arnComponentCount) {
+    return components;
+  }
+
+  return [
+    ...components.slice(0, arnComponentCount - 1),
+    components.slice(arnComponentCount - 1).join(":"),
+  ];
+}

--- a/src/service/iam/authorize/sim-iam-auth-z-principal.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-principal.iso.test.ts
@@ -9,6 +9,29 @@ import {
 } from "@kensio/smartass";
 import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
 import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamResourcePolicyInput } from "./context/sim-iam-auth-z-context-builder.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:orders";
+
+/**
+ * A function resource policy granting one service principal the invoke action.
+ */
+function servicePolicy(service: string): SimIamResourcePolicyInput {
+  return {
+    document: {
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: service },
+          Action: "lambda:InvokeFunction",
+          Resource: functionArn,
+        },
+      ],
+    },
+    policyName: "FunctionPolicy",
+    resourceArn: functionArn,
+  };
+}
 
 describe("sim IAM authorization principal", () => {
   it("authorizes from caller context principal", async () => {
@@ -119,5 +142,48 @@ describe("sim IAM authorization principal", () => {
     assertFalse(decision.isExplicitDeny);
     assertArrayLength(decision.allowStatements, 1);
     assertArrayLength(decision.explicitDenyStatements, 0);
+  });
+
+  it("allows the service a resource policy names", () => {
+    // Given a resource policy granting one AWS service the action
+    const simIam = new SimAws().iam();
+
+    // When that service asks for it
+    const decision = simIam.authorize({
+      action: "lambda:InvokeFunction",
+      resource: functionArn,
+      caller: { kind: "service", service: "apigateway.amazonaws.com" },
+      resourcePolicies: [servicePolicy("apigateway.amazonaws.com")],
+    });
+
+    // Then the statement names the caller, which has no Account for it to
+    // delegate to
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not allow another service, or a principal that is not one", () => {
+    // Given the same resource policy
+    const simIam = new SimAws().iam();
+
+    // When another service asks, and when an ordinary Role principal does
+    const otherService = simIam.authorize({
+      action: "lambda:InvokeFunction",
+      resource: functionArn,
+      caller: { kind: "service", service: "s3.amazonaws.com" },
+      resourcePolicies: [servicePolicy("apigateway.amazonaws.com")],
+    });
+    const role = simIam.authorize({
+      action: "lambda:InvokeFunction",
+      resource: functionArn,
+      caller: {
+        kind: "arn",
+        arn: "arn:aws:iam::888888888888:role/Caller",
+      },
+      resourcePolicies: [servicePolicy("apigateway.amazonaws.com")],
+    });
+
+    // Then neither is the service the statement names
+    assertTrue(otherService.isImplicitDeny);
+    assertTrue(role.isImplicitDeny);
   });
 });

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission.iso.test.ts
@@ -174,8 +174,9 @@ describe("Lambda CloudFormation Permission deployment", () => {
     await stack.waitForDeployComplete();
 
     // Then the statement carries each of them, so GetPolicy reports the grant
-    // that was made even though the simulator supplies no value for them and
-    // they therefore never match
+    // that was made. Nothing here can match it: only an API Gateway
+    // integration supplies a source ARN, and nothing supplies a source Account
+    // or a Function URL flag, so an S3 grant like this one never matches
     const policy = await simAws
       .lambda()
       .getPolicy(new GetPolicyCommand({ FunctionName: "greeter" }));

--- a/src/service/lambda/function/policy/sim-lambda-permission.ts
+++ b/src/service/lambda/function/policy/sim-lambda-permission.ts
@@ -89,11 +89,12 @@ export class SimLambdaPermission {
   /**
    * The condition block the qualifying properties expand into.
    *
-   * Only `lambda:FunctionUrlAuthType` is given a value at request time, so it
-   * is the only one that can match. The rest are still written into the
-   * statement, because `GetPolicy` should report the permission that was
-   * granted; a statement carrying one of them simply never matches, which is
-   * the safe direction for a condition the simulator cannot evaluate.
+   * `lambda:FunctionUrlAuthType` is given a value when a Function URL is
+   * invoked, and `AWS:SourceArn` when an API Gateway HTTP API integration
+   * invokes the function. The rest are still written into the statement,
+   * because `GetPolicy` should report the permission that was granted; a
+   * statement carrying one of them simply never matches, which is the safe
+   * direction for a condition the simulator cannot evaluate.
    */
   private condition(): SimIamPolicyDocumentCondition | undefined {
     const stringEquals = this.stringEqualsConditions();


### PR DESCRIPTION
…its Lambda integration

A matched route authorizes lambda:InvokeFunction on the function ARN before invoking it, as the service principal apigateway.amazonaws.com and with the matched route supplied as AWS:SourceArn. A denied or absent permission answers 500 {"message":"Internal Server Error"} and the handler does not run.

ArnLike and ArnEquals become supported condition operators, so a SourceArn written by AddPermission or by AWS::Lambda::Permission starts matching. Both compare the six components of an ARN separately, as AWS documents.

Resolves https://github.com/KensioSoftware/yulin/issues/300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API Gateway HTTP APIs now verify Lambda invocation permissions before invoking integrated functions.
  * Added support for route-, method-, stage-, and account-specific permission matching.
  * Added IAM `ArnEquals` and `ArnLike` condition support with wildcard ARN matching.
  * Lambda proxy examples now grant API Gateway permission by default, with configurable function accounts and permission behavior.

* **Bug Fixes**
  * Unauthorized Lambda integrations now return HTTP 500 responses instead of executing functions.

* **Documentation**
  * Expanded guidance on Lambda permissions, source ARN construction, matching behavior, and supported limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->