### PR TITLE
fix: apply a simulated TransactWriteItems atomically

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2244,13 +2244,15 @@ the `ConditionalCheckFailedException` a single `PutItem` throws.
 An action that sets `ReturnValuesOnConditionCheckFailure` to `ALL_OLD` gets `Item` on its
 cancellation reason, holding the item as it was, so a retry needs no second read.
 
-Five things refuse the request outright rather than cancelling it, with nothing written either way:
+These refuse the request outright rather than cancelling it, with nothing written either way:
 
 - more than 100 actions
 - an action carrying more than one of `Put`, `Update`, `Delete` and `ConditionCheck`, or none of them
 - two actions on the same item of one table
 - a table that is not there, or a key that does not match its key schema
 - an update that would move the item's primary key
+- an item carrying a secondary index key attribute as a type the index did not declare
+- an update that would take the item past the 400 KB one item holds
 
 One table may be named as often as the transaction likes, which is the difference from a batch. What
 it may not do is touch one item twice.

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -153,8 +153,16 @@ For a table with partition key `pk` and sort key `sk`, the internal key includes
 { "pk": "user-123", "sk": "profile" }
 ```
 
-This is an implementation detail, but it is important when changing item storage because `putItem()`
+This is an implementation detail, but it is important when changing item storage because a write
 uses the key schema to overwrite items with the same primary key.
+
+`SimDynamoDbTableWrites` is how a table takes a write, in two steps. `prepareItem` and
+`prepareRemoval` do everything a write can be refused for: reading the primary key, and checking the
+item against the secondary indexes. Committing the `SimDynamoDbTableWrite` they answer with stores
+what was prepared and nothing else, so it cannot throw. `SimDynamoDbTable.putItem` and
+`SimDynamoDbTable.deleteItem` are the two steps run together, which is what an ordinary write wants.
+TransactWriteItems runs them apart, so a check added on the preparing side holds a whole transaction
+back rather than stopping it half applied.
 
 ## Secondary index model
 
@@ -248,7 +256,7 @@ AWS and refuses one; a local secondary index and the table both answer it. That 
 after `IndexName` has been resolved to a view rather than off the request alone.
 
 The one thing a write is held to on account of an index is `assertItemKeyTypes`, applied in
-`SimDynamoDbTable.putItem`, which every write in the service goes through. An item missing an index
+`SimDynamoDbTableWrites.prepareItem`, which every write in the service goes through. An item missing an index
 key attribute is fine, since a secondary index of either kind is sparse and simply does not hold it.
 An item carrying one as a type the index did not declare is a `ValidationException`, since the index
 could never hold it.
@@ -717,12 +725,27 @@ write:
 3. Every key is marshalled through its table's key schema, which is both the key check and what
    tells two actions on one item apart. Unlike a batch, one table may be named as often as the
    request likes.
-4. Every action is checked against what is stored, and only then does the first of them write.
+4. Every action is checked against what is stored, which is where a `ConditionExpression` is
+   applied.
+5. Every action's write is prepared, which is where everything else the table would refuse the
+   write for is applied: the updated item is worked out and held to the 400 KB one item holds, and
+   the item is checked against the table's secondary index key types.
+6. Only once every write is prepared is the first of them committed.
+
+Steps 4 and 5 are apart because they answer differently. A condition that did not hold cancels the
+transaction and is reported as that action's cancellation reason, so every action is asked before
+any is prepared. Anything else is the request being wrong rather than the transaction being
+cancelled, and it only comes out of preparing the write.
+
+Preparing every write before committing any of them is staging rather than moving the remaining
+checks up into `assertApplicableTo`. Moving them would work today and would quietly stop working the
+moment a check was added anywhere else on the write path. Staging holds whatever the write path
+refuses, wherever the check lives.
 
 The parts a transaction is made of split by what they know:
 
 - `SimDynamoDbTransactWrite` is one action, as the item or key it carries, the condition guarding
-  it, the IAM action it needs and what it does to a table. The four implementations are in
+  it, the IAM action it needs and the write it prepares against a table. The four implementations are in
   `sim-dynamodb-transact-put-action.ts`, `sim-dynamodb-transact-update-action.ts` and
   `sim-dynamodb-transact-key-actions.ts`, which holds the delete and the condition check together
   since both are a key and a condition against what is stored under it. Each file reads its own
@@ -735,11 +758,12 @@ The parts a transaction is made of split by what they know:
   `ProjectionExpression` through the same `readSimDynamoDbProjection` GetItem uses.
 - `reachSimDynamoDbTransactTables` is how both reach their tables, and where the one-action-per-item
   rule is applied.
-- `sim-dynamodb-transact-cancellation.ts` is the check and the writing, in that order. It asks every
-  action whether it applies, turning a `SimDynamoDbConditionalCheckFailedException` into that
-  action's cancellation reason and leaving anything else to throw, since a request DynamoDB would
-  refuse is refused rather than cancelled. Only once every action has answered does the first of
-  them write.
+- `sim-dynamodb-transact-cancellation.ts` is the checking, the preparing and the committing, in that
+  order. It asks every action whether it applies, turning a
+  `SimDynamoDbConditionalCheckFailedException` into that action's cancellation reason and leaving
+  anything else to throw, since a request DynamoDB would refuse is refused rather than cancelled.
+  It then asks every action for its `SimDynamoDbTableWrite` through `prepareFor`, and only once it
+  holds all of them does it commit the first.
 
 Every action is checked rather than stopping at the first failure, because a caller reads which of
 its actions failed out of `CancellationReasons`. The reasons line up with the request positionally,
@@ -987,7 +1011,9 @@ Current uses:
 - DeleteTable schedules the removal of the table from the store, which is what takes a table from
   DELETING to gone.
 - `SimDynamoDbTable.putItem()` writes the item at once. A write a caller has been told about is a
-  write that is there, so nothing about it waits on the scheduler.
+  write that is there, so nothing about it waits on the scheduler. The TTL removal a write schedules
+  is scheduled by `SimDynamoDbTableWrite.commit()`, so a prepared write that is never committed
+  schedules nothing.
 - `SimDynamoDbTransactionTokens` reads the scheduler's clock, which is what makes the ten minute
   `ClientRequestToken` window something `simAws.clock().advanceBy(...)` can move past.
 - UpdateTimeToLive schedules the settle that takes the status from ENABLING to ENABLED, or from
@@ -1050,7 +1076,7 @@ table state rather than request handling.
   under the key now, so one check covers a deleted item, an overwrite with a later TTL, a TTL
   attribute that has gone or changed type, and time to live having been switched off.
 
-`SimDynamoDbTable.putItem()` is the single hook. Every write in the service goes through it,
+`SimDynamoDbTableWrite.commit()` is the single hook. Every write in the service goes through it,
 including batch and transactional ones, so nothing needs a scheduling call of its own.
 
 Tests that need eventual state should call the broader sim AWS background-drain helper, for example:

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-cancellation.ts
@@ -29,14 +29,28 @@ const conditionalCheckFailed = "ConditionalCheckFailed";
  * Nothing is written until every action has been checked against what is
  * stored, which is what makes a transaction one step rather than a run of
  * writes that might stop part way.
+ *
+ * The checking is in two parts, because they answer differently. A condition
+ * that did not hold cancels the transaction and is reported as that action's
+ * reason, so every action is asked before any of them is prepared. Anything
+ * else the table would refuse the write for is the request being wrong, and it
+ * only comes out of preparing the write itself.
+ *
+ * So every write is prepared before any of them is committed, rather than the
+ * checks a prepared write makes being moved up into `assertApplicableTo`.
+ * Moving them would work today and would quietly stop working the moment a
+ * check was added anywhere else on the write path. Staging holds whatever the
+ * write path refuses, wherever the check lives.
  */
 export function applySimDynamoDbTransaction(
   targets: readonly SimDynamoDbTransactTarget<SimDynamoDbTransactWrite>[],
 ): void {
   assertApplies(targets);
 
-  for (const { item, table } of targets) {
-    item.applyTo(table);
+  const writes = targets.map(({ item, table }) => item.prepareFor(table));
+
+  for (const write of writes) {
+    write.commit();
   }
 }
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-key-actions.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-key-actions.ts
@@ -1,6 +1,7 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableWrite } from "../../table/sim-dynamodb-table-writes.js";
 import { SimDynamoDbConditionCheck } from "../item/sim-dynamodb-condition-check.js";
 import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
 import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
@@ -45,7 +46,7 @@ abstract class SimDynamoDbTransactKeyAction implements SimDynamoDbTransactWrite 
     this.check.assertHoldsFor(table.getItem(this.key));
   }
 
-  abstract applyTo(table: SimDynamoDbTable): void;
+  abstract prepareFor(table: SimDynamoDbTable): SimDynamoDbTableWrite;
 }
 
 /**
@@ -55,8 +56,20 @@ abstract class SimDynamoDbTransactKeyAction implements SimDynamoDbTransactWrite 
 class SimDynamoDbTransactDeleteAction extends SimDynamoDbTransactKeyAction {
   public readonly action = "dynamodb:DeleteItem";
 
-  applyTo(table: SimDynamoDbTable): void {
-    table.deleteItem(this.key);
+  prepareFor(table: SimDynamoDbTable): SimDynamoDbTableWrite {
+    return table.writes.prepareRemoval(this.key);
+  }
+}
+
+/**
+ * The write a condition check makes, which is none.
+ *
+ * A condition check is prepared and committed like the actions that do write,
+ * so a transaction has one shape to apply rather than two.
+ */
+class SimDynamoDbTransactNoWrite implements SimDynamoDbTableWrite {
+  commit(): undefined {
+    return;
   }
 }
 
@@ -69,9 +82,10 @@ class SimDynamoDbTransactDeleteAction extends SimDynamoDbTransactKeyAction {
 class SimDynamoDbTransactConditionCheckAction extends SimDynamoDbTransactKeyAction {
   public readonly action = "dynamodb:ConditionCheckItem";
 
-  applyTo(): void {
+  prepareFor(): SimDynamoDbTableWrite {
     // A condition check changes nothing. What it does happened when its
     // condition was checked against the item it names.
+    return new SimDynamoDbTransactNoWrite();
   }
 }
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-put-action.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-put-action.ts
@@ -1,6 +1,7 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableWrite } from "../../table/sim-dynamodb-table-writes.js";
 import { SimDynamoDbConditionCheck } from "../item/sim-dynamodb-condition-check.js";
 import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
 import type { SimDynamoDbTransactPut } from "./transact.command.js";
@@ -37,8 +38,8 @@ class SimDynamoDbTransactPutAction implements SimDynamoDbTransactWrite {
     this.check.assertHoldsFor(table.itemUnder(this.item));
   }
 
-  applyTo(table: SimDynamoDbTable): void {
-    table.putItem(this.item);
+  prepareFor(table: SimDynamoDbTable): SimDynamoDbTableWrite {
+    return table.writes.prepareItem(this.item);
   }
 }
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-update-action.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-update-action.ts
@@ -1,6 +1,7 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableWrite } from "../../table/sim-dynamodb-table-writes.js";
 import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
 import { SimDynamoDbUpdatePlan } from "../item/sim-dynamodb-update-plan.js";
 import type { SimDynamoDbTransactWrite } from "./sim-dynamodb-transact-write.js";
@@ -39,8 +40,14 @@ class SimDynamoDbTransactUpdateAction implements SimDynamoDbTransactWrite {
     this.plan.assertLeavesKeyAlone(table.keySchema.attributeNames());
   }
 
-  applyTo(table: SimDynamoDbTable): void {
-    table.putItem(this.plan.applyTo(table.getItem(this.key), this.key));
+  prepareFor(table: SimDynamoDbTable): SimDynamoDbTableWrite {
+    // Working the updated item out is itself refusable, since an update can
+    // take an item past the 400 KB one item holds. Doing it here rather than
+    // on the way to the table store is what keeps that failure ahead of the
+    // first write of the transaction.
+    return table.writes.prepareItem(
+      this.plan.applyTo(table.getItem(this.key), this.key),
+    );
   }
 }
 

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-atomicity.iso.test.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write-atomicity.iso.test.ts
@@ -1,0 +1,244 @@
+import { TransactWriteItemsCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+
+/**
+ * A table with an index keyed on an attribute the table itself is not keyed on.
+ *
+ * An index is what lets a write be refused for a reason no condition covers, so
+ * it is how a transaction is made to fail after its first action would have
+ * gone through.
+ */
+async function indexedTable(simAws: SimAws): Promise<SimDynamoDb> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable({
+    input: {
+      TableName: "FoobarTable",
+      KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+      AttributeDefinitions: [
+        { AttributeName: "pk", AttributeType: "S" },
+        { AttributeName: "status", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: "byStatus",
+          KeySchema: [{ AttributeName: "status", KeyType: "HASH" }],
+          Projection: { ProjectionType: "ALL" },
+        },
+      ],
+    },
+  });
+  await simAws.backgroundTasksComplete();
+
+  return simDynamoDb;
+}
+
+/**
+ * A string of a given number of kilobytes, for pushing an item over 400 KB.
+ */
+function kilobytes(count: number): string {
+  return "x".repeat(count * 1024);
+}
+
+describe("DynamoDB transactional write atomicity", () => {
+  it("writes nothing when a later action carries a wrong-typed index key", async () => {
+    // Given a table with an index whose partition key is a string.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    // When the second action of a transaction carries that attribute as a
+    // number, which no index could hold.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "FoobarTable",
+                Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+              },
+            },
+            {
+              Put: {
+                TableName: "FoobarTable",
+                Item: { pk: { S: "order-2" }, status: { N: "1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the transaction is refused, and the action ahead of the bad one is
+    // not written either.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Type mismatch for Index Key status");
+
+    const first = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertUndefined(first.Item);
+  });
+
+  it("writes nothing when a later action would pass the item size limit", async () => {
+    // Given an item already holding 300 KB.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-2" }, blob: { S: kilobytes(300) } },
+      },
+    });
+
+    // When the second action of a transaction updates it past 400 KB.
+    const error = await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "FoobarTable",
+                Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+              },
+            },
+            {
+              Update: {
+                TableName: "FoobarTable",
+                Key: { pk: { S: "order-2" } },
+                UpdateExpression: "SET extra = :extra",
+                ExpressionAttributeValues: { ":extra": { S: kilobytes(200) } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the transaction is refused, the first action is not written, and
+    // the item the update named is exactly as it was.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "Item size has exceeded the maximum allowed size of 409600 bytes",
+    );
+
+    const first = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertUndefined(first.Item);
+
+    const updated = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-2" } } },
+    });
+    assertUndefined(updated.Item?.["extra"]);
+  });
+
+  it("leaves a delete undone when a later action is refused", async () => {
+    // Given an item a transaction is going to delete.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+      },
+    });
+
+    // When the action after the delete carries a wrong-typed index key.
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDb.transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Delete: {
+                TableName: "FoobarTable",
+                Key: { pk: { S: "order-1" } },
+              },
+            },
+            {
+              Put: {
+                TableName: "FoobarTable",
+                Item: { pk: { S: "order-2" }, status: { N: "1" } },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then the item is still there.
+    const stored = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertIdentical(stored.Item?.["title"]?.S, "A hat");
+  });
+
+  it("applies every action of a transaction that is not refused", async () => {
+    // Given a table with an index, holding an item to delete.
+    const simAws = new SimAws();
+    const simDynamoDb = await indexedTable(simAws);
+
+    await simDynamoDb.putItem({
+      input: {
+        TableName: "FoobarTable",
+        Item: { pk: { S: "order-1" }, title: { S: "A hat" } },
+      },
+    });
+
+    // When a transaction deletes it, puts one item and updates another.
+    await simDynamoDb.transactWriteItems(
+      new TransactWriteItemsCommand({
+        TransactItems: [
+          {
+            Delete: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+          },
+          {
+            Put: {
+              TableName: "FoobarTable",
+              Item: { pk: { S: "order-2" }, status: { S: "OPEN" } },
+            },
+          },
+          {
+            Update: {
+              TableName: "FoobarTable",
+              Key: { pk: { S: "order-3" } },
+              UpdateExpression: "SET title = :title",
+              ExpressionAttributeValues: { ":title": { S: "A coat" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then all three landed, so staging the writes did not stop any of them
+    // being made.
+    const deleted = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-1" } } },
+    });
+    assertUndefined(deleted.Item);
+
+    const put = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-2" } } },
+    });
+    assertIdentical(put.Item?.["status"]?.S, "OPEN");
+
+    const updated = await simDynamoDb.getItem({
+      input: { TableName: "FoobarTable", Key: { pk: { S: "order-3" } } },
+    });
+    assertIdentical(updated.Item?.["title"]?.S, "A coat");
+  });
+});

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-write.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-write.ts
@@ -1,5 +1,6 @@
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+import type { SimDynamoDbTableWrite } from "../../table/sim-dynamodb-table-writes.js";
 import {
   readSimDynamoDbTransactConditionCheck,
   readSimDynamoDbTransactDelete,
@@ -53,9 +54,12 @@ export interface SimDynamoDbTransactWrite {
   assertApplicableTo(table: SimDynamoDbTable): void;
 
   /**
-   * Apply this action to the table.
+   * Work out the write this action makes, without making it.
+   *
+   * Anything the table would refuse the write for is refused here, so the
+   * transaction can prepare every action before committing any of them.
    */
-  applyTo(table: SimDynamoDbTable): void;
+  prepareFor(table: SimDynamoDbTable): SimDynamoDbTableWrite;
 }
 
 /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-writes.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-writes.ts
@@ -1,0 +1,124 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
+import type { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
+import type { SimDynamoDbTableDefinition } from "./sim-dynamodb-table-definition.js";
+import type { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
+
+/**
+ * Where a prepared write lands once it is committed.
+ */
+interface SimDynamoDbTableStore {
+  readonly items: SimDynamoDbTableItems;
+  readonly timeToLive: SimDynamoDbTableTimeToLive;
+}
+
+interface SimDynamoDbTableWritesProperties extends SimDynamoDbTableStore {
+  readonly definition: SimDynamoDbTableDefinition;
+  readonly indexes: SimDynamoDbSecondaryIndexes;
+}
+
+/**
+ * A write to a table that has passed everything it could be refused for.
+ *
+ * Committing it stores what was prepared and nothing else, so it cannot throw.
+ * That is what lets a transaction prepare all of its writes and then apply them
+ * knowing none of them will fail part way through.
+ */
+export interface SimDynamoDbTableWrite {
+  /**
+   * Make this write, and answer with whatever item it displaced.
+   */
+  commit(): SimDynamoDbItem | undefined;
+}
+
+/**
+ * A prepared put, which is an item and the key it goes under.
+ */
+class SimDynamoDbTableItemWrite implements SimDynamoDbTableWrite {
+  private readonly store: SimDynamoDbTableStore;
+  private readonly key: string;
+  private readonly item: SimDynamoDbItem;
+
+  constructor(
+    store: SimDynamoDbTableStore,
+    key: string,
+    item: SimDynamoDbItem,
+  ) {
+    this.store = store;
+    this.key = key;
+    this.item = item;
+  }
+
+  commit(): SimDynamoDbItem | undefined {
+    const replaced = this.store.items.put(this.key, this.item);
+
+    this.store.timeToLive.scheduleFor(this.key, this.item);
+
+    return replaced;
+  }
+}
+
+/**
+ * A prepared delete, which is the key the item to remove is held under.
+ */
+class SimDynamoDbTableItemRemoval implements SimDynamoDbTableWrite {
+  private readonly store: SimDynamoDbTableStore;
+  private readonly key: string;
+
+  constructor(store: SimDynamoDbTableStore, key: string) {
+    this.store = store;
+    this.key = key;
+  }
+
+  commit(): SimDynamoDbItem | undefined {
+    return this.store.items.remove(this.key);
+  }
+}
+
+/**
+ * How one table takes a write, in the two steps a transaction needs.
+ *
+ * Preparing a write does everything that can be refused, and committing it does
+ * everything that cannot. Every write in the service goes through both, so a
+ * check added to the write path is on the preparing side by construction rather
+ * than by anyone remembering to put it there.
+ */
+export class SimDynamoDbTableWrites {
+  private readonly store: SimDynamoDbTableStore;
+  private readonly definition: SimDynamoDbTableDefinition;
+  private readonly indexes: SimDynamoDbSecondaryIndexes;
+
+  constructor(properties: SimDynamoDbTableWritesProperties) {
+    this.store = { items: properties.items, timeToLive: properties.timeToLive };
+    this.definition = properties.definition;
+    this.indexes = properties.indexes;
+  }
+
+  /**
+   * Check an item can be written to this table, without writing it.
+   */
+  prepareItem(item: SimDynamoDbItem): SimDynamoDbTableWrite {
+    const key = this.definition.itemKey.of(item);
+
+    // An item need not carry an index's key attributes, since a secondary
+    // index of either kind is sparse. Carrying one as a type the index did not
+    // declare is refused, since the index could never hold it.
+    this.indexes.assertItemKeyTypes(item, this.definition.attributeDefinitions);
+
+    return new SimDynamoDbTableItemWrite(this.store, key, item);
+  }
+
+  /**
+   * Check a key can be removed from this table, without removing it.
+   *
+   * A key holding nothing is prepared as readily as one holding an item.
+   * DynamoDB deletes by key rather than by item, so removing a key that is
+   * already free asks for the state it is already in.
+   */
+  prepareRemoval(key: SimDynamoDbItem): SimDynamoDbTableWrite {
+    return new SimDynamoDbTableItemRemoval(
+      this.store,
+      this.definition.itemKey.ofKey(key),
+    );
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -19,6 +19,7 @@ import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
 import { SimDynamoDbTableLifecycle } from "./sim-dynamodb-table-lifecycle.js";
 import { simDynamoDbTableReadView } from "./sim-dynamodb-table-read-view.js";
 import { SimDynamoDbTableTags } from "./sim-dynamodb-table-tags.js";
+import { SimDynamoDbTableWrites } from "./sim-dynamodb-table-writes.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -78,6 +79,12 @@ export class SimDynamoDbTable {
    */
   public readonly timeToLive: SimDynamoDbTableTimeToLive;
 
+  /**
+   * How this table takes a write, as a check and then a commit, which is what
+   * lets a transaction prepare all of its writes before committing any.
+   */
+  public readonly writes: SimDynamoDbTableWrites;
+
   private readonly items = new SimDynamoDbTableItems();
   private readonly definition: SimDynamoDbTableDefinition;
   private readonly lifecycle: SimDynamoDbTableLifecycle;
@@ -114,6 +121,12 @@ export class SimDynamoDbTable {
       tableName: name.value,
       items: this.items,
       background,
+    });
+    this.writes = new SimDynamoDbTableWrites({
+      items: this.items,
+      timeToLive: this.timeToLive,
+      definition: this.definition,
+      indexes: this.indexes,
     });
     this.creationDateTime = background.now();
   }
@@ -214,24 +227,12 @@ export class SimDynamoDbTable {
   }
 
   /**
-   * Put an item into the table, and answer with whatever it replaced.
-   *
-   * The item is there by the time this returns. Real DynamoDB acknowledges a
-   * write once it is durable, so a read that follows it finds it.
+   * Put an item into the table, and answer with whatever it replaced. The item
+   * is there by the time this returns, since real DynamoDB acknowledges a write
+   * once it is durable.
    */
   public putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    const key = this.definition.itemKey.of(item);
-
-    // An item need not carry an index's key attributes, since a secondary
-    // index of either kind is sparse. Carrying one as a type the index did not
-    // declare is refused, since the index could never hold it.
-    this.indexes.assertItemKeyTypes(item, this.attributeDefinitions);
-
-    const replaced = this.items.put(key, item);
-
-    this.timeToLive.scheduleFor(key, item);
-
-    return replaced;
+    return this.writes.prepareItem(item).commit();
   }
 
   /**
@@ -279,7 +280,7 @@ export class SimDynamoDbTable {
    * Remove the item a primary key names, and answer with whatever was removed.
    */
   public deleteItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.items.remove(this.definition.itemKey.ofKey(key));
+    return this.writes.prepareRemoval(key).commit();
   }
 
   /**


### PR DESCRIPTION
A transaction could write its first actions and then throw, because the secondary index key type check and the 400 KB item size check both fired from inside applyTo rather than from assertApplicableTo.

Every action now prepares its write before any of them is committed. SimDynamoDbTableWrites splits a write into a prepare that can be refused and a commit that cannot, and putItem and deleteItem run the two together, so no write reaches the item store unprepared.

Resolves https://github.com/KensioSoftware/yulin/issues/336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DynamoDB transactions now validate all writes before committing, preserving atomicity when a later write is invalid.
  * Transactions reject invalid secondary-index key types and items exceeding the 400 KB size limit.
  * TTL scheduling now occurs only for successfully committed writes.
  * Transaction cancellation reasons are preserved while failed transactions leave existing data unchanged.
* **Documentation**
  * Updated DynamoDB documentation to describe transactional write preparation, atomic commits, validation, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->