### PR TITLE
feat: authorize simulated HTTP API routes with AWS_IAM and SigV4-sign…

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -636,6 +636,205 @@ claim. None of that is published by AWS; all of it is what the real endpoint was
 A route with `AuthorizationType: "NONE"` has no caller to describe, so `requestContext.authorizer` is
 left out of its events entirely.
 
+## Protecting a route with IAM
+
+A route declared `AuthorizationType: "AWS_IAM"` reaches its integration only when the caller is
+allowed `execute-api:Invoke` on the ARN of the route being called. The route takes no authorizer, and
+naming one is refused: IAM itself is what decides.
+
+The caller comes from the request, through either a SigV4 signature or an `x-sim-aws-caller` header
+naming a principal directly. A request that offers neither is anonymous, owns no policies, and is
+refused. See [callers of HTTP requests](../iam/#callers-of-http-requests) in the IAM docs for how that
+resolution works and how to sign a served request.
+
+The ARN a request is authorized against is:
+
+```text
+arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
+```
+
+- The Account and Region are the API's own, not the caller's.
+- The stage is the one that served the request, so `$default` for the default stage.
+- The method is the one the client sent, upper case, so a `GET` reaching a route keyed `ANY /orders`
+  gives `GET`.
+- The path is the request path with the stage segment and the leading slash taken off, so `/dev/orders/42`
+  served from stage `dev` gives `orders/42`. It is the path asked for rather than the route key, because
+  this is the resource a policy is written against by hand. A request to the API root gives an ARN
+  ending `/GET/`.
+
+An identity policy may wildcard any part of that. `<apiId>/*`, `<apiId>/$default/*` and
+`<apiId>/*/GET/orders/*` all allow a `GET` of `/orders/42` on the default stage.
+
+```typescript sim-apigatewayv2-iam-authorizer
+/**
+ * Protecting a simulated HTTP API route with IAM.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::888888888888:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `orders for ${
+          event.requestContext.authorizer?.iam?.userArn ?? "nobody"
+        }`,
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /orders/{orderId}",
+    Target: `integrations/${IntegrationId}`,
+    AuthorizationType: "AWS_IAM",
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// A Role of the API's own Account, allowed to call the orders routes of this
+// API on the default stage.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Reporter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::888888888888:root" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reporter",
+    PolicyName: "InvokeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "execute-api:Invoke",
+          Resource: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/$default/GET/orders/*`,
+        },
+      ],
+    }),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${ApiEndpoint}/orders/42`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status); // 403
+console.log(await anonymous.text()); // '{"message":"Forbidden"}'
+
+const reporter = await fetch(url, {
+  headers: { "x-sim-aws-caller": "arn:aws:iam::888888888888:role/Reporter" },
+});
+
+console.log(await reporter.text()); // "orders for arn:aws:iam::888888888888:role/Reporter"
+
+srv.close();
+```
+
+### What a refused request gets back
+
+A caller IAM does not allow is answered with a 403 and `{"message":"Forbidden"}`, and the integration
+is never invoked. That is the answer for an unsigned request too: the serving boundary resolves it to
+an anonymous caller, and nothing allows an anonymous caller anything. An explicit `Deny` beats an
+`Allow`, as it does in any IAM evaluation.
+
+A request whose signature is malformed, or is scoped to another service, does not reach the route at
+all. The serving boundary refuses it first, with `{"Message":"Forbidden"}` and a capital `M`.
+
+### The caller the handler receives
+
+An admitted request carries its caller into the event as `requestContext.authorizer.iam`:
+
+```json
+{
+  "accessKey": "",
+  "accountId": "888888888888",
+  "callerId": "arn:aws:iam::888888888888:role/Reporter",
+  "cognitoIdentity": null,
+  "principalOrgId": null,
+  "userArn": "arn:aws:iam::888888888888:role/Reporter",
+  "userId": "arn:aws:iam::888888888888:role/Reporter"
+}
+```
+
+`accountId` and `userArn` come from the resolved principal's ARN. `requestContext.accountId` is that
+Account too, rather than `anonymous`. The block is the same one a Lambda Function URL produces, so
+handler code reading it behaves the same behind either.
+
+### Callers from another Account
+
+A principal of another Account is refused, whatever its own Account allows it. A cross-Account request
+needs an Allow from the resource side as well, and an HTTP API has nowhere to put one: unlike a REST
+API, it has no resource policy at all. Real AWS behaves the same way.
+
+The way through, here and on AWS, is for that principal to assume a Role in the API's Account through
+STS and sign with the session credentials. The request is then made by a principal of the API's own
+Account.
+
 ## The event the handler receives
 
 The handler is invoked with the API Gateway HTTP API payload format 2.0 event, exported as
@@ -900,6 +1099,10 @@ simulated properties are:
 - `Route`: `ApiId`, `RouteKey`, `Target`, `AuthorizationType`, `AuthorizerId`, `AuthorizationScopes`
 - `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`
 
+CDK's `HttpIamAuthorizer` deploys too. It emits no `AWS::ApiGatewayV2::Authorizer` and no
+`AuthorizerId`, only `AuthorizationType: "AWS_IAM"` on the `Route`, and the deployed route then
+requires IAM authorization when it is served.
+
 CDK's `HttpJwtAuthorizer` and `HttpUserPoolAuthorizer` both deploy. `HttpUserPoolAuthorizer` builds
 its issuer from `Fn::GetAtt <UserPool>.ProviderURL`, which resolves to the same string the pool's
 tokens name as their issuer, so a CDK-declared authorizer and a CDK-deployed pool agree with nothing
@@ -910,6 +1113,10 @@ authorizer adds a client of its own with CDK's defaults, and those emit the OAut
 A `Route` with `AuthorizationType: "JWT"` whose `AuthorizerId` does not resolve to an authorizer of
 that API fails the stack, naming both. That covers a `Ref` to a Resource this simulation skipped: a
 skipped Resource resolves to its own logical ID, and no authorizer has that id.
+
+An `Api` carrying a `Policy` property is refused with its own message rather than the generic one. AWS
+has no such property on this Resource type, because an HTTP API has no resource policy, so a template
+carrying one was written for a REST API.
 
 `AWS::ApiGatewayV2::Deployment`, `DomainName`, `ApiMapping`, `VpcLink` and the WebSocket-only
 `Model`, `RouteResponse` and `IntegrationResponse` create nothing, so a template carrying one has
@@ -947,6 +1154,9 @@ the simulation without being given one. See the
 - Real RS256 verification of a token against the keys its issuer publishes, with the claims checked
   against the simulation's clock, and the accepted claims reaching the handler as
   `event.requestContext.authorizer.jwt`
+- Routes protected with `AuthorizationType: "AWS_IAM"`, evaluating `execute-api:Invoke` against the
+  `execute-api` ARN of the route being called, for a caller resolved from a SigV4 signature or an
+  `x-sim-aws-caller` header, and reaching the handler as `event.requestContext.authorizer.iam`
 - `CreateStage` and `GetStages` for the `$default` stage and for named stages served under their own
   path segment, including stage variables
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
@@ -979,8 +1189,34 @@ Current documented limitations:
   integrations and AWS service integrations are not simulated.
 - Payload format 1.0 is refused. A handler written for 1.0 reads event fields a 2.0 event does not
   have, so treating one as the other would pass here and fail on AWS.
-- `AuthorizationType` is `NONE` or `JWT`. `AWS_IAM` and `CUSTOM` routes are refused rather than
-  created open, since a route asking for either would admit anyone here and refuse them on AWS.
+- `AuthorizationType` is `NONE`, `JWT` or `AWS_IAM`. A `CUSTOM` route is refused rather than created
+  open, since a route asking for it would admit anyone here and refuse them on AWS.
+- `AuthorizationScopes` on an `AWS_IAM` route is refused. This is stricter than AWS, which documents
+  route scopes as meaningful only for `JWT` and ignores them here. Accepting one would let a test
+  assert on a scope restriction that nothing applies.
+- The method and path segments of the ARN an `AWS_IAM` route is authorized against are inferred
+  rather than documented, and the two callers of that ARN builder fill them differently: this one
+  names the request's own method and path, while the integration's invoke permission names the route
+  key template. AWS documents one format for both. See
+  [Protecting a route with IAM](#protecting-a-route-with-iam).
+- A `*` in a policy resource is uniformly greedy here, so it crosses `/` boundaries. AWS distinguishes
+  `*` from `*/*` in some ARN path positions, which makes the simulator more permissive than AWS for a
+  policy relying on that distinction.
+- Only `execute-api:Invoke` is evaluated. Nothing constrains the action string a policy may name, so
+  a policy can be written with `execute-api:ManageConnections` or `execute-api:InvalidateCache` and
+  nothing will ever ask about it.
+- `accessKey` in the `iam` block is empty, `callerId` and `userId` carry the caller ARN rather than
+  the `AIDA`/`AROA` unique id real AWS puts there, and `cognitoIdentity` and `principalOrgId` are
+  always null. None of those is available at the simulator's request boundary.
+- A request signed for another service is refused by the serving boundary before route matching, even
+  on a `NONE` route, where real API Gateway would ignore the signature. That boundary answers
+  `{"Message":"Forbidden"}` with a capital `M`, unlike the API's own refusals.
+- An unsigned request to an `AWS_IAM` route is a 403 rather than the 403 with an
+  `x-amzn-ErrorType` of `IncompleteSignatureException` real API Gateway was observed to send. The
+  simulator resolves such a request to an anonymous caller and refuses it by ordinary IAM evaluation.
+- HTTP API resource policies are not simulated, because AWS does not have them. A caller from another
+  Account is therefore always refused, since a cross-Account request needs an Allow from the resource
+  side. Assume a Role in the API's Account instead, which is the route through on AWS as well.
 - Lambda `REQUEST` authorizers are not simulated, of either payload version. `CreateAuthorizer`
   refuses `AuthorizerType: "REQUEST"` by name, as does an `AWS::ApiGatewayV2::Authorizer` asking for
   one, since nothing here runs the code that would make the decision.
@@ -1033,6 +1269,9 @@ Current documented limitations:
   `corsPreflight` does not deploy.
 - `AWS::ApiGatewayV2::Api` refuses `Body` and `BodyS3Location` by name. Importing an OpenAPI document
   is a second way to declare routes and integrations, and none of that translation is simulated.
+- `AWS::ApiGatewayV2::Api` refuses `Policy` with a message of its own saying an HTTP API has no
+  resource policy. There is no such property on the real Resource type, so a template carrying one
+  was written for a REST API rather than hitting a gap here.
 - Stack updates and deletes are not supported for these resource types, as they are not for any
   others. See the [CloudFormation limitations](../cloudformation/#limitations).
 - Access logging, throttling, usage plans and API keys are not simulated.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-iam-authorizer.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-iam-authorizer.example.ts
@@ -1,0 +1,127 @@
+/**
+ * Protecting a simulated HTTP API route with IAM.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::888888888888:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: `orders for ${
+          event.requestContext.authorizer?.iam?.userArn ?? "nobody"
+        }`,
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /orders/{orderId}",
+    Target: `integrations/${IntegrationId}`,
+    AuthorizationType: "AWS_IAM",
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "orders",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// A Role of the API's own Account, allowed to call the orders routes of this
+// API on the default stage.
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "Reporter",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { AWS: "arn:aws:iam::888888888888:root" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Reporter",
+    PolicyName: "InvokeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "execute-api:Invoke",
+          Resource: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/$default/GET/orders/*`,
+        },
+      ],
+    }),
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${ApiEndpoint}/orders/42`);
+
+const anonymous = await fetch(url);
+
+console.log(anonymous.status); // 403
+console.log(await anonymous.text()); // '{"message":"Forbidden"}'
+
+const reporter = await fetch(url, {
+  headers: { "x-sim-aws-caller": "arn:aws:iam::888888888888:role/Reporter" },
+});
+
+console.log(await reporter.text()); // "orders for arn:aws:iam::888888888888:role/Reporter"
+
+srv.close();

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -103,9 +103,13 @@ naming the localhost origin it is served from, while a token's `iss` names the r
 OIDC-conformant discovery client would reject its own pool's tokens. Resolving in process compares
 `pool.issuerUrl` against the token's `iss`, and both come from the same getter.
 
-`SimHttpApiAuthorization` is what a decision answers with: `SimHttpApiAdmitted`, carrying the `jwt`
-block for the event, or `SimHttpApiRefused`, which is a 401 for everything up to and including claim
-validation and a 403 only for an unmet route scope.
+`SimHttpApiAuthorization` is what a decision answers with: `SimHttpApiAdmitted`, carrying whatever the
+event needs to describe the caller, or `SimHttpApiRefused`, which is a 401 for everything up to and
+including claim validation and a 403 for an unmet route scope or an IAM refusal.
+
+The other kind of route authorization is `AWS_IAM`, which has nothing under `api/authorizer/` at all:
+it configures nothing on the API, so there is nothing to store. It lives entirely in `serve/auth/`,
+because it is decided from the request rather than from anything the API holds.
 
 `registry/sim-http-api-registry.ts` is the one thing outside that tree. A served request carries the
 API id and the region in its hostname, but not the Account, so the registry maps an id to the
@@ -142,9 +146,23 @@ lives.
    Region its own ARN names, which need not be the API's, and the router hands back that Account's
    IAM alongside the function.
 2. `serve/auth/sim-http-api-route-authorizer.ts` asks whether the client may have the matched route.
-   This comes first, before the integration is even looked up: a request presenting no token is
-   refused whether or not the integration behind the route would have worked. A route with
-   `AuthorizationType: NONE` admits everyone with no caller to describe.
+   This comes first, before the integration is even looked up: a request presenting no credentials is
+   refused whether or not the integration behind the route would have worked. It settles which kind
+   of authorization the route asks for and hands the decision to the one that makes it:
+
+   ```text
+   SimHttpApiRouteAuthorizer
+   ├── NONE     admits everyone, with no caller to describe
+   ├── JWT      SimHttpApiJwtRouteAuthorizer, over the API's own authorizers
+   └── AWS_IAM  SimHttpApiIamRouteAuthorizer, evaluating execute-api:Invoke
+   ```
+
+   The IAM one asks the API's own Account, which the router resolves, and supplies no resource
+   policies, because an HTTP API has none. That is also what makes a caller from another Account
+   always refused: a cross-Account request needs an Allow from the resource side. The resource is the
+   `execute-api` ARN of the request, built by `api/sim-http-api-execute-api-arn.ts` from the concrete
+   method and path rather than from the route key.
+
 3. `serve/auth/sim-http-api-integration-authorizer.ts` asks whether the API may invoke the function
    at all. The caller is the service principal `apigateway.amazonaws.com`, the action is
    `lambda:InvokeFunction`, and the request supplies `AWS:SourceArn` from
@@ -203,8 +221,10 @@ simulation exists to avoid:
 - an integration type other than `AWS_PROXY`, and an integration URI that is not an unqualified
   Lambda function ARN
 - a malformed route key, refused at `CreateRoute`, which is where real API Gateway refuses it
-- an authorization type other than `NONE` or `JWT`, and an `AuthorizerId` or `AuthorizationScopes` on
-  a route that authorizes nobody
+- an authorization type other than `NONE`, `JWT` or `AWS_IAM`, and an `AuthorizerId` or
+  `AuthorizationScopes` on a route that has no use for either
+- a `Policy` on `AWS::ApiGatewayV2::Api`, with a message of its own: AWS has no such property, since
+  an HTTP API has no resource policy
 - an authorizer type other than `JWT`, and every option only a Lambda `REQUEST` authorizer takes,
   including `AuthorizerResultTtlInSeconds`
 - more than one `IdentitySource`, and an identity source naming neither a header nor a query string

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-authorization.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-authorization.ts
@@ -1,4 +1,5 @@
 import type { SimPayload2JwtAuthorizer } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
 
 /**
  * Why an endpoint refused a request, which decides the response it gets.
@@ -11,20 +12,30 @@ import type { SimPayload2JwtAuthorizer } from "../../../../serve/payload-2/sim-p
  */
 export type SimHttpApiRefusalKind = "unauthorized" | "forbidden";
 
+interface SimHttpApiAdmittedProperties {
+  /** The token a `JWT` route's authorizer accepted. */
+  readonly jwt?: SimPayload2JwtAuthorizer | undefined;
+  /** The principal an `AWS_IAM` route allowed the request. */
+  readonly caller?: SimAwsRequestCaller | undefined;
+}
+
 /**
  * A request the endpoint admitted, and what its authorizer knows about the
  * caller.
  *
- * `jwt` is absent on a route that authorizes nobody, since there is no caller
- * to describe, which is what leaves `requestContext.authorizer` out of the
- * event entirely.
+ * Both members are absent on a route that authorizes nobody, since there is no
+ * caller to describe, which is what leaves `requestContext.authorizer` out of
+ * the event entirely. Which one is present says which kind of authorization
+ * admitted the request.
  */
 export class SimHttpApiAdmitted {
   public readonly admitted = true as const;
   public readonly jwt: SimPayload2JwtAuthorizer | undefined;
+  public readonly caller: SimAwsRequestCaller | undefined;
 
-  constructor(jwt?: SimPayload2JwtAuthorizer) {
-    this.jwt = jwt;
+  constructor(properties: SimHttpApiAdmittedProperties = {}) {
+    this.jwt = properties.jwt;
+    this.caller = properties.caller;
   }
 }
 
@@ -34,6 +45,11 @@ export class SimHttpApiAdmitted {
  * `errorDescription` is the one AWS publishes for a token whose audience does
  * not match, and is absent everywhere else rather than filled in with text
  * AWS was not seen to send.
+ *
+ * An `AWS_IAM` route refuses with `forbidden`, whoever the caller turned out
+ * to be: nothing about an unsigned request makes it a 401 here, because the
+ * boundary already resolved it to an anonymous caller and IAM then allows that
+ * caller nothing.
  */
 export class SimHttpApiRefused {
   public readonly admitted = false as const;
@@ -53,7 +69,8 @@ export class SimHttpApiRefused {
   }
 
   /**
-   * The token verified, and none of its scopes is one the route asks for.
+   * The token verified and none of its scopes is one the route asks for, or
+   * IAM did not allow the caller `execute-api:Invoke` on the route.
    */
   static forbidden(): SimHttpApiRefused {
     return new SimHttpApiRefused("forbidden");

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.ts
@@ -72,9 +72,9 @@ export class SimHttpApiJwtVerification {
 
     return (
       this.claimChecks.check(jwt.claims, jwtConfiguration) ??
-      new SimHttpApiAdmitted(
-        new SimHttpApiJwtClaims(jwt.claims).toAuthorizerContext(),
-      )
+      new SimHttpApiAdmitted({
+        jwt: new SimHttpApiJwtClaims(jwt.claims).toAuthorizerContext(),
+      })
     );
   }
 

--- a/src/service/apigatewayv2/api/route/sim-http-api-route.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route.ts
@@ -16,12 +16,14 @@ import {
 export type SimHttpApiRouteId = Brand<string, "SimHttpApiRouteId">;
 
 /**
- * The authorization types simulated: none, so anyone may call the route, or a
- * JWT the route's authorizer verifies.
+ * The authorization types simulated: none, so anyone may call the route, a JWT
+ * the route's authorizer verifies, or a SigV4-signed caller IAM allows
+ * `execute-api:Invoke` on the route being called.
  *
- * `AWS_IAM` and `CUSTOM` are refused at creation rather than created open.
+ * `CUSTOM`, which is a Lambda authorizer, is refused at creation rather than
+ * created open.
  */
-export type SimHttpApiAuthorizationType = "NONE" | "JWT";
+export type SimHttpApiAuthorizationType = "NONE" | "JWT" | "AWS_IAM";
 
 /**
  * Allocate a route id, in the same opaque shape as an integration id.
@@ -50,8 +52,9 @@ export class SimHttpApiRoute {
   public readonly authorizationType: SimHttpApiAuthorizationType;
 
   /**
-   * The authorizer this route sends requests through, which a `JWT` route
-   * always has and a `NONE` route never does.
+   * The authorizer this route sends requests through, which only a `JWT` route
+   * has. An `AWS_IAM` route takes no authorizer, since IAM itself is what
+   * decides, and a `NONE` route authorizes nobody.
    */
   public readonly authorizerId: SimHttpApiAuthorizerId | undefined;
 

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -34,6 +34,11 @@ export interface SimHttpApiLambdaProxyInput {
    * whose routes admit anyone.
    */
   readonly jwtAuthorizer: SimHttpApiProxyAuthorizer | undefined;
+  /**
+   * Whether every route is authorized by IAM instead, which is what an
+   * `AWS_IAM` route asks for.
+   */
+  readonly iamAuthorization: boolean;
   /** The scopes every route asks a token for. */
   readonly authorizationScopes: readonly string[];
   /** The stages the API serves from. */
@@ -87,6 +92,7 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     disableExecuteApiEndpoint: false,
     routeKeys: ["$default"],
     jwtAuthorizer: undefined,
+    iamAuthorization: false,
     authorizationScopes: [],
     stageNames: ["$default"],
     stageVariables: {},
@@ -124,6 +130,7 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     const authorization = await simHttpApiProxyAuthorization(simApiGatewayV2, {
       apiId,
       jwtAuthorizer: input.jwtAuthorizer,
+      iamAuthorization: input.iamAuthorization,
       authorizationScopes: input.authorizationScopes,
     });
 

--- a/src/service/apigatewayv2/api/sim-http-api-match.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-match.ts
@@ -20,6 +20,15 @@ export interface SimHttpApiMatch {
   readonly integration: SimHttpApiIntegration;
   readonly stage: SimHttpApiStage;
   readonly pathParameters: SimHttpApiPathParameters;
+  /**
+   * The request path the stage left for the routes, with the stage segment and
+   * the leading slash taken off: `/dev/pets/6` served from stage `dev` is
+   * `pets/6`, and a request to the root is the empty string.
+   *
+   * This is the form an `execute-api` ARN names a request by, which is what
+   * an `AWS_IAM` route is authorized against.
+   */
+  readonly pathAfterStage: string;
 }
 
 /**
@@ -82,6 +91,7 @@ export class SimHttpApiMatcher {
       integration,
       stage: stage.stage,
       pathParameters: selected.pathParameters,
+      pathAfterStage: stage.segments.join("/"),
     };
   }
 }

--- a/src/service/apigatewayv2/api/sim-http-api-proxy-authorization.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-proxy-authorization.ts
@@ -14,6 +14,8 @@ interface SimHttpApiProxyAuthorizationInput {
   readonly apiId: string;
   /** Undefined for an API whose routes admit anyone. */
   readonly jwtAuthorizer: SimHttpApiProxyAuthorizer | undefined;
+  /** Whether every route is authorized by IAM instead. */
+  readonly iamAuthorization: boolean;
   readonly authorizationScopes: readonly string[];
 }
 
@@ -29,6 +31,16 @@ export async function simHttpApiProxyAuthorization(
   input: SimHttpApiProxyAuthorizationInput,
 ): Promise<SimCreateRouteCommandInput> {
   const { apiId, jwtAuthorizer } = input;
+
+  if (input.iamAuthorization) {
+    // An AWS_IAM route takes no authorizer at all, so there is nothing to
+    // create. The scopes are still passed on, so a test asking for one is
+    // refused by CreateRoute rather than quietly getting an unchecked scope.
+    return {
+      AuthorizationType: "AWS_IAM",
+      AuthorizationScopes: input.authorizationScopes,
+    };
+  }
 
   if (jwtAuthorizer === undefined) {
     // The scopes are passed on rather than dropped, so a test asking for one

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-properties.ts
@@ -39,6 +39,7 @@ export class SimCfnHttpApiProperties {
     this.resource = properties.resource;
     this.properties = properties.properties;
 
+    this.requireNoResourcePolicy();
     this.propertyParser.requireOnlySimulated(this.resource, this.properties);
   }
 
@@ -71,5 +72,27 @@ export class SimCfnHttpApiProperties {
         "DisableExecuteApiEndpoint",
       ),
     };
+  }
+
+  /**
+   * Refuse a `Policy` property with the reason it cannot be deployed.
+   *
+   * The generic refusal reports a property as not simulated, which reads as a
+   * gap that will be filled later. There is no such property on this Resource
+   * type: HTTP APIs have no resource policies at all, so the only template
+   * carrying one was written for a REST API.
+   */
+  private requireNoResourcePolicy(): void {
+    if (this.properties["Policy"] === undefined) {
+      return;
+    }
+
+    throw new Error(
+      `AWS::ApiGatewayV2::Api ${this.resource.logicalId} property Policy ` +
+        `cannot be deployed: an HTTP API has no resource policy, and AWS ` +
+        `has no such property on this Resource type. A resource policy is a ` +
+        `REST API feature, declared on AWS::ApiGateway::RestApi. Authorize ` +
+        `the API's routes with AuthorizationType AWS_IAM instead.`,
+    );
   }
 }

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-iam-route.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-iam-route.iso.test.ts
@@ -1,0 +1,79 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApi,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+const accountId = "888888888888";
+const reporterArn = `arn:aws:iam::${accountId}:role/Reporter`;
+
+/**
+ * A Role allowed every `execute-api` resource, so what the test turns on is
+ * whether the deployed route asks IAM at all.
+ */
+async function reporterRole(simAws: SimAws): Promise<void> {
+  const iam = simAws.iam();
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Reporter",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Reporter",
+      PolicyName: "InvokeApi",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: "execute-api:Invoke", Resource: "*" },
+      }),
+    }),
+  );
+}
+
+describe("Deploying an IAM-authorized AWS::ApiGatewayV2::Route", () => {
+  it("deploys the route CDK's HttpIamAuthorizer emits, and closes it", async () => {
+    // Given the Route properties CDK synthesises for an HttpIamAuthorizer,
+    // which are AuthorizationType alone, with no Authorizer Resource at all
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        routeProperties: { AuthorizationType: "AWS_IAM" },
+      }),
+    );
+    await reporterRole(simAws);
+
+    // When the deployed route is called with nothing, and then as a Role
+    // allowed to invoke it
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    const url = new SimAwsLocalUrl({
+      input: `${apiEndpoint}/orders`,
+    }).toString();
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const anonymous = await simAwsHttp.fetch(url);
+    const reporter = await simAwsHttp.fetch(url, {
+      headers: { [simAwsCallerHeaderName]: reporterArn },
+    });
+
+    // Then the stack deployed, and the route it deployed is one IAM decides
+    assertIdentical(anonymous.status, 403);
+    assertIdentical(reporter.status, 200);
+    assertIdentical(await reporter.text(), '"orders"');
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -123,21 +123,49 @@ describe("API Gateway v2 CloudFormation validation", () => {
   });
 
   it("refuses a route authorization type that is not simulated", async () => {
-    // Given a route asking for IAM authorization
+    // Given a route asking for a Lambda authorizer
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
     const error = await deployHttpApiFailure(
       simAws,
       simCfnHttpApiTemplateFactory.make({
-        routeProperties: { AuthorizationType: "AWS_IAM" },
+        routeProperties: { AuthorizationType: "CUSTOM" },
       }),
     );
 
     // Then CreateRoute refuses it rather than deploying an open route
     assertStringIncludes(
       error.message,
-      "CreateRoute AuthorizationType 'AWS_IAM' is not simulated",
+      "CreateRoute AuthorizationType 'CUSTOM' is not simulated",
+    );
+  });
+
+  it("refuses an Api declaring a resource policy", async () => {
+    // Given a template carrying the Policy property a REST API takes
+    const simAws = simAwsInEuWest2();
+
+    // When it is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        apiProperties: {
+          Policy: {
+            Version: "2012-10-17",
+            Statement: [
+              { Effect: "Allow", Action: "execute-api:Invoke", Resource: "*" },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is refused by name, saying an HTTP API has no such property
+    // rather than reporting a gap that will be filled later
+    assertStringIncludes(
+      error.message,
+      "an HTTP API has no resource policy, and AWS has no such property on " +
+        "this Resource type",
     );
   });
 

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-authorization.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-authorization.ts
@@ -34,8 +34,14 @@ export class SimHttpApiRouteAuthorizationInput {
    * The authorization this route is created with.
    */
   read(api: SimHttpApi): SimHttpApiRouteAuthorization {
-    if ((this.input.AuthorizationType ?? "NONE") === "NONE") {
+    const authorizationType = this.input.AuthorizationType ?? "NONE";
+
+    if (authorizationType === "NONE") {
       return this.open();
+    }
+
+    if (authorizationType === "AWS_IAM") {
+      return this.iam();
     }
 
     return {
@@ -52,26 +58,75 @@ export class SimHttpApiRouteAuthorizationInput {
    * `AuthorizationType` out.
    */
   private open(): SimHttpApiRouteAuthorization {
-    if (this.input.AuthorizerId !== undefined) {
-      throw new SimApiGatewayV2BadRequest(
-        `CreateRoute AuthorizerId is set on a route with ` +
-          `AuthorizationType NONE, which would be ignored here and would ` +
-          `leave the route open on AWS too`,
-      );
-    }
-
-    if ((this.input.AuthorizationScopes ?? []).length > 0) {
-      throw new SimApiGatewayV2BadRequest(
-        `CreateRoute AuthorizationScopes is set on a route with ` +
-          `AuthorizationType NONE, and nothing checks a scope on a route ` +
-          `that authorizes nobody`,
-      );
-    }
+    this.refuseAuthorizerId(
+      "NONE",
+      "which would be ignored here and would leave the route open on AWS too",
+    );
+    this.refuseAuthorizationScopes(
+      "NONE",
+      "and nothing checks a scope on a route that authorizes nobody",
+    );
 
     return {
       authorizationType: "NONE",
       authorizationScopes: new SimHttpApiRouteScopes(),
     };
+  }
+
+  /**
+   * A route IAM decides, which takes neither an authorizer nor scopes.
+   *
+   * Refusing scopes is stricter than AWS, which documents route scopes as
+   * meaningful only for `JWT` and ignores them for `AWS_IAM`. Accepting them
+   * here would let a test assert on a scope restriction that nothing applies.
+   */
+  private iam(): SimHttpApiRouteAuthorization {
+    this.refuseAuthorizerId(
+      "AWS_IAM",
+      "and IAM itself decides an AWS_IAM route, so there is no authorizer to " +
+        "send the request through",
+    );
+    this.refuseAuthorizationScopes(
+      "AWS_IAM",
+      "and AWS applies route scopes to a JWT route only, so a scope written " +
+        "here would restrict nothing",
+    );
+
+    return {
+      authorizationType: "AWS_IAM",
+      authorizationScopes: new SimHttpApiRouteScopes(),
+    };
+  }
+
+  /**
+   * Refuse an `AuthorizerId` on an authorization type that takes none.
+   */
+  private refuseAuthorizerId(authorizationType: string, reason: string): void {
+    if (this.input.AuthorizerId === undefined) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateRoute AuthorizerId is set on a route with AuthorizationType ` +
+        `${authorizationType}, ${reason}`,
+    );
+  }
+
+  /**
+   * Refuse `AuthorizationScopes` on an authorization type that checks none.
+   */
+  private refuseAuthorizationScopes(
+    authorizationType: string,
+    reason: string,
+  ): void {
+    if ((this.input.AuthorizationScopes ?? []).length === 0) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateRoute AuthorizationScopes is set on a route with ` +
+        `AuthorizationType ${authorizationType}, ${reason}`,
+    );
   }
 
   private authorizer(api: SimHttpApi): SimHttpApiAuthorizerId {

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-commands.iso.test.ts
@@ -4,7 +4,7 @@ import {
   CreateRouteCommand,
   GetRoutesCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -202,6 +202,84 @@ describe("Sim API Gateway v2 route commands", () => {
         }),
       ),
     ).rejects.toThrow(SimApiGatewayV2NotFound);
+  });
+
+  it("creates an IAM-authorized route and reports it back", async () => {
+    // Given an API with an integration
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+
+    // When a route asks for AWS_IAM
+    await simAws.apiGatewayV2().createRoute(
+      new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: "GET /orders/{orderId}",
+        Target: target,
+        AuthorizationType: "AWS_IAM",
+      }),
+    );
+
+    // Then it is created with no authorizer and no scopes, which is what an
+    // AWS_IAM route has, and GetRoutes reports the type back
+    const { Items: routes } = await simAws
+      .apiGatewayV2()
+      .getRoutes(new GetRoutesCommand({ ApiId: apiId }));
+    expect(routes).toStrictEqual([
+      expect.objectContaining({
+        RouteKey: "GET /orders/{orderId}",
+        Target: target,
+        AuthorizationType: "AWS_IAM",
+      }),
+    ]);
+    assertUndefined(routes[0]?.AuthorizerId);
+    assertUndefined(routes[0]?.AuthorizationScopes);
+  });
+
+  it("refuses an AuthorizerId on an IAM-authorized route", async () => {
+    // Given an API with an integration
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+
+    // When an AWS_IAM route also names an authorizer
+    // Then it is refused: IAM itself decides such a route, so there is no
+    // authorizer to send the request through
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /orders",
+          Target: target,
+          AuthorizationType: "AWS_IAM",
+          AuthorizerId: "abcdefgh",
+        }),
+      ),
+    ).rejects.toThrow(
+      /AuthorizerId is set on a route with AuthorizationType AWS_IAM/,
+    );
+  });
+
+  it("refuses AuthorizationScopes on an IAM-authorized route", async () => {
+    // Given an API with an integration
+    const simAws = new SimAws();
+    const { apiId, target } = await apiWithIntegration(simAws);
+
+    // When an AWS_IAM route asks for a scope
+    // Then it is refused. This is stricter than AWS, which ignores route
+    // scopes outside a JWT route: accepting one would let a test assert on a
+    // restriction nothing applies.
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /orders",
+          Target: target,
+          AuthorizationType: "AWS_IAM",
+          AuthorizationScopes: ["orders.read"],
+        }),
+      ),
+    ).rejects.toThrow(
+      /AuthorizationScopes is set on a route with AuthorizationType AWS_IAM/,
+    );
   });
 
   it("refuses a target that is not an integration", async () => {

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
@@ -26,10 +26,10 @@ const acceptedCreateRouteOptions = [
 /**
  * The authorization types a route may ask for.
  *
- * `AWS_IAM` and `CUSTOM` are refused rather than created open: a route asking
- * for either would admit anyone here and refuse them on AWS.
+ * `CUSTOM`, a Lambda authorizer, is refused rather than created open: a route
+ * asking for it would admit anyone here and refuse them on AWS.
  */
-const simulatedAuthorizationTypes = ["NONE", "JWT"];
+const simulatedAuthorizationTypes = ["NONE", "JWT", "AWS_IAM"];
 
 interface SimHttpApiRouteCommandsProperties {
   readonly access: SimHttpApiAccess;
@@ -67,7 +67,7 @@ export class SimHttpApiRouteCommands {
       "AuthorizationType",
       input.AuthorizationType,
       simulatedAuthorizationTypes,
-      "IAM and Lambda route authorization are not simulated",
+      "Lambda route authorization is not simulated",
     );
     const target = unsimulated.require("Target", input.Target);
 

--- a/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
+++ b/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
@@ -129,19 +129,19 @@ describe("What sim API Gateway v2 refuses rather than ignores", () => {
     const simAws = new SimAws();
     const apiId = await createdApiId(simAws);
 
-    // When a route asks for IAM authorization
-    // Then it is refused, because nothing here would check a signature and the
-    // route would be open where the real one is closed
+    // When a route asks for a Lambda authorizer
+    // Then it is refused, because nothing here runs the code that would make
+    // the decision and the route would be open where the real one is closed
     await expect(
       simAws.apiGatewayV2().createRoute(
         new CreateRouteCommand({
           ApiId: apiId,
           RouteKey: "$default",
           Target: "integrations/abcdefgh",
-          AuthorizationType: "AWS_IAM",
+          AuthorizationType: "CUSTOM",
         }),
       ),
-    ).rejects.toThrow(/AuthorizationType 'AWS_IAM' is not simulated/);
+    ).rejects.toThrow(/AuthorizationType 'CUSTOM' is not simulated/);
   });
 
   it("refuses a JWT route naming no authorizer of its API", async () => {

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-iam-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-iam-route-authorizer.ts
@@ -1,0 +1,69 @@
+import {
+  SimHttpApiAdmitted,
+  type SimHttpApiAuthorization,
+  SimHttpApiRefused,
+} from "../../api/authorizer/sim-http-api-authorization.js";
+import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
+import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
+
+/**
+ * The IAM action a request to an `AWS_IAM` route is authorized against.
+ *
+ * It is the only `execute-api` action evaluated here. The others AWS defines
+ * are WebSocket management and REST API cache invalidation, and nothing
+ * constrains the action string a policy may name, so a policy is free to grant
+ * one of them and nothing will ask about it.
+ */
+export const simExecuteApiInvokeAction = "execute-api:Invoke";
+
+/**
+ * Decides whether a caller may have an `AWS_IAM` route.
+ *
+ * This is the client's own authorization, evaluated against the identity
+ * policies of the caller the serving boundary resolved. An HTTP API has no
+ * resource policy, so no resource policies are supplied, and the caller's
+ * identity policies are the whole decision. That is also why a caller from
+ * another Account is always refused: a cross-Account request needs an Allow
+ * from each side, and there is nowhere on an HTTP API to put the resource side.
+ * The way through, here as on AWS, is to assume a Role in the API's Account.
+ */
+export class SimHttpApiIamRouteAuthorizer {
+  /**
+   * Evaluate `execute-api:Invoke` for the caller against the route being
+   * called.
+   */
+  authorize(input: SimHttpApiRouteAuthorizeInput): SimHttpApiAuthorization {
+    const decision = input.iam.authorize({
+      action: simExecuteApiInvokeAction,
+      resource: this.routeArn(input).toString(),
+      caller: input.caller.toCaller(),
+    });
+
+    if (decision.isDenied) {
+      return SimHttpApiRefused.forbidden();
+    }
+
+    return new SimHttpApiAdmitted({ caller: input.caller });
+  }
+
+  /**
+   * The `execute-api` ARN of the request being authorized.
+   *
+   * An identity policy is written by hand against the request a caller is
+   * making, so this names the concrete method and the concrete path, unlike
+   * the ARN the integration's invoke permission is matched against. The method
+   * is upper-cased because AWS puts a verb there and a policy names one, while
+   * a Fetch request may carry a method in any case.
+   */
+  private routeArn(
+    input: SimHttpApiRouteAuthorizeInput,
+  ): SimHttpApiExecuteApiArn {
+    const { api, match, request } = input;
+
+    return new SimHttpApiExecuteApiArn({
+      api,
+      stageName: match.stage.stageName,
+      methodAndPath: `${request.method.toUpperCase()}/${match.pathAfterStage}`,
+    });
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
@@ -1,0 +1,72 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  type SimHttpApiAuthorization,
+  SimHttpApiRefused,
+} from "../../api/authorizer/sim-http-api-authorization.js";
+import { SimHttpApiJwtVerification } from "../../api/authorizer/sim-http-api-jwt-verification.js";
+import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
+
+interface SimHttpApiJwtRouteAuthorizerProperties {
+  /**
+   * Clock the token's time claims are checked against, so advancing simulated
+   * time expires a token that was accepted before it.
+   */
+  readonly clock: SimClock;
+}
+
+/**
+ * Decides whether one request may have a `JWT` route.
+ *
+ * The token has to verify against the keys its issuer publishes, and the
+ * route's scopes have to be met. Every refusal up to and including claim
+ * validation is one 401; an unmet scope is the one 403.
+ */
+export class SimHttpApiJwtRouteAuthorizer {
+  private readonly clock: SimClock;
+
+  constructor(properties: SimHttpApiJwtRouteAuthorizerProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Authorize one request against the `JWT` route that matched it.
+   */
+  authorize(input: SimHttpApiRouteAuthorizeInput): SimHttpApiAuthorization {
+    const { api, match, request } = input;
+    const { route } = match;
+
+    // A JWT route always names an authorizer, and that authorizer can still be
+    // deleted out from under it, so the two come to the same thing here: with
+    // no authorizer to ask, the route stays closed.
+    const authorizer = api.authorizers.find(route.authorizerId ?? "");
+
+    if (authorizer === undefined) {
+      return SimHttpApiRefused.unauthorized();
+    }
+
+    const presented = authorizer.identitySource.token(request);
+
+    if (presented === undefined) {
+      return SimHttpApiRefused.unauthorized();
+    }
+
+    const authorization = new SimHttpApiJwtVerification({
+      issuerKeys: api.jwtIssuerKeys,
+      clock: this.clock,
+    }).verify(authorizer, presented);
+
+    if (!authorization.admitted) {
+      return authorization;
+    }
+
+    // The scopes are the route's own rather than the authorizer's, so one
+    // authorizer covers routes asking for different scopes. An unmet scope is
+    // the one refusal that is a 403: the token was accepted, and it does not
+    // allow this route.
+    if (!route.authorizationScopes.permits(authorization.jwt?.scopes ?? null)) {
+      return SimHttpApiRefused.forbidden();
+    }
+
+    return authorization;
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
@@ -1,0 +1,28 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
+import type { SimHttpApiMatch } from "../../api/sim-http-api-match.js";
+import type { SimHttpApi } from "../../api/sim-http-api.js";
+
+/**
+ * Everything a route authorization decision is made from.
+ *
+ * The whole match is carried rather than only the route, because an `AWS_IAM`
+ * route is authorized against an ARN naming the stage that served the request
+ * and the path it asked for, both of which the match settled.
+ */
+export interface SimHttpApiRouteAuthorizeInput {
+  readonly api: SimHttpApi;
+  readonly match: SimHttpApiMatch;
+  readonly request: Request;
+  /**
+   * The principal the serving boundary attributed the request to, from a
+   * signature or from a named caller, and anonymous when it carried neither.
+   */
+  readonly caller: SimAwsRequestCaller;
+  /**
+   * IAM of the Account that owns the API, which is what decides an `AWS_IAM`
+   * route. It is the API's own rather than the caller's, and rather than the
+   * integrated function's.
+   */
+  readonly iam: SimIamInterServiceAuthZ;
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorizer.ts
@@ -2,85 +2,56 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import {
   SimHttpApiAdmitted,
   type SimHttpApiAuthorization,
-  SimHttpApiRefused,
 } from "../../api/authorizer/sim-http-api-authorization.js";
-import { SimHttpApiJwtVerification } from "../../api/authorizer/sim-http-api-jwt-verification.js";
-import type { SimHttpApiRoute } from "../../api/route/sim-http-api-route.js";
-import type { SimHttpApi } from "../../api/sim-http-api.js";
+import { SimHttpApiIamRouteAuthorizer } from "./sim-http-api-iam-route-authorizer.js";
+import { SimHttpApiJwtRouteAuthorizer } from "./sim-http-api-jwt-route-authorizer.js";
+import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
 
 interface SimHttpApiRouteAuthorizerProperties {
   /**
-   * Clock the token's time claims are checked against, so advancing simulated
-   * time expires a token that was accepted before it.
+   * Clock a JWT route's time claims are checked against, so advancing
+   * simulated time expires a token that was accepted before it.
    */
   readonly clock: SimClock;
-}
-
-interface SimHttpApiRouteAuthorizeInput {
-  readonly api: SimHttpApi;
-  readonly route: SimHttpApiRoute;
-  readonly request: Request;
 }
 
 /**
  * Decides whether one request may have the route that matched it.
  *
  * This is the client's side of the question, and it runs before the API asks
- * whether it may invoke the integration: a request presenting no token is
- * refused with a 401 whether or not the integration behind the route would
- * have worked.
+ * whether it may invoke the integration: a request presenting no credentials
+ * is refused whether or not the integration behind the route would have
+ * worked.
+ *
+ * Which kind of authorization the route asks for is settled here, and each
+ * kind decides on its own terms.
  */
 export class SimHttpApiRouteAuthorizer {
-  private readonly clock: SimClock;
+  private readonly jwtAuthorizer: SimHttpApiJwtRouteAuthorizer;
+  private readonly iamAuthorizer = new SimHttpApiIamRouteAuthorizer();
 
   constructor(properties: SimHttpApiRouteAuthorizerProperties) {
-    this.clock = properties.clock;
+    this.jwtAuthorizer = new SimHttpApiJwtRouteAuthorizer({
+      clock: properties.clock,
+    });
   }
 
   /**
    * Authorize one request against the route that matched it.
    */
   authorize(input: SimHttpApiRouteAuthorizeInput): SimHttpApiAuthorization {
-    const { api, route, request } = input;
-
-    if (route.authorizationType === "NONE") {
-      // Nobody was authorized, so there is no caller to describe, which is
-      // what leaves requestContext.authorizer out of the event entirely.
-      return new SimHttpApiAdmitted();
+    switch (input.match.route.authorizationType) {
+      case "NONE": {
+        // Nobody was authorized, so there is no caller to describe, which is
+        // what leaves requestContext.authorizer out of the event entirely.
+        return new SimHttpApiAdmitted();
+      }
+      case "JWT": {
+        return this.jwtAuthorizer.authorize(input);
+      }
+      case "AWS_IAM": {
+        return this.iamAuthorizer.authorize(input);
+      }
     }
-
-    // A JWT route always names an authorizer, and that authorizer can still be
-    // deleted out from under it, so the two come to the same thing here: with
-    // no authorizer to ask, the route stays closed.
-    const authorizer = api.authorizers.find(route.authorizerId ?? "");
-
-    if (authorizer === undefined) {
-      return SimHttpApiRefused.unauthorized();
-    }
-
-    const presented = authorizer.identitySource.token(request);
-
-    if (presented === undefined) {
-      return SimHttpApiRefused.unauthorized();
-    }
-
-    const authorization = new SimHttpApiJwtVerification({
-      issuerKeys: api.jwtIssuerKeys,
-      clock: this.clock,
-    }).verify(authorizer, presented);
-
-    if (!authorization.admitted) {
-      return authorization;
-    }
-
-    // The scopes are the route's own rather than the authorizer's, so one
-    // authorizer covers routes asking for different scopes. An unmet scope is
-    // the one refusal that is a 403: the token was accepted, and it does not
-    // allow this route.
-    if (!route.authorizationScopes.permits(authorization.jwt?.scopes ?? null)) {
-      return SimHttpApiRefused.forbidden();
-    }
-
-    return authorization;
   }
 }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -28,9 +28,10 @@ interface SimApiGatewayV2ServiceControllerProperties {
  * format 2.0 event. The function runs as its execution Role, as it does for
  * any other invocation.
  *
- * A route with a JWT authorizer is checked before any of that: the client's
- * token has to verify, and the route's scopes have to be met, or the request
- * is refused and the function is never invoked. Whether the API may invoke the
+ * A route that authorizes anybody is checked before any of that: a JWT route's
+ * token has to verify and meet the route's scopes, and an `AWS_IAM` route's
+ * caller has to be allowed `execute-api:Invoke` on the route, or the request is
+ * refused and the function is never invoked. Whether the API may invoke the
  * function is a separate question, and the API's own rather than the client's.
  */
 export class SimApiGatewayV2ServiceController implements SimAwsServiceController {
@@ -70,10 +71,14 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       return this.errorResponse.forbidden();
     }
 
-    return await this.invoke(httpApi, serviceRequest.request);
+    return await this.invoke(httpApi, serviceRequest);
   }
 
-  private async invoke(api: SimHttpApi, request: Request): Promise<Response> {
+  private async invoke(
+    api: SimHttpApi,
+    serviceRequest: SimAwsServiceRequest,
+  ): Promise<Response> {
+    const { request } = serviceRequest;
     // The whole request path, stage segment and all: the stage takes its own
     // segment off, and `rawPath` reports the path as the client sent it.
     const match = api.match(
@@ -87,12 +92,15 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       return this.errorResponse.notFound();
     }
 
-    // The client's own authorization comes first: a request with no token is
-    // refused whether or not the integration behind the route would work.
+    // The client's own authorization comes first: a request with no
+    // credentials is refused whether or not the integration behind the route
+    // would work.
     const authorization = this.routeAuthorizer.authorize({
       api,
-      route: match.route,
+      match,
       request,
+      caller: serviceRequest.caller,
+      iam: this.router.iamFor(api),
     });
 
     if (!authorization.admitted) {
@@ -129,7 +137,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       const event = await this.eventBuilder.build(
         request,
         simHttpApiEndpoint(api, match),
-        { jwt: authorization.jwt },
+        { jwt: authorization.jwt, caller: authorization.caller },
       );
 
       return this.responseBuilder.build(await target.simFunction.invoke(event));
@@ -145,8 +153,9 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
   /**
    * The response a refused request gets back.
    *
-   * An unmet route scope is the one refusal that is a 403: the token was
-   * accepted, and it does not allow this route. Everything else is one 401.
+   * A 403 is an unmet route scope, where the token was accepted and does not
+   * allow this route, or an `AWS_IAM` route IAM did not allow the caller.
+   * Everything else is one 401.
    */
   private refusalResponse(refused: SimHttpApiRefused): Response {
     if (refused.kind === "forbidden") {

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
@@ -33,11 +33,13 @@ export class SimApiGatewayV2ErrorResponse {
   }
 
   /**
-   * The API's generated endpoint is switched off, or the route asks for a
-   * scope the accepted token does not claim.
+   * The API's generated endpoint is switched off, the route asks for a scope
+   * the accepted token does not claim, or IAM did not allow the caller the
+   * `AWS_IAM` route being called.
    *
-   * AWS publishes neither the status nor the body for either case, so both are
-   * what the endpoint was observed to answer rather than something documented.
+   * AWS publishes neither the status nor the body for any of these, so both
+   * are what the endpoint was observed to answer rather than something
+   * documented.
    */
   forbidden(): Response {
     return this.jsonResponse(403, "Forbidden");

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -67,6 +67,20 @@ export class SimApiGatewayV2Router {
   }
 
   /**
+   * IAM of the Account that owns an API, which is what an `AWS_IAM` route's
+   * authorization is evaluated against.
+   *
+   * It is the API's own Account rather than the caller's, so a caller from
+   * elsewhere is decided by the API's Account the way any cross-Account
+   * request is.
+   */
+  iamFor(api: SimHttpApi): SimIamInterServiceAuthZ {
+    const { accountId, regionName } = api.accountRegionScope;
+
+    return this.simAws.accountRegionScope(accountId, regionName).iam();
+  }
+
+  /**
    * Find the function an integration invokes, and the IAM deciding whether it
    * may be invoked.
    *

--- a/src/service/apigatewayv2/serve/sim-http-api-iam-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-iam-authorizer.iso.test.ts
@@ -1,0 +1,236 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2RequestContext } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+const accountId = "888888888888";
+const reporterArn = `arn:aws:iam::${accountId}:role/Reporter`;
+
+/**
+ * A handler reporting its own requestContext, so a test can assert on what the
+ * authorizer told it about the caller rather than only on the status.
+ */
+const reportContext = (event: {
+  requestContext: SimPayload2RequestContext;
+}): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext),
+});
+
+/**
+ * A Role in the API's own Account, allowed to invoke one `execute-api`
+ * resource.
+ */
+async function reporterRole(simAws: SimAws, resource: string): Promise<void> {
+  const iam = simAws.iam();
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: "Reporter",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Reporter",
+      PolicyName: "InvokeOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: "execute-api:Invoke", Resource: resource },
+      }),
+    }),
+  );
+}
+
+function get(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+  callerArn?: string,
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString(),
+    callerArn === undefined
+      ? {}
+      : { headers: { [simAwsCallerHeaderName]: callerArn } },
+  );
+}
+
+describe("Authorizing a sim HTTP API route with AWS_IAM", () => {
+  it("refuses an unsigned request and never invokes the integration", async () => {
+    // Given an AWS_IAM route
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        routeKeys: ["GET /orders/{orderId}"],
+        handler: (): string => {
+          invocations += 1;
+          return "one order";
+        },
+      },
+      simAws,
+    );
+
+    // When it is called with no credentials at all
+    const response = await get(simAws, api, "/orders/42");
+
+    // Then the request resolved to an anonymous caller, nothing allows that
+    // caller anything, and the handler never ran
+    assertIdentical(response.status, 403);
+    assertIdentical(await response.text(), '{"message":"Forbidden"}');
+    assertIdentical(invocations, 0);
+  });
+
+  it("admits a caller allowed execute-api:Invoke on the route", async () => {
+    // Given an AWS_IAM route and a Role allowed to invoke it
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        routeKeys: ["GET /orders/{orderId}"],
+        handler: (): string => "one order",
+      },
+      simAws,
+    );
+    await reporterRole(
+      simAws,
+      `arn:aws:execute-api:us-east-1:${accountId}:${api.apiId}` +
+        `/$default/GET/orders/*`,
+    );
+
+    // When that Role calls it
+    const response = await get(simAws, api, "/orders/42", reporterArn);
+
+    // Then the handler ran
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), '"one order"');
+  });
+
+  it("refuses a caller whose policies allow something else", async () => {
+    // Given an AWS_IAM route and a Role allowed another API's routes
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { iamAuthorization: true, routeKeys: ["GET /orders/{orderId}"] },
+      simAws,
+    );
+    await reporterRole(
+      simAws,
+      `arn:aws:execute-api:us-east-1:${accountId}:another01/*`,
+    );
+
+    // When that Role calls it
+    const response = await get(simAws, api, "/orders/42", reporterArn);
+
+    // Then being a known principal is not enough: nothing allows this route
+    assertIdentical(response.status, 403);
+  });
+
+  it("lets an explicit Deny beat an Allow", async () => {
+    // Given a Role allowed every API and denied this one route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { iamAuthorization: true, routeKeys: ["GET /orders/{orderId}"] },
+      simAws,
+    );
+    await reporterRole(simAws, "*");
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "DenyOrders",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Effect: "Deny",
+            Action: "execute-api:Invoke",
+            Resource:
+              `arn:aws:execute-api:us-east-1:${accountId}:${api.apiId}` +
+              `/$default/GET/orders/*`,
+          },
+        }),
+      }),
+    );
+
+    // When that Role calls the denied route
+    const response = await get(simAws, api, "/orders/42", reporterArn);
+
+    // Then the Deny wins, as it does in any IAM evaluation
+    assertIdentical(response.status, 403);
+  });
+
+  it("describes the admitted caller in the event", async () => {
+    // Given an admitted caller on an AWS_IAM route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        routeKeys: ["GET /orders/{orderId}"],
+        handler: reportContext,
+      },
+      simAws,
+    );
+    await reporterRole(simAws, "*");
+
+    // When the handler reads its invocation event
+    const response = await get(simAws, api, "/orders/42", reporterArn);
+    const context = (await response.json()) as SimPayload2RequestContext;
+
+    // Then it can tell who called it and from which Account, which is the
+    // point of the authorization type for handler code
+    assertObjectMatches(context.authorizer?.iam ?? {}, {
+      accountId,
+      userArn: reporterArn,
+    });
+    assertIdentical(context.accountId, accountId);
+  });
+
+  it("still serves a NONE route on the same API to anyone", async () => {
+    // Given an API with one IAM-authorized route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        iamAuthorization: true,
+        routeKeys: ["GET /orders"],
+        handler: reportContext,
+      },
+      simAws,
+    );
+
+    // And an open route alongside it, on the same integration
+    const [integration] = api.integrations.list();
+    await simAws.apiGatewayV2().createRoute({
+      input: {
+        ApiId: api.apiId,
+        RouteKey: "GET /health",
+        Target: `integrations/${integration?.integrationId ?? ""}`,
+        AuthorizationType: "NONE",
+      },
+    });
+
+    // When each is called with nothing
+    const protectedRoute = await get(simAws, api, "/orders");
+    const openRoute = await get(simAws, api, "/health");
+    const context = (await openRoute.json()) as SimPayload2RequestContext;
+
+    // Then only the IAM route is closed, and the open one describes no caller
+    assertIdentical(protectedRoute.status, 403);
+    assertIdentical(openRoute.status, 200);
+    assertUndefined(context.authorizer);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-iam-cross-account.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-iam-cross-account.iso.test.ts
@@ -1,0 +1,151 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+const apiAccountId = "888888888888";
+const callerAccountId = "222222222222";
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/Caller`;
+
+/**
+ * Create a Role with a trust policy naming one principal, and an identity
+ * policy allowing one action on everything.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  input: {
+    readonly accountId: string;
+    readonly roleName: string;
+    readonly trusts: string;
+    readonly action: string;
+  },
+): Promise<void> {
+  const iam = simAws.account(input.accountId).iam();
+  await iam.createRole(
+    new CreateRoleCommand({
+      RoleName: input.roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: input.trusts },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await iam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: input.roleName,
+      PolicyName: `${input.roleName}Policy`,
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: input.action, Resource: "*" },
+      }),
+    }),
+  );
+}
+
+async function iamApi(simAws: SimAws): Promise<SimHttpApi> {
+  return await simHttpApiLambdaProxyFactory.make(
+    {
+      iamAuthorization: true,
+      routeKeys: ["GET /orders"],
+      handler: (): string => "orders",
+    },
+    simAws,
+  );
+}
+
+function url(api: SimHttpApi): string {
+  return new SimAwsLocalUrl({
+    input: `${api.apiEndpoint}/orders`,
+  }).toString();
+}
+
+describe("Calling an AWS_IAM sim HTTP API route from another Account", () => {
+  it("refuses a caller from another Account its own Account allows", async () => {
+    // Given an AWS_IAM route, and a Role in another Account allowed to invoke
+    // any execute-api resource
+    const simAws = new SimAws();
+    const api = await iamApi(simAws);
+    await roleAllowing(simAws, {
+      accountId: callerAccountId,
+      roleName: "Caller",
+      trusts: `arn:aws:iam::${callerAccountId}:root`,
+      action: "execute-api:Invoke",
+    });
+
+    // When that Role calls the route
+    const response = await new SimAwsHttp({ simAws }).fetch(url(api), {
+      headers: { [simAwsCallerHeaderName]: callerRoleArn },
+    });
+
+    // Then it is refused: a cross-Account request needs an Allow from the
+    // resource side too, and an HTTP API has nowhere to put one
+    assertIdentical(response.status, 403);
+  });
+
+  it("admits the same caller once it assumes a Role in the API's Account", async () => {
+    // Given an AWS_IAM route, and a Role in another Account allowed to assume
+    // a Role in the API's Account
+    const simAws = new SimAws();
+    const api = await iamApi(simAws);
+    await roleAllowing(simAws, {
+      accountId: callerAccountId,
+      roleName: "Caller",
+      trusts: `arn:aws:iam::${callerAccountId}:root`,
+      action: "sts:AssumeRole",
+    });
+
+    // And that Role in the API's Account, trusting the caller and allowed to
+    // invoke the API
+    await roleAllowing(simAws, {
+      accountId: apiAccountId,
+      roleName: "Reporter",
+      trusts: callerRoleArn,
+      action: "execute-api:Invoke",
+    });
+
+    // When the caller assumes it and signs with the session credentials
+    const assumed = await simAws
+      .account(callerAccountId)
+      .sts()
+      .assumeRole(
+        new AssumeRoleCommand({
+          RoleArn: `arn:aws:iam::${apiAccountId}:role/Reporter`,
+          RoleSessionName: "reporting",
+        }),
+        { caller: { kind: "arn", arn: callerRoleArn } },
+      );
+    const credentials = assumed.Credentials;
+    assertNonNullable(credentials);
+    assertNonNullable(credentials.AccessKeyId);
+    assertNonNullable(credentials.SecretAccessKey);
+    assertNonNullable(credentials.SessionToken);
+
+    const signed = await signAwsRequest({
+      url: url(api),
+      credentials: {
+        accessKeyId: credentials.AccessKeyId,
+        secretAccessKey: credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken,
+      },
+      service: "execute-api",
+      region: api.accountRegionScope.regionName,
+    });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then the request is now made by a principal of the API's own Account,
+    // which is the way through on AWS as well
+    assertIdentical(response.status, 200);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-iam-route-arn.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-iam-route-arn.iso.test.ts
@@ -1,0 +1,197 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsCallerHeaderName } from "../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+const accountId = "888888888888";
+const reporterArn = `arn:aws:iam::${accountId}:role/Reporter`;
+
+interface IamRouteInput {
+  /** The route keys the API serves. */
+  readonly routeKeys?: readonly string[];
+  /** The stages the API serves from. */
+  readonly stageNames?: readonly string[];
+}
+
+/**
+ * An API whose routes are IAM-authorized, and a Role in its Account with no
+ * policies yet.
+ */
+async function iamRoute(
+  simAws: SimAws,
+  input: IamRouteInput = {},
+): Promise<SimHttpApi> {
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      iamAuthorization: true,
+      routeKeys: input.routeKeys ?? ["GET /orders/{orderId}"],
+      ...(input.stageNames !== undefined && { stageNames: input.stageNames }),
+      handler: (): string => "one order",
+    },
+    simAws,
+  );
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "Reporter",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  return api;
+}
+
+/**
+ * Allow the Role one `execute-api` resource, named by the part of the ARN
+ * after the API id.
+ */
+async function allowResource(
+  simAws: SimAws,
+  api: SimHttpApi,
+  suffix: string,
+): Promise<void> {
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "Reporter",
+      PolicyName: `Invoke${suffix.replaceAll(/\W/g, "")}`,
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: "execute-api:Invoke",
+          Resource:
+            `arn:aws:execute-api:us-east-1:${accountId}:` +
+            `${api.apiId}/${suffix}`,
+        },
+      }),
+    }),
+  );
+}
+
+function callAs(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+  method = "GET",
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString(),
+    { method, headers: { [simAwsCallerHeaderName]: reporterArn } },
+  );
+}
+
+describe("The execute-api ARN an AWS_IAM route is authorized against", () => {
+  it("is matched by a policy naming the API and nothing else", async () => {
+    // Given a Role allowed everything under the API
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws);
+    await allowResource(simAws, api, "*");
+
+    // When it calls a route
+    const response = await callAs(simAws, api, "/orders/42");
+
+    // Then the wildcard covers the stage, the method and the path
+    assertIdentical(response.status, 200);
+  });
+
+  it("names the default stage as $default", async () => {
+    // Given a Role allowed everything on the $default stage
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws);
+    await allowResource(simAws, api, "$default/*");
+
+    // When it calls a route served from that stage
+    const response = await callAs(simAws, api, "/orders/42");
+
+    // Then the stage segment is the literal `$default`, not an empty segment
+    assertIdentical(response.status, 200);
+  });
+
+  it("names the request's own method and path", async () => {
+    // Given a Role allowed one method under one path, on any stage
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws);
+    await allowResource(simAws, api, "*/GET/orders/*");
+
+    // When it calls a route matching that
+    const response = await callAs(simAws, api, "/orders/42");
+
+    // Then the ARN carries the concrete method and the concrete path, so a
+    // policy written the way a human writes one matches
+    assertIdentical(response.status, 200);
+  });
+
+  it("is not matched by a policy naming another stage", async () => {
+    // Given an API with two stages, and a Role allowed one of them
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws, {
+      routeKeys: ["GET /orders"],
+      stageNames: ["dev", "prod"],
+    });
+    await allowResource(simAws, api, "dev/*");
+
+    // When each stage serves the same route
+    const development = await callAs(simAws, api, "/dev/orders");
+    const production = await callAs(simAws, api, "/prod/orders");
+
+    // Then only the named stage is allowed, and the path in the ARN is the one
+    // left after the stage segment was taken off
+    assertIdentical(development.status, 200);
+    assertIdentical(production.status, 403);
+  });
+
+  it("is not matched by a policy naming a lowercase method", async () => {
+    // Given a Role allowed the method in lower case
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws);
+    await allowResource(simAws, api, "$default/get/orders/*");
+
+    // When it calls the route
+    const response = await callAs(simAws, api, "/orders/42");
+
+    // Then it is refused: IAM resource matching is case-sensitive, and API
+    // Gateway puts an upper-case verb in the ARN
+    assertIdentical(response.status, 403);
+  });
+
+  it("takes the method from the request rather than from an ANY route", async () => {
+    // Given an ANY route, and a Role allowed only POST
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws, { routeKeys: ["ANY /orders"] });
+    await allowResource(simAws, api, "$default/POST/orders");
+
+    // When each method reaches that one route
+    const posted = await callAs(simAws, api, "/orders", "POST");
+    const fetched = await callAs(simAws, api, "/orders");
+
+    // Then the ARN names what the client asked for, not the route key's `ANY`
+    assertIdentical(posted.status, 200);
+    assertIdentical(fetched.status, 403);
+  });
+
+  it("names a root request with an empty path", async () => {
+    // Given a Role allowed the API root and nothing under it
+    const simAws = new SimAws();
+    const api = await iamRoute(simAws, { routeKeys: ["$default"] });
+    await allowResource(simAws, api, "$default/GET/");
+
+    // When the root is called, and then a path under it
+    const root = await callAs(simAws, api, "/");
+    const nested = await callAs(simAws, api, "/orders");
+
+    // Then the ARN of a root request ends with the method and an empty path,
+    // which a policy has to name exactly
+    assertIdentical(root.status, 200);
+    assertIdentical(nested.status, 403);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-iam-signed.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-iam-signed.iso.test.ts
@@ -1,0 +1,177 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { signAwsRequest } from "../../../../test/sigv4/sign-aws-request.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { simAwsAuthHeaderName } from "../../../serve/http/response/sim-aws-response-hints.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2RequestContext } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+const accountId = "888888888888";
+
+/**
+ * A handler reporting its own requestContext, so a test can read the caller
+ * the signature was attributed to.
+ */
+const reportContext = (event: {
+  requestContext: SimPayload2RequestContext;
+}): unknown => ({
+  statusCode: 200,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(event.requestContext),
+});
+
+/**
+ * A User with one identity policy, and the access key it signs with.
+ */
+async function signingUser(
+  simAws: SimAws,
+  resource: string,
+): Promise<{ accessKeyId: string; secretAccessKey: string }> {
+  const iam = simAws.iam();
+  await iam.createUser(new CreateUserCommand({ UserName: "Reporter" }));
+  await iam.putUserPolicy(
+    new PutUserPolicyCommand({
+      UserName: "Reporter",
+      PolicyName: "InvokeOrders",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: "execute-api:Invoke", Resource: resource },
+      }),
+    }),
+  );
+  const key = await iam.createAccessKey(
+    new CreateAccessKeyCommand({ UserName: "Reporter" }),
+  );
+
+  return {
+    accessKeyId: key.AccessKey.AccessKeyId,
+    secretAccessKey: key.AccessKey.SecretAccessKey,
+  };
+}
+
+/**
+ * Sign a request to a route of the API, for the `execute-api` service and the
+ * API's own Region, and serve it.
+ */
+async function signedGet(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+  credentials: { accessKeyId: string; secretAccessKey: string },
+): Promise<Response> {
+  const signed = await signAwsRequest({
+    url: new SimAwsLocalUrl({
+      input: `${api.apiEndpoint}${path}`,
+    }).toString(),
+    credentials,
+    service: "execute-api",
+    region: api.accountRegionScope.regionName,
+  });
+
+  return await new SimAwsHttp({ simAws }).handleRequest(signed.request);
+}
+
+async function iamApi(simAws: SimAws): Promise<SimHttpApi> {
+  return await simHttpApiLambdaProxyFactory.make(
+    {
+      iamAuthorization: true,
+      routeKeys: ["GET /orders/{orderId}"],
+      handler: reportContext,
+    },
+    simAws,
+  );
+}
+
+describe("Calling an AWS_IAM sim HTTP API route with a signed request", () => {
+  it("admits a signed caller the API's Account allows", async () => {
+    // Given an AWS_IAM route and a User allowed to invoke it
+    const simAws = new SimAws();
+    const api = await iamApi(simAws);
+    const credentials = await signingUser(
+      simAws,
+      `arn:aws:execute-api:us-east-1:${accountId}:${api.apiId}` +
+        `/$default/GET/orders/*`,
+    );
+
+    // When they sign a request to the route and it is served
+    const response = await signedGet(simAws, api, "/orders/42", credentials);
+    const context = (await response.json()) as SimPayload2RequestContext;
+
+    // Then the signature identified them, and the handler was told who called
+    assertIdentical(response.status, 200);
+    assertIdentical(response.headers.get(simAwsAuthHeaderName), "sigv4");
+    assertIdentical(
+      context.authorizer?.iam?.userArn,
+      `arn:aws:iam::${accountId}:user/Reporter`,
+    );
+  });
+
+  it("refuses a signed caller with no matching Allow", async () => {
+    // Given an AWS_IAM route and a User allowed something else entirely
+    const simAws = new SimAws();
+    const api = await iamApi(simAws);
+    const credentials = await signingUser(simAws, "arn:aws:s3:::orders/*");
+
+    // When they sign a request to the route and it is served
+    const response = await signedGet(simAws, api, "/orders/42", credentials);
+
+    // Then a sound signature is not enough: the request is authenticated but
+    // not authorized
+    assertIdentical(response.status, 403);
+    assertIdentical(await response.text(), '{"message":"Forbidden"}');
+  });
+
+  it("serves a NONE route to a signed caller with no policies", async () => {
+    // Given an open route, and a User allowed nothing at all
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { routeKeys: ["GET /health"], handler: reportContext },
+      simAws,
+    );
+    const credentials = await signingUser(simAws, "arn:aws:s3:::orders/*");
+
+    // When they sign a request to it
+    const response = await signedGet(simAws, api, "/health", credentials);
+    const context = (await response.json()) as SimPayload2RequestContext;
+
+    // Then the route admits them, and describes no caller: a NONE route
+    // authorizes nobody, so there is nothing for the event to report
+    assertIdentical(response.status, 200);
+    assertUndefined(context.authorizer);
+    assertIdentical(context.accountId, "anonymous");
+  });
+
+  it("refuses a signature for another service before the route is reached", async () => {
+    // Given an AWS_IAM route and a User allowed to invoke it
+    const simAws = new SimAws();
+    const api = await iamApi(simAws);
+    const credentials = await signingUser(simAws, "*");
+
+    // When the request is signed for Lambda rather than for execute-api
+    const signed = await signAwsRequest({
+      url: new SimAwsLocalUrl({
+        input: `${api.apiEndpoint}/orders/42`,
+      }).toString(),
+      credentials,
+      service: "lambda",
+      region: "us-east-1",
+    });
+    const response = await new SimAwsHttp({ simAws }).handleRequest(
+      signed.request,
+    );
+
+    // Then the serving boundary refuses it before route authorization sees it,
+    // with the capital-M body the boundary answers rather than the API's own
+    assertIdentical(response.status, 403);
+    assertIdentical(await response.text(), '{"Message":"Forbidden"}');
+  });
+});

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-iam-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-iam-authorizer.loc.test.ts
@@ -1,0 +1,151 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed HTTP API over real localhost HTTP
+ * and calls its IAM-authorized route.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { simAwsCallerHeaderName } from "../../../iam/request/sim-aws-caller-header.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountId = "111111111111";
+const reporterArn = `arn:aws:iam::${accountId}:role/Reporter`;
+
+/**
+ * Inline function code, as CDK packages Code.fromInline source. The handler
+ * reports the caller the route's authorization attributed the request to.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.requestContext.authorizer.iam.userArn,
+});
+`;
+
+/**
+ * HttpIamAuthorizer emits AuthorizationType alone on the Route. There is no
+ * AWS::ApiGatewayV2::Authorizer Resource in the synthesised template at all,
+ * which is why the Route property parser has to accept the type on its own.
+ */
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as authorizers from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "${accountId}", region: "eu-west-2" },
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const httpApi = new apigwv2.HttpApi(stack, "HttpApi", { apiName: "orders" });
+
+httpApi.addRoutes({
+  path: "/orders",
+  methods: [apigwv2.HttpMethod.GET],
+  authorizer: new authorizers.HttpIamAuthorizer(),
+  integration: new integrations.HttpLambdaIntegration(
+    "OrdersIntegration",
+    ordersFunction,
+  ),
+});
+
+new cdk.CfnOutput(stack, "ApiEndpoint", { value: httpApi.apiEndpoint });
+
+app.synth();
+`;
+
+describe("Sim CDK HTTP API IAM authorizer local integration", () => {
+  it("closes a CDK-deployed route to everyone IAM does not allow", async () => {
+    // Given a CDK stack whose one route goes through an HttpIamAuthorizer.
+    const simAws = new SimAws({
+      defaultAccountId: accountId as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+
+    // And a Role of the API's Account is allowed to invoke that one route.
+    const iam = simAws.iam();
+    await iam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Reporter",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await iam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Reporter",
+        PolicyName: "InvokeOrders",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "execute-api:Invoke",
+            Resource:
+              `arn:aws:execute-api:eu-west-2:${accountId}:` +
+              `*/$default/GET/orders`,
+          },
+        }),
+      }),
+    );
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const url = srv.localUrl(`${apiEndpoint}/orders`);
+
+      // Then the deployed route is closed to a request carrying no identity.
+      const anonymous = await fetch(url);
+      assertIdentical(anonymous.status, 403);
+      assertIdentical(await anonymous.text(), '{"message":"Forbidden"}');
+
+      // And the allowed Role reaches the handler, which read its own ARN off
+      // the IAM block the route's authorization put in the event.
+      const reporter = await fetch(url, {
+        headers: { [simAwsCallerHeaderName]: reporterArn },
+      });
+      assertIdentical(reporter.status, 200);
+      assertIdentical(await reporter.text(), reporterArn);
+    } finally {
+      srv.close();
+    }
+
+    await simAws.backgroundTasksComplete();
+  });
+});


### PR DESCRIPTION
…ed requests

A route declared AuthorizationType AWS_IAM now reaches its integration only when the caller is allowed execute-api:Invoke on the ARN of the route being called, built from the API's own Account and Region, the stage that served the request, and the request's own method and path. A refusal is 403 and the integration is not invoked. An admitted caller reaches the handler as requestContext.authorizer.iam.

CDK's HttpIamAuthorizer emits only AuthorizationType on the Route, so the property parser accepts it on its own. AWS::ApiGatewayV2::Api refuses Policy with its own message, since an HTTP API has no resource policy.

Resolves https://github.com/KensioSoftware/yulin/issues/303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM authorization support for simulated API Gateway HTTP API routes.
  * Supports signed requests, caller identity propagation, route-specific permissions, and cross-account authorization behavior.
  * Added IAM-protected HTTP API examples and CDK deployment coverage.
* **Bug Fixes**
  * Improved authorization responses, including consistent handling of denied and unauthorized requests.
* **Documentation**
  * Documented IAM routes, permissions, ARN matching, caller details, limitations, and unsupported resource policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->