### PR TITLE
docs: describe the stand-in values a skipped CloudFormation Resource …

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -316,6 +316,71 @@ await stack.waitForDeployComplete();
 For `AWS::CloudFront::Distribution`, `Fn::GetAtt: ["Distribution", "DomainName"]` returns the
 simulated CloudFront hostname, such as `e123example.cloudfront.net`.
 
+#### Values from a skipped Resource
+
+A Resource that was skipped, because its type is not simulated or because it sets a property whose
+behaviour is not simulated, still answers both intrinsics. `Ref` returns the logical ID, and
+`Fn::GetAtt` returns the string `<logical ID>.<attribute name>`.
+
+```typescript sim-cloudformation-skipped-resource-values
+/**
+ * The stand-in values a skipped CloudFormation Resource answers with.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "stand-in-stack",
+  template: {
+    Resources: {
+      AlarmTopic: {
+        Type: "AWS::SNS::Topic",
+      },
+    },
+    Outputs: {
+      TopicRef: { Value: { Ref: "AlarmTopic" } },
+      TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.get("TopicRef")?.value);
+// "AlarmTopic"
+
+console.log(stack.outputs.get("TopicArn")?.value);
+// "AlarmTopic.TopicArn"
+
+for (const skipped of stack.skippedResources) {
+  console.log(skipped.logicalId, skipped.skippedReason);
+  // "AlarmTopic Unsupported sim CloudFormation Resource service SNS"
+}
+```
+
+The stand-ins are what lets a template with unsimulated Resources in it deploy at all. Without them,
+every Resource holding a `Ref` or `Fn::GetAtt` to a skipped Resource would fail too, and so would
+every Resource depending on those, until one SNS topic took the whole stack down with it. The skip
+stays where it happened.
+
+A stand-in is deliberately not ARN-shaped, so it fails closed wherever the simulator reads it.
+
+- In an IAM policy `Resource` it matches no ARN, so a caller relying on that statement is denied.
+- In a property that is parsed as an ARN it is refused as malformed, and that Resource fails.
+  Handing `Fn::GetAtt: ["Orders", "StreamArn"]` from a skipped DynamoDB table to an
+  `AWS::Lambda::EventSourceMapping` fails with
+  `EventSourceArn Orders.StreamArn is not an SQS queue ARN`.
+- Handed to a Lambda function through its environment, it names something that is not there, so the
+  function's own SDK call fails as a call for a missing resource does. A `PutItem` naming the
+  skipped table gets `ResourceNotFoundException: No DynamoDB Table named Orders`.
+
+A stand-in stands in for something absent, so it is not a value to rely on. A test asserting against
+one is asserting on a Resource that was never created. `stack.skippedResources` is where to find out
+which Resources those are and why, under
+[Inspecting stacks and resources](#inspecting-stacks-and-resources).
+
 ### `Fn::Join`
 
 ```typescript sim-cloudformation-fn-join
@@ -885,6 +950,48 @@ console.log(bucketResource?.simResource);
 This is useful in tests when you want to assert that a specific template resource created the
 expected simulated service resource.
 
+`stack.skippedResources` lists the Resources the deployment did not create. Each one carries a
+`skippedReason` naming the type or the property that is not simulated, so a test that expected a
+resource to exist can find out why it does not.
+
+```typescript sim-cloudformation-inspect-skipped
+/**
+ * Finding out which Resources a simulated CloudFormation Stack skipped.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "skipped-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "skipped-site-bucket",
+        },
+      },
+      AlarmTopic: {
+        Type: "AWS::SNS::Topic",
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.skippedResources.map((resource) => resource.logicalId));
+// ["AlarmTopic"]
+
+console.log(stack.getResource("AlarmTopic")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service SNS"
+```
+
+A skipped Resource is still in `stack.resources`, and still answers `Ref` and `Fn::GetAtt` with
+[stand-in values](#values-from-a-skipped-resource).
+
 ## Handling deployment failures
 
 Some deployment failures happen asynchronously after stack creation has started. To observe those
@@ -992,7 +1099,10 @@ Each service's own docs describe what its resource types support.
 - `TemplateBody` must be JSON when using `CreateStackCommand`. YAML parsing is not currently provided
   by the CloudFormation service.
 - Only supported resource types create simulated service resources. An unsupported resource may be
-  skipped or may fail the stack, depending on how safely the simulator can model it.
+  skipped or may fail the stack, depending on how safely the simulator can model it. A skipped
+  resource answers `Ref` and `Fn::GetAtt` with
+  [stand-in values](#values-from-a-skipped-resource) rather than the value a created resource would
+  have given.
 - Unsupported resource properties may be ignored or rejected depending on the resource simulator.
 - Stack updates and deletes are not supported.
 - Mappings, conditions, and many advanced CloudFormation features are not supported.

--- a/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
@@ -1,0 +1,32 @@
+/**
+ * Finding out which Resources a simulated CloudFormation Stack skipped.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "skipped-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "skipped-site-bucket",
+        },
+      },
+      AlarmTopic: {
+        Type: "AWS::SNS::Topic",
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.skippedResources.map((resource) => resource.logicalId));
+// ["AlarmTopic"]
+
+console.log(stack.getResource("AlarmTopic")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service SNS"

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
@@ -1,0 +1,35 @@
+/**
+ * The stand-in values a skipped CloudFormation Resource answers with.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "stand-in-stack",
+  template: {
+    Resources: {
+      AlarmTopic: {
+        Type: "AWS::SNS::Topic",
+      },
+    },
+    Outputs: {
+      TopicRef: { Value: { Ref: "AlarmTopic" } },
+      TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.outputs.get("TopicRef")?.value);
+// "AlarmTopic"
+
+console.log(stack.outputs.get("TopicArn")?.value);
+// "AlarmTopic.TopicArn"
+
+for (const skipped of stack.skippedResources) {
+  console.log(skipped.logicalId, skipped.skippedReason);
+  // "AlarmTopic Unsupported sim CloudFormation Resource service SNS"
+}

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2789,8 +2789,14 @@ that, which a template cannot predict either way. Two stacks deploying the same 
 differently named tables. The generated name is trimmed to the 255 characters a table name allows,
 ending in a hash of the untrimmed name so two long names that start the same stay apart.
 
-`Fn::GetAtt … StreamArn` is refused by name. Streams are not simulated, and an invented stream ARN
-would read as a working stream to whatever the template handed it to.
+`Fn::GetAtt … StreamArn` on a table that was created is refused by name. Streams are not simulated,
+and an invented stream ARN would read as a working stream to whatever the template handed it to.
+
+A table declaring `StreamSpecification` is skipped rather than created, though, and a skipped
+Resource never reaches that refusal. `Fn::GetAtt … StreamArn` on it resolves to the CloudFormation
+stand-in `OrdersTable.StreamArn` instead, which is not an ARN and fails wherever the simulator reads
+it as one. See
+[values from a skipped Resource](../cloudformation/README.md#values-from-a-skipped-resource).
 
 A property with behaviour that is not simulated skips the resource, with a reason naming the
 property, and the rest of the stack still deploys: `StreamSpecification`,

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.iso.test.ts
@@ -1,0 +1,83 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+
+/**
+ * A template whose only Resource is one no service claims, referenced both
+ * ways, so a test can read what a skipped Resource answers with.
+ */
+const skippedTopicTemplate: CfnTemplateBodyRecord = {
+  Resources: {
+    AlarmTopic: {
+      Type: "AWS::SNS::Topic",
+    },
+  },
+  Outputs: {
+    TopicRef: { Value: { Ref: "AlarmTopic" } },
+    TopicArn: { Value: { "Fn::GetAtt": ["AlarmTopic", "TopicArn"] } },
+  },
+};
+
+describe("skipped CloudFormation Resource values", () => {
+  it("answers a Ref with the logical ID", async () => {
+    // Given a template holding a Ref to a Resource type that is not simulated.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "stand-in-stack",
+      template: skippedTopicTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Ref resolved to the logical ID rather than failing the
+    // Resources that hold it.
+    assertIdentical(stack.outputs.get("TopicRef")?.value, "AlarmTopic");
+  });
+
+  it("answers an Fn::GetAtt with the logical ID and attribute name", async () => {
+    // Given a template holding an Fn::GetAtt to a Resource type that is not
+    // simulated.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "stand-in-stack",
+      template: skippedTopicTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the attribute resolved to a stand-in that is deliberately not
+    // ARN-shaped, so it fails closed wherever it is read as one.
+    assertIdentical(
+      stack.outputs.get("TopicArn")?.value,
+      "AlarmTopic.TopicArn",
+    );
+  });
+
+  it("records the skip the stand-ins came from", async () => {
+    // Given the same template, whose topic is skipped rather than created.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "stand-in-stack",
+      template: skippedTopicTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Stack says which Resource was skipped and why, which is how a
+    // reader finds out a value they got was a stand-in.
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.getResource("AlarmTopic")?.skippedReason ?? "",
+      "Unsupported sim CloudFormation Resource service SNS",
+    );
+  });
+});


### PR DESCRIPTION
…answers with

Ref returns the logical ID and Fn::GetAtt returns `<logical ID>.<attribute name>` for a Resource that was skipped, which is what stops one unsupported Resource failing everything that references it. Says why the fallback exists, that the stand-in is not ARN-shaped so it fails closed where it is read, and points at stack.skippedResources.

Corrects the DynamoDB docs, which said Fn::GetAtt StreamArn is refused. It is refused on a table that was created, but a table declaring StreamSpecification is skipped and answers with the stand-in instead.

Resolves https://github.com/KensioSoftware/yulin/issues/335