### PR TITLE
feat: delete an Object from a simulated S3 Bucket

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -195,6 +195,89 @@ for (const object of objectContentItems) {
 
 Object listings are sorted by key.
 
+## Deleting Objects
+
+Use `DeleteObjectCommand` to remove one Object, and `DeleteObjectsCommand` to remove several in one
+request. Both are authorized against `s3:DeleteObject` on the Object ARN, so a caller allowed to read
+a Bucket cannot empty it.
+
+```typescript sim-s3-delete-object
+/**
+ * Deleting Objects from a simulated S3 Bucket.
+ */
+
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(
+  new CreateBucketCommand({
+    Bucket: "uploads-bucket",
+  }),
+);
+
+for (const key of ["receipt.pdf", "invoice.pdf", "notes.txt"]) {
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "uploads-bucket",
+      Key: key,
+      Body: "file contents",
+    }),
+  );
+}
+
+await simS3.deleteObject(
+  new DeleteObjectCommand({
+    Bucket: "uploads-bucket",
+    Key: "receipt.pdf",
+  }),
+);
+
+const batchOutput = await simS3.deleteObjects(
+  new DeleteObjectsCommand({
+    Bucket: "uploads-bucket",
+    Delete: {
+      Objects: [{ Key: "invoice.pdf" }, { Key: "notes.txt" }],
+    },
+  }),
+);
+
+const removedObjects = batchOutput.Deleted ?? [];
+for (const removed of removedObjects) {
+  console.log(removed.Key);
+}
+
+const refusedObjects = batchOutput.Errors ?? [];
+for (const refused of refusedObjects) {
+  console.log(refused.Key, refused.Code);
+}
+```
+
+Deletion is idempotent, as it is in real S3. Deleting a key that is not in the Bucket succeeds, and
+`DeleteObjects` reports it among the keys it deleted. Deleting from a Bucket that does not exist
+raises `NoSuchBucket`.
+
+`DeleteObjects` authorizes each key on its own and carries on through the batch. A key the caller may
+not delete appears in `Errors` with the code `AccessDenied`, while the rest are still removed and
+reported in `Deleted`. Setting `Quiet: true` leaves `Deleted` out of the response, so only the
+failures come back.
+
+### Limitations
+
+- Object versioning is not simulated, so deletion removes the Object rather than writing a delete
+  marker, and neither `VersionId` nor `MFA` is read from the request.
+- A request naming no Objects, or more than the thousand S3 accepts, is refused with `MalformedXML`
+  before anything is deleted.
+- A Bucket using filesystem-backed storage refuses deletion. See
+  [Filesystem-backed Bucket storage](#filesystem-backed-bucket-storage).
+
 ## Bucket policies
 
 A Bucket policy is a resource policy stored on the Bucket. Sim IAM evaluates it alongside the
@@ -686,8 +769,9 @@ const s3Client = new S3Client({
 
 ### Limitations
 
-- `GET`, `HEAD` and `PUT` of an Object are served over the REST endpoint. Bucket operations, `DELETE`
-  and multipart uploads are not, and are refused with `501` rather than answered.
+- `GET`, `HEAD`, `PUT` and `DELETE` of an Object are served over the REST endpoint. Bucket operations
+  and multipart uploads are not, and are refused with `501` rather than answered. `DeleteObjects` is
+  a `POST` to the Bucket, so it is available through the SDK but not over HTTP.
 - `createPresignedPost` and SigV4A presigning are not simulated.
 - Checksums are verified for CRC32, SHA1 and SHA256. An upload stating a CRC32C or CRC64NVME checksum
   is refused rather than stored unchecked.
@@ -881,6 +965,13 @@ Filesystem storage is somewhat restrictive to make it slightly safer:
 - Object keys must not be absolute paths or contain `..`
 - Unsupported file extensions are rejected or ignored
 - Symlinks are ignored when listing Objects
+- Deletion is refused rather than unlinking a real file
+
+`DeleteObject` against a filesystem-backed Bucket raises `NotImplemented`, and `DeleteObjects`
+reports the same code for every key. This is stricter than real S3, deliberately: the directory a
+Bucket is mounted on is an ordinary directory of yours, and removing files from it because a test
+called `DeleteObject` is not a reasonable default. Leave a Bucket on the default in-memory storage
+when a test needs deletion to work.
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
 file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.xml`, and common
@@ -924,6 +1015,7 @@ Sim S3 currently supports:
 
 - `CreateBucketCommand` and `ListBucketsCommand`
 - `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
+- `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketWebsiteCommand`, for static website hosting
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies
@@ -931,7 +1023,7 @@ Sim S3 currently supports:
 - Block Public Access, on by default as in real S3, refusing a public Bucket policy unless the Bucket
   opts out with `PutPublicAccessBlockCommand` or `PublicAccessBlockConfiguration`
 - Serving static website requests on localhost with `serveSimAws`
-- Serving Object `GET`, `HEAD` and `PUT` over the S3 REST endpoint, authorized by sim IAM
+- Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
 - Bucket website index documents, error documents, trailing-slash redirects, redirect-all
   configuration, and routing-rule redirects

--- a/docs/services/s3/sim-s3-delete-object.example.ts
+++ b/docs/services/s3/sim-s3-delete-object.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Deleting Objects from a simulated S3 Bucket.
+ */
+
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(
+  new CreateBucketCommand({
+    Bucket: "uploads-bucket",
+  }),
+);
+
+for (const key of ["receipt.pdf", "invoice.pdf", "notes.txt"]) {
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "uploads-bucket",
+      Key: key,
+      Body: "file contents",
+    }),
+  );
+}
+
+await simS3.deleteObject(
+  new DeleteObjectCommand({
+    Bucket: "uploads-bucket",
+    Key: "receipt.pdf",
+  }),
+);
+
+const batchOutput = await simS3.deleteObjects(
+  new DeleteObjectsCommand({
+    Bucket: "uploads-bucket",
+    Delete: {
+      Objects: [{ Key: "invoice.pdf" }, { Key: "notes.txt" }],
+    },
+  }),
+);
+
+const removedObjects = batchOutput.Deleted ?? [];
+for (const removed of removedObjects) {
+  console.log(removed.Key);
+}
+
+const refusedObjects = batchOutput.Errors ?? [];
+for (const refused of refusedObjects) {
+  console.log(refused.Key, refused.Code);
+}

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -77,6 +77,8 @@ Supported command areas currently include:
 - `put-object/`
 - `get-object/`
 - `list-objects/`
+- `delete-object/`
+- `delete-objects/`
 
 `SimS3Commands` owns the wiring: every handler is built from the same Bucket map, IAM and background
 scheduler, so that construction lives in one place rather than being repeated once per command on
@@ -231,6 +233,7 @@ It keeps objects in a `Map<string, SimS3Object>` keyed by object key. It support
 - exact key lookup
 - prefix filtering for list operations
 - replacing objects by putting another object with the same key
+- removing an object by key, which is a no-op when the key is not stored
 
 This storage is fast, isolated, and appropriate for most tests.
 
@@ -252,9 +255,13 @@ Filesystem storage behaviour:
 - missing files are treated as missing S3 objects
 - file extensions are filtered through filesystem safety rules
 - path traversal and unsafe directory/object paths are rejected
+- `deleteObject` refuses with `SimS3NotImplemented` rather than unlinking the file
 
 The filesystem implementation includes safety checks to reduce accidental unsafe file access, but it
-should still be treated as local-development tooling rather than a sandbox boundary.
+should still be treated as local-development tooling rather than a sandbox boundary. That is why
+deletion is refused: a mounted directory belongs to the user, and unlinking files out of it because
+a test called `DeleteObject` is not a safe default. This is a deliberate divergence from real S3 and
+is recorded in the [usage docs](../../../docs/services/s3/README.md#filesystem-backed-bucket-storage).
 
 ## PutObject, GetObject, and ListObjects
 
@@ -298,6 +305,37 @@ should still be treated as local-development tooling rather than a sandbox bound
 
 `MaxKeys` defaults to `1000`. `NextMarker` is set to the last returned key only when the result is
 truncated.
+
+### DeleteObject
+
+`DeleteObjectCommandHandler`:
+
+1. requires `Bucket` and `Key`
+2. looks up the Bucket locally, throwing `SimS3NoSuchBucket` if absent
+3. sequences background work
+4. authorizes `s3:DeleteObject` against the Object ARN through `DeleteObjectAuthorizer`
+5. removes the object through the Bucket storage abstraction
+6. returns AWS-like `$metadata`
+
+A key that is not stored is not an error. Real S3 deletion is idempotent, so the handler answers the
+same way whether or not there was an object to remove.
+
+### DeleteObjects
+
+`DeleteObjectsCommandHandler` handles the batch form:
+
+1. requires `Bucket` and `Delete`
+2. reads the request through `DeleteObjectsRequest`, which refuses an empty list or more than 1000
+   keys with `SimS3MalformedXml`
+3. looks up the Bucket locally, throwing `SimS3NoSuchBucket` if absent
+4. sequences background work
+5. authorizes and deletes each key on its own, collecting the result in `DeleteObjectsOutcome`
+6. returns `Deleted` and `Errors`, omitting `Deleted` when the request asked to be `Quiet`
+
+A batch deletion is not all or nothing. `DeleteObjectsOutcome` turns a `SimIamAccessDenied` into an
+`AccessDenied` entry and any other `SimS3Error` into an entry carrying its error name, while the rest
+of the batch is still deleted. Anything else is re-raised, so a bug in the simulation cannot arrive
+as a per-key AWS error.
 
 ## Static website configuration
 
@@ -355,7 +393,7 @@ The main classes are:
 
 `SimS3RequestRouter` validates that the service target names a region, then routes by endpoint. The
 website endpoint accepts only `GET` and `HEAD` and takes the Bucket from the target's
-`resourceName`. The REST endpoint accepts `GET`, `HEAD` and `PUT`, and `SimS3ObjectAddress` reads
+`resourceName`. The REST endpoint accepts `GET`, `HEAD`, `PUT` and `DELETE`, and `SimS3ObjectAddress` reads
 the Bucket and key from either addressing style: virtual-hosted, where the hostname names the
 Bucket, or path style, where the first path segment does. `SimS3BucketLocator` then:
 
@@ -366,9 +404,12 @@ Bucket, or path style, where the first path segment does. `SimS3BucketLocator` t
 
 `SimS3RestController` serves the API rather than a website:
 
-- it calls `SimS3.getObject(...)` and `SimS3.putObject(...)` with the caller the authentication
-  boundary resolved, so an HTTP request is authorized by the same IAM code path an in-process SDK
-  call goes through, and a presigned URL grants no more than its signer holds
+- it calls `SimS3.getObject(...)`, `SimS3.putObject(...)` and `SimS3.deleteObject(...)` with the
+  caller the authentication boundary resolved, so an HTTP request is authorized by the same IAM code
+  path an in-process SDK call goes through, and a presigned URL grants no more than its signer holds
+- a `DELETE` answers `204 No Content` whether or not the Object was there, as real S3 does
+- `DeleteObjects` is a `POST` to the Bucket rather than an Object request, so it is reachable through
+  the SDK but not over this endpoint
 - it checks any `x-amz-checksum-*` an upload states before storing anything, through
   `SimS3UploadChecksum`
 - failures become the XML error document real S3 answers with, through `SimS3RestErrorResponse`,
@@ -456,6 +497,9 @@ Handlers throw AWS-like errors for supported failure cases, including:
 - access denied, for S3's own refusals such as Block Public Access
 - Bucket already exists
 - Bucket already owned by you
+- malformed XML, for a `DeleteObjects` request naming no Objects or more than 1000 of them
+- not implemented, for something the simulator refuses rather than approximates, such as deleting an
+  Object out of filesystem-backed storage
 
 These errors carry AWS-style names and HTTP status metadata where implemented. Tests should assert
 the specific simulator error when behaviour depends on AWS-compatible failure semantics.

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -75,6 +75,16 @@ export class SimS3Bucket {
   }
 
   /**
+   * Remove a simulated S3 Object from storage.
+   *
+   * Real S3 DeleteObject is idempotent, so this reports nothing about whether
+   * there was an Object to remove.
+   */
+  async deleteObject(key: string): Promise<void> {
+    await this.storage.deleteObject(key);
+  }
+
+  /**
    * Change the storage implementation for this simulated S3 Bucket.
    */
   configureSimStorage(storage: SimS3BucketStorage): void {

--- a/src/service/s3/command/delete-object/delete-object-authorizer.ts
+++ b/src/service/s3/command/delete-object/delete-object-authorizer.ts
@@ -1,0 +1,52 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface DeleteObjectAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to an S3 DeleteObject request.
+ *
+ * DeleteObject is authorized against the target Object ARN rather than the
+ * Bucket ARN, as the other Object commands are. An omitted caller is passed
+ * through to sim IAM so Account root fallback behaviour remains owned by IAM.
+ *
+ * DeleteObjects authorizes each key through this same class, because real S3
+ * evaluates `s3:DeleteObject` per Object in a batch and reports the keys it
+ * refused alongside the ones it removed.
+ */
+export class DeleteObjectAuthorizer {
+  private static readonly action = "s3:DeleteObject";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: DeleteObjectAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may remove the requested S3 Object.
+   */
+  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+    const resource = `${simS3BucketArn(bucket.bucketName)}/${key}`;
+    const decision = this.iam.authorize({
+      action: DeleteObjectAuthorizer.action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action: DeleteObjectAuthorizer.action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/delete-object/delete-object-iam.iso.test.ts
+++ b/src/service/s3/command/delete-object/delete-object-iam.iso.test.ts
@@ -1,0 +1,175 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { Readable } from "node:stream";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimS3 } from "../../sim-s3.js";
+import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
+
+const assumedByAccountRoot = (accountId: string): string =>
+  JSON.stringify({
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+      Action: "sts:AssumeRole",
+    },
+  });
+
+describe("S3 DeleteObjectCommand IAM authorization", () => {
+  it("denies a caller allowed to read but not to delete", async () => {
+    // Given a Role allowed to read Objects in a Bucket and nothing more
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const simS3 = simAws.account(accountId).region("eu-west-2").s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "read-only" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "read-only",
+        Key: "keep.txt",
+        Body: "kept",
+      }),
+    );
+
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ObjectReader",
+        AssumeRolePolicyDocument: assumedByAccountRoot(accountId),
+      }),
+    );
+    const roleArn = roleCreation.Role.Arn;
+
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ObjectReader",
+        PolicyName: "ReadObjects",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "arn:aws:s3:::read-only/*",
+          },
+        }),
+      }),
+    );
+
+    // When the Role tries to delete an Object
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObject(
+        new DeleteObjectCommand({ Bucket: "read-only", Key: "keep.txt" }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then IAM denies the delete action against the Object ARN
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:DeleteObject");
+    assertIdentical(error.resource, "arn:aws:s3:::read-only/keep.txt");
+
+    // And the Object is still there
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "read-only", Key: "keep.txt" }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+    assertInstanceOf(output.Body, Readable);
+  });
+
+  it("allows a caller a Bucket policy grants the delete action", async () => {
+    // Given an Object and a Role allowed to delete it by Bucket policy alone
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const simS3 = simAws.account(accountId).region("eu-west-2").s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "shared" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "shared",
+        Key: "stale.txt",
+        Body: "stale",
+      }),
+    );
+
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "Cleaner",
+        AssumeRolePolicyDocument: assumedByAccountRoot(accountId),
+      }),
+    );
+    const roleArn = roleCreation.Role.Arn;
+
+    await simS3.putBucketPolicy(
+      new PutBucketPolicyCommand({
+        Bucket: "shared",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: roleArn },
+            Action: "s3:DeleteObject",
+            Resource: "arn:aws:s3:::shared/*",
+          },
+        }),
+      }),
+    );
+
+    // When the Role deletes the Object
+    await simS3.deleteObject(
+      new DeleteObjectCommand({ Bucket: "shared", Key: "stale.txt" }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the resource policy was enough, and the Object is gone
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "shared", Key: "stale.txt" }),
+      ),
+    );
+    assertInstanceOf(error, SimS3NoSuchKey);
+  });
+
+  it("uses allow-all authorization when SimS3 is instantiated directly", async () => {
+    // Given standalone S3, which has no IAM to consult
+    const simS3 = new SimS3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "standalone" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "standalone",
+        Key: "gone.txt",
+        Body: "content",
+      }),
+    );
+
+    // When an anonymous caller deletes the Object
+    await simS3.deleteObject(
+      new DeleteObjectCommand({ Bucket: "standalone", Key: "gone.txt" }),
+      { caller: { kind: "anonymous" } },
+    );
+
+    // Then the allow-all fallback permits it
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "standalone", Key: "gone.txt" }),
+      ),
+    );
+    assertInstanceOf(error, SimS3NoSuchKey);
+  });
+});

--- a/src/service/s3/command/delete-object/delete-object.command.ts
+++ b/src/service/s3/command/delete-object/delete-object.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteObject command.
+ */
+export interface SimDeleteObjectCommand {
+  readonly input: SimDeleteObjectCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteObject input.
+ */
+export interface SimDeleteObjectCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteObject output.
+ *
+ * Real S3 reports `DeleteMarker` and `VersionId` on a versioned Bucket. Sim S3
+ * does not model versioning, so neither appears here.
+ */
+export interface SimDeleteObjectCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-object/delete-object.handler.ts
+++ b/src/service/s3/command/delete-object/delete-object.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import { DeleteObjectAuthorizer } from "./delete-object-authorizer.js";
+import type {
+  SimDeleteObjectCommand,
+  SimDeleteObjectCommandOutput,
+} from "./delete-object.command.js";
+
+interface DeleteObjectCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteObjectCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 DeleteObjectCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/DeleteObjectCommand/
+ */
+export class DeleteObjectCommandHandler implements CommandHandler<
+  SimDeleteObjectCommand,
+  SimDeleteObjectCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: DeleteObjectAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteObjectCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new DeleteObjectAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and remove an Object from a Bucket.
+   *
+   * A missing Bucket is reported, but a missing key is not: real S3 answers a
+   * deletion the same way whether or not the Object was there, so code that
+   * deletes something twice sees the same success both times.
+   */
+  async handle(
+    command: SimDeleteObjectCommand,
+    options?: DeleteObjectCommandHandlerOptions,
+  ): Promise<SimDeleteObjectCommandOutput> {
+    assertDefined(command.input.Bucket, "DeleteObjectCommand.input.Bucket");
+    assertDefined(command.input.Key, "DeleteObjectCommand.input.Key");
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(bucket, command.input.Key, options?.caller);
+
+    await bucket.deleteObject(command.input.Key);
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/delete-object/delete-object.iso.test.ts
+++ b/src/service/s3/command/delete-object/delete-object.iso.test.ts
@@ -1,0 +1,130 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeObject,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
+
+describe("S3 DeleteObjectCommand", () => {
+  it("removes an Object so a following GetObject cannot find it", async () => {
+    // Given an Object in a Bucket
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "receipt.pdf",
+        Body: "a receipt",
+      }),
+    );
+
+    // When it is deleted
+    await simS3.deleteObject(
+      new DeleteObjectCommand({ Bucket: "uploads", Key: "receipt.pdf" }),
+    );
+
+    // Then reading it back raises the missing-key error real S3 answers with
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: "uploads", Key: "receipt.pdf" }),
+      ),
+    );
+    assertInstanceOf(error, SimS3NoSuchKey);
+  });
+
+  it("leaves the other Objects in the Bucket alone", async () => {
+    // Given two Objects in a Bucket
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: "a.txt", Body: "a" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: "b.txt", Body: "b" }),
+    );
+
+    // When one of them is deleted
+    await simS3.deleteObject(
+      new DeleteObjectCommand({ Bucket: "uploads", Key: "a.txt" }),
+    );
+
+    // Then the other is still listed
+    const listing = await simS3.listObjects(
+      new ListObjectsCommand({ Bucket: "uploads" }),
+    );
+    assertArrayLength(listing.Contents ?? [], 1);
+    assertIdentical(listing.Contents?.[0]?.Key, "b.txt");
+  });
+
+  it("succeeds for a key that is not there", async () => {
+    // Given a Bucket with nothing in it
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a key that was never stored is deleted
+    const output = await simS3.deleteObject(
+      new DeleteObjectCommand({ Bucket: "uploads", Key: "never-here.pdf" }),
+    );
+
+    // Then it succeeds, as real S3 does: deletion is idempotent
+    assertTypeObject(output.$metadata);
+  });
+
+  it("reports a Bucket that does not exist", async () => {
+    // Given no Bucket of that name
+    const simS3 = new SimAws().s3();
+
+    // When an Object is deleted from it
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObject(
+        new DeleteObjectCommand({ Bucket: "absent", Key: "receipt.pdf" }),
+      ),
+    );
+
+    // Then the missing Bucket is reported before anything else
+    assertStringIncludes(error.message, "No S3 Bucket named absent");
+  });
+
+  it("rejects a request naming no Bucket", async () => {
+    // Given a command with no Bucket
+    const simS3 = new SimAws().s3();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObject(
+        new DeleteObjectCommand({ Bucket: undefined, Key: "receipt.pdf" }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(error.message, "DeleteObjectCommand.input.Bucket");
+  });
+
+  it("rejects a request naming no key", async () => {
+    // Given a command with no Key
+    const simS3 = new SimAws().s3();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: undefined }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(error.message, "DeleteObjectCommand.input.Key");
+  });
+});

--- a/src/service/s3/command/delete-objects/delete-object-attempt.ts
+++ b/src/service/s3/command/delete-objects/delete-object-attempt.ts
@@ -1,0 +1,15 @@
+/**
+ * What one key of a DeleteObjects request came to.
+ *
+ * A batch deletion carries on past a key it could not remove, so the failure
+ * travels with the key it belongs to rather than being raised.
+ */
+export class DeleteObjectAttempt {
+  public readonly key: string;
+  public readonly error: unknown;
+
+  constructor(key: string, error?: unknown) {
+    this.key = key;
+    this.error = error;
+  }
+}

--- a/src/service/s3/command/delete-objects/delete-objects-failures.iso.test.ts
+++ b/src/service/s3/command/delete-objects/delete-objects-failures.iso.test.ts
@@ -1,0 +1,162 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { DeleteObjectAttempt } from "./delete-object-attempt.js";
+import { DeleteObjectsOutcome } from "./delete-objects-outcome.js";
+
+describe("S3 DeleteObjectsCommand partial failures", () => {
+  it("deletes the rest of the batch when one key is denied", async () => {
+    // Given three Objects, and a Role allowed to delete all but one of them
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+    const simS3 = simAws.account(accountId).region("eu-west-2").s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await Promise.all(
+      ["a.txt", "protected.txt", "c.txt"].map(
+        async (key) =>
+          await simS3.putObject(
+            new PutObjectCommand({ Bucket: "uploads", Key: key, Body: key }),
+          ),
+      ),
+    );
+
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PartialCleaner",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    const roleArn = roleCreation.Role.Arn;
+
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "PartialCleaner",
+        PolicyName: "DeleteMostObjects",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "s3:DeleteObject",
+              Resource: "arn:aws:s3:::uploads/*",
+            },
+            {
+              Effect: "Deny",
+              Action: "s3:DeleteObject",
+              Resource: "arn:aws:s3:::uploads/protected.txt",
+            },
+          ],
+        }),
+      }),
+    );
+
+    // When the Role deletes all three in one request
+    const output = await simS3.deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "uploads",
+        Delete: {
+          Objects: [
+            { Key: "a.txt" },
+            { Key: "protected.txt" },
+            { Key: "c.txt" },
+          ],
+        },
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the denied key is reported and the other two are still deleted
+    assertArrayLength(output.Deleted ?? [], 2);
+
+    const errors = output.Errors ?? [];
+    assertArrayLength(errors, 1);
+    const refused = errors[0];
+    assertNonNullable(refused);
+    assertIdentical(refused.Key, "protected.txt");
+    assertIdentical(refused.Code, "AccessDenied");
+    assertStringIncludes(
+      refused.Message,
+      "s3:DeleteObject on resource: arn:aws:s3:::uploads/protected.txt",
+    );
+
+    const listing = await simS3.listObjects(
+      new ListObjectsCommand({ Bucket: "uploads" }),
+    );
+    const remaining = listing.Contents ?? [];
+    assertArrayLength(remaining, 1);
+    assertIdentical(remaining[0].Key, "protected.txt");
+  });
+
+  it("reports a filesystem-backed Bucket refusing to delete", async () => {
+    // Given a Bucket whose storage is a directory on the filesystem
+    const directory = new TemporaryDirectory();
+    await directory.resolvePath();
+
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "site" }));
+    simS3.mountBucketFilesystem("site", directory.join("public"));
+
+    // When a batch deletion is asked for
+    const output = await simS3.deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "site",
+        Delete: { Objects: [{ Key: "index.html" }] },
+      }),
+    );
+
+    // Then the refusal is reported per key rather than unlinking a real file
+    assertUndefined(output.Deleted);
+
+    const errors = output.Errors ?? [];
+    assertArrayLength(errors, 1);
+    const refused = errors[0];
+    assertNonNullable(refused);
+    assertIdentical(refused.Code, "NotImplemented");
+    assertStringIncludes(
+      refused.Message,
+      "will not delete index.html from filesystem-backed storage",
+    );
+  });
+
+  it("re-raises a failure that is not an S3 one", () => {
+    // Given an attempt that failed for a reason the simulator has no S3 code for
+    const attempt = new DeleteObjectAttempt(
+      "a.txt",
+      new TypeError("something went wrong"),
+    );
+
+    // When the outcome is collected
+    const error = assertThrowsError(() => {
+      new DeleteObjectsOutcome([attempt]);
+    });
+
+    // Then it is re-raised, so a bug cannot arrive as a per-key AWS error
+    assertStringIncludes(error.message, "something went wrong");
+  });
+});

--- a/src/service/s3/command/delete-objects/delete-objects-outcome.ts
+++ b/src/service/s3/command/delete-objects/delete-objects-outcome.ts
@@ -1,0 +1,77 @@
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { SimS3Error } from "../../error/sim-s3.error.js";
+import type { DeleteObjectAttempt } from "./delete-object-attempt.js";
+import type {
+  SimDeleteObjectsCommandOutput,
+  SimS3DeletedObject,
+  SimS3DeleteObjectsError,
+} from "./delete-objects.command.js";
+
+/**
+ * What a DeleteObjects request did to each key it named.
+ *
+ * A batch deletion is not all or nothing in real S3: a key it cannot remove is
+ * reported in the response while the rest are still deleted, so the failures
+ * are collected here rather than raised.
+ */
+export class DeleteObjectsOutcome {
+  private readonly deleted: SimS3DeletedObject[] = [];
+  private readonly errors: SimS3DeleteObjectsError[] = [];
+
+  constructor(attempts: readonly DeleteObjectAttempt[]) {
+    for (const attempt of attempts) {
+      this.record(attempt);
+    }
+  }
+
+  /**
+   * Build the DeleteObjects response.
+   *
+   * A quiet request asks for the failures alone, and real S3 leaves an empty
+   * list out of the response rather than sending it empty.
+   */
+  toOutput(quiet: boolean): SimDeleteObjectsCommandOutput {
+    return {
+      ...(!quiet && this.deleted.length > 0 && { Deleted: this.deleted }),
+      ...(this.errors.length > 0 && { Errors: this.errors }),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Sort one attempt into the deletions or the failures.
+   */
+  private record(attempt: DeleteObjectAttempt): void {
+    if (attempt.error === undefined) {
+      this.deleted.push({ Key: attempt.key });
+      return;
+    }
+
+    this.recordFailure(attempt.key, attempt.error);
+  }
+
+  /**
+   * Report why a key was not removed.
+   *
+   * Only failures S3 itself has a code for are reported. Anything the simulator
+   * does not recognise is re-raised, so a bug in the simulation cannot arrive
+   * as a per-key AWS error the test then asserts on.
+   */
+  private recordFailure(key: string, error: unknown): void {
+    if (error instanceof SimIamAccessDenied) {
+      this.errors.push({
+        Key: key,
+        Code: "AccessDenied",
+        Message: error.message,
+      });
+      return;
+    }
+
+    if (error instanceof SimS3Error) {
+      this.errors.push({ Key: key, Code: error.name, Message: error.message });
+      return;
+    }
+
+    throw error;
+  }
+}

--- a/src/service/s3/command/delete-objects/delete-objects-request.ts
+++ b/src/service/s3/command/delete-objects/delete-objects-request.ts
@@ -1,0 +1,48 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
+import type { SimDeleteObjectsRequest } from "./delete-objects.command.js";
+
+/**
+ * The most Objects real S3 accepts in one DeleteObjects request.
+ */
+const maximumKeys = 1000;
+
+/**
+ * The keys a DeleteObjects request names, and whether it asked to be quiet.
+ *
+ * Real S3 refuses the whole request before deleting anything when the document
+ * it was sent is not one it accepts, so the limits are checked here rather than
+ * reported per key.
+ */
+export class DeleteObjectsRequest {
+  public readonly keys: readonly string[];
+  public readonly quiet: boolean;
+
+  constructor(request: SimDeleteObjectsRequest) {
+    const objects = request.Objects ?? [];
+
+    if (objects.length === 0) {
+      throw new SimS3MalformedXml(
+        "DeleteObjectsCommand.input.Delete.Objects names no Objects to delete",
+      );
+    }
+
+    if (objects.length > maximumKeys) {
+      throw new SimS3MalformedXml(
+        `DeleteObjectsCommand.input.Delete.Objects names ` +
+          `${String(objects.length)} Objects, and S3 deletes at most ` +
+          `${String(maximumKeys)} in one request`,
+      );
+    }
+
+    this.keys = objects.map((object) => {
+      assertDefined(
+        object.Key,
+        "DeleteObjectsCommand.input.Delete.Objects Key",
+      );
+
+      return object.Key;
+    });
+    this.quiet = request.Quiet ?? false;
+  }
+}

--- a/src/service/s3/command/delete-objects/delete-objects.command.ts
+++ b/src/service/s3/command/delete-objects/delete-objects.command.ts
@@ -1,0 +1,59 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteObjects command.
+ */
+export interface SimDeleteObjectsCommand {
+  readonly input: SimDeleteObjectsCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteObjects input.
+ */
+export interface SimDeleteObjectsCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Delete?: SimDeleteObjectsRequest | undefined;
+}
+
+/**
+ * The Objects one DeleteObjects request asks to remove.
+ *
+ * `Quiet` asks S3 to report only the keys it could not remove, which is what
+ * bulk cleanup code usually wants.
+ */
+export interface SimDeleteObjectsRequest {
+  readonly Objects?: readonly SimS3ObjectIdentifier[] | undefined;
+  readonly Quiet?: boolean | undefined;
+}
+
+/**
+ * One Object named in a DeleteObjects request.
+ */
+export interface SimS3ObjectIdentifier {
+  readonly Key?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteObjects output.
+ */
+export interface SimDeleteObjectsCommandOutput {
+  readonly Deleted?: readonly SimS3DeletedObject[];
+  readonly Errors?: readonly SimS3DeleteObjectsError[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One Object a DeleteObjects request removed.
+ */
+export interface SimS3DeletedObject {
+  readonly Key: string;
+}
+
+/**
+ * One Object a DeleteObjects request could not remove.
+ */
+export interface SimS3DeleteObjectsError {
+  readonly Key: string;
+  readonly Code: string;
+  readonly Message: string;
+}

--- a/src/service/s3/command/delete-objects/delete-objects.handler.ts
+++ b/src/service/s3/command/delete-objects/delete-objects.handler.ts
@@ -1,0 +1,104 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { DeleteObjectAuthorizer } from "../delete-object/delete-object-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import { DeleteObjectAttempt } from "./delete-object-attempt.js";
+import { DeleteObjectsOutcome } from "./delete-objects-outcome.js";
+import { DeleteObjectsRequest } from "./delete-objects-request.js";
+import type {
+  SimDeleteObjectsCommand,
+  SimDeleteObjectsCommandOutput,
+} from "./delete-objects.command.js";
+
+interface DeleteObjectsCommandHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface DeleteObjectsCommandHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 DeleteObjectsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/DeleteObjectsCommand/
+ */
+export class DeleteObjectsCommandHandler implements CommandHandler<
+  SimDeleteObjectsCommand,
+  SimDeleteObjectsCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: DeleteObjectAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteObjectsCommandHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new DeleteObjectAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and remove each Object the request names.
+   *
+   * Each key is authorized on its own against `s3:DeleteObject`, as real S3
+   * does, and a key the caller may not remove is reported in the response while
+   * the rest of the batch is still deleted.
+   */
+  async handle(
+    command: SimDeleteObjectsCommand,
+    options?: DeleteObjectsCommandHandlerOptions,
+  ): Promise<SimDeleteObjectsCommandOutput> {
+    assertDefined(command.input.Bucket, "DeleteObjectsCommand.input.Bucket");
+    assertDefined(command.input.Delete, "DeleteObjectsCommand.input.Delete");
+
+    const request = new DeleteObjectsRequest(command.input.Delete);
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    const attempts = await Promise.all(
+      request.keys.map(
+        async (key) => await this.deleteKey(bucket, key, options?.caller),
+      ),
+    );
+
+    return new DeleteObjectsOutcome(attempts).toOutput(request.quiet);
+  }
+
+  private async deleteKey(
+    bucket: SimS3Bucket,
+    key: string,
+    caller?: SimAwsCaller,
+  ): Promise<DeleteObjectAttempt> {
+    try {
+      this.authorizer.authorize(bucket, key, caller);
+      await bucket.deleteObject(key);
+
+      return new DeleteObjectAttempt(key);
+    } catch (error) {
+      return new DeleteObjectAttempt(key, error);
+    }
+  }
+}

--- a/src/service/s3/command/delete-objects/delete-objects.iso.test.ts
+++ b/src/service/s3/command/delete-objects/delete-objects.iso.test.ts
@@ -1,0 +1,212 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
+
+/**
+ * A Bucket holding three Objects, which is enough to see a batch deletion
+ * remove some of them and leave the rest.
+ */
+async function bucketOfThree(): Promise<ReturnType<SimAws["s3"]>> {
+  const simS3 = new SimAws().s3();
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+  await Promise.all(
+    ["a.txt", "b.txt", "c.txt"].map(
+      async (key) =>
+        await simS3.putObject(
+          new PutObjectCommand({ Bucket: "uploads", Key: key, Body: key }),
+        ),
+    ),
+  );
+
+  return simS3;
+}
+
+describe("S3 DeleteObjectsCommand", () => {
+  it("removes every Object it names and reports each one", async () => {
+    // Given a Bucket holding three Objects
+    const simS3 = await bucketOfThree();
+
+    // When two of them are deleted in one request
+    const output = await simS3.deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "uploads",
+        Delete: { Objects: [{ Key: "a.txt" }, { Key: "b.txt" }] },
+      }),
+    );
+
+    // Then both are reported deleted, and the third is still in the Bucket
+    const deleted = output.Deleted ?? [];
+    assertArrayLength(deleted, 2);
+    assertIdentical(deleted[0].Key, "a.txt");
+    assertIdentical(deleted[1].Key, "b.txt");
+    assertUndefined(output.Errors);
+
+    const listing = await simS3.listObjects(
+      new ListObjectsCommand({ Bucket: "uploads" }),
+    );
+    const remaining = listing.Contents ?? [];
+    assertArrayLength(remaining, 1);
+    assertIdentical(remaining[0].Key, "c.txt");
+  });
+
+  it("reports a quiet request's failures alone", async () => {
+    // Given a Bucket holding three Objects
+    const simS3 = await bucketOfThree();
+
+    // When a quiet request deletes one of them
+    const output = await simS3.deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "uploads",
+        Delete: { Objects: [{ Key: "a.txt" }], Quiet: true },
+      }),
+    );
+
+    // Then nothing is reported, because nothing failed
+    assertUndefined(output.Deleted);
+    assertUndefined(output.Errors);
+  });
+
+  it("succeeds for keys that are not there", async () => {
+    // Given a Bucket with nothing in it
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When keys that were never stored are deleted
+    const output = await simS3.deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "uploads",
+        Delete: { Objects: [{ Key: "gone.txt" }] },
+      }),
+    );
+
+    // Then they are reported deleted, as real S3 reports an idempotent removal
+    assertArrayLength(output.Deleted ?? [], 1);
+    assertUndefined(output.Errors);
+  });
+
+  it("reports a Bucket that does not exist", async () => {
+    // Given no Bucket of that name
+    const simS3 = new SimAws().s3();
+
+    // When Objects are deleted from it
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({
+          Bucket: "absent",
+          Delete: { Objects: [{ Key: "a.txt" }] },
+        }),
+      ),
+    );
+
+    // Then the whole request fails, rather than each key failing separately
+    assertStringIncludes(error.message, "No S3 Bucket named absent");
+  });
+
+  it("refuses a request naming no Objects", async () => {
+    // Given a Bucket and an empty deletion request
+    const simS3 = await bucketOfThree();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({
+          Bucket: "uploads",
+          Delete: { Objects: [] },
+        }),
+      ),
+    );
+
+    // Then it is refused as malformed, as real S3 refuses it
+    assertInstanceOf(error, SimS3MalformedXml);
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+  });
+
+  it("refuses a request naming more Objects than S3 accepts", async () => {
+    // Given more than the thousand keys one request may carry
+    const simS3 = await bucketOfThree();
+    const objects = Array.from({ length: 1001 }, (_unused, index) => ({
+      Key: `key-${String(index)}.txt`,
+    }));
+
+    // When they are all named in one request
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({
+          Bucket: "uploads",
+          Delete: { Objects: objects },
+        }),
+      ),
+    );
+
+    // Then the request is refused before anything is deleted
+    assertInstanceOf(error, SimS3MalformedXml);
+    assertStringIncludes(error.message, "at most 1000");
+  });
+
+  it("rejects a request naming no Bucket", async () => {
+    // Given a command with no Bucket
+    const simS3 = new SimAws().s3();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({
+          Bucket: undefined,
+          Delete: { Objects: [{ Key: "a.txt" }] },
+        }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(error.message, "DeleteObjectsCommand.input.Bucket");
+  });
+
+  it("rejects a request with no deletion document", async () => {
+    // Given a command with no Delete
+    const simS3 = new SimAws().s3();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({ Bucket: "uploads", Delete: undefined }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(error.message, "DeleteObjectsCommand.input.Delete");
+  });
+
+  it("rejects an entry naming no key", async () => {
+    // Given a deletion entry with no Key
+    const simS3 = new SimAws().s3();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.deleteObjects(
+        new DeleteObjectsCommand({
+          Bucket: "uploads",
+          Delete: { Objects: [{ Key: undefined }] },
+        }),
+      ),
+    );
+
+    // Then the malformed entry is reported
+    assertStringIncludes(error.message, "Delete.Objects Key");
+  });
+});

--- a/src/service/s3/command/object/sim-s3-object-commands.ts
+++ b/src/service/s3/command/object/sim-s3-object-commands.ts
@@ -1,3 +1,5 @@
+import { DeleteObjectCommandHandler } from "../delete-object/delete-object.handler.js";
+import { DeleteObjectsCommandHandler } from "../delete-objects/delete-objects.handler.js";
 import { GetObjectCommandHandler } from "../get-object/get-object.handler.js";
 import { ListObjectsCommandHandler } from "../list-objects/list-objects.handler.js";
 import { PutObjectCommandHandler } from "../put-object/put-object.handler.js";
@@ -36,6 +38,32 @@ export class SimS3ObjectCommands {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimGetObjectCommandOutput> {
     return await new GetObjectCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Remove an Object from a Bucket.
+   */
+  async delete(
+    command: simS3Commands.SimDeleteObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectCommandOutput> {
+    return await new DeleteObjectCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Remove several Objects from a Bucket in one request.
+   */
+  async deleteMany(
+    command: simS3Commands.SimDeleteObjectsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectsCommandOutput> {
+    return await new DeleteObjectsCommandHandler(this.state).handle(
       command,
       options,
     );

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -14,6 +14,14 @@ export type {
   SimDeleteBucketPolicyCommandOutput,
 } from "./delete-bucket-policy/delete-bucket-policy.command.js";
 export type {
+  SimDeleteObjectCommand,
+  SimDeleteObjectCommandOutput,
+} from "./delete-object/delete-object.command.js";
+export type {
+  SimDeleteObjectsCommand,
+  SimDeleteObjectsCommandOutput,
+} from "./delete-objects/delete-objects.command.js";
+export type {
   SimDeletePublicAccessBlockCommand,
   SimDeletePublicAccessBlockCommandOutput,
 } from "./delete-public-access-block/delete-public-access-block.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -90,6 +90,35 @@ export class SimS3BucketAlreadyOwnedByYou extends SimS3Error {
 }
 
 /**
+ * Simulated S3 MalformedXML error.
+ *
+ * Real S3 answers this when the request document is not one it accepts, which
+ * is how a DeleteObjects request naming no Objects, or more than a thousand of
+ * them, is refused.
+ */
+export class SimS3MalformedXml extends SimS3Error {
+  public override readonly name = "MalformedXML";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated S3 NotImplemented error.
+ *
+ * Something real S3 does that the simulator refuses rather than approximates.
+ * Real S3 uses the same code for a request it will not carry out.
+ */
+export class SimS3NotImplemented extends SimS3Error {
+  public override readonly name = "NotImplemented";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 501 });
+  }
+}
+
+/**
  * Simulated S3 InvalidBucketName error.
  */
 export class SimS3InvalidBucketName extends SimS3Error {

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "vitest";
 import {
   CreateBucketCommand,
   DeleteBucketPolicyCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
   DeletePublicAccessBlockCommand,
   GetBucketPolicyCommand,
   GetPublicAccessBlockCommand,
@@ -166,13 +168,54 @@ describe("simulated S3 SDK Command routing", () => {
     assertTrue(restoredOut.PublicAccessBlockConfiguration?.BlockPublicPolicy);
   });
 
+  it("routes the Object deletion Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-delete" }));
+    await Promise.all(
+      ["a.txt", "b.txt", "c.txt"].map(
+        async (key) =>
+          await client.send(
+            new PutObjectCommand({
+              Bucket: "bucket-delete",
+              Key: key,
+              Body: key,
+            }),
+          ),
+      ),
+    );
+
+    await client.send(
+      new DeleteObjectCommand({ Bucket: "bucket-delete", Key: "a.txt" }),
+    );
+
+    const batchOut = await client.send(
+      new DeleteObjectsCommand({
+        Bucket: "bucket-delete",
+        Delete: { Objects: [{ Key: "b.txt" }] },
+      }),
+    );
+    assertIdentical(batchOut.Deleted?.length, 1);
+
+    const listOut = await client.send(
+      new ListObjectsCommand({ Bucket: "bucket-delete" }),
+    );
+    const remaining = listOut.Contents ?? [];
+    assertArrayLength(remaining, 1);
+    assertIdentical(remaining[0].Key, "c.txt");
+  });
+
   it("lists its supported SDK Command names", () => {
     const router = new SimS3SdkCommandRouter({} as SimS3);
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 12);
+    assertArrayLength(supported, 14);
     assertArrayIncludes(supported, "GetObjectCommand");
+    assertArrayIncludes(supported, "DeleteObjectCommand");
+    assertArrayIncludes(supported, "DeleteObjectsCommand");
     assertArrayIncludes(supported, "GetBucketPolicyCommand");
     assertArrayIncludes(supported, "DeleteBucketPolicyCommand");
     assertArrayIncludes(supported, "PutPublicAccessBlockCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -12,6 +12,8 @@ import type {
 import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.command.js";
 import type { SimListObjectsCommand } from "../command/list-objects/list-objects.command.js";
 import type { SimDeleteBucketPolicyCommand } from "../command/delete-bucket-policy/delete-bucket-policy.command.js";
+import type { SimDeleteObjectCommand } from "../command/delete-object/delete-object.command.js";
+import type { SimDeleteObjectsCommand } from "../command/delete-objects/delete-objects.command.js";
 import type { SimGetBucketPolicyCommand } from "../command/get-bucket-policy/get-bucket-policy.command.js";
 import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.command.js";
 import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.command.js";
@@ -42,6 +44,22 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.deleteBucketPolicy(
             command as SimDeleteBucketPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteObjectCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deleteObject(
+            command as SimDeleteObjectCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteObjectsCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deleteObjects(
+            command as SimDeleteObjectsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/serve/sim-s3-rest-controller.ts
+++ b/src/service/s3/serve/sim-s3-rest-controller.ts
@@ -2,6 +2,7 @@ import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
 import { SimS3RestErrorResponse } from "./sim-s3-rest-error-response.js";
+import { SimS3RestObjectReader } from "./sim-s3-rest-object-reader.js";
 import { SimS3UploadChecksum } from "./sim-s3-upload-checksum.js";
 import type { SimS3 } from "../sim-s3.js";
 
@@ -20,6 +21,7 @@ interface SimS3RestControllerProperties {
  */
 export class SimS3RestController {
   private readonly simAws: SimAws;
+  private readonly reader = new SimS3RestObjectReader();
 
   constructor(properties: SimS3RestControllerProperties) {
     this.simAws = properties.simAws;
@@ -52,30 +54,29 @@ export class SimS3RestController {
       return await this.putObject(route, serviceRequest);
     }
 
-    return await this.getObject(route, serviceRequest);
+    if (serviceRequest.request.method === "DELETE") {
+      return await this.deleteObject(route, serviceRequest);
+    }
+
+    return await this.reader.read(this.s3For(route), route, serviceRequest);
   }
 
-  private async getObject(
+  /**
+   * Remove an Object.
+   *
+   * Real S3 answers a deletion with `204 No Content` whether or not the Object
+   * was there, so a client cannot tell the two apart.
+   */
+  private async deleteObject(
     route: SimS3RestObjectRoute,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
-    const output = await this.s3For(route).getObject(
+    await this.s3For(route).deleteObject(
       { input: { Bucket: route.bucket.bucketName, Key: route.objectKey } },
       { caller: serviceRequest.caller.toCaller() },
     );
 
-    const body = await bodyBytes(output.Body);
-    const contentType = output.Metadata?.["content-type"];
-    const headers = {
-      "content-length": String(body.length),
-      ...(contentType !== undefined && { "content-type": contentType }),
-    };
-
-    if (serviceRequest.request.method === "HEAD") {
-      return new Response(undefined, { status: 200, headers });
-    }
-
-    return new Response(body, { status: 200, headers });
+    return new Response(undefined, { status: 204 });
   }
 
   /**
@@ -120,24 +121,4 @@ export class SimS3RestController {
       )
       .s3();
   }
-}
-
-/**
- * Read a GetObject response body into the bytes an HTTP response carries.
- */
-async function bodyBytes(
-  body: { [Symbol.asyncIterator](): AsyncIterator<unknown> } | undefined,
-): Promise<Buffer> {
-  /* v8 ignore if -- the loader always answers with a body */
-  if (body === undefined) {
-    return Buffer.alloc(0);
-  }
-
-  const chunks: Buffer[] = [];
-
-  for await (const chunk of body) {
-    chunks.push(Buffer.from(chunk as Uint8Array));
-  }
-
-  return Buffer.concat(chunks);
 }

--- a/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
@@ -92,16 +93,72 @@ describe("The simulated S3 REST endpoint", () => {
     assertIdentical(await response.text(), "");
   });
 
+  it("deletes an Object over a presigned DELETE", async () => {
+    // Given a user allowed to delete Objects, and a URL they presigned
+    const { client, http } = await presignSimulation({
+      allowedActions: ["s3:GetObject", "s3:DeleteObject"],
+    });
+    const url = await getSignedUrl(
+      client,
+      new DeleteObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When the URL is used
+    const response = await http.fetch(url, { method: "DELETE" });
+
+    // Then S3 answers with no content, and the Object has gone
+    assertIdentical(response.status, 204);
+    assertIdentical(await response.text(), "");
+
+    const readBack = await http.fetch(
+      await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: presignBucketName,
+          Key: presignObjectKey,
+        }),
+        { expiresIn: 900 },
+      ),
+    );
+    assertIdentical(readBack.status, 404);
+  });
+
+  it("refuses a DELETE its signer cannot perform", async () => {
+    // Given a user allowed to read Objects but not to delete them
+    const { client, http } = await presignSimulation({
+      allowedActions: ["s3:GetObject"],
+    });
+    const url = await getSignedUrl(
+      client,
+      new DeleteObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When they presign a deletion and it is used
+    const response = await http.fetch(url, { method: "DELETE" });
+
+    // Then IAM refuses it, and the Object is still there
+    assertIdentical(response.status, 403);
+    expect(await response.text()).toMatch(/s3:DeleteObject/);
+  });
+
   it("refuses a method it does not simulate", async () => {
-    // Given a DELETE, which simulated S3 has no command for
+    // Given a POST, which simulated S3 has no REST command for
     const { http } = await presignSimulation();
 
     // When it reaches the REST endpoint
-    const response = await http.fetch(objectUrl, { method: "DELETE" });
+    const response = await http.fetch(objectUrl, { method: "POST" });
 
     // Then the gap is reported rather than answered with something plausible
     assertIdentical(response.status, 501);
-    expect(await response.text()).toMatch(/does not serve DELETE/);
+    expect(await response.text()).toMatch(/does not serve POST/);
   });
 
   it("refuses a request naming a Bucket and no Object", async () => {

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -1,0 +1,59 @@
+import type { SimS3 } from "../sim-s3.js";
+import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
+import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+
+/**
+ * Answers a `GET` or `HEAD` at the simulated S3 REST endpoint.
+ *
+ * The two share everything but the body, because a `HEAD` is a `GET` whose
+ * response real S3 stops short of sending, so they are read the same way here
+ * and differ only in what comes back.
+ */
+export class SimS3RestObjectReader {
+  /**
+   * Read an Object as the principal the boundary resolved.
+   */
+  async read(
+    simS3: SimS3,
+    route: SimS3RestObjectRoute,
+    serviceRequest: SimAwsServiceRequest,
+  ): Promise<Response> {
+    const output = await simS3.getObject(
+      { input: { Bucket: route.bucket.bucketName, Key: route.objectKey } },
+      { caller: serviceRequest.caller.toCaller() },
+    );
+
+    const body = await bodyBytes(output.Body);
+    const contentType = output.Metadata?.["content-type"];
+    const headers = {
+      "content-length": String(body.length),
+      ...(contentType !== undefined && { "content-type": contentType }),
+    };
+
+    if (serviceRequest.request.method === "HEAD") {
+      return new Response(undefined, { status: 200, headers });
+    }
+
+    return new Response(body, { status: 200, headers });
+  }
+}
+
+/**
+ * Read a GetObject response body into the bytes an HTTP response carries.
+ */
+async function bodyBytes(
+  body: { [Symbol.asyncIterator](): AsyncIterator<unknown> } | undefined,
+): Promise<Buffer> {
+  /* v8 ignore if -- the loader always answers with a body */
+  if (body === undefined) {
+    return Buffer.alloc(0);
+  }
+
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of body) {
+    chunks.push(Buffer.from(chunk as Uint8Array));
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/src/service/s3/serve/sim-s3-rest-refusal.ts
+++ b/src/service/s3/serve/sim-s3-rest-refusal.ts
@@ -4,7 +4,7 @@ import {
   simS3RouteFailure as failure,
 } from "./sim-s3-route.js";
 
-const restMethods = new Set(["GET", "HEAD", "PUT"]);
+const restMethods = new Set(["GET", "HEAD", "PUT", "DELETE"]);
 
 /**
  * Whether a REST request asks for something simulated S3 does not serve.
@@ -17,7 +17,7 @@ export function simS3RestRefusal(
     return failure(
       501,
       `Simulated S3 does not serve ${method} over its REST endpoint. ` +
-        `GET, HEAD and PUT of an Object are simulated.\n`,
+        `GET, HEAD, PUT and DELETE of an Object are simulated.\n`,
     );
   }
 

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -157,6 +157,26 @@ export class SimS3 {
   }
 
   /**
+   * Handle a Delete Object Command from the SDK.
+   */
+  async deleteObject(
+    command: simS3Commands.SimDeleteObjectCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectCommandOutput> {
+    return await this.commands.objects.delete(command, options);
+  }
+
+  /**
+   * Handle a Delete Objects Command from the SDK.
+   */
+  async deleteObjects(
+    command: simS3Commands.SimDeleteObjectsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteObjectsCommandOutput> {
+    return await this.commands.objects.deleteMany(command, options);
+  }
+
+  /**
    * Handle a List Objects Command from the SDK.
    */
   async listObjects(

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-keys.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-keys.ts
@@ -1,0 +1,72 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import type { FilesystemS3StorageSafety } from "./s3-filesystem-safety.js";
+import { filesystemPathExists } from "./filesystem-path-exists.js";
+
+interface FilesystemS3ObjectKeysProperties {
+  readonly directoryPath: string;
+  readonly safety: FilesystemS3StorageSafety;
+}
+
+/**
+ * Finds the Object keys a storage directory holds.
+ *
+ * A directory tree is a listing here, so the walk lives on its own rather than
+ * in the storage class: files become keys relative to the directory root, with
+ * platform separators normalised to the `/` an S3 key uses.
+ */
+export class FilesystemS3ObjectKeys {
+  private readonly directoryPath: string;
+  private readonly safety: FilesystemS3StorageSafety;
+
+  constructor(properties: FilesystemS3ObjectKeysProperties) {
+    this.directoryPath = properties.directoryPath;
+    this.safety = properties.safety;
+  }
+
+  /**
+   * List every Object key under the storage directory.
+   *
+   * A directory that is not there holds nothing, which is what an empty Bucket
+   * looks like.
+   */
+  async list(): Promise<string[]> {
+    if (!(await filesystemPathExists(this.directoryPath))) {
+      return [];
+    }
+
+    return await this.listInDirectory(this.directoryPath);
+  }
+
+  private async listInDirectory(directoryPath: string): Promise<string[]> {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+    const keys: string[] = [];
+    const nestedKeyPromises: Promise<string[]>[] = [];
+
+    for (const entry of entries) {
+      const entryPath = path.join(directoryPath, entry.name);
+
+      if (entry.isDirectory()) {
+        nestedKeyPromises.push(this.listInDirectory(entryPath));
+        continue;
+      }
+
+      if (entry.isFile()) {
+        const key = path
+          .relative(this.directoryPath, entryPath)
+          .split(path.sep)
+          .join("/");
+
+        if (this.safety.isAllowedObjectKeyExtension(key)) {
+          keys.push(key);
+        }
+      }
+    }
+
+    const nestedKeys = await Promise.all(nestedKeyPromises);
+
+    return [...keys, ...nestedKeys.flat()];
+  }
+}

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
@@ -4,9 +4,13 @@ import {
   assertArrayLength,
   assertBufferEqual,
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
+import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
 import { FilesystemS3BucketStorage } from "./s3-filesystem-storage.js";
 import { SimS3Object } from "../../object/s3-object.js";
 import { TemporaryDirectory as TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
@@ -178,5 +182,25 @@ describe("Filesystem simulated S3 storage", () => {
 
     assertArrayLength(objects, 1);
     assertIdentical(objects[0].key, "safe.txt");
+  });
+
+  it("refuses to delete an Object rather than unlinking the file", async () => {
+    // Given a file backing a simulated Object
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "keep.txt"], "keep");
+
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When the Object is deleted
+    const error = await assertThrowsErrorAsync(async () => {
+      await storage.deleteObject("keep.txt");
+    });
+
+    // Then the refusal is reported, and the file is still there
+    assertInstanceOf(error, SimS3NotImplemented);
+    assertStringIncludes(error.message, "will not delete keep.txt");
+    assertNonNullable(await storage.getObject("keep.txt"));
   });
 });

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -1,11 +1,12 @@
 import type { SimS3BucketStorage } from "../s3-bucket-storage.js";
 import { SimS3Object } from "../../object/s3-object.js";
 import path from "node:path";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { FilesystemS3StorageSafety } from "./s3-filesystem-safety.js";
 import { metadataForFilesystemS3ObjectKey } from "./s3-filesystem-object-metadata.js";
-import { filesystemPathExists } from "./filesystem-path-exists.js";
+import { FilesystemS3ObjectKeys } from "./s3-filesystem-object-keys.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
 
 interface FilesystemS3BucketStorageProperties {
   readonly directoryPath: string;
@@ -23,6 +24,7 @@ interface FilesystemS3BucketStorageProperties {
 export class FilesystemS3BucketStorage implements SimS3BucketStorage {
   private readonly directoryPath: string;
   private readonly safety: FilesystemS3StorageSafety;
+  private readonly objectKeys: FilesystemS3ObjectKeys;
 
   constructor(properties: FilesystemS3BucketStorageProperties) {
     this.safety = new FilesystemS3StorageSafety({
@@ -30,6 +32,10 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
     });
     this.safety.assertSafeDirectoryPath(properties.directoryPath);
     this.directoryPath = path.resolve(properties.directoryPath);
+    this.objectKeys = new FilesystemS3ObjectKeys({
+      directoryPath: this.directoryPath,
+      safety: this.safety,
+    });
   }
 
   /**
@@ -69,7 +75,7 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
    * List simulated Objects based on files in the directory.
    */
   async listObjects(prefix?: string): Promise<SimS3Object[]> {
-    const objectKeys = await this.listObjectKeys();
+    const objectKeys = await this.objectKeys.list();
 
     return await Promise.all(
       objectKeys
@@ -95,6 +101,25 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
     await writeFile(filePath, object.body);
   }
 
+  /**
+   * Refuse to remove the file backing a simulated Object.
+   *
+   * This is stricter than real S3, deliberately. `mountBucketFilesystem` points
+   * a Bucket at an ordinary directory of the user's, and the safety checks here
+   * are local-development tooling rather than a sandbox boundary. Unlinking
+   * someone's files because a test called DeleteObject is the wrong default, so
+   * filesystem-backed Buckets are read and written but never emptied.
+   */
+  deleteObject(key: string): Promise<void> {
+    return Promise.reject(
+      new SimS3NotImplemented(
+        `Simulated S3 will not delete ${key} from filesystem-backed storage ` +
+          `at ${this.directoryPath}, because it would remove a real file. ` +
+          `Use the default in-memory Bucket storage to simulate deletion.`,
+      ),
+    );
+  }
+
   private filePathForObjectKey(key: string): string {
     this.safety.assertSafeObjectKey(key);
 
@@ -111,46 +136,5 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
     }
 
     return filePath;
-  }
-
-  private async listObjectKeys(): Promise<string[]> {
-    if (!(await filesystemPathExists(this.directoryPath))) {
-      return [];
-    }
-
-    return await this.listObjectKeysInDirectory(this.directoryPath);
-  }
-
-  private async listObjectKeysInDirectory(
-    directoryPath: string,
-  ): Promise<string[]> {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    const entries = await readdir(directoryPath, { withFileTypes: true });
-    const keys: string[] = [];
-    const nestedKeyPromises: Promise<string[]>[] = [];
-
-    for (const entry of entries) {
-      const entryPath = path.join(directoryPath, entry.name);
-
-      if (entry.isDirectory()) {
-        nestedKeyPromises.push(this.listObjectKeysInDirectory(entryPath));
-        continue;
-      }
-
-      if (entry.isFile()) {
-        const key = path
-          .relative(this.directoryPath, entryPath)
-          .split(path.sep)
-          .join("/");
-
-        if (this.safety.isAllowedObjectKeyExtension(key)) {
-          keys.push(key);
-        }
-      }
-    }
-
-    const nestedKeys = await Promise.all(nestedKeyPromises);
-
-    return [...keys, ...nestedKeys.flat()];
   }
 }

--- a/src/service/s3/storage/s3-bucket-storage.ts
+++ b/src/service/s3/storage/s3-bucket-storage.ts
@@ -15,4 +15,11 @@ export interface SimS3BucketStorage {
    * List simulated Objects in storage.
    */
   listObjects(prefix?: string): Promise<SimS3Object[]>;
+
+  /**
+   * Remove a simulated Object from storage.
+   *
+   * S3 deletion is idempotent, so a key that is not stored is not an error.
+   */
+  deleteObject(key: string): Promise<void>;
 }

--- a/src/service/s3/storage/s3-memory-storage.ts
+++ b/src/service/s3/storage/s3-memory-storage.ts
@@ -32,4 +32,15 @@ export class MemoryS3BucketStorage implements SimS3BucketStorage {
     this.objects.set(object.key, object);
     return Promise.resolve();
   }
+
+  /**
+   * Remove a simulated Object from in-memory storage.
+   *
+   * A key that is not stored is not an error, as real S3 answers a deletion the
+   * same way whether or not there was anything there.
+   */
+  deleteObject(key: string): Promise<void> {
+    this.objects.delete(key);
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
DeleteObject and DeleteObjects remove Objects through the normal command path, authorized per Object against s3:DeleteObject, reachable through the SDK and through the REST endpoint's DELETE verb.

Filesystem-backed Bucket storage refuses deletion rather than unlinking a real file, which is stricter than AWS and is recorded in Limitations.

Resolves https://github.com/KensioSoftware/yulin/issues/329