### PR TITLE
feat: authorize simulated HTTP API routes with a Lambda REQUEST autho…

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -835,6 +835,236 @@ The way through, here and on AWS, is for that principal to assume a Role in the 
 STS and sign with the session credentials. The request is then made by a principal of the API's own
 Account.
 
+## Protecting a route with a Lambda authorizer
+
+A Lambda `REQUEST` authorizer runs a function of its own before the integration is invoked, and that
+function decides. `CreateAuthorizerCommand` with `AuthorizerType: "REQUEST"` creates one, and a route
+asks for it with `AuthorizationType: "CUSTOM"` and the authorizer's id.
+
+`IdentitySource` is what the request has to carry before the function is invoked at all. Each entry
+is `$request.header.<name>` or `$request.querystring.<name>`, and a request missing any one of them is
+refused without the function running.
+
+`EnableSimpleResponses: true` asks the function for `{ isAuthorized, context }`. With it off, the
+function answers a `principalId` and an IAM `policyDocument` instead. Either way, the `context` it
+returns reaches the integration handler as `event.requestContext.authorizer.lambda`.
+
+```typescript sim-apigatewayv2-lambda-authorizer
+/**
+ * Protecting a simulated HTTP API route with a Lambda REQUEST authorizer.
+ */
+
+import {
+  CreateApiCommand,
+  CreateAuthorizerCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type {
+  SimHttpApiAuthorizerEvent,
+  SimPayload2Event,
+} from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+const { FunctionArn: AuthorizerFunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "session-authorizer",
+    Role: "arn:aws:iam::888888888888:role/AuthorizerRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimHttpApiAuthorizerEvent) => ({
+        isAuthorized: event.identitySource[0] === "session=valid",
+        context: { tenant: "acme" },
+      })),
+    },
+  }),
+);
+
+const { FunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "account",
+    Role: "arn:aws:iam::888888888888:role/AccountRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event.requestContext.authorizer?.lambda),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "account", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+const { AuthorizerId } = await apiGateway.createAuthorizer(
+  new CreateAuthorizerCommand({
+    ApiId,
+    Name: "session-cookie",
+    AuthorizerType: "REQUEST",
+    AuthorizerUri: AuthorizerFunctionArn,
+    AuthorizerPayloadFormatVersion: "2.0",
+    EnableSimpleResponses: true,
+    IdentitySource: ["$request.header.cookie"],
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /account",
+    Target: `integrations/${IntegrationId}`,
+    AuthorizationType: "CUSTOM",
+    AuthorizerId,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+// Each function needs its own grant: the integration is invoked under the ARN
+// of the route, and the authorizer under an ARN naming the authorizer.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "account",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "session-authorizer",
+    StatementId: "api-gateway-invoke-authorizer",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/authorizers/${AuthorizerId}`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${ApiEndpoint}/account`);
+
+const refused = await fetch(url, { headers: { cookie: "session=expired" } });
+
+console.log(refused.status); // 403
+
+const admitted = await fetch(url, { headers: { cookie: "session=valid" } });
+
+console.log(await admitted.text()); // '{"tenant":"acme"}'
+
+srv.close();
+```
+
+The authorizer function is invoked once per request reaching the route. Nothing is cached between
+requests.
+
+### The event the authorizer receives
+
+The function is invoked with the payload format 2.0 request event, plus three members of its own,
+exported as `SimHttpApiAuthorizerEvent`:
+
+```json
+{
+  "version": "2.0",
+  "type": "REQUEST",
+  "routeArn": "arn:aws:execute-api:us-east-1:888888888888:a1b2c3d4e5/$default/GET/account",
+  "identitySource": ["session=valid"],
+  "routeKey": "GET /account",
+  "rawPath": "/account",
+  "rawQueryString": "",
+  "headers": { "cookie": "session=valid" },
+  "requestContext": { "...": "as the integration receives it" }
+}
+```
+
+`identitySource` carries the values found at the authorizer's identity sources, in the order they were
+configured, rather than the expressions that found them. `routeArn` names the route the request
+matched, with the route key's path template rather than the path asked for, so `GET /orders/{orderId}`
+is `<apiId>/<stage>/GET/orders/{orderId}` whichever order was asked for.
+
+There is no `body` and no `isBase64Encoded`. AWS's published example of this event carries neither, so
+an authorizer cannot read the request body here, as it cannot on AWS.
+
+### Answering with a policy
+
+With `EnableSimpleResponses` left off, the function answers a `principalId` and an IAM policy
+document, and simulated IAM evaluates it for `execute-api:Invoke` against the route ARN. That is the
+same evaluation an [`AWS_IAM` route](#protecting-a-route-with-iam) goes through, with one difference:
+the returned document is the whole decision, since there is no IAM principal behind it. `principalId`
+is a name the function chose for the caller and grants nothing.
+
+```typescript
+makeLambdaZipFileInput((event: SimHttpApiAuthorizerEvent) => ({
+  principalId: "user-1",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: event.identitySource[0] === "session=valid" ? "Allow" : "Deny",
+        Action: "execute-api:Invoke",
+        Resource: event.routeArn,
+      },
+    ],
+  },
+  context: { tenant: "acme" },
+}));
+```
+
+An explicit `Deny` beats an `Allow`, and a document allowing nothing relevant refuses the request.
+
+### What a refused request gets back
+
+- A request missing any configured identity source is a 401 and `{"message":"Unauthorized"}`, and the
+  authorizer function is never invoked.
+- `isAuthorized: false`, or a policy that does not allow `execute-api:Invoke` on the route ARN, is a
+  403 and `{"message":"Forbidden"}`.
+- Returning `{ "errorMessage": "Unauthorized" }` is a 401. That is the only way an authorizer produces
+  one, and it is read whichever response format the authorizer is configured for.
+- A function that throws, returns a shape neither response format matches, returns a policy document
+  IAM cannot read, or has no invoke permission, is a 500 and `{"message":"Internal Server Error"}`.
+  The caller is told nothing further, as it is told nothing about a failed integration.
+
+The integration is never invoked in any of these cases.
+
+### The authorizer's invoke permission
+
+The authorizer's function is invoked under
+`arn:aws:execute-api:<region>:<account>:<apiId>/authorizers/<authorizerId>`, which is the `SourceArn`
+AWS documents for granting API Gateway permission to invoke one. That ARN names no stage and no
+route, so it is a different grant from the integration's, and a function used for both needs both.
+
+### The context the handler receives
+
+The `context` the authorizer returned arrives as `event.requestContext.authorizer.lambda`, with its
+values as the function returned them rather than stringified. An authorizer that allowed the request
+and returned no context leaves `null` there, so the block still says which kind of authorizer ran.
+
 ## The event the handler receives
 
 The handler is invoked with the API Gateway HTTP API payload format 2.0 event, exported as
@@ -1354,12 +1584,16 @@ the simulation without being given one. See the
 - Routes protected with `AuthorizationType: "AWS_IAM"`, evaluating `execute-api:Invoke` against the
   `execute-api` ARN of the route being called, for a caller resolved from a SigV4 signature or an
   `x-sim-aws-caller` header, and reaching the handler as `event.requestContext.authorizer.iam`
+- `CreateAuthorizer` for a Lambda `REQUEST` authorizer, and routes protected by one with
+  `AuthorizationType: "CUSTOM"`, invoking the authorizer's function with the payload format 2.0
+  authorizer event, reading a simple response or an IAM policy response, and passing the returned
+  context to the handler as `event.requestContext.authorizer.lambda`
 - `CreateStage` and `GetStages` for the `$default` stage and for named stages served under their own
   path segment, including stage variables
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
   payload format 2.0 event and turning its result back into an HTTP response
-- The integration's invoke permission, evaluated against the function's resource policy with the
-  matched route supplied as `AWS:SourceArn`
+- The invoke permission of an integration's function and of an authorizer's, each evaluated against
+  that function's resource policy with its own `AWS:SourceArn`
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - `ImportApi` for an OpenAPI 3.0 document, creating one route and one integration per operation and
   one JWT authorizer per security scheme an operation names
@@ -1392,11 +1626,9 @@ Current documented limitations:
   proxy integrations and AWS service integrations are not simulated.
 - Payload format 1.0 is refused. A handler written for 1.0 reads event fields a 2.0 event does not
   have, so treating one as the other would pass here and fail on AWS.
-- `AuthorizationType` is `NONE`, `JWT` or `AWS_IAM`. A `CUSTOM` route is refused rather than created
-  open, since a route asking for it would admit anyone here and refuse them on AWS.
-- `AuthorizationScopes` on an `AWS_IAM` route is refused. This is stricter than AWS, which documents
-  route scopes as meaningful only for `JWT` and ignores them here. Accepting one would let a test
-  assert on a scope restriction that nothing applies.
+- `AuthorizationScopes` on an `AWS_IAM` or `CUSTOM` route is refused. This is stricter than AWS, which
+  documents route scopes as meaningful only for `JWT` and ignores them here. Accepting one would let a
+  test assert on a scope restriction that nothing applies.
 - The method and path segments of the ARN an `AWS_IAM` route is authorized against are inferred
   rather than documented, and the two callers of that ARN builder fill them differently: this one
   names the request's own method and path, while the integration's invoke permission names the route
@@ -1420,13 +1652,29 @@ Current documented limitations:
 - HTTP API resource policies are not simulated, because AWS does not have them. A caller from another
   Account is therefore always refused, since a cross-Account request needs an Allow from the resource
   side. Assume a Role in the API's Account instead, which is the route through on AWS as well.
-- Lambda `REQUEST` authorizers are not simulated, of either payload version. `CreateAuthorizer`
-  refuses `AuthorizerType: "REQUEST"` by name, as does an `AWS::ApiGatewayV2::Authorizer` asking for
-  one, since nothing here runs the code that would make the decision.
-- Authorizer result caching is not simulated. `AuthorizerResultTtlInSeconds` configures it and is one
-  of the `REQUEST`-only options refused by name, so it cannot be asked for at all.
-- One `IdentitySource`, either `$request.header.<name>` or `$request.querystring.<name>`. Multiple
-  identity sources are refused rather than partly read.
+- A Lambda `REQUEST` authorizer is created by `CreateAuthorizer` only.
+  `AWS::ApiGatewayV2::Authorizer` refuses `AuthorizerType: "REQUEST"` by name, and so does an
+  OpenAPI security scheme declaring one, so a `CUSTOM` route deployed from a template or an imported
+  document is not available yet.
+- `AuthorizerPayloadFormatVersion: "2.0"` is required on a `REQUEST` authorizer, and stating nothing
+  is refused too. AWS defaults it to `1.0`, which builds a different event and answers a policy
+  against a method ARN, and none of that is built here.
+- A `REQUEST` authorizer's event carries no `body` and no `isBase64Encoded`. AWS's published example
+  of that event carries neither, so an authorizer cannot read the request body.
+- An authorizer function that throws is a 500 rather than a 401. Real Lambda turns a thrown error
+  into a payload carrying `errorMessage`, and simulated Lambda rejects with the error itself, so
+  returning `{ "errorMessage": "Unauthorized" }` is how an authorizer asks for a 401 here.
+- `AuthorizerCredentialsArn` is refused. It names a Role API Gateway assumes to invoke the authorizer,
+  and the function's own resource policy is the whole decision here.
+- Authorizer result caching is not simulated. `AuthorizerResultTtlInSeconds` configures it, and only
+  `0`, the value that switches it off, is accepted. Every request reaching a `CUSTOM` route invokes
+  the authorizer's function.
+- A `REQUEST` authorizer requires at least one `IdentitySource`. An authorizer with none is invoked
+  for every request on AWS, including one carrying nothing, and that is not simulated.
+- An identity source is `$request.header.<name>` or `$request.querystring.<name>`. `$context.*` and
+  `$stagevariables.*`, which a `REQUEST` authorizer may also name on AWS, are refused rather than
+  read from nowhere. A JWT authorizer takes one identity source, and a second is refused rather than
+  partly read.
 - `JwtConfiguration.Audience` is required. What real API Gateway does with an authorizer that has an
   empty audience list is not documented, so this is stricter than AWS may be, in the direction that
   cannot quietly admit an app client.

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1584,10 +1584,10 @@ the simulation without being given one. See the
 - Routes protected with `AuthorizationType: "AWS_IAM"`, evaluating `execute-api:Invoke` against the
   `execute-api` ARN of the route being called, for a caller resolved from a SigV4 signature or an
   `x-sim-aws-caller` header, and reaching the handler as `event.requestContext.authorizer.iam`
-- `CreateAuthorizer` for a Lambda `REQUEST` authorizer, and routes protected by one with
-  `AuthorizationType: "CUSTOM"`, invoking the authorizer's function with the payload format 2.0
-  authorizer event, reading a simple response or an IAM policy response, and passing the returned
-  context to the handler as `event.requestContext.authorizer.lambda`
+- `CreateAuthorizer`, `GetAuthorizers` and `DeleteAuthorizer` for a Lambda `REQUEST` authorizer, and
+  routes protected by one with `AuthorizationType: "CUSTOM"`, invoking the authorizer's function with
+  the payload format 2.0 authorizer event, reading a simple response or an IAM policy response, and
+  passing the returned context to the handler as `event.requestContext.authorizer.lambda`
 - `CreateStage` and `GetStages` for the `$default` stage and for named stages served under their own
   path segment, including stage variables
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a

--- a/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-lambda-authorizer.example.ts
@@ -1,0 +1,129 @@
+/**
+ * Protecting a simulated HTTP API route with a Lambda REQUEST authorizer.
+ */
+
+import {
+  CreateApiCommand,
+  CreateAuthorizerCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type {
+  SimHttpApiAuthorizerEvent,
+  SimPayload2Event,
+} from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+const { FunctionArn: AuthorizerFunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "session-authorizer",
+    Role: "arn:aws:iam::888888888888:role/AuthorizerRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimHttpApiAuthorizerEvent) => ({
+        isAuthorized: event.identitySource[0] === "session=valid",
+        context: { tenant: "acme" },
+      })),
+    },
+  }),
+);
+
+const { FunctionArn } = await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "account",
+    Role: "arn:aws:iam::888888888888:role/AccountRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event.requestContext.authorizer?.lambda),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "account", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+const { AuthorizerId } = await apiGateway.createAuthorizer(
+  new CreateAuthorizerCommand({
+    ApiId,
+    Name: "session-cookie",
+    AuthorizerType: "REQUEST",
+    AuthorizerUri: AuthorizerFunctionArn,
+    AuthorizerPayloadFormatVersion: "2.0",
+    EnableSimpleResponses: true,
+    IdentitySource: ["$request.header.cookie"],
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /account",
+    Target: `integrations/${IntegrationId}`,
+    AuthorizationType: "CUSTOM",
+    AuthorizerId,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+// Each function needs its own grant: the integration is invoked under the ARN
+// of the route, and the authorizer under an ARN naming the authorizer.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "account",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "session-authorizer",
+    StatementId: "api-gateway-invoke-authorizer",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/authorizers/${AuthorizerId}`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const url = srv.localUrl(`${ApiEndpoint}/account`);
+
+const refused = await fetch(url, { headers: { cookie: "session=expired" } });
+
+console.log(refused.status); // 403
+
+const admitted = await fetch(url, { headers: { cookie: "session=valid" } });
+
+console.log(await admitted.text()); // '{"tenant":"acme"}'
+
+srv.close();

--- a/src/serve/payload-2/sim-payload-2-event.type.ts
+++ b/src/serve/payload-2/sim-payload-2-event.type.ts
@@ -1,3 +1,5 @@
+import type { JSONValue } from "../../util/type-guard/json.js";
+
 /**
  * A Lambda proxy invocation event in API Gateway HTTP API payload format 2.0.
  *
@@ -50,12 +52,25 @@ export interface SimPayload2RequestContext {
  * An endpoint that admits anyone has no caller to describe, so real AWS leaves
  * this out entirely rather than filling it with blanks. Which member is
  * present says which kind of authorizer admitted the request: `iam` for a
- * SigV4-signed request, `jwt` for a JWT authorizer.
+ * SigV4-signed request, `jwt` for a JWT authorizer, `lambda` for a Lambda
+ * `REQUEST` authorizer.
  */
 export interface SimPayload2AuthorizerContext {
   iam?: SimPayload2IamAuthorizer;
   jwt?: SimPayload2JwtAuthorizer;
+  lambda?: SimPayload2LambdaAuthorizer | null;
 }
+
+/**
+ * The context a Lambda `REQUEST` authorizer passed on to the integration.
+ *
+ * The values arrive as the authorizer returned them rather than stringified,
+ * which is what payload format 2.0 does with them: a REST API's `$context`
+ * variables are strings, and this is not one of those. An authorizer that
+ * allowed the request and returned no context at all leaves `null` here, so
+ * the authorizer block is still there to say which kind of authorizer ran.
+ */
+export type SimPayload2LambdaAuthorizer = Readonly<Record<string, JSONValue>>;
 
 /**
  * The IAM caller of a SigV4-authorized invocation.

--- a/src/serve/payload-2/sim-payload-2-request-context.ts
+++ b/src/serve/payload-2/sim-payload-2-request-context.ts
@@ -5,6 +5,7 @@ import { simPayload2SourceIp } from "./sim-payload-2-connection.js";
 import type { SimPayload2Endpoint } from "./sim-payload-2-endpoint.js";
 import type {
   SimPayload2JwtAuthorizer,
+  SimPayload2LambdaAuthorizer,
   SimPayload2RequestContext,
 } from "./sim-payload-2-event.type.js";
 import { simPayload2EventTime } from "./sim-payload-2-event-time.js";
@@ -25,6 +26,11 @@ export interface SimPayload2Authorization {
   readonly caller?: SimAwsRequestCaller | undefined;
   /** The token a JWT authorizer accepted. */
   readonly jwt?: SimPayload2JwtAuthorizer | undefined;
+  /**
+   * The context a Lambda `REQUEST` authorizer returned, which is `null` when
+   * it allowed the request and returned none.
+   */
+  readonly lambda?: SimPayload2LambdaAuthorizer | null | undefined;
 }
 
 interface SimPayload2RequestContextInput {
@@ -76,6 +82,11 @@ export class SimPayload2RequestContextBuilder {
     const jwt = input.authorization?.jwt;
     if (jwt !== undefined) {
       requestContext.authorizer = { jwt };
+    }
+
+    const lambda = input.authorization?.lambda;
+    if (lambda !== undefined) {
+      requestContext.authorizer = { lambda };
     }
 
     const authorizer = iamCaller?.authorizerContext();

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -97,8 +97,9 @@ holds a function and no configuration, and neither reads the other's half. A rou
 and `CreateRoute` refuses a route whose authorization type and authorizer disagree, since such a
 route is refused by AWS and could only be served here by guessing which half applied.
 
-`SimHttpApiIdentitySources` is a list because a `REQUEST` authorizer takes one, while a JWT
-authorizer takes a single source and `SimHttpApiJwtAuthorizerInput` is where that rule lives.
+`SimHttpApiIdentitySources` is a list because a `REQUEST` authorizer takes several, while a JWT
+authorizer takes exactly one and `SimHttpApiJwtAuthorizerInput` is where that single-source rule
+lives.
 
 The token parsing and RS256 verification itself is `src/util/jwt/`, which knows nothing about API
 Gateway. It is real verification against the issuer's published JWK, with `node:crypto`: nothing is

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -76,16 +76,29 @@ route, and creating the second is a conflict.
 
 ## Authorizing a request
 
-`api/authorizer/` holds the JWT authorizer and everything the decision needs:
+`api/authorizer/` holds the two kinds of authorizer an API stores, and everything the JWT one's
+decision needs:
 
 ```text
-SimHttpApiAuthorizer
-├── SimHttpApiIdentitySource     which header or query parameter carries the token
-├── SimHttpApiJwtConfiguration   the issuer trusted and the audiences accepted
-└── SimHttpApiJwtVerification    the ordered checks, answering an authorization
-    ├── SimHttpApiJwtClaimChecks the issuer, the audience, then the time claims
-    └── SimHttpApiJwtClaims      the claims as the handler receives them
+SimHttpApiAuthorizer             an id, a name, and which kind it is
+├── SimHttpApiJwtAuthorizer      which token a route asks for, and who signed it
+│   ├── SimHttpApiIdentitySource which header or query parameter carries the token
+│   ├── SimHttpApiJwtConfiguration  the issuer trusted and the audiences accepted
+│   └── SimHttpApiJwtVerification   the ordered checks, answering an authorization
+│       ├── SimHttpApiJwtClaimChecks the issuer, the audience, then the time claims
+│       └── SimHttpApiJwtClaims      the claims as the handler receives them
+└── SimHttpApiRequestAuthorizer  which function decides, and what it needs first
+    └── SimHttpApiIdentitySources   the sources a request has to carry, as a list
 ```
+
+The two share an id, a name and nothing else, which is why the base is abstract rather than a class
+with optional members: a JWT authorizer holds configuration and no function, a `REQUEST` authorizer
+holds a function and no configuration, and neither reads the other's half. A route names one by id,
+and `CreateRoute` refuses a route whose authorization type and authorizer disagree, since such a
+route is refused by AWS and could only be served here by guessing which half applied.
+
+`SimHttpApiIdentitySources` is a list because a `REQUEST` authorizer takes one, while a JWT
+authorizer takes a single source and `SimHttpApiJwtAuthorizerInput` is where that rule lives.
 
 The token parsing and RS256 verification itself is `src/util/jwt/`, which knows nothing about API
 Gateway. It is real verification against the issuer's published JWK, with `node:crypto`: nothing is
@@ -105,7 +118,8 @@ OIDC-conformant discovery client would reject its own pool's tokens. Resolving i
 
 `SimHttpApiAuthorization` is what a decision answers with: `SimHttpApiAdmitted`, carrying whatever the
 event needs to describe the caller, or `SimHttpApiRefused`, which is a 401 for everything up to and
-including claim validation and a 403 for an unmet route scope or an IAM refusal.
+including claim validation, a 403 for an unmet route scope, an IAM refusal or a Lambda authorizer
+that said no, and a 500 for a Lambda authorizer that could not answer at all.
 
 The other kind of route authorization is `AWS_IAM`, which has nothing under `api/authorizer/` at all:
 it configures nothing on the API, so there is nothing to store. It lives entirely in `serve/auth/`,
@@ -132,6 +146,11 @@ which is the error category AWS describes.
 `command/sim-api-gateway-v2-unsimulated-input.ts` refuses the inputs this simulation does not model.
 It works from an allow-list of the options each command accepts, so an option nobody thought about
 is refused rather than silently dropped.
+
+`command/authorizer/` is the one area whose input reading is split by kind. `CreateAuthorizer` takes
+one input describing either kind of authorizer, so `simHttpApiAuthorizerInput` picks the reader for
+the type asked for, and each reader states what its own kind requires and refuses what belongs to
+the other. The command handler itself then knows only that an authorizer came back.
 
 ### IAM
 
@@ -201,8 +220,16 @@ fails the stack rather than deploying a template written two ways at once.
    SimHttpApiRouteAuthorizer
    ├── NONE     admits everyone, with no caller to describe
    ├── JWT      SimHttpApiJwtRouteAuthorizer, over the API's own authorizers
-   └── AWS_IAM  SimHttpApiIamRouteAuthorizer, evaluating execute-api:Invoke
+   ├── AWS_IAM  SimHttpApiIamRouteAuthorizer, evaluating execute-api:Invoke
+   └── CUSTOM   SimHttpApiRequestRouteAuthorizer, invoking a Lambda function
    ```
+
+   The `CUSTOM` one is the reason this step is asynchronous: it invokes a function and waits for it.
+   Its three collaborators split what that involves, since none of them is small:
+   `SimHttpApiAuthorizerEventBuilder` builds the event, over the shared payload 2.0 builder;
+   `SimHttpApiAuthorizerResponse` reads whichever of the two answer shapes came back; and
+   `SimHttpApiAuthorizerPolicy` puts a returned policy document to IAM, evaluating it as the only
+   policy in the decision, since there is no IAM principal behind it to gather policies for.
 
    The IAM one asks the API's own Account, which the router resolves, and supplies no resource
    policies, because an HTTP API has none. That is also what makes a caller from another Account
@@ -210,20 +237,24 @@ fails the stack rather than deploying a template written two ways at once.
    `execute-api` ARN of the request, built by `api/sim-http-api-execute-api-arn.ts` from the concrete
    method and path rather than from the route key.
 
-3. `serve/auth/sim-http-api-integration-authorizer.ts` asks whether the API may invoke the function
-   at all. The caller is the service principal `apigateway.amazonaws.com`, the action is
+3. `serve/auth/sim-http-api-invoke-authorizer.ts` asks whether the API may invoke a function at all.
+   The caller is the service principal `apigateway.amazonaws.com`, the action is
    `lambda:InvokeFunction`, and the request supplies `AWS:SourceArn` from
    `api/sim-http-api-execute-api-arn.ts`. A function with no matching permission answers 500 and is
-   never invoked, as it is on real AWS. That ARN builder carries the reasoning for what the method
-   and path segments of the ARN hold, since neither is documented by AWS.
-4. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
+   never invoked, as it is on real AWS. Both an integration's function and an authorizer's go
+   through this, under different ARNs: the route for one, `<apiId>/authorizers/<authorizerId>` for
+   the other. That ARN builder carries the reasoning for what the method and path segments of the
+   ARN hold, since neither is documented by AWS.
+4. `sim-http-api-integration-invocation.ts` invokes the integrated function and turns its result into
+   the response. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
    `SimPayload2Endpoint`, including what the route captured from the path.
 5. `src/serve/payload-2/` builds the payload format 2.0 event and turns the handler's result back
    into an HTTP response. That machinery is shared with Lambda Function URLs, which speak the same
    format.
-6. `sim-api-gateway-v2-error-response.ts` answers the cases where there is nothing to proxy to. The
-   field is lower-case `message`, which is what an HTTP API uses; a Function URL uses `Message` for
-   the same thing.
+6. `sim-api-gateway-v2-error-response.ts` answers the cases where there is nothing to proxy to, and
+   `sim-http-api-refusal-response.ts` maps a route authorization refusal onto one of them. The field
+   is lower-case `message`, which is what an HTTP API uses; a Function URL uses `Message` for the
+   same thing.
 
 ## CloudFormation
 
@@ -269,14 +300,20 @@ simulation exists to avoid:
 - an integration type other than `AWS_PROXY`, and an integration URI that is not an unqualified
   Lambda function ARN
 - a malformed route key, refused at `CreateRoute`, which is where real API Gateway refuses it
-- an authorization type other than `NONE`, `JWT` or `AWS_IAM`, and an `AuthorizerId` or
-  `AuthorizationScopes` on a route that has no use for either
+- an `AuthorizerId` or `AuthorizationScopes` on a route that has no use for either, and an
+  `AuthorizerId` naming an authorizer of the kind the route's authorization type does not take
 - a `Policy` on `AWS::ApiGatewayV2::Api`, with a message of its own: AWS has no such property, since
   an HTTP API has no resource policy
-- an authorizer type other than `JWT`, and every option only a Lambda `REQUEST` authorizer takes,
-  including `AuthorizerResultTtlInSeconds`
-- more than one `IdentitySource`, and an identity source naming neither a header nor a query string
-  parameter
+- an option belonging to the other kind of authorizer, such as an `AuthorizerUri` on a `JWT`
+  authorizer or a `JwtConfiguration` on a `REQUEST` one
+- an `AuthorizerPayloadFormatVersion` that is not `2.0`, including an unstated one, which AWS reads
+  as `1.0`
+- a non-zero `AuthorizerResultTtlInSeconds`, since nothing here reuses a decision, and an
+  `AuthorizerCredentialsArn`, since the function's own resource policy is the whole decision
+- a `REQUEST` authorizer declared by `AWS::ApiGatewayV2::Authorizer` or by an OpenAPI security
+  scheme, which `CreateAuthorizer` does create
+- more than one `IdentitySource` on a `JWT` authorizer, no `IdentitySource` at all on a `REQUEST`
+  one, and an identity source naming neither a header nor a query string parameter
 - a stage name that is neither `$default` nor something a URL path segment could hold, and a stage
   without `AutoDeploy: true`, since Deployments are not simulated and such a stage serves nothing on
   real AWS

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-authorization.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-authorization.ts
@@ -1,4 +1,7 @@
-import type { SimPayload2JwtAuthorizer } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import type {
+  SimPayload2JwtAuthorizer,
+  SimPayload2LambdaAuthorizer,
+} from "../../../../serve/payload-2/sim-payload-2-event.type.js";
 import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-caller.js";
 
 /**
@@ -7,23 +10,29 @@ import type { SimAwsRequestCaller } from "../../../iam/request/sim-aws-request-c
  * `unauthorized` covers everything up to and including claim validation: real
  * API Gateway answers all of it with one 401 and one body, so a client learns
  * that its token was not accepted and nothing about which check it failed.
- * `forbidden` is only ever an unmet route scope, which is a token that was
- * accepted and does not allow this route.
+ * `forbidden` is an accepted caller the route does not allow, such as an unmet
+ * route scope or an authorizer that said no. `error` is the authorizer itself
+ * failing, which is the API's problem rather than the caller's.
  */
-export type SimHttpApiRefusalKind = "unauthorized" | "forbidden";
+export type SimHttpApiRefusalKind = "unauthorized" | "forbidden" | "error";
 
 interface SimHttpApiAdmittedProperties {
   /** The token a `JWT` route's authorizer accepted. */
   readonly jwt?: SimPayload2JwtAuthorizer | undefined;
   /** The principal an `AWS_IAM` route allowed the request. */
   readonly caller?: SimAwsRequestCaller | undefined;
+  /**
+   * What a `CUSTOM` route's Lambda authorizer passed on to the integration,
+   * which is `null` when it allowed the request and returned no context.
+   */
+  readonly lambda?: SimPayload2LambdaAuthorizer | null | undefined;
 }
 
 /**
  * A request the endpoint admitted, and what its authorizer knows about the
  * caller.
  *
- * Both members are absent on a route that authorizes nobody, since there is no
+ * Every member is absent on a route that authorizes nobody, since there is no
  * caller to describe, which is what leaves `requestContext.authorizer` out of
  * the event entirely. Which one is present says which kind of authorization
  * admitted the request.
@@ -32,10 +41,12 @@ export class SimHttpApiAdmitted {
   public readonly admitted = true as const;
   public readonly jwt: SimPayload2JwtAuthorizer | undefined;
   public readonly caller: SimAwsRequestCaller | undefined;
+  public readonly lambda: SimPayload2LambdaAuthorizer | null | undefined;
 
   constructor(properties: SimHttpApiAdmittedProperties = {}) {
     this.jwt = properties.jwt;
     this.caller = properties.caller;
+    this.lambda = properties.lambda;
   }
 }
 
@@ -62,18 +73,30 @@ export class SimHttpApiRefused {
   }
 
   /**
-   * The token was missing, unreadable, or did not verify.
+   * The token was missing, unreadable, or did not verify, or the request did
+   * not carry an identity source a Lambda authorizer was told to read.
    */
   static unauthorized(errorDescription?: string): SimHttpApiRefused {
     return new SimHttpApiRefused("unauthorized", errorDescription);
   }
 
   /**
-   * The token verified and none of its scopes is one the route asks for, or
-   * IAM did not allow the caller `execute-api:Invoke` on the route.
+   * The token verified and none of its scopes is one the route asks for, IAM
+   * did not allow the caller `execute-api:Invoke` on the route, or a Lambda
+   * authorizer decided against the request.
    */
   static forbidden(): SimHttpApiRefused {
     return new SimHttpApiRefused("forbidden");
+  }
+
+  /**
+   * The route's authorizer could not answer at all: its function is missing,
+   * may not be invoked, failed, or replied in a shape API Gateway does not
+   * understand. None of that is the caller's doing, so it is the same 500 an
+   * integration failure gets rather than a refusal the caller could act on.
+   */
+  static error(): SimHttpApiRefused {
+    return new SimHttpApiRefused("error");
   }
 }
 

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-authorizer.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-authorizer.ts
@@ -1,11 +1,7 @@
 import { faker } from "@faker-js/faker";
 
 import type { Brand } from "../../../../util/brand.type.js";
-import type { SimHttpApiIdentitySource } from "./sim-http-api-identity-source.js";
-import type {
-  SimHttpApiJwtConfiguration,
-  SimHttpApiJwtConfigurationView,
-} from "./sim-http-api-jwt-configuration.js";
+import type { SimHttpApiJwtConfigurationView } from "./sim-http-api-jwt-configuration.js";
 
 /**
  * The id API Gateway allocates for one authorizer.
@@ -13,13 +9,13 @@ import type {
 export type SimHttpApiAuthorizerId = Brand<string, "SimHttpApiAuthorizerId">;
 
 /**
- * The only authorizer type simulated.
+ * The two kinds of authorizer an HTTP API has.
  *
- * A Lambda `REQUEST` authorizer runs code of its own to make the decision, and
- * none of that is simulated, so it is refused at creation rather than created
- * and ignored.
+ * A `JWT` authorizer verifies a token against the keys its issuer publishes. A
+ * `REQUEST` authorizer invokes a Lambda function of its own and does whatever
+ * that function decides.
  */
-export type SimHttpApiAuthorizerType = "JWT";
+export type SimHttpApiAuthorizerType = "JWT" | "REQUEST";
 
 /**
  * Allocate an authorizer id, in the same opaque shape as a route id.
@@ -31,56 +27,52 @@ export function makeSimHttpApiAuthorizerId(): SimHttpApiAuthorizerId {
 interface SimHttpApiAuthorizerProperties {
   readonly authorizerId: SimHttpApiAuthorizerId;
   readonly name: string;
-  readonly identitySource: SimHttpApiIdentitySource;
-  readonly jwtConfiguration: SimHttpApiJwtConfiguration;
 }
 
 /**
  * Minimal structural authorizer view, as the Create and Get commands return.
+ *
+ * The members below the identity sources belong to one kind of authorizer
+ * each, and only the kind that has them reports them, which is what real API
+ * Gateway answers with.
  */
 export interface SimHttpApiAuthorizerView {
   AuthorizerId: string;
   Name: string;
   AuthorizerType: SimHttpApiAuthorizerType;
   IdentitySource: string[];
-  JwtConfiguration: SimHttpApiJwtConfigurationView;
+  JwtConfiguration?: SimHttpApiJwtConfigurationView;
+  AuthorizerUri?: string;
+  AuthorizerPayloadFormatVersion?: string;
+  EnableSimpleResponses?: boolean;
 }
 
 /**
- * A simulated HTTP API JWT authorizer: which token a route asks for, and which
- * issuer signed it.
+ * A simulated HTTP API authorizer: what a route sends a request through before
+ * it reaches an integration.
  *
  * An authorizer belongs to an API and is attached to routes by id, so one
- * authorizer covers as many routes of the API as name it.
+ * authorizer covers as many routes of the API as name it. What it does with a
+ * request is the subclass's business: the two kinds share an id, a name and
+ * nothing else.
  */
-export class SimHttpApiAuthorizer {
-  /**
-   * The type of authorizer this is, which is the only one simulated.
-   */
-  public readonly authorizerType: SimHttpApiAuthorizerType = "JWT";
-
+export abstract class SimHttpApiAuthorizer {
   public readonly authorizerId: SimHttpApiAuthorizerId;
   public readonly name: string;
-  public readonly identitySource: SimHttpApiIdentitySource;
-  public readonly jwtConfiguration: SimHttpApiJwtConfiguration;
+
+  /**
+   * The kind of authorizer this is, which is what a route's own authorization
+   * type has to agree with.
+   */
+  abstract readonly authorizerType: SimHttpApiAuthorizerType;
 
   constructor(properties: SimHttpApiAuthorizerProperties) {
     this.authorizerId = properties.authorizerId;
     this.name = properties.name;
-    this.identitySource = properties.identitySource;
-    this.jwtConfiguration = properties.jwtConfiguration;
   }
 
   /**
    * Get the AWS-like view of this authorizer.
    */
-  view(): SimHttpApiAuthorizerView {
-    return {
-      AuthorizerId: this.authorizerId,
-      Name: this.name,
-      AuthorizerType: this.authorizerType,
-      IdentitySource: [this.identitySource.expression],
-      JwtConfiguration: this.jwtConfiguration.view(),
-    };
-  }
+  abstract view(): SimHttpApiAuthorizerView;
 }

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-identity-source.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-identity-source.ts
@@ -16,13 +16,14 @@ const queryStringPrefix = "$request.querystring.";
 const bearerPrefix = /^bearer\s+/i;
 
 /**
- * Where a JWT authorizer takes the token from.
+ * Where an authorizer takes what it identifies the caller by.
  *
  * An identity source is a request mapping expression naming one header or one
  * query string parameter. Anything else is refused rather than accepted and
- * looked for nowhere, since a route whose authorizer never finds a token
- * refuses every request, which looks like a signing problem rather than a
- * configuration one.
+ * looked for nowhere, since a route whose authorizer never finds what it looks
+ * for refuses every request, which looks like a signing problem rather than a
+ * configuration one. That leaves out `$context.*` and `$stagevariables.*`,
+ * which a Lambda `REQUEST` authorizer may also name.
  */
 export class SimHttpApiIdentitySource {
   /**
@@ -68,21 +69,43 @@ export class SimHttpApiIdentitySource {
   }
 
   /**
+   * What this request carries at this identity source, if it carries anything.
+   *
+   * An empty value is the same as no value here: real API Gateway treats a
+   * source it finds nothing at as one the request did not supply, and refuses
+   * the request without asking the authorizer anything.
+   */
+  value(request: Request): string | undefined {
+    return this.present(this.rawValue(request)?.trim());
+  }
+
+  /**
    * The token this request carries, if it carries one at all.
    *
-   * An empty value is the same as no value here: real API Gateway has nothing
-   * to decode either way, and both answer the same 401.
+   * The bearer scheme is stripped when it is there, which is what a JWT
+   * authorizer does with it. A `REQUEST` authorizer is handed the value as it
+   * arrived instead, since it may be a cookie or an API key rather than a
+   * bearer token.
    */
   token(request: Request): string | undefined {
-    const value = this.rawValue(request);
+    const value = this.value(request);
 
     if (value === undefined) {
       return undefined;
     }
 
-    const token = value.replace(bearerPrefix, "").trim();
+    return this.present(value.replace(bearerPrefix, "").trim());
+  }
 
-    return token.length === 0 ? undefined : token;
+  /**
+   * A value the request actually supplied, rather than an empty one.
+   */
+  private present(value: string | undefined): string | undefined {
+    if (value === undefined || value.length === 0) {
+      return undefined;
+    }
+
+    return value;
   }
 
   private rawValue(request: Request): string | undefined {

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-identity-sources.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-identity-sources.ts
@@ -1,0 +1,47 @@
+import type { SimHttpApiIdentitySource } from "./sim-http-api-identity-source.js";
+
+/**
+ * The identity sources a Lambda `REQUEST` authorizer is configured with.
+ *
+ * A `REQUEST` authorizer takes a list rather than the single source a JWT
+ * authorizer takes, and API Gateway checks the whole list before it invokes
+ * anything: a request missing any one of them is refused with a 401 and the
+ * authorizer function never runs.
+ */
+export class SimHttpApiIdentitySources {
+  private readonly sources: readonly SimHttpApiIdentitySource[];
+
+  constructor(sources: readonly SimHttpApiIdentitySource[]) {
+    this.sources = [...sources];
+  }
+
+  /**
+   * The expressions as they were written, which is what the API reports back.
+   */
+  get expressions(): string[] {
+    return this.sources.map((source) => source.expression);
+  }
+
+  /**
+   * The values this request carries, in the order the sources were configured,
+   * or nothing at all when it is missing any one of them.
+   *
+   * This is what reaches the authorizer as the event's `identitySource`: the
+   * values rather than the expressions that found them.
+   */
+  values(request: Request): string[] | undefined {
+    const values: string[] = [];
+
+    for (const source of this.sources) {
+      const value = source.value(request);
+
+      if (value === undefined) {
+        return undefined;
+      }
+
+      values.push(value);
+    }
+
+    return values;
+  }
+}

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-authorizer.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-authorizer.ts
@@ -1,0 +1,48 @@
+import {
+  SimHttpApiAuthorizer,
+  type SimHttpApiAuthorizerId,
+  type SimHttpApiAuthorizerView,
+} from "./sim-http-api-authorizer.js";
+import type { SimHttpApiIdentitySource } from "./sim-http-api-identity-source.js";
+import type { SimHttpApiJwtConfiguration } from "./sim-http-api-jwt-configuration.js";
+
+interface SimHttpApiJwtAuthorizerProperties {
+  readonly authorizerId: SimHttpApiAuthorizerId;
+  readonly name: string;
+  readonly identitySource: SimHttpApiIdentitySource;
+  readonly jwtConfiguration: SimHttpApiJwtConfiguration;
+}
+
+/**
+ * A simulated HTTP API JWT authorizer: which token a route asks for, and which
+ * issuer signed it.
+ *
+ * There is one identity source rather than a list, which is what a JWT
+ * authorizer takes: a token arrives in one place, and API Gateway refuses a
+ * second source on this kind of authorizer.
+ */
+export class SimHttpApiJwtAuthorizer extends SimHttpApiAuthorizer {
+  public readonly authorizerType = "JWT" as const;
+
+  public readonly identitySource: SimHttpApiIdentitySource;
+  public readonly jwtConfiguration: SimHttpApiJwtConfiguration;
+
+  constructor(properties: SimHttpApiJwtAuthorizerProperties) {
+    super(properties);
+    this.identitySource = properties.identitySource;
+    this.jwtConfiguration = properties.jwtConfiguration;
+  }
+
+  /**
+   * Get the AWS-like view of this authorizer.
+   */
+  view(): SimHttpApiAuthorizerView {
+    return {
+      AuthorizerId: this.authorizerId,
+      Name: this.name,
+      AuthorizerType: this.authorizerType,
+      IdentitySource: [this.identitySource.expression],
+      JwtConfiguration: this.jwtConfiguration.view(),
+    };
+  }
+}

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.iso.test.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.iso.test.ts
@@ -13,16 +13,14 @@ import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCognitoUserPoolRegistry } from "../../../cognito/registry/sim-cognito-user-pool-registry.js";
 import { simCognitoSignedInFactory } from "../../../cognito/user-pool/auth/sim-cognito-signed-in.factory.js";
 import { SimCognitoHttpApiJwtIssuerKeys } from "./sim-cognito-http-api-jwt-issuer-keys.js";
-import {
-  makeSimHttpApiAuthorizerId,
-  SimHttpApiAuthorizer,
-} from "./sim-http-api-authorizer.js";
+import { makeSimHttpApiAuthorizerId } from "./sim-http-api-authorizer.js";
 import {
   SimHttpApiAdmitted,
   type SimHttpApiAuthorization,
   type SimHttpApiRefused,
 } from "./sim-http-api-authorization.js";
 import { SimHttpApiIdentitySource } from "./sim-http-api-identity-source.js";
+import { SimHttpApiJwtAuthorizer } from "./sim-http-api-jwt-authorizer.js";
 import { SimHttpApiJwtConfiguration } from "./sim-http-api-jwt-configuration.js";
 import { SimHttpApiNoJwtIssuerKeys } from "./sim-http-api-jwt-issuer-keys.js";
 import { SimHttpApiJwtVerification } from "./sim-http-api-jwt-verification.js";
@@ -73,8 +71,11 @@ function refusalOf(authorization: SimHttpApiAuthorization): SimHttpApiRefused {
   return authorization;
 }
 
-function authorizerFor(issuer: string, audience: string): SimHttpApiAuthorizer {
-  return new SimHttpApiAuthorizer({
+function authorizerFor(
+  issuer: string,
+  audience: string,
+): SimHttpApiJwtAuthorizer {
+  return new SimHttpApiJwtAuthorizer({
     authorizerId: makeSimHttpApiAuthorizerId(),
     name: "pool-authorizer",
     identitySource: SimHttpApiIdentitySource.parse(

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-jwt-verification.ts
@@ -1,7 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimJwtRs256 } from "../../../../util/jwt/sim-jwt-rs256.js";
 import { SimJwt } from "../../../../util/jwt/sim-jwt.js";
-import type { SimHttpApiAuthorizer } from "./sim-http-api-authorizer.js";
+import type { SimHttpApiJwtAuthorizer } from "./sim-http-api-jwt-authorizer.js";
 import {
   SimHttpApiAdmitted,
   type SimHttpApiAuthorization,
@@ -48,7 +48,7 @@ export class SimHttpApiJwtVerification {
    * that carried it.
    */
   verify(
-    authorizer: SimHttpApiAuthorizer,
+    authorizer: SimHttpApiJwtAuthorizer,
     token: string,
   ): SimHttpApiAuthorization {
     const jwt = this.decode(token);

--- a/src/service/apigatewayv2/api/authorizer/sim-http-api-request-authorizer.ts
+++ b/src/service/apigatewayv2/api/authorizer/sim-http-api-request-authorizer.ts
@@ -1,0 +1,70 @@
+import type { SimHttpApiLambdaUri } from "../integration/sim-http-api-lambda-uri.js";
+import {
+  SimHttpApiAuthorizer,
+  type SimHttpApiAuthorizerId,
+  type SimHttpApiAuthorizerView,
+} from "./sim-http-api-authorizer.js";
+import type { SimHttpApiIdentitySources } from "./sim-http-api-identity-sources.js";
+
+/**
+ * The only authorizer payload format simulated, which is the one the rest of
+ * this simulation builds events in.
+ */
+export const simHttpApiAuthorizerPayloadFormatVersion = "2.0";
+
+interface SimHttpApiRequestAuthorizerProperties {
+  readonly authorizerId: SimHttpApiAuthorizerId;
+  readonly name: string;
+  readonly lambdaUri: SimHttpApiLambdaUri;
+  readonly identitySources: SimHttpApiIdentitySources;
+  readonly enableSimpleResponses: boolean;
+}
+
+/**
+ * A simulated HTTP API Lambda `REQUEST` authorizer: the function a route sends
+ * a request to before it reaches its integration.
+ *
+ * The function decides, so nothing here says what a caller has to present. All
+ * this holds is which function to invoke, what has to be on the request before
+ * it is worth invoking, and which of the two answer shapes the function
+ * replies in.
+ */
+export class SimHttpApiRequestAuthorizer extends SimHttpApiAuthorizer {
+  public readonly authorizerType = "REQUEST" as const;
+
+  /**
+   * The Lambda function this authorizer invokes, read from its
+   * `AuthorizerUri`.
+   */
+  public readonly lambdaUri: SimHttpApiLambdaUri;
+
+  public readonly identitySources: SimHttpApiIdentitySources;
+
+  /**
+   * Whether the function answers `{ isAuthorized, context }` rather than a
+   * principal and an IAM policy document.
+   */
+  public readonly enableSimpleResponses: boolean;
+
+  constructor(properties: SimHttpApiRequestAuthorizerProperties) {
+    super(properties);
+    this.lambdaUri = properties.lambdaUri;
+    this.identitySources = properties.identitySources;
+    this.enableSimpleResponses = properties.enableSimpleResponses;
+  }
+
+  /**
+   * Get the AWS-like view of this authorizer.
+   */
+  view(): SimHttpApiAuthorizerView {
+    return {
+      AuthorizerId: this.authorizerId,
+      Name: this.name,
+      AuthorizerType: this.authorizerType,
+      IdentitySource: this.identitySources.expressions,
+      AuthorizerUri: this.lambdaUri.uri,
+      AuthorizerPayloadFormatVersion: simHttpApiAuthorizerPayloadFormatVersion,
+      EnableSimpleResponses: this.enableSimpleResponses,
+    };
+  }
+}

--- a/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
+++ b/src/service/apigatewayv2/api/integration/sim-http-api-lambda-uri.ts
@@ -18,8 +18,9 @@ const apiGatewayLambdaPathUri =
   /^arn:[^:]+:apigateway:[^:]+:lambda:path\/2015-03-31\/functions\/(?<functionArn>arn:[^/]+)\/invocations$/;
 
 /**
- * The `IntegrationUri` of an `AWS_PROXY` integration: the ARN of the Lambda
- * function the integration invokes.
+ * A URI naming the Lambda function something on an API invokes: the
+ * `IntegrationUri` of an `AWS_PROXY` integration, or the `AuthorizerUri` of a
+ * `REQUEST` authorizer. Both are written the same way.
  *
  * Only an unqualified function ARN is accepted. A version or alias qualifier
  * on the end names a published function version, and simulated Lambda has no
@@ -50,14 +51,38 @@ export class SimHttpApiLambdaUri {
    * ARN.
    */
   static parse(uri: string): SimHttpApiLambdaUri {
+    return this.read(
+      "IntegrationUri",
+      uri,
+      "an AWS_PROXY integration is simulated only for an unqualified Lambda " +
+        "function ARN",
+    );
+  }
+
+  /**
+   * Read a `REQUEST` authorizer's URI, which names its function the same way.
+   */
+  static parseAuthorizerUri(uri: string): SimHttpApiLambdaUri {
+    return this.read(
+      "AuthorizerUri",
+      uri,
+      "a REQUEST authorizer is simulated only for an unqualified Lambda " +
+        "function ARN",
+    );
+  }
+
+  private static read(
+    option: string,
+    uri: string,
+    refusal: string,
+  ): SimHttpApiLambdaUri {
     const functionArn = this.functionArn(uri);
     const groups = lambdaFunctionArn.exec(functionArn)?.groups;
 
     if (groups === undefined) {
       throw new SimApiGatewayV2BadRequest(
-        `IntegrationUri '${uri}' is not a simulated integration target: an ` +
-          `AWS_PROXY integration is simulated only for an unqualified Lambda ` +
-          `function ARN, such as ` +
+        `${option} '${uri}' is not a simulated invocation target: ` +
+          `${refusal}, such as ` +
           `arn:aws:lambda:eu-west-2:111111111111:function:orders`,
       );
     }

--- a/src/service/apigatewayv2/api/route/sim-http-api-route.ts
+++ b/src/service/apigatewayv2/api/route/sim-http-api-route.ts
@@ -16,14 +16,12 @@ import {
 export type SimHttpApiRouteId = Brand<string, "SimHttpApiRouteId">;
 
 /**
- * The authorization types simulated: none, so anyone may call the route, a JWT
- * the route's authorizer verifies, or a SigV4-signed caller IAM allows
- * `execute-api:Invoke` on the route being called.
- *
- * `CUSTOM`, which is a Lambda authorizer, is refused at creation rather than
- * created open.
+ * The authorization types a route asks for: none, so anyone may call the
+ * route, a JWT the route's authorizer verifies, a SigV4-signed caller IAM
+ * allows `execute-api:Invoke` on the route being called, or a Lambda
+ * `REQUEST` authorizer that decides for itself.
  */
-export type SimHttpApiAuthorizationType = "NONE" | "JWT" | "AWS_IAM";
+export type SimHttpApiAuthorizationType = "NONE" | "JWT" | "AWS_IAM" | "CUSTOM";
 
 /**
  * Allocate a route id, in the same opaque shape as an integration id.
@@ -52,9 +50,9 @@ export class SimHttpApiRoute {
   public readonly authorizationType: SimHttpApiAuthorizationType;
 
   /**
-   * The authorizer this route sends requests through, which only a `JWT` route
-   * has. An `AWS_IAM` route takes no authorizer, since IAM itself is what
-   * decides, and a `NONE` route authorizes nobody.
+   * The authorizer this route sends requests through, which a `JWT` and a
+   * `CUSTOM` route each have. An `AWS_IAM` route takes no authorizer, since
+   * IAM itself is what decides, and a `NONE` route authorizes nobody.
    */
   public readonly authorizerId: SimHttpApiAuthorizerId | undefined;
 

--- a/src/service/apigatewayv2/api/sim-http-api-execute-api-arn.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-execute-api-arn.ts
@@ -17,13 +17,17 @@ interface SimHttpApiExecuteApiArnProperties {
  * arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
  * ```
  *
- * Two things want this ARN and they fill the last part differently:
+ * Three things want this ARN and they fill the last part differently:
  *
  * - the invoke permission a Lambda integration is authorized against, where
  *   the path is the matched route key's template with its braces intact,
  *   because that is the form a permission's `SourceArn` is written in;
  * - `AWS_IAM` route authorization, where the path is the path the request
- *   asked for, because that is the resource the caller is acting on.
+ *   asked for, because that is the resource the caller is acting on;
+ * - the `routeArn` a Lambda `REQUEST` authorizer is given, and the resource
+ *   the policy it answers with is evaluated against, which is the route key
+ *   form: AWS's own example of that event names a `$default` route as
+ *   `<apiId>/<stage>/$default`.
  *
  * Neither part is documented by AWS as the value API Gateway supplies. The
  * path is the better supported of the two: CDK synthesises a `SourceArn`
@@ -48,6 +52,30 @@ export class SimHttpApiExecuteApiArn {
     this.api = properties.api;
     this.stageName = properties.stageName;
     this.methodAndPath = properties.methodAndPath;
+  }
+
+  /**
+   * The ARN API Gateway invokes one of an API's authorizers under.
+   *
+   * ```text
+   * arn:aws:execute-api:<region>:<account>:<apiId>/authorizers/<authorizerId>
+   * ```
+   *
+   * This is the `SourceArn` AWS documents for granting API Gateway permission
+   * to invoke a Lambda authorizer's function, and it names no stage: an
+   * authorizer belongs to the API rather than to anything serving a request.
+   * A function integrated behind a route and used as that route's authorizer
+   * therefore needs two permissions, as it does on AWS.
+   */
+  static forAuthorizer(
+    api: SimHttpApi,
+    authorizerId: string,
+  ): SimHttpApiExecuteApiArn {
+    return new SimHttpApiExecuteApiArn({
+      api,
+      stageName: "authorizers",
+      methodAndPath: authorizerId,
+    });
   }
 
   /**

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -5,12 +5,13 @@ import { assertDefined } from "../../../util/type-guard/defined.js";
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
-import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-integration-authorizer.js";
+import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-invoke-authorizer.js";
 import type { SimHttpApi } from "./sim-http-api.js";
 import {
   simHttpApiProxyAuthorization,
   type SimHttpApiProxyAuthorizer,
 } from "./sim-http-api-proxy-authorization.js";
+import type { SimHttpApiProxyRequestAuthorizer } from "./sim-http-api-proxy-request-authorizer.js";
 
 /**
  * What a test asks for when it wants an HTTP API that serves something.
@@ -34,6 +35,11 @@ export interface SimHttpApiLambdaProxyInput {
    * whose routes admit anyone.
    */
   readonly jwtAuthorizer: SimHttpApiProxyAuthorizer | undefined;
+  /**
+   * The Lambda `REQUEST` authorizer every route goes through, or undefined for
+   * an API whose routes do not send requests through a function.
+   */
+  readonly requestAuthorizer: SimHttpApiProxyRequestAuthorizer | undefined;
   /**
    * Whether every route is authorized by IAM instead, which is what an
    * `AWS_IAM` route asks for.
@@ -92,6 +98,7 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     disableExecuteApiEndpoint: false,
     routeKeys: ["$default"],
     jwtAuthorizer: undefined,
+    requestAuthorizer: undefined,
     iamAuthorization: false,
     authorizationScopes: [],
     stageNames: ["$default"],
@@ -129,7 +136,10 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
 
     const authorization = await simHttpApiProxyAuthorization(simApiGatewayV2, {
       apiId,
+      simAws,
+      roleArn: input.roleArn,
       jwtAuthorizer: input.jwtAuthorizer,
+      requestAuthorizer: input.requestAuthorizer,
       iamAuthorization: input.iamAuthorization,
       authorizationScopes: input.authorizationScopes,
     });

--- a/src/service/apigatewayv2/api/sim-http-api-proxy-authorization.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-proxy-authorization.ts
@@ -1,5 +1,10 @@
+import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimCreateRouteCommandInput } from "../command/route/route.command.js";
 import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
+import {
+  simHttpApiProxyRequestAuthorizer,
+  type SimHttpApiProxyRequestAuthorizer,
+} from "./sim-http-api-proxy-request-authorizer.js";
 
 /**
  * A JWT authorizer every route of a test's API goes through.
@@ -14,9 +19,14 @@ interface SimHttpApiProxyAuthorizationInput {
   readonly apiId: string;
   /** Undefined for an API whose routes admit anyone. */
   readonly jwtAuthorizer: SimHttpApiProxyAuthorizer | undefined;
+  /** Undefined unless every route goes through a Lambda authorizer. */
+  readonly requestAuthorizer: SimHttpApiProxyRequestAuthorizer | undefined;
   /** Whether every route is authorized by IAM instead. */
   readonly iamAuthorization: boolean;
   readonly authorizationScopes: readonly string[];
+  /** The Role the authorizer's own function runs as. */
+  readonly roleArn: string;
+  readonly simAws: SimAws;
 }
 
 /**
@@ -30,7 +40,16 @@ export async function simHttpApiProxyAuthorization(
   simApiGatewayV2: SimApiGatewayV2,
   input: SimHttpApiProxyAuthorizationInput,
 ): Promise<SimCreateRouteCommandInput> {
-  const { apiId, jwtAuthorizer } = input;
+  const { apiId, jwtAuthorizer, requestAuthorizer } = input;
+
+  if (requestAuthorizer !== undefined) {
+    return await simHttpApiProxyRequestAuthorizer(input.simAws, {
+      apiId,
+      roleArn: input.roleArn,
+      authorizer: requestAuthorizer,
+      authorizationScopes: input.authorizationScopes,
+    });
+  }
 
   if (input.iamAuthorization) {
     // An AWS_IAM route takes no authorizer at all, so there is nothing to

--- a/src/service/apigatewayv2/api/sim-http-api-proxy-request-authorizer.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-proxy-request-authorizer.ts
@@ -1,0 +1,96 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimCreateRouteCommandInput } from "../command/route/route.command.js";
+import { simApiGatewayServicePrincipal } from "../serve/auth/sim-http-api-invoke-authorizer.js";
+import type { SimHttpApiAuthorizerEvent } from "../serve/auth/sim-http-api-authorizer-event.js";
+
+/**
+ * A Lambda `REQUEST` authorizer every route of a test's API goes through.
+ */
+export interface SimHttpApiProxyRequestAuthorizer {
+  /** The function code the authorizer invokes. */
+  readonly handler: (event: SimHttpApiAuthorizerEvent) => unknown;
+  readonly functionName: string;
+  readonly identitySource: readonly string[];
+  readonly enableSimpleResponses: boolean;
+  /**
+   * The `AuthorizerUri`, which defaults to the function just created. A test
+   * about an authorizer whose function is not there names one nothing created.
+   */
+  readonly uri?: string | undefined;
+  /**
+   * Whether the authorizer's function grants the API permission to invoke it.
+   *
+   * The grant names the authorizer rather than any route, so it is a separate
+   * one from the integration's. A test about the permission itself turns this
+   * off.
+   */
+  readonly invokePermission: boolean;
+}
+
+interface SimHttpApiProxyRequestAuthorizerInput {
+  readonly apiId: string;
+  readonly roleArn: string;
+  readonly authorizer: SimHttpApiProxyRequestAuthorizer;
+  readonly authorizationScopes: readonly string[];
+}
+
+/**
+ * Create the function a test's Lambda authorizer invokes, the authorizer
+ * itself, and the permission letting the API invoke it, and answer the
+ * authorization every route of that API is then created with.
+ *
+ * Three commands and a function stand between a test and a `CUSTOM` route it
+ * can serve, and a test about the authorizer is about none of them.
+ */
+export async function simHttpApiProxyRequestAuthorizer(
+  simAws: SimAws,
+  input: SimHttpApiProxyRequestAuthorizerInput,
+): Promise<SimCreateRouteCommandInput> {
+  const { apiId, authorizer } = input;
+  const simLambda = simAws.lambda();
+  const { FunctionArn: functionArn } = await simLambda.createFunction({
+    input: {
+      FunctionName: authorizer.functionName,
+      Role: input.roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(authorizer.handler) },
+    },
+  });
+
+  const created = await simAws.apiGatewayV2().createAuthorizer({
+    input: {
+      ApiId: apiId,
+      Name: "request-authorizer",
+      AuthorizerType: "REQUEST",
+      AuthorizerUri: authorizer.uri ?? functionArn,
+      AuthorizerPayloadFormatVersion: "2.0",
+      EnableSimpleResponses: authorizer.enableSimpleResponses,
+      IdentitySource: [...authorizer.identitySource],
+    },
+  });
+
+  if (authorizer.invokePermission) {
+    const { accountId, regionName } =
+      simAws.accountRegionScope().accountRegionScope;
+    await simLambda.addPermission({
+      input: {
+        FunctionName: authorizer.functionName,
+        StatementId: "api-gateway-invoke-authorizer",
+        Action: "lambda:InvokeFunction",
+        Principal: simApiGatewayServicePrincipal,
+        SourceArn:
+          `arn:aws:execute-api:${regionName}:${accountId}:${apiId}` +
+          `/authorizers/${created.AuthorizerId}`,
+      },
+    });
+  }
+
+  // The scopes are passed on rather than dropped, so a test asking for one on
+  // a route a Lambda authorizer decides is refused by CreateRoute rather than
+  // quietly getting an unchecked scope.
+  return {
+    AuthorizationType: "CUSTOM",
+    AuthorizerId: created.AuthorizerId,
+    AuthorizationScopes: input.authorizationScopes,
+  };
+}

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
@@ -2,13 +2,16 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateAuthorizerCommandInput } from "../../command/authorizer/authorizer.command.js";
 import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+import { SimCfnHttpApiJwtConfigurationProperties } from "./sim-cfn-http-api-jwt-configuration-properties.js";
 
 /**
  * The AWS::ApiGatewayV2::Authorizer properties this simulation deploys.
  *
  * Everything a Lambda `REQUEST` authorizer is configured with is left out, so
  * a template carrying one is refused by name rather than deploying an
- * authorizer that would decide differently here.
+ * authorizer that would decide differently here. `CreateAuthorizer` does
+ * create a `REQUEST` authorizer for an SDK caller; declaring one in a template
+ * is the part that is not simulated yet.
  */
 const simulatedProperties = [
   "ApiId",
@@ -57,10 +60,8 @@ export class SimCfnHttpApiAuthorizerProperties {
   /**
    * The CreateAuthorizer input this Resource asks for.
    *
-   * `AuthorizerType` is passed through, so a type that is not simulated is
-   * refused by CreateAuthorizer with the reason it refuses it. The issuer
-   * arrives as the string CDK builds from `Fn::GetAtt <UserPool>.ProviderURL`,
-   * which is the same string the pool's tokens name as their issuer.
+   * Everything but the type is passed through, so what an authorizer requires
+   * is refused by CreateAuthorizer with the reason it refuses it.
    */
   createAuthorizerInput(): SimCreateAuthorizerCommandInput {
     return {
@@ -70,11 +71,7 @@ export class SimCfnHttpApiAuthorizerProperties {
         this.properties["Name"],
         "Name",
       ),
-      AuthorizerType: this.propertyParser.optionalString(
-        this.resource,
-        this.properties["AuthorizerType"],
-        "AuthorizerType",
-      ),
+      AuthorizerType: this.authorizerType(),
       IdentitySource: this.propertyParser.optionalStringList(
         this.resource,
         this.properties["IdentitySource"],
@@ -84,28 +81,37 @@ export class SimCfnHttpApiAuthorizerProperties {
     };
   }
 
-  private jwtConfiguration(): SimCreateAuthorizerCommandInput["JwtConfiguration"] {
-    const configuration = this.propertyParser.optionalRecord(
+  /**
+   * The type this Resource declares, refusing `REQUEST` by name.
+   *
+   * A `REQUEST` authorizer needs the properties naming its function, and those
+   * are not deployed from a template yet, so a Resource declaring one would
+   * fail further down for a reason that reads as a missing property rather
+   * than as the feature it is.
+   */
+  private authorizerType(): string | undefined {
+    const authorizerType = this.propertyParser.optionalString(
       this.resource,
-      this.properties["JwtConfiguration"],
-      "JwtConfiguration",
+      this.properties["AuthorizerType"],
+      "AuthorizerType",
     );
 
-    if (configuration === undefined) {
-      return undefined;
+    if (authorizerType === "REQUEST") {
+      throw new Error(
+        `AWS::ApiGatewayV2::Authorizer ${this.resource.logicalId} declares a ` +
+          `Lambda REQUEST authorizer, which is not deployed from a template ` +
+          `yet. Create it with CreateAuthorizer instead.`,
+      );
     }
 
-    return {
-      Issuer: this.propertyParser.optionalString(
-        this.resource,
-        configuration["Issuer"],
-        "JwtConfiguration.Issuer",
-      ),
-      Audience: this.propertyParser.optionalStringList(
-        this.resource,
-        configuration["Audience"],
-        "JwtConfiguration.Audience",
-      ),
-    };
+    return authorizerType;
+  }
+
+  private jwtConfiguration(): SimCreateAuthorizerCommandInput["JwtConfiguration"] {
+    return new SimCfnHttpApiJwtConfigurationProperties({
+      resource: this.resource,
+      properties: this.properties,
+      propertyParser: this.propertyParser,
+    }).read();
   }
 }

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-jwt-configuration-properties.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-jwt-configuration-properties.ts
@@ -1,0 +1,59 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateAuthorizerCommandInput } from "../../command/authorizer/authorizer.command.js";
+import type { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+interface SimCfnHttpApiJwtConfigurationPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+}
+
+/**
+ * Reads the JwtConfiguration of an AWS::ApiGatewayV2::Authorizer Resource.
+ *
+ * The issuer arrives as the string CDK builds from
+ * `Fn::GetAtt <UserPool>.ProviderURL`, which is the same string the pool's
+ * tokens name as their issuer. Nothing is checked here: what an authorizer
+ * requires is stated by CreateAuthorizer, so a template is held to the same
+ * rules an SDK caller is.
+ */
+export class SimCfnHttpApiJwtConfigurationProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+
+  constructor(properties: SimCfnHttpApiJwtConfigurationPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The JwtConfiguration this Resource declares, if it declares one.
+   */
+  read(): SimCreateAuthorizerCommandInput["JwtConfiguration"] {
+    const configuration = this.propertyParser.optionalRecord(
+      this.resource,
+      this.properties["JwtConfiguration"],
+      "JwtConfiguration",
+    );
+
+    if (configuration === undefined) {
+      return undefined;
+    }
+
+    return {
+      Issuer: this.propertyParser.optionalString(
+        this.resource,
+        configuration["Issuer"],
+        "JwtConfiguration.Issuer",
+      ),
+      Audience: this.propertyParser.optionalStringList(
+        this.resource,
+        configuration["Audience"],
+        "JwtConfiguration.Audience",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
@@ -1,0 +1,152 @@
+import { assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApiFailure,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+describe("API Gateway v2 CloudFormation authorization validation", () => {
+  it("refuses a route authorization type that is not one AWS has", async () => {
+    // Given a route asking for something that is not an authorization type
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizationType: "LAMBDA" },
+      }),
+    );
+
+    // Then CreateRoute refuses it rather than deploying an open route
+    assertStringIncludes(
+      error.message,
+      "CreateRoute AuthorizationType 'LAMBDA' is not simulated",
+    );
+  });
+
+  it("refuses a CUSTOM route naming no authorizer", async () => {
+    // Given a route asking for a Lambda authorizer without saying which
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizationType: "CUSTOM" },
+      }),
+    );
+
+    // Then the stack fails rather than deploying a route with nothing to send
+    // its requests through
+    assertStringIncludes(
+      error.message,
+      "CreateRoute with AuthorizationType CUSTOM requires AuthorizerId",
+    );
+  });
+
+  it("refuses a JWT route naming an authorizer the template did not deploy", async () => {
+    // Given a route asking for JWT authorization with an authorizer id that
+    // is not one of this API's
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizationType: "JWT", AuthorizerId: "auth01" },
+      }),
+    );
+
+    // Then the stack fails rather than deploying a route that is open here and
+    // closed on AWS
+    assertStringIncludes(
+      error.message,
+      "AuthorizerId auth01 names no authorizer",
+    );
+  });
+
+  it("refuses an authorizer Resource declaring no JwtConfiguration", async () => {
+    // Given a template carrying a JWT authorizer with no issuer stated
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGatewayV2::Authorizer",
+            Properties: {
+              ApiId: { Ref: "Api" },
+              AuthorizerType: "JWT",
+              Name: "pool",
+              IdentitySource: ["$request.header.Authorization"],
+            },
+          },
+        },
+      }),
+    );
+
+    // Then CreateAuthorizer refuses it with the reason it gives an SDK caller,
+    // rather than the template deploying an authorizer trusting nothing
+    assertStringIncludes(
+      error.message,
+      "CreateAuthorizer requires JwtConfiguration",
+    );
+  });
+
+  it("refuses a Lambda authorizer declared as a Resource", async () => {
+    // Given a template carrying a Lambda REQUEST authorizer
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGatewayV2::Authorizer",
+            Properties: {
+              ApiId: { Ref: "Api" },
+              AuthorizerType: "REQUEST",
+              Name: "lambda",
+              IdentitySource: ["$request.header.Authorization"],
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the stack fails, saying where a REQUEST authorizer can be created
+    // instead, rather than deploying one the template did not fully describe
+    assertStringIncludes(
+      error.message,
+      "declares a Lambda REQUEST authorizer, which is not deployed from a " +
+        "template yet",
+    );
+  });
+
+  it("refuses an authorizer id on a route that authorizes nobody", async () => {
+    // Given a route naming an authorizer while leaving its authorization type
+    // at NONE
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: { AuthorizerId: "abc123" },
+      }),
+    );
+
+    // Then CreateRoute refuses it, since the authorizer would be ignored here
+    // and would leave the route open on AWS too
+    assertStringIncludes(
+      error.message,
+      "CreateRoute AuthorizerId is set on a route with AuthorizationType NONE",
+    );
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -103,25 +103,6 @@ describe("API Gateway v2 CloudFormation validation", () => {
     );
   });
 
-  it("refuses a route authorization type that is not simulated", async () => {
-    // Given a route asking for a Lambda authorizer
-    const simAws = simAwsInEuWest2();
-
-    // When the template is deployed
-    const error = await deployHttpApiFailure(
-      simAws,
-      simCfnHttpApiTemplateFactory.make({
-        routeProperties: { AuthorizationType: "CUSTOM" },
-      }),
-    );
-
-    // Then CreateRoute refuses it rather than deploying an open route
-    assertStringIncludes(
-      error.message,
-      "CreateRoute AuthorizationType 'CUSTOM' is not simulated",
-    );
-  });
-
   it("refuses an Api declaring a resource policy", async () => {
     // Given a template carrying the Policy property a REST API takes
     const simAws = simAwsInEuWest2();
@@ -150,57 +131,6 @@ describe("API Gateway v2 CloudFormation validation", () => {
     );
   });
 
-  it("refuses a JWT route naming an authorizer the template did not deploy", async () => {
-    // Given a route asking for JWT authorization with an authorizer id that
-    // is not one of this API's
-    const simAws = simAwsInEuWest2();
-
-    // When the template is deployed
-    const error = await deployHttpApiFailure(
-      simAws,
-      simCfnHttpApiTemplateFactory.make({
-        routeProperties: { AuthorizationType: "JWT", AuthorizerId: "auth01" },
-      }),
-    );
-
-    // Then the stack fails rather than deploying a route that is open here and
-    // closed on AWS
-    assertStringIncludes(
-      error.message,
-      "AuthorizerId auth01 names no authorizer",
-    );
-  });
-
-  it("refuses a Lambda authorizer Resource", async () => {
-    // Given a template carrying a Lambda REQUEST authorizer
-    const simAws = simAwsInEuWest2();
-
-    // When the template is deployed
-    const error = await deployHttpApiFailure(
-      simAws,
-      simCfnHttpApiTemplateFactory.make({
-        resources: {
-          Authorizer: {
-            Type: "AWS::ApiGatewayV2::Authorizer",
-            Properties: {
-              ApiId: { Ref: "Api" },
-              AuthorizerType: "REQUEST",
-              Name: "lambda",
-              IdentitySource: ["$request.header.Authorization"],
-            },
-          },
-        },
-      }),
-    );
-
-    // Then the stack fails rather than deploying an authorizer that would
-    // decide with code nothing here runs
-    assertStringIncludes(
-      error.message,
-      "CreateAuthorizer AuthorizerType 'REQUEST' is not simulated",
-    );
-  });
-
   it("refuses route scopes that are not a list of strings", async () => {
     // Given a route whose AuthorizationScopes is a single string
     const simAws = simAwsInEuWest2();
@@ -217,27 +147,6 @@ describe("API Gateway v2 CloudFormation validation", () => {
     assertStringIncludes(
       error.message,
       "AuthorizationScopes must be a list of strings",
-    );
-  });
-
-  it("refuses an authorizer id on a route that authorizes nobody", async () => {
-    // Given a route naming an authorizer while leaving its authorization type
-    // at NONE
-    const simAws = simAwsInEuWest2();
-
-    // When the template is deployed
-    const error = await deployHttpApiFailure(
-      simAws,
-      simCfnHttpApiTemplateFactory.make({
-        routeProperties: { AuthorizerId: "abc123" },
-      }),
-    );
-
-    // Then CreateRoute refuses it, since the authorizer would be ignored here
-    // and would leave the route open on AWS too
-    assertStringIncludes(
-      error.message,
-      "CreateRoute AuthorizerId is set on a route with AuthorizationType NONE",
     );
   });
 

--- a/src/service/apigatewayv2/command/authorizer/authorizer.command.ts
+++ b/src/service/apigatewayv2/command/authorizer/authorizer.command.ts
@@ -12,8 +12,9 @@ export interface SimHttpApiJwtConfigurationInput {
 /**
  * Minimal structural sim API Gateway v2 CreateAuthorizer command.
  *
- * The `REQUEST`-only options are absent here on purpose, so a Lambda
- * authorizer is refused by name rather than created as something else.
+ * `AuthorizerCredentialsArn` is absent here on purpose. It names a Role API
+ * Gateway assumes to invoke the authorizer function, and nothing here assumes
+ * one, so it is refused by name rather than accepted and ignored.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/CreateAuthorizerCommand/
  */
@@ -27,6 +28,10 @@ export interface SimCreateAuthorizerCommandInput {
   readonly AuthorizerType?: string | undefined;
   readonly IdentitySource?: readonly string[] | undefined;
   readonly JwtConfiguration?: SimHttpApiJwtConfigurationInput | undefined;
+  readonly AuthorizerUri?: string | undefined;
+  readonly AuthorizerPayloadFormatVersion?: string | undefined;
+  readonly EnableSimpleResponses?: boolean | undefined;
+  readonly AuthorizerResultTtlInSeconds?: number | undefined;
 }
 
 export interface SimCreateAuthorizerCommandOutput extends SimHttpApiAuthorizerView {

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-commands.iso.test.ts
@@ -155,31 +155,33 @@ describe("The authorizers of a sim HTTP API", () => {
 });
 
 describe("What CreateAuthorizer refuses rather than ignores", () => {
-  it("refuses a Lambda authorizer", async () => {
+  it("refuses an authorizer type an HTTP API does not have", async () => {
     // Given an API
     const simAws = new SimAws();
     const apiId = await createdApiId(simAws);
 
-    // When a REQUEST authorizer is created
-    // Then it is refused, because nothing here runs the code that would decide
+    // When an authorizer of a REST API's token kind is created. The command is
+    // sent structurally rather than through the SDK, since the SDK types allow
+    // only the two values an HTTP API has.
+    // Then it is refused rather than created as something else
     await expect(
-      simAws.apiGatewayV2().createAuthorizer(
-        new CreateAuthorizerCommand({
+      simAws.apiGatewayV2().createAuthorizer({
+        input: {
           ApiId: apiId,
-          Name: "lambda",
-          AuthorizerType: "REQUEST",
+          Name: "token",
+          AuthorizerType: "TOKEN",
           IdentitySource: ["$request.header.Authorization"],
-        }),
-      ),
-    ).rejects.toThrow(/AuthorizerType 'REQUEST' is not simulated/);
+        },
+      }),
+    ).rejects.toThrow(/AuthorizerType 'TOKEN' is not simulated/);
   });
 
-  it("refuses the options only a Lambda authorizer takes", async () => {
+  it("refuses the options only a Lambda authorizer takes on a JWT one", async () => {
     // Given an API
     const simAws = new SimAws();
     const apiId = await createdApiId(simAws);
 
-    // When an authorizer asks for a result cache, or for the function to call
+    // When a JWT authorizer asks for a result cache, or for a function to call
     // Then each is refused by name rather than dropped
     await expect(
       simAws.apiGatewayV2().createAuthorizer(
@@ -192,7 +194,7 @@ describe("What CreateAuthorizer refuses rather than ignores", () => {
           AuthorizerResultTtlInSeconds: 300,
         }),
       ),
-    ).rejects.toThrow(/AuthorizerResultTtlInSeconds is not simulated/);
+    ).rejects.toThrow(/AuthorizerResultTtlInSeconds is set on a JWT/);
 
     await expect(
       simAws.apiGatewayV2().createAuthorizer(
@@ -205,7 +207,7 @@ describe("What CreateAuthorizer refuses rather than ignores", () => {
           AuthorizerUri: functionArn,
         }),
       ),
-    ).rejects.toThrow(/AuthorizerUri is not simulated/);
+    ).rejects.toThrow(/AuthorizerUri is set on a JWT authorizer/);
   });
 
   it("requires an issuer and an audience", async () => {
@@ -286,7 +288,7 @@ describe("What CreateAuthorizer refuses rather than ignores", () => {
           JwtConfiguration: { Issuer: issuer, Audience: ["client-1"] },
         }),
       ),
-    ).rejects.toThrow(/more than one identity source is not simulated/);
+    ).rejects.toThrow(/a JWT authorizer takes one/);
 
     await expect(
       simAws.apiGatewayV2().createAuthorizer(

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-commands.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-commands.ts
@@ -1,4 +1,3 @@
-import { SimHttpApiAuthorizer } from "../../api/authorizer/sim-http-api-authorizer.js";
 import { SimApiGatewayV2NotFound } from "../../error/sim-api-gateway-v2.error.js";
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
@@ -11,7 +10,7 @@ import type {
   SimGetAuthorizersCommand,
   SimGetAuthorizersCommandOutput,
 } from "./authorizer.command.js";
-import { SimHttpApiJwtAuthorizerInput } from "./sim-http-api-jwt-authorizer-input.js";
+import { simHttpApiAuthorizerInput } from "./sim-http-api-authorizer-input.js";
 
 const authorizersPath = "/authorizers";
 
@@ -21,7 +20,16 @@ const acceptedCreateAuthorizerOptions = [
   "AuthorizerType",
   "IdentitySource",
   "JwtConfiguration",
+  "AuthorizerUri",
+  "AuthorizerPayloadFormatVersion",
+  "EnableSimpleResponses",
+  "AuthorizerResultTtlInSeconds",
 ];
+
+/**
+ * The authorizer types simulated.
+ */
+const simulatedAuthorizerTypes = ["JWT", "REQUEST"];
 
 /**
  * The commands addressing the authorizers of an API.
@@ -36,11 +44,10 @@ export class SimHttpApiAuthorizerCommands {
   /**
    * Handle a CreateAuthorizer command.
    *
-   * Everything a Lambda `REQUEST` authorizer is configured with, including
-   * `AuthorizerResultTtlInSeconds`, is outside the accepted set and refused by
-   * name. Nothing here runs authorizer code or caches a decision, so an
-   * authorizer that looked configured for either would behave differently on
-   * every request.
+   * The two kinds of authorizer are configured by different halves of this
+   * input, and which half applies is settled by the reader for the type asked
+   * for, so an option written against the other kind is refused by name rather
+   * than accepted and never applied.
    */
   createAuthorizer(
     command: SimCreateAuthorizerCommand,
@@ -50,19 +57,16 @@ export class SimHttpApiAuthorizerCommands {
     const unsimulated = new SimApiGatewayV2UnsimulatedInput("CreateAuthorizer");
     unsimulated.refuseUnaccepted(input, acceptedCreateAuthorizerOptions);
     const apiId = unsimulated.require("ApiId", input.ApiId);
-    const name = unsimulated.require("Name", input.Name);
+    unsimulated.require("Name", input.Name);
     unsimulated.require("AuthorizerType", input.AuthorizerType);
-    unsimulated.refuseUnless(
+    unsimulated.refuseUnlessOneOf(
       "AuthorizerType",
       input.AuthorizerType,
-      "JWT",
-      "a Lambda authorizer runs code of its own to decide, and none of that " +
-        "is simulated",
+      simulatedAuthorizerTypes,
+      "an HTTP API has these two kinds of authorizer and no others",
     );
 
-    const authorizerInput = new SimHttpApiJwtAuthorizerInput(input);
-    const identitySource = authorizerInput.identitySource();
-    const jwtConfiguration = authorizerInput.jwtConfiguration();
+    const authorizerInput = simHttpApiAuthorizerInput(input);
 
     const api = this.access.api({
       method: "POST",
@@ -71,12 +75,7 @@ export class SimHttpApiAuthorizerCommands {
       caller: options?.caller,
     });
 
-    const authorizer = new SimHttpApiAuthorizer({
-      authorizerId: api.authorizers.allocateId(),
-      name,
-      identitySource,
-      jwtConfiguration,
-    });
+    const authorizer = authorizerInput.read(api.authorizers.allocateId());
     api.authorizers.add(authorizer);
 
     return { ...authorizer.view(), $metadata: {} };
@@ -110,11 +109,11 @@ export class SimHttpApiAuthorizerCommands {
   /**
    * Handle a DeleteAuthorizer command.
    *
-   * A route still pointing at the deleted authorizer keeps its
-   * `AuthorizationType: JWT` and refuses every request, since there is no
-   * longer anything to verify a token against. What real API Gateway does with
-   * such a route is not established, so the route stays closed rather than
-   * being opened or repointed.
+   * A route still pointing at the deleted authorizer keeps its authorization
+   * type and refuses every request, since there is no longer anything to send
+   * the request through. What real API Gateway does with such a route is not
+   * established, so the route stays closed rather than being opened or
+   * repointed.
    */
   deleteAuthorizer(
     command: SimDeleteAuthorizerCommand,

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-input.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-input.ts
@@ -1,0 +1,34 @@
+import type {
+  SimHttpApiAuthorizer,
+  SimHttpApiAuthorizerId,
+} from "../../api/authorizer/sim-http-api-authorizer.js";
+import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+import { SimHttpApiJwtAuthorizerInput } from "./sim-http-api-jwt-authorizer-input.js";
+import { SimHttpApiRequestAuthorizerInput } from "./sim-http-api-request-authorizer-input.js";
+
+/**
+ * Reads one kind of authorizer out of a CreateAuthorizer input.
+ *
+ * The two kinds are configured by different halves of the same input, so each
+ * reader states what its own kind requires and refuses what belongs to the
+ * other, rather than the command handler knowing both.
+ */
+export interface SimHttpApiAuthorizerInput {
+  read(authorizerId: SimHttpApiAuthorizerId): SimHttpApiAuthorizer;
+}
+
+/**
+ * The reader for the kind of authorizer this input asks for.
+ *
+ * The type itself is checked by the command before this is reached, so
+ * anything that is not `REQUEST` here is `JWT`.
+ */
+export function simHttpApiAuthorizerInput(
+  input: SimCreateAuthorizerCommandInput,
+): SimHttpApiAuthorizerInput {
+  if (input.AuthorizerType === "REQUEST") {
+    return new SimHttpApiRequestAuthorizerInput(input);
+  }
+
+  return new SimHttpApiJwtAuthorizerInput(input);
+}

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-options.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-authorizer-options.ts
@@ -1,0 +1,41 @@
+import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
+
+/**
+ * The value shapes an authorizer option arrives in.
+ */
+type SimHttpApiAuthorizerOption =
+  string | number | boolean | object | undefined;
+
+/**
+ * Refuses an option belonging to the other kind of authorizer.
+ *
+ * The two kinds are configured by different halves of one command input, and
+ * API Gateway refuses an option written against the kind that has no use for
+ * it. Accepting it here would make an authorizer look configured for something
+ * nothing would apply.
+ */
+export class SimHttpApiAuthorizerOptions {
+  private readonly authorizerType: string;
+
+  constructor(authorizerType: string) {
+    this.authorizerType = authorizerType;
+  }
+
+  /**
+   * Refuse an option this kind of authorizer does not take.
+   */
+  refuse(
+    option: string,
+    value: SimHttpApiAuthorizerOption,
+    reason: string,
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateAuthorizer ${option} is set on a ${this.authorizerType} ` +
+        `authorizer, ${reason}`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-jwt-authorizer-input.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-jwt-authorizer-input.ts
@@ -1,7 +1,11 @@
+import type { SimHttpApiAuthorizerId } from "../../api/authorizer/sim-http-api-authorizer.js";
 import { SimHttpApiIdentitySource } from "../../api/authorizer/sim-http-api-identity-source.js";
+import { SimHttpApiJwtAuthorizer } from "../../api/authorizer/sim-http-api-jwt-authorizer.js";
 import { SimHttpApiJwtConfiguration } from "../../api/authorizer/sim-http-api-jwt-configuration.js";
 import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
 import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+import type { SimHttpApiAuthorizerInput } from "./sim-http-api-authorizer-input.js";
+import { SimHttpApiAuthorizerOptions } from "./sim-http-api-authorizer-options.js";
 
 /**
  * Reads the two structured inputs a JWT authorizer is created from.
@@ -11,17 +15,68 @@ import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
  * and an authorizer with no identity source would look for the token nowhere,
  * and both of those look like a signing problem to whoever hits the route.
  */
-export class SimHttpApiJwtAuthorizerInput {
+export class SimHttpApiJwtAuthorizerInput implements SimHttpApiAuthorizerInput {
   private readonly input: SimCreateAuthorizerCommandInput;
+  private readonly options = new SimHttpApiAuthorizerOptions("JWT");
 
   constructor(input: SimCreateAuthorizerCommandInput) {
     this.input = input;
   }
 
   /**
-   * The one header or query string parameter the token is read from.
+   * The JWT authorizer this input asks for.
    */
-  identitySource(): SimHttpApiIdentitySource {
+  read(authorizerId: SimHttpApiAuthorizerId): SimHttpApiJwtAuthorizer {
+    this.refuseRequestOptions();
+
+    return new SimHttpApiJwtAuthorizer({
+      authorizerId,
+      name: this.input.Name ?? "",
+      identitySource: this.identitySource(),
+      jwtConfiguration: this.jwtConfiguration(),
+    });
+  }
+
+  /**
+   * Refuse the options only a Lambda `REQUEST` authorizer takes.
+   *
+   * Real API Gateway refuses each of these on a JWT authorizer too: there is
+   * no function to invoke, no event to build and no decision to cache.
+   */
+  private refuseRequestOptions(): void {
+    this.options.refuse(
+      "AuthorizerUri",
+      this.input.AuthorizerUri,
+      "which names the function a REQUEST authorizer invokes, and a JWT " +
+        "authorizer invokes nothing",
+    );
+    this.options.refuse(
+      "AuthorizerPayloadFormatVersion",
+      this.input.AuthorizerPayloadFormatVersion,
+      "which is the format a REQUEST authorizer's event is built in, and a " +
+        "JWT authorizer builds no event",
+    );
+    this.options.refuse(
+      "EnableSimpleResponses",
+      this.input.EnableSimpleResponses,
+      "which chooses the shape a REQUEST authorizer answers in, and a JWT " +
+        "authorizer answers nothing",
+    );
+    this.options.refuse(
+      "AuthorizerResultTtlInSeconds",
+      this.input.AuthorizerResultTtlInSeconds,
+      "and a JWT authorizer caches nothing: every request is verified again",
+    );
+  }
+
+  /**
+   * The one header or query string parameter the token is read from.
+   *
+   * A JWT authorizer takes one source and API Gateway refuses a second, so the
+   * rule is here rather than on the command input a `REQUEST` authorizer takes
+   * a list through.
+   */
+  private identitySource(): SimHttpApiIdentitySource {
     const sources = this.input.IdentitySource ?? [];
 
     if (sources.length === 0) {
@@ -33,8 +88,8 @@ export class SimHttpApiJwtAuthorizerInput {
     if (sources.length > 1) {
       throw new SimApiGatewayV2BadRequest(
         `CreateAuthorizer IdentitySource has ${String(sources.length)} ` +
-          `entries: more than one identity source is not simulated, and only ` +
-          `the first would be read here`,
+          `entries: a JWT authorizer takes one, and only the first would be ` +
+          `read here`,
       );
     }
 
@@ -44,7 +99,7 @@ export class SimHttpApiJwtAuthorizerInput {
   /**
    * The issuer this authorizer trusts and the audiences it accepts.
    */
-  jwtConfiguration(): SimHttpApiJwtConfiguration {
+  private jwtConfiguration(): SimHttpApiJwtConfiguration {
     const configuration = this.input.JwtConfiguration;
 
     if (configuration === undefined) {

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-commands.iso.test.ts
@@ -1,0 +1,234 @@
+import {
+  CreateApiCommand,
+  CreateAuthorizerCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  GetAuthorizersCommand,
+  GetRoutesCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const functionArn = "arn:aws:lambda:eu-west-2:111111111111:function:session";
+const issuer = "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_abc123";
+
+async function createdApiId(simAws: SimAws): Promise<string> {
+  const created = await simAws
+    .apiGatewayV2()
+    .createApi(new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }));
+
+  return created.ApiId;
+}
+
+async function createdIntegrationId(
+  simAws: SimAws,
+  apiId: string,
+): Promise<string> {
+  const created = await simAws.apiGatewayV2().createIntegration(
+    new CreateIntegrationCommand({
+      ApiId: apiId,
+      IntegrationType: "AWS_PROXY",
+      IntegrationUri: "arn:aws:lambda:eu-west-2:111111111111:function:orders",
+      PayloadFormatVersion: "2.0",
+    }),
+  );
+
+  return created.IntegrationId;
+}
+
+function createRequestAuthorizer(apiId: string): CreateAuthorizerCommand {
+  return new CreateAuthorizerCommand({
+    ApiId: apiId,
+    Name: "session-cookie",
+    AuthorizerType: "REQUEST",
+    AuthorizerUri: functionArn,
+    AuthorizerPayloadFormatVersion: "2.0",
+    EnableSimpleResponses: true,
+    IdentitySource: ["$request.header.cookie"],
+  });
+}
+
+describe("Creating a sim HTTP API Lambda REQUEST authorizer", () => {
+  it("creates one and reports it back", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When a REQUEST authorizer is created
+    const created = await simAws
+      .apiGatewayV2()
+      .createAuthorizer(createRequestAuthorizer(apiId));
+
+    // Then it reports the function it invokes and the shape it answers in,
+    // and no JwtConfiguration, which it has no use for
+    assertObjectMatches(created, {
+      Name: "session-cookie",
+      AuthorizerType: "REQUEST",
+      AuthorizerUri: functionArn,
+      AuthorizerPayloadFormatVersion: "2.0",
+      EnableSimpleResponses: true,
+      IdentitySource: ["$request.header.cookie"],
+    });
+    assertUndefined(created.JwtConfiguration);
+  });
+
+  it("takes more than one identity source", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer reads two places on the request
+    await simAws.apiGatewayV2().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ApiId: apiId,
+        Name: "two-sources",
+        AuthorizerType: "REQUEST",
+        AuthorizerUri: functionArn,
+        AuthorizerPayloadFormatVersion: "2.0",
+        IdentitySource: [
+          "$request.header.cookie",
+          "$request.querystring.tenant",
+        ],
+      }),
+    );
+
+    // Then both are held, unlike a JWT authorizer, which takes one
+    const listed = await simAws
+      .apiGatewayV2()
+      .getAuthorizers(new GetAuthorizersCommand({ ApiId: apiId }));
+    expect(listed.Items[0]?.IdentitySource).toStrictEqual([
+      "$request.header.cookie",
+      "$request.querystring.tenant",
+    ]);
+  });
+
+  it("takes the wrapped URI form a template writes", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When the authorizer names its function the long way round
+    const created = await simAws.apiGatewayV2().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ApiId: apiId,
+        Name: "wrapped",
+        AuthorizerType: "REQUEST",
+        AuthorizerUri:
+          `arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/` +
+          `${functionArn}/invocations`,
+        AuthorizerPayloadFormatVersion: "2.0",
+        IdentitySource: ["$request.header.cookie"],
+      }),
+    );
+
+    // Then it is held as the function ARN, the way an integration URI is
+    assertIdentical(created.AuthorizerUri, functionArn);
+  });
+
+  it("attaches to a route as CUSTOM authorization", async () => {
+    // Given an API with a REQUEST authorizer and an integration
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+    const integrationId = await createdIntegrationId(simAws, apiId);
+    const authorizer = await simAws
+      .apiGatewayV2()
+      .createAuthorizer(createRequestAuthorizer(apiId));
+
+    // When a route names it
+    await simAws.apiGatewayV2().createRoute(
+      new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: "GET /account",
+        Target: `integrations/${integrationId}`,
+        AuthorizationType: "CUSTOM",
+        AuthorizerId: authorizer.AuthorizerId,
+      }),
+    );
+
+    // Then the route reports what it sends its requests through
+    const routes = await simAws
+      .apiGatewayV2()
+      .getRoutes(new GetRoutesCommand({ ApiId: apiId }));
+    assertObjectMatches(routes.Items[0] ?? {}, {
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: authorizer.AuthorizerId,
+    });
+  });
+
+  it("refuses a route pointing the wrong kind of authorizer at itself", async () => {
+    // Given an API with one authorizer of each kind
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+    const integrationId = await createdIntegrationId(simAws, apiId);
+    const request = await simAws
+      .apiGatewayV2()
+      .createAuthorizer(createRequestAuthorizer(apiId));
+    const jwt = await simAws.apiGatewayV2().createAuthorizer(
+      new CreateAuthorizerCommand({
+        ApiId: apiId,
+        Name: "pool",
+        AuthorizerType: "JWT",
+        IdentitySource: ["$request.header.Authorization"],
+        JwtConfiguration: { Issuer: issuer, Audience: ["client-1"] },
+      }),
+    );
+
+    // When each route names the other kind
+    // Then both are refused, rather than serving a request through an
+    // authorizer that cannot answer for them
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /account",
+          Target: `integrations/${integrationId}`,
+          AuthorizationType: "CUSTOM",
+          AuthorizerId: jwt.AuthorizerId,
+        }),
+      ),
+    ).rejects.toThrow(/names a JWT authorizer.+takes a REQUEST one/);
+
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /orders",
+          Target: `integrations/${integrationId}`,
+          AuthorizationType: "JWT",
+          AuthorizerId: request.AuthorizerId,
+        }),
+      ),
+    ).rejects.toThrow(/names a REQUEST authorizer.+takes a JWT one/);
+  });
+
+  it("refuses route scopes on a route a Lambda authorizer decides", async () => {
+    // Given an API with a REQUEST authorizer
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+    const integrationId = await createdIntegrationId(simAws, apiId);
+    const authorizer = await simAws
+      .apiGatewayV2()
+      .createAuthorizer(createRequestAuthorizer(apiId));
+
+    // When a CUSTOM route asks a caller for a scope
+    // Then it is refused, since AWS applies route scopes to a JWT route only
+    await expect(
+      simAws.apiGatewayV2().createRoute(
+        new CreateRouteCommand({
+          ApiId: apiId,
+          RouteKey: "GET /account",
+          Target: `integrations/${integrationId}`,
+          AuthorizationType: "CUSTOM",
+          AuthorizerId: authorizer.AuthorizerId,
+          AuthorizationScopes: ["account.read"],
+        }),
+      ),
+    ).rejects.toThrow(/AuthorizationScopes is set on a route with/);
+  });
+});

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-input.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-input.ts
@@ -38,6 +38,7 @@ export class SimHttpApiRequestAuthorizerInput implements SimHttpApiAuthorizerInp
       "and a REQUEST authorizer verifies no token: its function decides",
     );
     this.refuseResultCache();
+    this.requirePayloadFormatVersion();
 
     return new SimHttpApiRequestAuthorizer({
       authorizerId,
@@ -62,8 +63,6 @@ export class SimHttpApiRequestAuthorizerInput implements SimHttpApiAuthorizerInp
         "CreateAuthorizer with AuthorizerType REQUEST requires AuthorizerUri",
       );
     }
-
-    this.requirePayloadFormatVersion();
 
     return SimHttpApiLambdaUri.parseAuthorizerUri(uri);
   }

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-input.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-input.ts
@@ -1,0 +1,143 @@
+import type { SimHttpApiAuthorizerId } from "../../api/authorizer/sim-http-api-authorizer.js";
+import { SimHttpApiIdentitySource } from "../../api/authorizer/sim-http-api-identity-source.js";
+import { SimHttpApiIdentitySources } from "../../api/authorizer/sim-http-api-identity-sources.js";
+import {
+  simHttpApiAuthorizerPayloadFormatVersion,
+  SimHttpApiRequestAuthorizer,
+} from "../../api/authorizer/sim-http-api-request-authorizer.js";
+import { SimHttpApiLambdaUri } from "../../api/integration/sim-http-api-lambda-uri.js";
+import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
+import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+import type { SimCreateAuthorizerCommandInput } from "./authorizer.command.js";
+import type { SimHttpApiAuthorizerInput } from "./sim-http-api-authorizer-input.js";
+import { SimHttpApiAuthorizerOptions } from "./sim-http-api-authorizer-options.js";
+
+/**
+ * Reads the inputs a Lambda `REQUEST` authorizer is created from.
+ *
+ * The function and the payload format are both required rather than defaulted.
+ * An authorizer naming no function has nothing to ask, and API Gateway itself
+ * defaults the payload format to `1.0`, which builds a different event and is
+ * refused across this simulation, so it is named rather than assumed.
+ */
+export class SimHttpApiRequestAuthorizerInput implements SimHttpApiAuthorizerInput {
+  private readonly input: SimCreateAuthorizerCommandInput;
+  private readonly options = new SimHttpApiAuthorizerOptions("REQUEST");
+
+  constructor(input: SimCreateAuthorizerCommandInput) {
+    this.input = input;
+  }
+
+  /**
+   * The `REQUEST` authorizer this input asks for.
+   */
+  read(authorizerId: SimHttpApiAuthorizerId): SimHttpApiRequestAuthorizer {
+    this.options.refuse(
+      "JwtConfiguration",
+      this.input.JwtConfiguration,
+      "and a REQUEST authorizer verifies no token: its function decides",
+    );
+    this.refuseResultCache();
+
+    return new SimHttpApiRequestAuthorizer({
+      authorizerId,
+      name: this.input.Name ?? "",
+      lambdaUri: this.lambdaUri(),
+      identitySources: this.identitySources(),
+      enableSimpleResponses: this.input.EnableSimpleResponses ?? false,
+    });
+  }
+
+  /**
+   * The function this authorizer invokes.
+   *
+   * An `AuthorizerUri` is written in the same wrapped form an integration URI
+   * is, so it is read by the same parser and refused for the same reasons.
+   */
+  private lambdaUri(): SimHttpApiLambdaUri {
+    const uri = this.input.AuthorizerUri;
+
+    if (uri === undefined || uri.length === 0) {
+      throw new SimApiGatewayV2BadRequest(
+        "CreateAuthorizer with AuthorizerType REQUEST requires AuthorizerUri",
+      );
+    }
+
+    this.requirePayloadFormatVersion();
+
+    return SimHttpApiLambdaUri.parseAuthorizerUri(uri);
+  }
+
+  /**
+   * Require payload format 2.0 by name.
+   *
+   * A `REQUEST` authorizer with no payload format is a `1.0` authorizer on
+   * real AWS, which builds a different event and answers in a different shape,
+   * so an unstated format is refused rather than read as the one simulated.
+   */
+  private requirePayloadFormatVersion(): void {
+    const version = this.input.AuthorizerPayloadFormatVersion;
+
+    if (version === undefined) {
+      throw new SimApiGatewayV2BadRequest(
+        "CreateAuthorizer with AuthorizerType REQUEST requires " +
+          "AuthorizerPayloadFormatVersion: AWS defaults it to '1.0', which " +
+          "builds a different event and is not simulated",
+      );
+    }
+
+    new SimApiGatewayV2UnsimulatedInput("CreateAuthorizer").refuseUnless(
+      "AuthorizerPayloadFormatVersion",
+      version,
+      simHttpApiAuthorizerPayloadFormatVersion,
+      "a 1.0 authorizer receives a different event and answers a policy " +
+        "against a method ARN, and none of that is built here",
+    );
+  }
+
+  /**
+   * Refuse a result cache, which is a decision this simulation never reuses.
+   *
+   * Zero is the value that switches caching off, so it is what an authorizer
+   * behaving as this one does is configured with, and is accepted.
+   */
+  private refuseResultCache(): void {
+    const ttl = this.input.AuthorizerResultTtlInSeconds;
+
+    if (ttl === undefined || ttl === 0) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateAuthorizer AuthorizerResultTtlInSeconds is ${String(ttl)}: ` +
+        `caching an authorizer's decision is not simulated, so every request ` +
+        `would invoke the function here and one in ${String(ttl)} would on ` +
+        `real AWS`,
+    );
+  }
+
+  /**
+   * The identity sources every request has to carry before the function is
+   * invoked at all.
+   *
+   * At least one is required. An authorizer with none is invoked for every
+   * request on real AWS, including requests carrying nothing, and that is a
+   * different thing from the authorizer this simulation runs, so it is refused
+   * rather than treated as an authorizer nothing gates.
+   */
+  private identitySources(): SimHttpApiIdentitySources {
+    const sources = this.input.IdentitySource ?? [];
+
+    if (sources.length === 0) {
+      throw new SimApiGatewayV2BadRequest(
+        "CreateAuthorizer requires IdentitySource: an authorizer with none " +
+          "is invoked for every request on AWS, including one carrying " +
+          "nothing, and that is not simulated",
+      );
+    }
+
+    return new SimHttpApiIdentitySources(
+      sources.map((source) => SimHttpApiIdentitySource.parse(source)),
+    );
+  }
+}

--- a/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-refusals.iso.test.ts
+++ b/src/service/apigatewayv2/command/authorizer/sim-http-api-request-authorizer-refusals.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  CreateApiCommand,
+  CreateAuthorizerCommand,
+  type CreateAuthorizerCommandInput,
+} from "@aws-sdk/client-apigatewayv2";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const functionArn = "arn:aws:lambda:eu-west-2:111111111111:function:session";
+const issuer = "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_abc123";
+
+async function createdApiId(simAws: SimAws): Promise<string> {
+  const created = await simAws
+    .apiGatewayV2()
+    .createApi(new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }));
+
+  return created.ApiId;
+}
+
+/**
+ * A REQUEST authorizer input with one member changed, so each test says only
+ * what it is about.
+ */
+function requestAuthorizer(
+  apiId: string,
+  changed: Partial<CreateAuthorizerCommandInput>,
+): CreateAuthorizerCommand {
+  return new CreateAuthorizerCommand({
+    ApiId: apiId,
+    Name: "session-cookie",
+    AuthorizerType: "REQUEST",
+    AuthorizerUri: functionArn,
+    AuthorizerPayloadFormatVersion: "2.0",
+    IdentitySource: ["$request.header.cookie"],
+    ...changed,
+  });
+}
+
+describe("What a Lambda REQUEST authorizer refuses rather than ignores", () => {
+  it("refuses payload format 1.0, and an unstated format", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer asks for the older payload format, and when it says
+    // nothing, which is the same thing on AWS
+    // Then both are refused by name, since a 1.0 authorizer receives a
+    // different event and answers against a different ARN
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .createAuthorizer(
+          requestAuthorizer(apiId, { AuthorizerPayloadFormatVersion: "1.0" }),
+        ),
+    ).rejects.toThrow(/AuthorizerPayloadFormatVersion '1.0' is not simulated/);
+
+    await expect(
+      simAws.apiGatewayV2().createAuthorizer(
+        new CreateAuthorizerCommand({
+          ApiId: apiId,
+          Name: "unstated",
+          AuthorizerType: "REQUEST",
+          AuthorizerUri: functionArn,
+          IdentitySource: ["$request.header.cookie"],
+        }),
+      ),
+    ).rejects.toThrow(/AWS defaults it to '1.0'/);
+  });
+
+  it("refuses a result cache, and accepts the value that switches it off", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer asks for its decision to be cached
+    // Then it is refused, because every request here invokes the function
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .createAuthorizer(
+          requestAuthorizer(apiId, { AuthorizerResultTtlInSeconds: 300 }),
+        ),
+    ).rejects.toThrow(/caching an authorizer's decision is not simulated/);
+
+    // And when it asks for no caching at all, that is what this one does
+    const created = await simAws
+      .apiGatewayV2()
+      .createAuthorizer(
+        requestAuthorizer(apiId, { AuthorizerResultTtlInSeconds: 0 }),
+      );
+    expect(created.AuthorizerId).toHaveLength(6);
+  });
+
+  it("refuses the Role API Gateway would assume to invoke the function", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer names credentials to invoke its function with
+    // Then it is refused, since the function's own resource policy is what
+    // decides here and the Role would apply on AWS
+    await expect(
+      simAws.apiGatewayV2().createAuthorizer(
+        new CreateAuthorizerCommand({
+          ApiId: apiId,
+          Name: "credentialed",
+          AuthorizerType: "REQUEST",
+          AuthorizerUri: functionArn,
+          AuthorizerPayloadFormatVersion: "2.0",
+          IdentitySource: ["$request.header.cookie"],
+          AuthorizerCredentialsArn: "arn:aws:iam::111111111111:role/Invoker",
+        }),
+      ),
+    ).rejects.toThrow(/AuthorizerCredentialsArn is not simulated/);
+  });
+
+  it("requires a function, and one it could invoke", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer names no function, then a qualified one
+    // Then each is refused rather than created with nothing to ask
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .createAuthorizer(requestAuthorizer(apiId, { AuthorizerUri: "" })),
+    ).rejects.toThrow(/AuthorizerType REQUEST requires AuthorizerUri/);
+
+    await expect(
+      simAws.apiGatewayV2().createAuthorizer(
+        requestAuthorizer(apiId, {
+          AuthorizerUri: `${functionArn}:live`,
+        }),
+      ),
+    ).rejects.toThrow(/AuthorizerUri .+ is not a simulated invocation target/);
+  });
+
+  it("requires an identity source, and one it would read", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When an authorizer names none, then one naming neither a header nor a
+    // query string parameter
+    // Then each is refused: an authorizer with no source runs for every
+    // request on AWS, and a `$context` source is read from nowhere here
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .createAuthorizer(requestAuthorizer(apiId, { IdentitySource: [] })),
+    ).rejects.toThrow(/CreateAuthorizer requires IdentitySource/);
+
+    await expect(
+      simAws.apiGatewayV2().createAuthorizer(
+        requestAuthorizer(apiId, {
+          IdentitySource: ["$context.identity.sourceIp"],
+        }),
+      ),
+    ).rejects.toThrow(/IdentitySource '\$context.identity.sourceIp'/);
+  });
+
+  it("refuses a JwtConfiguration on a REQUEST authorizer", async () => {
+    // Given an API
+    const simAws = new SimAws();
+    const apiId = await createdApiId(simAws);
+
+    // When a REQUEST authorizer also states an issuer
+    // Then it is refused, since its function decides and nothing here would
+    // verify a token against that issuer
+    await expect(
+      simAws.apiGatewayV2().createAuthorizer(
+        requestAuthorizer(apiId, {
+          JwtConfiguration: { Issuer: issuer, Audience: ["client-1"] },
+        }),
+      ),
+    ).rejects.toThrow(/JwtConfiguration is set on a REQUEST authorizer/);
+  });
+});

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-authorization-options.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-authorization-options.ts
@@ -1,0 +1,86 @@
+import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
+import type { SimCreateRouteCommandInput } from "./route.command.js";
+
+/**
+ * Refuses the options a route's authorization type has no use for.
+ *
+ * An authorizer nothing would ask, or a scope nothing would check, is refused
+ * rather than stored, so a route cannot report a restriction that applies to
+ * none of its requests. Refusing scopes anywhere but on a `JWT` route is
+ * stricter than AWS, which documents route scopes as meaningful only there and
+ * ignores them elsewhere. Accepting them would let a test assert on a scope
+ * restriction that nothing applies.
+ */
+export class SimHttpApiRouteAuthorizationOptions {
+  private readonly input: SimCreateRouteCommandInput;
+
+  constructor(input: SimCreateRouteCommandInput) {
+    this.input = input;
+  }
+
+  /**
+   * Refuse what a route that authorizes nobody has no use for.
+   */
+  refuseOnOpenRoute(): void {
+    this.refuseAuthorizerId(
+      "NONE",
+      "which would be ignored here and would leave the route open on AWS too",
+    );
+    this.refuseAuthorizationScopes(
+      "NONE",
+      "and nothing checks a scope on a route that authorizes nobody",
+    );
+  }
+
+  /**
+   * Refuse what a route IAM decides has no use for.
+   */
+  refuseOnIamRoute(): void {
+    this.refuseAuthorizerId(
+      "AWS_IAM",
+      "and IAM itself decides an AWS_IAM route, so there is no authorizer to " +
+        "send the request through",
+    );
+    this.refuseAuthorizationScopes(
+      "AWS_IAM",
+      "and AWS applies route scopes to a JWT route only, so a scope written " +
+        "here would restrict nothing",
+    );
+  }
+
+  /**
+   * Refuse what a route a Lambda authorizer decides has no use for.
+   */
+  refuseOnCustomRoute(): void {
+    this.refuseAuthorizationScopes(
+      "CUSTOM",
+      "and AWS applies route scopes to a JWT route only: what a Lambda " +
+        "authorizer accepts is the function's own business",
+    );
+  }
+
+  private refuseAuthorizerId(authorizationType: string, reason: string): void {
+    if (this.input.AuthorizerId === undefined) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateRoute AuthorizerId is set on a route with AuthorizationType ` +
+        `${authorizationType}, ${reason}`,
+    );
+  }
+
+  private refuseAuthorizationScopes(
+    authorizationType: string,
+    reason: string,
+  ): void {
+    if ((this.input.AuthorizationScopes ?? []).length === 0) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `CreateRoute AuthorizationScopes is set on a route with ` +
+        `AuthorizationType ${authorizationType}, ${reason}`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-authorization.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-authorization.ts
@@ -1,9 +1,13 @@
-import type { SimHttpApiAuthorizerId } from "../../api/authorizer/sim-http-api-authorizer.js";
+import type {
+  SimHttpApiAuthorizerId,
+  SimHttpApiAuthorizerType,
+} from "../../api/authorizer/sim-http-api-authorizer.js";
 import type { SimHttpApiAuthorizationType } from "../../api/route/sim-http-api-route.js";
 import { SimHttpApiRouteScopes } from "../../api/route/sim-http-api-route-scopes.js";
 import type { SimHttpApi } from "../../api/sim-http-api.js";
-import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
 import type { SimCreateRouteCommandInput } from "./route.command.js";
+import { SimHttpApiRouteAuthorizationOptions } from "./sim-http-api-route-authorization-options.js";
+import { SimHttpApiRouteAuthorizerInput } from "./sim-http-api-route-authorizer-input.js";
 
 /**
  * How a route says who may call it.
@@ -18,16 +22,19 @@ export interface SimHttpApiRouteAuthorization {
  * Reads the authorization a CreateRoute input asks for, against the API it is
  * being created on.
  *
- * A `JWT` route has to name an authorizer the API has. A route deploying with
- * an `AuthorizerId` that resolved to nothing would be open here and closed on
- * AWS, which is the failure this whole area exists to avoid, so it is refused
- * rather than created.
+ * A `JWT` and a `CUSTOM` route each name an authorizer, and the other two name
+ * none. Which options each type has a use for is
+ * `SimHttpApiRouteAuthorizationOptions`, and finding the authorizer named is
+ * `SimHttpApiRouteAuthorizerInput`, so what is left here is which of the four
+ * a route asked for.
  */
 export class SimHttpApiRouteAuthorizationInput {
   private readonly input: SimCreateRouteCommandInput;
+  private readonly options: SimHttpApiRouteAuthorizationOptions;
 
   constructor(input: SimCreateRouteCommandInput) {
     this.input = input;
+    this.options = new SimHttpApiRouteAuthorizationOptions(input);
   }
 
   /**
@@ -44,13 +51,11 @@ export class SimHttpApiRouteAuthorizationInput {
       return this.iam();
     }
 
-    return {
-      authorizationType: "JWT",
-      authorizerId: this.authorizer(api),
-      authorizationScopes: new SimHttpApiRouteScopes(
-        this.input.AuthorizationScopes ?? [],
-      ),
-    };
+    if (authorizationType === "CUSTOM") {
+      return this.custom(api);
+    }
+
+    return this.jwt(api);
   }
 
   /**
@@ -58,14 +63,7 @@ export class SimHttpApiRouteAuthorizationInput {
    * `AuthorizationType` out.
    */
   private open(): SimHttpApiRouteAuthorization {
-    this.refuseAuthorizerId(
-      "NONE",
-      "which would be ignored here and would leave the route open on AWS too",
-    );
-    this.refuseAuthorizationScopes(
-      "NONE",
-      "and nothing checks a scope on a route that authorizes nobody",
-    );
+    this.options.refuseOnOpenRoute();
 
     return {
       authorizationType: "NONE",
@@ -75,22 +73,9 @@ export class SimHttpApiRouteAuthorizationInput {
 
   /**
    * A route IAM decides, which takes neither an authorizer nor scopes.
-   *
-   * Refusing scopes is stricter than AWS, which documents route scopes as
-   * meaningful only for `JWT` and ignores them for `AWS_IAM`. Accepting them
-   * here would let a test assert on a scope restriction that nothing applies.
    */
   private iam(): SimHttpApiRouteAuthorization {
-    this.refuseAuthorizerId(
-      "AWS_IAM",
-      "and IAM itself decides an AWS_IAM route, so there is no authorizer to " +
-        "send the request through",
-    );
-    this.refuseAuthorizationScopes(
-      "AWS_IAM",
-      "and AWS applies route scopes to a JWT route only, so a scope written " +
-        "here would restrict nothing",
-    );
+    this.options.refuseOnIamRoute();
 
     return {
       authorizationType: "AWS_IAM",
@@ -99,54 +84,39 @@ export class SimHttpApiRouteAuthorizationInput {
   }
 
   /**
-   * Refuse an `AuthorizerId` on an authorization type that takes none.
+   * A route a Lambda `REQUEST` authorizer decides, which takes no scopes.
    */
-  private refuseAuthorizerId(authorizationType: string, reason: string): void {
-    if (this.input.AuthorizerId === undefined) {
-      return;
-    }
+  private custom(api: SimHttpApi): SimHttpApiRouteAuthorization {
+    this.options.refuseOnCustomRoute();
 
-    throw new SimApiGatewayV2BadRequest(
-      `CreateRoute AuthorizerId is set on a route with AuthorizationType ` +
-        `${authorizationType}, ${reason}`,
-    );
+    return {
+      authorizationType: "CUSTOM",
+      authorizerId: this.authorizer(api, "REQUEST"),
+      authorizationScopes: new SimHttpApiRouteScopes(),
+    };
   }
 
   /**
-   * Refuse `AuthorizationScopes` on an authorization type that checks none.
+   * A route a JWT authorizer decides, which is the one kind route scopes
+   * apply to.
    */
-  private refuseAuthorizationScopes(
-    authorizationType: string,
-    reason: string,
-  ): void {
-    if ((this.input.AuthorizationScopes ?? []).length === 0) {
-      return;
-    }
-
-    throw new SimApiGatewayV2BadRequest(
-      `CreateRoute AuthorizationScopes is set on a route with ` +
-        `AuthorizationType ${authorizationType}, ${reason}`,
-    );
+  private jwt(api: SimHttpApi): SimHttpApiRouteAuthorization {
+    return {
+      authorizationType: "JWT",
+      authorizerId: this.authorizer(api, "JWT"),
+      authorizationScopes: new SimHttpApiRouteScopes(
+        this.input.AuthorizationScopes ?? [],
+      ),
+    };
   }
 
-  private authorizer(api: SimHttpApi): SimHttpApiAuthorizerId {
-    const authorizerId = this.input.AuthorizerId;
-
-    if (authorizerId === undefined || authorizerId.length === 0) {
-      throw new SimApiGatewayV2BadRequest(
-        "CreateRoute with AuthorizationType JWT requires AuthorizerId",
-      );
-    }
-
-    const authorizer = api.authorizers.find(authorizerId);
-
-    if (authorizer === undefined) {
-      throw new SimApiGatewayV2BadRequest(
-        `CreateRoute AuthorizerId ${authorizerId} names no authorizer on ` +
-          `API ${api.apiId}. The route would be open here and closed on AWS.`,
-      );
-    }
-
-    return authorizer.authorizerId;
+  private authorizer(
+    api: SimHttpApi,
+    authorizerType: SimHttpApiAuthorizerType,
+  ): SimHttpApiAuthorizerId {
+    return new SimHttpApiRouteAuthorizerInput({
+      authorizationType: this.input.AuthorizationType ?? "",
+      authorizerId: this.input.AuthorizerId,
+    }).read(api, authorizerType);
   }
 }

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-authorizer-input.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-authorizer-input.ts
@@ -1,0 +1,67 @@
+import type {
+  SimHttpApiAuthorizerId,
+  SimHttpApiAuthorizerType,
+} from "../../api/authorizer/sim-http-api-authorizer.js";
+import type { SimHttpApi } from "../../api/sim-http-api.js";
+import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
+
+interface SimHttpApiRouteAuthorizerInputProperties {
+  /** The route's own authorization type, which names the kind it needs. */
+  readonly authorizationType: string;
+  readonly authorizerId: string | undefined;
+}
+
+/**
+ * Finds the authorizer a route names, of the kind that route authorizes with.
+ *
+ * A route deploying with an `AuthorizerId` that resolved to nothing, or to the
+ * other kind of authorizer, would be open here and closed on AWS, which is the
+ * failure this whole area exists to avoid, so both are refused rather than
+ * created.
+ */
+export class SimHttpApiRouteAuthorizerInput {
+  private readonly authorizationType: string;
+  private readonly authorizerId: string | undefined;
+
+  constructor(properties: SimHttpApiRouteAuthorizerInputProperties) {
+    this.authorizationType = properties.authorizationType;
+    this.authorizerId = properties.authorizerId;
+  }
+
+  /**
+   * The id of the authorizer this route sends its requests through.
+   */
+  read(
+    api: SimHttpApi,
+    authorizerType: SimHttpApiAuthorizerType,
+  ): SimHttpApiAuthorizerId {
+    const authorizerId = this.authorizerId;
+
+    if (authorizerId === undefined || authorizerId.length === 0) {
+      throw new SimApiGatewayV2BadRequest(
+        `CreateRoute with AuthorizationType ${this.authorizationType} ` +
+          `requires AuthorizerId`,
+      );
+    }
+
+    const authorizer = api.authorizers.find(authorizerId);
+
+    if (authorizer === undefined) {
+      throw new SimApiGatewayV2BadRequest(
+        `CreateRoute AuthorizerId ${authorizerId} names no authorizer on ` +
+          `API ${api.apiId}. The route would be open here and closed on AWS.`,
+      );
+    }
+
+    if (authorizer.authorizerType !== authorizerType) {
+      throw new SimApiGatewayV2BadRequest(
+        `CreateRoute AuthorizerId ${authorizerId} names a ` +
+          `${authorizer.authorizerType} authorizer on API ${api.apiId}, and ` +
+          `an AuthorizationType of ${this.authorizationType} takes a ` +
+          `${authorizerType} one`,
+      );
+    }
+
+    return authorizer.authorizerId;
+  }
+}

--- a/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
+++ b/src/service/apigatewayv2/command/route/sim-http-api-route-commands.ts
@@ -24,12 +24,10 @@ const acceptedCreateRouteOptions = [
 ];
 
 /**
- * The authorization types a route may ask for.
- *
- * `CUSTOM`, a Lambda authorizer, is refused rather than created open: a route
- * asking for it would admit anyone here and refuse them on AWS.
+ * The authorization types a route may ask for, which is every one an HTTP API
+ * route has.
  */
-const simulatedAuthorizationTypes = ["NONE", "JWT", "AWS_IAM"];
+const simulatedAuthorizationTypes = ["NONE", "JWT", "AWS_IAM", "CUSTOM"];
 
 interface SimHttpApiRouteCommandsProperties {
   readonly access: SimHttpApiAccess;
@@ -67,7 +65,7 @@ export class SimHttpApiRouteCommands {
       "AuthorizationType",
       input.AuthorizationType,
       simulatedAuthorizationTypes,
-      "Lambda route authorization is not simulated",
+      "an HTTP API route authorizes with one of these and nothing else",
     );
     const target = unsimulated.require("Target", input.Target);
 

--- a/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
+++ b/src/service/apigatewayv2/command/sim-api-gateway-v2-validation.iso.test.ts
@@ -124,24 +124,26 @@ describe("What sim API Gateway v2 refuses rather than ignores", () => {
     ).rejects.toThrow(/IntegrationType 'HTTP_PROXY' is not simulated/);
   });
 
-  it("refuses a route with an authorization type that is not simulated", async () => {
+  it("refuses a route with an authorization type AWS does not have", async () => {
     // Given an API
     const simAws = new SimAws();
     const apiId = await createdApiId(simAws);
 
-    // When a route asks for a Lambda authorizer
-    // Then it is refused, because nothing here runs the code that would make
-    // the decision and the route would be open where the real one is closed
+    // When a route asks for something that is not an authorization type. The
+    // command is sent structurally rather than through the SDK, since the SDK
+    // types allow only the four values AWS has.
+    // Then it is refused, rather than created open because nothing recognised
+    // what it asked for
     await expect(
-      simAws.apiGatewayV2().createRoute(
-        new CreateRouteCommand({
+      simAws.apiGatewayV2().createRoute({
+        input: {
           ApiId: apiId,
           RouteKey: "$default",
           Target: "integrations/abcdefgh",
-          AuthorizationType: "CUSTOM",
-        }),
-      ),
-    ).rejects.toThrow(/AuthorizationType 'CUSTOM' is not simulated/);
+          AuthorizationType: "LAMBDA",
+        },
+      }),
+    ).rejects.toThrow(/AuthorizationType 'LAMBDA' is not simulated/);
   });
 
   it("refuses a JWT route naming no authorizer of its API", async () => {

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -28,7 +28,13 @@ export {
   type SimHttpApiAuthorizerType,
   type SimHttpApiAuthorizerView,
 } from "./api/authorizer/sim-http-api-authorizer.js";
+export { SimHttpApiJwtAuthorizer } from "./api/authorizer/sim-http-api-jwt-authorizer.js";
+export {
+  simHttpApiAuthorizerPayloadFormatVersion,
+  SimHttpApiRequestAuthorizer,
+} from "./api/authorizer/sim-http-api-request-authorizer.js";
 export { SimHttpApiIdentitySource } from "./api/authorizer/sim-http-api-identity-source.js";
+export { SimHttpApiIdentitySources } from "./api/authorizer/sim-http-api-identity-sources.js";
 export {
   SimHttpApiJwtConfiguration,
   type SimHttpApiJwtConfigurationView,
@@ -72,12 +78,14 @@ export {
   SimApiGatewayV2Error,
   SimApiGatewayV2NotFound,
 } from "./error/sim-api-gateway-v2.error.js";
+export type { SimHttpApiAuthorizerEvent } from "./serve/auth/sim-http-api-authorizer-event.js";
 export type {
   SimPayload2AuthorizerContext,
   SimPayload2Event,
   SimPayload2HttpContext,
   SimPayload2IamAuthorizer,
   SimPayload2JwtAuthorizer,
+  SimPayload2LambdaAuthorizer,
   SimPayload2RequestContext,
   SimPayload2Result,
 } from "../../serve/payload-2/sim-payload-2-event.type.js";

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme.ts
@@ -79,8 +79,9 @@ export class SimHttpApiOpenApiSecurityScheme {
       throw authorizer
         .member("type")
         .refusal(
-          "is not jwt, and a JWT authorizer is the only kind simulated: a " +
-            "Lambda authorizer runs code of its own to decide",
+          "is not jwt, and a JWT authorizer is the only kind an imported " +
+            "document creates. Create a Lambda REQUEST authorizer with " +
+            "CreateAuthorizer instead",
         );
     }
 

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-security.iso.test.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-security.iso.test.ts
@@ -72,7 +72,7 @@ describe("Importing a sim HTTP API's JWT authorizers", () => {
     expect(authorizer.IdentitySource).toStrictEqual([
       "$request.header.Authorization",
     ]);
-    assertIdentical(authorizer.JwtConfiguration.Issuer, issuer);
+    assertIdentical(authorizer.JwtConfiguration?.Issuer, issuer);
 
     // And the operation's route is the one pointed at that authorizer, asking
     // a token for the scopes the requirement named

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-event.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-event.ts
@@ -1,0 +1,119 @@
+import type { SimPayload2Endpoint } from "../../../../serve/payload-2/sim-payload-2-endpoint.js";
+import { SimPayload2EventBuilder } from "../../../../serve/payload-2/sim-payload-2-event-builder.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+
+/**
+ * The event a payload format 2.0 Lambda `REQUEST` authorizer is invoked with.
+ *
+ * It is the payload format 2.0 request event with three members added and the
+ * body left out. AWS's own example of this event carries no `body` and no
+ * `isBase64Encoded`, which is the one published account of what an authorizer
+ * receives, so neither is sent here: an authorizer written against a body it
+ * would not get on AWS is exactly the divergence worth refusing to create.
+ */
+export interface SimHttpApiAuthorizerEvent extends Omit<
+  SimPayload2Event,
+  "body" | "isBase64Encoded"
+> {
+  type: "REQUEST";
+  /**
+   * The route the request matched, as an `execute-api` ARN. A policy response
+   * is evaluated against this same ARN.
+   */
+  routeArn: string;
+  /**
+   * What the request carried at each of the authorizer's identity sources, in
+   * the order they were configured. These are the values, not the expressions
+   * that found them.
+   */
+  identitySource: string[];
+}
+
+interface SimHttpApiAuthorizerEventInput {
+  readonly request: Request;
+  readonly endpoint: SimPayload2Endpoint;
+  readonly routeArn: string;
+  readonly identitySource: readonly string[];
+}
+
+interface SimHttpApiAuthorizerEventBuilderProperties {
+  /** Clock stamping the event's requestContext time. */
+  readonly clock: SimClock;
+}
+
+/**
+ * Builds the event a Lambda `REQUEST` authorizer is invoked with.
+ *
+ * The members are copied across one at a time rather than spread, so what an
+ * authorizer receives is stated here rather than following from whatever the
+ * integration event happens to hold.
+ */
+export class SimHttpApiAuthorizerEventBuilder {
+  private readonly eventBuilder: SimPayload2EventBuilder;
+
+  constructor(properties: SimHttpApiAuthorizerEventBuilderProperties) {
+    this.eventBuilder = new SimPayload2EventBuilder({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Build the authorizer event for one request.
+   */
+  async build(
+    input: SimHttpApiAuthorizerEventInput,
+  ): Promise<SimHttpApiAuthorizerEvent> {
+    // The request is cloned because reading it consumes its body, and the
+    // integration behind the route still has to build an event of its own from
+    // the same request.
+    const requestEvent = await this.eventBuilder.build(
+      input.request.clone(),
+      input.endpoint,
+    );
+
+    const event: SimHttpApiAuthorizerEvent = {
+      version: requestEvent.version,
+      type: "REQUEST",
+      routeArn: input.routeArn,
+      identitySource: [...input.identitySource],
+      routeKey: requestEvent.routeKey,
+      rawPath: requestEvent.rawPath,
+      rawQueryString: requestEvent.rawQueryString,
+      headers: requestEvent.headers,
+      requestContext: requestEvent.requestContext,
+    };
+
+    this.addPresentFields(event, requestEvent);
+
+    return event;
+  }
+
+  /**
+   * Copy across the members the request only sometimes has, which the event
+   * builder leaves out when it has nothing to put there.
+   */
+  private addPresentFields(
+    event: SimHttpApiAuthorizerEvent,
+    requestEvent: SimPayload2Event,
+  ): void {
+    const { cookies, queryStringParameters, pathParameters, stageVariables } =
+      requestEvent;
+
+    if (cookies !== undefined) {
+      event.cookies = cookies;
+    }
+
+    if (queryStringParameters !== undefined) {
+      event.queryStringParameters = queryStringParameters;
+    }
+
+    if (pathParameters !== undefined) {
+      event.pathParameters = pathParameters;
+    }
+
+    if (stageVariables !== undefined) {
+      event.stageVariables = stageVariables;
+    }
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
@@ -1,0 +1,59 @@
+import { SimIamEitherSideAllowRequirement } from "../../../iam/authorize/allow/sim-iam-allow-requirement.js";
+import { SimIamPolicyDecision } from "../../../iam/authorize/sim-iam-decision.js";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import { simExecuteApiInvokeAction } from "./sim-http-api-iam-route-authorizer.js";
+
+/**
+ * The IAM policy document a Lambda authorizer answers with, evaluated for
+ * `execute-api:Invoke` on the route the request matched.
+ *
+ * This is the same evaluation an `AWS_IAM` route goes through, with one
+ * difference: the document the authorizer returned is the whole decision.
+ * There are no stored policies to gather, because there is no IAM principal
+ * here at all. The `principalId` the authorizer returns alongside is a name it
+ * chose for the caller rather than anything IAM knows, so it identifies the
+ * caller in the authorizer's own logs and grants nothing.
+ *
+ * An explicit Deny still wins over an Allow, and a document allowing nothing
+ * relevant refuses the request, which is how IAM reads any policy.
+ */
+export class SimHttpApiAuthorizerPolicy {
+  private readonly document: SimIamPolicyDocument;
+
+  constructor(document: SimIamPolicyDocument) {
+    this.document = document;
+  }
+
+  /**
+   * Whether this document allows the request to reach the route.
+   *
+   * Throws the way IAM does for a document it cannot read, which the caller
+   * answers with the same 500 any other unusable authorizer response gets.
+   */
+  allows(routeArn: string): boolean {
+    return new SimIamPolicyDecision({
+      // The document is evaluated as the identity side, which is the side with
+      // no Principal to state: an authorizer's policy says what the caller it
+      // just identified may do, not who may reach the route.
+      identityPolicies: [
+        {
+          sourceType: "identity-inline",
+          document: this.document,
+          policyName: "AuthorizerPolicyDocument",
+        },
+      ],
+      resourcePolicies: [],
+      allowRequirement: new SimIamEitherSideAllowRequirement(),
+      action: simExecuteApiInvokeAction,
+      resource: routeArn,
+      conditionContext: {},
+      // There is no principal behind this document, and nothing in it can name
+      // one, so the caller is anonymous. A condition on a principal key
+      // therefore never matches, which is the strict direction to be wrong in.
+      caller: {
+        principal: { kind: "anonymous" },
+        identityPolicyPrincipal: { kind: "anonymous" },
+      },
+    }).isAllowed;
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-response.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-response.ts
@@ -1,0 +1,155 @@
+import type { SimPayload2LambdaAuthorizer } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimIamPolicyDocument } from "../../../iam/policy/sim-iam-policy.js";
+import {
+  SimHttpApiAdmitted,
+  type SimHttpApiAuthorization,
+  SimHttpApiRefused,
+} from "../../api/authorizer/sim-http-api-authorization.js";
+import type { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-api-request-authorizer.js";
+import { SimHttpApiAuthorizerPolicy } from "./sim-http-api-authorizer-policy.js";
+
+/**
+ * The one message a Lambda authorizer answers a 401 with.
+ */
+const unauthorizedErrorMessage = "Unauthorized";
+
+/**
+ * Whether the returned `policyDocument` is worth handing to IAM at all.
+ *
+ * Only its outer shape is checked here. What is inside it is IAM's business,
+ * and a document IAM cannot read is a response API Gateway could not have used
+ * either, so both end up as the same 500.
+ */
+function isPolicyDocument(value: unknown): value is SimIamPolicyDocument {
+  return isRecord(value);
+}
+
+interface SimHttpApiAuthorizerResponseProperties {
+  readonly authorizer: SimHttpApiRequestAuthorizer;
+  /** The route ARN a policy response is evaluated against. */
+  readonly routeArn: string;
+}
+
+/**
+ * Reads what a Lambda `REQUEST` authorizer answered.
+ *
+ * There are two shapes, and `EnableSimpleResponses` says which one applies:
+ * `{ isAuthorized, context }`, or a `principalId` with an IAM `policyDocument`
+ * that has to allow `execute-api:Invoke` on the route. A response that is not
+ * the shape its authorizer was configured for is a 500 rather than a refusal,
+ * because API Gateway could not read it either.
+ *
+ * `{ "errorMessage": "Unauthorized" }` is the one answer that produces a 401,
+ * and it is read whichever shape the authorizer is configured for. A function
+ * that throws is an invocation failure here rather than that value: real
+ * Lambda turns a thrown error into a payload carrying this member, while
+ * simulated Lambda rejects with the error itself, so returning the value is
+ * the way to ask for a 401.
+ */
+export class SimHttpApiAuthorizerResponse {
+  private readonly authorizer: SimHttpApiRequestAuthorizer;
+  private readonly routeArn: string;
+
+  constructor(properties: SimHttpApiAuthorizerResponseProperties) {
+    this.authorizer = properties.authorizer;
+    this.routeArn = properties.routeArn;
+  }
+
+  /**
+   * What the endpoint should do with the request, given what the authorizer
+   * answered.
+   */
+  read(result: unknown): SimHttpApiAuthorization {
+    if (!isRecord(result)) {
+      return SimHttpApiRefused.error();
+    }
+
+    if (result["errorMessage"] === unauthorizedErrorMessage) {
+      return SimHttpApiRefused.unauthorized();
+    }
+
+    if (this.authorizer.enableSimpleResponses) {
+      return this.simpleResponse(result);
+    }
+
+    return this.policyResponse(result);
+  }
+
+  /**
+   * Read a simple response, which says yes or no and nothing else.
+   */
+  private simpleResponse(
+    result: Record<string, unknown>,
+  ): SimHttpApiAuthorization {
+    const isAuthorized = result["isAuthorized"];
+
+    if (typeof isAuthorized !== "boolean") {
+      return SimHttpApiRefused.error();
+    }
+
+    if (!isAuthorized) {
+      return SimHttpApiRefused.forbidden();
+    }
+
+    return this.admitted(result);
+  }
+
+  /**
+   * Read a policy response, and put the document it carries to IAM.
+   */
+  private policyResponse(
+    result: Record<string, unknown>,
+  ): SimHttpApiAuthorization {
+    const policyDocument = result["policyDocument"];
+
+    if (
+      typeof result["principalId"] !== "string" ||
+      !isPolicyDocument(policyDocument)
+    ) {
+      return SimHttpApiRefused.error();
+    }
+
+    try {
+      return this.evaluated(policyDocument, result);
+    } catch {
+      // IAM refused to read the document, which is a malformed policy rather
+      // than a policy that says no.
+      return SimHttpApiRefused.error();
+    }
+  }
+
+  private evaluated(
+    policyDocument: SimIamPolicyDocument,
+    result: Record<string, unknown>,
+  ): SimHttpApiAuthorization {
+    const allowed = new SimHttpApiAuthorizerPolicy(policyDocument).allows(
+      this.routeArn,
+    );
+
+    if (!allowed) {
+      return SimHttpApiRefused.forbidden();
+    }
+
+    return this.admitted(result);
+  }
+
+  /**
+   * The admitted request, carrying whatever the authorizer passed on.
+   *
+   * A context that is not an object is left out rather than passed on as it
+   * stands, since `requestContext.authorizer.lambda` is a JSON object on AWS
+   * and a handler reading a member off it would find something else here.
+   */
+  private admitted(result: Record<string, unknown>): SimHttpApiAdmitted {
+    const context = result["context"];
+
+    if (!isRecord(context)) {
+      return new SimHttpApiAdmitted({ lambda: null });
+    }
+
+    return new SimHttpApiAdmitted({
+      lambda: context as SimPayload2LambdaAuthorizer,
+    });
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
@@ -7,7 +7,8 @@ import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-func
 import type { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
 
 /**
- * The service principal API Gateway invokes a Lambda integration as.
+ * The service principal API Gateway invokes a Lambda function as, whether that
+ * function is behind an integration or behind an authorizer.
  */
 export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
 
@@ -17,49 +18,52 @@ export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
  */
 const sourceArnConditionKey = "AWS:SourceArn";
 
-interface SimHttpApiIntegrationAuthorizerProperties {
+interface SimHttpApiInvokeAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
 }
 
-interface SimHttpApiIntegrationAuthorizationInput {
+interface SimHttpApiInvokeAuthorizationInput {
   readonly simFunction: SimLambdaFunction;
   readonly sourceArn: SimHttpApiExecuteApiArn;
 }
 
 /**
- * Decides whether an API Gateway integration may invoke its Lambda function.
+ * Decides whether an HTTP API may invoke one of its Lambda functions.
  *
  * A Lambda proxy integration created through CloudFormation, the CLI or an SDK
  * does not work until the function's resource policy allows
- * `apigateway.amazonaws.com` to invoke it. API Gateway is the caller, so the
- * caller's own identity policies are not what admits the call: a service
- * principal owns none, and the function's resource policy is the whole
- * decision.
+ * `apigateway.amazonaws.com` to invoke it, and a Lambda `REQUEST` authorizer's
+ * function needs the same grant under an ARN of its own. API Gateway is the
+ * caller, so the caller's own identity policies are not what admits the call:
+ * a service principal owns none, and the function's resource policy is the
+ * whole decision.
  *
  * The answer is a decision rather than a thrown error, because a refusal is an
  * ordinary HTTP outcome: the endpoint answers 500 the way real API Gateway
  * does, with nothing to propagate to a caller in process.
  */
-export class SimHttpApiIntegrationAuthorizer {
+export class SimHttpApiInvokeAuthorizer {
   private static readonly action = "lambda:InvokeFunction";
 
   private readonly iam: SimIamInterServiceAuthZ;
 
-  constructor(properties: SimHttpApiIntegrationAuthorizerProperties) {
+  constructor(properties: SimHttpApiInvokeAuthorizerProperties) {
     this.iam = properties.iam;
   }
 
   /**
    * Evaluate `lambda:InvokeFunction` for the API against the function.
    *
-   * The route the request matched is supplied as `AWS:SourceArn`, so a
-   * permission granted for one route does not open another.
+   * What the API is invoking the function for is supplied as `AWS:SourceArn`,
+   * so a permission granted for one route does not open another, and a
+   * permission granted for an integration does not make the same function
+   * usable as an authorizer.
    */
   authorize(
-    input: SimHttpApiIntegrationAuthorizationInput,
+    input: SimHttpApiInvokeAuthorizationInput,
   ): SimIamAuthorizationDecision {
     return this.iam.authorize({
-      action: SimHttpApiIntegrationAuthorizer.action,
+      action: SimHttpApiInvokeAuthorizer.action,
       resource: input.simFunction.arn,
       caller: { kind: "service", service: simApiGatewayServicePrincipal },
       resourcePolicies: simLambdaResourcePolicies(input.simFunction),

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-jwt-route-authorizer.ts
@@ -3,6 +3,7 @@ import {
   type SimHttpApiAuthorization,
   SimHttpApiRefused,
 } from "../../api/authorizer/sim-http-api-authorization.js";
+import { SimHttpApiJwtAuthorizer } from "../../api/authorizer/sim-http-api-jwt-authorizer.js";
 import { SimHttpApiJwtVerification } from "../../api/authorizer/sim-http-api-jwt-verification.js";
 import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
 
@@ -35,12 +36,12 @@ export class SimHttpApiJwtRouteAuthorizer {
     const { api, match, request } = input;
     const { route } = match;
 
-    // A JWT route always names an authorizer, and that authorizer can still be
-    // deleted out from under it, so the two come to the same thing here: with
-    // no authorizer to ask, the route stays closed.
+    // A JWT route always names a JWT authorizer, and that authorizer can still
+    // be deleted out from under it, so the two come to the same thing here:
+    // with no authorizer to ask, the route stays closed.
     const authorizer = api.authorizers.find(route.authorizerId ?? "");
 
-    if (authorizer === undefined) {
+    if (!(authorizer instanceof SimHttpApiJwtAuthorizer)) {
       return SimHttpApiRefused.unauthorized();
     }
 

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-request-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-request-route-authorizer.ts
@@ -1,0 +1,149 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import {
+  type SimHttpApiAuthorization,
+  SimHttpApiRefused,
+} from "../../api/authorizer/sim-http-api-authorization.js";
+import { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-api-request-authorizer.js";
+import type { SimHttpApiLambdaUri } from "../../api/integration/sim-http-api-lambda-uri.js";
+import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
+import type { SimHttpApi } from "../../api/sim-http-api.js";
+import type { SimHttpApiFunctionTarget } from "../sim-api-gateway-v2-router.js";
+import { simHttpApiEndpoint } from "../sim-http-api-endpoint.js";
+import { SimHttpApiAuthorizerEventBuilder } from "./sim-http-api-authorizer-event.js";
+import { SimHttpApiAuthorizerResponse } from "./sim-http-api-authorizer-response.js";
+import { SimHttpApiInvokeAuthorizer } from "./sim-http-api-invoke-authorizer.js";
+import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
+
+/**
+ * Finds the function an authorizer names, which the serving router does.
+ */
+export interface SimHttpApiAuthorizerFunctions {
+  functionFor(
+    lambdaUri: SimHttpApiLambdaUri,
+  ): SimHttpApiFunctionTarget | undefined;
+}
+
+interface SimHttpApiRequestRouteAuthorizerProperties {
+  /** Clock the authorizer's own invocation event is stamped with. */
+  readonly clock: SimClock;
+  readonly functions: SimHttpApiAuthorizerFunctions;
+}
+
+/**
+ * Decides whether one request may have a `CUSTOM` route, by invoking the
+ * Lambda function the route's authorizer names.
+ *
+ * The steps are the ones real API Gateway takes, in this order:
+ *
+ * 1. the request has to carry every identity source the authorizer was
+ *    configured with, or it is refused with a 401 and the function is never
+ *    invoked;
+ * 2. the function has to exist and to allow the API to invoke it, under an ARN
+ *    naming the authorizer rather than any route;
+ * 3. the function is invoked with the payload format 2.0 authorizer event;
+ * 4. what it answered decides, and anything unreadable is a 500.
+ *
+ * Nothing is cached between requests, so the function is invoked once per
+ * request reaching the route. That is what `AuthorizerResultTtlInSeconds: 0`
+ * asks for, and it is the only configuration `CreateAuthorizer` accepts.
+ */
+export class SimHttpApiRequestRouteAuthorizer {
+  private readonly functions: SimHttpApiAuthorizerFunctions;
+  private readonly eventBuilder: SimHttpApiAuthorizerEventBuilder;
+
+  constructor(properties: SimHttpApiRequestRouteAuthorizerProperties) {
+    this.functions = properties.functions;
+    this.eventBuilder = new SimHttpApiAuthorizerEventBuilder({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Authorize one request against the `CUSTOM` route that matched it.
+   */
+  async authorize(
+    input: SimHttpApiRouteAuthorizeInput,
+  ): Promise<SimHttpApiAuthorization> {
+    const { api, match, request } = input;
+    const authorizer = api.authorizers.find(match.route.authorizerId ?? "");
+
+    // A CUSTOM route always names a REQUEST authorizer, and that authorizer
+    // can still be deleted out from under it, so the two come to the same
+    // thing here: with nothing to ask, the route stays closed.
+    if (!(authorizer instanceof SimHttpApiRequestAuthorizer)) {
+      return SimHttpApiRefused.unauthorized();
+    }
+
+    const identitySource = authorizer.identitySources.values(request);
+
+    if (identitySource === undefined) {
+      return SimHttpApiRefused.unauthorized();
+    }
+
+    return await this.invoke(input, authorizer, identitySource);
+  }
+
+  /**
+   * Invoke the authorizer function and read what it answered.
+   */
+  private async invoke(
+    input: SimHttpApiRouteAuthorizeInput,
+    authorizer: SimHttpApiRequestAuthorizer,
+    identitySource: readonly string[],
+  ): Promise<SimHttpApiAuthorization> {
+    const { api, match, request } = input;
+    const target = this.functions.functionFor(authorizer.lambdaUri);
+
+    if (target === undefined || this.mayNotInvoke(api, authorizer, target)) {
+      // A function that is not there, and one the API may not invoke, are both
+      // 500s on real AWS: the caller is told nothing about the API's own
+      // wiring.
+      return SimHttpApiRefused.error();
+    }
+
+    const routeArn = new SimHttpApiExecuteApiArn({
+      api,
+      stageName: match.stage.stageName,
+      methodAndPath: match.route.key.methodAndPath(request.method),
+    }).toString();
+
+    try {
+      const event = await this.eventBuilder.build({
+        request,
+        endpoint: simHttpApiEndpoint(api, match),
+        routeArn,
+        identitySource,
+      });
+
+      return new SimHttpApiAuthorizerResponse({ authorizer, routeArn }).read(
+        await target.simFunction.invoke(event),
+      );
+    } catch {
+      // An authorizer that failed tells the caller nothing, the way an
+      // integration that failed does not. Reading the request to build the
+      // event can fail the same way, so it is inside this too.
+      return SimHttpApiRefused.error();
+    }
+  }
+
+  /**
+   * Whether the API lacks permission to invoke the authorizer's function.
+   *
+   * The source ARN names the authorizer rather than the route, so a function
+   * granted the invoke action for the API's routes is not thereby usable as
+   * its authorizer, as on real AWS.
+   */
+  private mayNotInvoke(
+    api: SimHttpApi,
+    authorizer: SimHttpApiRequestAuthorizer,
+    target: SimHttpApiFunctionTarget,
+  ): boolean {
+    return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
+      simFunction: target.simFunction,
+      sourceArn: SimHttpApiExecuteApiArn.forAuthorizer(
+        api,
+        authorizer.authorizerId,
+      ),
+    }).isDenied;
+  }
+}

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorizer.ts
@@ -5,14 +5,24 @@ import {
 } from "../../api/authorizer/sim-http-api-authorization.js";
 import { SimHttpApiIamRouteAuthorizer } from "./sim-http-api-iam-route-authorizer.js";
 import { SimHttpApiJwtRouteAuthorizer } from "./sim-http-api-jwt-route-authorizer.js";
+import {
+  type SimHttpApiAuthorizerFunctions,
+  SimHttpApiRequestRouteAuthorizer,
+} from "./sim-http-api-request-route-authorizer.js";
 import type { SimHttpApiRouteAuthorizeInput } from "./sim-http-api-route-authorize-input.js";
 
 interface SimHttpApiRouteAuthorizerProperties {
   /**
    * Clock a JWT route's time claims are checked against, so advancing
-   * simulated time expires a token that was accepted before it.
+   * simulated time expires a token that was accepted before it, and the one a
+   * Lambda authorizer's own invocation event is stamped with.
    */
   readonly clock: SimClock;
+  /**
+   * Where a Lambda authorizer's function is found, which is the same router
+   * that finds an integration's.
+   */
+  readonly functions: SimHttpApiAuthorizerFunctions;
 }
 
 /**
@@ -28,18 +38,25 @@ interface SimHttpApiRouteAuthorizerProperties {
  */
 export class SimHttpApiRouteAuthorizer {
   private readonly jwtAuthorizer: SimHttpApiJwtRouteAuthorizer;
+  private readonly requestAuthorizer: SimHttpApiRequestRouteAuthorizer;
   private readonly iamAuthorizer = new SimHttpApiIamRouteAuthorizer();
 
   constructor(properties: SimHttpApiRouteAuthorizerProperties) {
     this.jwtAuthorizer = new SimHttpApiJwtRouteAuthorizer({
       clock: properties.clock,
     });
+    this.requestAuthorizer = new SimHttpApiRequestRouteAuthorizer({
+      clock: properties.clock,
+      functions: properties.functions,
+    });
   }
 
   /**
    * Authorize one request against the route that matched it.
    */
-  authorize(input: SimHttpApiRouteAuthorizeInput): SimHttpApiAuthorization {
+  async authorize(
+    input: SimHttpApiRouteAuthorizeInput,
+  ): Promise<SimHttpApiAuthorization> {
     switch (input.match.route.authorizationType) {
       case "NONE": {
         // Nobody was authorized, so there is no caller to describe, which is
@@ -51,6 +68,9 @@ export class SimHttpApiRouteAuthorizer {
       }
       case "AWS_IAM": {
         return this.iamAuthorizer.authorize(input);
+      }
+      case "CUSTOM": {
+        return await this.requestAuthorizer.authorize(input);
       }
     }
   }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -2,18 +2,14 @@ import type {
   SimAwsServiceController,
   SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
-import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-event-builder.js";
-import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import type { SimHttpApiRefused } from "../api/authorizer/sim-http-api-authorization.js";
-import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js";
 import { SimHttpApiRequest } from "../api/sim-http-api-request.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
-import { SimHttpApiIntegrationAuthorizer } from "./auth/sim-http-api-integration-authorizer.js";
 import { SimHttpApiRouteAuthorizer } from "./auth/sim-http-api-route-authorizer.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
-import { simHttpApiEndpoint } from "./sim-http-api-endpoint.js";
+import { SimHttpApiIntegrationInvocation } from "./sim-http-api-integration-invocation.js";
+import { SimHttpApiRefusalResponse } from "./sim-http-api-refusal-response.js";
 
 interface SimApiGatewayV2ServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -29,28 +25,31 @@ interface SimApiGatewayV2ServiceControllerProperties {
  * any other invocation.
  *
  * A route that authorizes anybody is checked before any of that: a JWT route's
- * token has to verify and meet the route's scopes, and an `AWS_IAM` route's
- * caller has to be allowed `execute-api:Invoke` on the route, or the request is
- * refused and the function is never invoked. Whether the API may invoke the
- * function is a separate question, and the API's own rather than the client's.
+ * token has to verify and meet the route's scopes, an `AWS_IAM` route's caller
+ * has to be allowed `execute-api:Invoke` on the route, and a `CUSTOM` route's
+ * Lambda authorizer has to allow the request, or the request is refused and the
+ * integration is never invoked. Whether the API may invoke a function is a
+ * separate question, and the API's own rather than the client's.
  */
 export class SimApiGatewayV2ServiceController implements SimAwsServiceController {
   private readonly router: SimApiGatewayV2Router;
-  private readonly eventBuilder: SimPayload2EventBuilder;
   private readonly routeAuthorizer: SimHttpApiRouteAuthorizer;
-  private readonly responseBuilder = new SimPayload2ResponseBuilder();
+  private readonly integration: SimHttpApiIntegrationInvocation;
   private readonly errorResponse = new SimApiGatewayV2ErrorResponse();
+  private readonly refusalResponse = new SimHttpApiRefusalResponse();
 
   constructor(properties: SimApiGatewayV2ServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.router = properties.router ?? new SimApiGatewayV2Router({ simAws });
-    // Taken from the router rather than from properties, so a supplied router,
-    // the event timestamps and the token expiry checks all belong to the same
-    // simulation.
-    this.eventBuilder = new SimPayload2EventBuilder({
-      clock: this.router.simAws,
-    });
+    // The clock is taken from the router rather than from properties, so a
+    // supplied router, the event timestamps and the token expiry checks all
+    // belong to the same simulation.
     this.routeAuthorizer = new SimHttpApiRouteAuthorizer({
+      clock: this.router.simAws,
+      functions: this.router,
+    });
+    this.integration = new SimHttpApiIntegrationInvocation({
+      router: this.router,
       clock: this.router.simAws,
     });
   }
@@ -95,7 +94,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
     // The client's own authorization comes first: a request with no
     // credentials is refused whether or not the integration behind the route
     // would work.
-    const authorization = this.routeAuthorizer.authorize({
+    const authorization = await this.routeAuthorizer.authorize({
       api,
       match,
       request,
@@ -104,64 +103,14 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
     });
 
     if (!authorization.admitted) {
-      return this.refusalResponse(authorization);
+      return this.refusalResponse.build(authorization);
     }
 
-    const target = this.router.targetFor(match.integration);
-
-    if (target === undefined) {
-      // The integration names a function that is not there, which real API
-      // Gateway discovers the same way: only when it tries to invoke it.
-      return this.errorResponse.internalServerError();
-    }
-
-    const decision = new SimHttpApiIntegrationAuthorizer({
-      iam: target.iam,
-    }).authorize({
-      simFunction: target.simFunction,
-      sourceArn: new SimHttpApiExecuteApiArn({
-        api,
-        stageName: match.stage.stageName,
-        methodAndPath: match.route.key.methodAndPath(request.method),
-      }),
+    return await this.integration.invoke({
+      api,
+      match,
+      request,
+      authorization,
     });
-
-    if (decision.isDenied) {
-      // Real API Gateway answers a missing invoke permission with a 500 and
-      // never invokes the function, which is the same answer as an integration
-      // that failed. The refusal is only visible in the API's own logs.
-      return this.errorResponse.internalServerError();
-    }
-
-    try {
-      const event = await this.eventBuilder.build(
-        request,
-        simHttpApiEndpoint(api, match),
-        { jwt: authorization.jwt, caller: authorization.caller },
-      );
-
-      return this.responseBuilder.build(await target.simFunction.invoke(event));
-    } catch {
-      // Real API Gateway reports an unhandled integration error as a 500, with
-      // the error itself only visible in the function's logs. Reading the
-      // request body can fail the same way, so building the event is inside
-      // this too.
-      return this.errorResponse.internalServerError();
-    }
-  }
-
-  /**
-   * The response a refused request gets back.
-   *
-   * A 403 is an unmet route scope, where the token was accepted and does not
-   * allow this route, or an `AWS_IAM` route IAM did not allow the caller.
-   * Everything else is one 401.
-   */
-  private refusalResponse(refused: SimHttpApiRefused): Response {
-    if (refused.kind === "forbidden") {
-      return this.errorResponse.forbidden();
-    }
-
-    return this.errorResponse.unauthorized(refused.errorDescription);
   }
 }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -4,6 +4,7 @@ import { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-function.js";
 import type { SimHttpApiIntegration } from "../api/integration/sim-http-api-integration.js";
+import type { SimHttpApiLambdaUri } from "../api/integration/sim-http-api-lambda-uri.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
 import type { SimHttpApiRegistry } from "../registry/sim-http-api-registry.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
@@ -13,13 +14,13 @@ interface SimApiGatewayV2RouterProperties {
 }
 
 /**
- * What an integration invokes, and what decides whether it may.
+ * A function the API invokes, and what decides whether it may.
  */
-export interface SimHttpApiIntegrationTarget {
+export interface SimHttpApiFunctionTarget {
   readonly simFunction: SimLambdaFunction;
   /**
-   * IAM of the Account that owns the function, which is what the integration's
-   * invoke permission is evaluated against. It need not be the API's Account.
+   * IAM of the Account that owns the function, which is what the API's invoke
+   * permission is evaluated against. It need not be the API's Account.
    */
   readonly iam: SimIamInterServiceAuthZ;
 }
@@ -83,14 +84,25 @@ export class SimApiGatewayV2Router {
   /**
    * Find the function an integration invokes, and the IAM deciding whether it
    * may be invoked.
-   *
-   * The function is looked up in the Account and Region its ARN names, not the
-   * API's, because an integration ARN is free to name either.
    */
   targetFor(
     integration: SimHttpApiIntegration,
-  ): SimHttpApiIntegrationTarget | undefined {
-    const { accountId, regionName, functionName } = integration.lambdaUri;
+  ): SimHttpApiFunctionTarget | undefined {
+    return this.functionFor(integration.lambdaUri);
+  }
+
+  /**
+   * Find the function a URI names, and the IAM deciding whether API Gateway
+   * may invoke it.
+   *
+   * The function is looked up in the Account and Region its own ARN names, not
+   * the API's, because an integration URI and an authorizer URI are each free
+   * to name either.
+   */
+  functionFor(
+    lambdaUri: SimHttpApiLambdaUri,
+  ): SimHttpApiFunctionTarget | undefined {
+    const { accountId, regionName, functionName } = lambdaUri;
 
     const scope = this.simAws.accountRegionScope(
       accountId as SimAwsAccountId,

--- a/src/service/apigatewayv2/serve/sim-http-api-authorizer-event.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-authorizer-event.iso.test.ts
@@ -1,0 +1,143 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimHttpApiAuthorizerEvent } from "./auth/sim-http-api-authorizer-event.js";
+
+/**
+ * An authorizer that admits everything and hands the event it received to the
+ * integration, so a test can assert on what an authorizer sees.
+ */
+function echoAuthorizer(): (event: SimHttpApiAuthorizerEvent) => unknown {
+  return (event) => ({ isAuthorized: true, context: { event } });
+}
+
+/**
+ * An API whose one route reports the authorizer event back as its response.
+ */
+async function echoingApi(
+  simAws: SimAws,
+  routeKeys: readonly string[] = ["GET /account"],
+  stageVariables: Record<string, string> = {},
+): Promise<SimHttpApi> {
+  return await simHttpApiLambdaProxyFactory.make(
+    {
+      routeKeys,
+      stageVariables,
+      handler: (event: SimPayload2Event): unknown => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          event.requestContext.authorizer?.lambda?.["event"] ?? null,
+        ),
+      }),
+      requestAuthorizer: {
+        functionName: "session-authorizer",
+        handler: echoAuthorizer(),
+        identitySource: ["$request.header.cookie"],
+        enableSimpleResponses: true,
+        invokePermission: true,
+      },
+    },
+    simAws,
+  );
+}
+
+async function authorizerEvent(
+  simAws: SimAws,
+  api: SimHttpApi,
+  path: string,
+  init: RequestInit = {},
+): Promise<SimHttpApiAuthorizerEvent> {
+  const response = await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString(),
+    { headers: { cookie: "session=valid" }, ...init },
+  );
+
+  return (await response.json()) as SimHttpApiAuthorizerEvent;
+}
+
+describe("The event a sim HTTP API Lambda authorizer receives", () => {
+  it("is the payload 2.0 request event with the three authorizer members", async () => {
+    // Given a route behind a Lambda authorizer
+    const simAws = new SimAws();
+    const api = await echoingApi(simAws);
+
+    // When it is called with a query string
+    const event = await authorizerEvent(simAws, api, "/account?tenant=acme");
+
+    // Then the authorizer saw the request, the route it matched as an ARN, and
+    // the values found at its identity sources
+    const { accountId, regionName } = api.accountRegionScope;
+    assertObjectMatches(event, {
+      version: "2.0",
+      type: "REQUEST",
+      routeArn:
+        `arn:aws:execute-api:${regionName}:${accountId}:${api.apiId}` +
+        `/$default/GET/account`,
+      identitySource: ["session=valid"],
+      routeKey: "GET /account",
+      rawPath: "/account",
+      rawQueryString: "tenant=acme",
+      queryStringParameters: { tenant: "acme" },
+    });
+    assertIdentical(event.requestContext.apiId, api.apiId);
+  });
+
+  it("names the route key rather than the path asked for", async () => {
+    // Given a parameterised route behind the same authorizer
+    const simAws = new SimAws();
+    const api = await echoingApi(simAws, ["GET /orders/{orderId}"]);
+
+    // When a concrete order is asked for
+    const event = await authorizerEvent(simAws, api, "/orders/42");
+
+    // Then the route ARN carries the template with its braces intact, which is
+    // the form AWS's own example of this event shows, and the captured
+    // parameter arrives separately
+    expect(event.routeArn).toMatch(/\/\$default\/GET\/orders\/\{orderId\}$/u);
+    assertObjectMatches(event, { pathParameters: { orderId: "42" } });
+  });
+
+  it("carries the stage variables the request was served under", async () => {
+    // Given a stage carrying a variable
+    const simAws = new SimAws();
+    const api = await echoingApi(simAws, ["GET /account"], {
+      table: "accounts-dev",
+    });
+
+    // When the route is called
+    const event = await authorizerEvent(simAws, api, "/account");
+
+    // Then the authorizer sees it, as the integration behind the route does
+    assertObjectMatches(event, { stageVariables: { table: "accounts-dev" } });
+  });
+
+  it("carries no request body", async () => {
+    // Given a route behind the same authorizer
+    const simAws = new SimAws();
+    const api = await echoingApi(simAws, ["POST /account"]);
+
+    // When a request with a body reaches it
+    const event = await authorizerEvent(simAws, api, "/account", {
+      method: "POST",
+      headers: { cookie: "session=valid", "content-type": "text/plain" },
+      body: "a body",
+    });
+
+    // Then the authorizer sees no body, which is what AWS's published example
+    // of this event carries, and the integration behind the route still gets
+    // the request in full
+    assertFalse(Object.hasOwn(event, "body"));
+    assertFalse(Object.hasOwn(event, "isBase64Encoded"));
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -1,0 +1,108 @@
+import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-event-builder.js";
+import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimHttpApiAdmitted } from "../api/authorizer/sim-http-api-authorization.js";
+import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
+import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import { SimHttpApiInvokeAuthorizer } from "./auth/sim-http-api-invoke-authorizer.js";
+import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
+import type {
+  SimApiGatewayV2Router,
+  SimHttpApiFunctionTarget,
+} from "./sim-api-gateway-v2-router.js";
+import { simHttpApiEndpoint } from "./sim-http-api-endpoint.js";
+
+interface SimHttpApiIntegrationInvocationProperties {
+  readonly router: SimApiGatewayV2Router;
+  /** Clock the invocation event is stamped with. */
+  readonly clock: SimClock;
+}
+
+interface SimHttpApiIntegrationInvocationInput {
+  readonly api: SimHttpApi;
+  readonly match: SimHttpApiMatch;
+  readonly request: Request;
+  /** What the route's authorization knows about the caller. */
+  readonly authorization: SimHttpApiAdmitted;
+}
+
+/**
+ * Invokes the Lambda function behind the matched route's integration, and
+ * turns what it returns into the HTTP response.
+ *
+ * Whether the API may invoke the function is asked first, and is the API's own
+ * question rather than the client's: the client's was already answered by the
+ * route's authorization. A function that is not there, one the API may not
+ * invoke, and one that failed are the same 500, as they are on real AWS.
+ */
+export class SimHttpApiIntegrationInvocation {
+  private readonly router: SimApiGatewayV2Router;
+  private readonly eventBuilder: SimPayload2EventBuilder;
+  private readonly responseBuilder = new SimPayload2ResponseBuilder();
+  private readonly errorResponse = new SimApiGatewayV2ErrorResponse();
+
+  constructor(properties: SimHttpApiIntegrationInvocationProperties) {
+    this.router = properties.router;
+    this.eventBuilder = new SimPayload2EventBuilder({
+      clock: properties.clock,
+    });
+  }
+
+  /**
+   * Invoke the integration for one authorized request.
+   */
+  async invoke(input: SimHttpApiIntegrationInvocationInput): Promise<Response> {
+    const { api, match, request, authorization } = input;
+    const target = this.router.targetFor(match.integration);
+
+    if (target === undefined || this.mayNotInvoke(input, target)) {
+      // The integration names a function that is not there, or one that
+      // granted the API nothing. Real API Gateway discovers both only when it
+      // tries to invoke, answers 500, and leaves the reason in its own logs.
+      return this.errorResponse.internalServerError();
+    }
+
+    try {
+      const event = await this.eventBuilder.build(
+        request,
+        simHttpApiEndpoint(api, match),
+        {
+          jwt: authorization.jwt,
+          caller: authorization.caller,
+          lambda: authorization.lambda,
+        },
+      );
+
+      return this.responseBuilder.build(await target.simFunction.invoke(event));
+    } catch {
+      // Real API Gateway reports an unhandled integration error as a 500, with
+      // the error itself only visible in the function's logs. Reading the
+      // request body can fail the same way, so building the event is inside
+      // this too.
+      return this.errorResponse.internalServerError();
+    }
+  }
+
+  /**
+   * Whether the API lacks permission to invoke the integrated function.
+   *
+   * The route the request matched is supplied as the source ARN, so a
+   * permission granted for one route does not open another.
+   */
+  private mayNotInvoke(
+    input: SimHttpApiIntegrationInvocationInput,
+    target: SimHttpApiFunctionTarget,
+  ): boolean {
+    const { api, match, request } = input;
+
+    return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
+      simFunction: target.simFunction,
+      sourceArn: new SimHttpApiExecuteApiArn({
+        api,
+        stageName: match.stage.stageName,
+        methodAndPath: match.route.key.methodAndPath(request.method),
+      }),
+    }).isDenied;
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer-failures.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer-failures.iso.test.ts
@@ -90,6 +90,30 @@ describe("When a sim HTTP API Lambda authorizer cannot answer", () => {
     assertIdentical(response.status, 500);
   });
 
+  it("answers 500 for a policy response from a simple-response authorizer", async () => {
+    // Given an authorizer configured for simple responses whose function
+    // answers a well-formed policy instead
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      handler: (): unknown => ({
+        principalId: "user-1",
+        policyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            { Effect: "Allow", Action: "execute-api:Invoke", Resource: "*" },
+          ],
+        },
+      }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then the configured shape is the only one read: an authorizer answering
+    // the other one is a 500 rather than quietly allowing the request
+    assertIdentical(response.status, 500);
+  });
+
   it("answers 500 for a policy response missing its policy", async () => {
     // Given an authorizer answering policies that returns only a principal
     const simAws = new SimAws();

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer-failures.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer-failures.iso.test.ts
@@ -1,0 +1,200 @@
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApiProxyRequestAuthorizer } from "../api/sim-http-api-proxy-request-authorizer.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+const cookie = "session=valid";
+
+interface AuthorizedApi {
+  readonly api: SimHttpApi;
+  /** How many times the route's integration handler ran. */
+  readonly invocations: () => number;
+}
+
+async function protectedApi(
+  simAws: SimAws,
+  authorizer: Partial<SimHttpApiProxyRequestAuthorizer>,
+): Promise<AuthorizedApi> {
+  let invocations = 0;
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      routeKeys: ["GET /account"],
+      handler: (): string => {
+        invocations += 1;
+        return "account";
+      },
+      requestAuthorizer: {
+        functionName: "session-authorizer",
+        handler: (): unknown => ({ isAuthorized: true }),
+        identitySource: ["$request.header.cookie"],
+        enableSimpleResponses: true,
+        invokePermission: true,
+        ...authorizer,
+      },
+    },
+    simAws,
+  );
+
+  return { api, invocations: () => invocations };
+}
+
+function get(simAws: SimAws, api: SimHttpApi): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}/account` }).toString(),
+    { headers: { cookie } },
+  );
+}
+
+describe("When a sim HTTP API Lambda authorizer cannot answer", () => {
+  it("answers 500 for an authorizer that throws", async () => {
+    // Given an authorizer whose function fails
+    const simAws = new SimAws();
+    const { api, invocations } = await protectedApi(simAws, {
+      handler: (): unknown => {
+        throw new Error("no session store");
+      },
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then the caller is told nothing about it, as with a failed integration,
+    // and the integration never ran
+    assertIdentical(response.status, 500);
+    assertIdentical(
+      await response.text(),
+      '{"message":"Internal Server Error"}',
+    );
+    assertIdentical(invocations(), 0);
+  });
+
+  it("answers 500 for a simple response with no answer in it", async () => {
+    // Given an authorizer configured for simple responses that returns
+    // something else
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      handler: (): unknown => ({ allowed: true }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then API Gateway could not read the answer either, so it is a 500
+    // rather than a refusal the caller could act on
+    assertIdentical(response.status, 500);
+  });
+
+  it("answers 500 for a policy response missing its policy", async () => {
+    // Given an authorizer answering policies that returns only a principal
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      enableSimpleResponses: false,
+      handler: (): unknown => ({ principalId: "user-1" }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then the response is not the shape the authorizer was configured for
+    assertIdentical(response.status, 500);
+  });
+
+  it("answers 500 for a policy document IAM cannot read", async () => {
+    // Given an authorizer returning a document with no statements at all
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      enableSimpleResponses: false,
+      handler: (): unknown => ({
+        principalId: "user-1",
+        policyDocument: { Version: "2012-10-17" },
+      }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then the malformed document is the authorizer failing rather than the
+    // authorizer saying no
+    assertIdentical(response.status, 500);
+  });
+
+  it("answers 500 for an authorizer returning nothing at all", async () => {
+    // Given an authorizer whose function returns no value
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      handler: (): unknown => undefined,
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then there is nothing to read, which is neither response format
+    assertIdentical(response.status, 500);
+  });
+
+  it("answers 500 for an authorizer naming a function that is not there", async () => {
+    // Given an authorizer pointed at a function nothing created
+    const simAws = new SimAws();
+    const { api } = await protectedApi(simAws, {
+      uri: "arn:aws:lambda:eu-west-2:111111111111:function:gone",
+    });
+
+    // When the route is called
+    const response = await get(simAws, api);
+
+    // Then it is discovered the way real API Gateway discovers it, when it
+    // tries to invoke it
+    assertIdentical(response.status, 500);
+  });
+
+  it("needs an invoke permission of the authorizer's own", async () => {
+    // Given an authorizer whose function granted the API nothing
+    const simAws = new SimAws();
+    const { api, invocations } = await protectedApi(simAws, {
+      invokePermission: false,
+    });
+    const { accountId, regionName } = api.accountRegionScope;
+    const executeApiArn = `arn:aws:execute-api:${regionName}:${accountId}:${api.apiId}`;
+
+    // When the route is called, then again once the function grants the API
+    // the invoke action for the route being called, and again once it grants
+    // it for the authorizer itself
+    const ungranted = await get(simAws, api);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "session-authorizer",
+        StatementId: "route-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceArn: `${executeApiArn}/$default/GET/account`,
+      }),
+    );
+    const routeGranted = await get(simAws, api);
+    const [authorizer] = api.authorizers.list();
+    assertNonNullable(authorizer);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "session-authorizer",
+        StatementId: "authorizer-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceArn: `${executeApiArn}/authorizers/${authorizer.authorizerId}`,
+      }),
+    );
+    const authorizerGranted = await get(simAws, api);
+
+    // Then only the grant naming the authorizer opens it: an authorizer is
+    // invoked under an ARN of its own rather than under the route's, and the
+    // integration ran only once, behind the request that got through
+    assertIdentical(ungranted.status, 500);
+    assertIdentical(routeGranted.status, 500);
+    assertIdentical(authorizerGranted.status, 200);
+    assertIdentical(invocations(), 1);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
@@ -1,0 +1,269 @@
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApiProxyRequestAuthorizer } from "../api/sim-http-api-proxy-request-authorizer.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+/**
+ * The cookie the authorizers below accept, and the one they do not.
+ */
+const goodCookie = "session=valid";
+const badCookie = "session=expired";
+
+/**
+ * An integration handler reporting what the authorizer passed on to it, so a
+ * test can assert on the context rather than only on the status.
+ */
+function contextHandler(): (event: {
+  requestContext: { authorizer?: { lambda?: unknown } };
+}) => unknown {
+  return (event) => ({
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(event.requestContext.authorizer?.lambda ?? null),
+  });
+}
+
+/**
+ * An authorizer answering the simple format, allowing only the good cookie.
+ */
+function simpleAuthorizer(): (event: { identitySource: string[] }) => unknown {
+  return (event) => ({
+    isAuthorized: event.identitySource[0] === "session=valid",
+    context: { tenant: "acme", plan: "pro" },
+  });
+}
+
+/**
+ * An authorizer answering a policy, allowing only the good cookie.
+ */
+function policyAuthorizer(): (event: {
+  identitySource: string[];
+  routeArn: string;
+}) => unknown {
+  return (event) => ({
+    principalId: "user-1",
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect:
+            event.identitySource[0] === "session=valid" ? "Allow" : "Deny",
+          Action: "execute-api:Invoke",
+          Resource: event.routeArn,
+        },
+      ],
+    },
+    context: { tenant: "acme" },
+  });
+}
+
+async function protectedApi(
+  simAws: SimAws,
+  authorizer: Partial<SimHttpApiProxyRequestAuthorizer>,
+): Promise<SimHttpApi> {
+  return await simHttpApiLambdaProxyFactory.make(
+    {
+      routeKeys: ["GET /account"],
+      handler: contextHandler(),
+      requestAuthorizer: {
+        functionName: "session-authorizer",
+        handler: simpleAuthorizer(),
+        identitySource: ["$request.header.cookie"],
+        enableSimpleResponses: true,
+        invokePermission: true,
+        ...authorizer,
+      },
+    },
+    simAws,
+  );
+}
+
+function get(
+  simAws: SimAws,
+  api: SimHttpApi,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${api.apiEndpoint}/account` }).toString(),
+    { headers },
+  );
+}
+
+describe("Authorizing a sim HTTP API route with a Lambda REQUEST authorizer", () => {
+  it("lets a request its authorizer accepts through to the handler", async () => {
+    // Given a route behind an authorizer that reads the session cookie
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {});
+
+    // When the route is called with a cookie it accepts
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the handler ran, and it saw the context the authorizer returned
+    assertIdentical(response.status, 200);
+    assertObjectMatches(await response.json(), {
+      tenant: "acme",
+      plan: "pro",
+    });
+  });
+
+  it("refuses a request its authorizer says no to, without invoking the integration", async () => {
+    // Given a route behind that authorizer, and a handler counting its runs
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        routeKeys: ["GET /account"],
+        handler: (): string => {
+          invocations += 1;
+          return "account";
+        },
+        requestAuthorizer: {
+          functionName: "session-authorizer",
+          handler: simpleAuthorizer(),
+          identitySource: ["$request.header.cookie"],
+          enableSimpleResponses: true,
+          invokePermission: true,
+        },
+      },
+      simAws,
+    );
+
+    // When the route is called with a cookie the authorizer does not accept
+    const response = await get(simAws, api, { cookie: badCookie });
+
+    // Then the request is forbidden and the integration never ran
+    assertIdentical(response.status, 403);
+    assertIdentical(await response.text(), '{"message":"Forbidden"}');
+    assertIdentical(invocations, 0);
+  });
+
+  it("evaluates the policy document an authorizer answers with", async () => {
+    // Given an authorizer answering a policy rather than a plain yes or no
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {
+      handler: policyAuthorizer(),
+      enableSimpleResponses: false,
+    });
+
+    // When the route is called with each cookie
+    const allowed = await get(simAws, api, { cookie: goodCookie });
+    const denied = await get(simAws, api, { cookie: badCookie });
+
+    // Then IAM's reading of the document decides, and the context still
+    // reaches the handler
+    assertIdentical(allowed.status, 200);
+    assertObjectMatches(await allowed.json(), { tenant: "acme" });
+    assertIdentical(denied.status, 403);
+  });
+
+  it("refuses a policy allowing some other route", async () => {
+    // Given an authorizer allowing a route other than the one being called
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {
+      enableSimpleResponses: false,
+      handler: (): unknown => ({
+        principalId: "user-1",
+        policyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "execute-api:Invoke",
+              Resource:
+                "arn:aws:execute-api:eu-west-2:111111111111:*/$default/GET/orders",
+            },
+          ],
+        },
+      }),
+    });
+
+    // When the account route is called with an accepted cookie
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the policy does not reach this route, so the request is refused
+    assertIdentical(response.status, 403);
+  });
+
+  it("answers 401 for the one message that asks for one", async () => {
+    // Given an authorizer answering the way a function signals Unauthorized
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {
+      handler: (): unknown => ({ errorMessage: "Unauthorized" }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the request is unauthorized rather than forbidden, which is the
+    // only way an authorizer produces a 401
+    assertIdentical(response.status, 401);
+    assertIdentical(await response.text(), '{"message":"Unauthorized"}');
+  });
+
+  it("admits a request an authorizer allowed without any context", async () => {
+    // Given an authorizer that says yes and passes nothing on
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {
+      handler: (): unknown => ({ isAuthorized: true }),
+    });
+
+    // When the route is called
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the handler ran, and the authorizer block is there with nothing in
+    // it rather than missing, so a handler can still tell what admitted it
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "null");
+  });
+
+  it("reads every identity source, and refuses a request missing one", async () => {
+    // Given an authorizer reading a header and a query string parameter
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await protectedApi(simAws, {
+      identitySource: ["$request.header.cookie", "$request.querystring.tenant"],
+      handler: (event): unknown => {
+        invocations += 1;
+        return { isAuthorized: true, context: { seen: event.identitySource } };
+      },
+    });
+
+    // When a request carries both, and when one carries only the cookie
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const both = await simAwsHttp.fetch(
+      new SimAwsLocalUrl({
+        input: `${api.apiEndpoint}/account?tenant=acme`,
+      }).toString(),
+      { headers: { cookie: goodCookie } },
+    );
+    const missing = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the authorizer saw both values, and the request missing one was
+    // refused without the function being invoked a second time
+    assertIdentical(both.status, 200);
+    assertObjectMatches(await both.json(), { seen: [goodCookie, "acme"] });
+    assertIdentical(missing.status, 401);
+    assertIdentical(invocations, 1);
+  });
+
+  it("refuses every request once the route's authorizer is deleted", async () => {
+    // Given a route whose authorizer is then deleted
+    const simAws = new SimAws();
+    const api = await protectedApi(simAws, {});
+    const [authorizer] = api.authorizers.list();
+    await simAws.apiGatewayV2().deleteAuthorizer({
+      input: { ApiId: api.apiId, AuthorizerId: authorizer?.authorizerId },
+    });
+
+    // When a cookie that worked before is presented
+    const response = await get(simAws, api, { cookie: goodCookie });
+
+    // Then the route stays closed rather than falling open
+    assertIdentical(response.status, 401);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-lambda-authorizer.iso.test.ts
@@ -1,4 +1,8 @@
-import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
@@ -256,8 +260,9 @@ describe("Authorizing a sim HTTP API route with a Lambda REQUEST authorizer", ()
     const simAws = new SimAws();
     const api = await protectedApi(simAws, {});
     const [authorizer] = api.authorizers.list();
+    assertNonNullable(authorizer);
     await simAws.apiGatewayV2().deleteAuthorizer({
-      input: { ApiId: api.apiId, AuthorizerId: authorizer?.authorizerId },
+      input: { ApiId: api.apiId, AuthorizerId: authorizer.authorizerId },
     });
 
     // When a cookie that worked before is presented

--- a/src/service/apigatewayv2/serve/sim-http-api-refusal-response.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-refusal-response.ts
@@ -1,0 +1,32 @@
+import type { SimHttpApiRefused } from "../api/authorizer/sim-http-api-authorization.js";
+import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
+
+/**
+ * The response a request the route's authorization refused gets back.
+ *
+ * A 403 is an unmet route scope, where the token was accepted and does not
+ * allow this route, an `AWS_IAM` route IAM did not allow the caller, or a
+ * Lambda authorizer that said no. A 500 is that authorizer failing, which is
+ * the API's problem rather than the caller's, and is the same answer a failed
+ * integration gets. Everything else is one 401.
+ */
+export class SimHttpApiRefusalResponse {
+  private readonly errorResponse = new SimApiGatewayV2ErrorResponse();
+
+  /**
+   * Build the response for one refusal.
+   */
+  build(refused: SimHttpApiRefused): Response {
+    switch (refused.kind) {
+      case "forbidden": {
+        return this.errorResponse.forbidden();
+      }
+      case "error": {
+        return this.errorResponse.internalServerError();
+      }
+      case "unauthorized": {
+        return this.errorResponse.unauthorized(refused.errorDescription);
+      }
+    }
+  }
+}


### PR DESCRIPTION
…rizer

CreateAuthorizer takes AuthorizerType: "REQUEST", and a route asks for one with AuthorizationType: "CUSTOM". A request reaching that route invokes the authorizer's function with the payload format 2.0 authorizer event, and the integration is only invoked if the authorizer allowed it.

The authorizer is now two kinds behind one base, since a JWT authorizer and a REQUEST one share an id, a name and nothing else. The authorizer's own invoke permission is a separate grant from the integration's, under an ARN naming the authorizer.

Resolves https://github.com/KensioSoftware/yulin/issues/322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Lambda `REQUEST` authorizers on simulated HTTP APIs.
  * Supports simple responses, IAM-policy responses, multiple identity sources, authorizer context, and authorization outcomes.
  * Added `CUSTOM` route authorization and separate Lambda invocation permission handling.
  * Added a complete local simulation example demonstrating accepted and rejected requests.

* **Bug Fixes**
  * Improved validation and error responses for invalid authorizer configurations, failures, and missing permissions.

* **Documentation**
  * Documented setup, events, responses, limitations, permissions, and supported configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->