### PR TITLE
feat: notify a simulated Lambda function when an Object is created or…

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -278,6 +278,180 @@ failures come back.
 - A Bucket using filesystem-backed storage refuses deletion. See
   [Filesystem-backed Bucket storage](#filesystem-backed-bucket-storage).
 
+## Event notifications
+
+A simulated S3 Bucket can notify a simulated Lambda function when an Object is created or removed.
+The configuration is applied with `PutBucketNotificationConfigurationCommand` and read back with
+`GetBucketNotificationConfigurationCommand`.
+
+The function's resource policy decides whether S3 may invoke it. That is checked when the
+configuration is applied, and again for every event, as real S3 does.
+
+```typescript sim-s3-event-notifications
+/**
+ * Notifying a simulated Lambda function when an Object is created.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const thumbnailerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`;
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "thumbnailer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/ThumbnailerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+        console.log(event.Records[0].eventName, event.Records[0].s3.object.key);
+
+        return "thumbnailed";
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "thumbnailer",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "thumbnail-raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: thumbnailerArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+```
+
+The event types a configuration can name are `s3:ObjectCreated:*`, `s3:ObjectCreated:Put`,
+`s3:ObjectRemoved:*` and `s3:ObjectRemoved:Delete`. Any other S3 event type is refused by name rather
+than stored and never raised.
+
+A configuration can filter on an object key prefix, a suffix, or both. Two configurations that share
+an event type and whose filters could both match the same key are refused with `InvalidArgument`, as
+real S3 refuses them. Overlapping prefixes are fine when the suffixes do not overlap, so one function
+can take the `.jpg` files under a prefix while another takes the `.png` files under the same one.
+
+`PutBucketNotificationConfigurationCommand` replaces the whole configuration rather than adding to
+it. `GetBucketNotificationConfigurationCommand` answers an empty configuration for a Bucket that has
+none. Note that the response carries the destination groups at the top level, while the request nests
+them under `NotificationConfiguration`:
+
+```typescript
+const read = await simAws
+  .s3()
+  .getBucketNotificationConfiguration(
+    new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+  );
+const configurations = read.LambdaFunctionConfigurations ?? [];
+```
+
+The two commands are authorized as `s3:PutBucketNotification` and `s3:GetBucketNotification`. Those
+are the real IAM action names, and they do not match the API names.
+
+### What arrives at the handler
+
+The handler is invoked with the `Records` document real S3 sends. One event produces one record.
+
+Creation records carry the Object's `size` and its `eTag`, which is the MD5 of the bytes as it is for
+an Object real S3 stored in one part. Removal records carry neither, because the Object they describe
+is gone. Both carry a `sequencer`, which orders the events for one object key. The object key is
+form-URL-encoded, so `red flower.jpg` arrives as `red+flower.jpg`.
+
+`eventTime` comes from the simulation's clock, so a frozen clock produces a fixed timestamp.
+
+### When delivery fails
+
+Real S3 tells the caller who wrote the Object nothing about a delivery, and neither does the
+simulator: a handler that throws does not fail the `PutObject` and does not reject
+`backgroundTasksComplete()`. The outcome is still readable:
+
+```typescript
+for (const failure of simAws.s3().getNotificationDeliveryFailures()) {
+  console.log(failure.destinationArn, failure.reason, failure.wasRefused);
+}
+```
+
+A handler that threw is also warned about on the console, once per destination and cause. A
+destination that refused the event, because its resource policy no longer admits the Bucket, is
+recorded without a warning.
+
+A handler that writes back into the Bucket that triggered it notifies itself forever, and in process
+there is nothing to slow it down. Filter the configuration by prefix or suffix so the handler's own
+writes do not match it. Without that, the simulation stops after a thousand deliveries and
+`backgroundTasksComplete()` raises an error naming the Bucket.
+
+### Limitations
+
+- Lambda is the only destination. An SQS queue, an SNS topic and EventBridge are each refused by
+  name.
+- Only `s3:ObjectCreated:Put` and `s3:ObjectRemoved:Delete` are raised. `Copy`, `Post`,
+  `CompleteMultipartUpload`, `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`,
+  `LifecycleExpiration:*` and `ObjectTagging:*` families, `LifecycleTransition`,
+  `IntelligentTiering`, `ObjectAcl:Put` and `ReducedRedundancyLostObject` are refused by name.
+  `s3:ObjectCreated:*` and `s3:ObjectRemoved:*` therefore expand to one member each.
+- `userIdentity.principalId` carries the caller's ARN rather than the `AIDA...` unique id real S3
+  puts there. Simulated IAM has no unique-id namespace to draw one from, and an ARN is what a test
+  would assert on. `requestParameters.sourceIPAddress` is the loopback address, because the request
+  was made in this process, and the `responseElements` request ids are generated per event and match
+  nothing.
+- `eventVersion` is the version the S3 event message structure page documents now. AWS increments the
+  minor version whenever it adds a field, so compare the major for equality rather than asserting on
+  the whole string.
+- `versionId` is absent from every record, which is what real S3 does for a Bucket without
+  versioning. Versioning is not simulated.
+- A notification cannot be configured on a standalone `SimS3`. It has no other simulated services to
+  notify, and no shared background scheduler for `backgroundTasksComplete()` to drain. Reach
+  simulated S3 through `SimAws` instead.
+- CloudFormation and CDK cannot configure notifications. A CDK `BucketDeployment` and
+  `mountBucketFilesystem(...)` both replace the whole storage backend rather than putting Objects, so
+  neither raises anything, where real CDK `BucketDeployment` fires one `ObjectCreated:Put` per file.
+- A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
+- `s3:TestEvent` is not sent. It is an SQS and SNS mechanism.
+
 ## Bucket policies
 
 A Bucket policy is a resource policy stored on the Bucket. Sim IAM evaluates it alongside the
@@ -1016,6 +1190,8 @@ Sim S3 currently supports:
 - `CreateBucketCommand` and `ListBucketsCommand`
 - `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
+- `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
+  Object events delivered to a simulated Lambda function
 - `PutBucketWebsiteCommand`, for static website hosting
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies
@@ -1034,3 +1210,18 @@ Sim S3 currently supports:
 The simulator focuses on useful behaviour for tests and local development rather than full S3 feature
 parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
 needs them to model the requested behaviour.
+
+## Limitations
+
+These apply across the page. The sections above each list what is specific to them.
+
+- Object versioning is not simulated. There are no version ids, no delete markers and no
+  `VersionId` on any request or response.
+- Multipart uploads are not simulated. An Object is stored by one `PutObject`, so an ETag is always
+  the MD5 of the whole body.
+- `GetObject` and `ListObjects` do not report an ETag or a last-modified time. Object event
+  notifications do carry an ETag, since they compute it at the moment the Object is written.
+- Object tags, ACLs, storage classes, lifecycle rules, replication and server-side encryption are
+  not simulated.
+- A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
+  notifications, because it swaps the whole storage backend rather than putting Objects.

--- a/docs/services/s3/sim-s3-event-notifications.example.ts
+++ b/docs/services/s3/sim-s3-event-notifications.example.ts
@@ -1,0 +1,76 @@
+/**
+ * Notifying a simulated Lambda function when an Object is created.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const thumbnailerArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`;
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "thumbnailer",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/ThumbnailerRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+        console.log(event.Records[0].eventName, event.Records[0].s3.object.key);
+
+        return "thumbnailed";
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "thumbnailer",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "thumbnail-raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: thumbnailerArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -20,6 +20,9 @@ import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimS3 } from "../../s3/sim-s3.js";
+import { SimAwsS3NotificationFunctions } from "../../s3/notification/destination/lambda/sim-aws-s3-notification-functions.js";
+import { SimS3LambdaNotificationDestination } from "../../s3/notification/destination/lambda/sim-s3-lambda-notification-destination.js";
+import { SimS3ServiceNotificationDestinations } from "../../s3/notification/destination/sim-s3-service-notification-destinations.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -194,13 +197,24 @@ export class SimAwsAccountRegionServiceBuilder {
     });
   }
 
-  /** Create simulated S3 for an Account Region scope. */
+  /**
+   * Create simulated S3 for an Account Region scope.
+   *
+   * Bucket event notification destinations are resolved when a configuration
+   * is applied or an event is delivered, never here. Simulated Lambda already
+   * reaches this scope's simulated S3 as it is built, for function code in a
+   * Bucket, so building S3 by reaching for Lambda would be a cycle: the memo
+   * only records a service once its factory has returned, and has no
+   * re-entrancy guard. That holds for a service that would not close the cycle
+   * today as well, since a later one could.
+   */
   createS3(scope: SimAwsAccountRegionContainer): SimS3 {
     return new SimS3({
       accountRegionScope: scope.accountRegionScope,
       s3GlobalRegistry: this.registries.s3,
       iam: this.accountServices.createIam(scope),
       background: this.background,
+      notificationDestinations: this.s3NotificationDestinations(),
     });
   }
 
@@ -255,6 +269,23 @@ export class SimAwsAccountRegionServiceBuilder {
       accountRegionScope: scope.accountRegionScope,
       background: this.background,
       iamResolver: this.iamRegistry,
+    });
+  }
+
+  /**
+   * Where a simulated S3 Bucket can send its event notifications.
+   *
+   * A notification configuration names a function by ARN, and that ARN can
+   * name any Account and Region, so the functions come from the whole
+   * simulation rather than from one scope.
+   */
+  private s3NotificationDestinations(): SimS3ServiceNotificationDestinations {
+    const functions = new SimAwsS3NotificationFunctions({
+      simAws: this.simAws,
+    });
+
+    return new SimS3ServiceNotificationDestinations({
+      lambda: new SimS3LambdaNotificationDestination({ functions }),
     });
   }
 }

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -16,7 +16,9 @@ familiar AWS SDK command shapes, CloudFormation resources, and local HTTP reques
 - `sim-s3-global-registry.ts` records Bucket ownership across account/region scopes inside one
   simulated AWS instance.
 - `Bucket/` contains the simulated Bucket model, Bucket-name validation, name-availability checks,
-  and static website configuration.
+  static website configuration, and the event notification configuration.
+- `notification/` contains event notification delivery: the event, its `Records` serialisation, and
+  the destinations S3 pushes to.
 - `object/` contains the simulated S3 Object model.
 - `storage/` contains pluggable Bucket storage implementations.
 - `command/` contains AWS SDK-style command handlers.
@@ -79,6 +81,8 @@ Supported command areas currently include:
 - `list-objects/`
 - `delete-object/`
 - `delete-objects/`
+- `put-bucket-notification-configuration/`
+- `get-bucket-notification-configuration/`
 
 `SimS3Commands` owns the wiring: every handler is built from the same Bucket map, IAM and background
 scheduler, so that construction lives in one place rather than being repeated once per command on
@@ -88,6 +92,7 @@ the service facade. It groups the commands into areas, each a small class under 
 - `SimS3BucketPolicyCommands` in `command/bucket-policy/`
 - `SimS3PublicAccessBlockCommands` in `command/public-access-block/`
 - `SimS3ObjectCommands` in `command/object/`
+- `SimS3NotificationCommands` in `command/notification/`
 
 An area holds the shared `SimS3BucketCommandState` and hands it to the handler it runs, so adding a
 command means adding one method to the area it belongs to. `requireSimS3Bucket` is the shared Bucket lookup
@@ -160,6 +165,8 @@ Its public methods are small:
 - `configurePublicAccessBlock(publicAccessBlock)`
 - `getPublicAccessBlock()`
 - `deletePublicAccessBlock()`
+- `configureNotifications(notifications)`
+- `getNotifications()`
 
 The Bucket resource policy is stored parsed rather than as a JSON string, because that is the shape
 sim IAM evaluates. `GetBucketPolicy` serializes it back on the way out, so the string a caller reads
@@ -337,6 +344,65 @@ A batch deletion is not all or nothing. `DeleteObjectsOutcome` turns a `SimIamAc
 of the batch is still deleted. Anything else is re-raised, so a bug in the simulation cannot arrive
 as a per-key AWS error.
 
+## Event notifications
+
+Sim S3 usage docs:
+[`../../../docs/services/s3/README.md#event-notifications`](../../../docs/services/s3/README.md#event-notifications)
+
+Notifications are split between the configuration, which is Bucket state, and delivery, which is not.
+
+`bucket/notification/` holds the configuration. `SimS3NotificationConfiguration` is what a Bucket
+stores, `SimS3LambdaNotification` is one destination in it, and `SimS3NotificationFilter` is the
+object key filter. `SimS3NotificationConfigurationReader` turns a
+`PutBucketNotificationConfiguration` request into one, refusing everything it cannot honour before
+anything is stored, so a refused request leaves the previous configuration alone.
+
+Two rules in there are worth knowing about:
+
+- `simS3ExpandNotificationEvent` expands a configured event type into the concrete events the
+  simulator can raise. Everything works on expanded sets rather than on the configured strings,
+  because the overlap rule is about event sets: real S3 refuses `s3:ObjectCreated:*` alongside
+  `s3:ObjectCreated:Put` on the same filter, and comparing the two as strings would accept it.
+- `simS3AssertNoNotificationOverlap` applies that rule. Two configurations conflict when their event
+  sets intersect and their filters could both match a key, which needs both the prefixes and the
+  suffixes to overlap. That is why `images` with `.jpg` alongside `images` with `.png` is accepted,
+  as it is on real S3.
+
+`notification/` holds delivery. The pieces are small on purpose:
+
+- `SimS3ObjectNotifier` is what the Object commands call. It is held in `SimS3BucketCommandState`, so
+  one notifier is shared across the commands of a scope and the sequence numbers and delivery ceiling
+  see every event.
+- `SimS3ObjectEventBuilder` turns something that happened to an Object into a `SimS3ObjectEvent`,
+  which is destination-agnostic. `simS3EventRecordsDocument` is the separate serialisation into the
+  `Records` document, so a later SNS or EventBridge destination can shape it differently.
+- `SimS3NotificationSchedule` consults the Bucket's configuration and schedules delivery on the
+  background scheduler. The event is built only once something wants it, because building one hashes
+  the Object's bytes.
+- `SimS3NotificationDispatcher` offers one event to one destination and records what came of it.
+  Everything a destination raises is caught, because a rejected background task would fail an
+  unrelated `backgroundTasksComplete()` and real S3 never reports a delivery failure to the caller
+  who wrote the Object. `SimS3NotificationCeiling` is the exception: it is counted outside the guard
+  so a notification loop surfaces as a named error rather than as a hung test.
+
+`notification/destination/` is the port. `SimS3NotificationDestination` owns both `validate` and
+`deliver`, because configuration-time validation and delivery-time re-check are the same
+per-destination question asked twice, as real S3 asks it.
+`SimS3ServiceNotificationDestinations` resolves a destination ARN through a `ReadonlyMap` keyed on
+the ARN's service segment. `SimS3NoNotificationDestinations` is what a standalone `SimS3` gets, and
+it refuses by name.
+
+`SimAwsS3NotificationFunctions` resolves and invokes the function. It resolves lazily from the
+`SimAws` it was built with, never at construction time: `createLambda` already reaches
+`scope.s3()` for function code, so an eager `scope.lambda()` in `createS3` would recurse, because the
+scope memo records a service only once its factory has returned. Whether S3 may invoke a function is
+Lambda's own rule, so the decision comes from `SimLambdaServiceInvokeAuthorizer` with the Bucket ARN
+and Account supplied as the source.
+
+The raise point is one call in `PutObjectCommandHandler` and one in each of the two deletion
+handlers, after the write and with the caller the authorizer resolved. Every write path funnels
+through those, so the SDK, an intercepted SDK client and the REST endpoint are all covered.
+
 ## Static website configuration
 
 Static website support is represented by `SimS3BucketWebsite`.
@@ -497,6 +563,8 @@ Handlers throw AWS-like errors for supported failure cases, including:
 - access denied, for S3's own refusals such as Block Public Access
 - Bucket already exists
 - Bucket already owned by you
+- invalid argument, for a notification configuration with overlapping filters, a repeated
+  configuration id, or a destination that could not be validated
 - malformed XML, for a `DeleteObjects` request naming no Objects or more than 1000 of them
 - not implemented, for something the simulator refuses rather than approximates, such as deleting an
   Object out of filesystem-backed storage

--- a/src/service/s3/bucket/notification/sim-s3-lambda-notification.ts
+++ b/src/service/s3/bucket/notification/sim-s3-lambda-notification.ts
@@ -1,0 +1,64 @@
+import type { SimS3LambdaFunctionConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
+import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
+
+interface SimS3LambdaNotificationProperties {
+  readonly id: string;
+  readonly functionArn: string;
+  readonly events: readonly string[];
+  readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
+  readonly filter: SimS3NotificationFilter;
+}
+
+/**
+ * One Lambda function destination in a Bucket's notification configuration.
+ *
+ * Both the configured event types and what they expand to are kept: the
+ * configured ones are what GetBucketNotificationConfiguration reports back, and
+ * the expanded ones are what delivery and the overlap rule work on.
+ */
+export class SimS3LambdaNotification {
+  public readonly id: string;
+  public readonly functionArn: string;
+  public readonly events: readonly string[];
+  public readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
+  public readonly filter: SimS3NotificationFilter;
+
+  constructor(properties: SimS3LambdaNotificationProperties) {
+    this.id = properties.id;
+    this.functionArn = properties.functionArn;
+    this.events = properties.events;
+    this.concreteEvents = properties.concreteEvents;
+    this.filter = properties.filter;
+  }
+
+  /**
+   * Whether this configuration wants an event about an object key.
+   */
+  matches(event: SimS3NotificationEvent, key: string): boolean {
+    return this.concreteEvents.has(event) && this.filter.matches(key);
+  }
+
+  /**
+   * Whether this configuration and another cover any of the same events.
+   */
+  sharesEventsWith(other: SimS3LambdaNotification): boolean {
+    return [...this.concreteEvents].some((event) =>
+      other.concreteEvents.has(event),
+    );
+  }
+
+  /**
+   * This configuration as GetBucketNotificationConfiguration reports it.
+   */
+  toOutput(): SimS3LambdaFunctionConfigurationInput {
+    const filter = this.filter.toOutput();
+
+    return {
+      Id: this.id,
+      LambdaFunctionArn: this.functionArn,
+      Events: [...this.events],
+      ...(filter !== undefined && { Filter: filter }),
+    };
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import type {
+  SimS3LambdaFunctionConfigurationInput,
+  SimS3NotificationConfigurationInput,
+} from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import {
+  SimS3InvalidArgument,
+  SimS3NotImplemented,
+} from "../../error/sim-s3.error.js";
+import { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
+import { SimS3NotificationConfiguration } from "./sim-s3-notification-configuration.js";
+import { simS3ExpandNotificationEvent } from "./sim-s3-notification-event.js";
+import { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
+import { simS3AssertNoNotificationOverlap } from "./sim-s3-notification-overlap.js";
+
+/**
+ * The destination groups a request can carry that this simulator does not
+ * deliver to, and what to say about each.
+ */
+const unsimulatedDestinations = new Map<string, string>([
+  ["QueueConfigurations", "SQS queue"],
+  ["TopicConfigurations", "SNS topic"],
+  ["EventBridgeConfiguration", "EventBridge"],
+]);
+
+/**
+ * Reads a PutBucketNotificationConfiguration request into a Bucket's stored
+ * configuration.
+ *
+ * Everything the request states is checked before anything is stored, so a
+ * request the simulator refuses leaves the Bucket's previous configuration
+ * exactly as it was.
+ */
+export class SimS3NotificationConfigurationReader {
+  /**
+   * Read a whole notification configuration.
+   */
+  read(
+    input: SimS3NotificationConfigurationInput,
+  ): SimS3NotificationConfiguration {
+    this.refuseUnsimulatedDestinations(input);
+
+    const notifications = (input.LambdaFunctionConfigurations ?? []).map(
+      (configuration) => this.readLambdaNotification(configuration),
+    );
+
+    this.refuseRepeatedIds(notifications);
+    simS3AssertNoNotificationOverlap(notifications);
+
+    return new SimS3NotificationConfiguration(notifications);
+  }
+
+  private readLambdaNotification(
+    configuration: SimS3LambdaFunctionConfigurationInput,
+  ): SimS3LambdaNotification {
+    const functionArn = configuration.LambdaFunctionArn;
+
+    if (functionArn === undefined || functionArn === "") {
+      throw new SimS3InvalidArgument(
+        "A Lambda function notification configuration must name a " +
+          "LambdaFunctionArn.",
+      );
+    }
+
+    const events = configuration.Events ?? [];
+
+    if (events.length === 0) {
+      throw new SimS3InvalidArgument(
+        `Notification configuration for ${functionArn} names no events.`,
+      );
+    }
+
+    return new SimS3LambdaNotification({
+      // S3 generates a configuration id for a configuration that omits one,
+      // and reports it back through GetBucketNotificationConfiguration.
+      id: configuration.Id ?? randomUUID(),
+      functionArn,
+      events,
+      concreteEvents: new Set(
+        events.flatMap((event) => simS3ExpandNotificationEvent(event)),
+      ),
+      filter: SimS3NotificationFilter.fromInput(configuration.Filter),
+    });
+  }
+
+  /**
+   * Refuse a destination group this simulator cannot deliver to.
+   *
+   * Naming the destination matters more than the refusal: a configuration
+   * quietly accepted and never delivered is the failure this feature exists to
+   * remove, so an SQS or SNS destination says so rather than being dropped.
+   */
+  private refuseUnsimulatedDestinations(
+    input: SimS3NotificationConfigurationInput,
+  ): void {
+    for (const [property, destination] of unsimulatedDestinations) {
+      // Read-only lookup of a fixed set of property names.
+
+      const configured = input[property as keyof typeof input];
+
+      if (configured === undefined) {
+        continue;
+      }
+
+      if (Array.isArray(configured) && configured.length === 0) {
+        continue;
+      }
+
+      throw new SimS3NotImplemented(
+        `Simulated S3 cannot notify a ${destination}. ${property} is not ` +
+          "simulated; use LambdaFunctionConfigurations.",
+      );
+    }
+  }
+
+  private refuseRepeatedIds(
+    notifications: readonly SimS3LambdaNotification[],
+  ): void {
+    const seen = new Set<string>();
+
+    for (const notification of notifications) {
+      if (seen.has(notification.id)) {
+        throw new SimS3InvalidArgument(
+          `Configuration id ${notification.id} is used more than once. ` +
+            "Configuration ids must be unique within a Bucket.",
+        );
+      }
+
+      seen.add(notification.id);
+    }
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
@@ -1,0 +1,62 @@
+import type { SimS3NotificationConfigurationOutput } from "../../command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.js";
+import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
+import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
+
+/**
+ * The event notification configuration of one simulated S3 Bucket.
+ *
+ * A Bucket has one configuration rather than a list of them, which is why
+ * PutBucketNotificationConfiguration replaces the whole thing: real S3 has no
+ * way to add one destination without restating the others.
+ */
+export class SimS3NotificationConfiguration {
+  public readonly lambdaNotifications: readonly SimS3LambdaNotification[];
+
+  constructor(lambdaNotifications: readonly SimS3LambdaNotification[] = []) {
+    this.lambdaNotifications = lambdaNotifications;
+  }
+
+  /**
+   * The configuration a Bucket nobody has configured has.
+   */
+  static empty(): SimS3NotificationConfiguration {
+    return new SimS3NotificationConfiguration();
+  }
+
+  /**
+   * Whether this Bucket notifies anything at all.
+   */
+  get notifiesNothing(): boolean {
+    return this.lambdaNotifications.length === 0;
+  }
+
+  /**
+   * The destinations an event about an object key should reach.
+   */
+  matching(
+    event: SimS3NotificationEvent,
+    key: string,
+  ): readonly SimS3LambdaNotification[] {
+    return this.lambdaNotifications.filter((notification) =>
+      notification.matches(event, key),
+    );
+  }
+
+  /**
+   * This configuration as GetBucketNotificationConfiguration reports it.
+   *
+   * A destination group with nothing in it is left out rather than reported
+   * empty, which is what real S3 answers for a Bucket with no configuration.
+   */
+  toOutput(): SimS3NotificationConfigurationOutput {
+    if (this.notifiesNothing) {
+      return {};
+    }
+
+    return {
+      LambdaFunctionConfigurations: this.lambdaNotifications.map(
+        (notification) => notification.toOutput(),
+      ),
+    };
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-event.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-event.ts
@@ -1,0 +1,67 @@
+import {
+  SimS3InvalidArgument,
+  SimS3NotImplemented,
+} from "../../error/sim-s3.error.js";
+import { SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS } from "./sim-s3-unsimulated-notification-events.js";
+
+/**
+ * The event types simulated S3 can actually raise.
+ *
+ * These are the concrete members that a configured event expands to. Real S3
+ * has many more, and the ones it has that this simulator cannot produce are
+ * refused by name rather than accepted and never delivered.
+ */
+export const SIM_S3_NOTIFICATION_EVENTS = [
+  "s3:ObjectCreated:Put",
+  "s3:ObjectRemoved:Delete",
+] as const;
+
+export type SimS3NotificationEvent =
+  (typeof SIM_S3_NOTIFICATION_EVENTS)[number];
+
+/**
+ * What each configurable event type expands to.
+ *
+ * A `:*` event is expanded before anything compares two configurations,
+ * because the overlap rule is about event sets rather than event strings: real
+ * S3 refuses `s3:ObjectCreated:*` alongside `s3:ObjectCreated:Put` on the same
+ * filter, and comparing the two as strings would accept it.
+ *
+ * The wildcards expand only to the members this simulator can raise. The other
+ * members are refused by name, so nothing can configure one and then wonder
+ * why the wildcard never covered it.
+ */
+const eventExpansions = new Map<string, readonly SimS3NotificationEvent[]>([
+  ["s3:ObjectCreated:*", ["s3:ObjectCreated:Put"]],
+  ["s3:ObjectCreated:Put", ["s3:ObjectCreated:Put"]],
+  ["s3:ObjectRemoved:*", ["s3:ObjectRemoved:Delete"]],
+  ["s3:ObjectRemoved:Delete", ["s3:ObjectRemoved:Delete"]],
+]);
+
+/**
+ * The concrete events a configured event type covers.
+ *
+ * An event type real S3 has but this simulator cannot raise is refused as not
+ * implemented. Anything else is not an S3 event type at all, which is what
+ * real S3 answers InvalidArgument to.
+ */
+export function simS3ExpandNotificationEvent(
+  event: string,
+): readonly SimS3NotificationEvent[] {
+  const expansion = eventExpansions.get(event);
+
+  if (expansion !== undefined) {
+    return expansion;
+  }
+
+  if (SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS.has(event)) {
+    throw new SimS3NotImplemented(
+      `Simulated S3 does not raise the event type ${event}. It raises ` +
+        `${eventExpansions.keys().toArray().join(", ")}.`,
+    );
+  }
+
+  throw new SimS3InvalidArgument(
+    `The event ${event} is not a supported S3 event type.`,
+  );
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-filter.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-filter.ts
@@ -1,0 +1,126 @@
+import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
+import type {
+  SimS3NotificationFilterInput,
+  SimS3NotificationFilterRuleInput,
+} from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+
+/**
+ * The object key filter of one notification configuration.
+ *
+ * An absent prefix or suffix is held as an empty string rather than as
+ * undefined, because that is what it means to S3: the root prefix matches every
+ * key and overlaps every other prefix, and the same goes for the root suffix.
+ */
+export class SimS3NotificationFilter {
+  public readonly prefix: string;
+  public readonly suffix: string;
+
+  constructor(prefix = "", suffix = "") {
+    this.prefix = prefix;
+    this.suffix = suffix;
+  }
+
+  /**
+   * Read the filter of one notification configuration.
+   *
+   * A filter rule name S3 does not have is refused by name, as is a rule name
+   * repeated twice, which real S3 refuses rather than taking the last one.
+   */
+  static fromInput(
+    filter: SimS3NotificationFilterInput | undefined,
+  ): SimS3NotificationFilter {
+    const rules = filter?.Key?.FilterRules ?? [];
+    const values = new Map<string, string>();
+
+    for (const rule of rules) {
+      const name = simS3NotificationFilterRuleName(rule);
+
+      if (values.has(name)) {
+        throw new SimS3InvalidArgument(
+          `Filter rule ${name} is specified more than once in one ` +
+            "notification configuration.",
+        );
+      }
+
+      values.set(name, rule.Value ?? "");
+    }
+
+    return new SimS3NotificationFilter(
+      values.get("prefix"),
+      values.get("suffix"),
+    );
+  }
+
+  /**
+   * Whether an object key passes this filter.
+   */
+  matches(key: string): boolean {
+    return key.startsWith(this.prefix) && key.endsWith(this.suffix);
+  }
+
+  /**
+   * Whether some object key could pass both this filter and another.
+   *
+   * Two prefixes overlap when a key could begin with both, which is to say
+   * when one is a prefix of the other, and two suffixes overlap on the same
+   * reasoning at the other end. A filter pair only conflicts when both ends
+   * overlap: `images` with `.jpg` and `images` with `.png` share a prefix but
+   * no key ends both ways, which is why real S3 accepts that pair.
+   */
+  overlaps(other: SimS3NotificationFilter): boolean {
+    return (
+      this.prefixesOverlap(other.prefix) && this.suffixesOverlap(other.suffix)
+    );
+  }
+
+  /**
+   * This filter as a notification configuration reports it, or nothing when it
+   * filters nothing.
+   */
+  toOutput(): SimS3NotificationFilterInput | undefined {
+    const rules: SimS3NotificationFilterRuleInput[] = [];
+
+    if (this.prefix !== "") {
+      rules.push({ Name: "prefix", Value: this.prefix });
+    }
+
+    if (this.suffix !== "") {
+      rules.push({ Name: "suffix", Value: this.suffix });
+    }
+
+    if (rules.length === 0) {
+      return undefined;
+    }
+
+    return { Key: { FilterRules: rules } };
+  }
+
+  private prefixesOverlap(other: string): boolean {
+    return this.prefix.startsWith(other) || other.startsWith(this.prefix);
+  }
+
+  private suffixesOverlap(other: string): boolean {
+    return this.suffix.endsWith(other) || other.endsWith(this.suffix);
+  }
+}
+
+/**
+ * The filter rule name a rule names, refusing anything S3 does not filter on.
+ *
+ * The name is matched case-insensitively because the SDK and the REST XML
+ * disagree about the capitalisation, while the value is taken as written.
+ */
+function simS3NotificationFilterRuleName(
+  rule: SimS3NotificationFilterRuleInput,
+): string {
+  const name = (rule.Name ?? "").toLowerCase();
+
+  if (name !== "prefix" && name !== "suffix") {
+    throw new SimS3InvalidArgument(
+      `Unsupported notification filter rule name ${rule.Name ?? "(none)"}. ` +
+        "S3 filters object keys on prefix and suffix.",
+    );
+  }
+
+  return name;
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-overlap.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-overlap.ts
@@ -1,0 +1,36 @@
+import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
+import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
+
+/**
+ * Refuse a configuration whose destinations would both want the same event.
+ *
+ * Real S3 will not store two configurations that share an event type and whose
+ * key filters could both match the same key, because it has no rule for which
+ * of them wins. Overlapping prefixes are allowed when the suffixes do not
+ * overlap, which is how one function takes the `.jpg` files under a prefix and
+ * another takes the `.png` files under the same one.
+ *
+ * The comparison is on expanded event sets rather than on the configured event
+ * strings, so `s3:ObjectCreated:*` conflicts with `s3:ObjectCreated:Put` as it
+ * does on real S3.
+ */
+export function simS3AssertNoNotificationOverlap(
+  notifications: readonly SimS3LambdaNotification[],
+): void {
+  for (const [index, notification] of notifications.entries()) {
+    const rest = notifications.slice(index + 1);
+
+    for (const other of rest) {
+      if (
+        notification.sharesEventsWith(other) &&
+        notification.filter.overlaps(other.filter)
+      ) {
+        throw new SimS3InvalidArgument(
+          `Configurations ${notification.id} and ${other.id} overlap. ` +
+            "Configurations on the same Bucket cannot share an event type " +
+            "with object key filters that could both match the same key.",
+        );
+      }
+    }
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
+++ b/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-events.ts
@@ -1,0 +1,37 @@
+/**
+ * The event types real S3 has that this simulator does not raise.
+ *
+ * Listed so an unsimulated event type is refused as unsimulated rather than as
+ * a typo, which are different problems with different fixes. Everything here
+ * either describes an S3 feature the simulator has no model of, such as
+ * versioning, replication or lifecycle rules, or a way of creating an Object
+ * that it has no command for.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
+ */
+export const SIM_S3_UNSIMULATED_NOTIFICATION_EVENTS: ReadonlySet<string> =
+  new Set([
+    "s3:IntelligentTiering",
+    "s3:LifecycleExpiration:*",
+    "s3:LifecycleExpiration:Delete",
+    "s3:LifecycleExpiration:DeleteMarkerCreated",
+    "s3:LifecycleTransition",
+    "s3:ObjectAcl:Put",
+    "s3:ObjectCreated:CompleteMultipartUpload",
+    "s3:ObjectCreated:Copy",
+    "s3:ObjectCreated:Post",
+    "s3:ObjectRemoved:DeleteMarkerCreated",
+    "s3:ObjectRestore:*",
+    "s3:ObjectRestore:Completed",
+    "s3:ObjectRestore:Delete",
+    "s3:ObjectRestore:Post",
+    "s3:ObjectTagging:*",
+    "s3:ObjectTagging:Delete",
+    "s3:ObjectTagging:Put",
+    "s3:ReducedRedundancyLostObject",
+    "s3:Replication:*",
+    "s3:Replication:OperationFailedReplication",
+    "s3:Replication:OperationMissedThreshold",
+    "s3:Replication:OperationNotTracked",
+    "s3:Replication:OperationReplicatedAfterThreshold",
+  ]);

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -4,6 +4,7 @@ import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
 import { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
+import { SimS3NotificationConfiguration } from "./notification/sim-s3-notification-configuration.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
@@ -19,6 +20,7 @@ interface SimS3BucketProperties {
   readonly website?: SimS3BucketWebsite;
   readonly policy?: SimIamPolicyDocument | undefined;
   readonly publicAccessBlock?: SimS3PublicAccessBlock;
+  readonly notifications?: SimS3NotificationConfiguration;
 }
 
 /**
@@ -32,6 +34,7 @@ export class SimS3Bucket {
   private website: SimS3BucketWebsite;
   private policy: SimIamPolicyDocument | undefined;
   private publicAccessBlock: SimS3PublicAccessBlock;
+  private notifications: SimS3NotificationConfiguration;
 
   constructor(properties: SimS3BucketProperties) {
     const {
@@ -41,6 +44,7 @@ export class SimS3Bucket {
       website = new SimS3BucketWebsite(),
       policy,
       publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
+      notifications = SimS3NotificationConfiguration.empty(),
     } = properties;
 
     validateS3BucketName(bucketName);
@@ -51,6 +55,7 @@ export class SimS3Bucket {
     this.website = website;
     this.policy = policy;
     this.publicAccessBlock = publicAccessBlock;
+    this.notifications = notifications;
   }
 
   /**
@@ -77,11 +82,14 @@ export class SimS3Bucket {
   /**
    * Remove a simulated S3 Object from storage.
    *
-   * Real S3 DeleteObject is idempotent, so this reports nothing about whether
-   * there was an Object to remove.
+   * Real S3 DeleteObject is idempotent, so a key that was not there is not an
+   * error. Whether there was an Object to remove is still reported, because a
+   * deletion that removed nothing is not an event: real S3 raises
+   * `s3:ObjectRemoved:Delete` when an Object was deleted, not when a deletion
+   * was requested.
    */
-  async deleteObject(key: string): Promise<void> {
-    await this.storage.deleteObject(key);
+  async deleteObject(key: string): Promise<boolean> {
+    return await this.storage.deleteObject(key);
   }
 
   /**
@@ -151,6 +159,23 @@ export class SimS3Bucket {
    */
   deletePublicAccessBlock(): void {
     this.publicAccessBlock = SimS3PublicAccessBlock.blockingAll();
+  }
+
+  /**
+   * Replace this Bucket's event notification configuration.
+   *
+   * Real S3 holds one configuration per Bucket rather than a list of them, so
+   * this replaces what was there instead of adding to it.
+   */
+  configureNotifications(notifications: SimS3NotificationConfiguration): void {
+    this.notifications = notifications;
+  }
+
+  /**
+   * Get this Bucket's event notification configuration.
+   */
+  getNotifications(): SimS3NotificationConfiguration {
+    return this.notifications;
   }
 
   /**

--- a/src/service/s3/command/delete-object/delete-object-authorizer.ts
+++ b/src/service/s3/command/delete-object/delete-object-authorizer.ts
@@ -1,4 +1,5 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
@@ -31,8 +32,16 @@ export class DeleteObjectAuthorizer {
 
   /**
    * Ensure the caller may remove the requested S3 Object.
+   *
+   * The resolved caller is returned rather than discarded, because it is the
+   * only place in the request where the principal has been worked out, and an
+   * Object event notification has to say who caused it.
    */
-  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+  authorize(
+    bucket: SimS3Bucket,
+    key: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
     const resource = `${simS3BucketArn(bucket.bucketName)}/${key}`;
     const decision = this.iam.authorize({
       action: DeleteObjectAuthorizer.action,
@@ -48,5 +57,7 @@ export class DeleteObjectAuthorizer {
         resource,
       });
     }
+
+    return decision.caller;
   }
 }

--- a/src/service/s3/command/delete-object/delete-object.handler.ts
+++ b/src/service/s3/command/delete-object/delete-object.handler.ts
@@ -13,6 +13,7 @@ import type {
   SimS3Bucket,
   SimS3BucketName,
 } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
 import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
 import { DeleteObjectAuthorizer } from "./delete-object-authorizer.js";
 import type {
@@ -24,6 +25,7 @@ interface DeleteObjectCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly notifications: SimS3ObjectNotifier;
 }
 
 interface DeleteObjectCommandHandlerOptions {
@@ -42,6 +44,7 @@ export class DeleteObjectCommandHandler implements CommandHandler<
   private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   private readonly authorizer: DeleteObjectAuthorizer;
   private readonly background: BackgroundScheduler;
+  private readonly notifications: SimS3ObjectNotifier;
 
   constructor(properties: DeleteObjectCommandHandlerProperties) {
     const {
@@ -53,6 +56,7 @@ export class DeleteObjectCommandHandler implements CommandHandler<
     this.buckets = buckets;
     this.authorizer = new DeleteObjectAuthorizer({ iam });
     this.background = background;
+    this.notifications = properties.notifications;
   }
 
   /**
@@ -74,9 +78,24 @@ export class DeleteObjectCommandHandler implements CommandHandler<
 
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, command.input.Key, options?.caller);
+    const caller = this.authorizer.authorize(
+      bucket,
+      command.input.Key,
+      options?.caller,
+    );
 
-    await bucket.deleteObject(command.input.Key);
+    const removed = await bucket.deleteObject(command.input.Key);
+
+    // A deletion that removed nothing is not an event: real S3 raises
+    // ObjectRemoved for an Object that was deleted, not for a request to
+    // delete one.
+    if (removed) {
+      this.notifications.objectRemoved({
+        bucket,
+        key: command.input.Key,
+        caller,
+      });
+    }
 
     return {
       $metadata: {},

--- a/src/service/s3/command/delete-objects/delete-objects-key-removal.ts
+++ b/src/service/s3/command/delete-objects/delete-objects-key-removal.ts
@@ -1,0 +1,55 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
+import { DeleteObjectAuthorizer } from "../delete-object/delete-object-authorizer.js";
+import { DeleteObjectAttempt } from "./delete-object-attempt.js";
+
+interface DeleteObjectsKeyRemovalProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly notifications: SimS3ObjectNotifier;
+}
+
+/**
+ * Removes one key of a batch deletion.
+ *
+ * A batch carries on past a key it could not remove, so what happened to each
+ * key travels with the key rather than being raised. Each key is authorized on
+ * its own against `s3:DeleteObject`, and raises its own event notification, as
+ * real S3 does.
+ */
+export class DeleteObjectsKeyRemoval {
+  private readonly authorizer: DeleteObjectAuthorizer;
+  private readonly notifications: SimS3ObjectNotifier;
+
+  constructor(properties: DeleteObjectsKeyRemovalProperties) {
+    this.authorizer = new DeleteObjectAuthorizer({ iam: properties.iam });
+    this.notifications = properties.notifications;
+  }
+
+  /**
+   * Authorize and remove one key, reporting what came of it.
+   */
+  async remove(
+    bucket: SimS3Bucket,
+    key: string,
+    caller?: SimAwsCaller,
+  ): Promise<DeleteObjectAttempt> {
+    try {
+      const resolvedCaller = this.authorizer.authorize(bucket, key, caller);
+      const removed = await bucket.deleteObject(key);
+
+      if (removed) {
+        this.notifications.objectRemoved({
+          bucket,
+          key,
+          caller: resolvedCaller,
+        });
+      }
+
+      return new DeleteObjectAttempt(key);
+    } catch (error) {
+      return new DeleteObjectAttempt(key, error);
+    }
+  }
+}

--- a/src/service/s3/command/delete-objects/delete-objects.handler.ts
+++ b/src/service/s3/command/delete-objects/delete-objects.handler.ts
@@ -13,9 +13,9 @@ import type {
   SimS3Bucket,
   SimS3BucketName,
 } from "../../bucket/sim-s3-bucket.js";
-import { DeleteObjectAuthorizer } from "../delete-object/delete-object-authorizer.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
 import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
-import { DeleteObjectAttempt } from "./delete-object-attempt.js";
+import { DeleteObjectsKeyRemoval } from "./delete-objects-key-removal.js";
 import { DeleteObjectsOutcome } from "./delete-objects-outcome.js";
 import { DeleteObjectsRequest } from "./delete-objects-request.js";
 import type {
@@ -27,6 +27,7 @@ interface DeleteObjectsCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly notifications: SimS3ObjectNotifier;
 }
 
 interface DeleteObjectsCommandHandlerOptions {
@@ -43,8 +44,8 @@ export class DeleteObjectsCommandHandler implements CommandHandler<
   SimDeleteObjectsCommandOutput
 > {
   private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
-  private readonly authorizer: DeleteObjectAuthorizer;
   private readonly background: BackgroundScheduler;
+  private readonly removal: DeleteObjectsKeyRemoval;
 
   constructor(properties: DeleteObjectsCommandHandlerProperties) {
     const {
@@ -54,16 +55,18 @@ export class DeleteObjectsCommandHandler implements CommandHandler<
     } = properties;
 
     this.buckets = buckets;
-    this.authorizer = new DeleteObjectAuthorizer({ iam });
     this.background = background;
+    this.removal = new DeleteObjectsKeyRemoval({
+      iam,
+      notifications: properties.notifications,
+    });
   }
 
   /**
    * Authorize and remove each Object the request names.
    *
-   * Each key is authorized on its own against `s3:DeleteObject`, as real S3
-   * does, and a key the caller may not remove is reported in the response while
-   * the rest of the batch is still deleted.
+   * A key the caller may not remove is reported in the response while the rest
+   * of the batch is still deleted.
    */
   async handle(
     command: SimDeleteObjectsCommand,
@@ -80,25 +83,10 @@ export class DeleteObjectsCommandHandler implements CommandHandler<
 
     const attempts = await Promise.all(
       request.keys.map(
-        async (key) => await this.deleteKey(bucket, key, options?.caller),
+        async (key) => await this.removal.remove(bucket, key, options?.caller),
       ),
     );
 
     return new DeleteObjectsOutcome(attempts).toOutput(request.quiet);
-  }
-
-  private async deleteKey(
-    bucket: SimS3Bucket,
-    key: string,
-    caller?: SimAwsCaller,
-  ): Promise<DeleteObjectAttempt> {
-    try {
-      this.authorizer.authorize(bucket, key, caller);
-      await bucket.deleteObject(key);
-
-      return new DeleteObjectAttempt(key);
-    } catch (error) {
-      return new DeleteObjectAttempt(key, error);
-    }
   }
 }

--- a/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
@@ -1,0 +1,38 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3LambdaFunctionConfigurationInput } from "../put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+
+/**
+ * Minimal structural sim S3 GetBucketNotificationConfiguration command.
+ */
+export interface SimGetBucketNotificationConfigurationCommand {
+  readonly input: SimGetBucketNotificationConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketNotificationConfiguration input.
+ */
+export interface SimGetBucketNotificationConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * The destination groups a notification configuration is read back as.
+ *
+ * These sit at the top level of the response rather than under a
+ * `NotificationConfiguration` property, which is where the same groups go on
+ * the way in. The asymmetry is real S3's, and the SDK carries it: the output
+ * type extends the configuration shape while the input type nests it. Reading
+ * `result.NotificationConfiguration` compiles and answers undefined, which
+ * looks exactly like a Bucket with nothing configured.
+ */
+export interface SimS3NotificationConfigurationOutput {
+  readonly LambdaFunctionConfigurations?:
+    readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketNotificationConfiguration output.
+ */
+export interface SimGetBucketNotificationConfigurationCommandOutput extends SimS3NotificationConfigurationOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.handler.ts
+++ b/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.handler.ts
@@ -1,0 +1,86 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NotificationAuthorizer } from "../notification/sim-s3-notification-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimGetBucketNotificationConfigurationCommand,
+  SimGetBucketNotificationConfigurationCommandOutput,
+} from "./get-bucket-notification-configuration.command.js";
+
+interface GetBucketNotificationConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+interface GetBucketNotificationConfigurationHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 GetBucketNotificationConfiguration command handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/GetBucketNotificationConfigurationCommand/
+ */
+export class GetBucketNotificationConfigurationCommandHandler implements CommandHandler<
+  SimGetBucketNotificationConfigurationCommand,
+  SimGetBucketNotificationConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3NotificationAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetBucketNotificationConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3NotificationAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Read a Bucket's event notification configuration.
+   *
+   * A Bucket nobody has configured answers an empty configuration rather than
+   * an error, which is what real S3 does: a Bucket always has a notification
+   * configuration, it is just usually empty.
+   */
+  async handle(
+    command: SimGetBucketNotificationConfigurationCommand,
+    options?: GetBucketNotificationConfigurationHandlerOptions,
+  ): Promise<SimGetBucketNotificationConfigurationCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "GetBucketNotificationConfigurationCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeRead(bucket, options?.caller);
+
+    return {
+      ...bucket.getNotifications().toOutput(),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
+++ b/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
@@ -1,0 +1,67 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+
+interface SimS3NotificationAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the S3 event notification commands.
+ *
+ * The IAM action names do not match the API names: reading the configuration
+ * is governed by s3:GetBucketNotification and replacing it by
+ * s3:PutBucketNotification, while the operations are called
+ * GetBucketNotificationConfiguration and PutBucketNotificationConfiguration.
+ * `sim-s3-public-access-block-authorizer.ts` has the same mismatch for the same
+ * reason: the permission is older than the operation name.
+ */
+export class SimS3NotificationAuthorizer {
+  private static readonly readAction = "s3:GetBucketNotification";
+  private static readonly writeAction = "s3:PutBucketNotification";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3NotificationAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may read the Bucket's notification configuration.
+   */
+  authorizeRead(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    this.authorize(SimS3NotificationAuthorizer.readAction, bucket, caller);
+  }
+
+  /**
+   * Ensure the caller may replace the Bucket's notification configuration.
+   */
+  authorizeWrite(bucket: SimS3Bucket, caller?: SimAwsCaller): void {
+    this.authorize(SimS3NotificationAuthorizer.writeAction, bucket, caller);
+  }
+
+  private authorize(
+    action: string,
+    bucket: SimS3Bucket,
+    caller?: SimAwsCaller,
+  ): void {
+    const resource = simS3BucketArn(bucket.bucketName);
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller,
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/notification/sim-s3-notification-commands.ts
+++ b/src/service/s3/command/notification/sim-s3-notification-commands.ts
@@ -1,0 +1,40 @@
+import { GetBucketNotificationConfigurationCommandHandler } from "../get-bucket-notification-configuration/get-bucket-notification-configuration.handler.js";
+import { PutBucketNotificationConfigurationCommandHandler } from "../put-bucket-notification-configuration/put-bucket-notification-configuration.handler.js";
+import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
+import type * as simS3Commands from "../sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/**
+ * The event notification commands of one simulated S3 scope.
+ */
+export class SimS3NotificationCommands {
+  private readonly state: SimS3BucketCommandState;
+
+  constructor(state: SimS3BucketCommandState) {
+    this.state = state;
+  }
+
+  /**
+   * Replace a Bucket's event notification configuration.
+   */
+  async put(
+    command: simS3Commands.SimPutBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketNotificationConfigurationCommandOutput> {
+    return await new PutBucketNotificationConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+
+  /**
+   * Read a Bucket's event notification configuration.
+   */
+  async get(
+    command: simS3Commands.SimGetBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketNotificationConfigurationCommandOutput> {
+    return await new GetBucketNotificationConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+}

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
@@ -1,0 +1,74 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 PutBucketNotificationConfiguration command.
+ */
+export interface SimPutBucketNotificationConfigurationCommand {
+  readonly input: SimPutBucketNotificationConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketNotificationConfiguration input.
+ */
+export interface SimPutBucketNotificationConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly NotificationConfiguration?:
+    SimS3NotificationConfigurationInput | undefined;
+  readonly SkipDestinationValidation?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketNotificationConfiguration output.
+ */
+export interface SimPutBucketNotificationConfigurationCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim S3 notification configuration.
+ *
+ * The four destination groups are nested under this on the way in and sit at
+ * the top level of the GetBucketNotificationConfiguration response on the way
+ * out, which is what real S3 does and what
+ * SimS3NotificationConfigurationOutput exists to say.
+ */
+export interface SimS3NotificationConfigurationInput {
+  readonly LambdaFunctionConfigurations?:
+    readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
+  readonly QueueConfigurations?: readonly unknown[] | undefined;
+  readonly TopicConfigurations?: readonly unknown[] | undefined;
+  readonly EventBridgeConfiguration?: object | undefined;
+}
+
+/**
+ * Minimal structural sim S3 Lambda function notification configuration.
+ */
+export interface SimS3LambdaFunctionConfigurationInput {
+  readonly Id?: string | undefined;
+  readonly LambdaFunctionArn?: string | undefined;
+  readonly Events?: readonly string[] | undefined;
+  readonly Filter?: SimS3NotificationFilterInput | undefined;
+}
+
+/**
+ * Minimal structural sim S3 notification object key filter.
+ */
+export interface SimS3NotificationFilterInput {
+  readonly Key?: SimS3NotificationKeyFilterInput | undefined;
+}
+
+/**
+ * Minimal structural sim S3 notification object key filter rules.
+ */
+export interface SimS3NotificationKeyFilterInput {
+  readonly FilterRules?:
+    readonly SimS3NotificationFilterRuleInput[] | undefined;
+}
+
+/**
+ * Minimal structural sim S3 notification object key filter rule.
+ */
+export interface SimS3NotificationFilterRuleInput {
+  readonly Name?: string | undefined;
+  readonly Value?: string | undefined;
+}

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.handler.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.handler.ts
@@ -1,0 +1,110 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3NotificationConfigurationReader } from "../../bucket/notification/sim-s3-notification-configuration-reader.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NotificationDestinationCheck } from "../../notification/destination/sim-s3-notification-destination-check.js";
+import type { SimS3NotificationDestinations } from "../../notification/destination/sim-s3-notification-destination.js";
+import { SimS3NotificationAuthorizer } from "../notification/sim-s3-notification-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimPutBucketNotificationConfigurationCommand,
+  SimPutBucketNotificationConfigurationCommandOutput,
+} from "./put-bucket-notification-configuration.command.js";
+
+interface PutBucketNotificationConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly notificationDestinations: SimS3NotificationDestinations;
+}
+
+interface PutBucketNotificationConfigurationHandlerOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Simulated S3 PutBucketNotificationConfiguration command handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutBucketNotificationConfigurationCommand/
+ */
+export class PutBucketNotificationConfigurationCommandHandler implements CommandHandler<
+  SimPutBucketNotificationConfigurationCommand,
+  SimPutBucketNotificationConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3NotificationAuthorizer;
+  private readonly background: BackgroundScheduler;
+  private readonly destinations: SimS3NotificationDestinationCheck;
+  private readonly reader = new SimS3NotificationConfigurationReader();
+
+  constructor(properties: PutBucketNotificationConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      notificationDestinations,
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3NotificationAuthorizer({ iam });
+    this.background = background;
+    this.destinations = new SimS3NotificationDestinationCheck(
+      notificationDestinations,
+    );
+  }
+
+  /**
+   * Replace a Bucket's whole event notification configuration.
+   *
+   * The request is read, then every destination it names is checked, and only
+   * then is anything stored, so a request the simulator refuses leaves the
+   * Bucket's previous configuration exactly as it was.
+   */
+  async handle(
+    command: SimPutBucketNotificationConfigurationCommand,
+    options?: PutBucketNotificationConfigurationHandlerOptions,
+  ): Promise<SimPutBucketNotificationConfigurationCommandOutput> {
+    const input = command.input;
+    assertDefined(
+      input.Bucket,
+      "PutBucketNotificationConfigurationCommand.input.Bucket",
+    );
+    assertDefined(
+      input.NotificationConfiguration,
+      "PutBucketNotificationConfigurationCommand.input.NotificationConfiguration",
+    );
+
+    const bucket = requireSimS3Bucket(
+      this.buckets,
+      input.Bucket as SimS3BucketName,
+    );
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options?.caller);
+
+    const configuration = this.reader.read(input.NotificationConfiguration);
+
+    if (input.SkipDestinationValidation !== true) {
+      this.destinations.check(bucket, configuration);
+    }
+
+    bucket.configureNotifications(configuration);
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.iso.test.ts
@@ -1,0 +1,319 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("S3 PutBucketNotificationConfigurationCommand", () => {
+  it("stores a configuration that GetBucketNotificationConfiguration reports", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // And a function that allows S3 to invoke it for that Bucket
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+        SourceAccount: simAws.defaultAccountId,
+      }),
+    );
+
+    // When a notification configuration is applied
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "thumbnail-raw-uploads",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then it is reported back as it was applied
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = read.LambdaFunctionConfigurations ?? [];
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "thumbnail-raw-uploads");
+    assertIdentical(configurations[0].LambdaFunctionArn, thumbnailerArn);
+    assertIdentical(configurations[0].Events?.[0], "s3:ObjectCreated:*");
+    assertIdentical(
+      configurations[0].Filter?.Key?.FilterRules?.[0]?.Value,
+      "raw/",
+    );
+  });
+
+  it("replaces the whole configuration rather than adding to it", async () => {
+    // Given a Bucket whose function allows S3 to invoke it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+
+    // And a configuration that notifies on creation
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "on-create",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When another configuration is applied
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "on-remove",
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then only the second one is there, as real S3 replaces rather than merges
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = read.LambdaFunctionConfigurations ?? [];
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "on-remove");
+  });
+
+  it("generates a configuration id for a configuration without one", async () => {
+    // Given a Bucket whose function allows S3 to invoke it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+
+    // When a configuration is applied without an Id
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then S3 gives it one and reports it back, as real S3 does
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertNonNullable(
+      read.LambdaFunctionConfigurations?.[0]?.Id,
+      "the configuration was given an id",
+    );
+  });
+
+  it("reports an empty configuration for a Bucket with none", async () => {
+    // Given a Bucket nobody has configured
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When its notification configuration is read
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+
+    // Then it answers nothing configured rather than an error
+    assertUndefined(read.LambdaFunctionConfigurations);
+  });
+
+  it("reports a Bucket that does not exist", async () => {
+    // Given no Bucket of that name
+    const simAws = new SimAws();
+
+    // When a configuration is applied to it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "absent",
+          NotificationConfiguration: {},
+        }),
+      ),
+    );
+
+    // Then the missing Bucket is reported before anything else
+    assertStringIncludes(error.message, "No S3 Bucket named absent");
+  });
+
+  it("reports a Bucket that does not exist when reading", async () => {
+    // Given no Bucket of that name
+    const simAws = new SimAws();
+
+    // When its notification configuration is read
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .s3()
+        .getBucketNotificationConfiguration(
+          new GetBucketNotificationConfigurationCommand({ Bucket: "absent" }),
+        ),
+    );
+
+    // Then the missing Bucket is reported
+    assertStringIncludes(error.message, "No S3 Bucket named absent");
+  });
+
+  it("rejects a request naming no Bucket", async () => {
+    // Given a command with no Bucket
+    const simAws = new SimAws();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: undefined,
+          NotificationConfiguration: {},
+        }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(
+      error.message,
+      "PutBucketNotificationConfigurationCommand.input.Bucket",
+    );
+  });
+
+  it("rejects a request carrying no configuration", async () => {
+    // Given a Bucket and a command with no NotificationConfiguration
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: undefined,
+        }),
+      ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(error.message, "NotificationConfiguration");
+  });
+
+  it("rejects a read naming no Bucket", async () => {
+    // Given a command with no Bucket
+    const simAws = new SimAws();
+
+    // When it is handled
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .s3()
+        .getBucketNotificationConfiguration(
+          new GetBucketNotificationConfigurationCommand({ Bucket: undefined }),
+        ),
+    );
+
+    // Then the malformed request is reported
+    assertStringIncludes(
+      error.message,
+      "GetBucketNotificationConfigurationCommand.input.Bucket",
+    );
+  });
+});

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTypeObject,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("What a simulated S3 notification destination refuses", () => {
+  it("refuses an SQS queue destination by name", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names a queue
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                QueueArn: "arn:aws:sqs:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the destination it cannot deliver to is named
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "SQS queue");
+  });
+
+  it("refuses an SNS topic destination by name", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names a topic
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            TopicConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the destination it cannot deliver to is named
+    assertStringIncludes(error.message, "SNS topic");
+  });
+
+  it("refuses an EventBridge destination by name", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration turns EventBridge on
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: { EventBridgeConfiguration: {} },
+        }),
+      ),
+    );
+
+    // Then the destination it cannot deliver to is named
+    assertStringIncludes(error.message, "EventBridge");
+  });
+
+  it("accepts a configuration whose other destination groups are empty", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration carries empty queue and topic lists, which is what
+    // an SDK caller restating a whole configuration sends
+    const output = await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [],
+          TopicConfigurations: [],
+        },
+      }),
+    );
+
+    // Then nothing is refused: there is no destination to refuse
+    assertTypeObject(output.$metadata);
+  });
+
+  it("refuses an event type real S3 has that it cannot raise", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration asks for an event the simulator never produces
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:Copy"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused as unsimulated rather than accepted and never
+    // delivered
+    assertIdentical(error.name, "NotImplemented");
+    assertStringIncludes(error.message, "s3:ObjectCreated:Copy");
+  });
+
+  it("refuses an event type S3 does not have", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names something that is not an S3 event type.
+    // The SDK's own types refuse this, so the request is built structurally,
+    // the way one arriving over the REST endpoint would be.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration({
+        input: {
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectUploaded:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is reported as a bad argument rather than as unsimulated
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "s3:ObjectUploaded:*");
+  });
+});

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
@@ -1,0 +1,240 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("The destination a simulated S3 notification configuration names", () => {
+  it("refuses a function whose resource policy does not admit S3", async () => {
+    // Given a Bucket and a function that grants S3 nothing
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+
+    // When a configuration names it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Id: "thumbnails",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused the way real S3 refuses a destination it could not
+    // validate
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "AddPermission");
+
+    // And nothing is stored
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertUndefined(read.LambdaFunctionConfigurations);
+  });
+
+  it("refuses a permission granted for another Bucket", async () => {
+    // Given a function that admits S3 only for a different Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowOtherBucket",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::archive",
+      }),
+    );
+
+    // When this Bucket's configuration names it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the grant for one Bucket does not open the function to another
+    assertStringIncludes(error.message, "arn:aws:s3:::uploads");
+  });
+
+  it("refuses a function that is not there", async () => {
+    // Given a Bucket and no function of that name
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the missing function is reported rather than stored and never
+    // reached
+    assertStringIncludes(error.message, "not a simulated Lambda function");
+  });
+
+  it("refuses a qualified function ARN", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names a function version
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: `${thumbnailerArn}:3`,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than read as the unqualified function
+    assertStringIncludes(error.message, "versions or aliases");
+  });
+
+  it("refuses a destination ARN naming another service", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the Lambda destination carries a queue ARN
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: "arn:aws:sqs:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the destination it cannot notify is named
+    assertStringIncludes(error.message, "cannot notify");
+  });
+
+  it("stores without checking when the request asks it to", async () => {
+    // Given a Bucket and a function that grants S3 nothing
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+
+    // When the configuration is applied with SkipDestinationValidation
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        SkipDestinationValidation: true,
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "thumbnails",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then it is stored, as real S3 stores an unchecked destination
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(read.LambdaFunctionConfigurations ?? [], 1);
+  });
+});

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-iam.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-iam.iso.test.ts
@@ -1,0 +1,113 @@
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+
+describe("IAM authorization of the S3 notification configuration commands", () => {
+  it("authorizes replacing the configuration as s3:PutBucketNotification", async () => {
+    // Given a Role allowed only to read the configuration. The IAM action
+    // names do not match the API names, which is what this is about.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "NotificationReader",
+        actions: ["s3:GetBucketNotification"],
+        resource: "arn:aws:s3:::uploads",
+      },
+      simAws,
+    );
+
+    // When it applies a configuration
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {},
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then it is denied, and nothing is stored
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "s3:PutBucketNotification");
+  });
+
+  it("allows a Role holding s3:PutBucketNotification", async () => {
+    // Given a Role allowed to replace the configuration
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "NotificationWriter",
+        actions: ["s3:PutBucketNotification"],
+        resource: "arn:aws:s3:::uploads",
+      },
+      simAws,
+    );
+
+    // When it applies an empty configuration
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {},
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then the request goes through
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertUndefined(read.LambdaFunctionConfigurations);
+  });
+
+  it("authorizes reading the configuration as s3:GetBucketNotification", async () => {
+    // Given a Role allowed only to replace the configuration
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "NotificationWriter",
+        actions: ["s3:PutBucketNotification"],
+        resource: "arn:aws:s3:::uploads",
+      },
+      simAws,
+    );
+
+    // When it reads the configuration
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .s3()
+        .getBucketNotificationConfiguration(
+          new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+          { caller: { kind: "arn", arn: role.Arn } },
+        ),
+    );
+
+    // Then it is denied: the two permissions are separate
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "s3:GetBucketNotification");
+  });
+});

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-overlap.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-overlap.iso.test.ts
@@ -1,0 +1,349 @@
+/**
+ * The overlap rule, worked through the examples in the AWS documentation.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-filtering.html
+ *
+ * AWS states the rule with SNS topic and SQS queue destinations, which this
+ * simulator does not deliver to. The prefixes, suffixes and event types are
+ * ported as they are written there; only the destination is a Lambda function.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("Overlapping S3 notification configurations", () => {
+  it("refuses a filtered configuration alongside an unfiltered one", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When one configuration filters nothing and another filters on a prefix,
+    // both for the same event
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Id: "everything",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+              {
+                Id: "images",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "prefix", Value: "images" }] },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: the root prefix overlaps every other prefix
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "overlap");
+  });
+
+  it("refuses suffixes where one ends the other", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When one configuration takes "jpg" and another takes "pg", and the
+    // wildcard event covers the concrete one
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Id: "jpg",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "suffix", Value: "jpg" }] },
+                },
+              },
+              {
+                Id: "pg",
+                Events: ["s3:ObjectCreated:Put"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "suffix", Value: "pg" }] },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: a key can end with both
+    assertStringIncludes(error.message, "overlap");
+  });
+
+  it("refuses overlapping prefixes and suffixes together", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When one configuration takes "images" with "jpg" and another takes "jpg"
+    // under any prefix
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Id: "images-jpg",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: {
+                    FilterRules: [
+                      { Name: "prefix", Value: "images" },
+                      { Name: "suffix", Value: "jpg" },
+                    ],
+                  },
+                },
+              },
+              {
+                Id: "any-jpg",
+                Events: ["s3:ObjectCreated:Put"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "suffix", Value: "jpg" }] },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: both ends overlap
+    assertStringIncludes(error.message, "overlap");
+  });
+
+  it("accepts a shared prefix with suffixes that cannot both match", async () => {
+    // Given a Bucket whose function allows S3 to invoke it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+
+    // When two configurations share the "images" prefix but take ".jpg" and
+    // ".png"
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "images-jpg",
+              Events: ["s3:ObjectCreated:Put"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: {
+                  FilterRules: [
+                    { Name: "prefix", Value: "images" },
+                    { Name: "suffix", Value: ".jpg" },
+                  ],
+                },
+              },
+            },
+            {
+              Id: "images-png",
+              Events: ["s3:ObjectCreated:Put"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: {
+                  FilterRules: [
+                    { Name: "prefix", Value: "images" },
+                    { Name: "suffix", Value: ".png" },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then both are stored: no key ends with both suffixes
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(read.LambdaFunctionConfigurations ?? [], 2);
+  });
+
+  it("accepts the same filter for different event types", async () => {
+    // Given a Bucket whose function allows S3 to invoke it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+
+    // When one configuration takes creations under "image/" and another takes
+    // removals under the same prefix
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "created",
+              Events: ["s3:ObjectCreated:Put"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "image/" }] },
+              },
+            },
+            {
+              Id: "removed",
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "image/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then both are stored: the rule is about filters sharing an event type
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(read.LambdaFunctionConfigurations ?? [], 2);
+  });
+
+  it("accepts prefixes neither of which starts the other", async () => {
+    // Given a Bucket whose function allows S3 to invoke it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+
+    // When one takes "images/" and the other takes "logs/"
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "images",
+              Events: ["s3:ObjectCreated:Put"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "images/" }] },
+              },
+            },
+            {
+              Id: "logs",
+              Events: ["s3:ObjectCreated:Put"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "logs/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then both are stored
+    const read = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(read.LambdaFunctionConfigurations ?? [], 2);
+  });
+});

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
@@ -1,0 +1,292 @@
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3 } from "../../sim-s3.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("What a simulated S3 notification configuration refuses", () => {
+  it("refuses a filter rule name S3 does not filter on", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration filters on something else. The SDK's own types
+    // refuse this, so the request is built structurally, the way one arriving
+    // over the REST endpoint would be.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration({
+        input: {
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "contains", Value: "raw" }] },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then the rule name is refused by name
+    assertStringIncludes(error.message, "contains");
+  });
+
+  it("refuses a filter rule name given twice", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration states two prefixes
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: {
+                    FilterRules: [
+                      { Name: "prefix", Value: "raw/" },
+                      { Name: "prefix", Value: "cooked/" },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the repeated rule is refused rather than one of them winning
+    assertStringIncludes(error.message, "more than once");
+  });
+
+  it("refuses a configuration id used twice", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When two configurations share an id
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Id: "thumbnails",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "suffix", Value: ".jpg" }] },
+                },
+              },
+              {
+                Id: "thumbnails",
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: {
+                  Key: { FilterRules: [{ Name: "suffix", Value: ".png" }] },
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the repeated id is reported
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "used more than once");
+  });
+
+  it("refuses a configuration naming no events", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration names no event types
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              { Id: "nothing", Events: [], LambdaFunctionArn: thumbnailerArn },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused rather than stored as a configuration for nothing
+    assertStringIncludes(error.message, "names no events");
+  });
+
+  it("refuses a configuration naming no function", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration has no LambdaFunctionArn. The SDK's own types
+    // require one, so the request is built structurally, the way one arriving
+    // over the REST endpoint would be.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration({
+        input: {
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              { Id: "nowhere", Events: ["s3:ObjectCreated:*"] },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then the missing destination is reported
+    assertStringIncludes(error.message, "LambdaFunctionArn");
+  });
+
+  it("refuses a destination that is not an ARN at all", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the destination is a bare function name
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: "thumbnailer",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then there is no service segment to route it by, so it is refused
+    assertStringIncludes(error.message, "cannot notify");
+  });
+
+  it("refuses a configuration carrying no events at all", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a configuration leaves Events out entirely. The SDK's own types
+    // require it, so the request is built structurally, the way one arriving
+    // over the REST endpoint would be.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration({
+        input: {
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              { LambdaFunctionArn: thumbnailerArn },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then it is refused the same way an empty event list is
+    assertStringIncludes(error.message, "names no events");
+  });
+
+  it("refuses a filter rule with no name", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a filter rule states a value and no name
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+                Filter: { Key: { FilterRules: [{ Value: "raw/" }] } },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the rule is refused, saying it named nothing
+    assertStringIncludes(error.message, "(none)");
+  });
+
+  it("refuses a simulated S3 built on its own", async () => {
+    // Given a SimS3 constructed outside SimAws, which has no other simulated
+    // services and no shared background scheduler
+    const simS3 = new SimS3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When a notification configuration is applied to one of its Buckets
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            LambdaFunctionConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                LambdaFunctionArn: thumbnailerArn,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it says so, and points at SimAws
+    assertStringIncludes(error.message, "constructed on its own");
+    assertStringIncludes(error.message, "SimAws");
+  });
+});

--- a/src/service/s3/command/put-object/put-object-authorizer.ts
+++ b/src/service/s3/command/put-object/put-object-authorizer.ts
@@ -1,4 +1,5 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
@@ -25,8 +26,16 @@ export class PutObjectAuthorizer {
 
   /**
    * Ensure the caller may create or replace the requested S3 Object.
+   *
+   * The resolved caller is returned rather than discarded, because it is the
+   * only place in the request where the principal has been worked out, and an
+   * Object event notification has to say who caused it.
    */
-  authorize(bucket: SimS3Bucket, key: string, caller?: SimAwsCaller): void {
+  authorize(
+    bucket: SimS3Bucket,
+    key: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
     const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
     const policy = bucket.getPolicy();
     const decision = this.iam.authorize({
@@ -52,5 +61,7 @@ export class PutObjectAuthorizer {
         resource,
       });
     }
+
+    return decision.caller;
   }
 }

--- a/src/service/s3/command/put-object/put-object.handler.ts
+++ b/src/service/s3/command/put-object/put-object.handler.ts
@@ -20,11 +20,13 @@ import {
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { PutObjectAuthorizer } from "./put-object-authorizer.js";
 import { PutObjectBuilder } from "./put-object-builder.js";
+import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
 
 interface PutObjectCommandHandlerProperties {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  readonly notifications: SimS3ObjectNotifier;
 }
 
 interface PutObjectCommandHandlerOptions {
@@ -44,6 +46,7 @@ export class PutObjectCommandHandler implements CommandHandler<
   private readonly authorizer: PutObjectAuthorizer;
   private readonly objectBuilder = new PutObjectBuilder();
   private readonly background: BackgroundScheduler;
+  private readonly notifications: SimS3ObjectNotifier;
 
   constructor(properties: PutObjectCommandHandlerProperties) {
     const {
@@ -54,6 +57,7 @@ export class PutObjectCommandHandler implements CommandHandler<
     this.buckets = buckets;
     this.authorizer = new PutObjectAuthorizer({ iam });
     this.background = background;
+    this.notifications = properties.notifications;
   }
 
   /**
@@ -84,10 +88,18 @@ export class PutObjectCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    this.authorizer.authorize(bucket, command.input.Key, options?.caller);
+    const caller = this.authorizer.authorize(
+      bucket,
+      command.input.Key,
+      options?.caller,
+    );
 
     const object = this.objectBuilder.build(command);
     await bucket.putObject(object);
+
+    // Every write path funnels through here, so this one call covers the SDK,
+    // an intercepted SDK client and the REST endpoint alike.
+    this.notifications.objectCreated({ bucket, object, caller });
 
     return {
       $metadata: {},

--- a/src/service/s3/command/sim-s3-bucket-command-state.ts
+++ b/src/service/s3/command/sim-s3-bucket-command-state.ts
@@ -1,6 +1,8 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimS3Bucket, SimS3BucketName } from "../bucket/sim-s3-bucket.js";
+import type { SimS3NotificationDestinations } from "../notification/destination/sim-s3-notification-destination.js";
+import type { SimS3ObjectNotifier } from "../notification/sim-s3-object-notifier.js";
 
 /**
  * The state and collaborators every Bucket-scoped command handler is built
@@ -8,10 +10,14 @@ import type { SimS3Bucket, SimS3BucketName } from "../bucket/sim-s3-bucket.js";
  *
  * Each command area holds one of these and hands it straight to the handler it
  * runs, so the same Bucket map, IAM and background scheduler are shared across
- * every command of one simulated S3 scope.
+ * every command of one simulated S3 scope. The notifier is shared for the same
+ * reason and one more: sequence numbers and the delivery ceiling only mean
+ * anything if every Object command counts into the same one.
  */
 export interface SimS3BucketCommandState {
   readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
+  readonly notificationDestinations: SimS3NotificationDestinations;
+  readonly notifications: SimS3ObjectNotifier;
 }

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -30,6 +30,10 @@ export type {
   SimGetBucketPolicyCommandOutput,
 } from "./get-bucket-policy/get-bucket-policy.command.js";
 export type {
+  SimGetBucketNotificationConfigurationCommand,
+  SimGetBucketNotificationConfigurationCommandOutput,
+} from "./get-bucket-notification-configuration/get-bucket-notification-configuration.command.js";
+export type {
   SimGetObjectCommand,
   SimGetObjectCommandOutput,
 } from "./get-object/get-object.command.js";
@@ -45,6 +49,10 @@ export type {
   SimListObjectsCommand,
   SimListObjectsCommandOutput,
 } from "./list-objects/list-objects.command.js";
+export type {
+  SimPutBucketNotificationConfigurationCommand,
+  SimPutBucketNotificationConfigurationCommandOutput,
+} from "./put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 export type {
   SimPutBucketPolicyCommand,
   SimPutBucketPolicyCommandOutput,

--- a/src/service/s3/error/sim-s3-notification.error.ts
+++ b/src/service/s3/error/sim-s3-notification.error.ts
@@ -1,0 +1,24 @@
+/**
+ * A destination that would not take an event when it was offered one.
+ *
+ * This is not an AWS API error: nothing is waiting for it, because real S3
+ * never reports a failed delivery to whoever wrote the Object. It exists so
+ * the delivery outcome can say why nothing arrived, rather than the event
+ * simply disappearing.
+ */
+export class SimS3NotificationNotPermitted extends Error {
+  public override readonly name = "SimS3NotificationNotPermitted";
+}
+
+/**
+ * The simulation delivered more notifications than it is willing to.
+ *
+ * A handler that writes back into the Bucket that triggered it is a loop, and
+ * in process it is a loop with nothing to slow it down: `backgroundTasksComplete()`
+ * drains until there is no work left, so the test hangs with no stack to read.
+ * This is the one delivery failure allowed to escape its background task, so
+ * the loop surfaces as a named failure instead.
+ */
+export class SimS3NotificationDeliveryLimit extends Error {
+  public override readonly name = "SimS3NotificationDeliveryLimit";
+}

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -105,6 +105,21 @@ export class SimS3MalformedXml extends SimS3Error {
 }
 
 /**
+ * Simulated S3 InvalidArgument error.
+ *
+ * Real S3 answers this when a request argument is not one it accepts, which is
+ * how a notification configuration with overlapping filters, a repeated
+ * configuration id or an unusable destination is refused.
+ */
+export class SimS3InvalidArgument extends SimS3Error {
+  public override readonly name = "InvalidArgument";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated S3 NotImplemented error.
  *
  * Something real S3 does that the simulator refuses rather than approximates.

--- a/src/service/s3/index.ts
+++ b/src/service/s3/index.ts
@@ -1,1 +1,2 @@
 export { SimS3 } from "./sim-s3.js";
+export type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.iso.test.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.iso.test.ts
@@ -1,0 +1,96 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../../lambda/function/code/lambda-zip-file-input.js";
+import { SimAwsS3NotificationFunctions } from "./sim-aws-s3-notification-functions.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("Simulated Lambda functions as S3 notification destinations", () => {
+  it("refuses to invoke a function that is not there", async () => {
+    // Given a simulation with no functions in it
+    const simAws = new SimAws();
+    const functions = new SimAwsS3NotificationFunctions({ simAws });
+
+    // When one is invoked anyway, which delivery only reaches if the function
+    // went away between the check and the invocation
+    const error = await assertThrowsErrorAsync(async () =>
+      functions.invoke(
+        {
+          destinationArn: thumbnailerArn,
+          bucketArn: "arn:aws:s3:::uploads",
+          bucketOwnerAccountId: simAws.defaultAccountId,
+        },
+        { Records: [] },
+      ),
+    );
+
+    // Then the missing function is reported rather than silently skipped
+    assertStringIncludes(error.message, "not a simulated Lambda function");
+  });
+
+  it("refuses an ARN that is not a Lambda function", () => {
+    // Given a simulation
+    const simAws = new SimAws();
+    const functions = new SimAwsS3NotificationFunctions({ simAws });
+
+    // When the destination names a Lambda layer rather than a function
+    let raised: unknown;
+    try {
+      functions.invokeRefusal({
+        destinationArn: "arn:aws:lambda:us-east-1:888888888888:layer:shared",
+        bucketArn: "arn:aws:s3:::uploads",
+        bucketOwnerAccountId: simAws.defaultAccountId,
+      });
+    } catch (error) {
+      raised = error;
+    }
+
+    // Then the ARN is refused for what it is
+    assertIdentical((raised as Error).name, "InvalidArgument");
+    assertStringIncludes(
+      (raised as Error).message,
+      "is not a Lambda function ARN",
+    );
+  });
+
+  it("has no refusal for a function that admits the Bucket", async () => {
+    // Given a function granting S3 the invoke action for a Bucket
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      },
+    });
+    await simAws.lambda().addPermission({
+      input: {
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      },
+    });
+
+    // When S3 asks whether it may invoke it
+    const refusal = new SimAwsS3NotificationFunctions({ simAws }).invokeRefusal(
+      {
+        destinationArn: thumbnailerArn,
+        bucketArn: "arn:aws:s3:::uploads",
+        bucketOwnerAccountId: simAws.defaultAccountId,
+      },
+    );
+
+    // Then there is nothing to report
+    assertUndefined(refusal);
+  });
+});

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
@@ -1,0 +1,113 @@
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import { SimLambdaServiceInvokeAuthorizer } from "../../../../lambda/command/authorize/sim-lambda-service-invoke-authorizer.js";
+import type { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
+import type { SimIamInterServiceAuthZ } from "../../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { SimS3NotificationFunctionArn } from "./sim-s3-notification-function-arn.js";
+import type { SimS3NotificationFunctions } from "./sim-s3-notification-functions.js";
+
+/**
+ * The service principal S3 invokes a Lambda function as.
+ */
+export const simS3ServicePrincipal = "s3.amazonaws.com";
+
+interface SimAwsS3NotificationFunctionsProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated Lambda functions of one simulated AWS instance, as S3
+ * notification destinations.
+ *
+ * Functions are looked up when a configuration is applied or an event is
+ * delivered, never when this is built. Simulated Lambda already reaches
+ * simulated S3 while it is being constructed, for function code in a Bucket, so
+ * reaching back the other way at construction time would be a cycle with no
+ * bottom to it.
+ */
+export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsS3NotificationFunctionsProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Why S3 may not invoke the function, or nothing when it may.
+   *
+   * Whether a service may invoke a function is Lambda's own rule, so the
+   * decision is made there. What S3 adds is which Bucket is calling, supplied
+   * as the source ARN and source Account, so a permission granted for one
+   * Bucket does not open the function to another.
+   */
+  invokeRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined {
+    const arn = SimS3NotificationFunctionArn.parse(request.destinationArn);
+    const simFunction = this.findFunction(arn);
+
+    if (simFunction === undefined) {
+      return `${request.destinationArn} is not a simulated Lambda function.`;
+    }
+
+    const decision = new SimLambdaServiceInvokeAuthorizer({
+      iam: this.iam(arn),
+    }).authorize({
+      simFunction,
+      servicePrincipal: simS3ServicePrincipal,
+      sourceArn: request.bucketArn,
+      sourceAccount: request.bucketOwnerAccountId,
+    });
+
+    if (decision.isDenied) {
+      return (
+        `The resource policy of ${request.destinationArn} does not allow ` +
+        `${simS3ServicePrincipal} to invoke it for ${request.bucketArn}. ` +
+        "Grant it with AddPermission."
+      );
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Invoke the function with the event document.
+   *
+   * The function is invoked directly rather than through an Invoke command,
+   * because S3 is already inside the background task that stands for the
+   * asynchronous invocation real S3 makes, and because a handler failure has
+   * to reach the delivery outcome rather than being swallowed as an
+   * asynchronous invocation error.
+   */
+  async invoke(
+    request: SimS3NotificationDestinationRequest,
+    event: object,
+  ): Promise<void> {
+    const arn = SimS3NotificationFunctionArn.parse(request.destinationArn);
+    const simFunction = this.findFunction(arn);
+
+    if (simFunction === undefined) {
+      throw new Error(
+        `${request.destinationArn} is not a simulated Lambda function.`,
+      );
+    }
+
+    await simFunction.invoke(event);
+  }
+
+  private findFunction(
+    arn: SimS3NotificationFunctionArn,
+  ): SimLambdaFunction | undefined {
+    return this.scope(arn).lambda().getSimFunctionByName(arn.functionName);
+  }
+
+  private iam(arn: SimS3NotificationFunctionArn): SimIamInterServiceAuthZ {
+    return this.scope(arn).iam();
+  }
+
+  private scope(
+    arn: SimS3NotificationFunctionArn,
+  ): ReturnType<SimAws["accountRegionScope"]> {
+    return this.simAws.accountRegionScope(arn.accountId, arn.regionName);
+  }
+}

--- a/src/service/s3/notification/destination/lambda/sim-s3-lambda-notification-destination.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-lambda-notification-destination.ts
@@ -1,0 +1,61 @@
+import { SimS3InvalidArgument } from "../../../error/sim-s3.error.js";
+import { SimS3NotificationNotPermitted } from "../../../error/sim-s3-notification.error.js";
+import { simS3EventRecordsDocument } from "../../event/sim-s3-event-records.js";
+import type {
+  SimS3NotificationDeliveryRequest,
+  SimS3NotificationDestination,
+  SimS3NotificationDestinationRequest,
+} from "../sim-s3-notification-destination.js";
+import type { SimS3NotificationFunctions } from "./sim-s3-notification-functions.js";
+
+interface SimS3LambdaNotificationDestinationProperties {
+  readonly functions: SimS3NotificationFunctions;
+}
+
+/**
+ * A simulated Lambda function as somewhere S3 sends Object events.
+ *
+ * The same question is asked twice on purpose. Real S3 checks the function's
+ * resource policy when the configuration is applied, and checks it again for
+ * every event, so a permission removed afterwards stops delivery. Nothing is
+ * remembered from the first check.
+ */
+export class SimS3LambdaNotificationDestination implements SimS3NotificationDestination {
+  private readonly functions: SimS3NotificationFunctions;
+
+  constructor(properties: SimS3LambdaNotificationDestinationProperties) {
+    this.functions = properties.functions;
+  }
+
+  /**
+   * Refuse a function the Bucket may not invoke.
+   *
+   * Real S3 answers InvalidArgument for a destination it could not validate,
+   * which is what a missing `AddPermission` for `s3.amazonaws.com` produces.
+   */
+  validate(request: SimS3NotificationDestinationRequest): void {
+    const refusal = this.functions.invokeRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3InvalidArgument(
+        `Unable to validate the following destination configurations: ${refusal}`,
+      );
+    }
+  }
+
+  /**
+   * Invoke the function with the event, if it still admits this Bucket.
+   */
+  async deliver(request: SimS3NotificationDeliveryRequest): Promise<void> {
+    const refusal = this.functions.invokeRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3NotificationNotPermitted(refusal);
+    }
+
+    await this.functions.invoke(
+      request,
+      simS3EventRecordsDocument(request.event, request.configurationId),
+    );
+  }
+}

--- a/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-notification-function-arn.ts
@@ -1,0 +1,76 @@
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import {
+  SimS3InvalidArgument,
+  SimS3NotImplemented,
+} from "../../../error/sim-s3.error.js";
+
+/**
+ * The Lambda function ARN a notification configuration names.
+ *
+ * Lambda addresses a function with colons rather than a slash, so this reads
+ * the ARN itself rather than going through the shared ARN parser, which is
+ * built for the slash form.
+ */
+export class SimS3NotificationFunctionArn {
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+  public readonly functionName: string;
+
+  private constructor(
+    regionName: AwsRegionName,
+    accountId: SimAwsAccountId,
+    functionName: string,
+  ) {
+    this.regionName = regionName;
+    this.accountId = accountId;
+    this.functionName = functionName;
+  }
+
+  /**
+   * Read a Lambda function ARN, refusing anything else.
+   *
+   * A qualified ARN naming a version or an alias is refused rather than being
+   * read as the unqualified function, because simulated Lambda has neither and
+   * silently notifying `$LATEST` instead would be the wrong function.
+   */
+  static parse(arn: string): SimS3NotificationFunctionArn {
+    const [
+      prefix,
+      partition,
+      service,
+      region,
+      accountId,
+      resourceType,
+      name,
+      qualifier,
+    ] = arn.split(":");
+
+    if (
+      prefix !== "arn" ||
+      partition !== "aws" ||
+      service !== "lambda" ||
+      resourceType !== "function" ||
+      region === undefined ||
+      accountId === undefined ||
+      name === undefined ||
+      name === ""
+    ) {
+      throw new SimS3InvalidArgument(`${arn} is not a Lambda function ARN.`);
+    }
+
+    if (qualifier !== undefined) {
+      throw new SimS3NotImplemented(
+        `Cannot notify ${arn}: simulated Lambda has no function versions or ` +
+          "aliases, so a qualified function ARN is refused rather than " +
+          "treated as the unqualified function.",
+      );
+    }
+
+    return new SimS3NotificationFunctionArn(
+      region as AwsRegionName,
+      accountId as SimAwsAccountId,
+      name,
+    );
+  }
+}

--- a/src/service/s3/notification/destination/lambda/sim-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-s3-notification-functions.ts
@@ -1,0 +1,29 @@
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+
+/**
+ * The narrow slice of simulated Lambda that S3 event notification needs.
+ *
+ * S3 asks two questions of a function: whether it may invoke it, and then to
+ * invoke it. Both are asked by ARN, because a notification configuration names
+ * a function by ARN and that ARN can name another Account or Region.
+ */
+export interface SimS3NotificationFunctions {
+  /**
+   * Why S3 may not invoke the function, or nothing when it may.
+   *
+   * A reason rather than a boolean, because both the configuration-time
+   * refusal and the delivery-time record repeat it back to whoever has to fix
+   * it.
+   */
+  invokeRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined;
+
+  /**
+   * Invoke the function with an event document.
+   */
+  invoke(
+    request: SimS3NotificationDestinationRequest,
+    event: object,
+  ): Promise<void>;
+}

--- a/src/service/s3/notification/destination/sim-s3-notification-destination-check.ts
+++ b/src/service/s3/notification/destination/sim-s3-notification-destination-check.ts
@@ -1,0 +1,39 @@
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3NotificationConfiguration } from "../../bucket/notification/sim-s3-notification-configuration.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3NotificationDestinations } from "./sim-s3-notification-destination.js";
+
+/**
+ * Checks that a Bucket can actually reach the destinations a configuration
+ * names.
+ *
+ * Real S3 validates the destinations as part of the call that applies the
+ * configuration, so a function that does not allow `s3.amazonaws.com` to invoke
+ * it is refused there rather than accepted and never delivered to.
+ */
+export class SimS3NotificationDestinationCheck {
+  private readonly destinations: SimS3NotificationDestinations;
+
+  constructor(destinations: SimS3NotificationDestinations) {
+    this.destinations = destinations;
+  }
+
+  /**
+   * Refuse a configuration naming a destination this Bucket cannot notify.
+   */
+  check(
+    bucket: SimS3Bucket,
+    configuration: SimS3NotificationConfiguration,
+  ): void {
+    const request = {
+      bucketArn: simS3BucketArn(bucket.bucketName),
+      bucketOwnerAccountId: bucket.getAccountRegionScope().accountId,
+    };
+
+    for (const notification of configuration.lambdaNotifications) {
+      this.destinations
+        .resolve(notification.functionArn)
+        .validate({ ...request, destinationArn: notification.functionArn });
+    }
+  }
+}

--- a/src/service/s3/notification/destination/sim-s3-notification-destination.ts
+++ b/src/service/s3/notification/destination/sim-s3-notification-destination.ts
@@ -1,0 +1,54 @@
+import type { SimS3ObjectEvent } from "../event/sim-s3-object-event.js";
+
+/**
+ * What a destination needs to know about the Bucket asking it a question.
+ *
+ * The Bucket ARN and the owning Account are both carried because a destination
+ * decides whether S3 may reach it from the resource policy on its own side, and
+ * that policy is usually written for one Bucket in one Account.
+ */
+export interface SimS3NotificationDestinationRequest {
+  readonly destinationArn: string;
+  readonly bucketArn: string;
+  readonly bucketOwnerAccountId: string;
+}
+
+/**
+ * A destination being asked to take one event.
+ */
+export interface SimS3NotificationDeliveryRequest extends SimS3NotificationDestinationRequest {
+  readonly configurationId: string;
+  readonly event: SimS3ObjectEvent;
+}
+
+/**
+ * Somewhere simulated S3 can send an Object event.
+ *
+ * Validation and delivery are the same per-destination question asked at two
+ * moments, which is why one object owns both. Real S3 checks the destination
+ * when the configuration is applied and checks it again for every event, so a
+ * permission removed afterwards stops delivery rather than being remembered
+ * from configuration time.
+ */
+export interface SimS3NotificationDestination {
+  /**
+   * Refuse a destination the Bucket cannot notify, when the configuration
+   * naming it is applied.
+   */
+  validate(request: SimS3NotificationDestinationRequest): void;
+
+  /**
+   * Deliver one event, refusing if the destination no longer admits S3.
+   */
+  deliver(request: SimS3NotificationDeliveryRequest): Promise<void>;
+}
+
+/**
+ * The destinations one simulated S3 scope can reach.
+ */
+export interface SimS3NotificationDestinations {
+  /**
+   * The destination an ARN names, refusing an ARN S3 cannot notify.
+   */
+  resolve(destinationArn: string): SimS3NotificationDestination;
+}

--- a/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
+++ b/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
@@ -1,0 +1,66 @@
+import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
+import type {
+  SimS3NotificationDestination,
+  SimS3NotificationDestinations,
+} from "./sim-s3-notification-destination.js";
+
+interface SimS3ServiceNotificationDestinationsProperties {
+  readonly lambda: SimS3NotificationDestination;
+}
+
+/**
+ * The destinations of one simulated S3 scope, keyed on the service an ARN
+ * names.
+ *
+ * An ARN's service segment is the only thing that decides which destination
+ * takes it, so the lookup is a map rather than a chain of checks, and a service
+ * this simulator has no destination for is refused by name.
+ */
+export class SimS3ServiceNotificationDestinations implements SimS3NotificationDestinations {
+  private readonly byService: ReadonlyMap<string, SimS3NotificationDestination>;
+
+  constructor(properties: SimS3ServiceNotificationDestinationsProperties) {
+    this.byService = new Map([["lambda", properties.lambda]]);
+  }
+
+  /**
+   * The destination an ARN names.
+   */
+  resolve(destinationArn: string): SimS3NotificationDestination {
+    const service = destinationArn.split(":", 3)[2];
+    const destination =
+      service === undefined ? undefined : this.byService.get(service);
+
+    if (destination === undefined) {
+      throw new SimS3NotImplemented(
+        `Simulated S3 cannot notify ${destinationArn}. It notifies a Lambda ` +
+          "function; SQS queue, SNS topic and EventBridge destinations are " +
+          "not simulated.",
+      );
+    }
+
+    return destination;
+  }
+}
+
+/**
+ * The destinations a simulated S3 built on its own has, which is none.
+ *
+ * A standalone SimS3 owns its own background scheduler, so nothing could wait
+ * for a delivery it made even if it could make one. Refusing when the
+ * configuration is applied says so at the point the mistake was made, rather
+ * than leaving a configured Bucket that never notifies anything.
+ */
+export class SimS3NoNotificationDestinations implements SimS3NotificationDestinations {
+  /**
+   * Refuse every destination, explaining how to get one.
+   */
+  resolve(destinationArn: string): never {
+    throw new SimS3NotImplemented(
+      `Cannot notify ${destinationArn}: this SimS3 was constructed on its ` +
+        "own, so it has no other simulated services to notify and no shared " +
+        "background scheduler to deliver on. Reach simulated S3 through " +
+        "SimAws to configure Bucket event notifications.",
+    );
+  }
+}

--- a/src/service/s3/notification/event/sim-s3-event-principal.iso.test.ts
+++ b/src/service/s3/notification/event/sim-s3-event-principal.iso.test.ts
@@ -1,0 +1,52 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsCallerResolver } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import { simS3EventPrincipalId } from "./sim-s3-event-principal.js";
+
+const resolver = new SimAwsCallerResolver();
+
+describe("The principal an S3 event says caused it", () => {
+  it("names an IAM principal by ARN", () => {
+    // Given a caller resolved to an IAM Role
+    const caller = resolver.resolve(
+      { kind: "arn", arn: "arn:aws:iam::888888888888:role/UploaderRole" },
+      { kind: "anonymous" },
+    );
+
+    // When the event names it
+    const principalId = simS3EventPrincipalId(caller);
+
+    // Then the ARN goes in. Real S3 puts the principal's unique id here, and
+    // simulated IAM has no unique-id namespace to draw one from.
+    assertIdentical(principalId, "arn:aws:iam::888888888888:role/UploaderRole");
+  });
+
+  it("names a service by its service principal", () => {
+    // Given a caller resolved to a simulated service
+    const caller = resolver.resolve(
+      { kind: "service", service: "cloudfront.amazonaws.com" },
+      { kind: "anonymous" },
+    );
+
+    // When the event names it
+    const principalId = simS3EventPrincipalId(caller);
+
+    // Then the service principal goes in
+    assertIdentical(principalId, "cloudfront.amazonaws.com");
+  });
+
+  it("says so when nobody was named", () => {
+    // Given an anonymous caller, which is what an unsigned request resolves to
+    const caller = resolver.resolve(
+      { kind: "anonymous" },
+      { kind: "anonymous" },
+    );
+
+    // When the event names it
+    const principalId = simS3EventPrincipalId(caller);
+
+    // Then the field is still there, saying there was no principal
+    assertIdentical(principalId, "anonymous");
+  });
+});

--- a/src/service/s3/notification/event/sim-s3-event-principal.ts
+++ b/src/service/s3/notification/event/sim-s3-event-principal.ts
@@ -1,0 +1,23 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+
+/**
+ * The principal an event says caused it.
+ *
+ * Real S3 puts the unique id of the IAM entity here, the `AIDA...` or
+ * `AROA...` form. Simulated IAM has no unique-id namespace: it carries ARNs,
+ * which is also what a test would assert on. The ARN goes in rather than an
+ * invented AIDA-shaped string, and the divergence is recorded in the usage
+ * docs. `src/serve/payload-2/sim-payload-2-event.type.ts` does the same thing
+ * for the same reason.
+ */
+export function simS3EventPrincipalId(caller: SimAwsResolvedCaller): string {
+  if (caller.arn !== undefined) {
+    return caller.arn;
+  }
+
+  if (caller.service !== undefined) {
+    return caller.service;
+  }
+
+  return "anonymous";
+}

--- a/src/service/s3/notification/event/sim-s3-event-records.ts
+++ b/src/service/s3/notification/event/sim-s3-event-records.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import type { SimS3ObjectEvent } from "./sim-s3-object-event.js";
+
+/**
+ * The event structure version this simulator emits.
+ *
+ * AWS increments the minor version whenever it adds a field or an event type,
+ * and the major version only for a change that breaks a consumer. Consumers
+ * are advised to compare the major for equality and treat the minor as a floor,
+ * so a test should assert on the major rather than on this whole string.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
+ */
+export const SIM_S3_EVENT_VERSION = "2.5";
+
+/**
+ * The event schema version inside the `s3` block, which is separate from the
+ * message version and has not moved off 1.0.
+ */
+const s3SchemaVersion = "1.0";
+
+/**
+ * The `Records` document a destination receives for one Object event.
+ *
+ * One event produces one record. Real S3 batches nothing for a Lambda
+ * destination either: a function configured for a Bucket is invoked once per
+ * event, with an array holding the single record.
+ */
+export function simS3EventRecordsDocument(
+  event: SimS3ObjectEvent,
+  configurationId: string,
+): object {
+  return {
+    Records: [
+      {
+        eventVersion: SIM_S3_EVENT_VERSION,
+        eventSource: "aws:s3",
+        awsRegion: event.regionName,
+        eventTime: event.eventTime.toISOString(),
+        // The record names the event type without the "s3:" prefix the
+        // configuration uses.
+        eventName: event.eventName.replace("s3:", ""),
+        userIdentity: { principalId: event.principalId },
+        requestParameters: { sourceIPAddress: simS3EventSourceIpAddress },
+        responseElements: {
+          "x-amz-request-id": simS3EventRequestId(),
+          "x-amz-id-2": simS3EventRequestId(),
+        },
+        s3: {
+          s3SchemaVersion,
+          configurationId,
+          bucket: {
+            name: event.bucketName,
+            ownerIdentity: { principalId: event.ownerAccountId },
+            arn: event.bucketArn,
+          },
+          object: {
+            key: simS3EventObjectKey(event.key),
+            ...(event.size !== undefined && { size: event.size }),
+            ...(event.eTag !== undefined && { eTag: event.eTag }),
+            sequencer: event.sequencer,
+          },
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * The address a simulated request came from.
+ *
+ * A request to simulated S3 is made in this process, so the loopback address
+ * is the honest answer. A test asserting on it is asserting on the simulator
+ * rather than on anything AWS would report, which is why the Limitations
+ * section says so.
+ */
+const simS3EventSourceIpAddress = "127.0.0.1";
+
+/**
+ * A request id for one event.
+ *
+ * Real S3 puts the ids of the request that caused the event here, so AWS
+ * Support can trace it. The simulator has no such ids, so these are generated
+ * per event and match nothing: they are present because the field is, not
+ * because they mean anything.
+ */
+function simS3EventRequestId(): string {
+  return randomUUID().replaceAll("-", "").toUpperCase();
+}
+
+/**
+ * The object key as a record carries it.
+ *
+ * Real S3 form-URL-encodes the key, so a space becomes a plus sign, while the
+ * slashes that make up a key prefix stay as they are.
+ */
+function simS3EventObjectKey(key: string): string {
+  return encodeURIComponent(key).replaceAll("%20", "+").replaceAll("%2F", "/");
+}

--- a/src/service/s3/notification/event/sim-s3-object-etag.ts
+++ b/src/service/s3/notification/event/sim-s3-object-etag.ts
@@ -1,0 +1,11 @@
+import { createHash } from "node:crypto";
+
+/**
+ * The ETag real S3 gives an Object uploaded in one part.
+ *
+ * It is the MD5 of the bytes, in hex. An Object uploaded in several parts gets
+ * a different form, which simulated S3 has no multipart upload to produce.
+ */
+export function simS3ObjectETag(body: Buffer): string {
+  return createHash("md5").update(body).digest("hex");
+}

--- a/src/service/s3/notification/event/sim-s3-object-event-builder.ts
+++ b/src/service/s3/notification/event/sim-s3-object-event-builder.ts
@@ -1,0 +1,110 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimS3NotificationEvent } from "../../bucket/notification/sim-s3-notification-event.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3Object } from "../../object/s3-object.js";
+import { SimS3ObjectSequencers } from "../sim-s3-object-sequencers.js";
+import { simS3EventPrincipalId } from "./sim-s3-event-principal.js";
+import { simS3ObjectETag } from "./sim-s3-object-etag.js";
+import { SimS3ObjectEvent } from "./sim-s3-object-event.js";
+
+/**
+ * An Object a command has just stored.
+ */
+export interface SimS3ObjectCreatedInput {
+  readonly bucket: SimS3Bucket;
+  readonly object: SimS3Object;
+  readonly caller: SimAwsResolvedCaller;
+}
+
+/**
+ * An Object key a command has just removed.
+ */
+export interface SimS3ObjectRemovedInput {
+  readonly bucket: SimS3Bucket;
+  readonly key: string;
+  readonly caller: SimAwsResolvedCaller;
+}
+
+/**
+ * Something that happened to an Object, before any Bucket configuration has
+ * been consulted about it.
+ */
+export interface SimS3RaisedObjectEvent {
+  readonly bucket: SimS3Bucket;
+  readonly eventName: SimS3NotificationEvent;
+  readonly key: string;
+  readonly caller: SimAwsResolvedCaller;
+  readonly size?: number | undefined;
+  readonly eTag?: string | undefined;
+}
+
+interface SimS3ObjectEventBuilderProperties {
+  readonly clock: SimClock;
+}
+
+/**
+ * Turns something that happened to an Object into the event a destination is
+ * offered.
+ *
+ * The sequence numbers live here because they belong to the event rather than
+ * to any destination: every destination configured for one event gets the same
+ * one, and a later event on the same key gets a greater one.
+ */
+export class SimS3ObjectEventBuilder {
+  private readonly clock: SimClock;
+  private readonly sequencers = new SimS3ObjectSequencers();
+
+  constructor(properties: SimS3ObjectEventBuilderProperties) {
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Build the event for an Object that was stored, which carries the Object's
+   * size and ETag.
+   */
+  forCreated(input: SimS3ObjectCreatedInput): SimS3ObjectEvent {
+    return this.build({
+      bucket: input.bucket,
+      eventName: "s3:ObjectCreated:Put",
+      key: input.object.key,
+      caller: input.caller,
+      size: input.object.body.length,
+      eTag: simS3ObjectETag(input.object.body),
+    });
+  }
+
+  /**
+   * Build the event for an Object that was removed, which carries neither size
+   * nor ETag, because the Object they described is gone.
+   */
+  forRemoved(input: SimS3ObjectRemovedInput): SimS3ObjectEvent {
+    return this.build({
+      bucket: input.bucket,
+      eventName: "s3:ObjectRemoved:Delete",
+      key: input.key,
+      caller: input.caller,
+    });
+  }
+
+  private build(raised: SimS3RaisedObjectEvent): SimS3ObjectEvent {
+    const scope = raised.bucket.getAccountRegionScope();
+    const bucketName = raised.bucket.bucketName;
+
+    return new SimS3ObjectEvent({
+      eventName: raised.eventName,
+      // The simulation's own clock, so a frozen clock produces a fixed time.
+      eventTime: this.clock.now(),
+      bucketName,
+      bucketArn: simS3BucketArn(bucketName),
+      regionName: scope.regionName,
+      ownerAccountId: scope.accountId,
+      principalId: simS3EventPrincipalId(raised.caller),
+      key: raised.key,
+      sequencer: this.sequencers.next(bucketName, raised.key),
+      size: raised.size,
+      eTag: raised.eTag,
+    });
+  }
+}

--- a/src/service/s3/notification/event/sim-s3-object-event.ts
+++ b/src/service/s3/notification/event/sim-s3-object-event.ts
@@ -1,0 +1,55 @@
+import type { SimS3NotificationEvent } from "../../bucket/notification/sim-s3-notification-event.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+
+interface SimS3ObjectEventProperties {
+  readonly eventName: SimS3NotificationEvent;
+  readonly eventTime: Date;
+  readonly bucketName: string;
+  readonly bucketArn: string;
+  readonly regionName: AwsRegionName;
+  readonly ownerAccountId: string;
+  readonly principalId: string;
+  readonly key: string;
+  readonly sequencer: string;
+  readonly size?: number | undefined;
+  readonly eTag?: string | undefined;
+}
+
+/**
+ * Something that happened to an Object, in terms no destination owns.
+ *
+ * The `Records` document an S3 event notification is delivered as is one
+ * serialisation of this rather than the thing itself, because a destination
+ * decides its own shape: an SNS topic wraps it, and EventBridge uses a
+ * different schema entirely.
+ *
+ * `size` and `eTag` describe an Object that exists, so a removal carries
+ * neither, as a real S3 removal record does not.
+ */
+export class SimS3ObjectEvent {
+  public readonly eventName: SimS3NotificationEvent;
+  public readonly eventTime: Date;
+  public readonly bucketName: string;
+  public readonly bucketArn: string;
+  public readonly regionName: AwsRegionName;
+  public readonly ownerAccountId: string;
+  public readonly principalId: string;
+  public readonly key: string;
+  public readonly sequencer: string;
+  public readonly size: number | undefined;
+  public readonly eTag: string | undefined;
+
+  constructor(properties: SimS3ObjectEventProperties) {
+    this.eventName = properties.eventName;
+    this.eventTime = properties.eventTime;
+    this.bucketName = properties.bucketName;
+    this.bucketArn = properties.bucketArn;
+    this.regionName = properties.regionName;
+    this.ownerAccountId = properties.ownerAccountId;
+    this.principalId = properties.principalId;
+    this.key = properties.key;
+    this.sequencer = properties.sequencer;
+    this.size = properties.size;
+    this.eTag = properties.eTag;
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-ceiling.ts
+++ b/src/service/s3/notification/sim-s3-notification-ceiling.ts
@@ -1,0 +1,45 @@
+import { SimS3NotificationDeliveryLimit } from "../error/sim-s3-notification.error.js";
+
+/**
+ * How many notifications one simulated S3 scope will deliver.
+ *
+ * High enough that no honest simulation reaches it, low enough that a loop
+ * fails in a moment rather than running until the test times out.
+ */
+export const SIM_S3_NOTIFICATION_DELIVERY_LIMIT = 1000;
+
+/**
+ * The ceiling on notifications a simulated S3 scope delivers.
+ *
+ * A handler that writes back into the Bucket that triggered it never stops in
+ * process, and `backgroundTasksComplete()` waits for work to run out, so the
+ * test hangs with nothing to read. Prefix and suffix filters are the way to
+ * write that architecture safely, and this is what says so when they are
+ * missing.
+ */
+export class SimS3NotificationCeiling {
+  private readonly limit: number;
+  private delivered = 0;
+
+  constructor(limit: number = SIM_S3_NOTIFICATION_DELIVERY_LIMIT) {
+    this.limit = limit;
+  }
+
+  /**
+   * Count one delivery, refusing once the ceiling is reached.
+   */
+  take(bucketName: string): void {
+    this.delivered += 1;
+
+    if (this.delivered > this.limit) {
+      throw new SimS3NotificationDeliveryLimit(
+        `Simulated S3 has delivered ${String(this.limit)} event ` +
+          `notifications and stopped, while notifying for Bucket ` +
+          `${bucketName}. A handler that writes back into the Bucket that ` +
+          "triggered it notifies itself " +
+          "forever; filter the notification configuration by prefix or " +
+          "suffix so the handler's own writes do not match it.",
+      );
+    }
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-delivery.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-notification-delivery.iso.test.ts
@@ -1,0 +1,237 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+  RemovePermissionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+describe("Delivering a simulated S3 event notification", () => {
+  it("stops delivering when the permission is removed afterwards", async () => {
+    // Given a configured Bucket whose function allowed S3 to invoke it
+    const simAws = new SimAws();
+    let invocations = 0;
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            invocations += 1;
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the permission is taken away and an Object is written
+    await simAws.lambda().removePermission(
+      new RemovePermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is delivered: the resource policy is checked again for
+    // every event, rather than remembered from configuration time
+    assertIdentical(invocations, 0);
+    const failures = simAws.s3().getNotificationDeliveryFailures();
+    assertArrayLength(failures, 1);
+    assertTrue(failures[0].wasRefused);
+    assertStringIncludes(failures[0].reason, "does not allow");
+  });
+
+  it("does not fail the PutObject when the handler throws", async () => {
+    // Given a configured Bucket whose function fails on every invocation
+    const simAws = new SimAws();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("could not read the image");
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When two Objects are written
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "dog.jpg",
+        Body: "dog",
+      }),
+    );
+
+    // Then waiting for the simulation to settle does not raise the handler's
+    // failure, as real S3 tells the writer nothing about a delivery
+    await simAws.backgroundTasksComplete();
+
+    // And both failures are there to be read, warned about once between them
+    const failures = simAws.s3().getNotificationDeliveryFailures();
+    assertArrayLength(failures, 2);
+    assertStringIncludes(failures[0].reason, "could not read the image");
+    assertArrayLength(warn.mock.calls, 1);
+    warn.mockRestore();
+  });
+
+  it("stops a notification loop rather than running forever", async () => {
+    // Given a Bucket whose handler writes back into the Bucket that triggered
+    // it, with no filter to keep its own writes out
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    let written = 0;
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            written += 1;
+
+            await simAws.s3().putObject(
+              new PutObjectCommand({
+                Bucket: "uploads",
+                Key: `thumb-${String(written)}.jpg`,
+                Body: "thumbnail",
+              }),
+            );
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the first Object starts it off
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+
+    // Then the simulation gives up with something to read, rather than
+    // draining background work that never runs out
+    let raised: unknown;
+    try {
+      await simAws.backgroundTasksComplete();
+    } catch (error) {
+      raised = error;
+    }
+
+    assertInstanceOf(raised, Error);
+    assertStringIncludes(raised.message, "notifies itself forever");
+  });
+});

--- a/src/service/s3/notification/sim-s3-notification-dispatcher.ts
+++ b/src/service/s3/notification/sim-s3-notification-dispatcher.ts
@@ -1,0 +1,69 @@
+import type { SimS3LambdaNotification } from "../bucket/notification/sim-s3-lambda-notification.js";
+import type { SimS3NotificationDestinations } from "./destination/sim-s3-notification-destination.js";
+import type { SimS3ObjectEvent } from "./event/sim-s3-object-event.js";
+import { SimS3NotificationCeiling } from "./sim-s3-notification-ceiling.js";
+import {
+  SimS3NotificationDeliveryFailure,
+  SimS3NotificationFailures,
+} from "./sim-s3-notification-failures.js";
+
+interface SimS3NotificationDispatcherProperties {
+  readonly destinations: SimS3NotificationDestinations;
+  readonly deliveryLimit?: number | undefined;
+}
+
+/**
+ * Offers one event to one destination, and keeps what came of it.
+ *
+ * Everything a destination raises is recorded rather than thrown, because a
+ * background task left rejected would fail an unrelated
+ * `backgroundTasksComplete()`, and real S3 never reports a delivery failure to
+ * the caller who wrote the Object. The delivery ceiling is the exception, and
+ * is counted outside the guard so that it escapes.
+ */
+export class SimS3NotificationDispatcher {
+  private readonly destinations: SimS3NotificationDestinations;
+  private readonly failures = new SimS3NotificationFailures();
+  private readonly ceiling: SimS3NotificationCeiling;
+
+  constructor(properties: SimS3NotificationDispatcherProperties) {
+    this.destinations = properties.destinations;
+    this.ceiling = new SimS3NotificationCeiling(properties.deliveryLimit);
+  }
+
+  /**
+   * Every notification this scope could not deliver.
+   */
+  get deliveryFailures(): readonly SimS3NotificationDeliveryFailure[] {
+    return this.failures.all;
+  }
+
+  /**
+   * Deliver one event to the destination one configuration names.
+   */
+  async deliver(
+    notification: SimS3LambdaNotification,
+    event: SimS3ObjectEvent,
+  ): Promise<void> {
+    this.ceiling.take(event.bucketName);
+
+    try {
+      await this.destinations.resolve(notification.functionArn).deliver({
+        destinationArn: notification.functionArn,
+        bucketArn: event.bucketArn,
+        bucketOwnerAccountId: event.ownerAccountId,
+        configurationId: notification.id,
+        event,
+      });
+    } catch (error) {
+      this.failures.record(
+        new SimS3NotificationDeliveryFailure({
+          event,
+          destinationArn: notification.functionArn,
+          configurationId: notification.id,
+          error,
+        }),
+      );
+    }
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-failures.ts
+++ b/src/service/s3/notification/sim-s3-notification-failures.ts
@@ -1,0 +1,104 @@
+import { SimS3NotificationNotPermitted } from "../error/sim-s3-notification.error.js";
+import type { SimS3ObjectEvent } from "./event/sim-s3-object-event.js";
+
+interface SimS3NotificationDeliveryFailureProperties {
+  readonly event: SimS3ObjectEvent;
+  readonly destinationArn: string;
+  readonly configurationId: string;
+  readonly error: unknown;
+}
+
+/**
+ * One event a destination did not take.
+ */
+export class SimS3NotificationDeliveryFailure {
+  public readonly event: SimS3ObjectEvent;
+  public readonly destinationArn: string;
+  public readonly configurationId: string;
+  public readonly error: unknown;
+
+  constructor(properties: SimS3NotificationDeliveryFailureProperties) {
+    this.event = properties.event;
+    this.destinationArn = properties.destinationArn;
+    this.configurationId = properties.configurationId;
+    this.error = properties.error;
+  }
+
+  /**
+   * Whether the destination refused the event rather than failing on it.
+   */
+  get wasRefused(): boolean {
+    return this.error instanceof SimS3NotificationNotPermitted;
+  }
+
+  /**
+   * What went wrong, in one line.
+   */
+  get reason(): string {
+    return this.error instanceof Error
+      ? this.error.message
+      : String(this.error);
+  }
+}
+
+/**
+ * What became of the notifications a simulated S3 scope could not deliver.
+ *
+ * Real S3 tells the caller who wrote the Object nothing about a failed
+ * delivery, and neither does this: a handler that throws must not fail the
+ * PutObject that triggered it. Swallowing the failure entirely would make a
+ * broken handler invisible, so every failure is kept for inspection and a
+ * handler that threw is also warned about once.
+ */
+export class SimS3NotificationFailures {
+  private readonly failures: SimS3NotificationDeliveryFailure[] = [];
+  private readonly warned = new Set<string>();
+
+  /**
+   * Every notification this scope could not deliver, oldest first.
+   */
+  get all(): readonly SimS3NotificationDeliveryFailure[] {
+    return this.failures;
+  }
+
+  /**
+   * Record a failed delivery.
+   */
+  record(failure: SimS3NotificationDeliveryFailure): void {
+    this.failures.push(failure);
+
+    if (failure.wasRefused) {
+      // A refusal is a modelled outcome rather than a fault: the resource
+      // policy says no, which is what a test removing a permission is
+      // checking for. It is recorded, not warned about.
+      return;
+    }
+
+    this.warn(failure);
+  }
+
+  /**
+   * Warn about a destination that failed, once per destination and cause.
+   *
+   * Warnings go to the console because that is where a test runner surfaces
+   * them next to the failing expectation they explain; the simulator has no
+   * logger of its own to route them through.
+   */
+  private warn(failure: SimS3NotificationDeliveryFailure): void {
+    const key = `${failure.destinationArn}:${failure.reason}`;
+
+    if (this.warned.has(key)) {
+      return;
+    }
+
+    this.warned.add(key);
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Simulated S3 Bucket ${failure.event.bucketName} could not notify ` +
+        `${failure.destinationArn} of ${failure.event.eventName}: ${
+          failure.reason
+        }`,
+    );
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-filtering.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-notification-filtering.iso.test.ts
@@ -1,0 +1,277 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { assertArrayEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+/**
+ * The part of the event document these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    { readonly s3: { readonly object: { readonly key: string } } },
+  ];
+}
+
+describe("Filtering simulated S3 event notifications by object key", () => {
+  it("notifies for a key under the configured prefix and no other", async () => {
+    // Given a Bucket that notifies a function only for the "raw/" prefix
+    const simAws = new SimAws();
+    const notifiedKeys: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            notifiedKeys.push(event.Records[0].s3.object.key);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // When one Object is written under the prefix and one outside it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cooked/cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the matching one is notified
+    assertArrayEquals(notifiedKeys, ["raw/cat.jpg"]);
+  });
+
+  it("notifies for a key with the configured suffix and no other", async () => {
+    // Given a Bucket that notifies a function only for ".jpg" keys
+    const simAws = new SimAws();
+    const notifiedKeys: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            notifiedKeys.push(event.Records[0].s3.object.key);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "suffix", Value: ".jpg" }] },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an image and a document are written
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "notes.txt",
+        Body: "notes",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the image is notified
+    assertArrayEquals(notifiedKeys, ["cat.jpg"]);
+  });
+
+  it("filters nothing when a rule states a name and no value", async () => {
+    // Given a Bucket whose prefix rule carries no value
+    const simAws = new SimAws();
+    const notifiedKeys: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            notifiedKeys.push(event.Records[0].s3.object.key);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+              Filter: { Key: { FilterRules: [{ Name: "prefix" }] } },
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is written under any prefix
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "anywhere/cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it is notified: the root prefix matches every key
+    assertArrayEquals(notifiedKeys, ["anywhere/cat.jpg"]);
+  });
+
+  it("notifies nothing for an event type nobody configured", async () => {
+    // Given a Bucket that notifies a function only when an Object is removed
+    const simAws = new SimAws();
+    const notifiedKeys: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            notifiedKeys.push(event.Records[0].s3.object.key);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is created
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is notified
+    assertArrayEquals(notifiedKeys, []);
+  });
+});

--- a/src/service/s3/notification/sim-s3-notification-schedule.ts
+++ b/src/service/s3/notification/sim-s3-notification-schedule.ts
@@ -1,0 +1,55 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimS3NotificationEvent } from "../bucket/notification/sim-s3-notification-event.js";
+import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectEvent } from "./event/sim-s3-object-event.js";
+import type { SimS3NotificationDispatcher } from "./sim-s3-notification-dispatcher.js";
+
+interface SimS3NotificationScheduleProperties {
+  readonly background: BackgroundScheduler;
+  readonly dispatcher: SimS3NotificationDispatcher;
+}
+
+/**
+ * Puts an Object event on its way to the destinations a Bucket configured.
+ *
+ * Delivery happens on the background scheduler, as real S3 delivers after the
+ * request that caused it has been answered. `simAws.backgroundTasksComplete()`
+ * is what waits for it.
+ */
+export class SimS3NotificationSchedule {
+  private readonly background: BackgroundScheduler;
+  private readonly dispatcher: SimS3NotificationDispatcher;
+
+  constructor(properties: SimS3NotificationScheduleProperties) {
+    this.background = properties.background;
+    this.dispatcher = properties.dispatcher;
+  }
+
+  /**
+   * Schedule delivery to every configuration that wants this event.
+   *
+   * The event is built only once something wants it, because building one
+   * hashes the Object's bytes and a Bucket nobody configured should not pay
+   * for that.
+   */
+  matching(
+    bucket: SimS3Bucket,
+    eventName: SimS3NotificationEvent,
+    key: string,
+    build: () => SimS3ObjectEvent,
+  ): void {
+    const wanting = bucket.getNotifications().matching(eventName, key);
+
+    if (wanting.length === 0) {
+      return;
+    }
+
+    const event = build();
+
+    for (const notification of wanting) {
+      this.background.schedule(async () => {
+        await this.dispatcher.deliver(notification, event);
+      });
+    }
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-service-construction.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-notification-service-construction.iso.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Simulated Lambda reaches this scope's simulated S3 while it is being built,
+ * for function code held in a Bucket. If simulated S3 reached back for Lambda
+ * the same way, building either one first would recurse: the memo behind the
+ * per-scope service accessors records a service only once its factory has
+ * returned, and has no re-entrancy guard.
+ *
+ * The bug only shows up under one construction order, so both are exercised
+ * here.
+ */
+
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+describe("Constructing simulated S3 and Lambda in either order", () => {
+  it("builds S3 first", async () => {
+    // Given a simulated AWS whose S3 is asked for first
+    const simAws = new SimAws();
+
+    // When a Bucket and then a function are created
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+
+    // Then both services are there
+    assertNonNullable(
+      simAws.s3().getSimBucketByName("uploads"),
+      "the Bucket was created",
+    );
+    assertIdentical(
+      simAws.lambda().getSimFunctionByName("thumbnailer")?.name,
+      "thumbnailer",
+    );
+  });
+
+  it("builds Lambda first", async () => {
+    // Given a simulated AWS whose Lambda is asked for first
+    const simAws = new SimAws();
+
+    // When a function and then a Bucket are created
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "thumbnailed") },
+      }),
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // Then both services are there
+    assertNonNullable(
+      simAws.s3().getSimBucketByName("uploads"),
+      "the Bucket was created",
+    );
+    assertIdentical(
+      simAws.lambda().getSimFunctionByName("thumbnailer")?.name,
+      "thumbnailer",
+    );
+  });
+});

--- a/src/service/s3/notification/sim-s3-object-created-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-object-created-notification.iso.test.ts
@@ -1,0 +1,385 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringStartsWith,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const thumbnailerArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
+
+/**
+ * The shape of the event document a handler receives, as far as these tests
+ * read it.
+ */
+interface S3EventRecord {
+  readonly eventVersion: string;
+  readonly eventSource: string;
+  readonly awsRegion: string;
+  readonly eventTime: string;
+  readonly eventName: string;
+  readonly userIdentity: { readonly principalId: string };
+  readonly s3: {
+    readonly configurationId: string;
+    readonly bucket: { readonly name: string; readonly arn: string };
+    readonly object: {
+      readonly key: string;
+      readonly size?: number;
+      readonly eTag?: string;
+      readonly sequencer: string;
+    };
+  };
+}
+
+interface S3EventDocument {
+  readonly Records: readonly [S3EventRecord];
+}
+
+describe("Notifying a simulated Lambda function of a created Object", () => {
+  it("invokes the function with the S3 event document", async () => {
+    // Given a Bucket that notifies a function when an Object is created
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+        SourceAccount: simAws.defaultAccountId,
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "thumbnails",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function was invoked once with the event S3 sends
+    assertArrayLength(received, 1);
+    const records = received[0].Records;
+    assertArrayLength(records, 1);
+    assertStringStartsWith(records[0].eventVersion, "2.");
+    assertIdentical(records[0].eventSource, "aws:s3");
+    assertIdentical(records[0].awsRegion, "us-east-1");
+    assertIdentical(records[0].eventName, "ObjectCreated:Put");
+    assertIdentical(records[0].s3.configurationId, "thumbnails");
+    assertIdentical(records[0].s3.bucket.name, "uploads");
+    assertIdentical(records[0].s3.bucket.arn, "arn:aws:s3:::uploads");
+    const { key, size, eTag } = records[0].s3.object;
+    assertIdentical(key, "raw/cat.jpg");
+    assertIdentical(size, 11);
+    // The ETag of an Object real S3 stored in one part is the MD5 of its bytes.
+    assertIdentical(eTag, "189f2c9e9bf1c7804c76384671f113ed");
+  });
+
+  it("takes its event time from the simulation's clock", async () => {
+    // Given a frozen simulated clock, and a Bucket notifying a function
+    const simAws = new SimAws();
+    simAws.clock().freeze();
+    await simAws.clock().setTo(new Date("2027-03-04T05:06:07.000Z"));
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "thumbnails",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the event carries the simulated instant rather than the host's
+    assertArrayLength(received, 1);
+    assertIdentical(
+      received[0].Records[0].eventTime,
+      "2027-03-04T05:06:07.000Z",
+    );
+  });
+
+  it("form-URL-encodes the object key, as real S3 does", async () => {
+    // Given a Bucket notifying a function
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object whose key contains a space is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "images/red flower.jpg",
+        Body: "flower",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the key arrives encoded, with the prefix separator left alone
+    assertArrayLength(received, 1);
+    assertIdentical(
+      received[0].Records[0].s3.object.key,
+      "images/red+flower.jpg",
+    );
+  });
+
+  it("names the caller that wrote the Object", async () => {
+    // Given a Bucket notifying a function
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a named principal writes an Object
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "UploaderRole",
+        actions: ["s3:PutObject"],
+        resource: "arn:aws:s3:::uploads/*",
+      },
+      simAws,
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the event names it. Real S3 puts the principal's unique id here;
+    // simulated IAM carries ARNs, so the ARN is what a test can assert on.
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].userIdentity.principalId, role.Arn);
+  });
+
+  it("orders the events for one key with the sequencer", async () => {
+    // Given a Bucket notifying a function
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the same key is written twice
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "one",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "two",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the later event carries the greater sequencer
+    assertArrayLength(received, 2);
+    const first = received[0].Records[0].s3.object.sequencer;
+    const second = received[1].Records[0].s3.object.sequencer;
+    assertTrue(first < second);
+  });
+});

--- a/src/service/s3/notification/sim-s3-object-notifier.ts
+++ b/src/service/s3/notification/sim-s3-object-notifier.ts
@@ -1,0 +1,73 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimS3NotificationDestinations } from "./destination/sim-s3-notification-destination.js";
+import {
+  type SimS3ObjectCreatedInput,
+  type SimS3ObjectRemovedInput,
+  SimS3ObjectEventBuilder,
+} from "./event/sim-s3-object-event-builder.js";
+import { SimS3NotificationDispatcher } from "./sim-s3-notification-dispatcher.js";
+import type { SimS3NotificationDeliveryFailure } from "./sim-s3-notification-failures.js";
+import { SimS3NotificationSchedule } from "./sim-s3-notification-schedule.js";
+
+interface SimS3ObjectNotifierProperties {
+  readonly destinations: SimS3NotificationDestinations;
+  readonly background: BackgroundScheduler;
+  readonly deliveryLimit?: number | undefined;
+}
+
+/**
+ * Raises simulated S3 Object events to the destinations a Bucket configured.
+ *
+ * The Object commands call this once each, after the write has happened and
+ * with the caller they authorized, because that is the only layer holding both
+ * the caller and the knowledge of which event this is. One notifier is shared
+ * across the commands of a simulated S3 scope, so the per-key sequence numbers
+ * and the delivery ceiling see every event rather than one command's worth.
+ */
+export class SimS3ObjectNotifier {
+  private readonly events: SimS3ObjectEventBuilder;
+  private readonly dispatcher: SimS3NotificationDispatcher;
+  private readonly schedule: SimS3NotificationSchedule;
+
+  constructor(properties: SimS3ObjectNotifierProperties) {
+    this.events = new SimS3ObjectEventBuilder({
+      clock: properties.background,
+    });
+    this.dispatcher = new SimS3NotificationDispatcher(properties);
+    this.schedule = new SimS3NotificationSchedule({
+      background: properties.background,
+      dispatcher: this.dispatcher,
+    });
+  }
+
+  /**
+   * Every notification this scope could not deliver.
+   */
+  get deliveryFailures(): readonly SimS3NotificationDeliveryFailure[] {
+    return this.dispatcher.deliveryFailures;
+  }
+
+  /**
+   * Raise an Object creation.
+   */
+  objectCreated(input: SimS3ObjectCreatedInput): void {
+    this.schedule.matching(
+      input.bucket,
+      "s3:ObjectCreated:Put",
+      input.object.key,
+      () => this.events.forCreated(input),
+    );
+  }
+
+  /**
+   * Raise an Object removal.
+   */
+  objectRemoved(input: SimS3ObjectRemovedInput): void {
+    this.schedule.matching(
+      input.bucket,
+      "s3:ObjectRemoved:Delete",
+      input.key,
+      () => this.events.forRemoved(input),
+    );
+  }
+}

--- a/src/service/s3/notification/sim-s3-object-removed-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-object-removed-notification.iso.test.ts
@@ -1,0 +1,240 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const cleanerArn = "arn:aws:lambda:us-east-1:888888888888:function:cleaner";
+
+/**
+ * The part of the event document these tests read.
+ */
+interface S3EventRecord {
+  readonly eventName: string;
+  readonly s3: {
+    readonly object: {
+      readonly key: string;
+      readonly size?: number;
+      readonly eTag?: string;
+      readonly sequencer: string;
+    };
+  };
+}
+
+interface S3EventDocument {
+  readonly Records: readonly [S3EventRecord];
+}
+
+describe("Notifying a simulated Lambda function of a removed Object", () => {
+  it("raises ObjectRemoved:Delete without a size or an ETag", async () => {
+    // Given a Bucket holding an Object, notifying a function when one is
+    // removed
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "cleaner",
+        Role: "arn:aws:iam::888888888888:role/CleanerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "cleaned";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "cleaner",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "cleanup",
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: cleanerArn,
+            },
+          ],
+        },
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+
+    // When the Object is deleted
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "cat.jpg" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the removal is notified, describing an Object that is no longer
+    // there
+    assertArrayLength(received, 1);
+    const record = received[0].Records[0];
+    assertIdentical(record.eventName, "ObjectRemoved:Delete");
+    assertIdentical(record.s3.object.key, "cat.jpg");
+    assertUndefined(record.s3.object.size);
+    assertUndefined(record.s3.object.eTag);
+  });
+
+  it("raises nothing for a key that was not there", async () => {
+    // Given a Bucket with nothing in it, notifying a function on removal
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "cleaner",
+        Role: "arn:aws:iam::888888888888:role/CleanerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "cleaned";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "cleaner",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: cleanerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a key that was never stored is deleted
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "never-here.jpg" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is notified: no deletion happened
+    assertArrayLength(received, 0);
+  });
+
+  it("raises one event per Object a batch deletion removed", async () => {
+    // Given a Bucket holding two Objects, notifying a function on removal
+    const simAws = new SimAws();
+    const notifiedKeys: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "cleaner",
+        Role: "arn:aws:iam::888888888888:role/CleanerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            notifiedKeys.push(event.Records[0].s3.object.key);
+
+            return "cleaned";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "cleaner",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: cleanerArn,
+            },
+          ],
+        },
+      }),
+    );
+    await simAws
+      .s3()
+      .putObject(
+        new PutObjectCommand({ Bucket: "uploads", Key: "a.jpg", Body: "a" }),
+      );
+    await simAws
+      .s3()
+      .putObject(
+        new PutObjectCommand({ Bucket: "uploads", Key: "b.jpg", Body: "b" }),
+      );
+
+    // When both are deleted in one request, alongside a key that is not there
+    await simAws.s3().deleteObjects(
+      new DeleteObjectsCommand({
+        Bucket: "uploads",
+        Delete: {
+          Objects: [{ Key: "a.jpg" }, { Key: "b.jpg" }, { Key: "c.jpg" }],
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then one event is raised per Object actually removed
+    assertArrayEquals(
+      notifiedKeys.toSorted((one, other) => one.localeCompare(other)),
+      ["a.jpg", "b.jpg"],
+    );
+  });
+});

--- a/src/service/s3/notification/sim-s3-object-sequencers.ts
+++ b/src/service/s3/notification/sim-s3-object-sequencers.ts
@@ -1,0 +1,25 @@
+/**
+ * The sequence numbers events about one Object key carry.
+ *
+ * Real S3 gives every create and remove event a hexadecimal string that orders
+ * the events for one key, so a consumer holding an index can tell a late
+ * arrival from a later change. It says nothing about the order of events on
+ * different keys, which is why the count is kept per key.
+ *
+ * The values are fixed width so a plain string comparison orders them, where
+ * real S3's vary in length and have to be left-padded before comparing.
+ */
+export class SimS3ObjectSequencers {
+  private readonly counts = new Map<string, number>();
+
+  /**
+   * The next sequence number for an Object key.
+   */
+  next(bucketName: string, key: string): string {
+    const id = `${bucketName}/${key}`;
+    const count = (this.counts.get(id) ?? 0) + 1;
+    this.counts.set(id, count);
+
+    return count.toString(16).toUpperCase().padStart(16, "0");
+  }
+}

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -5,9 +5,11 @@ import {
   DeleteObjectCommand,
   DeleteObjectsCommand,
   DeletePublicAccessBlockCommand,
+  GetBucketNotificationConfigurationCommand,
   GetBucketPolicyCommand,
   GetPublicAccessBlockCommand,
   ListObjectsCommand,
+  PutBucketNotificationConfigurationCommand,
   PutBucketPolicyCommand,
   PutBucketWebsiteCommand,
   PutObjectCommand,
@@ -207,13 +209,37 @@ describe("simulated S3 SDK Command routing", () => {
     assertIdentical(remaining[0].Key, "c.txt");
   });
 
+  it("routes the Bucket notification configuration Commands", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-n" }));
+    await client.send(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "bucket-n",
+        // Nothing is configured, so nothing has to exist to be notified. What
+        // this is about is that both Commands reach simulated S3 at all.
+        NotificationConfiguration: {},
+      }),
+    );
+
+    const read = await client.send(
+      new GetBucketNotificationConfigurationCommand({ Bucket: "bucket-n" }),
+    );
+
+    assertUndefined(read.LambdaFunctionConfigurations);
+  });
+
   it("lists its supported SDK Command names", () => {
     const router = new SimS3SdkCommandRouter({} as SimS3);
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 14);
+    assertArrayLength(supported, 16);
     assertArrayIncludes(supported, "GetObjectCommand");
+    assertArrayIncludes(supported, "PutBucketNotificationConfigurationCommand");
+    assertArrayIncludes(supported, "GetBucketNotificationConfigurationCommand");
     assertArrayIncludes(supported, "DeleteObjectCommand");
     assertArrayIncludes(supported, "DeleteObjectsCommand");
     assertArrayIncludes(supported, "GetBucketPolicyCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -14,7 +14,9 @@ import type { SimListObjectsCommand } from "../command/list-objects/list-objects
 import type { SimDeleteBucketPolicyCommand } from "../command/delete-bucket-policy/delete-bucket-policy.command.js";
 import type { SimDeleteObjectCommand } from "../command/delete-object/delete-object.command.js";
 import type { SimDeleteObjectsCommand } from "../command/delete-objects/delete-objects.command.js";
+import type { SimGetBucketNotificationConfigurationCommand } from "../command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.js";
 import type { SimGetBucketPolicyCommand } from "../command/get-bucket-policy/get-bucket-policy.command.js";
+import type { SimPutBucketNotificationConfigurationCommand } from "../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.command.js";
 import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.command.js";
 import type { SimPutObjectCommand } from "../command/put-object/put-object.command.js";
@@ -101,6 +103,22 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simS3.putBucketPolicy(
             command as SimPutBucketPolicyCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutBucketNotificationConfigurationCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.putBucketNotificationConfiguration(
+            command as SimPutBucketNotificationConfigurationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetBucketNotificationConfigurationCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.getBucketNotificationConfiguration(
+            command as SimGetBucketNotificationConfigurationCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -10,9 +10,13 @@ import {
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3BucketCommands } from "./command/bucket/sim-s3-bucket-commands.js";
 import { SimS3BucketPolicyCommands } from "./command/bucket-policy/sim-s3-bucket-policy-commands.js";
+import { SimS3NotificationCommands } from "./command/notification/sim-s3-notification-commands.js";
 import { SimS3ObjectCommands } from "./command/object/sim-s3-object-commands.js";
 import { SimS3PublicAccessBlockCommands } from "./command/public-access-block/sim-s3-public-access-block-commands.js";
 import type { SimS3BucketCommandState } from "./command/sim-s3-bucket-command-state.js";
+import type { SimS3NotificationDestinations } from "./notification/destination/sim-s3-notification-destination.js";
+import { SimS3NoNotificationDestinations } from "./notification/destination/sim-s3-service-notification-destinations.js";
+import { SimS3ObjectNotifier } from "./notification/sim-s3-object-notifier.js";
 import type { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
 
 /**
@@ -23,6 +27,12 @@ export interface SimS3Properties {
   readonly s3GlobalRegistry?: SimS3GlobalRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
+  /**
+   * Where this S3 can send Bucket event notifications. A SimS3 built on its own
+   * has nothing to notify, and says so when a configuration names a
+   * destination.
+   */
+  readonly notificationDestinations?: SimS3NotificationDestinations;
 }
 
 interface SimS3CommandsProperties extends SimS3Properties {
@@ -43,18 +53,28 @@ export class SimS3Commands {
   public readonly buckets: SimS3BucketCommands;
   public readonly bucketPolicies: SimS3BucketPolicyCommands;
   public readonly publicAccessBlocks: SimS3PublicAccessBlockCommands;
+  public readonly notifications: SimS3NotificationCommands;
   public readonly objects: SimS3ObjectCommands;
+  public readonly objectNotifier: SimS3ObjectNotifier;
 
   constructor(properties: SimS3CommandsProperties) {
     const {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
+      notificationDestinations = new SimS3NoNotificationDestinations(),
     } = properties;
+
+    this.objectNotifier = new SimS3ObjectNotifier({
+      destinations: notificationDestinations,
+      background,
+    });
 
     const state: SimS3BucketCommandState = {
       buckets: properties.buckets,
       iam,
       background,
+      notificationDestinations,
+      notifications: this.objectNotifier,
     };
 
     this.buckets = new SimS3BucketCommands({
@@ -64,6 +84,7 @@ export class SimS3Commands {
     });
     this.bucketPolicies = new SimS3BucketPolicyCommands(state);
     this.publicAccessBlocks = new SimS3PublicAccessBlockCommands(state);
+    this.notifications = new SimS3NotificationCommands(state);
     this.objects = new SimS3ObjectCommands(state);
   }
 }

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -15,6 +15,7 @@ import { SimS3Commands, type SimS3Properties } from "./sim-s3-commands.js";
 import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
+import type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";
 
 /**
  * Simulated S3. Handles SDK commands. Emulates AWS behaviour and state.
@@ -127,6 +128,26 @@ export class SimS3 {
   }
 
   /**
+   * Handle a Put Bucket Notification Configuration Command from the SDK.
+   */
+  async putBucketNotificationConfiguration(
+    command: simS3Commands.SimPutBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketNotificationConfigurationCommandOutput> {
+    return await this.commands.notifications.put(command, options);
+  }
+
+  /**
+   * Handle a Get Bucket Notification Configuration Command from the SDK.
+   */
+  async getBucketNotificationConfiguration(
+    command: simS3Commands.SimGetBucketNotificationConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketNotificationConfigurationCommandOutput> {
+    return await this.commands.notifications.get(command, options);
+  }
+
+  /**
    * Handle a List Buckets Command from the SDK.
    */
   async listBuckets(
@@ -193,6 +214,15 @@ export class SimS3 {
     bucketName: SimS3BucketName | string,
   ): SimS3Bucket | undefined {
     return this.buckets.get(bucketName as SimS3BucketName);
+  }
+
+  /**
+   * Get the Bucket event notifications this S3 could not deliver, which is the
+   * only place a handler that threw or a destination that refused shows up:
+   * real S3 tells the caller who wrote the Object nothing about a delivery.
+   */
+  getNotificationDeliveryFailures(): readonly SimS3NotificationDeliveryFailure[] {
+    return this.commands.objectNotifier.deliveryFailures;
   }
 
   /**

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -110,7 +110,7 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
    * someone's files because a test called DeleteObject is the wrong default, so
    * filesystem-backed Buckets are read and written but never emptied.
    */
-  deleteObject(key: string): Promise<void> {
+  deleteObject(key: string): Promise<boolean> {
     return Promise.reject(
       new SimS3NotImplemented(
         `Simulated S3 will not delete ${key} from filesystem-backed storage ` +

--- a/src/service/s3/storage/s3-bucket-storage.ts
+++ b/src/service/s3/storage/s3-bucket-storage.ts
@@ -17,9 +17,11 @@ export interface SimS3BucketStorage {
   listObjects(prefix?: string): Promise<SimS3Object[]>;
 
   /**
-   * Remove a simulated Object from storage.
+   * Remove a simulated Object from storage, reporting whether there was one.
    *
    * S3 deletion is idempotent, so a key that is not stored is not an error.
+   * Whether anything was removed is still worth answering, because an Object
+   * event notification describes a deletion that happened.
    */
-  deleteObject(key: string): Promise<void>;
+  deleteObject(key: string): Promise<boolean>;
 }

--- a/src/service/s3/storage/s3-memory-storage.ts
+++ b/src/service/s3/storage/s3-memory-storage.ts
@@ -39,8 +39,7 @@ export class MemoryS3BucketStorage implements SimS3BucketStorage {
    * A key that is not stored is not an error, as real S3 answers a deletion the
    * same way whether or not there was anything there.
    */
-  deleteObject(key: string): Promise<void> {
-    this.objects.delete(key);
-    return Promise.resolve();
+  deleteObject(key: string): Promise<boolean> {
+    return Promise.resolve(this.objects.delete(key));
   }
 }


### PR DESCRIPTION
… deleted in a simulated S3 Bucket

Configure a simulated S3 Bucket with PutBucketNotificationConfiguration and put or delete an Object, and a simulated Lambda function is invoked with the S3 event document. The function's resource policy decides whether S3 may invoke it, checked when the configuration is applied and again for every event.

Resolves https://github.com/KensioSoftware/yulin/issues/331