### PR TITLE
feat: deploy simulated HTTP API Lambda authorizers from CloudFormatio…

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -982,7 +982,8 @@ srv.close();
 ```
 
 The authorizer function is invoked once per request reaching the route. Nothing is cached between
-requests.
+requests until the authorizer is given an `AuthorizerResultTtlInSeconds`, which is what AWS defaults
+to as well. See [Caching the authorizer's decision](#caching-the-authorizers-decision).
 
 ### The event the authorizer receives
 
@@ -1335,7 +1336,7 @@ what a disabled endpoint was observed to answer rather than something documented
 ## Importing an OpenAPI definition
 
 `ImportApiCommand` takes a serialised OpenAPI 3.0 document and creates the API, one route and one
-integration per operation, and one JWT authorizer per security scheme an operation names. The route
+integration per operation, and one authorizer per security scheme an operation names. The route
 key is the operation key uppercased and the path taken verbatim, since OpenAPI path templating is
 already API Gateway's path parameter syntax.
 
@@ -1494,8 +1495,39 @@ as its `AuthorizationScopes`. An operation with no `security` is open.
 }
 ```
 
-`identitySource` is the comma-separated string a document writes, and a value carrying more than one
-entry is refused, as more than one `IdentitySource` is on `CreateAuthorizer`.
+A security scheme of type `apiKey` carrying an `x-amazon-apigateway-authorizer` with
+`type: "request"` becomes a Lambda `REQUEST` authorizer, and an operation naming it gets
+`AuthorizationType: "CUSTOM"`. The scheme's own `name` and `in` are read by AWS for the OpenAPI
+document to be valid, and `identitySource` is what decides where the values come from, here as there.
+
+```json
+{
+  "components": {
+    "securitySchemes": {
+      "session-authorizer": {
+        "type": "apiKey",
+        "name": "cookie",
+        "in": "header",
+        "x-amazon-apigateway-authorizer": {
+          "type": "request",
+          "identitySource": "$request.header.cookie",
+          "authorizerUri": "arn:aws:lambda:us-east-1:111111111111:function:session-authorizer",
+          "authorizerPayloadFormatVersion": "2.0",
+          "enableSimpleResponses": true,
+          "authorizerResultTtlInSeconds": 300
+        }
+      }
+    }
+  }
+}
+```
+
+A scheme whose type and whose authorizer disagree, such as a `jwt` authorizer under `apiKey`, is
+refused naming the extension's own `type`.
+
+`identitySource` is the comma-separated string a document writes. A JWT authorizer takes one entry
+and a value carrying more is refused, as more than one `IdentitySource` is on `CreateAuthorizer`. A
+`REQUEST` authorizer takes every entry the string names, and requires a request to carry all of them.
 
 ## CloudFormation
 
@@ -1643,7 +1675,9 @@ simulated properties are:
 
 - `Api`: `Name`, `ProtocolType`, `Description`, `DisableExecuteApiEndpoint`, `Body`,
   `FailOnWarnings`
-- `Authorizer`: `ApiId`, `Name`, `AuthorizerType`, `IdentitySource`, `JwtConfiguration`
+- `Authorizer`: `ApiId`, `Name`, `AuthorizerType`, `IdentitySource`, `JwtConfiguration`,
+  `AuthorizerUri`, `AuthorizerPayloadFormatVersion`, `EnableSimpleResponses`,
+  `AuthorizerResultTtlInSeconds`
 - `Integration`: `ApiId`, `IntegrationType`, `IntegrationUri`, `PayloadFormatVersion`, `Description`
 - `Route`: `ApiId`, `RouteKey`, `Target`, `AuthorizationType`, `AuthorizerId`, `AuthorizationScopes`
 - `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`
@@ -1659,9 +1693,37 @@ to configure. Pass the app client explicitly through `userPoolClients`, because 
 authorizer adds a client of its own with CDK's defaults, and those emit the OAuth properties
 [simulated Cognito refuses](../cognito/#limitations).
 
-A `Route` with `AuthorizationType: "JWT"` whose `AuthorizerId` does not resolve to an authorizer of
-that API fails the stack, naming both. That covers a `Ref` to a Resource this simulation skipped: a
-skipped Resource resolves to its own logical ID, and no authorizer has that id.
+An `Authorizer` with `AuthorizerType: "REQUEST"` deploys as a Lambda authorizer, and a `Route` with
+`AuthorizationType: "CUSTOM"` and a `Ref` to it is decided by that authorizer's function.
+`AuthorizerUri` is read the same way an integration's URI is, so the bare function ARN and the
+`arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form both
+work. The `AWS::Lambda::Permission` alongside it needs a `SourceArn` of
+`arn:aws:execute-api:<region>:<account>:<api-id>/authorizers/<authorizer-id>`, which is what CDK
+writes and what the authorizer is invoked under. A function used both as an integration and as an
+authorizer needs two permissions, as it does on AWS.
+
+CDK's `HttpLambdaAuthorizer` deploys when it is given `responseTypes: [HttpLambdaResponseType.SIMPLE]`.
+Its default is `IAM`, which sets `AuthorizerPayloadFormatVersion` to `1.0`, and that authorizer event
+is [not simulated](#limitations).
+
+```typescript
+const authorizer = new HttpLambdaAuthorizer("SessionAuthorizer", authorizerFn, {
+  responseTypes: [HttpLambdaResponseType.SIMPLE],
+  identitySource: ["$request.header.cookie"],
+});
+
+httpApi.addRoutes({
+  path: "/account",
+  methods: [HttpMethod.GET],
+  integration: new HttpLambdaIntegration("Account", accountFn),
+  authorizer,
+});
+```
+
+A `Route` with `AuthorizationType: "JWT"` or `"CUSTOM"` whose `AuthorizerId` does not resolve to an
+authorizer of that API, or resolves to one of the other kind, fails the stack, naming both. That
+covers a `Ref` to a Resource this simulation skipped: a skipped Resource resolves to its own logical
+ID, and no authorizer has that id.
 
 `Api.Body` carries an OpenAPI document as an inline JSON object, which CloudFormation resolves
 `Ref` and `Fn::GetAtt` inside as it does anywhere else, so an operation's integration URI can be an
@@ -1752,7 +1814,7 @@ the simulation without being given one. See the
   that function's resource policy with its own `AWS:SourceArn`
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - `ImportApi` for an OpenAPI 3.0 document, creating one route and one integration per operation and
-  one JWT authorizer per security scheme an operation names
+  one JWT or Lambda `REQUEST` authorizer per security scheme an operation names
 - Deployment of `AWS::ApiGatewayV2::Api`, `Authorizer`, `Integration`, `Route` and `Stage` from a
   CloudFormation template, including one synthesized by CDK from an `HttpApi`, and an `Api` declared
   as an OpenAPI document through `Body`
@@ -1808,20 +1870,21 @@ Current documented limitations:
 - HTTP API resource policies are not simulated, because AWS does not have them. A caller from another
   Account is therefore always refused, since a cross-Account request needs an Allow from the resource
   side. Assume a Role in the API's Account instead, which is the route through on AWS as well.
-- A Lambda `REQUEST` authorizer is created by `CreateAuthorizer` only.
-  `AWS::ApiGatewayV2::Authorizer` refuses `AuthorizerType: "REQUEST"` by name, and so does an
-  OpenAPI security scheme declaring one, so a `CUSTOM` route deployed from a template or an imported
-  document is not available yet.
 - `AuthorizerPayloadFormatVersion: "2.0"` is required on a `REQUEST` authorizer, and stating nothing
   is refused too. AWS defaults it to `1.0`, which builds a different event and answers a policy
-  against a method ARN, and none of that is built here.
+  against a method ARN, and none of that is built here. CDK defaults `HttpLambdaAuthorizer` to
+  `responseTypes: [HttpLambdaResponseType.IAM]`, which sets the format to `1.0`, so a default
+  `new HttpLambdaAuthorizer(...)` fails the stack. Pass
+  `responseTypes: [HttpLambdaResponseType.SIMPLE]` to get an authorizer that deploys.
 - A `REQUEST` authorizer's event carries no `body` and no `isBase64Encoded`. AWS's published example
   of that event carries neither, so an authorizer cannot read the request body.
 - An authorizer function that throws is a 500 rather than a 401. Real Lambda turns a thrown error
   into a payload carrying `errorMessage`, and simulated Lambda rejects with the error itself, so
   returning `{ "errorMessage": "Unauthorized" }` is how an authorizer asks for a 401 here.
-- `AuthorizerCredentialsArn` is refused. It names a Role API Gateway assumes to invoke the authorizer,
-  and the function's own resource policy is the whole decision here.
+- `AuthorizerCredentialsArn` is refused, as is `AuthorizerCredentialsArn` on an
+  `AWS::ApiGatewayV2::Authorizer` and `authorizerCredentials` in an imported document. It names a
+  Role API Gateway assumes to invoke the authorizer, and the function's own resource policy is the
+  whole decision here.
 - `AuthorizerResultTtlInSeconds` is accepted between 0 and 3600, which is the range AWS accepts, and
   is refused on an authorizer with no `IdentitySource`, since there would be nothing to key the held
   decision on.

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-creator.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-creator.ts
@@ -12,13 +12,12 @@ interface SimCfnHttpApiAuthorizerCreatorProperties {
 }
 
 /**
- * Creates simulated JWT authorizers from AWS::ApiGatewayV2::Authorizer
- * Resources.
+ * Creates simulated authorizers from AWS::ApiGatewayV2::Authorizer Resources.
  *
  * The authorizer goes through the ordinary CreateAuthorizer command, so a
- * Lambda authorizer, a missing issuer or audience, and an identity source that
- * is not a header or query string are all refused here with the reason the
- * command gives.
+ * missing issuer or audience, an identity source that is not a header or query
+ * string, and a `REQUEST` authorizer asking for payload format `1.0` are all
+ * refused here with the reason the command gives.
  */
 export class SimCfnHttpApiAuthorizerCreator {
   private readonly apiGatewayV2: SimApiGatewayV2;

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-properties.ts
@@ -3,15 +3,16 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCreateAuthorizerCommandInput } from "../../command/authorizer/authorizer.command.js";
 import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
 import { SimCfnHttpApiJwtConfigurationProperties } from "./sim-cfn-http-api-jwt-configuration-properties.js";
+import { SimCfnHttpApiRequestAuthorizerProperties } from "./sim-cfn-http-api-request-authorizer-properties.js";
 
 /**
  * The AWS::ApiGatewayV2::Authorizer properties this simulation deploys.
  *
- * Everything a Lambda `REQUEST` authorizer is configured with is left out, so
- * a template carrying one is refused by name rather than deploying an
- * authorizer that would decide differently here. `CreateAuthorizer` does
- * create a `REQUEST` authorizer for an SDK caller; declaring one in a template
- * is the part that is not simulated yet.
+ * Both kinds of authorizer are here, and each kind's own properties are
+ * refused on the other by CreateAuthorizer rather than by this list, which is
+ * per Resource type. `AuthorizerCredentialsArn` is left out: it names an IAM
+ * Role for API Gateway to assume instead of relying on the function's resource
+ * policy, and nothing here assumes one.
  */
 const simulatedProperties = [
   "ApiId",
@@ -19,6 +20,10 @@ const simulatedProperties = [
   "AuthorizerType",
   "IdentitySource",
   "JwtConfiguration",
+  "AuthorizerUri",
+  "AuthorizerPayloadFormatVersion",
+  "EnableSimpleResponses",
+  "AuthorizerResultTtlInSeconds",
 ];
 
 interface SimCfnHttpApiAuthorizerPropertiesProperties {
@@ -60,8 +65,11 @@ export class SimCfnHttpApiAuthorizerProperties {
   /**
    * The CreateAuthorizer input this Resource asks for.
    *
-   * Everything but the type is passed through, so what an authorizer requires
-   * is refused by CreateAuthorizer with the reason it refuses it.
+   * Everything but the shape of each value is passed through, so what an
+   * authorizer requires is refused by CreateAuthorizer with the reason it
+   * refuses it. That covers a JWT authorizer carrying a `REQUEST` property, a
+   * `REQUEST` authorizer carrying a `JwtConfiguration`, and an
+   * `AuthorizerPayloadFormatVersion` of `1.0`.
    */
   createAuthorizerInput(): SimCreateAuthorizerCommandInput {
     return {
@@ -71,44 +79,31 @@ export class SimCfnHttpApiAuthorizerProperties {
         this.properties["Name"],
         "Name",
       ),
-      AuthorizerType: this.authorizerType(),
+      AuthorizerType: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizerType"],
+        "AuthorizerType",
+      ),
       IdentitySource: this.propertyParser.optionalStringList(
         this.resource,
         this.properties["IdentitySource"],
         "IdentitySource",
       ),
       JwtConfiguration: this.jwtConfiguration(),
+      ...this.requestProperties(),
     };
-  }
-
-  /**
-   * The type this Resource declares, refusing `REQUEST` by name.
-   *
-   * A `REQUEST` authorizer needs the properties naming its function, and those
-   * are not deployed from a template yet, so a Resource declaring one would
-   * fail further down for a reason that reads as a missing property rather
-   * than as the feature it is.
-   */
-  private authorizerType(): string | undefined {
-    const authorizerType = this.propertyParser.optionalString(
-      this.resource,
-      this.properties["AuthorizerType"],
-      "AuthorizerType",
-    );
-
-    if (authorizerType === "REQUEST") {
-      throw new Error(
-        `AWS::ApiGatewayV2::Authorizer ${this.resource.logicalId} declares a ` +
-          `Lambda REQUEST authorizer, which is not deployed from a template ` +
-          `yet. Create it with CreateAuthorizer instead.`,
-      );
-    }
-
-    return authorizerType;
   }
 
   private jwtConfiguration(): SimCreateAuthorizerCommandInput["JwtConfiguration"] {
     return new SimCfnHttpApiJwtConfigurationProperties({
+      resource: this.resource,
+      properties: this.properties,
+      propertyParser: this.propertyParser,
+    }).read();
+  }
+
+  private requestProperties(): SimCreateAuthorizerCommandInput {
+    return new SimCfnHttpApiRequestAuthorizerProperties({
       resource: this.resource,
       properties: this.properties,
       propertyParser: this.propertyParser,

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-request-authorizer-properties.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-request-authorizer-properties.ts
@@ -1,0 +1,72 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateAuthorizerCommandInput } from "../../command/authorizer/authorizer.command.js";
+import type { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The half of a CreateAuthorizer input a Lambda `REQUEST` authorizer is
+ * configured by.
+ */
+type SimCfnHttpApiRequestAuthorizerInput = Pick<
+  SimCreateAuthorizerCommandInput,
+  | "AuthorizerUri"
+  | "AuthorizerPayloadFormatVersion"
+  | "EnableSimpleResponses"
+  | "AuthorizerResultTtlInSeconds"
+>;
+
+interface SimCfnHttpApiRequestAuthorizerPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+}
+
+/**
+ * Reads the properties only a Lambda `REQUEST` authorizer Resource carries.
+ *
+ * `AuthorizerUri` arrives as the wrapped
+ * `arn:aws:apigateway:<region>:lambda:path/...` form CDK builds with
+ * `Fn::Join`, which is one of the two forms CreateAuthorizer takes. Nothing is
+ * checked here: what a `REQUEST` authorizer requires is stated by
+ * CreateAuthorizer, so a template is held to the same rules an SDK caller is,
+ * and a JWT authorizer declaring one of these is refused the same way too.
+ */
+export class SimCfnHttpApiRequestAuthorizerProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+
+  constructor(properties: SimCfnHttpApiRequestAuthorizerPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * The `REQUEST` half of the CreateAuthorizer input this Resource asks for.
+   */
+  read(): SimCfnHttpApiRequestAuthorizerInput {
+    return {
+      AuthorizerUri: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizerUri"],
+        "AuthorizerUri",
+      ),
+      AuthorizerPayloadFormatVersion: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["AuthorizerPayloadFormatVersion"],
+        "AuthorizerPayloadFormatVersion",
+      ),
+      EnableSimpleResponses: this.propertyParser.optionalBoolean(
+        this.resource,
+        this.properties["EnableSimpleResponses"],
+        "EnableSimpleResponses",
+      ),
+      AuthorizerResultTtlInSeconds: this.propertyParser.optionalNumber(
+        this.resource,
+        this.properties["AuthorizerResultTtlInSeconds"],
+        "AuthorizerResultTtlInSeconds",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-values.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-values.ts
@@ -3,6 +3,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnApiGatewayV2ScalarValues } from "./sim-cfn-api-gateway-v2-scalar-values.js";
 
 /**
  * Reads the value shapes an AWS::ApiGatewayV2::* property can take.
@@ -13,79 +14,10 @@ import type {
  * property carrying the wrong shape is refused here rather than reaching a
  * command as something it cannot use.
  *
- * The Resource type is carried so a message names the template entry a reader
- * has to go and fix.
+ * The lists and objects are here, and the single values each entry of one has
+ * to be are `SimCfnApiGatewayV2ScalarValues` below.
  */
-export class SimCfnApiGatewayV2PropertyValues {
-  protected readonly resourceType: string;
-
-  constructor(resourceType: string) {
-    this.resourceType = resourceType;
-  }
-
-  /**
-   * Parse a property value that must be a string when present.
-   */
-  optionalString(
-    resource: SimCfnResource,
-    value: SimCfnTemplateValue | undefined,
-    label: string,
-  ): string | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value !== "string") {
-      throw this.invalidPropertyError(resource, label, "a string");
-    }
-
-    return value;
-  }
-
-  /**
-   * Parse a property value that has to be there and has to be a string.
-   */
-  requiredString(
-    resource: SimCfnResource,
-    value: SimCfnTemplateValue | undefined,
-    label: string,
-  ): string {
-    const parsed = this.optionalString(resource, value, label);
-
-    if (parsed === undefined) {
-      throw this.invalidPropertyError(resource, label, "a string");
-    }
-
-    return parsed;
-  }
-
-  /**
-   * Parse a property value that must be a boolean when present.
-   *
-   * CloudFormation carries template booleans as the strings "true" and "false"
-   * in places, so both forms are accepted, as CloudFormation itself accepts
-   * them.
-   */
-  optionalBoolean(
-    resource: SimCfnResource,
-    value: SimCfnTemplateValue | undefined,
-    label: string,
-  ): boolean | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value === "boolean") {
-      return value;
-    }
-
-    if (value === "true" || value === "false") {
-      return value === "true";
-    }
-
-    throw this.invalidPropertyError(resource, label, "a boolean");
-  }
-
+export class SimCfnApiGatewayV2PropertyValues extends SimCfnApiGatewayV2ScalarValues {
   /**
    * Parse a property value that must be a list of strings when present, which
    * is the shape a route's `AuthorizationScopes` and an authorizer's
@@ -155,20 +87,6 @@ export class SimCfnApiGatewayV2PropertyValues {
         name,
         this.requiredString(resource, entry, `${label}.${name}`),
       ]),
-    );
-  }
-
-  /**
-   * Build the diagnostic error for a malformed property value.
-   */
-  invalidPropertyError(
-    resource: SimCfnResource,
-    label: string,
-    expected: string,
-  ): TypeError {
-    return new TypeError(
-      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
-        `${label} must be ${expected}`,
     );
   }
 }

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-scalar-values.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-scalar-values.ts
@@ -1,0 +1,143 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Reads the single-value shapes an AWS::ApiGatewayV2::* property can take.
+ *
+ * The lists and objects are `SimCfnApiGatewayV2PropertyValues` above this, and
+ * they are built out of these readers, so the rules for what one string or one
+ * number may be are stated once whether it stands alone or sits in a list.
+ *
+ * The Resource type is carried so a message names the template entry a reader
+ * has to go and fix.
+ */
+export class SimCfnApiGatewayV2ScalarValues {
+  protected readonly resourceType: string;
+
+  constructor(resourceType: string) {
+    this.resourceType = resourceType;
+  }
+
+  /**
+   * Parse a property value that must be a string when present.
+   */
+  optionalString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parse a property value that has to be there and has to be a string.
+   */
+  requiredString(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): string {
+    const parsed = this.optionalString(resource, value, label);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a string");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Parse a property value that must be a boolean when present.
+   *
+   * CloudFormation carries template booleans as the strings "true" and "false"
+   * in places, so both forms are accepted, as CloudFormation itself accepts
+   * them.
+   */
+  optionalBoolean(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): boolean | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw this.invalidPropertyError(resource, label, "a boolean");
+  }
+
+  /**
+   * Parse a property value that must be a number when present, which is the
+   * shape an authorizer's `AuthorizerResultTtlInSeconds` takes.
+   *
+   * CloudFormation carries template numbers as strings in places, the same way
+   * it does booleans, so a string holding a number is read as that number.
+   */
+  optionalNumber(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "number") {
+      return value;
+    }
+
+    const parsed = this.numberString(value);
+
+    if (parsed === undefined) {
+      throw this.invalidPropertyError(resource, label, "a number");
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Build the diagnostic error for a malformed property value.
+   */
+  invalidPropertyError(
+    resource: SimCfnResource,
+    label: string,
+    expected: string,
+  ): TypeError {
+    return new TypeError(
+      `Invalid ${this.resourceType} ${resource.logicalId}: ` +
+        `${label} must be ${expected}`,
+    );
+  }
+
+  /**
+   * The number a template string holds, when it holds one.
+   */
+  private numberString(value: SimCfnTemplateValue): number | undefined {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+
+    if (Number.isNaN(parsed)) {
+      return undefined;
+    }
+
+    return parsed;
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-authorization.iso.test.ts
@@ -98,8 +98,33 @@ describe("API Gateway v2 CloudFormation authorization validation", () => {
     );
   });
 
-  it("refuses a Lambda authorizer declared as a Resource", async () => {
-    // Given a template carrying a Lambda REQUEST authorizer
+  it("refuses a CUSTOM route naming an authorizer the template did not deploy", async () => {
+    // Given a route asking for a Lambda authorizer with an authorizer id that
+    // is not one of this API's
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeProperties: {
+          AuthorizationType: "CUSTOM",
+          AuthorizerId: "auth01",
+        },
+      }),
+    );
+
+    // Then the stack fails, as it does for a JWT route, rather than deploying
+    // a route that is open here and closed on AWS
+    assertStringIncludes(
+      error.message,
+      "AuthorizerId auth01 names no authorizer",
+    );
+  });
+
+  it("refuses a REQUEST authorizer Resource asking for payload format 1.0", async () => {
+    // Given a template carrying a Lambda authorizer with CDK's default payload
+    // format, which is the one this simulation builds no event in
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
@@ -113,19 +138,51 @@ describe("API Gateway v2 CloudFormation authorization validation", () => {
               ApiId: { Ref: "Api" },
               AuthorizerType: "REQUEST",
               Name: "lambda",
-              IdentitySource: ["$request.header.Authorization"],
+              IdentitySource: ["$request.header.cookie"],
+              AuthorizerUri: { "Fn::GetAtt": ["Handler", "Arn"] },
+              AuthorizerPayloadFormatVersion: "1.0",
             },
           },
         },
       }),
     );
 
-    // Then the stack fails, saying where a REQUEST authorizer can be created
-    // instead, rather than deploying one the template did not fully describe
+    // Then the stack fails, naming the Resource and the format it declared
     assertStringIncludes(
       error.message,
-      "declares a Lambda REQUEST authorizer, which is not deployed from a " +
-        "template yet",
+      "Sim CloudFormation Resource Authorizer creation failed: " +
+        "CreateAuthorizer AuthorizerPayloadFormatVersion '1.0' is not " +
+        "simulated",
+    );
+  });
+
+  it("refuses an authorizer Resource naming a Role to assume", async () => {
+    // Given a template whose Lambda authorizer names credentials for API
+    // Gateway to assume rather than relying on the function's own policy
+    const simAws = simAwsInEuWest2();
+
+    // When the template is deployed
+    const error = await deployHttpApiFailure(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: {
+          Authorizer: {
+            Type: "AWS::ApiGatewayV2::Authorizer",
+            Properties: {
+              ApiId: { Ref: "Api" },
+              AuthorizerType: "REQUEST",
+              Name: "lambda",
+              AuthorizerCredentialsArn: "arn:aws:iam::111111111111:role/Auth",
+            },
+          },
+        },
+      }),
+    );
+
+    // Then it is refused by name, since nothing here assumes that Role
+    assertStringIncludes(
+      error.message,
+      "property AuthorizerCredentialsArn is not simulated",
     );
   });
 

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-request-authorizer.iso.test.ts
@@ -1,0 +1,256 @@
+import {
+  assertIdentical,
+  assertObjectMatches,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  deployHttpApi,
+  deployHttpApiFailure,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+/**
+ * The authorizer function, which admits one cookie and passes a tenant on.
+ */
+const authorizerSource =
+  "exports.handler = async (event) => ({ isAuthorized: " +
+  "event.identitySource[0] === 'session=valid', context: { tenant: 'acme' } });";
+
+/**
+ * The integration handler, reporting what the authorizer passed on to it.
+ */
+const handlerSource =
+  "exports.handler = async (event) => ({ statusCode: 200, body: " +
+  "event.requestContext.authorizer.lambda.tenant });";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * The Resources a template needs to protect a route with a Lambda authorizer:
+ * a function of its own, the grant API Gateway invokes it under, the
+ * authorizer, and the route pointing at it by `Ref`.
+ *
+ * The authorizer's `SourceArn` names the authorizer rather than a route, which
+ * is the ARN CDK writes and the one API Gateway invokes it under.
+ */
+function requestAuthorizerTemplate(
+  authorizerProperties: SimCfnTemplateValueRecord = {},
+): ReturnType<typeof simCfnHttpApiTemplateFactory.make> {
+  return simCfnHttpApiTemplateFactory.make({
+    routeKeys: ["GET /account"],
+    handlerSource,
+    routeProperties: {
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: { Ref: "Authorizer" },
+    },
+    resources: {
+      AuthorizerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "session-authorizer-role",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      AuthorizerFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "session-authorizer",
+          Role: { "Fn::GetAtt": ["AuthorizerRole", "Arn"] },
+          Code: { ZipFile: authorizerSource },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+        },
+      },
+      Authorizer: {
+        Type: "AWS::ApiGatewayV2::Authorizer",
+        Properties: {
+          ApiId: { Ref: "Api" },
+          Name: "session-cookie",
+          AuthorizerType: "REQUEST",
+          AuthorizerUri: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                { Ref: "AWS::Region" },
+                ":lambda:path/2015-03-31/functions/",
+                { "Fn::GetAtt": ["AuthorizerFunction", "Arn"] },
+                "/invocations",
+              ],
+            ],
+          },
+          AuthorizerPayloadFormatVersion: "2.0",
+          EnableSimpleResponses: true,
+          IdentitySource: ["$request.header.cookie"],
+          AuthorizerResultTtlInSeconds: 300,
+          ...authorizerProperties,
+        },
+      },
+      AuthorizerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["AuthorizerFunction", "Arn"] },
+          Principal: "apigateway.amazonaws.com",
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                { Ref: "Api" },
+                "/authorizers/",
+                { "Fn::GetAtt": ["Authorizer", "AuthorizerId"] },
+              ],
+            ],
+          },
+        },
+      },
+    },
+    outputs: {
+      ApiId: { Value: { "Fn::GetAtt": ["Api", "ApiId"] } },
+      AuthorizerId: { Value: { "Fn::GetAtt": ["Authorizer", "AuthorizerId"] } },
+    },
+  });
+}
+
+function get(
+  simAws: SimAws,
+  stack: SimCfnStack,
+  cookie: string,
+): Promise<Response> {
+  const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value as string;
+
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({ input: `${apiEndpoint}/account` }).toString(),
+    { headers: { cookie } },
+  );
+}
+
+describe("Deploying an AWS::ApiGatewayV2::Authorizer of type REQUEST", () => {
+  it("protects a CUSTOM route with the function the template deploys", async () => {
+    // Given a template whose route goes through a Lambda authorizer deployed
+    // by the same stack
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, requestAuthorizerTemplate());
+
+    // When the deployed route is called with a cookie the authorizer refuses,
+    // and then with one it accepts
+    const refused = await get(simAws, stack, "session=expired");
+    const admitted = await get(simAws, stack, "session=valid");
+
+    // Then the deployed authorizer decided both, and the context it returned
+    // reached the handler
+    assertIdentical(refused.status, 403);
+    assertIdentical(admitted.status, 200);
+    assertIdentical(await admitted.text(), "acme");
+  });
+
+  it("deploys the authorizer with the properties the Resource declared", async () => {
+    // Given the same stack
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(simAws, requestAuthorizerTemplate());
+
+    // When the API is read back
+    const apiId = stack.outputs.get("ApiId")?.value as string;
+    const authorizers = await simAws
+      .apiGatewayV2()
+      .getAuthorizers({ input: { ApiId: apiId } });
+    const routes = await simAws
+      .apiGatewayV2()
+      .getRoutes({ input: { ApiId: apiId } });
+
+    // Then the authorizer carries what the template gave it, including the
+    // function ARN the wrapped AuthorizerUri named, and the route is the one
+    // pointed at it
+    assertObjectMatches(authorizers.Items[0] ?? {}, {
+      Name: "session-cookie",
+      AuthorizerType: "REQUEST",
+      AuthorizerUri:
+        "arn:aws:lambda:eu-west-2:888888888888:function:session-authorizer",
+      AuthorizerPayloadFormatVersion: "2.0",
+      EnableSimpleResponses: true,
+      AuthorizerResultTtlInSeconds: 300,
+      IdentitySource: ["$request.header.cookie"],
+    });
+    assertObjectMatches(routes.Items[0] ?? {}, {
+      AuthorizationType: "CUSTOM",
+      AuthorizerId: stack.outputs.get("AuthorizerId")?.value,
+    });
+  });
+
+  it("reads a cache period written as a string, as CloudFormation does", async () => {
+    // Given a template whose TTL is the string form CloudFormation carries a
+    // number in
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      requestAuthorizerTemplate({ AuthorizerResultTtlInSeconds: "300" }),
+    );
+
+    // When the API is read back
+    const apiId = stack.outputs.get("ApiId")?.value as string;
+    const authorizers = await simAws
+      .apiGatewayV2()
+      .getAuthorizers({ input: { ApiId: apiId } });
+
+    // Then it deployed as the number it holds
+    assertIdentical(authorizers.Items[0]?.AuthorizerResultTtlInSeconds, 300);
+  });
+
+  it("refuses a cache period that is not a number", async () => {
+    // Given templates whose TTL is a word, and one where it is not even a
+    // string
+    const refused = "AuthorizerResultTtlInSeconds must be a number";
+
+    // When each is deployed
+    const word = await deployHttpApiFailure(
+      simAwsInEuWest2(),
+      requestAuthorizerTemplate({ AuthorizerResultTtlInSeconds: "soon" }),
+    );
+    const boolean = await deployHttpApiFailure(
+      simAwsInEuWest2(),
+      requestAuthorizerTemplate({ AuthorizerResultTtlInSeconds: true }),
+    );
+
+    // Then each stack fails saying what the property has to be
+    assertStringIncludes(word.message, refused);
+    assertStringIncludes(boolean.message, refused);
+  });
+
+  it("refuses the route when the authorizer's own grant is missing", async () => {
+    // Given the same template with the authorizer's invoke permission removed
+    const simAws = simAwsInEuWest2();
+    const template = requestAuthorizerTemplate();
+    const resources = template.Resources as Record<string, unknown>;
+    delete resources["AuthorizerPermission"];
+    const stack = await deployHttpApi(simAws, template);
+
+    // When the route is called with a cookie the authorizer would accept
+    const response = await get(simAws, stack, "session=valid");
+
+    // Then API Gateway could not invoke it, as on AWS: the integration's own
+    // grant names the route rather than the authorizer
+    assertIdentical(response.status, 500);
+  });
+});

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-identity-source.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-identity-source.ts
@@ -1,0 +1,51 @@
+import type { SimHttpApiOpenApiObject } from "./sim-http-api-openapi-object.js";
+import type { SimHttpApiOpenApiValue } from "./sim-http-api-openapi-value.js";
+
+/**
+ * The `identitySource` of an `x-amazon-apigateway-authorizer`.
+ *
+ * A document writes the sources as one comma-separated string, and
+ * CreateAuthorizer takes a list, so the translation is here. How many a
+ * document may name is the kind of authorizer's business: a JWT one reads the
+ * token from one place, and a `REQUEST` one requires everything it names.
+ */
+export class SimHttpApiOpenApiIdentitySource {
+  private readonly declared: SimHttpApiOpenApiValue;
+
+  constructor(authorizer: SimHttpApiOpenApiObject) {
+    this.declared = authorizer.member("identitySource");
+  }
+
+  /**
+   * Every source the document names, which is what a `REQUEST` authorizer
+   * requires a request to carry.
+   */
+  all(): string[] {
+    return this.sources();
+  }
+
+  /**
+   * The one place a JWT authorizer reads its token from, refusing a document
+   * naming more.
+   */
+  one(): string[] {
+    const sources = this.sources();
+
+    if (sources.length > 1) {
+      throw this.declared.refusal(
+        `carries ${String(sources.length)} identity sources, and only the ` +
+          `first would be read here`,
+      );
+    }
+
+    return sources;
+  }
+
+  private sources(): string[] {
+    return this.declared
+      .requiredString()
+      .split(",")
+      .map((source) => source.trim())
+      .filter((source) => source.length > 0);
+  }
+}

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-jwt-authorizer-scheme.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-jwt-authorizer-scheme.ts
@@ -1,0 +1,42 @@
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import { SimHttpApiOpenApiIdentitySource } from "./sim-http-api-openapi-identity-source.js";
+import type { SimHttpApiOpenApiObject } from "./sim-http-api-openapi-object.js";
+
+/**
+ * An `x-amazon-apigateway-authorizer` of `type: jwt`, read into the
+ * CreateAuthorizer input it asks for.
+ *
+ * The issuer and the audiences are handed to CreateAuthorizer as the document
+ * wrote them, so what an authorizer requires is stated where every other caller
+ * reads it.
+ */
+export class SimHttpApiOpenApiJwtAuthorizerScheme {
+  private readonly authorizer: SimHttpApiOpenApiObject;
+
+  constructor(authorizer: SimHttpApiOpenApiObject) {
+    this.authorizer = authorizer;
+  }
+
+  /**
+   * The CreateAuthorizer input this authorizer asks for.
+   */
+  createAuthorizerInput(
+    apiId: string,
+    name: string,
+  ): SimCreateAuthorizerCommandInput {
+    const configuration = this.authorizer.member("jwtConfiguration").object();
+
+    return {
+      ApiId: apiId,
+      Name: name,
+      AuthorizerType: "JWT",
+      IdentitySource: new SimHttpApiOpenApiIdentitySource(
+        this.authorizer,
+      ).one(),
+      JwtConfiguration: {
+        Issuer: configuration.member("issuer").optionalString(),
+        Audience: configuration.member("audience").optionalStringList(),
+      },
+    };
+  }
+}

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer-scheme.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer-scheme.ts
@@ -1,0 +1,69 @@
+import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import { SimHttpApiOpenApiIdentitySource } from "./sim-http-api-openapi-identity-source.js";
+import type { SimHttpApiOpenApiObject } from "./sim-http-api-openapi-object.js";
+
+const authorizerCredentials =
+  "names an IAM Role for API Gateway to assume before invoking the authorizer " +
+  "function, and nothing here assumes one: the function's own resource policy " +
+  "is what admits the call";
+
+/**
+ * The members that belong to a REST API's authorizers rather than an HTTP
+ * API's, refused rather than ignored so a document written for a REST API does
+ * not import as something quieter than it says.
+ */
+const restOnlyMembers = ["identityValidationExpression", "providerARNs"];
+
+const restOnly =
+  "configures a REST API authorizer, and an HTTP API applies none of it";
+
+/**
+ * An `x-amazon-apigateway-authorizer` of `type: request`, read into the
+ * CreateAuthorizer input it asks for.
+ *
+ * The values are handed to CreateAuthorizer as the document wrote them, so what
+ * a Lambda `REQUEST` authorizer requires is stated where an SDK caller and a
+ * template already meet it. That covers the function URI, and an
+ * `authorizerPayloadFormatVersion` of `1.0`, which builds a different event and
+ * is refused across this simulation.
+ */
+export class SimHttpApiOpenApiRequestAuthorizerScheme {
+  private readonly authorizer: SimHttpApiOpenApiObject;
+
+  constructor(authorizer: SimHttpApiOpenApiObject) {
+    this.authorizer = authorizer;
+  }
+
+  /**
+   * The CreateAuthorizer input this authorizer asks for.
+   */
+  createAuthorizerInput(
+    apiId: string,
+    name: string,
+  ): SimCreateAuthorizerCommandInput {
+    this.authorizer.refuseMember(
+      "authorizerCredentials",
+      authorizerCredentials,
+    );
+    this.authorizer.refuseMembers(restOnlyMembers, restOnly);
+
+    return {
+      ApiId: apiId,
+      Name: name,
+      AuthorizerType: "REQUEST",
+      IdentitySource: new SimHttpApiOpenApiIdentitySource(
+        this.authorizer,
+      ).all(),
+      AuthorizerUri: this.authorizer.member("authorizerUri").optionalString(),
+      AuthorizerPayloadFormatVersion: this.authorizer
+        .member("authorizerPayloadFormatVersion")
+        .optionalString(),
+      EnableSimpleResponses: this.authorizer
+        .member("enableSimpleResponses")
+        .optionalBoolean(),
+      AuthorizerResultTtlInSeconds: this.authorizer
+        .member("authorizerResultTtlInSeconds")
+        .optionalNumber(),
+    };
+  }
+}

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer.iso.test.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-request-authorizer.iso.test.ts
@@ -1,0 +1,222 @@
+import {
+  CreateStageCommand,
+  GetAuthorizersCommand,
+  GetRoutesCommand,
+  ImportApiCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { simHttpApiOpenApiDocumentFactory } from "./sim-http-api-openapi-document.factory.js";
+import { simHttpApiOpenApiIntegrationFactory } from "./sim-http-api-openapi-integration.factory.js";
+
+const unusedFunctionArn =
+  "arn:aws:lambda:us-east-1:111111111111:function:session-authorizer";
+
+/**
+ * The security scheme an HTTP API declares a Lambda `REQUEST` authorizer with:
+ * an `apiKey` scheme carrying an authorizer of type `request`.
+ */
+function requestScheme(functionArn = unusedFunctionArn): JSONObject {
+  return {
+    type: "apiKey",
+    name: "cookie",
+    in: "header",
+    "x-amazon-apigateway-authorizer": {
+      type: "request",
+      identitySource: "$request.header.cookie",
+      authorizerUri:
+        `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/` +
+        `${functionArn}/invocations`,
+      authorizerPayloadFormatVersion: "2.0",
+      enableSimpleResponses: true,
+      authorizerResultTtlInSeconds: 300,
+    },
+  };
+}
+
+/**
+ * A document whose one operation is protected by the scheme under test.
+ */
+function protectedDocument(
+  scheme: JSONObject = requestScheme(),
+  integrationArn = "arn:aws:lambda:us-east-1:111111111111:function:account",
+): string {
+  return JSON.stringify(
+    simHttpApiOpenApiDocumentFactory.make({
+      paths: {
+        "/account": {
+          get: {
+            security: [{ "session-authorizer": [] }],
+            "x-amazon-apigateway-integration":
+              simHttpApiOpenApiIntegrationFactory.make({
+                functionArn: integrationArn,
+              }),
+          },
+        },
+      },
+      components: { securitySchemes: { "session-authorizer": scheme } },
+    }),
+  );
+}
+
+/**
+ * One of the two functions the imported API invokes, with the grant API
+ * Gateway needs before it may invoke it.
+ */
+async function invokableFunction(
+  simAws: SimAws,
+  functionName: string,
+  handler: (event: never) => unknown,
+): Promise<string> {
+  const created = await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: `arn:aws:iam::111111111111:role/${functionName}`,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: functionName,
+      StatementId: "api-gateway-invoke",
+      Action: "lambda:InvokeFunction",
+      Principal: "apigateway.amazonaws.com",
+    }),
+  );
+
+  return created.FunctionArn;
+}
+
+describe("Importing a sim HTTP API's Lambda REQUEST authorizers", () => {
+  it("creates the authorizer the scheme declares, on a CUSTOM route", async () => {
+    // Given a document whose operation names an apiKey scheme carrying a
+    // request authorizer
+    const simAws = new SimAws();
+
+    // When it is imported
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .importApi(new ImportApiCommand({ Body: protectedDocument() }));
+
+    // Then the scheme key is the authorizer's name, and everything the
+    // extension declared reached it
+    const authorizers = await simAws
+      .apiGatewayV2()
+      .getAuthorizers(new GetAuthorizersCommand({ ApiId: apiId }));
+    const [authorizer] = authorizers.Items;
+    assertNonNullable(authorizer);
+    assertIdentical(authorizer.Name, "session-authorizer");
+    assertIdentical(authorizer.AuthorizerType, "REQUEST");
+    assertIdentical(authorizer.AuthorizerUri, unusedFunctionArn);
+    assertTrue(authorizer.EnableSimpleResponses);
+    assertIdentical(authorizer.AuthorizerResultTtlInSeconds, 300);
+    expect(authorizer.IdentitySource).toStrictEqual(["$request.header.cookie"]);
+
+    // And the operation's route is a CUSTOM one pointed at it, rather than the
+    // JWT one a token authorizer produces
+    const routes = await simAws
+      .apiGatewayV2()
+      .getRoutes(new GetRoutesCommand({ ApiId: apiId }));
+    const [route] = routes.Items;
+    assertNonNullable(route);
+    assertIdentical(route.AuthorizationType, "CUSTOM");
+    assertIdentical(route.AuthorizerId, authorizer.AuthorizerId);
+  });
+
+  it("reads more than one identity source, which a JWT authorizer refuses", async () => {
+    // Given a scheme naming a header and a query string parameter
+    const simAws = new SimAws();
+    const scheme = requestScheme();
+    const authorizer = {
+      ...(scheme["x-amazon-apigateway-authorizer"] as JSONObject),
+      identitySource: "$request.header.cookie, $request.querystring.tenant",
+    };
+
+    // When it is imported
+    const { ApiId: apiId } = await simAws.apiGatewayV2().importApi(
+      new ImportApiCommand({
+        Body: protectedDocument({
+          ...scheme,
+          "x-amazon-apigateway-authorizer": authorizer,
+        }),
+      }),
+    );
+
+    // Then both arrived, as a REQUEST authorizer requires every source it names
+    const authorizers = await simAws
+      .apiGatewayV2()
+      .getAuthorizers(new GetAuthorizersCommand({ ApiId: apiId }));
+    expect(authorizers.Items[0]?.IdentitySource).toStrictEqual([
+      "$request.header.cookie",
+      "$request.querystring.tenant",
+    ]);
+  });
+
+  it("serves the imported route through the authorizer's function", async () => {
+    // Given the two functions and the imported API, with the stage an import
+    // does not create
+    const simAws = new SimAws();
+    const authorizerArn = await invokableFunction(
+      simAws,
+      "session-authorizer",
+      (event: { identitySource: string[] }): unknown => ({
+        isAuthorized: event.identitySource[0] === "session=valid",
+        context: { tenant: "acme" },
+      }),
+    );
+    const accountArn = await invokableFunction(
+      simAws,
+      "account",
+      (event: {
+        requestContext: { authorizer?: { lambda?: { tenant?: string } } };
+      }): unknown => ({
+        statusCode: 200,
+        body: event.requestContext.authorizer?.lambda?.tenant ?? "none",
+      }),
+    );
+    const body = protectedDocument(requestScheme(authorizerArn), accountArn);
+    const { ApiId: apiId, ApiEndpoint: apiEndpoint } = await simAws
+      .apiGatewayV2()
+      .importApi(new ImportApiCommand({ Body: body }));
+    await simAws.apiGatewayV2().createStage(
+      new CreateStageCommand({
+        ApiId: apiId,
+        StageName: "$default",
+        AutoDeploy: true,
+      }),
+    );
+
+    // When the route is called with a cookie the authorizer refuses, and then
+    // with one it accepts
+    const url = new SimAwsLocalUrl({
+      input: `${apiEndpoint}/account`,
+    }).toString();
+    const http = new SimAwsHttp({ simAws });
+    const refused = await http.fetch(url, {
+      headers: { cookie: "session=expired" },
+    });
+    const admitted = await http.fetch(url, {
+      headers: { cookie: "session=valid" },
+    });
+
+    // Then the imported authorizer decided both, and the context it returned
+    // reached the handler
+    assertIdentical(refused.status, 403);
+    assertIdentical(admitted.status, 200);
+    assertIdentical(await admitted.text(), "acme");
+  });
+});

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-route-authorization.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-route-authorization.ts
@@ -1,7 +1,11 @@
+import type { SimHttpApiAuthorizerView } from "../api/authorizer/sim-http-api-authorizer.js";
 import type { SimHttpApiAuthorizerCommands } from "../command/authorizer/sim-http-api-authorizer-commands.js";
 import type { SimCreateRouteCommandInput } from "../command/route/route.command.js";
 import type { SimHttpApiOpenApiCommand } from "./sim-http-api-openapi-command.js";
-import type { SimHttpApiOpenApiOperation } from "./sim-http-api-openapi-operation.js";
+import type {
+  SimHttpApiOpenApiOperation,
+  SimHttpApiOpenApiSecurityRequirement,
+} from "./sim-http-api-openapi-operation.js";
 import type { SimHttpApiOpenApiSecuritySchemes } from "./sim-http-api-openapi-security-schemes.js";
 
 /**
@@ -47,31 +51,57 @@ export class SimHttpApiOpenApiAuthorization {
       return { AuthorizationType: "NONE" };
     }
 
-    const shared = schemes.createdId(requirement.schemeName);
+    const shared = schemes.createdAuthorizer(requirement.schemeName);
 
     if (shared !== undefined) {
-      return this.jwt(shared, requirement.scopes);
+      return this.authorization(shared, requirement.scopes);
     }
 
+    const created = this.create(apiId, requirement, schemes);
+
+    return this.authorization(created, requirement.scopes);
+  }
+
+  /**
+   * Create the authorizer a requirement's scheme declares, remembering it for
+   * the next operation naming the same scheme.
+   */
+  private create(
+    apiId: string,
+    requirement: SimHttpApiOpenApiSecurityRequirement,
+    schemes: SimHttpApiOpenApiSecuritySchemes,
+  ): SimHttpApiAuthorizerView {
     const input = schemes.authorizerInput(apiId, requirement);
     const created = this.command.run(requirement.value.pointer, () =>
       this.authorizerCommands.createAuthorizer({ input }),
     );
-    schemes.remember(requirement.schemeName, created.AuthorizerId);
+    schemes.remember(requirement.schemeName, created);
 
-    return this.jwt(created.AuthorizerId, requirement.scopes);
+    return created;
   }
 
   /**
-   * A route the named authorizer decides, asking for the requirement's scopes.
+   * A route the named authorizer decides, of the type that authorizer is.
+   *
+   * A Lambda `REQUEST` authorizer makes a `CUSTOM` route, and the requirement's
+   * scopes go with it rather than being dropped: AWS applies route scopes to a
+   * `JWT` route only, so CreateRoute refuses them here.
    */
-  private jwt(
-    authorizerId: string,
+  private authorization(
+    authorizer: SimHttpApiAuthorizerView,
     scopes: readonly string[],
   ): SimHttpApiOpenApiRouteAuthorization {
+    if (authorizer.AuthorizerType === "REQUEST") {
+      return {
+        AuthorizationType: "CUSTOM",
+        AuthorizerId: authorizer.AuthorizerId,
+        AuthorizationScopes: scopes,
+      };
+    }
+
     return {
       AuthorizationType: "JWT",
-      AuthorizerId: authorizerId,
+      AuthorizerId: authorizer.AuthorizerId,
       AuthorizationScopes: scopes,
     };
   }

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme-refusals.iso.test.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme-refusals.iso.test.ts
@@ -19,13 +19,16 @@ const schemePointer = "#/components/securitySchemes/pool-authorizer";
  * Every case here is one scheme and one refusal, and the document around it is
  * the same each time, so it is built here rather than restated.
  */
-async function refusalFor(scheme: JSONObject): Promise<string> {
+async function refusalFor(
+  scheme: JSONObject,
+  scopes: string[] = [],
+): Promise<string> {
   const body = JSON.stringify(
     simHttpApiOpenApiDocumentFactory.make({
       paths: {
         "/orders": {
           get: {
-            security: [{ "pool-authorizer": [] }],
+            security: [{ "pool-authorizer": scopes }],
             "x-amazon-apigateway-integration":
               simHttpApiOpenApiIntegrationFactory.make(),
           },
@@ -50,6 +53,26 @@ function schemeCarrying(authorizer: JSONObject): JSONObject {
   return { type: "oauth2", "x-amazon-apigateway-authorizer": authorizer };
 }
 
+/**
+ * An apiKey scheme carrying a Lambda `REQUEST` authorizer, with whatever the
+ * case under test adds to or overrides on it.
+ */
+function requestSchemeCarrying(authorizer: JSONObject): JSONObject {
+  return {
+    type: "apiKey",
+    name: "cookie",
+    in: "header",
+    "x-amazon-apigateway-authorizer": {
+      type: "request",
+      identitySource: "$request.header.cookie",
+      authorizerUri:
+        "arn:aws:lambda:us-east-1:111111111111:function:session-authorizer",
+      authorizerPayloadFormatVersion: "2.0",
+      ...authorizer,
+    },
+  };
+}
+
 describe("What a sim HTTP API import refuses in a security scheme", () => {
   it("refuses an OpenID Connect scheme, which would need a fetch", async () => {
     // Given and when a scheme naming its discovery document is imported
@@ -66,7 +89,7 @@ describe("What a sim HTTP API import refuses in a security scheme", () => {
   it("refuses the security scheme types an HTTP API route cannot use", async () => {
     // Given and when schemes of each other type are imported
     const refusals = await Promise.all(
-      ["apiKey", "http", "mutualTLS"].map(async (type) => refusalFor({ type })),
+      ["http", "mutualTLS"].map(async (type) => refusalFor({ type })),
     );
 
     // Then each is refused, naming the scheme's own type member
@@ -76,19 +99,37 @@ describe("What a sim HTTP API import refuses in a security scheme", () => {
     expect(named).toHaveLength(refusals.length);
   });
 
-  it("refuses a Lambda authorizer declared in a security scheme", async () => {
-    // Given and when each authorizer type that is not a JWT one is imported
+  it("refuses an authorizer of a kind its security scheme does not declare", async () => {
+    // Given and when authorizer types an HTTP API has no route for, under the
+    // oauth2 scheme AWS declares a JWT one with
     const refusals = await Promise.all(
       ["request", "token", "cognito_user_pools"].map(async (type) =>
         refusalFor(schemeCarrying({ type, identitySource: header })),
       ),
     );
 
-    // Then each is refused, since nothing here runs the code that would decide
+    // Then each is refused, since the scheme and its extension disagree about
+    // which kind of authorizer the document declared
     const named = refusals.filter((refusal) =>
       refusal.includes(`${schemePointer}/x-amazon-apigateway-authorizer/type`),
     );
     expect(named).toHaveLength(refusals.length);
+  });
+
+  it("refuses a JWT authorizer under the apiKey scheme a Lambda one uses", async () => {
+    // Given and when a jwt authorizer declared under an apiKey scheme
+    const refusal = await refusalFor({
+      type: "apiKey",
+      name: "Authorization",
+      in: "header",
+      "x-amazon-apigateway-authorizer": { type: "jwt", identitySource: header },
+    });
+
+    // Then it is refused, naming the kind the scheme itself declares
+    expect(refusal).toContain(
+      "is 'jwt', and the security scheme carrying it declares a 'request' " +
+        "authorizer",
+    );
   });
 
   it("refuses a scheme carrying no authorizer extension", async () => {
@@ -125,6 +166,69 @@ describe("What a sim HTTP API import refuses in a security scheme", () => {
     // nothing and refuse every request
     expect(refusal).toContain(
       "x-amazon-apigateway-authorizer/jwtConfiguration: is required",
+    );
+  });
+
+  it("refuses a request authorizer asking for payload format 1.0", async () => {
+    // Given and when a Lambda authorizer written for the payload format AWS
+    // defaults to
+    const refusal = await refusalFor(
+      requestSchemeCarrying({ authorizerPayloadFormatVersion: "1.0" }),
+    );
+
+    // Then it is refused, naming the requirement's own pointer, since a 1.0
+    // authorizer receives an event nothing here builds
+    expect(refusal).toContain("#/paths/~1orders/get/security/0");
+    expect(refusal).toContain(
+      "CreateAuthorizer AuthorizerPayloadFormatVersion '1.0' is not simulated",
+    );
+  });
+
+  it("refuses a request authorizer naming a Role for API Gateway to assume", async () => {
+    // Given and when an authorizer with credentials of its own
+    const refusal = await refusalFor(
+      requestSchemeCarrying({
+        authorizerCredentials: "arn:aws:iam::111111111111:role/Authorizer",
+      }),
+    );
+
+    // Then it is refused, since the function's resource policy is the whole
+    // decision here
+    expect(refusal).toContain(
+      "authorizerCredentials: names an IAM Role for API Gateway to assume",
+    );
+  });
+
+  it("refuses a request authorizer member written in the wrong shape", async () => {
+    // Given and when a boolean written as a word and a number written as a
+    // string, neither of which JSON needed
+    const [enableSimpleResponses, resultTtl] = await Promise.all([
+      refusalFor(requestSchemeCarrying({ enableSimpleResponses: "yes" })),
+      refusalFor(
+        requestSchemeCarrying({ authorizerResultTtlInSeconds: "300" }),
+      ),
+    ]);
+
+    // Then each is refused, naming the member and the shape it has to be
+    expect(enableSimpleResponses).toContain(
+      "enableSimpleResponses: has to be a boolean",
+    );
+    expect(resultTtl).toContain(
+      "authorizerResultTtlInSeconds: has to be a number",
+    );
+  });
+
+  it("refuses scopes on a route a Lambda authorizer decides", async () => {
+    // Given and when a requirement asking a request authorizer for scopes
+    const refusal = await refusalFor(requestSchemeCarrying({}), [
+      "orders.read",
+    ]);
+
+    // Then CreateRoute refuses them, as AWS applies route scopes to a JWT
+    // route only
+    expect(refusal).toContain(
+      "CreateRoute AuthorizationScopes is set on a route with " +
+        "AuthorizationType CUSTOM",
     );
   });
 

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-scheme.ts
@@ -1,5 +1,7 @@
 import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
+import { SimHttpApiOpenApiJwtAuthorizerScheme } from "./sim-http-api-openapi-jwt-authorizer-scheme.js";
 import type { SimHttpApiOpenApiObject } from "./sim-http-api-openapi-object.js";
+import { SimHttpApiOpenApiRequestAuthorizerScheme } from "./sim-http-api-openapi-request-authorizer-scheme.js";
 
 /**
  * The security scheme types that are not a JWT authorizer.
@@ -15,13 +17,22 @@ const openIdConnect =
   "scheme as oauth2 with an explicit jwtConfiguration.issuer instead.";
 
 /**
+ * The `x-amazon-apigateway-authorizer` type each security scheme type carries,
+ * which is what AWS documents for an HTTP API: a JWT authorizer under `oauth2`,
+ * and a Lambda `REQUEST` authorizer under `apiKey`.
+ */
+const authorizerTypes = new Map([
+  ["oauth2", "jwt"],
+  ["apiKey", "request"],
+]);
+
+/**
  * One `components.securitySchemes` member, read into the CreateAuthorizer
  * input the operations naming it ask for.
  *
- * The issuer and the audiences are handed to CreateAuthorizer as the document
- * wrote them, so what an authorizer requires is stated where every other
- * caller reads it. Only the translation is here: a document writes the
- * identity sources as one comma-separated string, and the command takes a list.
+ * Which of the two kinds of authorizer a scheme carries is decided here, and
+ * reading each kind is the class named after it. A scheme whose type and
+ * whose extension disagree is refused rather than resolved either way.
  */
 export class SimHttpApiOpenApiSecurityScheme {
   private readonly scheme: SimHttpApiOpenApiObject;
@@ -37,75 +48,63 @@ export class SimHttpApiOpenApiSecurityScheme {
     apiId: string,
     name: string,
   ): SimCreateAuthorizerCommandInput {
-    const authorizer = this.jwtAuthorizer();
-    const configuration = authorizer.member("jwtConfiguration").object();
+    const authorizerType = this.authorizerType();
+    const authorizer = this.authorizer(authorizerType);
 
-    return {
-      ApiId: apiId,
-      Name: name,
-      AuthorizerType: "JWT",
-      IdentitySource: this.identitySource(authorizer),
-      JwtConfiguration: {
-        Issuer: configuration.member("issuer").optionalString(),
-        Audience: configuration.member("audience").optionalStringList(),
-      },
-    };
+    if (authorizerType === "request") {
+      return new SimHttpApiOpenApiRequestAuthorizerScheme(
+        authorizer,
+      ).createAuthorizerInput(apiId, name);
+    }
+
+    return new SimHttpApiOpenApiJwtAuthorizerScheme(
+      authorizer,
+    ).createAuthorizerInput(apiId, name);
   }
 
   /**
-   * The `x-amazon-apigateway-authorizer` this scheme carries, refusing every
-   * other kind of scheme and every other kind of authorizer.
+   * The kind of authorizer this scheme's own type declares, refusing every
+   * scheme type an HTTP API route cannot use.
    */
-  private jwtAuthorizer(): SimHttpApiOpenApiObject {
+  private authorizerType(): string {
     const declared = this.scheme.member("type");
-    const type = declared.requiredString();
+    const schemeType = declared.requiredString();
 
-    if (type === "openIdConnect") {
+    if (schemeType === "openIdConnect") {
       throw declared.refusal(openIdConnect);
     }
 
-    if (type !== "oauth2") {
+    const authorizerType = authorizerTypes.get(schemeType);
+
+    if (authorizerType === undefined) {
       throw declared.refusal(
-        `is '${type}', and only an oauth2 scheme carrying a JWT ` +
-          `x-amazon-apigateway-authorizer is simulated`,
+        `is '${schemeType}', and an HTTP API declares a JWT authorizer under ` +
+          `oauth2 and a Lambda REQUEST authorizer under apiKey`,
       );
     }
 
-    const authorizer = this.scheme
-      .member("x-amazon-apigateway-authorizer")
-      .object();
-
-    if (authorizer.member("type").requiredString() !== "jwt") {
-      throw authorizer
-        .member("type")
-        .refusal(
-          "is not jwt, and a JWT authorizer is the only kind an imported " +
-            "document creates. Create a Lambda REQUEST authorizer with " +
-            "CreateAuthorizer instead",
-        );
-    }
-
-    return authorizer;
+    return authorizerType;
   }
 
   /**
-   * The one header or query string parameter the token is read from.
+   * The `x-amazon-apigateway-authorizer` this scheme carries, refusing one of a
+   * kind the scheme's own type does not declare.
    */
-  private identitySource(authorizer: SimHttpApiOpenApiObject): string[] {
-    const declared = authorizer.member("identitySource");
-    const sources = declared
-      .requiredString()
-      .split(",")
-      .map((source) => source.trim())
-      .filter((source) => source.length > 0);
+  private authorizer(authorizerType: string): SimHttpApiOpenApiObject {
+    const authorizer = this.scheme
+      .member("x-amazon-apigateway-authorizer")
+      .object();
+    const declared = authorizer.member("type");
+    const declaredType = declared.requiredString();
 
-    if (sources.length > 1) {
+    if (declaredType !== authorizerType) {
       throw declared.refusal(
-        `carries ${String(sources.length)} identity sources, and only the ` +
-          `first would be read here`,
+        `is '${declaredType}', and the security scheme carrying it declares a ` +
+          `'${authorizerType}' authorizer. A JWT authorizer and a Lambda ` +
+          `REQUEST authorizer are the two an HTTP API has.`,
       );
     }
 
-    return sources;
+    return authorizer;
   }
 }

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-schemes.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-security-schemes.ts
@@ -1,3 +1,4 @@
+import type { SimHttpApiAuthorizerView } from "../api/authorizer/sim-http-api-authorizer.js";
 import type { SimCreateAuthorizerCommandInput } from "../command/authorizer/authorizer.command.js";
 import type { SimHttpApiOpenApiObject } from "./sim-http-api-openapi-object.js";
 import type { SimHttpApiOpenApiSecurityRequirement } from "./sim-http-api-openapi-operation.js";
@@ -18,7 +19,7 @@ interface SimHttpApiOpenApiSecuritySchemesProperties {
  */
 export class SimHttpApiOpenApiSecuritySchemes {
   private readonly schemes: SimHttpApiOpenApiValue;
-  private readonly created = new Map<string, string>();
+  private readonly created = new Map<string, SimHttpApiAuthorizerView>();
 
   constructor(properties: SimHttpApiOpenApiSecuritySchemesProperties) {
     this.schemes = properties.schemes;
@@ -41,7 +42,7 @@ export class SimHttpApiOpenApiSecuritySchemes {
   /**
    * The authorizer already created for a scheme, if one was.
    */
-  createdId(schemeName: string): string | undefined {
+  createdAuthorizer(schemeName: string): SimHttpApiAuthorizerView | undefined {
     return this.created.get(schemeName);
   }
 
@@ -49,8 +50,8 @@ export class SimHttpApiOpenApiSecuritySchemes {
    * Remember the authorizer created for a scheme, so the next operation naming
    * it shares that one.
    */
-  remember(schemeName: string, authorizerId: string): void {
-    this.created.set(schemeName, authorizerId);
+  remember(schemeName: string, authorizer: SimHttpApiAuthorizerView): void {
+    this.created.set(schemeName, authorizer);
   }
 
   /**

--- a/src/service/apigatewayv2/openapi/sim-http-api-openapi-value.ts
+++ b/src/service/apigatewayv2/openapi/sim-http-api-openapi-value.ts
@@ -106,6 +106,38 @@ export class SimHttpApiOpenApiValue {
   }
 
   /**
+   * This value as a boolean when the document carries one, which is the shape
+   * an authorizer's `enableSimpleResponses` takes.
+   */
+  optionalBoolean(): boolean | undefined {
+    if (this.value === undefined) {
+      return undefined;
+    }
+
+    if (typeof this.value !== "boolean") {
+      throw this.refusal("has to be a boolean");
+    }
+
+    return this.value;
+  }
+
+  /**
+   * This value as a number when the document carries one, which is the shape
+   * an authorizer's `authorizerResultTtlInSeconds` takes.
+   */
+  optionalNumber(): number | undefined {
+    if (this.value === undefined) {
+      return undefined;
+    }
+
+    if (typeof this.value !== "number") {
+      throw this.refusal("has to be a number");
+    }
+
+    return this.value;
+  }
+
+  /**
    * The entries of this value as an array, when the document carries one.
    */
   optionalArray(): readonly SimHttpApiOpenApiValue[] | undefined {

--- a/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
+++ b/src/service/cloudformation/cdk/apigatewayv2/sim-cdk-http-api-lambda-authorizer.loc.test.ts
@@ -1,0 +1,146 @@
+import { assertIdentical, assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file, then serves the deployed HTTP API over real localhost HTTP
+ * and calls it through the authorizer the stack deployed.
+ */
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * The authorizer function, which admits one cookie and passes a tenant on.
+ */
+const authorizerSource = `
+exports.handler = async (event) => ({
+  isAuthorized: event.identitySource[0] === "session=valid",
+  context: { tenant: "acme" },
+});
+`;
+
+/**
+ * The route's own handler, reporting what the authorizer passed on to it.
+ */
+const ordersHandlerSource = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.requestContext.authorizer.lambda.tenant,
+});
+`;
+
+/**
+ * `responseTypes` is passed explicitly. Left to itself, HttpLambdaAuthorizer
+ * asks for an IAM response, which sets `payloadFormatVersion` to `1.0`, and
+ * that authorizer event is not simulated.
+ */
+const cdkApp = `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as authorizers from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const authorizerFunction = new lambda.Function(stack, "AuthorizerFunction", {
+  functionName: "cdk-session-authorizer",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(authorizerSource)}),
+});
+
+const ordersFunction = new lambda.Function(stack, "OrdersFunction", {
+  functionName: "cdk-orders",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(ordersHandlerSource)}),
+});
+
+const httpApi = new apigwv2.HttpApi(stack, "HttpApi", { apiName: "orders" });
+
+httpApi.addRoutes({
+  path: "/orders",
+  methods: [apigwv2.HttpMethod.GET],
+  authorizer: new authorizers.HttpLambdaAuthorizer(
+    "SessionAuthorizer",
+    authorizerFunction,
+    {
+      responseTypes: [authorizers.HttpLambdaResponseType.SIMPLE],
+      identitySource: ["$request.header.cookie"],
+    },
+  ),
+  integration: new integrations.HttpLambdaIntegration(
+    "OrdersIntegration",
+    ordersFunction,
+  ),
+});
+
+new cdk.CfnOutput(stack, "ApiEndpoint", { value: httpApi.apiEndpoint });
+
+app.synth();
+`;
+
+describe("Sim CDK HTTP API Lambda authorizer local integration", () => {
+  it("protects a CDK-deployed route with a CDK-deployed authorizer", async () => {
+    // Given a CDK stack whose one route goes through an HttpLambdaAuthorizer
+    // answering the simple response format.
+    const simAws = new SimAws({
+      defaultAccountId: "111111111111" as SimAwsAccountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const projectDirectory = new TemporaryDirectory();
+    const cdkProject = new TestCdkProject({ projectDirectory });
+    await cdkProject.writeCdkAppFile(cdkApp);
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the template into sim CloudFormation.
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      const url = srv.localUrl(`${apiEndpoint}/orders`);
+
+      // Then the deployed route is closed to a request carrying no cookie,
+      // without the authorizer function being invoked at all.
+      const anonymous = await fetch(url);
+      assertIdentical(anonymous.status, 401);
+
+      // And closed to a cookie the deployed authorizer refuses.
+      const refused = await fetch(url, {
+        headers: { cookie: "session=expired" },
+      });
+      assertIdentical(refused.status, 403);
+
+      // And open to the one it accepts, whose context reached the handler.
+      const admitted = await fetch(url, {
+        headers: { cookie: "session=valid" },
+      });
+      assertIdentical(admitted.status, 200);
+      assertIdentical(await admitted.text(), "acme");
+    } finally {
+      srv.close();
+    }
+
+    await simAws.backgroundTasksComplete();
+  });
+});


### PR DESCRIPTION
…n and OpenAPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Lambda `REQUEST` authorizers in HTTP API OpenAPI imports and CloudFormation deployments.
  * Added configurable identity sources, caching, payload formats, simple responses, and Lambda permissions.
  * Added CDK integration for configuring and using Lambda authorizers.
  * Routes using request-based authorizers now support custom authorization and context propagation.

* **Bug Fixes**
  * Added validation for unsupported authorizer properties, payload formats, credentials, references, and invalid cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->