### PR TITLE
feat: supply the source Account when a simulated service invokes a La…

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -181,8 +181,13 @@ arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<route path>
 A `SourceArn` may wildcard any part of that, which is what the usual grant does:
 `<apiId>/*/*` allows every route of the API on every stage.
 
-`AWS:SourceArn` is the only condition key supplied here. A permission that also carries
-`SourceAccount`, `PrincipalOrgID` or `InvokedViaFunctionUrl` never matches, since nothing gives those
+The API's own Account is supplied as `AWS:SourceAccount`, so a permission carrying a `SourceAccount`
+matches when it names the Account the API belongs to. That is the Account the source ARN names, not
+the one owning the function, which matters for an integration reaching across Accounts. CDK writes
+both keys for some grants, and a permission carrying either or both is evaluated on what it says.
+
+`AWS:SourceArn` and `AWS:SourceAccount` are the only condition keys supplied here. A permission that
+also carries `PrincipalOrgID` or `InvokedViaFunctionUrl` never matches, since nothing gives those
 keys a value at request time, so the request is refused with the same 500.
 
 Neither the method nor the path is documented by AWS as the value API Gateway supplies. Both are

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -868,17 +868,18 @@ else is read as a service principal, and `*` stays `*`.
 Function URL is invoked. That is what a Function URL grant conditions on in practice: a permission
 granted for `AWS_IAM` does not also open a URL later switched to `NONE`.
 
-`SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, which is evaluated when a simulated
-API Gateway HTTP API invokes the function through a Lambda proxy integration. That is the one
-request-time value supplied for the key, so a grant naming an API's routes decides whether those
-requests are served. See
+`SourceArn` becomes an `ArnLike` condition on `AWS:SourceArn`, and `SourceAccount` a `StringEquals`
+condition on `AWS:SourceAccount`. Both are evaluated when another simulated service invokes the
+function, which today means a simulated API Gateway HTTP API invoking it through a Lambda proxy
+integration or as a `REQUEST` authorizer. The source ARN is what the API is invoking the function
+for, and the source Account is the API's own. See
 [Granting the API permission to invoke the function](../apigatewayv2/README.md#granting-the-api-permission-to-invoke-the-function).
-A direct `Invoke`, a Function URL request and an SQS event source mapping supply no source ARN, so a
+A direct `Invoke`, a Function URL request and an SQS event source mapping supply neither, so a
 statement carrying one does not match them.
 
-`SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so
-`GetPolicy` reports the grant that was made, but nothing supplies a value for them at request time,
-so a statement carrying one of those never matches.
+`PrincipalOrgID` and `InvokedViaFunctionUrl` are written into the statement so `GetPolicy` reports
+the grant that was made, but nothing supplies a value for them at request time, so a statement
+carrying one of those never matches.
 
 A function that has been granted nothing has no policy at all, which `GetPolicy` reports as a
 `ResourceNotFoundException` rather than as an empty document. Granting a `StatementId` that is
@@ -1341,12 +1342,12 @@ Current documented limitations:
 - A cross-account grant is only half of what admits a call: the caller's own Account has to allow
   the action too, and its IAM has to be part of the same `SimAws` instance for its policies to be
   found. A caller from an Account the simulation knows nothing about is denied.
-- `lambda:FunctionUrlAuthType` and `AWS:SourceArn` are the only condition keys given a value at
-  request time, the first when a Function URL is invoked and the second when a simulated API Gateway
-  HTTP API invokes the function. `SourceAccount`, `PrincipalOrgID` and `InvokedViaFunctionUrl` are
-  written into the statement so `GetPolicy` reports the grant that was made, but nothing supplies a
-  value for them, so a statement carrying one never matches. Neither does a `SourceArn` statement on
-  a request from anything but an HTTP API integration.
+- `lambda:FunctionUrlAuthType`, `AWS:SourceArn` and `AWS:SourceAccount` are the only condition keys
+  given a value at request time, the first when a Function URL is invoked and the other two when a
+  simulated API Gateway HTTP API invokes the function. `PrincipalOrgID` and `InvokedViaFunctionUrl`
+  are written into the statement so `GetPolicy` reports the grant that was made, but nothing supplies
+  a value for them, so a statement carrying one never matches. Neither does a `SourceArn` or
+  `SourceAccount` statement on a request from anything but an HTTP API.
 - `Qualifier`, `RevisionId` and `EventSourceToken` on the permission commands are not simulated,
   as versions and aliases are not.
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -260,13 +260,16 @@ fails the stack rather than deploying a template written two ways at once.
    method and path rather than from the route key.
 
 3. `serve/auth/sim-http-api-invoke-authorizer.ts` asks whether the API may invoke a function at all.
-   The caller is the service principal `apigateway.amazonaws.com`, the action is
-   `lambda:InvokeFunction`, and the request supplies `AWS:SourceArn` from
-   `api/sim-http-api-execute-api-arn.ts`. A function with no matching permission answers 500 and is
-   never invoked, as it is on real AWS. Both an integration's function and an authorizer's go
-   through this, under different ARNs: the route for one, `<apiId>/authorizers/<authorizerId>` for
-   the other. That ARN builder carries the reasoning for what the method and path segments of the
-   ARN hold, since neither is documented by AWS.
+   The decision itself belongs to Lambda and is made by
+   `src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.ts`, which every
+   simulated service invoking a function goes through. This supplies the part API Gateway knows: the
+   service principal `apigateway.amazonaws.com`, `AWS:SourceArn` from
+   `api/sim-http-api-execute-api-arn.ts`, and the API's own Account as `AWS:SourceAccount`, which is
+   the Account the source ARN names rather than the one owning the function. A function with no
+   matching permission answers 500 and is never invoked, as it is on real AWS. Both an integration's
+   function and an authorizer's go through this, under different ARNs: the route for one,
+   `<apiId>/authorizers/<authorizerId>` for the other. That ARN builder carries the reasoning for
+   what the method and path segments of the ARN hold, since neither is documented by AWS.
 4. `sim-http-api-integration-invocation.ts` invokes the integrated function and turns its result into
    the response. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
    `SimPayload2Endpoint`, including what the route captured from the path.

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-invoke-authorizer.ts
@@ -2,7 +2,7 @@ import type {
   SimIamAuthorizationDecision,
   SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { simLambdaResourcePolicies } from "../../../lambda/command/authorize/sim-lambda-resource-policies.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
 import type { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
 import type { SimHttpApiRequestAuthorizer } from "../../api/authorizer/sim-http-api-request-authorizer.js";
 import { SimHttpApiExecuteApiArn } from "../../api/sim-http-api-execute-api-arn.js";
@@ -15,17 +15,12 @@ import type { SimHttpApiFunctionTarget } from "../sim-api-gateway-v2-router.js";
  */
 export const simApiGatewayServicePrincipal = "apigateway.amazonaws.com";
 
-/**
- * The condition key the invoking API is supplied under, which is what an
- * `AddPermission` `SourceArn` is written against.
- */
-const sourceArnConditionKey = "AWS:SourceArn";
-
 interface SimHttpApiInvokeAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
 }
 
 interface SimHttpApiInvokeAuthorizationInput {
+  readonly api: SimHttpApi;
   readonly simFunction: SimLambdaFunction;
   readonly sourceArn: SimHttpApiExecuteApiArn;
 }
@@ -36,22 +31,23 @@ interface SimHttpApiInvokeAuthorizationInput {
  * A Lambda proxy integration created through CloudFormation, the CLI or an SDK
  * does not work until the function's resource policy allows
  * `apigateway.amazonaws.com` to invoke it, and a Lambda `REQUEST` authorizer's
- * function needs the same grant under an ARN of its own. API Gateway is the
- * caller, so the caller's own identity policies are not what admits the call:
- * a service principal owns none, and the function's resource policy is the
- * whole decision.
+ * function needs the same grant under an ARN of its own.
+ *
+ * Whether a service may invoke a function is Lambda's own rule, so the decision
+ * is made there. What this adds is the part only API Gateway knows: which API
+ * is calling, and what it is calling for.
  *
  * The answer is a decision rather than a thrown error, because a refusal is an
  * ordinary HTTP outcome: the endpoint answers 500 the way real API Gateway
  * does, with nothing to propagate to a caller in process.
  */
 export class SimHttpApiInvokeAuthorizer {
-  private static readonly action = "lambda:InvokeFunction";
-
-  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly lambdaAuthorizer: SimLambdaServiceInvokeAuthorizer;
 
   constructor(properties: SimHttpApiInvokeAuthorizerProperties) {
-    this.iam = properties.iam;
+    this.lambdaAuthorizer = new SimLambdaServiceInvokeAuthorizer({
+      iam: properties.iam,
+    });
   }
 
   /**
@@ -60,19 +56,18 @@ export class SimHttpApiInvokeAuthorizer {
    * What the API is invoking the function for is supplied as `AWS:SourceArn`,
    * so a permission granted for one route does not open another, and a
    * permission granted for an integration does not make the same function
-   * usable as an authorizer.
+   * usable as an authorizer. The API's own Account is supplied as
+   * `AWS:SourceAccount`, which is the Account the source ARN names rather than
+   * the one owning the function.
    */
   authorize(
     input: SimHttpApiInvokeAuthorizationInput,
   ): SimIamAuthorizationDecision {
-    return this.iam.authorize({
-      action: SimHttpApiInvokeAuthorizer.action,
-      resource: input.simFunction.arn,
-      caller: { kind: "service", service: simApiGatewayServicePrincipal },
-      resourcePolicies: simLambdaResourcePolicies(input.simFunction),
-      conditionContext: {
-        [sourceArnConditionKey]: input.sourceArn.toString(),
-      },
+    return this.lambdaAuthorizer.authorize({
+      simFunction: input.simFunction,
+      servicePrincipal: simApiGatewayServicePrincipal,
+      sourceArn: input.sourceArn.toString(),
+      sourceAccount: input.api.accountRegionScope.accountId,
     });
   }
 }
@@ -90,6 +85,7 @@ export function simHttpApiMayNotInvokeAuthorizer(
   target: SimHttpApiFunctionTarget,
 ): boolean {
   return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
+    api,
     simFunction: target.simFunction,
     sourceArn: SimHttpApiExecuteApiArn.forAuthorizer(
       api,

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -97,6 +97,7 @@ export class SimHttpApiIntegrationInvocation {
     const { api, match, request } = input;
 
     return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
+      api,
       simFunction: target.simFunction,
       sourceArn: SimHttpApiExecuteApiArn.forMatchedRoute(
         api,

--- a/src/service/apigatewayv2/serve/sim-http-api-invoke-source-account.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-invoke-source-account.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+function localUrl(api: SimHttpApi, path: string): string {
+  return new SimAwsLocalUrl({ input: `${api.apiEndpoint}${path}` }).toString();
+}
+
+describe("The source Account an HTTP API invokes its function with", () => {
+  it("allows a permission naming the API's own Account", async () => {
+    // Given an API whose function grants the invoke action to the Account the
+    // API belongs to
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { invokePermission: false, handler: (): string => "orders" },
+      simAws,
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceAccount: api.accountRegionScope.accountId,
+      }),
+    );
+
+    // When a request reaches the route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the API supplies that Account, so the condition matches
+    assertIdentical(response.status, 200);
+  });
+
+  it("refuses a permission naming another Account", async () => {
+    // Given a grant conditioned on an Account the API does not belong to
+    const simAws = new SimAws();
+    let invocations = 0;
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        handler: (): string => {
+          invocations += 1;
+
+          return "orders";
+        },
+      },
+      simAws,
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-gateway-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceAccount: "222222222222",
+      }),
+    );
+
+    // When a request reaches the route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api, "/orders"),
+    );
+
+    // Then the grant belongs to another Account's API, so this one is answered
+    // the way a missing permission is
+    assertIdentical(response.status, 500);
+    assertIdentical(invocations, 0);
+  });
+
+  it("names the API's Account rather than the function's", async () => {
+    // Given an API whose integrated function belongs to another Account, and a
+    // grant on that function naming the function's own Account
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        invokePermission: false,
+        functionAccountId: "222222222222",
+        roleArn: "arn:aws:iam::222222222222:role/OrdersRole",
+        handler: (): string => "orders",
+      },
+      simAws,
+    );
+    const otherAccountLambda = simAws.account("222222222222").lambda();
+    await otherAccountLambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "own-account-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceAccount: "222222222222",
+      }),
+    );
+
+    // When a request is served with that grant, and again once the function
+    // names the API's Account instead
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const ownAccount = await simAwsHttp.fetch(localUrl(api, "/orders"));
+    await otherAccountLambda.removePermission(
+      new RemovePermissionCommand({
+        FunctionName: "orders",
+        StatementId: "own-account-invoke",
+      }),
+    );
+    await otherAccountLambda.addPermission(
+      new AddPermissionCommand({
+        FunctionName: "orders",
+        StatementId: "api-account-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: "apigateway.amazonaws.com",
+        SourceAccount: api.accountRegionScope.accountId,
+      }),
+    );
+    const apiAccount = await simAwsHttp.fetch(localUrl(api, "/orders"));
+
+    // Then the source Account is the one the request arrives in, which is the
+    // API's rather than the function's
+    assertIdentical(ownAccount.status, 500);
+    assertIdentical(apiAccount.status, 200);
+  });
+});

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -376,6 +376,16 @@ account-scoped simulated IAM implementation when constructed through `SimAws`
 direct standalone construction. The Function URL commands share one `FunctionUrlAuthorizer` taking
 the action as a constructor value, since only the action name varies between them.
 
+`command/authorize/sim-lambda-service-invoke-authorizer.ts` answers the other question: whether
+another simulated service may invoke a function. The caller is a service principal, which owns no
+identity policies, so the function's resource policy is the whole decision. The calling service
+supplies what it knows about the invocation as condition values, `AWS:SourceArn` for what it is
+invoking the function for and `AWS:SourceAccount` for the Account its own resource belongs to, and
+gets a decision back rather than a thrown error, since what a refusal means is the calling service's
+business. Simulated API Gateway calls it through `SimHttpApiInvokeAuthorizer`, which fills in the
+`execute-api` ARN and the API's Account. This lives here rather than in the calling service because
+who may invoke a function is Lambda's rule, and a second copy of it would drift.
+
 ## CloudFormation
 
 `cfn/` owns `AWS::Lambda::*` resource creation, following the shared per-service factory pattern

--- a/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.iso.test.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.iso.test.ts
@@ -1,0 +1,203 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { assertFalse, assertNonNullable, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import { SimLambdaServiceInvokeAuthorizer } from "./sim-lambda-service-invoke-authorizer.js";
+
+const bucketAccountId = "111111111111";
+const s3ServicePrincipal = "s3.amazonaws.com";
+const bucketArn = "arn:aws:s3:::orders";
+
+/**
+ * Create the function every case here authorizes against.
+ */
+async function createNotifier(simAws: SimAws): Promise<SimLambdaFunction> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "notify",
+      Role: "arn:aws:iam::888888888888:role/NotifyRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => "notified") },
+    }),
+  );
+  const simFunction = simAws.lambda().getSimFunctionByName("notify");
+  assertNonNullable(simFunction);
+
+  return simFunction;
+}
+
+describe("Authorizing a simulated service to invoke a Lambda function", () => {
+  it("refuses a service the function granted nothing", async () => {
+    // Given a function with no resource policy at all
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+
+    // When a service asks to invoke it
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+      sourceArn: bucketArn,
+      sourceAccount: bucketAccountId,
+    });
+
+    // Then nothing admits the call, since a service principal has no identity
+    // policies of its own
+    assertTrue(decision.isDenied);
+  });
+
+  it("allows a matching source Account", async () => {
+    // Given a grant naming the Account the invoking resource belongs to, as
+    // CDK writes for an S3 event notification
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "notify",
+        StatementId: "s3-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: s3ServicePrincipal,
+        SourceAccount: bucketAccountId,
+      }),
+    );
+
+    // When the service invokes it from that Account
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+      sourceArn: bucketArn,
+      sourceAccount: bucketAccountId,
+    });
+
+    // Then the condition matches and the invoke is allowed
+    assertTrue(decision.isAllowed);
+  });
+
+  it("refuses a different source Account", async () => {
+    // Given a grant naming one Account
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "notify",
+        StatementId: "s3-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: s3ServicePrincipal,
+        SourceAccount: bucketAccountId,
+      }),
+    );
+
+    // When the invoking resource belongs to another one
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+      sourceArn: bucketArn,
+      sourceAccount: "222222222222",
+    });
+
+    // Then the grant does not admit it, which is what a source Account is for:
+    // another Account's Bucket cannot reach the function by naming its ARN
+    assertTrue(decision.isDenied);
+    assertFalse(decision.isAllowed);
+  });
+
+  it("requires both when the grant names an ARN and an Account", async () => {
+    // Given a grant naming both, as CDK's LambdaDestination writes
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "notify",
+        StatementId: "s3-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: s3ServicePrincipal,
+        SourceArn: bucketArn,
+        SourceAccount: bucketAccountId,
+      }),
+    );
+    const authorizer = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    });
+
+    // When both match, and when only one of them does
+    const both = authorizer.authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+      sourceArn: bucketArn,
+      sourceAccount: bucketAccountId,
+    });
+    const otherBucket = authorizer.authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+      sourceArn: "arn:aws:s3:::refunds",
+      sourceAccount: bucketAccountId,
+    });
+
+    // Then every condition on the statement has to hold
+    assertTrue(both.isAllowed);
+    assertTrue(otherBucket.isDenied);
+  });
+
+  it("refuses a conditioned grant when the service supplies no value", async () => {
+    // Given a grant conditioned on a source Account
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "notify",
+        StatementId: "s3-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: s3ServicePrincipal,
+        SourceAccount: bucketAccountId,
+      }),
+    );
+
+    // When the invoking service knows of no source Account to supply
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: s3ServicePrincipal,
+    });
+
+    // Then the missing key fails the condition rather than passing it
+    assertTrue(decision.isDenied);
+  });
+
+  it("refuses a grant made to a different service principal", async () => {
+    // Given a grant to one service
+    const simAws = new SimAws();
+    const simFunction = await createNotifier(simAws);
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "notify",
+        StatementId: "s3-invoke",
+        Action: "lambda:InvokeFunction",
+        Principal: s3ServicePrincipal,
+        SourceAccount: bucketAccountId,
+      }),
+    );
+
+    // When another service invokes the function from the same Account
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: simAws.iam(),
+    }).authorize({
+      simFunction,
+      servicePrincipal: "events.amazonaws.com",
+      sourceAccount: bucketAccountId,
+    });
+
+    // Then the principal of the statement decides, not the condition
+    assertTrue(decision.isDenied);
+  });
+});

--- a/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-service-invoke-authorizer.ts
@@ -1,0 +1,96 @@
+import type {
+  SimIamAuthorizationDecision,
+  SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import {
+  simLambdaSourceAccountConditionKey,
+  simLambdaSourceArnConditionKey,
+} from "../../function/policy/sim-lambda-permission.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimIamConditionValue } from "../../../iam/policy/sim-iam-policy.js";
+import { simLambdaResourcePolicies } from "./sim-lambda-resource-policies.js";
+
+interface SimLambdaServiceInvokeAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+interface SimLambdaServiceInvokeAuthorizationInput {
+  readonly simFunction: SimLambdaFunction;
+
+  /** The service principal the invoking service calls Lambda as. */
+  readonly servicePrincipal: string;
+
+  /**
+   * What the service is invoking the function for, such as the API Gateway
+   * route a request matched or the S3 Bucket an event came from.
+   */
+  readonly sourceArn?: string | undefined;
+
+  /** The Account the invoking service's own resource belongs to. */
+  readonly sourceAccount?: string | undefined;
+}
+
+/**
+ * Decides whether a simulated AWS service may invoke a Lambda function.
+ *
+ * A function invoked by another service does not run until its resource policy
+ * allows that service principal to invoke it, which is what `AddPermission`
+ * grants. The invoking service is the caller, so the caller's own identity
+ * policies are not what admits the call: a service principal owns none, and the
+ * function's resource policy is the whole decision.
+ *
+ * Who may invoke a function is Lambda's rule rather than the calling service's,
+ * so every service that invokes a function asks here. The answer is a decision
+ * rather than a thrown error, because what a refusal means is the calling
+ * service's own business: API Gateway answers 500, and an event source drops
+ * the event.
+ */
+export class SimLambdaServiceInvokeAuthorizer {
+  private static readonly action = "lambda:InvokeFunction";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimLambdaServiceInvokeAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Evaluate `lambda:InvokeFunction` for a service against the function.
+   *
+   * The source ARN and the source Account are supplied as `AWS:SourceArn` and
+   * `AWS:SourceAccount`, so a permission granted for one resource does not open
+   * another, and a permission naming an Account only admits that Account's
+   * resources.
+   */
+  authorize(
+    input: SimLambdaServiceInvokeAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    return this.iam.authorize({
+      action: SimLambdaServiceInvokeAuthorizer.action,
+      resource: input.simFunction.arn,
+      caller: { kind: "service", service: input.servicePrincipal },
+      resourcePolicies: simLambdaResourcePolicies(input.simFunction),
+      conditionContext: this.conditionContext(input),
+    });
+  }
+
+  /**
+   * The request-time values a statement's conditions are matched against.
+   *
+   * A value the calling service does not have is left out rather than supplied
+   * empty, so a statement conditioned on it fails to match instead of matching
+   * an empty string.
+   */
+  private conditionContext(
+    input: SimLambdaServiceInvokeAuthorizationInput,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    return {
+      ...(input.sourceArn !== undefined && {
+        [simLambdaSourceArnConditionKey]: input.sourceArn,
+      }),
+      ...(input.sourceAccount !== undefined && {
+        [simLambdaSourceAccountConditionKey]: input.sourceAccount,
+      }),
+    };
+  }
+}

--- a/src/service/lambda/function/policy/sim-lambda-permission.ts
+++ b/src/service/lambda/function/policy/sim-lambda-permission.ts
@@ -25,6 +25,18 @@ export const simLambdaFunctionUrlAuthTypeConditionKey =
 export const simLambdaInvokedViaFunctionUrlConditionKey =
   "lambda:InvokedViaFunctionUrl";
 
+/**
+ * The condition key naming what a simulated service is invoking the function
+ * for, such as the API Gateway route a request matched.
+ */
+export const simLambdaSourceArnConditionKey = "AWS:SourceArn";
+
+/**
+ * The condition key naming the Account the invoking simulated service resource
+ * belongs to.
+ */
+export const simLambdaSourceAccountConditionKey = "AWS:SourceAccount";
+
 interface SimLambdaPermissionProperties {
   readonly statementId: string;
   readonly action: string;
@@ -90,8 +102,9 @@ export class SimLambdaPermission {
    * The condition block the qualifying properties expand into.
    *
    * `lambda:FunctionUrlAuthType` is given a value when a Function URL is
-   * invoked, and `AWS:SourceArn` when an API Gateway HTTP API integration
-   * invokes the function. The rest are still written into the statement,
+   * invoked, and `AWS:SourceArn` and `AWS:SourceAccount` when a simulated
+   * service invokes the function. `aws:PrincipalOrgID` and
+   * `lambda:InvokedViaFunctionUrl` are still written into the statement,
    * because `GetPolicy` should report the permission that was granted; a
    * statement carrying one of them simply never matches, which is the safe
    * direction for a condition the simulator cannot evaluate.
@@ -105,7 +118,9 @@ export class SimLambdaPermission {
     }
 
     if (this.sourceArn !== undefined) {
-      condition["ArnLike"] = { "AWS:SourceArn": this.sourceArn };
+      condition["ArnLike"] = {
+        [simLambdaSourceArnConditionKey]: this.sourceArn,
+      };
     }
 
     if (this.invokedViaFunctionUrl !== undefined) {
@@ -124,7 +139,7 @@ export class SimLambdaPermission {
         [simLambdaFunctionUrlAuthTypeConditionKey]: this.functionUrlAuthType,
       }),
       ...(this.sourceAccount !== undefined && {
-        "AWS:SourceAccount": this.sourceAccount,
+        [simLambdaSourceAccountConditionKey]: this.sourceAccount,
       }),
       ...(this.principalOrgId !== undefined && {
         "aws:PrincipalOrgID": this.principalOrgId,


### PR DESCRIPTION
…mbda function

Who may invoke a function is Lambda's rule, so the decision moves into SimLambdaServiceInvokeAuthorizer, which every simulated service calls. API Gateway now supplies its own Account as AWS:SourceAccount alongside the execute-api source ARN, so a permission carrying either or both is evaluated on what it says.

Resolves https://github.com/KensioSoftware/yulin/issues/328