### PR TITLE
feat: deploy a simulated HTTP API from AWS::ApiGatewayV2 CloudFormati…

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -496,6 +496,160 @@ only through a custom domain is configured. A request to it is answered with a 4
 `{"message":"Forbidden"}`. AWS publishes neither the status nor the body for that case, so both are
 what a disabled endpoint was observed to answer rather than something documented.
 
+## CloudFormation
+
+[Simulated CloudFormation](../cloudformation/ "Simulated CloudFormation docs") deploys
+`AWS::ApiGatewayV2::Api`, `AWS::ApiGatewayV2::Integration`, `AWS::ApiGatewayV2::Route` and
+`AWS::ApiGatewayV2::Stage`, so a synthesized or hand-written template produces an API that serves
+requests.
+
+`Ref` and `Fn::GetAtt` return what real CloudFormation returns for each type:
+
+| Resource type | `Ref`              | `Fn::GetAtt`                |
+| ------------- | ------------------ | --------------------------- |
+| `Api`         | the API id         | `ApiId`, `ApiEndpoint`      |
+| `Integration` | the integration id | `IntegrationId`             |
+| `Route`       | the route id       | `RouteId`                   |
+| `Stage`       | the stage name     | none, as AWS documents none |
+
+`Fn::GetAtt: ["Api", "ApiEndpoint"]` is the generated endpoint with no trailing slash and no stage
+segment, on the real `amazonaws.com` hostname. CDK's `httpApi.url` is built from `AWS::URLSuffix`
+instead, which resolves to the local `sim-aws.localhost` form. Both reach the same served API.
+
+An integration's `IntegrationUri` is accepted as the bare Lambda function ARN CDK emits, and as the
+`arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form. A
+route's `Target` is the `integrations/<integration-id>` string, which CDK builds with `Fn::Join` over
+a `Ref` to the integration.
+
+```typescript sim-apigatewayv2-cloudformation
+/**
+ * Deploying a simulated HTTP API from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "orders-role",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async () => ({ statusCode: 200, body: 'orders' });",
+          },
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:us-east-1:111111111111:",
+                { Ref: "Api" },
+                "/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGatewayV2::Api",
+        Properties: { Name: "orders", ProtocolType: "HTTP" },
+      },
+      Stage: {
+        Type: "AWS::ApiGatewayV2::Stage",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          StageName: "$default",
+          AutoDeploy: true,
+        },
+      },
+      Integration: {
+        Type: "AWS::ApiGatewayV2::Integration",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          IntegrationType: "AWS_PROXY",
+          IntegrationUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+          PayloadFormatVersion: "2.0",
+        },
+      },
+      Route: {
+        Type: "AWS::ApiGatewayV2::Route",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          RouteKey: "GET /orders",
+          AuthorizationType: "NONE",
+          Target: {
+            "Fn::Join": ["", ["integrations/", { Ref: "Integration" }]],
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiEndpoint: { Value: { "Fn::GetAtt": ["Api", "ApiEndpoint"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// https://<api-id>.execute-api.us-east-1.amazonaws.com
+const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
+
+console.log(response.status);
+console.log(await response.text());
+
+srv.close();
+```
+
+Every property outside the simulated set is refused by name, and the refusal fails the stack. The
+simulated properties are:
+
+- `Api`: `Name`, `ProtocolType`, `Description`, `DisableExecuteApiEndpoint`
+- `Integration`: `ApiId`, `IntegrationType`, `IntegrationUri`, `PayloadFormatVersion`, `Description`
+- `Route`: `ApiId`, `RouteKey`, `Target`, `AuthorizationType`
+- `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`
+
+`AWS::ApiGatewayV2::Authorizer`, `Deployment`, `DomainName`, `ApiMapping`, `VpcLink` and the
+WebSocket-only `Model`, `RouteResponse` and `IntegrationResponse` create nothing, so a template
+carrying one has that resource skipped rather than deployed. A route pointing at a skipped authorizer
+through `AuthorizerId` fails the stack instead, naming both the route and the authorizer, because
+that route would be open here and closed on AWS.
+
 ## Authorization
 
 Every command is authorized by simulated IAM. API Gateway is unusual in what it asks for: the action
@@ -530,6 +684,8 @@ the simulation without being given one. See the
 - The integration's invoke permission, evaluated against the function's resource policy with the
   matched route supplied as `AWS:SourceArn`
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
+- Deployment of `AWS::ApiGatewayV2::Api`, `Integration`, `Route` and `Stage` from a CloudFormation
+  template, including one synthesized by CDK from an `HttpApi`
 - Authorization of every command by simulated IAM, against the HTTP method and resource path real
   API Gateway uses
 - SDK interception of an `ApiGatewayV2Client`
@@ -570,8 +726,15 @@ Current documented limitations:
 - `CorsConfiguration` and `Tags` are refused, as is the `RouteKey`/`Target` quick-create shorthand on
   `CreateApi`. Anything else the real commands accept and this one does not is refused by name rather
   than dropped.
+- `AWS::ApiGatewayV2::Api` refuses `CorsConfiguration` by name rather than accepting it with no
+  effect. CORS request handling is not simulated, and a template that configured it would otherwise
+  get an API that answered preflight requests here differently from AWS. A CDK stack using
+  `corsPreflight` does not deploy.
+- `AWS::ApiGatewayV2::Api` refuses `Body` and `BodyS3Location` by name. Importing an OpenAPI document
+  is a second way to declare routes and integrations, and none of that translation is simulated.
+- Stack updates and deletes are not supported for these resource types, as they are not for any
+  others. See the [CloudFormation limitations](../cloudformation/#limitations).
 - Access logging, throttling, usage plans and API keys are not simulated.
-- No CloudFormation resource types yet, so an `AWS::ApiGatewayV2::Api` in a template is not created.
 - The response an API Gateway endpoint returns itself uses a lower-case `message` field, as a real
   HTTP API does. A Lambda Function URL uses `Message` for the same thing, so the two are not
   interchangeable.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-cloudformation.example.ts
@@ -1,0 +1,112 @@
+/**
+ * Deploying a simulated HTTP API from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "orders-role",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "orders",
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+          Code: {
+            ZipFile:
+              "exports.handler = async () => ({ statusCode: 200, body: 'orders' });",
+          },
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:us-east-1:111111111111:",
+                { Ref: "Api" },
+                "/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGatewayV2::Api",
+        Properties: { Name: "orders", ProtocolType: "HTTP" },
+      },
+      Stage: {
+        Type: "AWS::ApiGatewayV2::Stage",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          StageName: "$default",
+          AutoDeploy: true,
+        },
+      },
+      Integration: {
+        Type: "AWS::ApiGatewayV2::Integration",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          IntegrationType: "AWS_PROXY",
+          IntegrationUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+          PayloadFormatVersion: "2.0",
+        },
+      },
+      Route: {
+        Type: "AWS::ApiGatewayV2::Route",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          RouteKey: "GET /orders",
+          AuthorizationType: "NONE",
+          Target: {
+            "Fn::Join": ["", ["integrations/", { Ref: "Integration" }]],
+          },
+        },
+      },
+    },
+    Outputs: {
+      ApiEndpoint: { Value: { "Fn::GetAtt": ["Api", "ApiEndpoint"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// https://<api-id>.execute-api.us-east-1.amazonaws.com
+const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(srv.localUrl(`${apiEndpoint}/orders`));
+
+console.log(response.status);
+console.log(await response.text());
+
+srv.close();

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -967,6 +967,8 @@ Sim CloudFormation currently supports:
 
 The resource types it creates are:
 
+- `AWS::ApiGatewayV2::Api`, `AWS::ApiGatewayV2::Integration`, `AWS::ApiGatewayV2::Route` and
+  `AWS::ApiGatewayV2::Stage`
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
 - `AWS::CloudFront::Distribution` and `AWS::CloudFront::Function`

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -118,6 +118,36 @@ lives.
    field is lower-case `message`, which is what an HTTP API uses; a Function URL uses `Message` for
    the same thing.
 
+## CloudFormation
+
+`cfn/` creates the four `AWS::ApiGatewayV2::*` Resource types this simulation deploys, one directory
+per type, each with a creator and a properties reader:
+
+```text
+cfn/
+├── sim-cfn-api-gateway-v2-resource-factory.ts   switches on the bare type name
+├── sim-cfn-api-gateway-v2-property-parser.ts    the allow-list and the value shapes
+├── sim-cfn-http-api-template.factory.ts         the template tests deploy
+├── api/         Api
+├── integration/ Integration, and the two IntegrationUri forms
+├── route/       Route, and the skipped-authorizer refusal
+└── stage/       Stage
+```
+
+Every creator goes through the ordinary command, so a template is held to the same rules an SDK
+caller is, and the refusals above apply to a deployed Resource as well. Each properties reader states
+the properties its type simulates and refuses every other one by name, which is what keeps a template
+from deploying an API that looks configured to the template and unconfigured to every request.
+
+`route/sim-cfn-http-api-skipped-authorizer.ts` is the one refusal that is not about a property shape.
+An `AWS::ApiGatewayV2::Authorizer` is skipped rather than failed, and a `Ref` to a skipped Resource
+resolves to its own logical ID, so a route would otherwise deploy holding a logical ID where an
+authorizer id belongs.
+
+The CloudFormation-facing `Ref` and `Fn::GetAtt` values live in
+`src/service/cloudformation/resource/cfn/apigatewayv2/` instead, beside the other services' adapters,
+so the simulated API, route, integration and stage objects stay service-focused.
+
 ## What is deliberately refused
 
 Each of these is refused by name rather than accepted and ignored, because an API that looked

--- a/src/service/apigatewayv2/api/route/sim-http-api-route-store.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route-store.ts
@@ -42,6 +42,19 @@ export class SimHttpApiRouteStore {
   }
 
   /**
+   * Find a route by the id the API allocated for it.
+   *
+   * Routes are stored by route key signature rather than by id, so this is a
+   * scan. It is how a route is addressed after creation, which an API has few
+   * enough routes for the scan not to matter.
+   */
+  find(routeId: string): SimHttpApiRoute | undefined {
+    return this.routes
+      .values()
+      .find((route) => route.routeId === (routeId as SimHttpApiRouteId));
+  }
+
+  /**
    * Find the route holding a route key signature, which is what tells whether
    * the API is already routing a route key.
    */

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-creator.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-creator.ts
@@ -1,0 +1,50 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApi } from "../../api/sim-http-api.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnHttpApiProperties } from "./sim-cfn-http-api-properties.js";
+
+interface SimCfnHttpApiCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated HTTP APIs from AWS::ApiGatewayV2::Api Resources.
+ *
+ * The API goes through the ordinary CreateApi command, so a WebSocket protocol
+ * type and anything else the command refuses is refused here too, with the
+ * reason the command gives.
+ */
+export class SimCfnHttpApiCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnHttpApiCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create an API from an AWS::ApiGatewayV2::Api Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimHttpApi> {
+    const apiProperties = new SimCfnHttpApiProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.apiGatewayV2.createApi({
+      input: apiProperties.createApiInput(),
+    });
+
+    const httpApi = this.apiGatewayV2.findApi(created.ApiId);
+    assertDefined(
+      httpApi,
+      `sim HTTP API ${created.ApiId} after CloudFormation creation`,
+    );
+
+    return httpApi;
+  }
+}

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
@@ -1,0 +1,75 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateApiCommandInput } from "../../command/api/api.command.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The AWS::ApiGatewayV2::Api properties this simulation deploys.
+ *
+ * `Body`, `BodyS3Location`, `CorsConfiguration`, `Tags`, and the
+ * `Target`/`RouteKey` quick-create shorthand are all left out, so a template
+ * carrying one is refused by name. Each of them changes what the API serves,
+ * and none of them is modelled.
+ */
+const simulatedProperties = [
+  "Name",
+  "ProtocolType",
+  "Description",
+  "DisableExecuteApiEndpoint",
+];
+
+interface SimCfnHttpApiPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::Api CloudFormation properties into the CreateApi
+ * input the API creator needs.
+ */
+export class SimCfnHttpApiProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::Api",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnHttpApiPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The CreateApi input this Resource asks for.
+   *
+   * `ProtocolType` is passed through rather than fixed at `HTTP`, so a
+   * WebSocket API is refused by CreateApi with the reason it is refused.
+   */
+  createApiInput(): SimCreateApiCommandInput {
+    return {
+      Name: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["Name"],
+        "Name",
+      ),
+      ProtocolType: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["ProtocolType"],
+        "ProtocolType",
+      ),
+      Description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+      DisableExecuteApiEndpoint: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["DisableExecuteApiEndpoint"],
+        "DisableExecuteApiEndpoint",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-creator.ts
+++ b/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-creator.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiIntegration } from "../../api/integration/sim-http-api-integration.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnHttpApiIntegrationProperties } from "./sim-cfn-http-api-integration-properties.js";
+
+interface SimCfnHttpApiIntegrationCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated integrations from AWS::ApiGatewayV2::Integration Resources.
+ *
+ * The integration goes through the ordinary CreateIntegration command, so an
+ * unsimulated integration type, payload format or integration URI is refused
+ * here with the reason the command gives.
+ */
+export class SimCfnHttpApiIntegrationCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnHttpApiIntegrationCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create an integration from an AWS::ApiGatewayV2::Integration Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimHttpApiIntegration> {
+    const integrationProperties = new SimCfnHttpApiIntegrationProperties({
+      resource,
+      properties,
+    });
+    const apiId = integrationProperties.apiId();
+
+    const created = await this.apiGatewayV2.createIntegration({
+      input: integrationProperties.createIntegrationInput(),
+    });
+
+    const integration = this.apiGatewayV2
+      .findApi(apiId)
+      ?.integrations.find(created.IntegrationId);
+    assertDefined(
+      integration,
+      `sim HTTP API integration ${created.IntegrationId} after ` +
+        `CloudFormation creation`,
+    );
+
+    return integration;
+  }
+}

--- a/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-properties.ts
+++ b/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-properties.ts
@@ -1,0 +1,106 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateIntegrationCommandInput } from "../../command/integration/integration.command.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+import { simCfnHttpApiIntegrationUri } from "./sim-cfn-http-api-integration-uri.js";
+
+/**
+ * The AWS::ApiGatewayV2::Integration properties this simulation deploys.
+ *
+ * `IntegrationMethod`, `ParameterMapping`, `TimeoutInMillis`, `CredentialsArn`
+ * and the rest are left out, so a template carrying one is refused by name.
+ * Each of them changes what the integration does with a request, and none of
+ * them is modelled.
+ */
+const simulatedProperties = [
+  "ApiId",
+  "IntegrationType",
+  "IntegrationUri",
+  "PayloadFormatVersion",
+  "Description",
+];
+
+interface SimCfnHttpApiIntegrationPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::Integration CloudFormation properties into the
+ * CreateIntegration input the integration creator needs.
+ */
+export class SimCfnHttpApiIntegrationProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::Integration",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnHttpApiIntegrationPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this integration belongs to, which a template reaches with a `Ref`
+   * on its AWS::ApiGatewayV2::Api.
+   */
+  apiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["ApiId"],
+      "ApiId",
+    );
+  }
+
+  /**
+   * The CreateIntegration input this Resource asks for.
+   *
+   * Everything but the API id is passed through as the template wrote it, so
+   * an absent, unsimulated integration type or payload format is refused by
+   * CreateIntegration with the reason it is refused rather than as a shape
+   * complaint here.
+   */
+  createIntegrationInput(): SimCreateIntegrationCommandInput {
+    return {
+      ApiId: this.apiId(),
+      IntegrationType: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["IntegrationType"],
+        "IntegrationType",
+      ),
+      IntegrationUri: this.integrationUri(),
+      PayloadFormatVersion: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["PayloadFormatVersion"],
+        "PayloadFormatVersion",
+      ),
+      Description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+    };
+  }
+
+  /**
+   * The Lambda function ARN this integration invokes, read from either URI
+   * form a template may write.
+   */
+  private integrationUri(): string | undefined {
+    const uri = this.propertyParser.optionalString(
+      this.resource,
+      this.properties["IntegrationUri"],
+      "IntegrationUri",
+    );
+
+    if (uri === undefined) {
+      return undefined;
+    }
+
+    return simCfnHttpApiIntegrationUri(uri);
+  }
+}

--- a/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-uri.ts
+++ b/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-uri.ts
@@ -1,0 +1,23 @@
+/**
+ * The API Gateway integration URI form that wraps a Lambda function ARN in an
+ * API Gateway path:
+ *
+ *   arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/<function-arn>/invocations
+ *
+ * The date is the Lambda invoke API version and is part of the literal, not
+ * something a template chooses.
+ */
+const apiGatewayLambdaPathUri =
+  /^arn:[^:]+:apigateway:[^:]+:lambda:path\/2015-03-31\/functions\/(?<functionArn>arn:[^/]+)\/invocations$/;
+
+/**
+ * Read the Lambda function ARN an `IntegrationUri` names.
+ *
+ * CDK emits the bare function ARN, and a hand-written template may use either
+ * that or the longer API Gateway path form, so both reach the same function.
+ * A URI in neither form is handed on unchanged, so CreateIntegration is what
+ * refuses it and says what an integration URI may be.
+ */
+export function simCfnHttpApiIntegrationUri(uri: string): string {
+  return apiGatewayLambdaPathUri.exec(uri)?.groups?.["functionArn"] ?? uri;
+}

--- a/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-creator.ts
+++ b/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-creator.ts
@@ -1,0 +1,65 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiRoute } from "../../api/route/sim-http-api-route.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnHttpApiRouteProperties } from "./sim-cfn-http-api-route-properties.js";
+import { SimCfnHttpApiSkippedAuthorizer } from "./sim-cfn-http-api-skipped-authorizer.js";
+
+interface SimCfnHttpApiRouteCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated routes from AWS::ApiGatewayV2::Route Resources.
+ *
+ * The route goes through the ordinary CreateRoute command, so a malformed
+ * route key, a route key the API already has, and a target naming no
+ * integration are all refused here with the reason the command gives.
+ */
+export class SimCfnHttpApiRouteCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+  private readonly skippedAuthorizer = new SimCfnHttpApiSkippedAuthorizer();
+
+  constructor(properties: SimCfnHttpApiRouteCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create a route from an AWS::ApiGatewayV2::Route Resource.
+   *
+   * The skipped-authorizer check comes first, because it is the one refusal
+   * that can explain itself: an `AuthorizerId` refused only by the allow-list
+   * would not say that the authorizer it names was skipped.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimHttpApiRoute> {
+    this.skippedAuthorizer.refuse(resource, properties, context.resources);
+
+    const routeProperties = new SimCfnHttpApiRouteProperties({
+      resource,
+      properties,
+    });
+    const apiId = routeProperties.apiId();
+
+    const created = await this.apiGatewayV2.createRoute({
+      input: routeProperties.createRouteInput(),
+    });
+
+    const route = this.apiGatewayV2
+      .findApi(apiId)
+      ?.routes.find(created.RouteId);
+    assertDefined(
+      route,
+      `sim HTTP API route ${created.RouteId} after CloudFormation creation`,
+    );
+
+    return route;
+  }
+}

--- a/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-properties.ts
+++ b/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-properties.ts
@@ -1,0 +1,85 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateRouteCommandInput } from "../../command/route/route.command.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The AWS::ApiGatewayV2::Route properties this simulation deploys.
+ *
+ * `AuthorizerId` and `AuthorizationScopes` are left out along with the
+ * authorizer Resource type itself, so a template carrying one is refused by
+ * name rather than deploying a route that would be closed on AWS.
+ */
+const simulatedProperties = [
+  "ApiId",
+  "RouteKey",
+  "Target",
+  "AuthorizationType",
+];
+
+interface SimCfnHttpApiRoutePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::Route CloudFormation properties into the CreateRoute
+ * input the route creator needs.
+ */
+export class SimCfnHttpApiRouteProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::Route",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnHttpApiRoutePropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this route belongs to, which a template reaches with a `Ref` on
+   * its AWS::ApiGatewayV2::Api.
+   */
+  apiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["ApiId"],
+      "ApiId",
+    );
+  }
+
+  /**
+   * The CreateRoute input this Resource asks for.
+   *
+   * The target arrives as the `integrations/<integration-id>` string CDK
+   * builds with `Fn::Join`, which is also the only form the command takes, so
+   * it is passed straight through. `AuthorizationType` is passed through too,
+   * so an authorization type that is not simulated is refused by CreateRoute
+   * with the reason it is refused.
+   */
+  createRouteInput(): SimCreateRouteCommandInput {
+    return {
+      ApiId: this.apiId(),
+      RouteKey: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["RouteKey"],
+        "RouteKey",
+      ),
+      Target: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Target"],
+        "Target",
+      ),
+      AuthorizationType: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizationType"],
+        "AuthorizationType",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-skipped-authorizer.ts
+++ b/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-skipped-authorizer.ts
@@ -1,0 +1,48 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Refuses a route pointing at an authorizer that was never created.
+ *
+ * AWS::ApiGatewayV2::Authorizer is not simulated, so a template carrying one
+ * has that Resource skipped rather than failed. A skipped Resource matches no
+ * value adapter, so a `Ref` to it resolves to its own logical ID, and a route
+ * would then deploy holding a logical ID where an authorizer id belongs. Left
+ * alone that is a route open here and closed on AWS, which is the divergence
+ * worth failing for.
+ *
+ * The skip reason is deliberately not quoted into the message. A skip reason
+ * says "Unsupported sim ... CloudFormation", which is what CloudFormation
+ * Resource creation matches to decide a failure is a skip, so repeating it
+ * would turn this refusal into another skip.
+ */
+export class SimCfnHttpApiSkippedAuthorizer {
+  /**
+   * Refuse a route whose `AuthorizerId` names a Resource this simulation did
+   * not create.
+   */
+  refuse(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    resources: ReadonlyMap<string, SimCfnResource>,
+  ): void {
+    const authorizerId = properties["AuthorizerId"];
+
+    if (typeof authorizerId !== "string") {
+      return;
+    }
+
+    const referenced = resources.get(authorizerId);
+
+    if (referenced?.skipped !== true) {
+      return;
+    }
+
+    throw new Error(
+      `AWS::ApiGatewayV2::Route ${resource.logicalId} property AuthorizerId ` +
+        `is ${authorizerId}, the logical ID of a Resource this simulation ` +
+        `did not create. The route would deploy pointing at an authorizer ` +
+        `that does not exist, and would then be open here and closed on AWS.`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-parser.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-parser.ts
@@ -1,0 +1,169 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface SimCfnApiGatewayV2PropertyParserProperties {
+  readonly resourceType: string;
+  readonly simulated: readonly string[];
+}
+
+/**
+ * Validates the AWS::ApiGatewayV2::* CloudFormation properties of one Resource
+ * type, both which of them may appear and what shape each has to be.
+ *
+ * Each Resource type states the properties it simulates, and every other
+ * property is refused. An allow-list rather than a list of known-unsimulated
+ * properties is what keeps a template from quietly deploying an API that looks
+ * configured to the template that configured it and unconfigured to every
+ * request it serves.
+ *
+ * The Resource type is carried here because four of them are created, and a
+ * message naming the wrong one would send a reader to the wrong template entry.
+ */
+export class SimCfnApiGatewayV2PropertyParser {
+  private readonly resourceType: string;
+  private readonly simulated: readonly string[];
+
+  constructor(properties: SimCfnApiGatewayV2PropertyParserProperties) {
+    this.resourceType = properties.resourceType;
+    this.simulated = properties.simulated;
+  }
+
+  /**
+   * Refuse every property this Resource type does not simulate.
+   *
+   * A property whose only simulated value is one of the values it can take,
+   * such as `ProtocolType`, counts as simulated here and is refused further
+   * down by the API Gateway command that receives it, which is where the
+   * reason lives.
+   */
+  requireOnlySimulated(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): void {
+    for (const name of Object.keys(properties)) {
+      if (!this.simulated.includes(name)) {
+        throw this.unsimulatedPropertyError(resource, name);
+      }
+    }
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and "false"
+   * in places, so both forms are accepted, as CloudFormation itself accepts
+   * them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Parse a property value that must be an object of strings when present,
+   * which is the shape a stage's `StageVariables` takes.
+   */
+  optionalStringMap(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): Record<string, string> | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "an object of strings");
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([name, entry]) => [
+        name,
+        this.requiredString(resource, entry, `${label}.${name}`),
+      ]),
+    );
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+
+  /**
+   * Build the diagnostic error for a property this simulator does not model.
+   */
+  private unsimulatedPropertyError(
+    resource: SimCfnResource,
+    label: string,
+  ): Error {
+    return new Error(
+      `${this.resourceType} ${resource.logicalId} property ${label} is not ` +
+        `simulated, and a deployed Resource ignoring it would behave ` +
+        `differently here than on AWS. The simulated properties are ` +
+        `${this.simulated.join(", ")}.`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
@@ -1,0 +1,93 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
+import { SimCfnHttpApiCreator } from "./api/sim-cfn-http-api-creator.js";
+import { SimCfnHttpApiIntegrationCreator } from "./integration/sim-cfn-http-api-integration-creator.js";
+import { SimCfnHttpApiRouteCreator } from "./route/sim-cfn-http-api-route-creator.js";
+import { SimCfnHttpApiStageCreator } from "./stage/sim-cfn-http-api-stage-creator.js";
+
+/**
+ * The Resource types belonging to a WebSocket API, which is the half of API
+ * Gateway v2 this simulation does not model at all.
+ */
+const webSocketResourceTypeNames = new Set([
+  "Model",
+  "RouteResponse",
+  "IntegrationResponse",
+]);
+
+interface SimApiGatewayV2CfnResourceFactoryProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * CloudFormation Resource factory for simulated API Gateway v2 resources.
+ */
+export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly apiCreator: SimCfnHttpApiCreator;
+  private readonly integrationCreator: SimCfnHttpApiIntegrationCreator;
+  private readonly routeCreator: SimCfnHttpApiRouteCreator;
+  private readonly stageCreator: SimCfnHttpApiStageCreator;
+
+  constructor(properties: SimApiGatewayV2CfnResourceFactoryProperties) {
+    const { apiGatewayV2 } = properties;
+
+    this.apiCreator = new SimCfnHttpApiCreator({ apiGatewayV2 });
+    this.integrationCreator = new SimCfnHttpApiIntegrationCreator({
+      apiGatewayV2,
+    });
+    this.routeCreator = new SimCfnHttpApiRouteCreator({ apiGatewayV2 });
+    this.stageCreator = new SimCfnHttpApiStageCreator({ apiGatewayV2 });
+  }
+
+  /**
+   * Create a simulated API Gateway v2 resource from a CloudFormation Resource.
+   *
+   * Authorizers, deployments, custom domain names and the WebSocket-only
+   * Resource types are not simulated, so their Resource types are reported as
+   * unsupported rather than quietly treated as deployed.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    switch (resourceTypeName) {
+      case "Api": {
+        return await this.apiCreator.create(resource, properties);
+      }
+      case "Integration": {
+        return await this.integrationCreator.create(resource, properties);
+      }
+      case "Route": {
+        return await this.routeCreator.create(resource, properties, context);
+      }
+      case "Stage": {
+        return await this.stageCreator.create(resource, properties);
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim API Gateway v2 CloudFormation Resource ` +
+            `${resourceTypeName}${this.unsupportedReason(resourceTypeName)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Say why a Resource type is unsupported when there is more to say than that
+   * nothing creates it yet.
+   */
+  private unsupportedReason(resourceTypeName: string): string {
+    if (webSocketResourceTypeNames.has(resourceTypeName)) {
+      return ", which belongs to a WebSocket API and is not simulated";
+    }
+
+    return "";
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-deploy.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-deploy.iso.test.ts
@@ -1,0 +1,216 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployHttpApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+/**
+ * A handler reporting which route served the request, so a test with several
+ * routes can tell them apart.
+ */
+const routeReportingHandler = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.routeKey + " " + JSON.stringify(event.pathParameters ?? {}),
+});
+`;
+
+function localUrl(endpoint: string, path = "/"): string {
+  return new SimAwsLocalUrl({ input: `${endpoint}${path}` }).toString();
+}
+
+describe("API Gateway v2 CloudFormation deployment", () => {
+  it("serves a request through a deployed API, route and integration", async () => {
+    // Given a template declaring an API, a stage, an integration and a route
+    // in front of a Lambda function
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        routeKeys: ["GET /orders/{orderId}"],
+      }),
+    );
+
+    // When the deployed endpoint is requested
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiEndpoint, "/orders/YL-1"),
+    );
+
+    // Then the request reached the integration's function through the route
+    assertIdentical(response.status, 200);
+    assertIdentical(
+      await response.text(),
+      'GET /orders/{orderId} {"orderId":"YL-1"}',
+    );
+  });
+
+  it("resolves the endpoint CDK builds from AWS::URLSuffix to the same API", async () => {
+    // Given a template whose output is the URL CDK's `httpApi.url` resolves
+    // to, which joins AWS::URLSuffix rather than reading ApiEndpoint
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        routeKeys: ["GET /orders"],
+        outputs: {
+          CdkApiUrl: {
+            Value: {
+              "Fn::Join": [
+                "",
+                [
+                  "https://",
+                  { Ref: "Api" },
+                  ".execute-api.eu-west-2.",
+                  { Ref: "AWS::URLSuffix" },
+                  "/",
+                ],
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    // When both endpoint forms are requested
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    const cdkApiUrl = stack.outputs.get("CdkApiUrl")?.value;
+    assertTypeString(apiEndpoint);
+    assertTypeString(cdkApiUrl);
+    const http = new SimAwsHttp({ simAws });
+    const fromApiEndpoint = await http.fetch(localUrl(apiEndpoint, "/orders"));
+    const fromCdkUrl = await http.fetch(localUrl(cdkApiUrl, "orders"));
+
+    // Then the amazonaws.com form and the local suffix form reach one API
+    assertIdentical(fromApiEndpoint.status, 200);
+    assertIdentical(fromCdkUrl.status, 200);
+    assertIdentical(await fromApiEndpoint.text(), await fromCdkUrl.text());
+  });
+
+  it("routes several routes through one integration", async () => {
+    // Given a template with three routes all targeting the one integration
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        routeKeys: ["GET /orders", "POST /orders", "GET /orders/{orderId}"],
+      }),
+    );
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    const http = new SimAwsHttp({ simAws });
+
+    // When each is requested, including the one the stage was created before
+    const list = await http.fetch(localUrl(apiEndpoint, "/orders"));
+    const create = await http.fetch(localUrl(apiEndpoint, "/orders"), {
+      method: "POST",
+    });
+    const read = await http.fetch(localUrl(apiEndpoint, "/orders/YL-1"));
+
+    // Then each reaches the function through the route that matched it
+    assertIdentical(await list.text(), "GET /orders {}");
+    assertIdentical(await create.text(), "POST /orders {}");
+    assertIdentical(
+      await read.text(),
+      'GET /orders/{orderId} {"orderId":"YL-1"}',
+    );
+  });
+
+  it("refuses the generated endpoint when the API disables it", async () => {
+    // Given an API deployed with the generated endpoint turned off
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        apiProperties: { DisableExecuteApiEndpoint: true },
+      }),
+    );
+
+    // When the generated endpoint is requested
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiEndpoint, "/orders"),
+    );
+
+    // Then it is refused rather than served
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({ message: "Forbidden" });
+  });
+
+  it("carries the stage variables the template gave the stage", async () => {
+    // Given a stage declaring variables
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        stageProperties: {
+          StageVariables: { catalogue: "v2" },
+          Description: "the default stage",
+        },
+      }),
+    );
+
+    // When the deployed stage is read back
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const stage = simAws.apiGatewayV2().findApi(apiId)?.stages.find("$default");
+
+    // Then it holds them, as a stage created by an SDK caller would
+    assertNonNullable(stage);
+    expect(stage.stageVariables).toStrictEqual({ catalogue: "v2" });
+    assertIdentical(stage.description, "the default stage");
+  });
+
+  it("accepts the API Gateway path form of an integration URI", async () => {
+    // Given an integration URI written as the API Gateway Lambda invoke path
+    // rather than as the bare function ARN CDK emits
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: routeReportingHandler,
+        routeKeys: ["GET /orders"],
+        integrationProperties: {
+          IntegrationUri: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/",
+                { "Fn::GetAtt": ["Handler", "Arn"] },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+      }),
+    );
+
+    // When the deployed endpoint is requested
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(apiEndpoint, "/orders"),
+    );
+
+    // Then it reached the same function
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "GET /orders {}");
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-properties.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-properties.iso.test.ts
@@ -1,0 +1,116 @@
+import {
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApi,
+  deployHttpApiFailure,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+describe("API Gateway v2 CloudFormation property shapes", () => {
+  it("refuses a property that has to be a string and is not", async () => {
+    // Given an API whose description is a number
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: { Description: 42 },
+      }),
+    );
+
+    // Then the stack fails saying what the property has to be
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGatewayV2::Api Api: Description must be a string",
+    );
+  });
+
+  it("refuses a required property the template left out", async () => {
+    // Given an API with no name, which CreateApi cannot work without
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: { Name: undefined },
+      }),
+    );
+
+    // Then the stack fails naming the property it needed
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGatewayV2::Api Api: Name must be a string",
+    );
+  });
+
+  it("refuses an integration with no URI", async () => {
+    // Given an integration naming no function
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        integrationProperties: { IntegrationUri: undefined },
+      }),
+    );
+
+    // Then CreateIntegration refuses it, since an AWS_PROXY integration with
+    // nothing to proxy to would match requests and hand them nowhere
+    assertStringIncludes(
+      error.message,
+      "CreateIntegration requires IntegrationUri",
+    );
+  });
+
+  it("reads a boolean written as a template string", async () => {
+    // Given an API turning its generated endpoint off with the string
+    // CloudFormation carries booleans as in places
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        apiProperties: { DisableExecuteApiEndpoint: "true" },
+        stageProperties: { AutoDeploy: "true" },
+      }),
+    );
+
+    // Then the deployed API reads it as a boolean, as CloudFormation does
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    assertTrue(
+      simAws.apiGatewayV2().findApi(apiId)?.disableExecuteApiEndpoint ?? false,
+    );
+  });
+
+  it("refuses a property that has to be a boolean and is not", async () => {
+    // Given a stage whose AutoDeploy is neither a boolean nor one of the
+    // strings CloudFormation carries a boolean as
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        stageProperties: { AutoDeploy: "yes" },
+      }),
+    );
+
+    // Then the stack fails saying what the property has to be
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGatewayV2::Stage Stage: AutoDeploy must be a boolean",
+    );
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-template.factory.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-template.factory.ts
@@ -1,0 +1,186 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * What a test asks for when it wants a template deploying an HTTP API in front
+ * of a Lambda function.
+ *
+ * Six Resources stand between a test and an API it can call, and most tests
+ * about the API Gateway Resource types are about one property of one of them.
+ * The four `*Properties` records are merged in last, so a test states the one
+ * property it is about rather than the whole template.
+ */
+export interface SimCfnHttpApiTemplateInput {
+  readonly functionName: string;
+  /** The inline function code every route of the API hands its requests to. */
+  readonly handlerSource: string;
+  /** The route keys the API routes, all onto the one integration. */
+  readonly routeKeys: readonly string[];
+  readonly apiProperties: SimCfnTemplateValueRecord;
+  readonly stageProperties: SimCfnTemplateValueRecord;
+  readonly integrationProperties: SimCfnTemplateValueRecord;
+  /** Applied to every route the template carries. */
+  readonly routeProperties: SimCfnTemplateValueRecord;
+  /** Resources the template carries beyond the six built here. */
+  readonly resources: SimCfnTemplateValueRecord;
+  readonly outputs: SimCfnTemplateValueRecord;
+}
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * Builds a template deploying an HTTP API that proxies to a Lambda function.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "orders-stack",
+ *   template: simCfnHttpApiTemplateFactory.make({
+ *     routeKeys: ["GET /orders"],
+ *   }),
+ * });
+ * ```
+ *
+ * The `AWS::Lambda::Permission` is the grant CDK writes for an HTTP API
+ * integration, so a request served through this template is one a real
+ * permission admitted.
+ */
+export const simCfnHttpApiTemplateFactory = new MappedFactory<
+  SimCfnHttpApiTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    functionName: "orders",
+    handlerSource: "exports.handler = async () => 'orders';",
+    routeKeys: ["$default"],
+    apiProperties: {},
+    stageProperties: {},
+    integrationProperties: {},
+    routeProperties: {},
+    resources: {},
+    outputs: {},
+  }),
+  (input) => ({
+    Resources: {
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: `${input.functionName}-role`,
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: input.functionName,
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Code: { ZipFile: input.handlerSource },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+        },
+      },
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                { Ref: "Api" },
+                "/*/*",
+              ],
+            ],
+          },
+        },
+      },
+      Api: {
+        Type: "AWS::ApiGatewayV2::Api",
+        Properties: {
+          Name: "orders",
+          ProtocolType: "HTTP",
+          ...input.apiProperties,
+        },
+      },
+      Stage: {
+        Type: "AWS::ApiGatewayV2::Stage",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          StageName: "$default",
+          AutoDeploy: true,
+          ...input.stageProperties,
+        },
+      },
+      Integration: {
+        Type: "AWS::ApiGatewayV2::Integration",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          IntegrationType: "AWS_PROXY",
+          IntegrationUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+          PayloadFormatVersion: "2.0",
+          ...input.integrationProperties,
+        },
+      },
+      ...routeResources(input),
+      ...input.resources,
+    },
+    Outputs: {
+      ApiEndpoint: { Value: { "Fn::GetAtt": ["Api", "ApiEndpoint"] } },
+      ...input.outputs,
+    },
+  }),
+);
+
+/**
+ * The logical ID of the Resource carrying one of the template's route keys.
+ *
+ * A test asserting on a route names it through here, so the numbering stays in
+ * one place.
+ */
+export function simCfnHttpApiRouteLogicalId(index: number): string {
+  return `Route${String(index + 1)}`;
+}
+
+/**
+ * One AWS::ApiGatewayV2::Route Resource per route key, all pointing at the one
+ * integration through the `Fn::Join` target CDK writes.
+ */
+function routeResources(
+  input: SimCfnHttpApiTemplateInput,
+): SimCfnTemplateValueRecord {
+  const routes: SimCfnTemplateValueRecord = {};
+
+  for (const [index, routeKey] of input.routeKeys.entries()) {
+    routes[simCfnHttpApiRouteLogicalId(index)] = {
+      Type: "AWS::ApiGatewayV2::Route",
+      Properties: {
+        ApiId: { Ref: "Api" },
+        RouteKey: routeKey,
+        AuthorizationType: "NONE",
+        Target: {
+          "Fn::Join": ["", ["integrations/", { Ref: "Integration" }]],
+        },
+        ...input.routeProperties,
+      },
+    };
+  }
+
+  return routes;
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -1,0 +1,305 @@
+import {
+  assertFalse,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApi,
+  deployHttpApiFailure,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+describe("API Gateway v2 CloudFormation validation", () => {
+  it("refuses an API property outside the simulated set", async () => {
+    // Given an API asking for CORS, which is not simulated
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: {
+          CorsConfiguration: { AllowOrigins: ["https://example.com"] },
+        },
+      }),
+    );
+
+    // Then the stack fails, naming the Resource type, the logical ID, the
+    // property and what is simulated
+    assertStringIncludes(error.message, "Api");
+    assertStringIncludes(
+      error.message,
+      "AWS::ApiGatewayV2::Api Api property CorsConfiguration is not simulated",
+    );
+    assertStringIncludes(
+      error.message,
+      "The simulated properties are Name, ProtocolType, Description, " +
+        "DisableExecuteApiEndpoint.",
+    );
+  });
+
+  it("refuses an OpenAPI document body on an API", async () => {
+    // Given an API declared as an OpenAPI document rather than as Resources
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: { Body: { openapi: "3.0.1" } },
+      }),
+    );
+
+    // Then the stack fails rather than deploying an API with no routes
+    assertStringIncludes(
+      error.message,
+      "AWS::ApiGatewayV2::Api Api property Body is not simulated",
+    );
+  });
+
+  it("refuses a WebSocket API", async () => {
+    // Given an API asking for the WebSocket protocol
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: { ProtocolType: "WEBSOCKET" },
+      }),
+    );
+
+    // Then CreateApi refuses it, with the reason it refuses it
+    assertStringIncludes(error.message, "WebSocket APIs are not simulated");
+  });
+
+  it("refuses an integration property outside the simulated set", async () => {
+    // Given an integration asking for a request timeout
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        integrationProperties: { TimeoutInMillis: 5000 },
+      }),
+    );
+
+    // Then the stack fails, naming the Resource type, the logical ID, the
+    // property and what is simulated
+    assertStringIncludes(
+      error.message,
+      "AWS::ApiGatewayV2::Integration Integration property TimeoutInMillis " +
+        "is not simulated",
+    );
+    assertStringIncludes(
+      error.message,
+      "The simulated properties are ApiId, IntegrationType, IntegrationUri, " +
+        "PayloadFormatVersion, Description.",
+    );
+  });
+
+  it("refuses payload format 1.0", async () => {
+    // Given an integration asking for the older payload format
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        integrationProperties: { PayloadFormatVersion: "1.0" },
+      }),
+    );
+
+    // Then CreateIntegration refuses it, with the reason it refuses it
+    assertStringIncludes(
+      error.message,
+      "payload format 1.0 builds a different event",
+    );
+  });
+
+  it("refuses a route authorization type that is not simulated", async () => {
+    // Given a route asking for a JWT authorizer
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizationType: "JWT" },
+      }),
+    );
+
+    // Then CreateRoute refuses it rather than deploying an open route
+    assertStringIncludes(
+      error.message,
+      "CreateRoute AuthorizationType 'JWT' is not simulated",
+    );
+  });
+
+  it("refuses a route naming an authorizer that was skipped", async () => {
+    // Given a template with an authorizer Resource, which is not simulated,
+    // and a route pointing at it
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizerId: { Ref: "Authorizer" } },
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGatewayV2::Authorizer",
+            Properties: {
+              ApiId: { Ref: "Api" },
+              AuthorizerType: "JWT",
+              Name: "jwt",
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the stack fails naming both the route and the authorizer it would
+    // have pointed at, rather than deploying a route open here and closed on
+    // AWS
+    assertStringIncludes(error.message, "Route1");
+    assertStringIncludes(
+      error.message,
+      "property AuthorizerId is Authorizer, the logical ID of a Resource " +
+        "this simulation did not create",
+    );
+  });
+
+  it("refuses an authorizer id naming nothing in the template", async () => {
+    // Given a route carrying an authorizer id written out rather than
+    // referenced, so no skipped Resource explains it
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizerId: "abc123" },
+      }),
+    );
+
+    // Then the allow-list refuses the property, since authorizers are not
+    // simulated at all
+    assertStringIncludes(
+      error.message,
+      "AWS::ApiGatewayV2::Route Route1 property AuthorizerId is not simulated",
+    );
+  });
+
+  it("refuses a stage property outside the simulated set", async () => {
+    // Given a stage asking for throttling settings
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        stageProperties: {
+          DefaultRouteSettings: { ThrottlingBurstLimit: 10 },
+        },
+      }),
+    );
+
+    // Then the stack fails, naming the Resource type, the logical ID, the
+    // property and what is simulated
+    assertStringIncludes(
+      error.message,
+      "AWS::ApiGatewayV2::Stage Stage property DefaultRouteSettings is not " +
+        "simulated",
+    );
+    assertStringIncludes(
+      error.message,
+      "The simulated properties are ApiId, StageName, AutoDeploy, " +
+        "StageVariables, Description.",
+    );
+  });
+
+  it("refuses a stage that does not deploy itself", async () => {
+    // Given a stage waiting for a Deployment, which is not simulated
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        stageProperties: { AutoDeploy: false },
+      }),
+    );
+
+    // Then CreateStage refuses it, with the reason it refuses it
+    assertStringIncludes(
+      error.message,
+      "CreateStage requires AutoDeploy: true",
+    );
+  });
+
+  it("refuses a malformed property value by shape", async () => {
+    // Given a stage whose variables are a list rather than an object
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        stageProperties: { StageVariables: ["catalogue"] },
+      }),
+    );
+
+    // Then the stack fails saying what the property has to be
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::ApiGatewayV2::Stage Stage: StageVariables must be an " +
+        "object of strings",
+    );
+  });
+
+  it("skips a Resource type nothing creates yet", async () => {
+    // Given a template carrying an authorizer no route points at
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGatewayV2::Authorizer",
+            Properties: { ApiId: { Ref: "Api" }, AuthorizerType: "JWT" },
+          },
+          Model: {
+            Type: "AWS::ApiGatewayV2::Model",
+            Properties: { ApiId: { Ref: "Api" }, Name: "Order", Schema: {} },
+          },
+        },
+      }),
+    );
+
+    // Then the rest of the stack deployed, and each unsupported Resource was
+    // skipped with a reason, the WebSocket-only one saying so
+    const authorizer = stack.getResource("Authorizer");
+    const model = stack.getResource("Model");
+    assertNonNullable(authorizer);
+    assertNonNullable(model);
+    assertTrue(authorizer.skipped);
+    assertFalse(stack.getResource("Api")?.skipped ?? true);
+    assertStringIncludes(
+      authorizer.skippedReason ?? "",
+      "Unsupported sim API Gateway v2 CloudFormation Resource Authorizer",
+    );
+    assertStringIncludes(
+      model.skippedReason ?? "",
+      "which belongs to a WebSocket API and is not simulated",
+    );
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-values.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-values.iso.test.ts
@@ -1,0 +1,143 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimHttpApi } from "../api/sim-http-api.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+const template = simCfnHttpApiTemplateFactory.make({
+  routeKeys: ["GET /orders"],
+  outputs: {
+    ApiRef: { Value: { Ref: "Api" } },
+    ApiIdAttribute: { Value: { "Fn::GetAtt": ["Api", "ApiId"] } },
+    IntegrationRef: { Value: { Ref: "Integration" } },
+    IntegrationIdAttribute: {
+      Value: { "Fn::GetAtt": ["Integration", "IntegrationId"] },
+    },
+    RouteRef: { Value: { Ref: "Route1" } },
+    RouteIdAttribute: { Value: { "Fn::GetAtt": ["Route1", "RouteId"] } },
+    StageRef: { Value: { Ref: "Stage" } },
+  },
+});
+
+/**
+ * A resolved Stack Output, which every Output in this template is a string.
+ */
+function output(
+  outputs: ReadonlyMap<string, { readonly value: unknown }>,
+  name: string,
+): string {
+  const value = outputs.get(name)?.value;
+  assertTypeString(value);
+
+  return value;
+}
+
+describe("API Gateway v2 CloudFormation Ref and Fn::GetAtt", () => {
+  it("resolves each Resource type the way CloudFormation resolves it", async () => {
+    // Given a deployed API, integration, route and stage
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, template);
+    const { outputs } = stack;
+
+    // When the deployed API is read back
+    const httpApi = simAws.apiGatewayV2().findApi(output(outputs, "ApiRef"));
+    assertNonNullable(httpApi);
+
+    // Then Ref on the API is its id, and so is the ApiId attribute
+    assertIdentical(output(outputs, "ApiRef"), httpApi.apiId);
+    assertIdentical(output(outputs, "ApiIdAttribute"), httpApi.apiId);
+
+    // And Ref on the integration is the integration id, which is what the
+    // route target was joined onto
+    const integrationId = output(outputs, "IntegrationRef");
+    assertNonNullable(httpApi.integrations.find(integrationId));
+    assertIdentical(output(outputs, "IntegrationIdAttribute"), integrationId);
+
+    // And Ref on the route is the route id
+    const routeId = output(outputs, "RouteRef");
+    assertIdentical(
+      httpApi.routes.find(routeId)?.target,
+      `integrations/${integrationId}`,
+    );
+    assertIdentical(output(outputs, "RouteIdAttribute"), routeId);
+
+    // And Ref on the stage is the stage name, which is how a stage is named
+    assertIdentical(output(outputs, "StageRef"), "$default");
+  });
+
+  it("returns the generated endpoint with no trailing slash or stage segment", async () => {
+    // Given a deployed API in eu-west-2
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, template);
+
+    // When Fn::GetAtt ApiEndpoint is read
+    const apiEndpoint = output(stack.outputs, "ApiEndpoint");
+    const apiId = output(stack.outputs, "ApiRef");
+
+    // Then it is the real AWS endpoint API Gateway generates
+    assertIdentical(
+      apiEndpoint,
+      `https://${apiId}.execute-api.eu-west-2.amazonaws.com`,
+    );
+  });
+
+  it("refuses an attribute a Resource type does not publish", async () => {
+    // Given a deployed API and its stage
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, template);
+    const apiResource = stack.getResource("Api");
+    const integrationResource = stack.getResource("Integration");
+    const routeResource = stack.getResource("Route1");
+    const stageResource = stack.getResource("Stage");
+    assertNonNullable(apiResource);
+    assertNonNullable(integrationResource);
+    assertNonNullable(routeResource);
+    assertNonNullable(stageResource);
+
+    // When an attribute none of them publishes is asked for
+    // Then each says so, and the stage says so for every attribute name,
+    // since AWS documents none for it
+    assertStringIncludes(
+      assertThrowsError(() => apiResource.attributeValue("Endpoint")).message,
+      "Unsupported AWS::ApiGatewayV2::Api attribute Endpoint",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => integrationResource.attributeValue("Uri"))
+        .message,
+      "Unsupported AWS::ApiGatewayV2::Integration attribute Uri",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => routeResource.attributeValue("RouteKey")).message,
+      "Unsupported AWS::ApiGatewayV2::Route attribute RouteKey",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => stageResource.attributeValue("StageName"))
+        .message,
+      "Unsupported AWS::ApiGatewayV2::Stage attribute StageName",
+    );
+  });
+
+  it("deploys the API as a simulated HTTP API object", async () => {
+    // Given a deployed API
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, template);
+
+    // When the CloudFormation Resource is read
+    const apiResource = stack.getResource("Api");
+
+    // Then it is backed by the simulated API itself, not a stand-in
+    assertNonNullable(apiResource);
+    assertInstanceOf(apiResource.simResource, SimHttpApi);
+  });
+});

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-creator.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-creator.ts
@@ -1,0 +1,54 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiStage } from "../../api/stage/sim-http-api-stage.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnHttpApiStageProperties } from "./sim-cfn-http-api-stage-properties.js";
+
+interface SimCfnHttpApiStageCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated stages from AWS::ApiGatewayV2::Stage Resources.
+ *
+ * A stage depends on its API and on nothing else, so CDK's `$default` stage is
+ * created before any of the routes it serves. That is the same order real
+ * CloudFormation uses, and it works here because a stage holds no copy of the
+ * routes: it is matched against whatever the API has when a request arrives.
+ */
+export class SimCfnHttpApiStageCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnHttpApiStageCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create a stage from an AWS::ApiGatewayV2::Stage Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimHttpApiStage> {
+    const stageProperties = new SimCfnHttpApiStageProperties({
+      resource,
+      properties,
+    });
+    const apiId = stageProperties.apiId();
+
+    const created = await this.apiGatewayV2.createStage({
+      input: stageProperties.createStageInput(),
+    });
+
+    const stage = this.apiGatewayV2
+      .findApi(apiId)
+      ?.stages.find(created.StageName);
+    assertDefined(
+      stage,
+      `sim HTTP API stage ${created.StageName} after CloudFormation creation`,
+    );
+
+    return stage;
+  }
+}

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
@@ -1,0 +1,97 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateStageCommandInput } from "../../command/stage/stage.command.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The AWS::ApiGatewayV2::Stage properties this simulation deploys.
+ *
+ * `DeploymentId`, `AccessLogSettings`, `RouteSettings`, `DefaultRouteSettings`
+ * and `Tags` are left out, so a template carrying one is refused by name. None
+ * of them is modelled, and a stage that looked throttled or logged to the
+ * template and did neither when serving is the failure worth avoiding.
+ */
+const simulatedProperties = [
+  "ApiId",
+  "StageName",
+  "AutoDeploy",
+  "StageVariables",
+  "Description",
+];
+
+interface SimCfnHttpApiStagePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::Stage CloudFormation properties into the CreateStage
+ * input the stage creator needs.
+ */
+export class SimCfnHttpApiStageProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::Stage",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnHttpApiStagePropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.requireOnlySimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The API this stage belongs to, which a template reaches with a `Ref` on
+   * its AWS::ApiGatewayV2::Api.
+   */
+  apiId(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["ApiId"],
+      "ApiId",
+    );
+  }
+
+  /**
+   * The stage's name, which is also what a `Ref` on this Resource returns.
+   */
+  stageName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["StageName"],
+      "StageName",
+    );
+  }
+
+  /**
+   * The CreateStage input this Resource asks for.
+   *
+   * `AutoDeploy` is passed through as the template wrote it, so a stage that
+   * does not deploy itself is refused by CreateStage with the reason it is
+   * refused.
+   */
+  createStageInput(): SimCreateStageCommandInput {
+    return {
+      ApiId: this.apiId(),
+      StageName: this.stageName(),
+      AutoDeploy: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["AutoDeploy"],
+        "AutoDeploy",
+      ),
+      StageVariables: this.propertyParser.optionalStringMap(
+        this.resource,
+        this.properties["StageVariables"],
+        "StageVariables",
+      ),
+      Description: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["Description"],
+        "Description",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/sim-api-gateway-v2.ts
+++ b/src/service/apigatewayv2/sim-api-gateway-v2.ts
@@ -10,6 +10,7 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimHttpApiStore } from "./api/sim-http-api-store.js";
+import { SimApiGatewayV2CfnResourceFactory } from "./cfn/sim-cfn-api-gateway-v2-resource-factory.js";
 import type { SimHttpApi } from "./api/sim-http-api.js";
 import { SimHttpApiCommands } from "./command/api/sim-http-api-commands.js";
 import { SimApiGatewayV2Authorizer } from "./command/authorize/sim-api-gateway-v2-authorizer.js";
@@ -49,6 +50,9 @@ export class SimApiGatewayV2 {
   private readonly stageCommands: SimHttpApiStageCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimApiGatewayV2SdkCommandRouter(this);
+  private readonly cfnFactory = new SimApiGatewayV2CfnResourceFactory({
+    apiGatewayV2: this,
+  });
 
   constructor(properties: SimApiGatewayV2Properties = {}) {
     const {
@@ -197,6 +201,13 @@ export class SimApiGatewayV2 {
   ): Promise<simApiGatewayV2Commands.SimGetStagesCommandOutput> {
     await this.background.sequence();
     return this.stageCommands.getStages(command, options);
+  }
+
+  /**
+   * Get this service's CloudFormation Resource factory.
+   */
+  cfnResourceFactory(): SimApiGatewayV2CfnResourceFactory {
+    return this.cfnFactory;
   }
 
   /**

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api.loc.test.ts
@@ -1,0 +1,146 @@
+import { GetPolicyCommand } from "@aws-sdk/client-lambda";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed HTTP API over real localhost HTTP.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The handler
+ * reads the path parameter the route captured out of the payload format 2.0
+ * event.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: "order " + (event.pathParameters?.orderId ?? "none"),
+});
+`;
+
+/**
+ * The route path the CDK app adds, kept out of the app source below because a
+ * `{name}` route parameter inside a template literal reads as an interpolation
+ * that lost its dollar sign.
+ */
+const orderRoutePath = "/orders/{orderId}";
+
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const httpApi = new apigwv2.HttpApi(stack, "HttpApi", { apiName: "orders" });
+
+httpApi.addRoutes({
+  path: ${JSON.stringify(orderRoutePath)},
+  methods: [apigwv2.HttpMethod.GET],
+  integration: new integrations.HttpLambdaIntegration(
+    "OrdersIntegration",
+    ordersFunction,
+  ),
+});
+
+new cdk.CfnOutput(stack, "ApiUrl", { value: httpApi.url });
+new cdk.CfnOutput(stack, "ApiEndpoint", { value: httpApi.apiEndpoint });
+
+app.synth();
+`;
+
+describe("Sim CDK HTTP API deployment local integration", () => {
+  it("serves a CDK-deployed HTTP API over localhost", async () => {
+    // Given a CDK stack with an HttpApi routing to a Lambda function, and a
+    // simulated AWS scoped to the Account and Region the stack names, which
+    // is what CDK baked into the endpoint it publishes.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation and serve it.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the two endpoint forms CDK publishes both name the deployed API:
+    // `httpApi.url` resolves through AWS::URLSuffix to the local hostname,
+    // and `apiEndpoint` is the real AWS one.
+    const apiUrl = stack.outputs.get("ApiUrl")?.value;
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiUrl);
+    assertTypeString(apiEndpoint);
+    assertStringIncludes(apiUrl, ".execute-api.eu-west-2.sim-aws.localhost/");
+    assertStringIncludes(apiEndpoint, ".execute-api.eu-west-2.amazonaws.com");
+
+    // And a request to either reaches the integration's function through the
+    // route, with the path parameter the route captured.
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const fromCdkUrl = await fetch(srv.localUrl(`${apiUrl}orders/YL-1`));
+      assertIdentical(fromCdkUrl.status, 200);
+      assertIdentical(fromCdkUrl.headers.get("content-type"), "text/plain");
+      assertIdentical(await fromCdkUrl.text(), "order YL-1");
+
+      const fromApiEndpoint = await fetch(
+        srv.localUrl(`${apiEndpoint}/orders/YL-2`),
+      );
+      assertIdentical(fromApiEndpoint.status, 200);
+      assertIdentical(await fromApiEndpoint.text(), "order YL-2");
+    } finally {
+      srv.close();
+    }
+
+    // And the invocation was gated by the AWS::Lambda::Permission CDK pairs
+    // with the integration, which is deployed rather than skipped.
+    const permissionResource = stack.resources
+      .values()
+      .find((resource) => resource.type === "AWS::Lambda::Permission");
+    assertNonNullable(permissionResource);
+    assertFalse(permissionResource.skipped);
+
+    const policy = await simAws
+      .lambda()
+      .getPolicy(new GetPolicyCommand({ FunctionName: "cdk-orders" }));
+    assertStringIncludes(policy.Policy, "lambda:InvokeFunction");
+    assertStringIncludes(policy.Policy, "apigateway.amazonaws.com");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.ts
@@ -1,0 +1,52 @@
+import { SimHttpApiIntegration } from "../../../../apigatewayv2/api/integration/sim-http-api-integration.js";
+import { SimHttpApiRoute } from "../../../../apigatewayv2/api/route/sim-http-api-route.js";
+import { SimHttpApi } from "../../../../apigatewayv2/api/sim-http-api.js";
+import { SimHttpApiStage } from "../../../../apigatewayv2/api/stage/sim-http-api-stage.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimHttpApiCfn } from "./sim-http-api-cfn.js";
+import { SimHttpApiIntegrationCfn } from "./sim-http-api-integration-cfn.js";
+import { SimHttpApiRouteCfn } from "./sim-http-api-route-cfn.js";
+import { SimHttpApiStageCfn } from "./sim-http-api-stage-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated API Gateway v2
+ * Resource.
+ */
+export function apiGatewayV2ValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::ApiGatewayV2::Api" &&
+    properties.simResource instanceof SimHttpApi
+  ) {
+    return new SimHttpApiCfn({ httpApi: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGatewayV2::Integration" &&
+    properties.simResource instanceof SimHttpApiIntegration
+  ) {
+    return new SimHttpApiIntegrationCfn({
+      integration: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::ApiGatewayV2::Route" &&
+    properties.simResource instanceof SimHttpApiRoute
+  ) {
+    return new SimHttpApiRouteCfn({ route: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGatewayV2::Stage" &&
+    properties.simResource instanceof SimHttpApiStage
+  ) {
+    return new SimHttpApiStageCfn({ stage: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-cfn.ts
@@ -1,0 +1,48 @@
+import type { SimHttpApi } from "../../../../apigatewayv2/api/sim-http-api.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimHttpApiCfnProperties {
+  readonly httpApi: SimHttpApi;
+}
+
+/**
+ * CloudFormation-facing values for a simulated HTTP API.
+ */
+export class SimHttpApiCfn implements SimCfnResourceValueAdapter {
+  private readonly httpApi: SimHttpApi;
+
+  constructor(properties: SimHttpApiCfnProperties) {
+    this.httpApi = properties.httpApi;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Api Ref returns the API id, which is what every route,
+   * integration and stage under the API names it by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.httpApi.apiId;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Api publishes ApiEndpoint and ApiId.
+   *
+   * `ApiEndpoint` is the generated endpoint with no trailing slash and no
+   * stage segment, as real API Gateway reports it. That is the real AWS
+   * hostname rather than the localhost one, in the same way a Lambda Function
+   * URL reports its real hostname; the serving layer accepts both.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "ApiEndpoint") {
+      return this.httpApi.apiEndpoint;
+    }
+
+    if (attributeName === "ApiId") {
+      return this.httpApi.apiId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::Api attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-integration-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-integration-cfn.ts
@@ -1,0 +1,40 @@
+import type { SimHttpApiIntegration } from "../../../../apigatewayv2/api/integration/sim-http-api-integration.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimHttpApiIntegrationCfnProperties {
+  readonly integration: SimHttpApiIntegration;
+}
+
+/**
+ * CloudFormation-facing values for a simulated HTTP API integration.
+ */
+export class SimHttpApiIntegrationCfn implements SimCfnResourceValueAdapter {
+  private readonly integration: SimHttpApiIntegration;
+
+  constructor(properties: SimHttpApiIntegrationCfnProperties) {
+    this.integration = properties.integration;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Integration Ref returns the integration id, which is
+   * what a route target names the integration by. CDK builds that target by
+   * joining this Ref onto `integrations/`.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.integration.integrationId;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Integration publishes IntegrationId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "IntegrationId") {
+      return this.integration.integrationId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::Integration attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-route-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-route-cfn.ts
@@ -1,0 +1,39 @@
+import type { SimHttpApiRoute } from "../../../../apigatewayv2/api/route/sim-http-api-route.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimHttpApiRouteCfnProperties {
+  readonly route: SimHttpApiRoute;
+}
+
+/**
+ * CloudFormation-facing values for a simulated HTTP API route.
+ */
+export class SimHttpApiRouteCfn implements SimCfnResourceValueAdapter {
+  private readonly route: SimHttpApiRoute;
+
+  constructor(properties: SimHttpApiRouteCfnProperties) {
+    this.route = properties.route;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Route Ref returns the route id, which is how a route is
+   * addressed once it exists. The route key is what identifies it to the API.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.route.routeId;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Route publishes RouteId.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "RouteId") {
+      return this.route.routeId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::Route attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-stage-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-stage-cfn.ts
@@ -1,0 +1,35 @@
+import type { SimHttpApiStage } from "../../../../apigatewayv2/api/stage/sim-http-api-stage.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimHttpApiStageCfnProperties {
+  readonly stage: SimHttpApiStage;
+}
+
+/**
+ * CloudFormation-facing values for a simulated HTTP API stage.
+ */
+export class SimHttpApiStageCfn implements SimCfnResourceValueAdapter {
+  private readonly stage: SimHttpApiStage;
+
+  constructor(properties: SimHttpApiStageCfnProperties) {
+    this.stage = properties.stage;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Stage Ref returns the stage name, which is what every
+   * stage operation names the stage by. A stage has no id of its own.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.stage.stageName;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::Stage publishes no Fn::GetAtt attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::Stage attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -1,5 +1,6 @@
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
+import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
 import { dynamoDbValueAdapter } from "./dynamodb/sim-dynamodb-cfn-value-adapter.js";
@@ -48,6 +49,7 @@ export function simCfnResourceValueAdapter(
 ): SimCfnResourceValueAdapter {
   return (
     acmValueAdapter(properties) ??
+    apiGatewayV2ValueAdapter(properties) ??
     cloudFrontValueAdapter(properties) ??
     cognitoValueAdapter(properties) ??
     dynamoDbValueAdapter(properties) ??

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -1,0 +1,102 @@
+import type { SimAwsAccountRegionContainer } from "../../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
+import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
+
+/**
+ * How one simulated service hands over its CloudFormation Resource factory,
+ * given the Account and Region scope the Stack is deploying into.
+ */
+type SimCfnScopedServiceFactory = (
+  scopedAws: SimAwsAccountRegionContainer,
+) => SimCfnServiceResourceFactory;
+
+/**
+ * Certificates arrive under two service names. `AWS::CertificateManager::*` is
+ * the real one, and `AWS::ACM::*` is the shorthand some templates use, so both
+ * reach the same simulated service.
+ */
+const acmResourceFactory: SimCfnScopedServiceFactory = (
+  scopedAws,
+): SimCfnServiceResourceFactory => scopedAws.acm().cfnResourceFactory();
+
+/**
+ * The simulated service behind each `AWS::<Service>::*` Resource type.
+ *
+ * A map rather than a switch. Every entry is the same one-line delegation, and
+ * the list is long enough that a switch over it is the most complex thing in
+ * the CloudFormation engine without saying anything a lookup does not.
+ *
+ * A service name with no entry here is not created, which is what the resolver
+ * turns into an unsupported-Resource error.
+ */
+export const simCfnServiceResourceFactories = new Map<
+  string,
+  SimCfnScopedServiceFactory
+>([
+  ["ACM", acmResourceFactory],
+  ["CertificateManager", acmResourceFactory],
+  [
+    "ApiGatewayV2",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.apiGatewayV2().cfnResourceFactory(),
+  ],
+  [
+    "CloudFormation",
+    (): SimCfnServiceResourceFactory => new SimCfnCfnResourceFactory(),
+  ],
+  [
+    "CloudFront",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.cloudFront().cfnResourceFactory(),
+  ],
+  [
+    "Cognito",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.cognitoIdentityProvider().cfnResourceFactory(),
+  ],
+  [
+    "DynamoDB",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.dynamoDb().cfnResourceFactory(),
+  ],
+  [
+    "IAM",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.iam().cfnResourceFactory(),
+  ],
+  [
+    "KMS",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.kms().cfnResourceFactory(),
+  ],
+  [
+    "Lambda",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.lambda().cfnResourceFactory(),
+  ],
+  [
+    "Route53",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.route53().cfnResourceFactory(),
+  ],
+  [
+    "S3",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.s3().cfnResourceFactory(),
+  ],
+  [
+    "SecretsManager",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.secretsManager().cfnResourceFactory(),
+  ],
+  [
+    "SQS",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.sqs().cfnResourceFactory(),
+  ],
+  [
+    "SSM",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.ssm().cfnResourceFactory(),
+  ],
+]);

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -29,10 +29,10 @@ const acmResourceFactory: SimCfnScopedServiceFactory = (
  * A service name with no entry here is not created, which is what the resolver
  * turns into an unsupported-Resource error.
  */
-export const simCfnServiceResourceFactories = new Map<
+export const simCfnServiceResourceFactories: ReadonlyMap<
   string,
   SimCfnScopedServiceFactory
->([
+> = new Map([
   ["ACM", acmResourceFactory],
   ["CertificateManager", acmResourceFactory],
   [

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -4,8 +4,8 @@ import type {
   SimCloudFormationParsedResourceType,
   SimCfnServiceResourceFactory,
 } from "../../factory/sim-cfn-resource-factory.type.js";
-import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
 import { SimCdkBucketDeploymentResourceFactory } from "../../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
+import { simCfnServiceResourceFactories } from "./sim-cfn-service-factories.js";
 
 /**
  * Resolve a scoped simulated service CloudFormation Resource factory.
@@ -35,56 +35,20 @@ export function resolveSimCloudFormationServiceResourceFactory(
     );
   }
 
-  const scopedAws = simAws.accountRegionScope(
-    accountRegionScope.accountId,
-    accountRegionScope.regionName,
+  const serviceFactory = simCfnServiceResourceFactories.get(
+    resourceType.serviceName,
   );
 
-  switch (resourceType.serviceName) {
-    case "ACM":
-    case "CertificateManager": {
-      return scopedAws.acm().cfnResourceFactory();
-    }
-    case "CloudFormation": {
-      return new SimCfnCfnResourceFactory();
-    }
-    case "CloudFront": {
-      return scopedAws.cloudFront().cfnResourceFactory();
-    }
-    case "Cognito": {
-      return scopedAws.cognitoIdentityProvider().cfnResourceFactory();
-    }
-    case "DynamoDB": {
-      return scopedAws.dynamoDb().cfnResourceFactory();
-    }
-    case "IAM": {
-      return scopedAws.iam().cfnResourceFactory();
-    }
-    case "KMS": {
-      return scopedAws.kms().cfnResourceFactory();
-    }
-    case "Lambda": {
-      return scopedAws.lambda().cfnResourceFactory();
-    }
-    case "Route53": {
-      return scopedAws.route53().cfnResourceFactory();
-    }
-    case "S3": {
-      return scopedAws.s3().cfnResourceFactory();
-    }
-    case "SecretsManager": {
-      return scopedAws.secretsManager().cfnResourceFactory();
-    }
-    case "SQS": {
-      return scopedAws.sqs().cfnResourceFactory();
-    }
-    case "SSM": {
-      return scopedAws.ssm().cfnResourceFactory();
-    }
-    default: {
-      throw new Error(
-        `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,
-      );
-    }
+  if (serviceFactory === undefined) {
+    throw new Error(
+      `Unsupported sim CloudFormation Resource service ${resourceType.serviceName}`,
+    );
   }
+
+  return serviceFactory(
+    simAws.accountRegionScope(
+      accountRegionScope.accountId,
+      accountRegionScope.regionName,
+    ),
+  );
 }

--- a/test/apigatewayv2/cfn-deploy.ts
+++ b/test/apigatewayv2/cfn-deploy.ts
@@ -1,0 +1,56 @@
+/**
+ * Deployment helpers the API Gateway v2 CloudFormation test files share.
+ *
+ * Both the deployment and the validation suites deploy a template and then
+ * read either the stack or the error it failed with. This lives under `test/`
+ * for the same reasons as `test/cognito/`: eslint rejects a test file that
+ * exports helpers alongside its own `describe` calls, and `test/**` is
+ * type-checked with everything else, excluded from the published build, not
+ * collected as a suite, and not counted in coverage.
+ */
+
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCfnStack } from "../../src/service/cloudformation/stack/sim-cfn-stack.js";
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+
+/**
+ * A simulated AWS in the region the API Gateway CloudFormation tests deploy
+ * into, which is not the default one, so a region reaching an endpoint is a
+ * region the template put there.
+ */
+export function simAwsInEuWest2(): SimAws {
+  return new SimAws({ defaultRegionName: "eu-west-2" });
+}
+
+/**
+ * Deploy a template and wait for it to finish.
+ */
+export async function deployHttpApi(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<SimCfnStack> {
+  const stack = await simAws
+    .cloudFormation()
+    .deployTemplate({ stackName: "orders-stack", template });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * Deploy a template that is expected to fail, and give back the error.
+ */
+export async function deployHttpApiFailure(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): Promise<Error> {
+  const error = await assertThrowsErrorAsync(async () => {
+    await deployHttpApi(simAws, template);
+  });
+
+  assertInstanceOf(error, Error);
+
+  return error;
+}


### PR DESCRIPTION
…on resources

AWS::ApiGatewayV2::Api, Integration, Route and Stage now create simulated resources, so a CDK-synthesized or hand-written template deploys an HTTP API that serves requests. Ref and Fn::GetAtt resolve per resource type, and every property outside the simulated set is refused by name rather than ignored.

Adding the service case pushed the CloudFormation service resolver over the complexity limit, so its switch is now a map of per-service delegations.

Resolves https://github.com/KensioSoftware/yulin/issues/301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for simulated API Gateway v2 HTTP APIs, integrations, routes, and stages.
  * Supports API deployment, Lambda integrations, multiple routes, stages, stage variables, and generated endpoints.
  * Added support for CloudFormation `Ref` and `Fn::GetAtt` values, including API, integration, and route identifiers.
* **Bug Fixes**
  * Improved validation and diagnostics for unsupported properties, invalid values, unresolved authorizers, and unsupported resource types.
* **Documentation**
  * Added deployment examples and documented supported properties, limitations, URI formats, and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->