### PR TITLE
feat: authorize a simulated SQS request against a queue policy

### DIFF
--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -440,8 +440,9 @@ console.log(read.Attributes?.["ApproximateNumberOfMessagesNotVisible"]); // "1"
 console.log(read.Attributes?.["QueueArn"]); // "arn:aws:sqs:us-east-1:888888888888:orders"
 ```
 
-`RedrivePolicy` is the one other settable attribute, covered under
-[dead-letter queues](#dead-letter-queues) above.
+The other two settable attributes are JSON documents: `RedrivePolicy`, covered under
+[dead-letter queues](#dead-letter-queues) above, and `Policy`, covered under
+[queue policies](#queue-policies) below. Both are reported back as the string they were set with.
 
 An attribute real SQS reports and this simulation does not model, `RedriveAllowPolicy` for one, is
 left out of a response rather than refused, since that is what real SQS does with an attribute a queue
@@ -460,6 +461,10 @@ can get wrong:
   `arn:aws:sqs:<region>:<account-id>:*`. A policy naming one queue grants no listing.
 - The batch operations are authorized as their singular action. There is no `sqs:SendMessageBatch`,
   `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action for a policy to name.
+
+The queue's own policy is part of the decision too, covered under [queue policies](#queue-policies)
+below. A caller with no permission is refused whether or not the queue exists, since a queue that is
+not there has no policy to admit anyone with.
 
 ```typescript sim-sqs-iam-policy
 /**
@@ -536,6 +541,93 @@ try {
   console.log((error as Error).name); // "AccessDenied"
 }
 ```
+
+## Queue policies
+
+A queue's `Policy` attribute is its resource policy, and simulated IAM evaluates it as one. It is
+what admits a caller that has no identity policy of its own: a principal from another account, or a
+service principal such as `s3.amazonaws.com`, which owns no identity policies anywhere.
+
+The policy is set with `CreateQueue` or `SetQueueAttributes` and read back with
+`GetQueueAttributes`.
+
+```typescript sim-sqs-queue-policy
+/**
+ * A queue policy admitting S3 to send to a queue, for one Bucket only.
+ */
+
+import {
+  CreateQueueCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "s3.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+// S3 has no identity policies anywhere, so the queue policy is the whole
+// decision. What it is sending for goes in as aws:SourceArn.
+const s3 = { kind: "service", service: "s3.amazonaws.com" } as const;
+
+const sent = await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "uploads/order-1.json" }),
+  { caller: s3, sourceArn: "arn:aws:s3:::uploads" },
+);
+
+console.log(sent.MessageId !== undefined); // true
+
+// A Bucket the condition does not cover is refused.
+try {
+  await sqs.sendMessage(
+    new SendMessageCommand({ QueueUrl, MessageBody: "reports/order-1.json" }),
+    { caller: s3, sourceArn: "arn:aws:s3:::reports" },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}
+```
+
+`sourceArn` is what a request says it is being made on behalf of. A request that does not carry one
+leaves the key out rather than supplying an empty string, so a statement conditioned on
+`aws:SourceArn` does not match it at all.
+
+A caller from another account needs both sides to allow the request, as it does on real AWS: the
+queue policy naming the principal, and that principal's own account allowing the action. Either one
+on its own is a denial.
+
+The policy is validated when it is set, by `CreateQueue` or `SetQueueAttributes`, so a malformed
+document fails there rather than the first time something is authorized against it. It has to be a
+JSON policy document whose statements each carry an `Effect` of `Allow` or `Deny`, an `Action` or
+`NotAction`, and a `Resource` or `NotResource`. Anything else fails with `InvalidAttributeValue`.
+
+`GetQueueAttributes` reports `Policy` back as the string it was set with.
 
 ## Batches
 
@@ -969,12 +1061,35 @@ dropped: `RedrivePolicy`, `RedriveAllowPolicy`, `KmsMasterKeyId`, `KmsDataKeyReu
 `SqsManagedSseEnabled`, `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and
 `Tags`. So does a property `AWS::SQS::Queue` does not have.
 
-`AWS::SQS::QueuePolicy` is skipped rather than deployed, since queue policies are not simulated. The
-rest of the stack still deploys.
+`AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
+`SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
+one set through the SDK, and a document SQS would refuse fails the resource. `Queues` carries queue
+URLs, which is what `Ref` on an `AWS::SQS::Queue` gives.
+
+```typescript
+{
+  Type: "AWS::SQS::QueuePolicy",
+  Properties: {
+    Queues: [{ Ref: "OrdersQueue" }],
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: { "Fn::GetAtt": ["OrdersQueue", "Arn"] },
+        },
+      ],
+    },
+  },
+}
+```
 
 CDK works without hand-editing. An `sqs.Queue` with `grantSendMessages(fn)` synthesises a template
 that deploys here, with the queue URL reaching the function through its environment and the grant
-policy naming the queue by the ARN `Fn::GetAtt` gives.
+policy naming the queue by the ARN `Fn::GetAtt` gives. A grant to a service principal synthesises an
+`AWS::SQS::QueuePolicy` alongside it, which deploys too.
 
 ## Available functionality
 
@@ -992,11 +1107,13 @@ Sim SQS currently supports:
 - The `SentTimestamp`, `ApproximateReceiveCount`, `ApproximateFirstReceiveTimestamp` and
   `DeadLetterQueueSourceArn` system attributes
 - Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
+- The `Policy` attribute as the queue's resource policy, admitting another account's principal or a
+  service principal, with `aws:SourceArn` conditions honoured
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - Lambda event source mappings, delivering messages to a simulated function and deleting the batches
   it handles
-- `AWS::SQS::Queue` in a CloudFormation or CDK template, with `Ref` giving the queue URL and
-  `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`
+- `AWS::SQS::Queue` and `AWS::SQS::QueuePolicy` in a CloudFormation or CDK template, with `Ref`
+  giving the queue URL and `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`
 
 ## Limitations
 
@@ -1027,9 +1144,13 @@ Current documented limitations:
 - The `RedrivePolicy` property on `AWS::SQS::Queue` is not simulated, so a dead-letter queue is
   configured by an SDK call rather than by a template. The property fails the resource rather than
   being dropped.
-- Queue policies are not simulated (`AddPermission`, `RemovePermission` and the `Policy` attribute),
-  so cross-account access to a queue cannot be granted. A request naming a
-  `QueueOwnerAWSAccountId` other than the scope's own Account is refused.
+- A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
+  which are shorthands for writing one statement of it, are not supported.
+- `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document
+  and adds an `Id` and a `Sid` to it, so what comes back there is not byte for byte what went in.
+- A request naming a `QueueOwnerAWSAccountId` other than the scope's own account is refused. A queue
+  policy admits another account's principal to a queue here; it does not make another account's
+  queues reachable through this one.
 - Encryption is not simulated. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
   `SqsManagedSseEnabled` are refused, and message bodies are held in process memory as they were
   sent. That is not a security boundary: anything sharing the process can reach them.
@@ -1046,7 +1167,7 @@ Current documented limitations:
   and scales them with the queue, so nothing here shows what that concurrency does to ordering. See
   [simulated Lambda](../lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event
 source mapping docs") for the rest of the mapping limitations.
-- `AWS::SQS::Queue` is the only SQS resource type CloudFormation creates. `AWS::SQS::QueuePolicy` is
-  skipped, and the queue properties this simulation has no behaviour for fail the resource rather
-  than being dropped.
+- `AWS::SQS::Queue` and `AWS::SQS::QueuePolicy` are the SQS resource types CloudFormation creates.
+  Any other is skipped, and the queue properties this simulation has no behaviour for fail the
+  resource rather than being dropped.
 - SQS is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/sqs/sim-sqs-queue-policy.example.ts
+++ b/docs/services/sqs/sim-sqs-queue-policy.example.ts
@@ -1,0 +1,60 @@
+/**
+ * A queue policy admitting S3 to send to a queue, for one Bucket only.
+ */
+
+import {
+  CreateQueueCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await sqs.createQueue(
+  new CreateQueueCommand({ QueueName: "orders" }),
+);
+
+await sqs.setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "s3.amazonaws.com" },
+            Action: "sqs:SendMessage",
+            Resource: queueArn,
+            Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+          },
+        ],
+      }),
+    },
+  }),
+);
+
+// S3 has no identity policies anywhere, so the queue policy is the whole
+// decision. What it is sending for goes in as aws:SourceArn.
+const s3 = { kind: "service", service: "s3.amazonaws.com" } as const;
+
+const sent = await sqs.sendMessage(
+  new SendMessageCommand({ QueueUrl, MessageBody: "uploads/order-1.json" }),
+  { caller: s3, sourceArn: "arn:aws:s3:::uploads" },
+);
+
+console.log(sent.MessageId !== undefined); // true
+
+// A Bucket the condition does not cover is refused.
+try {
+  await sqs.sendMessage(
+    new SendMessageCommand({ QueueUrl, MessageBody: "reports/order-1.json" }),
+    { caller: s3, sourceArn: "arn:aws:s3:::reports" },
+  );
+} catch (error) {
+  console.log((error as Error).name); // "AccessDenied"
+}

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -41,9 +41,12 @@ splits reading an attribute from setting one: an attribute real SQS has and this
 is left out of a response, as real SQS leaves out an attribute a queue has no value for, but setting
 one is refused rather than ignored.
 
-`SimSqsRedrivePolicy` is held apart from the numeric attributes, because it is a JSON object and
-because a queue has none until one is set. It keeps the string it was parsed from, so
-`GetQueueAttributes` reports back what was set rather than a re-serialised version of it.
+`SimSqsRedrivePolicy` and `SimSqsQueuePolicy` are held apart from the numeric attributes, because they
+are JSON documents and because a queue has neither until one is set. Both keep the string they were
+parsed from, so `GetQueueAttributes` reports back what was set rather than a re-serialised version of
+it. `SimSqsQueuePolicy` validates through sim IAM's own `SimIamPolicyDocumentValidator`, so a queue
+policy is held to the same rules as any other policy document, and it is held to them when the
+attribute is set rather than when the policy is first evaluated.
 `SimSqsDeadLetterTargets` resolves the queue a policy names, matching whole ARNs rather than reading
 the name out of one: that keeps the account and region in the comparison, which is what makes an ARN
 naming another scope find nothing. The target is checked when the policy is set, because a policy
@@ -117,9 +120,10 @@ rather than one class per command, so the `SimSqs` facade stays a delegation:
 - `command/sim-sqs-command.types.ts` — the command types gathered for the facade
 
 `SimSqsQueueAccess` is how every operation but `ListQueues` reaches its queue: read the queue URL,
-authorize the action against the ARN that URL implies, then look the queue up. Authorization comes
-first because real IAM decides before the service does anything, so a caller with no permission is
-refused whether or not the queue exists.
+find the queue that URL implies, authorize the action against it, then require it to be there.
+Finding the queue comes before authorizing because the queue's own policy is part of the decision.
+A caller with no permission is still refused for a queue that does not exist rather than told the
+queue is missing, because a queue that is not there contributes no policy and cannot admit anyone.
 
 `SimSqsMessageWriter` is shared by `SendMessage` and every entry of `SendMessageBatch`, so the two
 cannot drift apart on what a delay means or how large a body may be. `SimSqsReceiveRequest` is the
@@ -137,10 +141,16 @@ command instances.
 
 ## CloudFormation
 
-`cfn/` holds the `AWS::SQS::Queue` resource factory. `SimCfnSqsQueueProperties` reads the template
-properties into the shape `CreateQueue` takes, and `SimCfnSqsQueueCreator` sends that command, so a
-queue a template deployed is the same thing an SDK caller would have got. Nothing about the attribute
-ranges or the name rules is repeated here.
+`cfn/` holds the `AWS::SQS::Queue` and `AWS::SQS::QueuePolicy` resource factories.
+`SimCfnSqsQueueProperties` reads the template properties into the shape `CreateQueue` takes, and
+`SimCfnSqsQueueCreator` sends that command, so a queue a template deployed is the same thing an SDK
+caller would have got. Nothing about the attribute ranges or the name rules is repeated here.
+
+`SimCfnSqsQueuePolicyCreator` goes through `SetQueueAttributes` for the same reason, so a policy
+declared in a template is validated and enforced exactly as one set through the SDK. A queue policy
+has no existence of its own in SQS: it is the `Policy` attribute of the queues it names, so the
+resource's simulated object is the first queue it named. `Ref` on an `AWS::SQS::Queue` gives its URL,
+which is what `Queues` carries and what `SetQueueAttributes` takes.
 
 The properties this simulation has no behaviour for fail the resource rather than being dropped,
 including `FifoQueue: true`. A queue deployed without its redrive policy would look to the template
@@ -169,9 +179,21 @@ Two details are real SQS behaviour worth keeping:
   `sqs:DeleteMessageBatch` or `sqs:ChangeMessageVisibilityBatch` action, so a policy naming one grants
   nothing.
 
-There is no queue policy support, so this service passes no resource policies into the IAM decision.
-Cross-account access to a queue therefore cannot be granted, and a request naming another owner is
-refused rather than quietly answered with a local queue of the same name.
+The queue's `Policy` attribute goes into the decision as its resource policy, through
+`simSqsQueueResourcePolicies`. That is what admits a caller with no identity policy of its own: a
+principal from another Account, or a service principal such as `s3.amazonaws.com`, which owns no
+identity policies anywhere. A queue with no policy contributes nothing and the decision is left to
+the caller's identity policies, as it is on real AWS.
+
+`SimSqsRequestOptions` carries a `sourceArn` alongside the caller, supplied to IAM as
+`aws:SourceArn`. A simulated service reaching a queue on a resource's behalf sets it, which is how a
+queue policy granting a service principal under an `ArnLike aws:SourceArn` condition tells one
+Bucket from another. A request that does not carry one leaves the key out rather than supplying an
+empty string, so a statement conditioned on it fails to match.
+
+A request naming another Account as the queue owner is still refused rather than quietly answered
+with a local queue of the same name: a queue policy admits another Account's principal to a queue
+here, it does not make another Account's queues reachable through this one.
 
 ## Divergences worth knowing
 
@@ -185,9 +207,13 @@ refused rather than quietly answered with a local queue of the same name.
   The 60 second hold on a deleted queue's name is simulated.
 - A queue name ending in `.fifo` is refused, as are the FIFO-only request fields.
 - `SenderId` is not reported, because a simulated principal has no user or role id to report it as.
-- Tags, `RedriveAllowPolicy`, queue policies and the encryption attributes are refused rather than
-  ignored, whether a request or a CloudFormation template asks for them. So is `RedrivePolicy` on a
-  CloudFormation resource, where it is not simulated, unlike the queue attribute of the same name.
+- Tags, `RedriveAllowPolicy` and the encryption attributes are refused rather than ignored, whether a
+  request or a CloudFormation template asks for them. So is `RedrivePolicy` on a CloudFormation
+  resource, where it is not simulated, unlike the queue attribute of the same name.
+- A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
+  which are shorthands for writing one statement of it, are not implemented.
+- `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document
+  and adds an `Id` and a `Sid`, so what comes back there is not byte for byte what went in.
 - A message moved to a dead-letter queue keeps its sent timestamp, which is documented AWS behaviour,
   and starts its receive count again, which is not documented either way.
 - A Lambda event source mapping polls one batch at a time, where real Lambda runs several pollers and

--- a/src/service/sqs/cfn/queue-policy/sim-cfn-sqs-queue-policy-creator.ts
+++ b/src/service/sqs/cfn/queue-policy/sim-cfn-sqs-queue-policy-creator.ts
@@ -1,0 +1,130 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import { simSqsQueuePolicyAttributeName } from "../../queue/sim-sqs-queue-attribute-specs.js";
+import { SimSqsQueueUrl } from "../../queue/sim-sqs-queue-url.js";
+import type { SimSqs } from "../../sim-sqs.js";
+
+interface SimCfnSqsQueuePolicyCreatorProperties {
+  readonly sqs: SimSqs;
+}
+
+/**
+ * Creates simulated queue policies from AWS::SQS::QueuePolicy Resources.
+ *
+ * This is what CDK emits for `grantSendMessages` to a service principal and for
+ * every `addToResourcePolicy`, so a synthesized template reaches it whether or
+ * not the app mentions a queue policy itself. The policy is set through the
+ * ordinary SetQueueAttributes command, so one declared in a template is
+ * validated and enforced exactly as one set through the SDK.
+ */
+export class SimCfnSqsQueuePolicyCreator {
+  private readonly sqs: SimSqs;
+
+  constructor(properties: SimCfnSqsQueuePolicyCreatorProperties) {
+    this.sqs = properties.sqs;
+  }
+
+  /**
+   * Attach a policy to each queue the Resource names.
+   *
+   * The first queue is returned as the Resource's simulated object, because a
+   * queue policy has no existence of its own in SQS: it is the `Policy`
+   * attribute of the queues it names.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimSqsQueue> {
+    const queueUrls = this.queueUrlsForResource(resource, properties);
+    const policy = jsonStringify(
+      this.policyDocumentForResource(resource, properties),
+    );
+
+    const queues = await Promise.all(
+      queueUrls.map(async (queueUrl) => this.policyApplied(queueUrl, policy)),
+    );
+
+    const first = queues[0];
+    assertDefined(
+      first,
+      `sim SQS queue after CloudFormation queue policy creation for ${resource.logicalId}`,
+    );
+
+    return first;
+  }
+
+  /**
+   * Set the policy on one queue and hand back the queue it was set on.
+   */
+  private async policyApplied(
+    queueUrl: string,
+    policy: string,
+  ): Promise<SimSqsQueue> {
+    await this.sqs.setQueueAttributes({
+      input: {
+        QueueUrl: queueUrl,
+        Attributes: { [simSqsQueuePolicyAttributeName]: policy },
+      },
+    });
+
+    const parts = SimSqsQueueUrl.parse(queueUrl);
+    assertDefined(parts, `queue URL ${queueUrl} SetQueueAttributes accepted`);
+
+    const queue = this.sqs.findQueue(parts.name);
+    assertDefined(queue, `sim SQS queue at ${queueUrl}`);
+
+    return queue;
+  }
+
+  /**
+   * The queue URLs the Resource names.
+   *
+   * `Ref` on an AWS::SQS::Queue gives its URL, so a template naming its queues
+   * the way CDK does arrives here as the URLs SetQueueAttributes takes.
+   */
+  private queueUrlsForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): readonly string[] {
+    const queues = properties["Queues"];
+
+    if (!Array.isArray(queues) || queues.length === 0) {
+      throw new TypeError(
+        `AWS::SQS::QueuePolicy ${resource.logicalId} requires a Queues list of queue URLs`,
+      );
+    }
+
+    return queues.map((queue) => {
+      if (typeof queue !== "string") {
+        throw new TypeError(
+          `AWS::SQS::QueuePolicy ${resource.logicalId} requires each entry of Queues to be a queue URL string, got ${typeof queue}`,
+        );
+      }
+
+      return queue;
+    });
+  }
+
+  private policyDocumentForResource(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): object {
+    const policyDocument = properties["PolicyDocument"];
+
+    if (
+      policyDocument === undefined ||
+      policyDocument === null ||
+      typeof policyDocument !== "object" ||
+      Array.isArray(policyDocument)
+    ) {
+      throw new TypeError(
+        `AWS::SQS::QueuePolicy ${resource.logicalId} requires a PolicyDocument object`,
+      );
+    }
+
+    return policyDocument;
+  }
+}

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-policy.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-policy.iso.test.ts
@@ -1,0 +1,222 @@
+import {
+  GetQueueAttributesCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const s3ServicePrincipal = {
+  kind: "service",
+  service: "s3.amazonaws.com",
+} as const;
+
+/**
+ * A template deploying a queue and the queue policy admitting S3 to it, which
+ * is what CDK synthesises for a Bucket notifying a queue.
+ */
+function ordersTemplate(
+  policyStatement: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders" },
+      },
+      OrdersQueuePolicy: {
+        Type: "AWS::SQS::QueuePolicy",
+        Properties: {
+          Queues: [{ Ref: "OrdersQueue" }],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [policyStatement],
+          },
+        },
+      },
+    },
+    Outputs: { OrdersQueueUrl: { Value: { Ref: "OrdersQueue" } } },
+  };
+}
+
+describe("AWS::SQS::QueuePolicy", () => {
+  it("deploys the policy it names onto the queue", async () => {
+    // Given a template declaring a queue and a policy admitting S3 to it.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTemplate({
+        Effect: "Allow",
+        Principal: { Service: "s3.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue carries the policy the template named.
+    const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["Policy"],
+      }),
+    );
+
+    assertNonNullable(read.Attributes?.["Policy"]);
+    assertStringIncludes(read.Attributes["Policy"], "s3.amazonaws.com");
+
+    // And the policy takes effect: S3 may send to the queue.
+    const sent = await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller: s3ServicePrincipal },
+      );
+
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("deploys a policy that admits nobody it does not name", async () => {
+    // Given a template whose queue policy admits S3 for another queue.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: ordersTemplate({
+        Effect: "Allow",
+        Principal: { Service: "s3.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:invoices`,
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then S3 is refused, rather than the deployed policy admitting anyone who
+    // asks.
+    const queueUrl = stack.outputs.get("OrdersQueueUrl")?.value as string;
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().sendMessage(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "order-1",
+        }),
+        { caller: s3ServicePrincipal },
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("fails the Resource when it names no queues", async () => {
+    // Given a template whose queue policy names no queue to attach to.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueuePolicy: {
+              Type: "AWS::SQS::QueuePolicy",
+              Properties: {
+                Queues: [],
+                PolicyDocument: { Version: "2012-10-17", Statement: [] },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Resource failed rather than being quietly treated as deployed.
+    assertStringIncludes(error.message, "requires a Queues list of queue URLs");
+  });
+
+  it("fails the Resource when a queue is named by something other than a URL", async () => {
+    // Given a template whose queue policy names a queue as a number.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueuePolicy: {
+              Type: "AWS::SQS::QueuePolicy",
+              Properties: {
+                Queues: [42],
+                PolicyDocument: { Version: "2012-10-17", Statement: [] },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Resource failed.
+    assertStringIncludes(error.message, "to be a queue URL string");
+  });
+
+  it("fails the Resource when it carries no policy document", async () => {
+    // Given a template whose queue policy has no PolicyDocument.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: { QueueName: "orders" },
+            },
+            OrdersQueuePolicy: {
+              Type: "AWS::SQS::QueuePolicy",
+              Properties: { Queues: [{ Ref: "OrdersQueue" }] },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Resource failed rather than attaching an empty policy.
+    assertStringIncludes(error.message, "requires a PolicyDocument object");
+  });
+
+  it("fails the Resource when the policy document is one SQS would refuse", async () => {
+    // Given a template whose queue policy statement names no Action.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: ordersTemplate({
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Resource: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`,
+        }),
+      });
+    });
+
+    // Then the Resource failed, because the policy goes through the same
+    // validation an SDK caller's would.
+    assertStringIncludes(error.message, "Action or NotAction");
+  });
+});

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
@@ -263,9 +263,9 @@ describe("SQS CloudFormation Queue validation", () => {
     );
   });
 
-  it("records a queue policy as skipped", async () => {
-    // Given a template declaring an SQS Resource type that is not a queue.
-    // Queue policies grant cross-account access, which is not simulated.
+  it("records an SQS Resource type it cannot create as skipped", async () => {
+    // Given a template declaring an SQS Resource type this simulation has no
+    // behaviour for.
     const simAws = new SimAws();
 
     // When the template is deployed.
@@ -277,9 +277,9 @@ describe("SQS CloudFormation Queue validation", () => {
             Type: "AWS::SQS::Queue",
             Properties: { QueueName: "orders" },
           },
-          OrdersQueuePolicy: {
-            Type: "AWS::SQS::QueuePolicy",
-            Properties: { Queues: [{ Ref: "OrdersQueue" }] },
+          OrdersQueueInboundPermission: {
+            Type: "AWS::SQS::QueueInboundPermission",
+            Properties: { QueueUrl: { Ref: "OrdersQueue" } },
           },
         },
       },
@@ -294,7 +294,7 @@ describe("SQS CloudFormation Queue validation", () => {
     assertTrue(skipped.skipped);
     assertIdentical(
       skipped.skippedReason,
-      "Unsupported sim SQS CloudFormation Resource QueuePolicy",
+      "Unsupported sim SQS CloudFormation Resource QueueInboundPermission",
     );
   });
 });

--- a/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
+++ b/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimSqs } from "../sim-sqs.js";
 import { SimCfnSqsQueueCreator } from "./queue/sim-cfn-sqs-queue-creator.js";
+import { SimCfnSqsQueuePolicyCreator } from "./queue-policy/sim-cfn-sqs-queue-policy-creator.js";
 
 interface SimSqsCfnResourceFactoryProperties {
   readonly sqs: SimSqs;
@@ -15,17 +16,20 @@ interface SimSqsCfnResourceFactoryProperties {
  */
 export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly queueCreator: SimCfnSqsQueueCreator;
+  private readonly queuePolicyCreator: SimCfnSqsQueuePolicyCreator;
 
   constructor(properties: SimSqsCfnResourceFactoryProperties) {
     this.queueCreator = new SimCfnSqsQueueCreator({ sqs: properties.sqs });
+    this.queuePolicyCreator = new SimCfnSqsQueuePolicyCreator({
+      sqs: properties.sqs,
+    });
   }
 
   /**
    * Create a simulated SQS resource from a CloudFormation Resource.
    *
-   * The queue is the only AWS::SQS::* Resource type this simulation models. A
-   * queue policy grants cross-account access, which is not simulated, so
-   * AWS::SQS::QueuePolicy is reported as unsupported and skipped rather than
+   * The queue and its policy are the AWS::SQS::* Resource types this simulation
+   * models. Anything else is reported as unsupported and skipped rather than
    * quietly treated as deployed.
    */
   async create(
@@ -36,6 +40,12 @@ export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
     switch (resourceTypeName) {
       case "Queue": {
         return await this.queueCreator.create(
+          resource,
+          context.resolvedProperties ?? resource.properties,
+        );
+      }
+      case "QueuePolicy": {
+        return await this.queuePolicyCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
         );

--- a/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
@@ -1,13 +1,37 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import { sqsAnyQueueArn } from "../../queue/sim-sqs-queue-arn.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
+import { simSqsConditionContext } from "./sim-sqs-condition-context.js";
+import { simSqsQueueResourcePolicies } from "./sim-sqs-queue-resource-policies.js";
 
 interface SimSqsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+interface SimSqsQueueAuthorizationInput {
+  readonly action: string;
+  readonly queueArn: string;
+
+  /**
+   * The queue itself, when there is one. Its policy is what admits a caller
+   * with no identity policy of its own.
+   */
+  readonly queue?: SimSqsQueue | undefined;
+
+  readonly options?: SimSqsRequestOptions | undefined;
+}
+
+interface SimSqsResourceAuthorizationInput {
+  readonly action: string;
+  readonly resource: string;
+  readonly resourcePolicies: readonly SimIamResourcePolicyInput[];
+  readonly options: SimSqsRequestOptions | undefined;
 }
 
 /**
@@ -18,9 +42,13 @@ interface SimSqsAuthorizerProperties {
  * written with a `queue/` in the resource matches nothing here, as it matches
  * nothing on real AWS.
  *
+ * The queue's own policy goes into the decision as its resource policy. That is
+ * what admits a caller from another Account or a service principal, since
+ * neither is covered by an identity policy in the Account owning the queue.
+ *
  * ListQueues is the exception: real SQS gives it no queue-level permission, so
  * it authorizes against every queue in the account and region rather than one of
- * them. A policy naming a single queue ARN therefore allows no listing.
+ * them, and no queue policy applies to it.
  */
 export class SimSqsAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
@@ -34,17 +62,18 @@ export class SimSqsAuthorizer {
   /**
    * Ensure the caller may perform an action on a queue, named by its ARN.
    *
-   * The queue need not exist. Real IAM evaluates a request before the service
-   * handles it, so a caller with no permission is refused whether or not the
-   * queue is there, and CreateQueue authorizes against the ARN the queue is
-   * about to have.
+   * The queue need not exist. A queue that is not there contributes no policy,
+   * so a caller with no permission is refused whether or not the queue is
+   * there, and CreateQueue authorizes against the ARN the queue is about to
+   * have.
    */
-  authorizeQueue(
-    action: string,
-    queueArn: string,
-    caller?: SimAwsCaller,
-  ): SimAwsResolvedCaller {
-    return this.authorizeResource(action, queueArn, caller);
+  authorizeQueue(input: SimSqsQueueAuthorizationInput): SimAwsResolvedCaller {
+    return this.authorizeResource({
+      action: input.action,
+      resource: input.queueArn,
+      resourcePolicies: simSqsQueueResourcePolicies(input.queue),
+      options: input.options,
+    });
   }
 
   /**
@@ -52,27 +81,32 @@ export class SimSqsAuthorizer {
    */
   authorizeAnyQueue(
     action: string,
-    caller?: SimAwsCaller,
+    options?: SimSqsRequestOptions,
   ): SimAwsResolvedCaller {
-    return this.authorizeResource(
+    return this.authorizeResource({
       action,
-      sqsAnyQueueArn(this.accountRegionScope),
-      caller,
-    );
+      resource: sqsAnyQueueArn(this.accountRegionScope),
+      resourcePolicies: [],
+      options,
+    });
   }
 
   private authorizeResource(
-    action: string,
-    resource: string,
-    caller: SimAwsCaller | undefined,
+    input: SimSqsResourceAuthorizationInput,
   ): SimAwsResolvedCaller {
-    const decision = this.iam.authorize({ action, resource, caller });
+    const decision = this.iam.authorize({
+      action: input.action,
+      resource: input.resource,
+      caller: input.options?.caller,
+      resourcePolicies: input.resourcePolicies,
+      conditionContext: simSqsConditionContext(input.options),
+    });
 
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
-        action,
-        resource,
+        action: input.action,
+        resource: input.resource,
       });
     }
 

--- a/src/service/sqs/command/authorize/sim-sqs-condition-context.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-condition-context.ts
@@ -1,0 +1,24 @@
+import type { SimIamConditionValue } from "../../../iam/policy/sim-iam-policy.js";
+import {
+  simSqsSourceArnConditionKey,
+  type SimSqsRequestOptions,
+} from "../sim-sqs-request-options.js";
+
+/**
+ * The request-time values a queue policy statement's conditions are matched
+ * against.
+ *
+ * A value the request does not carry is left out rather than supplied empty, so
+ * a statement conditioned on it fails to match instead of matching an empty
+ * string. That is the safe direction: a grant written for one Bucket should not
+ * admit a request that says nothing about where it came from.
+ */
+export function simSqsConditionContext(
+  options: SimSqsRequestOptions | undefined,
+): Readonly<Record<string, SimIamConditionValue>> {
+  if (options?.sourceArn === undefined) {
+    return {};
+  }
+
+  return { [simSqsSourceArnConditionKey]: options.sourceArn };
+}

--- a/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-iam.iso.test.ts
@@ -282,8 +282,9 @@ describe("SQS IAM authorization", () => {
       );
     });
 
-    // Then IAM decides first, as real IAM decides before the service looks
-    // anything up.
+    // Then it is denied rather than told the queue is missing. Finding the
+    // queue comes first now that its policy is part of the decision, and a
+    // queue that is not there contributes no policy to admit anyone.
     assertIdentical(error.name, "AccessDenied");
   });
 });

--- a/src/service/sqs/command/authorize/sim-sqs-queue-policy-auth-z.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-queue-policy-auth-z.iso.test.ts
@@ -1,0 +1,325 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateQueueCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const ownerAccountId = "111111111111";
+const callerAccountId = "222222222222";
+const callerRoleArn = `arn:aws:iam::${callerAccountId}:role/OrderWriter`;
+const regionName = "us-east-1";
+const queueArn = `arn:aws:sqs:${regionName}:${ownerAccountId}:orders`;
+const bucketArn = "arn:aws:s3:::uploads";
+
+const s3ServicePrincipal = {
+  kind: "service",
+  service: "s3.amazonaws.com",
+} as const;
+
+/**
+ * A simulated AWS with a queue in the owning Account, carrying the queue policy
+ * a test is about.
+ */
+async function simAwsWithQueuePolicy(policy: string): Promise<{
+  simAws: SimAws;
+  queueUrl: string;
+}> {
+  const simAws = new SimAws();
+  const simSqs = simAws.account(ownerAccountId).region(regionName).sqs();
+  const created = await simSqs.createQueue(
+    new CreateQueueCommand({ QueueName: "orders" }),
+  );
+
+  await simSqs.setQueueAttributes(
+    new SetQueueAttributesCommand({
+      QueueUrl: created.QueueUrl,
+      Attributes: { Policy: policy },
+    }),
+  );
+
+  assertNonNullable(created.QueueUrl);
+
+  return { simAws, queueUrl: created.QueueUrl };
+}
+
+describe("SQS queue policy authorization", () => {
+  it("admits a service principal the queue policy allows", async () => {
+    // Given a queue whose policy lets S3 send to it.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+        },
+      }),
+    );
+
+    // When S3 sends to it, as a service principal owning no identity policies
+    // anywhere.
+    const sent = await simAws
+      .account(ownerAccountId)
+      .region(regionName)
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller: s3ServicePrincipal },
+      );
+
+    // Then the queue policy is the whole of what admitted it.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("refuses a service principal the queue policy does not name", async () => {
+    // Given a queue whose policy lets S3 send to it.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+        },
+      }),
+    );
+
+    // When another service sends to it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account(ownerAccountId)
+        .region(regionName)
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: "order-1",
+          }),
+          { caller: { kind: "service", service: "events.amazonaws.com" } },
+        );
+    });
+
+    // Then it is denied, since a service principal has nothing else to be
+    // allowed by.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("honours an ArnLike aws:SourceArn condition on the statement", async () => {
+    // Given a queue admitting S3 only for one Bucket.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnLike: { "aws:SourceArn": bucketArn } },
+        },
+      }),
+    );
+
+    // When S3 sends on behalf of that Bucket.
+    const sent = await simAws
+      .account(ownerAccountId)
+      .region(regionName)
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller: s3ServicePrincipal, sourceArn: bucketArn },
+      );
+
+    // Then the condition matched.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("refuses a request whose source ARN the condition does not cover", async () => {
+    // Given a queue admitting S3 only for one Bucket.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnLike: { "aws:SourceArn": bucketArn } },
+        },
+      }),
+    );
+
+    // When S3 sends on behalf of another Bucket.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account(ownerAccountId)
+        .region(regionName)
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: "order-1",
+          }),
+          { caller: s3ServicePrincipal, sourceArn: "arn:aws:s3:::reports" },
+        );
+    });
+
+    // Then it is denied, so a grant written for one Bucket does not open
+    // another.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a conditioned request that carries no source ARN", async () => {
+    // Given a queue admitting S3 only for one Bucket.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnLike: { "aws:SourceArn": bucketArn } },
+        },
+      }),
+    );
+
+    // When S3 sends without saying what it is sending for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account(ownerAccountId)
+        .region(regionName)
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: "order-1",
+          }),
+          { caller: s3ServicePrincipal },
+        );
+    });
+
+    // Then the condition has nothing to match, so the statement does not
+    // apply.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("admits another Account's Role when both sides allow it", async () => {
+    // Given a queue whose policy grants another Account's Role.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: callerRoleArn },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+        },
+      }),
+    );
+
+    // And that Role's own Account allowing it too.
+    const callerIam = simAws.account(callerAccountId).iam();
+    await callerIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "OrderWriter",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${callerAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await callerIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrderWriter",
+        PolicyName: "SendOrders",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "sqs:SendMessage", Resource: queueArn },
+        }),
+      }),
+    );
+
+    // When that Role sends to the queue.
+    const sent = await simAws
+      .account(ownerAccountId)
+      .region(regionName)
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+        { caller: { kind: "arn", arn: callerRoleArn } },
+      );
+
+    // Then it is allowed, which is what a queue policy is for.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("refuses another Account's Role its own Account does not allow", async () => {
+    // Given a queue whose policy grants another Account's Role.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: callerRoleArn },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+        },
+      }),
+    );
+
+    // And nothing in that Role's own Account allowing it.
+    simAws.account(callerAccountId).iam();
+
+    // When that Role sends to the queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account(ownerAccountId)
+        .region(regionName)
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: "order-1",
+          }),
+          { caller: { kind: "arn", arn: callerRoleArn } },
+        );
+    });
+
+    // Then it is denied: real AWS requires the caller's Account to allow the
+    // action as well as the queue policy.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a caller the queue policy allows on another queue", async () => {
+    // Given a queue whose policy admits S3 to a queue that is not this one.
+    const { simAws, queueUrl } = await simAwsWithQueuePolicy(
+      simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: `arn:aws:sqs:${regionName}:${ownerAccountId}:invoices`,
+        },
+      }),
+    );
+
+    // When S3 sends to the queue carrying the policy.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account(ownerAccountId)
+        .region(regionName)
+        .sqs()
+        .sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: "order-1",
+          }),
+          { caller: s3ServicePrincipal },
+        );
+    });
+
+    // Then the statement's Resource keeps it from applying.
+    assertIdentical(error.name, "AccessDenied");
+  });
+});

--- a/src/service/sqs/command/authorize/sim-sqs-queue-resource-policies.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-queue-resource-policies.ts
@@ -1,0 +1,32 @@
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+
+/**
+ * The resource policies sim IAM should evaluate for a request against a queue.
+ *
+ * A queue that is not there contributes nothing, which is what keeps a caller
+ * with no permission refused for a queue that does not exist: an absent queue
+ * cannot admit anyone. A queue with no policy contributes nothing either, and
+ * the decision is left to the caller's identity policies.
+ */
+export function simSqsQueueResourcePolicies(
+  queue: SimSqsQueue | undefined,
+): readonly SimIamResourcePolicyInput[] {
+  if (queue === undefined) {
+    return [];
+  }
+
+  const policy = queue.attributes.queuePolicy;
+
+  if (policy === undefined) {
+    return [];
+  }
+
+  return [
+    {
+      document: policy.document,
+      policyName: "QueuePolicy",
+      resourceArn: queue.arn.value,
+    },
+  ];
+}

--- a/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
+++ b/src/service/sqs/command/message/sim-sqs-change-message-visibility.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import {
   SimSqsInvalidParameterValue,
   SimSqsMessageNotInflight,
@@ -16,10 +16,6 @@ const maximumVisibilityTimeoutSeconds = 43_200;
 interface SimSqsChangeMessageVisibilityProperties {
   readonly access: SimSqsQueueAccess;
   readonly clock: BackgroundScheduler;
-}
-
-interface SimSqsChangeMessageVisibilityOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -46,12 +42,12 @@ export class SimSqsChangeMessageVisibility {
    */
   handle(
     command: SimChangeMessageVisibilityCommand,
-    options?: SimSqsChangeMessageVisibilityOptions,
+    options?: SimSqsRequestOptions,
   ): SimChangeMessageVisibilityCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:ChangeMessageVisibility",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const timeout = visibilityTimeout(command.input.VisibilityTimeout);
     const changedAt = this.clock.now();

--- a/src/service/sqs/command/message/sim-sqs-delete-message-commands.ts
+++ b/src/service/sqs/command/message/sim-sqs-delete-message-commands.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
 import { requireBatchEntries, runBatch } from "./sim-sqs-batch-entries.js";
@@ -24,10 +24,6 @@ interface SimSqsDeleteMessageCommandsProperties {
   readonly clock: BackgroundScheduler;
 }
 
-interface SimSqsDeleteMessageCommandsOptions {
-  readonly caller?: SimAwsCaller;
-}
-
 /**
  * The commands a consumer finishes a message with.
  */
@@ -45,12 +41,12 @@ export class SimSqsDeleteMessageCommands {
    */
   deleteMessage(
     command: SimDeleteMessageCommand,
-    options?: SimSqsDeleteMessageCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimDeleteMessageCommandOutput {
     const queue = this.access.requireByUrl(
       messageDeletionAction,
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
 
     this.delete(queue, command.input.ReceiptHandle);
@@ -63,12 +59,12 @@ export class SimSqsDeleteMessageCommands {
    */
   deleteMessageBatch(
     command: SimDeleteMessageBatchCommand,
-    options?: SimSqsDeleteMessageCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimDeleteMessageBatchCommandOutput {
     const queue = this.access.requireByUrl(
       messageDeletionAction,
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const entries = requireBatchEntries(command.input.Entries, "DeleteMessage");
 

--- a/src/service/sqs/command/message/sim-sqs-receive-message.ts
+++ b/src/service/sqs/command/message/sim-sqs-receive-message.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
 import type {
   SimReceiveMessageCommand,
@@ -10,10 +10,6 @@ import { SimSqsReceiveRequest } from "./sim-sqs-receive-request.js";
 interface SimSqsReceiveMessageProperties {
   readonly access: SimSqsQueueAccess;
   readonly clock: BackgroundScheduler;
-}
-
-interface SimSqsReceiveMessageOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -40,12 +36,12 @@ export class SimSqsReceiveMessage {
    */
   handle(
     command: SimReceiveMessageCommand,
-    options?: SimSqsReceiveMessageOptions,
+    options?: SimSqsRequestOptions,
   ): SimReceiveMessageCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:ReceiveMessage",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const request = SimSqsReceiveRequest.of(command.input, queue);
     const receivedAt = this.clock.now();

--- a/src/service/sqs/command/message/sim-sqs-send-message-commands.ts
+++ b/src/service/sqs/command/message/sim-sqs-send-message-commands.ts
@@ -1,4 +1,4 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import type { SimSqsMessageWriter } from "../../message/sim-sqs-message-writer.js";
 import type { SimSqsQueueAccess } from "../queue/sim-sqs-queue-access.js";
 import { requireBatchEntries, runBatch } from "./sim-sqs-batch-entries.js";
@@ -25,10 +25,6 @@ interface SimSqsSendMessageCommandsProperties {
   readonly writer: SimSqsMessageWriter;
 }
 
-interface SimSqsSendMessageCommandsOptions {
-  readonly caller?: SimAwsCaller;
-}
-
 /**
  * The commands that put messages on a queue.
  */
@@ -46,12 +42,12 @@ export class SimSqsSendMessageCommands {
    */
   send(
     command: SimSendMessageCommand,
-    options?: SimSqsSendMessageCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimSendMessageCommandOutput {
     const queue = this.access.requireByUrl(
       messageSendAction,
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const message = this.writer.write(queue, sentMessageWrite(command.input));
 
@@ -71,12 +67,12 @@ export class SimSqsSendMessageCommands {
    */
   sendBatch(
     command: SimSendMessageBatchCommand,
-    options?: SimSqsSendMessageCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimSendMessageBatchCommandOutput {
     const queue = this.access.requireByUrl(
       messageSendAction,
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const entries = requireBatchEntries(command.input.Entries, "SendMessage");
 

--- a/src/service/sqs/command/queue/sim-sqs-create-queue.ts
+++ b/src/service/sqs/command/queue/sim-sqs-create-queue.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimSqsDeadLetterTargets } from "../../queue/sim-sqs-dead-letter-targets.js";
 import { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
@@ -24,10 +24,6 @@ interface SimSqsCreateQueueProperties {
   readonly clock: BackgroundScheduler;
   readonly deadLetterTargets: SimSqsDeadLetterTargets;
   readonly activity: SimSqsQueueActivity;
-}
-
-interface SimSqsCreateQueueOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -60,7 +56,7 @@ export class SimSqsCreateQueue {
    */
   handle(
     command: SimCreateQueueCommand,
-    options?: SimSqsCreateQueueOptions,
+    options?: SimSqsRequestOptions,
   ): SimCreateQueueCommandOutput {
     const input = command.input;
 
@@ -69,7 +65,7 @@ export class SimSqsCreateQueue {
     const name = SimSqsQueueName.required(input.QueueName);
     const requested = input.Attributes ?? {};
 
-    this.access.authorizeName("sqs:CreateQueue", name.value, options?.caller);
+    this.access.authorizeName("sqs:CreateQueue", name.value, options);
 
     const existing = this.queues.find(name.value);
 

--- a/src/service/sqs/command/queue/sim-sqs-queue-access.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-access.ts
@@ -1,5 +1,4 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   SimSqsInvalidAddress,
@@ -11,6 +10,7 @@ import { sqsQueueArnPrefix } from "../../queue/sim-sqs-queue-arn.js";
 import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
 import { SimSqsQueueUrl } from "../../queue/sim-sqs-queue-url.js";
 import type { SimSqsAuthorizer } from "../authorize/sim-sqs-authorizer.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 
 /**
  * The operation an IAM action names, for a message about a missing request
@@ -31,10 +31,14 @@ interface SimSqsQueueAccessProperties {
  * How a request reaches the queue it names.
  *
  * Every operation but ListQueues and CreateQueue starts the same way: read the
- * queue URL, authorize the action against the ARN that URL implies, then look the
- * queue up. Authorization comes first because real IAM decides before the
- * service does anything, so a caller with no permission is refused whether or not
- * the queue exists.
+ * queue URL, find the queue that URL implies, authorize the action against it,
+ * then require it to be there.
+ *
+ * Finding the queue comes before authorizing because the queue's own policy is
+ * part of the decision, and nothing can supply a policy without first having the
+ * queue. A caller with no permission is still refused for a queue that does not
+ * exist rather than told the queue is missing, because a queue that is not there
+ * contributes no policy and cannot admit anyone.
  */
 export class SimSqsQueueAccess {
   private readonly queues: SimSqsQueueStore;
@@ -51,20 +55,29 @@ export class SimSqsQueueAccess {
 
   /**
    * Ensure the caller may perform an action on the queue of a given name.
+   *
+   * The queue need not exist, which is what CreateQueue needs: it authorizes
+   * against the ARN the queue is about to have. A queue that is there brings its
+   * policy into the decision.
    */
-  authorizeName(action: string, name: string, caller?: SimAwsCaller): void {
-    this.authorizer.authorizeQueue(
+  authorizeName(
+    action: string,
+    name: string,
+    options?: SimSqsRequestOptions,
+  ): void {
+    this.authorizer.authorizeQueue({
       action,
-      sqsQueueArnPrefix(this.accountRegionScope) + name,
-      caller,
-    );
+      queueArn: sqsQueueArnPrefix(this.accountRegionScope) + name,
+      queue: this.queues.find(name),
+      options,
+    });
   }
 
   /**
    * Ensure the caller may perform an action naming no particular queue.
    */
-  authorizeAnyQueue(action: string, caller?: SimAwsCaller): void {
-    this.authorizer.authorizeAnyQueue(action, caller);
+  authorizeAnyQueue(action: string, options?: SimSqsRequestOptions): void {
+    this.authorizer.authorizeAnyQueue(action, options);
   }
 
   /**
@@ -73,7 +86,7 @@ export class SimSqsQueueAccess {
   requireByName(
     action: string,
     name: string | undefined,
-    caller?: SimAwsCaller,
+    options?: SimSqsRequestOptions,
   ): SimSqsQueue {
     if (name === undefined || name === "") {
       throw new SimSqsValidationException(
@@ -81,9 +94,7 @@ export class SimSqsQueueAccess {
       );
     }
 
-    this.authorizeName(action, name, caller);
-
-    return this.upToDate(name);
+    return this.authorized(action, name, options);
   }
 
   /**
@@ -92,24 +103,25 @@ export class SimSqsQueueAccess {
   requireByUrl(
     action: string,
     queueUrl: string | undefined,
-    caller?: SimAwsCaller,
+    options?: SimSqsRequestOptions,
   ): SimSqsQueue {
-    const name = this.nameFromUrl(action, queueUrl);
-
-    this.authorizeName(action, name, caller);
-
-    return this.upToDate(name);
+    return this.authorized(action, this.nameFromUrl(action, queueUrl), options);
   }
 
   /**
-   * The queue of a name, with every queue brought up to date first.
+   * The queue of a name, once the caller is allowed to reach it.
    *
-   * Every queue and not just this one, because a message moves to a dead-letter
-   * queue when its source queue notices, and a request may be about the
-   * dead-letter queue rather than the source.
+   * Every queue is brought up to date first and not just this one, because a
+   * message moves to a dead-letter queue when its source queue notices, and a
+   * request may be about the dead-letter queue rather than the source.
    */
-  private upToDate(name: string): SimSqsQueue {
+  private authorized(
+    action: string,
+    name: string,
+    options: SimSqsRequestOptions | undefined,
+  ): SimSqsQueue {
     this.queues.applyLifecycle(this.clock.now());
+    this.authorizeName(action, name, options);
 
     return this.queues.require(name);
   }

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.iso.test.ts
@@ -264,12 +264,16 @@ describe("SQS queue attribute commands", () => {
     // Given a queue.
     const { simAws, queueUrl } = await simAwsWithQueue();
 
-    // When a queue policy is set.
+    // When a redrive allow policy is set.
     const error = await assertThrowsErrorAsync(async () => {
       await simAws.sqs().setQueueAttributes(
         new SetQueueAttributesCommand({
           QueueUrl: queueUrl,
-          Attributes: { Policy: "{}" },
+          Attributes: {
+            RedriveAllowPolicy: JSON.stringify({
+              redrivePermission: "allowAll",
+            }),
+          },
         }),
       );
     });

--- a/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-attribute-commands.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import { SimSqsValidationException } from "../../error/sim-sqs.error.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import { SimSqsQueueAttributeNames } from "../../queue/sim-sqs-queue-attribute-names.js";
@@ -16,10 +16,6 @@ import type {
 interface SimSqsQueueAttributeCommandsProperties {
   readonly access: SimSqsQueueAccess;
   readonly clock: BackgroundScheduler;
-}
-
-interface SimSqsQueueAttributeCommandsOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -45,12 +41,12 @@ export class SimSqsQueueAttributeCommands {
    */
   getQueueAttributes(
     command: SimGetQueueAttributesCommand,
-    options?: SimSqsQueueAttributeCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimGetQueueAttributesCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:GetQueueAttributes",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const requested = command.input.AttributeNames ?? [];
 
@@ -72,12 +68,12 @@ export class SimSqsQueueAttributeCommands {
    */
   setQueueAttributes(
     command: SimSetQueueAttributesCommand,
-    options?: SimSqsQueueAttributeCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimSetQueueAttributesCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:SetQueueAttributes",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
     const requested = command.input.Attributes;
 
@@ -102,12 +98,12 @@ export class SimSqsQueueAttributeCommands {
    */
   purgeQueue(
     command: SimPurgeQueueCommand,
-    options?: SimSqsQueueAttributeCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimPurgeQueueCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:PurgeQueue",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
 
     queue.purge(this.clock.now());

--- a/src/service/sqs/command/queue/sim-sqs-queue-commands.ts
+++ b/src/service/sqs/command/queue/sim-sqs-queue-commands.ts
@@ -1,5 +1,5 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimSqsRequestOptions } from "../sim-sqs-request-options.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimSqsQueueStore } from "../../queue/sim-sqs-queue-store.js";
 import type { SimSqsQueueAccess } from "./sim-sqs-queue-access.js";
@@ -19,10 +19,6 @@ interface SimSqsQueueCommandsProperties {
   readonly access: SimSqsQueueAccess;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: BackgroundScheduler;
-}
-
-interface SimSqsQueueCommandsOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -46,7 +42,7 @@ export class SimSqsQueueCommands {
    */
   getQueueUrl(
     command: SimGetQueueUrlCommand,
-    options?: SimSqsQueueCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimGetQueueUrlCommandOutput {
     refuseForeignQueueOwner(
       command.input.QueueOwnerAWSAccountId,
@@ -56,7 +52,7 @@ export class SimSqsQueueCommands {
     const queue = this.access.requireByName(
       "sqs:GetQueueUrl",
       command.input.QueueName,
-      options?.caller,
+      options,
     );
 
     return { $metadata: {}, QueueUrl: queue.url };
@@ -71,11 +67,11 @@ export class SimSqsQueueCommands {
    */
   listQueues(
     command: SimListQueuesCommand,
-    options?: SimSqsQueueCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimListQueuesCommandOutput {
     const input = command.input;
 
-    this.access.authorizeAnyQueue("sqs:ListQueues", options?.caller);
+    this.access.authorizeAnyQueue("sqs:ListQueues", options);
 
     const page = new SimSqsQueuePage(
       this.queues.withNamePrefix(input.QueueNamePrefix),
@@ -98,12 +94,12 @@ export class SimSqsQueueCommands {
    */
   deleteQueue(
     command: SimDeleteQueueCommand,
-    options?: SimSqsQueueCommandsOptions,
+    options?: SimSqsRequestOptions,
   ): SimDeleteQueueCommandOutput {
     const queue = this.access.requireByUrl(
       "sqs:DeleteQueue",
       command.input.QueueUrl,
-      options?.caller,
+      options,
     );
 
     this.queues.remove(queue, this.clock.now());

--- a/src/service/sqs/command/queue/sim-sqs-unsimulated-queue-input.ts
+++ b/src/service/sqs/command/queue/sim-sqs-unsimulated-queue-input.ts
@@ -24,7 +24,10 @@ export function refuseUnsimulatedQueueInput(
 /**
  * Refuse a request for a queue owned by another Account.
  *
- * Cross-account access needs a queue policy, which is not simulated.
+ * One simulated SQS holds one Account's queues, so it has nothing of another
+ * Account's to answer with. A queue policy admits another Account's principal
+ * to a queue here; it does not make another Account's queues reachable through
+ * this one.
  */
 export function refuseForeignQueueOwner(
   owner: string | undefined,

--- a/src/service/sqs/command/sim-sqs-request-options.ts
+++ b/src/service/sqs/command/sim-sqs-request-options.ts
@@ -1,0 +1,33 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The condition key naming what a simulated service is reaching the queue for,
+ * such as the S3 Bucket an event came from.
+ *
+ * This is the key a queue policy granting a service principal access is nearly
+ * always conditioned on, under `ArnLike`, since a service principal is shared
+ * by every resource of that service.
+ */
+export const simSqsSourceArnConditionKey = "aws:SourceArn";
+
+/**
+ * What an SQS request carries besides its command input.
+ */
+export interface SimSqsRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+
+  /**
+   * What the caller is reaching the queue for, supplied to IAM as
+   * `aws:SourceArn`.
+   *
+   * This is for a simulated service making a request on a resource's behalf,
+   * which is how real AWS supplies it. A value the caller does not have is left
+   * out rather than supplied empty, so a statement conditioned on it fails to
+   * match instead of matching an empty string.
+   */
+  readonly sourceArn?: string;
+}

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -1,4 +1,8 @@
-export { SimSqs, type SimSqsRequestOptions } from "./sim-sqs.js";
+export { SimSqs } from "./sim-sqs.js";
+export {
+  simSqsSourceArnConditionKey,
+  type SimSqsRequestOptions,
+} from "./command/sim-sqs-request-options.js";
 export { SimSqsQueue } from "./queue/sim-sqs-queue.js";
 export {
   SimSqsQueueActivity,
@@ -15,6 +19,7 @@ export {
   SimSqsQueueAttributes,
 } from "./queue/sim-sqs-queue-attributes.js";
 export { SimSqsQueueName } from "./queue/sim-sqs-queue-name.js";
+export { SimSqsQueuePolicy } from "./queue/sim-sqs-queue-policy.js";
 export { SimSqsRedrivePolicy } from "./queue/sim-sqs-redrive-policy.js";
 export {
   SimSqsQueueUrl,

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-names.ts
@@ -3,7 +3,7 @@ import {
   SimSqsUnsupportedOperation,
 } from "../error/sim-sqs.error.js";
 import {
-  simSqsRedrivePolicyAttributeName,
+  simSqsJsonQueueAttributeNames,
   type SimSqsQueueAttributeSpec,
   simSqsSettableQueueAttributes,
 } from "./sim-sqs-queue-attribute-specs.js";
@@ -24,7 +24,8 @@ const readOnlyNames: ReadonlySet<string> = new Set([
 /**
  * Real SQS attributes this simulation does not model. A request setting one is
  * refused rather than quietly ignored, since a queue behaving as though it had
- * a queue policy it does not have is worse than being told it cannot have one.
+ * an encryption key it does not have is worse than being told it cannot have
+ * one.
  */
 const unsimulatedNames: ReadonlySet<string> = new Set([
   "ContentBasedDeduplication",
@@ -33,7 +34,6 @@ const unsimulatedNames: ReadonlySet<string> = new Set([
   "FifoThroughputLimit",
   "KmsDataKeyReusePeriodSeconds",
   "KmsMasterKeyId",
-  "Policy",
   "RedriveAllowPolicy",
   "SqsManagedSseEnabled",
 ]);
@@ -42,7 +42,7 @@ const knownNames = new Set<string>([
   ...simSqsSettableQueueAttributes.map((spec) => spec.name),
   ...readOnlyNames,
   ...unsimulatedNames,
-  simSqsRedrivePolicyAttributeName,
+  ...simSqsJsonQueueAttributeNames,
 ]);
 
 const settableSpecsByName = new Map<string, SimSqsQueueAttributeSpec>(

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-numbers.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-numbers.ts
@@ -1,7 +1,7 @@
 import { SimSqsInvalidAttributeValue } from "../error/sim-sqs.error.js";
 import { SimSqsQueueAttributeNames } from "./sim-sqs-queue-attribute-names.js";
 import {
-  simSqsRedrivePolicyAttributeName,
+  simSqsJsonQueueAttributeNames,
   type SimSqsQueueAttributeSpec,
 } from "./sim-sqs-queue-attribute-specs.js";
 import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
@@ -38,16 +38,16 @@ function attributeNumber(
  * The numeric attribute entries a request actually carries.
  *
  * An SDK attribute map is a partial record, so an explicitly undefined value is
- * the absence of an attribute rather than a request to set one. The redrive
- * policy is left out because it is a JSON object with no numeric range to be
- * checked against.
+ * the absence of an attribute rather than a request to set one. The JSON
+ * attributes are left out because they are documents with no numeric range to
+ * be checked against.
  */
 function numberEntries(
   requested: SimSqsQueueAttributeInput,
 ): readonly [string, string][] {
   return Object.entries(requested).filter(
     (entry): entry is [string, string] =>
-      entry[1] !== undefined && entry[0] !== simSqsRedrivePolicyAttributeName,
+      entry[1] !== undefined && !simSqsJsonQueueAttributeNames.has(entry[0]),
   );
 }
 
@@ -77,6 +77,26 @@ export class SimSqsQueueAttributeNumbers {
         ]),
       ),
     );
+  }
+
+  /** The delay a new message with no delay of its own waits out. */
+  get delaySeconds(): number {
+    return this.get("DelaySeconds");
+  }
+
+  /** The longest message body the queue accepts, in bytes. */
+  get maximumMessageSizeBytes(): number {
+    return this.get("MaximumMessageSize");
+  }
+
+  /** How long a message stays on the queue before SQS drops it. */
+  get messageRetentionSeconds(): number {
+    return this.get("MessageRetentionPeriod");
+  }
+
+  /** How long a received message is hidden from other consumers. */
+  get visibilityTimeoutSeconds(): number {
+    return this.get("VisibilityTimeout");
   }
 
   /**

--- a/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attribute-specs.ts
@@ -1,8 +1,25 @@
 /**
- * The one settable attribute that is a JSON object rather than a number, so it
- * has no numeric range to be checked against.
+ * The attribute naming the dead-letter queue a message goes to once a consumer
+ * has had enough attempts at it.
  */
 export const simSqsRedrivePolicyAttributeName = "RedrivePolicy";
+
+/**
+ * The attribute holding the queue's resource policy.
+ */
+export const simSqsQueuePolicyAttributeName = "Policy";
+
+/**
+ * The settable attributes that are JSON documents rather than numbers, so they
+ * have no numeric range to be checked against.
+ *
+ * Both are held apart from the numeric attributes, and both are read back as
+ * the string they were set with rather than as a re-serialised version of it.
+ */
+export const simSqsJsonQueueAttributeNames: ReadonlySet<string> = new Set([
+  simSqsRedrivePolicyAttributeName,
+  simSqsQueuePolicyAttributeName,
+]);
 
 /**
  * One queue attribute a request may set, and the range real SQS accepts for it.

--- a/src/service/sqs/queue/sim-sqs-queue-attributes.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-attributes.ts
@@ -1,6 +1,7 @@
 import { SimSqsQueueAttributeNumbers } from "./sim-sqs-queue-attribute-numbers.js";
-import { simSqsRedrivePolicyAttributeName } from "./sim-sqs-queue-attribute-specs.js";
-import { SimSqsRedrivePolicy } from "./sim-sqs-redrive-policy.js";
+import { SimSqsQueueJsonAttributes } from "./sim-sqs-queue-json-attributes.js";
+import type { SimSqsQueuePolicy } from "./sim-sqs-queue-policy.js";
+import type { SimSqsRedrivePolicy } from "./sim-sqs-redrive-policy.js";
 
 /**
  * Queue attributes as a request carries them: SQS passes every attribute value
@@ -14,52 +15,60 @@ export type SimSqsQueueAttributeInput = Readonly<
  * The attribute values held by one simulated queue.
  *
  * They come in two kinds. Most are amounts, held as numbers because that is
- * what the queue's behaviour is expressed in. The redrive policy is a JSON
- * object, and a queue has none until one is set, so it is held apart from the
- * rest rather than squeezed into the same map.
+ * what the queue's behaviour is expressed in. The redrive policy and the queue
+ * policy are JSON documents, and a queue has neither until one is set, so they
+ * are held apart from the rest rather than squeezed into the same map.
  */
 export class SimSqsQueueAttributes {
   private readonly numbers: SimSqsQueueAttributeNumbers;
-  private readonly redrive: SimSqsRedrivePolicy | undefined;
+  private readonly documents: SimSqsQueueJsonAttributes;
 
   private constructor(
     numbers: SimSqsQueueAttributeNumbers,
-    redrive: SimSqsRedrivePolicy | undefined,
+    documents: SimSqsQueueJsonAttributes,
   ) {
     this.numbers = numbers;
-    this.redrive = redrive;
+    this.documents = documents;
   }
 
   /**
    * The attribute values a queue created with no attributes has.
    */
   static defaults(): SimSqsQueueAttributes {
-    return new this(SimSqsQueueAttributeNumbers.defaults(), undefined);
+    return new this(
+      SimSqsQueueAttributeNumbers.defaults(),
+      SimSqsQueueJsonAttributes.defaults(),
+    );
   }
 
   /** The delay a new message with no delay of its own waits out. */
   get delaySeconds(): number {
-    return this.numbers.get("DelaySeconds");
+    return this.numbers.delaySeconds;
   }
 
   /** The longest message body the queue accepts, in bytes. */
   get maximumMessageSizeBytes(): number {
-    return this.numbers.get("MaximumMessageSize");
+    return this.numbers.maximumMessageSizeBytes;
   }
 
   /** How long a message stays on the queue before SQS drops it. */
   get messageRetentionSeconds(): number {
-    return this.numbers.get("MessageRetentionPeriod");
+    return this.numbers.messageRetentionSeconds;
   }
 
   /** How long a received message is hidden from other consumers. */
   get visibilityTimeoutSeconds(): number {
-    return this.numbers.get("VisibilityTimeout");
+    return this.numbers.visibilityTimeoutSeconds;
   }
 
   /** Where failed messages go, and after how many receives, if anywhere. */
   get redrivePolicy(): SimSqsRedrivePolicy | undefined {
-    return this.redrive;
+    return this.documents.redrivePolicy;
+  }
+
+  /** Who the queue itself admits, if anyone. */
+  get queuePolicy(): SimSqsQueuePolicy | undefined {
+    return this.documents.queuePolicy;
   }
 
   /**
@@ -68,7 +77,7 @@ export class SimSqsQueueAttributes {
   with(requested: SimSqsQueueAttributeInput): SimSqsQueueAttributes {
     return new SimSqsQueueAttributes(
       this.numbers.with(requested),
-      this.redriveIn(requested),
+      this.documents.with(requested),
     );
   }
 
@@ -80,51 +89,22 @@ export class SimSqsQueueAttributes {
    * request carrying none matches any existing queue.
    */
   matches(requested: SimSqsQueueAttributeInput): boolean {
-    return this.redriveMatches(requested) && this.numbers.matches(requested);
+    return this.documents.matches(requested) && this.numbers.matches(requested);
   }
 
   /**
    * The attributes as SQS reports them, back in their string form.
    *
-   * The redrive policy is reported as the string it was set with, since that is
-   * the string SQS holds the attribute as. A queue with no redrive policy
-   * reports none, as real SQS leaves out an attribute a queue has no value for.
+   * The JSON documents are reported as the strings they were set with, since
+   * those are the strings SQS holds the attributes as. A queue with no redrive
+   * policy or no queue policy reports neither, as real SQS leaves out an
+   * attribute a queue has no value for.
    */
   reported(): ReadonlyMap<string, string> {
     const reported = new Map(this.numbers.reported());
 
-    if (this.redrive !== undefined) {
-      reported.set(simSqsRedrivePolicyAttributeName, this.redrive.value);
-    }
+    this.documents.reportInto(reported);
 
     return reported;
-  }
-
-  /**
-   * The redrive policy after a request, which is the one it sets or the one
-   * already there.
-   */
-  private redriveIn(
-    requested: SimSqsQueueAttributeInput,
-  ): SimSqsRedrivePolicy | undefined {
-    // eslint-disable-next-line security/detect-object-injection -- a fixed key.
-    const value = requested[simSqsRedrivePolicyAttributeName];
-
-    if (value === undefined) {
-      return this.redrive;
-    }
-
-    return SimSqsRedrivePolicy.parse(value);
-  }
-
-  private redriveMatches(requested: SimSqsQueueAttributeInput): boolean {
-    // eslint-disable-next-line security/detect-object-injection -- a fixed key.
-    const value = requested[simSqsRedrivePolicyAttributeName];
-
-    if (value === undefined) {
-      return true;
-    }
-
-    return this.redrive?.matches(SimSqsRedrivePolicy.parse(value)) === true;
   }
 }

--- a/src/service/sqs/queue/sim-sqs-queue-json-attribute.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-json-attribute.ts
@@ -1,0 +1,94 @@
+import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
+
+/**
+ * What a queue attribute holding a JSON document has to be able to do: report
+ * the string it was set with, and say whether another one says the same thing.
+ */
+export interface SimSqsQueueJsonAttributeValue<T> {
+  readonly value: string;
+  matches(other: T): boolean;
+}
+
+interface SimSqsQueueJsonAttributeProperties<T> {
+  readonly name: string;
+  readonly parse: (value: string) => T;
+  readonly held: T | undefined;
+}
+
+/**
+ * One queue attribute that is a JSON document rather than an amount.
+ *
+ * The redrive policy and the queue policy are both this: parsed and validated
+ * when they are set, absent until then, and reported back as the string they
+ * were set with rather than as a re-serialised version of it. Only the parsing
+ * differs, so it is the one thing this is given.
+ */
+export class SimSqsQueueJsonAttribute<
+  T extends SimSqsQueueJsonAttributeValue<T>,
+> {
+  private readonly name: string;
+  private readonly parse: (value: string) => T;
+  private readonly held: T | undefined;
+
+  constructor(properties: SimSqsQueueJsonAttributeProperties<T>) {
+    this.name = properties.name;
+    this.parse = properties.parse;
+    this.held = properties.held;
+  }
+
+  /**
+   * The document the queue holds, or nothing when none has been set.
+   */
+  get document(): T | undefined {
+    return this.held;
+  }
+
+  /**
+   * This attribute after a request, which holds the document the request sets
+   * or the one already there.
+   */
+  with(requested: SimSqsQueueAttributeInput): SimSqsQueueJsonAttribute<T> {
+    const value = this.valueIn(requested);
+
+    if (value === undefined) {
+      return this;
+    }
+
+    return new SimSqsQueueJsonAttribute({
+      name: this.name,
+      parse: this.parse,
+      held: this.parse(value),
+    });
+  }
+
+  /**
+   * Whether the document a request names is the one already held, which is the
+   * question a repeated CreateQueue asks. A request naming none matches.
+   */
+  matches(requested: SimSqsQueueAttributeInput): boolean {
+    const value = this.valueIn(requested);
+
+    if (value === undefined) {
+      return true;
+    }
+
+    return this.held?.matches(this.parse(value)) === true;
+  }
+
+  /**
+   * Add this attribute to what SQS reports about the queue, leaving it out when
+   * the queue has no value for it.
+   */
+  reportInto(reported: Map<string, string>): void {
+    if (this.held !== undefined) {
+      reported.set(this.name, this.held.value);
+    }
+  }
+
+  /**
+   * The value a request carries for this attribute, if it carries one.
+   */
+  private valueIn(requested: SimSqsQueueAttributeInput): string | undefined {
+    return Object.entries(requested).find(([key]) => key === this.name)?.[1];
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-json-attributes.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-json-attributes.ts
@@ -1,0 +1,85 @@
+import type { SimSqsQueueAttributeInput } from "./sim-sqs-queue-attributes.js";
+import {
+  simSqsQueuePolicyAttributeName,
+  simSqsRedrivePolicyAttributeName,
+} from "./sim-sqs-queue-attribute-specs.js";
+import { SimSqsQueueJsonAttribute } from "./sim-sqs-queue-json-attribute.js";
+import { SimSqsQueuePolicy } from "./sim-sqs-queue-policy.js";
+import { SimSqsRedrivePolicy } from "./sim-sqs-redrive-policy.js";
+
+/**
+ * The JSON documents one queue holds: its redrive policy and its own policy.
+ *
+ * They are kept together and apart from the numeric attributes because they
+ * behave the same way as each other and differently from an amount. Each is
+ * absent until it is set, parsed and validated when it is set, and reported
+ * back as the string it was set with.
+ */
+export class SimSqsQueueJsonAttributes {
+  private readonly redrive: SimSqsQueueJsonAttribute<SimSqsRedrivePolicy>;
+  private readonly policy: SimSqsQueueJsonAttribute<SimSqsQueuePolicy>;
+
+  private constructor(
+    redrive: SimSqsQueueJsonAttribute<SimSqsRedrivePolicy>,
+    policy: SimSqsQueueJsonAttribute<SimSqsQueuePolicy>,
+  ) {
+    this.redrive = redrive;
+    this.policy = policy;
+  }
+
+  /**
+   * The documents a queue created with no attributes holds, which is neither
+   * of them.
+   */
+  static defaults(): SimSqsQueueJsonAttributes {
+    return new this(
+      new SimSqsQueueJsonAttribute({
+        name: simSqsRedrivePolicyAttributeName,
+        parse: (value) => SimSqsRedrivePolicy.parse(value),
+        held: undefined,
+      }),
+      new SimSqsQueueJsonAttribute({
+        name: simSqsQueuePolicyAttributeName,
+        parse: (value) => SimSqsQueuePolicy.parse(value),
+        held: undefined,
+      }),
+    );
+  }
+
+  /** Where failed messages go, and after how many receives, if anywhere. */
+  get redrivePolicy(): SimSqsRedrivePolicy | undefined {
+    return this.redrive.document;
+  }
+
+  /** Who the queue itself admits, if anyone. */
+  get queuePolicy(): SimSqsQueuePolicy | undefined {
+    return this.policy.document;
+  }
+
+  /**
+   * These attributes after a request, holding what it sets and keeping what it
+   * does not mention.
+   */
+  with(requested: SimSqsQueueAttributeInput): SimSqsQueueJsonAttributes {
+    return new SimSqsQueueJsonAttributes(
+      this.redrive.with(requested),
+      this.policy.with(requested),
+    );
+  }
+
+  /**
+   * Whether every document a request names is the one already held.
+   */
+  matches(requested: SimSqsQueueAttributeInput): boolean {
+    return this.redrive.matches(requested) && this.policy.matches(requested);
+  }
+
+  /**
+   * Add these attributes to what SQS reports about the queue, leaving out
+   * whichever of them the queue has no value for.
+   */
+  reportInto(reported: Map<string, string>): void {
+    this.redrive.reportInto(reported);
+    this.policy.reportInto(reported);
+  }
+}

--- a/src/service/sqs/queue/sim-sqs-queue-policy.iso.test.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-policy.iso.test.ts
@@ -1,0 +1,189 @@
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  SimSqsInvalidAttributeValue,
+  SimSqsQueueNameExists,
+} from "../error/sim-sqs.error.js";
+import { simAwsWithQueue } from "../../../../test/sqs/queue-fixture.js";
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:orders";
+
+/**
+ * A queue policy admitting S3 to send to the queue, written out the way a
+ * request carries it.
+ */
+function sendPolicy(sourceArn: string): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "s3.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+        Condition: { ArnLike: { "aws:SourceArn": sourceArn } },
+      },
+    ],
+  });
+}
+
+describe("SQS queue policy attribute", () => {
+  it("reports back the policy a queue was created with", async () => {
+    // Given a queue created with a queue policy.
+    const policy = sendPolicy("arn:aws:s3:::uploads");
+    const { simAws, queueUrl } = await simAwsWithQueue({ Policy: policy });
+
+    // When the policy is read back.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["Policy"],
+      }),
+    );
+
+    // Then it is the string the queue was created with, rather than a
+    // re-serialised version of it.
+    assertIdentical(read.Attributes?.["Policy"], policy);
+  });
+
+  it("reports back a policy set through SetQueueAttributes", async () => {
+    // Given a queue with no policy.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+    const policy = sendPolicy("arn:aws:s3:::uploads");
+
+    // When a policy is set on it.
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: { Policy: policy },
+      }),
+    );
+
+    // Then it is reported back verbatim.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    assertIdentical(read.Attributes?.["Policy"], policy);
+  });
+
+  it("reports no policy for a queue that has none", async () => {
+    // Given a queue created with no policy.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When every attribute is read.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        AttributeNames: ["All"],
+      }),
+    );
+
+    // Then the attribute is left out, as real SQS leaves out an attribute a
+    // queue has no value for.
+    assertUndefined(read.Attributes?.["Policy"]);
+  });
+
+  it("refuses a policy that is not JSON when it is set", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a policy that is not JSON is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes(
+        new SetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          Attributes: { Policy: "not a policy" },
+        }),
+      );
+    });
+
+    // Then it is refused there and then, rather than when it is first
+    // evaluated.
+    assertInstanceOf(error, SimSqsInvalidAttributeValue);
+    assertStringIncludes(error.message, "for parameter Policy is invalid");
+  });
+
+  it("refuses a policy statement with no Action", async () => {
+    // Given a queue.
+    const { simAws, queueUrl } = await simAwsWithQueue();
+
+    // When a policy whose statement names no Action is set.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().setQueueAttributes(
+        new SetQueueAttributesCommand({
+          QueueUrl: queueUrl,
+          Attributes: {
+            Policy: JSON.stringify({
+              Version: "2012-10-17",
+              Statement: [{ Effect: "Allow", Resource: queueArn }],
+            }),
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, as sim IAM refuses any other policy document without
+    // one.
+    assertInstanceOf(error, SimSqsInvalidAttributeValue);
+    assertStringIncludes(error.message, "Action or NotAction");
+  });
+
+  it("answers a repeated CreateQueue naming the same policy", async () => {
+    // Given a queue created with a policy.
+    const policy = sendPolicy("arn:aws:s3:::uploads");
+    const { simAws, queueUrl } = await simAwsWithQueue({ Policy: policy });
+
+    // When the same queue is created again with the same policy, written out
+    // with different whitespace.
+    const indented = JSON.stringify(JSON.parse(policy), undefined, 2);
+    const again = await simAws.sqs().createQueue(
+      new CreateQueueCommand({
+        QueueName: "orders",
+        Attributes: { Policy: indented },
+      }),
+    );
+
+    // Then it is the same queue, as CreateQueue is idempotent on real SQS.
+    assertIdentical(again.QueueUrl, queueUrl);
+  });
+
+  it("refuses a repeated CreateQueue naming a different policy", async () => {
+    // Given a queue created with a policy.
+    const simAws = new SimAws();
+    await simAwsWithQueue(
+      { Policy: sendPolicy("arn:aws:s3:::uploads") },
+      simAws,
+    );
+
+    // When the same queue is created again with a policy naming another
+    // Bucket.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders",
+          Attributes: { Policy: sendPolicy("arn:aws:s3:::reports") },
+        }),
+      );
+    });
+
+    // Then it is refused, as a queue with different attributes is.
+    assertInstanceOf(error, SimSqsQueueNameExists);
+  });
+});

--- a/src/service/sqs/queue/sim-sqs-queue-policy.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-policy.ts
@@ -1,0 +1,102 @@
+import { jsonParse, jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import { SimIamPolicyDocumentValidator } from "../../iam/validate/sim-iam-policy-document-validator.js";
+import { SimSqsInvalidAttributeValue } from "../error/sim-sqs.error.js";
+import { simSqsQueuePolicyAttributeName } from "./sim-sqs-queue-attribute-specs.js";
+
+const policyValidator: SimIamPolicyDocumentValidator =
+  new SimIamPolicyDocumentValidator();
+
+/**
+ * The error real SQS refuses a queue policy with.
+ *
+ * A queue policy is one of the queue's attributes, so a policy it will not take
+ * is an invalid attribute value rather than a malformed policy document.
+ */
+function invalidPolicy(value: string, reason: string): Error {
+  return new SimSqsInvalidAttributeValue(
+    `Value ${value} for parameter ${simSqsQueuePolicyAttributeName} is ` +
+      `invalid. Reason: ${reason}.`,
+  );
+}
+
+/**
+ * What a rejected policy document was rejected for.
+ */
+function reasonFor(error: unknown): string {
+  /* v8 ignore next 3 -- unreachable: JSON parsing and policy validation both
+     throw Errors, so nothing else reaches this. */
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  return error.message;
+}
+
+/**
+ * Read a queue policy attribute value as the IAM policy document it has to be.
+ *
+ * The document goes through sim IAM's own policy document validator, so a queue
+ * policy is held to the same rules as any other policy document, and it is held
+ * to them when the attribute is set rather than when the policy is first
+ * evaluated.
+ */
+function parsedDocument(value: string): SimIamPolicyDocument {
+  try {
+    policyValidator.validateRequired(value);
+
+    return jsonParse(value);
+  } catch (error) {
+    throw invalidPolicy(value, reasonFor(error));
+  }
+}
+
+interface SimSqsQueuePolicyProperties {
+  readonly value: string;
+  readonly document: SimIamPolicyDocument;
+}
+
+/**
+ * The resource policy of one simulated queue.
+ *
+ * It is what admits a caller with no identity policy of its own: another
+ * Account's principal, or a service principal such as `s3.amazonaws.com`, which
+ * owns no identity policies anywhere. Sim IAM evaluates it as the queue's
+ * resource policy, so the rules about who it lets in are IAM's rather than SQS's.
+ *
+ * The string the policy was set with is kept, so `GetQueueAttributes` reports
+ * back what was set rather than a re-serialised version of it.
+ */
+export class SimSqsQueuePolicy {
+  public readonly value: string;
+  public readonly document: SimIamPolicyDocument;
+
+  private constructor(properties: SimSqsQueuePolicyProperties) {
+    this.value = properties.value;
+    this.document = properties.document;
+  }
+
+  /**
+   * Read a queue policy attribute value, refusing one real SQS would refuse.
+   */
+  static parse(value: string): SimSqsQueuePolicy {
+    return new this({ value, document: parsedDocument(value) });
+  }
+
+  /**
+   * Whether another policy says the same thing, which is the question a
+   * repeated `CreateQueue` asks.
+   *
+   * The parsed documents are compared rather than the strings they were set
+   * with, so the same policy written out with different whitespace is the same
+   * policy. Written out with its keys in a different order it is not, which is
+   * stricter than AWS and is the safe direction for an idempotency check.
+   */
+  matches(other: SimSqsQueuePolicy): boolean {
+    return this.serialized() === other.serialized();
+  }
+
+  private serialized(): string {
+    return jsonStringify(this.document);
+  }
+}

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -3,7 +3,6 @@ import {
   BackgroundTasks,
 } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import {
@@ -20,6 +19,7 @@ import { SimSqsCreateQueue } from "./command/queue/sim-sqs-create-queue.js";
 import { SimSqsQueueAttributeCommands } from "./command/queue/sim-sqs-queue-attribute-commands.js";
 import { SimSqsQueueCommands } from "./command/queue/sim-sqs-queue-commands.js";
 import type * as simSqsCommands from "./command/sim-sqs-command.types.js";
+import type { SimSqsRequestOptions } from "./command/sim-sqs-request-options.js";
 import { SimSqsCfnResourceFactory } from "./cfn/sim-sqs-cfn-resource-factory.js";
 import { SimSqsMessageWriter } from "./message/sim-sqs-message-writer.js";
 import { SimSqsDeadLetterTargets } from "./queue/sim-sqs-dead-letter-targets.js";
@@ -27,10 +27,6 @@ import type { SimSqsQueue } from "./queue/sim-sqs-queue.js";
 import { SimSqsQueueActivity } from "./queue/sim-sqs-queue-activity.js";
 import { SimSqsQueueStore } from "./queue/sim-sqs-queue-store.js";
 import { SimSqsSdkCommandRouter } from "./sdk/sim-sqs-sdk-command-router.js";
-
-export interface SimSqsRequestOptions {
-  readonly caller?: SimAwsCaller;
-}
 
 interface SimSqsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;


### PR DESCRIPTION
A queue carries a Policy attribute, set through CreateQueue or SetQueueAttributes and reported back by GetQueueAttributes, and simulated IAM evaluates it as the queue's resource policy. A caller from another Account, or a service principal, is admitted by it. AWS::SQS::QueuePolicy deploys through SetQueueAttributes rather than being skipped.

Finding the queue now comes before authorizing, since the queue's own policy is part of the decision. A caller with no permission is still refused for a queue that does not exist, because an absent queue contributes no policy.

Resolves https://github.com/KensioSoftware/yulin/issues/330