### PR TITLE
feat: config sim S3 event notifications CDK bucket.addEventNotification

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -575,6 +575,21 @@ A CDK BucketDeployment can copy files from synthesized asset output into the sim
 the Bucket is configured for website hosting, those files can be served through Yulin's local
 server.
 
+## CDK S3 Bucket notifications
+
+`bucket.addEventNotification(...)` synthesizes a `Custom::S3BucketNotifications` resource rather than
+a Bucket property. Sim CloudFormation applies the configuration it carries through the ordinary
+`PutBucketNotificationConfiguration` path, so an Object put into the deployed Bucket reaches the
+deployed function.
+
+Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
+on the `AWS::Lambda::Permission` CDK writes beside the notification is a synth-time literal, so a
+stack deployed into another Account leaves S3 unable to validate the destination, and the stack
+fails.
+
+See [Event notifications](../s3/README.md#event-notifications) in the S3 docs for the configuration
+itself and what it refuses.
+
 ## CloudFront resources from CDK
 
 Sim CloudFormation can create CloudFront Distributions from CloudFormation or CDK templates.
@@ -1090,7 +1105,7 @@ The resource types it creates are:
 - `AWS::SecretsManager::Secret`
 - `AWS::SQS::Queue`
 - `AWS::SSM::Parameter`
-- selected CDK custom resources, including CDK S3 BucketDeployment
+- selected CDK custom resources: `Custom::CDKBucketDeployment` and `Custom::S3BucketNotifications`
 
 Each service's own docs describe what its resource types support.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -504,8 +504,8 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 - `Managed: false` on a `Custom::S3BucketNotifications` resource is refused rather than approximated,
   and a queue, topic or EventBridge destination in one is refused by name as it is for an SDK caller.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
-  rather than putting Objects, so neither raises anything, where real CDK `BucketDeployment` fires one
-  `ObjectCreated:Put` per file.
+  rather than putting Objects, so neither raises anything, whereas real CDK `BucketDeployment` fires
+  one `ObjectCreated:Put` per file.
 - A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
 - `s3:TestEvent` is not sent. It is an SQS and SNS mechanism.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -392,6 +392,58 @@ const configurations = read.LambdaFunctionConfigurations ?? [];
 The two commands are authorized as `s3:PutBucketNotification` and `s3:GetBucketNotification`. Those
 are the real IAM action names, and they do not match the API names.
 
+### From a CDK app
+
+`bucket.addEventNotification(...)` deploys through simulated CloudFormation. CDK does not write the
+`AWS::S3::Bucket` `NotificationConfiguration` property for it. It writes a
+`Custom::S3BucketNotifications` resource carrying the same request
+`PutBucketNotificationConfigurationCommand` takes, alongside the `AWS::Lambda::Permission` that lets
+S3 invoke the function. Yulin applies that request through the same command path an SDK caller
+reaches, so a configuration is validated the same way whichever it arrives by.
+
+Deploy into an Account and Region matching the ones the CDK app synthesized for. The `SourceAccount`
+on the permission CDK writes beside the notification is a synth-time literal, so a stack deployed
+into another Account leaves S3 unable to validate the destination, and the stack fails.
+
+```typescript sim-s3-cdk-event-notification
+/**
+ * Deploying a CDK Bucket event notification into simulated AWS.
+ */
+
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The Account and Region the CDK app synthesized for.
+const scope = simAws.account("111111111111").region("eu-west-2");
+
+await scope
+  .cloudFormation()
+  .deployTemplateFile("cdk.out/TestStack.template.json");
+
+await scope.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+```
+
+CDK's own provider function for this resource is written in Python, so simulated CloudFormation skips
+it on its runtime and Yulin does the work the function would have done. The `ServiceToken` naming it
+is read and ignored.
+
+A resource carrying `Managed: false` is refused, and the stack fails. CDK writes it for a Bucket the
+app imported rather than declared. It asks S3 to merge the configuration with the configurations
+already on the Bucket instead of replacing them, and simulated S3 only replaces, so applying it as
+written would drop configurations that survive on real AWS. Declare the Bucket in the same stack to
+get a managed notification configuration.
+
 ### What arrives at the handler
 
 The handler is invoked with the `Records` document real S3 sends. One event produces one record.
@@ -446,9 +498,14 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 - A notification cannot be configured on a standalone `SimS3`. It has no other simulated services to
   notify, and no shared background scheduler for `backgroundTasksComplete()` to drain. Reach
   simulated S3 through `SimAws` instead.
-- CloudFormation and CDK cannot configure notifications. A CDK `BucketDeployment` and
-  `mountBucketFilesystem(...)` both replace the whole storage backend rather than putting Objects, so
-  neither raises anything, where real CDK `BucketDeployment` fires one `ObjectCreated:Put` per file.
+- A CloudFormation template cannot configure notifications through the `AWS::S3::Bucket`
+  `NotificationConfiguration` property. That property is ignored. CDK never writes it, and reaches
+  notifications through the `Custom::S3BucketNotifications` resource described above.
+- `Managed: false` on a `Custom::S3BucketNotifications` resource is refused rather than approximated,
+  and a queue, topic or EventBridge destination in one is refused by name as it is for an SDK caller.
+- A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
+  rather than putting Objects, so neither raises anything, where real CDK `BucketDeployment` fires one
+  `ObjectCreated:Put` per file.
 - A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
 - `s3:TestEvent` is not sent. It is an SQS and SNS mechanism.
 

--- a/docs/services/s3/sim-s3-cdk-event-notification.example.ts
+++ b/docs/services/s3/sim-s3-cdk-event-notification.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Deploying a CDK Bucket event notification into simulated AWS.
+ */
+
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// The Account and Region the CDK app synthesized for.
+const scope = simAws.account("111111111111").region("eu-west-2");
+
+await scope
+  .cloudFormation()
+  .deployTemplateFile("cdk.out/TestStack.template.json");
+
+await scope.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
@@ -1,0 +1,101 @@
+import type {
+  SimS3LambdaFunctionConfigurationInput,
+  SimS3NotificationConfigurationInput,
+} from "../../../../../s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimCfnTemplateValue } from "../../../../template/value/sim-cfn-template-value.js";
+import { SimCdkBucketNotificationFilter } from "./sim-cdk-bucket-notification-filter.js";
+import { SimCdkBucketNotificationShape } from "./sim-cdk-bucket-notification-shape.js";
+
+/**
+ * Reads the `NotificationConfiguration` property of a
+ * Custom::S3BucketNotifications Resource into a
+ * PutBucketNotificationConfiguration request.
+ *
+ * CDK emits the SDK request shape into the Resource, so this translates types
+ * rather than structure: what the template says is what the command receives.
+ * Only the shape is read here. Whether the configuration is one simulated S3
+ * accepts is the command's question, so a template and an SDK caller are
+ * answered by the same validation.
+ */
+export class SimCdkBucketNotificationConfiguration {
+  private readonly shape: SimCdkBucketNotificationShape;
+  private readonly filter: SimCdkBucketNotificationFilter;
+
+  constructor(logicalId: string) {
+    this.shape = new SimCdkBucketNotificationShape(logicalId);
+    this.filter = new SimCdkBucketNotificationFilter(this.shape);
+  }
+
+  /**
+   * Read a whole notification configuration.
+   *
+   * A destination group this simulator cannot deliver to is carried through
+   * untouched, so the command refuses it by name rather than dropping it.
+   */
+  read(
+    value: SimCfnTemplateValue | undefined,
+  ): SimS3NotificationConfigurationInput {
+    const record = this.shape.record(value, "NotificationConfiguration");
+
+    return {
+      LambdaFunctionConfigurations: this.shape.present(
+        record["LambdaFunctionConfigurations"],
+        (configurations) => this.lambdaConfigurations(configurations),
+      ),
+      QueueConfigurations: this.shape.present(
+        record["QueueConfigurations"],
+        (configurations) =>
+          this.shape.list(configurations, "QueueConfigurations"),
+      ),
+      TopicConfigurations: this.shape.present(
+        record["TopicConfigurations"],
+        (configurations) =>
+          this.shape.list(configurations, "TopicConfigurations"),
+      ),
+      EventBridgeConfiguration: this.shape.present(
+        record["EventBridgeConfiguration"],
+        (configuration) =>
+          this.shape.record(configuration, "EventBridgeConfiguration"),
+      ),
+    };
+  }
+
+  private lambdaConfigurations(
+    value: SimCfnTemplateValue,
+  ): readonly SimS3LambdaFunctionConfigurationInput[] {
+    return this.shape
+      .list(value, "LambdaFunctionConfigurations")
+      .map((configuration) => this.lambdaConfiguration(configuration));
+  }
+
+  private lambdaConfiguration(
+    value: SimCfnTemplateValue,
+  ): SimS3LambdaFunctionConfigurationInput {
+    const record = this.shape.record(
+      value,
+      "LambdaFunctionConfigurations entry",
+    );
+
+    return {
+      Id: this.shape.present(record["Id"], (id) => this.shape.string(id, "Id")),
+      LambdaFunctionArn: this.shape.present(
+        record["LambdaFunctionArn"],
+        (arn) => this.shape.string(arn, "LambdaFunctionArn"),
+      ),
+      Events: this.shape.present(record["Events"], (events) =>
+        this.events(events),
+      ),
+      Filter: this.shape.present(record["Filter"], (filter) =>
+        this.filter.read(filter),
+      ),
+    };
+  }
+
+  private events(value: SimCfnTemplateValue): readonly string[] {
+    return this.shape
+      .list(value, "Events")
+      .map((event, index) =>
+        this.shape.string(event, `Events entry ${String(index)}`),
+      );
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-filter.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-filter.ts
@@ -1,0 +1,62 @@
+import type {
+  SimS3NotificationFilterInput,
+  SimS3NotificationFilterRuleInput,
+  SimS3NotificationKeyFilterInput,
+} from "../../../../../s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimCfnTemplateValue } from "../../../../template/value/sim-cfn-template-value.js";
+import type { SimCdkBucketNotificationShape } from "./sim-cdk-bucket-notification-shape.js";
+
+/**
+ * Reads the object key filter of one notification configuration.
+ *
+ * Which rule names S3 filters on, and what happens when one is repeated, is
+ * the command's question. This reads the three levels of nesting the request
+ * shape puts around the rules.
+ */
+export class SimCdkBucketNotificationFilter {
+  private readonly shape: SimCdkBucketNotificationShape;
+
+  constructor(shape: SimCdkBucketNotificationShape) {
+    this.shape = shape;
+  }
+
+  /**
+   * Read a whole filter.
+   */
+  read(value: SimCfnTemplateValue): SimS3NotificationFilterInput {
+    const record = this.shape.record(value, "Filter");
+
+    return {
+      Key: this.shape.present(record["Key"], (key) => this.keyFilter(key)),
+    };
+  }
+
+  private keyFilter(
+    value: SimCfnTemplateValue,
+  ): SimS3NotificationKeyFilterInput {
+    const record = this.shape.record(value, "Filter Key");
+
+    return {
+      FilterRules: this.shape.present(record["FilterRules"], (rules) =>
+        this.shape
+          .list(rules, "FilterRules")
+          .map((rule) => this.filterRule(rule)),
+      ),
+    };
+  }
+
+  private filterRule(
+    value: SimCfnTemplateValue,
+  ): SimS3NotificationFilterRuleInput {
+    const record = this.shape.record(value, "FilterRules entry");
+
+    return {
+      Name: this.shape.present(record["Name"], (name) =>
+        this.shape.string(name, "FilterRules entry Name"),
+      ),
+      Value: this.shape.present(record["Value"], (ruleValue) =>
+        this.shape.string(ruleValue, "FilterRules entry Value"),
+      ),
+    };
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-shape.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-shape.ts
@@ -1,0 +1,89 @@
+import { isRecord } from "../../../../../../util/type-guard/record.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../template/value/sim-cfn-template-value.js";
+import { bucketNotificationsError } from "../error/sim-cdk-bucket-notification-error.js";
+
+/**
+ * The shape checks a Custom::S3BucketNotifications Resource's properties are
+ * read through.
+ *
+ * A template is JSON, so a property can be anything, while the request it
+ * becomes has a shape. These are the four questions that gets asked, each
+ * naming what was wrong in the wording that fails the Stack rather than
+ * skipping the Resource.
+ */
+export class SimCdkBucketNotificationShape {
+  private readonly logicalId: string;
+
+  constructor(logicalId: string) {
+    this.logicalId = logicalId;
+  }
+
+  /**
+   * Read a property the template need not carry, leaving it out when it does
+   * not.
+   */
+  present<T>(
+    value: SimCfnTemplateValue | undefined,
+    read: (value: SimCfnTemplateValue) => T,
+  ): T | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    return read(value);
+  }
+
+  /**
+   * A value that has to be an object.
+   */
+  record(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): SimCfnTemplateValueRecord {
+    if (!isTemplateRecord(value)) {
+      throw bucketNotificationsError(
+        this.logicalId,
+        `${name} must be an object`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A value that has to be a list.
+   */
+  list(value: SimCfnTemplateValue, name: string): SimCfnTemplateValue[] {
+    if (!Array.isArray(value)) {
+      throw bucketNotificationsError(this.logicalId, `${name} must be a list`);
+    }
+
+    return value;
+  }
+
+  /**
+   * A value that has to be a string.
+   */
+  string(value: SimCfnTemplateValue, name: string): string {
+    if (typeof value !== "string") {
+      throw bucketNotificationsError(
+        this.logicalId,
+        `${name} must be a string`,
+      );
+    }
+
+    return value;
+  }
+}
+
+/**
+ * Whether a template value is an object rather than a list or a primitive.
+ */
+function isTemplateRecord(
+  value: SimCfnTemplateValue | undefined,
+): value is SimCfnTemplateValueRecord {
+  return isRecord(value);
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/error/sim-cdk-bucket-notification-error.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/error/sim-cdk-bucket-notification-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Build the error a Custom::S3BucketNotifications Resource is refused with.
+ *
+ * The wording matters. Sim CloudFormation downgrades a failure whose message
+ * reads as an unsupported Resource type into a skip, and a skipped notification
+ * Resource is exactly the silence this feature exists to remove: the Stack
+ * would deploy with the Bucket and the function and nothing between them. So
+ * every refusal here says `Invalid`, and none of them says `Unsupported sim`.
+ */
+export function bucketNotificationsError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid Custom::S3BucketNotifications Resource ${logicalId}: ${reason}`,
+  );
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.iso.test.ts
@@ -1,0 +1,24 @@
+import { assertFalse, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCdkBucketNotificationProperties } from "./sim-cdk-bucket-notification-properties.js";
+
+describe("CDK Bucket notification Resource properties", () => {
+  it("takes a Resource stating no flags as managed and validated", () => {
+    // Given a Resource carrying only the Bucket and the configuration, which
+    // is what a hand-written template can leave the flags out of.
+    const properties = new SimCdkBucketNotificationProperties(
+      "BucketNotifications",
+      {
+        BucketName: "uploads",
+        NotificationConfiguration: { LambdaFunctionConfigurations: [] },
+      },
+    );
+
+    // When the flags are read, then they are the ones CDK's own provider
+    // function defaults to.
+    properties.assertManaged();
+    assertFalse(properties.skipDestinationValidation);
+    assertIdentical(properties.bucketName, "uploads");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
@@ -1,0 +1,136 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../template/value/sim-cfn-template-value.js";
+import { bucketNotificationsError } from "../error/sim-cdk-bucket-notification-error.js";
+
+/**
+ * The properties CDK puts on a Custom::S3BucketNotifications Resource.
+ *
+ * `ServiceToken` is read and ignored. It points at CDK's own Python provider
+ * function, whose whole job is the PutBucketNotificationConfiguration call this
+ * factory makes instead.
+ */
+const knownPropertyNames: ReadonlySet<string> = new Set([
+  "BucketName",
+  "Managed",
+  "NotificationConfiguration",
+  "ServiceToken",
+  "SkipDestinationValidation",
+]);
+
+/**
+ * Reads the properties of one Custom::S3BucketNotifications Resource.
+ *
+ * A property name CDK does not emit is refused rather than ignored. This
+ * Resource is a private contract between CDK and its own provider function, so
+ * a name that turns up here is a version of CDK asking for something this
+ * simulator has not been told about, and quietly dropping it would leave the
+ * Bucket configured differently from the app that was deployed.
+ */
+export class SimCdkBucketNotificationProperties {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(logicalId: string, properties: SimCfnTemplateValueRecord) {
+    this.logicalId = logicalId;
+    this.properties = properties;
+
+    this.refuseUnknownProperties();
+  }
+
+  /**
+   * The Bucket the configuration is applied to.
+   */
+  get bucketName(): string {
+    const bucketName = this.properties["BucketName"];
+
+    if (typeof bucketName !== "string" || bucketName === "") {
+      throw bucketNotificationsError(
+        this.logicalId,
+        "BucketName must resolve to a Bucket name",
+      );
+    }
+
+    return bucketName;
+  }
+
+  /**
+   * The configuration to apply, still as the template wrote it.
+   */
+  get notificationConfiguration(): SimCfnTemplateValue | undefined {
+    return this.properties["NotificationConfiguration"];
+  }
+
+  /**
+   * Whether S3 validates the destinations as the configuration is applied.
+   */
+  get skipDestinationValidation(): boolean {
+    return this.flag("SkipDestinationValidation", false);
+  }
+
+  /**
+   * Refuse a Resource whose configuration CDK does not own outright.
+   *
+   * `Managed: false` is what CDK emits for a Bucket the app imported rather
+   * than declared, and it means merge this configuration with whatever the
+   * Bucket already has rather than replace it. Simulated S3 only replaces, so
+   * applying it as written would discard configurations that survive on real
+   * AWS. Refusing says so at deploy time instead.
+   */
+  assertManaged(): void {
+    if (!this.flag("Managed", true)) {
+      throw bucketNotificationsError(
+        this.logicalId,
+        "Managed is false, which asks S3 to merge this configuration with " +
+          "the configurations already on the Bucket rather than replace " +
+          "them. Simulated S3 replaces the whole configuration, so the " +
+          "merge is not simulated. CDK emits this for a Bucket the app " +
+          "imported rather than declared; declare the Bucket in the same " +
+          "Stack to get a managed notification configuration",
+      );
+    }
+  }
+
+  /**
+   * Read a boolean property.
+   *
+   * Real CloudFormation stringifies every custom Resource property before the
+   * provider function sees it, which is why CDK's own handler compares against
+   * the string "true". The template itself carries a JSON boolean, so both are
+   * read here.
+   */
+  private flag(name: string, whenAbsent: boolean): boolean {
+    // eslint-disable-next-line security/detect-object-injection -- one of the two flag names this class names itself.
+    const value = this.properties[name];
+
+    if (value === undefined) {
+      return whenAbsent;
+    }
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+
+    throw bucketNotificationsError(
+      this.logicalId,
+      `${name} must be true or false`,
+    );
+  }
+
+  private refuseUnknownProperties(): void {
+    for (const name of Object.keys(this.properties)) {
+      if (!knownPropertyNames.has(name)) {
+        throw bucketNotificationsError(
+          this.logicalId,
+          `${name} is not a Custom::S3BucketNotifications property this ` +
+            "simulation knows about, so it is refused rather than ignored",
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-refusals.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-refusals.iso.test.ts
@@ -1,0 +1,211 @@
+import { GetBucketNotificationConfigurationCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
+
+/**
+ * Deploy a notification template that is expected to fail the Stack, returning
+ * the error the deployment gave.
+ */
+async function deployFailing(
+  simAws: SimAws,
+  template: ReturnType<typeof simCdkBucketNotificationsTemplateFactory.make>,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "uploads-stack", template });
+  });
+}
+
+/**
+ * The Bucket a failed deployment left behind, which should carry no
+ * notification configuration at all.
+ */
+async function configuredNotificationCount(simAws: SimAws): Promise<number> {
+  const output = await simAws
+    .s3()
+    .getBucketNotificationConfiguration(
+      new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+    );
+
+  return (output.LambdaFunctionConfigurations ?? []).length;
+}
+
+describe("CDK Bucket notifications CloudFormation Custom Resource refusals", () => {
+  it("refuses an unmanaged configuration rather than replacing the Bucket's own", async () => {
+    // Given the template CDK synthesizes for a Bucket the app imported rather
+    // than declared, which asks for a merge instead of a replacement.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { Managed: false },
+      }),
+    );
+
+    // Then the Stack fails, naming what the template asked for.
+    assertStringIncludes(
+      error.message,
+      "Invalid Custom::S3BucketNotifications Resource BucketNotifications: " +
+        "Managed is false",
+    );
+
+    // And the Bucket is left unconfigured.
+    assertIdentical(await configuredNotificationCount(simAws), 0);
+  });
+
+  it("fails the Stack when nothing permits S3 to invoke the function", async () => {
+    // Given a template with no AWS::Lambda::Permission for the function the
+    // notification names.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({ permitted: false }),
+    );
+
+    // Then the Stack fails with the refusal PutBucketNotificationConfiguration
+    // gives, rather than deploying a Bucket that notifies nothing.
+    assertStringIncludes(
+      error.message,
+      "Unable to validate the following destination configurations",
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("uploads-stack");
+    assertNonNullable(stack);
+    assertIdentical(
+      stack.getResource("BucketNotifications")?.status,
+      "CREATE_FAILED",
+    );
+    assertIdentical(await configuredNotificationCount(simAws), 0);
+  });
+
+  it("fails the Stack for an invalid Resource, where an unsupported one is skipped", async () => {
+    // Given a template carrying a custom Resource this simulator has never
+    // heard of alongside an invalid notification Resource. The two are worded
+    // differently on purpose: an unsupported Resource type is skipped, and a
+    // Resource this simulator does support but cannot create as asked is not.
+    const simAws = new SimAws();
+
+    // When a template with only the unsupported Resource is deployed.
+    const skipStack = await simAws.cloudFormation().deployTemplate({
+      stackName: "other-stack",
+      template: {
+        Resources: {
+          Anything: { Type: "Custom::SomethingElse", Properties: {} },
+        },
+      },
+    });
+    await skipStack.waitForDeployComplete();
+
+    // Then it is skipped and the Stack still deploys.
+    const skipped = skipStack.getResource("Anything");
+    assertNonNullable(skipped);
+    assertTrue(skipped.skipped);
+    assertStringIncludes(
+      skipped.skippedReason ?? "",
+      "Unsupported sim CloudFormation Custom Resource SomethingElse",
+    );
+
+    // And when the invalid notification Resource is deployed, the Stack fails
+    // instead.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { Managed: false },
+      }),
+    );
+    assertStringIncludes(
+      error.message,
+      "Invalid Custom::S3BucketNotifications",
+    );
+  });
+
+  it("refuses a property CDK does not emit", async () => {
+    // Given a template carrying a property this simulation knows nothing
+    // about.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { Timeout: 300 },
+      }),
+    );
+
+    // Then the Stack fails naming the property, rather than ignoring it.
+    assertStringIncludes(
+      error.message,
+      "Timeout is not a Custom::S3BucketNotifications property this " +
+        "simulation knows about",
+    );
+  });
+
+  it("refuses a flag that is neither true nor false", async () => {
+    // Given a template whose Managed property is something else.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { Managed: "yes" },
+      }),
+    );
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(error.message, "Managed must be true or false");
+  });
+
+  it("refuses a Resource that names no Bucket", async () => {
+    // Given a template whose BucketName did not resolve to a name.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { BucketName: "" },
+      }),
+    );
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(
+      error.message,
+      "BucketName must resolve to a Bucket name",
+    );
+  });
+
+  it("leaves the rest of the Stack deployed", async () => {
+    // Given a template whose notification Resource is invalid.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await deployFailing(
+      simAws,
+      simCdkBucketNotificationsTemplateFactory.make({
+        notificationProperties: { Managed: false },
+      }),
+    );
+
+    // Then the Bucket and the function are still there, so a test can see what
+    // the Stack got as far as.
+    const stack = simAws.cloudFormation().getStackByName("uploads-stack");
+    assertNonNullable(stack);
+    assertTrue(stack.getResource("Bucket")?.deployed);
+    assertTrue(stack.getResource("Handler")?.deployed);
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
@@ -1,0 +1,229 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
+
+/**
+ * Deploy a template carrying the given notification configuration, which is
+ * expected to fail the Stack, returning the error the deployment gave.
+ *
+ * The configuration is the whole point of every test here, so the rest of the
+ * template stays where the factory put it.
+ */
+async function deployConfiguration(
+  configuration: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  const simAws = new SimAws();
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: configuration,
+      }),
+    });
+  });
+}
+
+describe("CDK Bucket notifications configuration shape", () => {
+  it("refuses a configuration that is not an object", async () => {
+    // Given a template whose NotificationConfiguration is a string.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "uploads-stack",
+        template: simCdkBucketNotificationsTemplateFactory.make({
+          notificationProperties: { NotificationConfiguration: "everything" },
+        }),
+      });
+    });
+
+    // Then the Stack fails naming what was wrong.
+    assertStringIncludes(
+      error.message,
+      "Invalid Custom::S3BucketNotifications Resource BucketNotifications: " +
+        "NotificationConfiguration must be an object",
+    );
+  });
+
+  it("refuses a destination group that is not a list", async () => {
+    // Given a configuration whose LambdaFunctionConfigurations is an object.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: {
+        Events: ["s3:ObjectCreated:*"],
+      },
+    });
+
+    // Then the Stack fails naming what was wrong.
+    assertStringIncludes(
+      error.message,
+      "LambdaFunctionConfigurations must be a list",
+    );
+  });
+
+  it("refuses a configuration entry that is not an object", async () => {
+    // Given a configuration listing a string where a configuration belongs.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: ["thumbnailer"],
+    });
+
+    // Then the Stack fails naming what was wrong.
+    assertStringIncludes(
+      error.message,
+      "LambdaFunctionConfigurations entry must be an object",
+    );
+  });
+
+  it("refuses an event that is not a string", async () => {
+    // Given a configuration naming its events as numbers.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: [
+        {
+          Events: [1],
+          LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+        },
+      ],
+    });
+
+    // Then the Stack fails naming which entry was wrong.
+    assertStringIncludes(error.message, "Events entry 0 must be a string");
+  });
+
+  it("refuses a function ARN that is not a string", async () => {
+    // Given a configuration whose LambdaFunctionArn did not resolve.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: [
+        { Events: ["s3:ObjectCreated:*"], LambdaFunctionArn: 12 },
+      ],
+    });
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(error.message, "LambdaFunctionArn must be a string");
+  });
+
+  it("refuses a filter that is not an object", async () => {
+    // Given a configuration whose Filter is a string.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: [
+        {
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Filter: "raw/",
+        },
+      ],
+    });
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(error.message, "Filter must be an object");
+  });
+
+  it("refuses filter rules that are not a list", async () => {
+    // Given a configuration whose FilterRules is an object.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: [
+        {
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Filter: { Key: { FilterRules: { Name: "prefix", Value: "raw/" } } },
+        },
+      ],
+    });
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(error.message, "FilterRules must be a list");
+  });
+
+  it("refuses a filter rule name that is not a string", async () => {
+    // Given a configuration whose filter rule name is a number.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      LambdaFunctionConfigurations: [
+        {
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Filter: { Key: { FilterRules: [{ Name: 1, Value: "raw/" }] } },
+        },
+      ],
+    });
+
+    // Then the Stack fails naming the property.
+    assertStringIncludes(
+      error.message,
+      "FilterRules entry Name must be a string",
+    );
+  });
+
+  it("refuses a queue destination by name", async () => {
+    // Given the configuration CDK synthesizes for an SQS destination, which
+    // simulated S3 cannot deliver to.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      QueueConfigurations: [
+        {
+          Events: ["s3:ObjectRemoved:*"],
+          QueueArn: "arn:aws:sqs:us-east-1:888888888888:removals",
+        },
+      ],
+    });
+
+    // Then the Stack fails, because a configuration that is accepted and never
+    // delivered is worse than one that is refused.
+    assertStringIncludes(
+      error.message,
+      "Simulated S3 cannot notify a SQS queue",
+    );
+  });
+
+  it("refuses a topic destination by name", async () => {
+    // Given a configuration naming an SNS topic.
+    // When the template is deployed.
+    const error = await deployConfiguration({
+      TopicConfigurations: [
+        {
+          Events: ["s3:ObjectCreated:*"],
+          TopicArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+        },
+      ],
+    });
+
+    // Then the Stack fails naming the destination.
+    assertStringIncludes(
+      error.message,
+      "Simulated S3 cannot notify a SNS topic",
+    );
+  });
+
+  it("refuses an EventBridge destination by name", async () => {
+    // Given the configuration CDK synthesizes for `eventBridgeEnabled: true`.
+    // When the template is deployed.
+    const error = await deployConfiguration({ EventBridgeConfiguration: {} });
+
+    // Then the Stack fails naming the destination.
+    assertStringIncludes(
+      error.message,
+      "Simulated S3 cannot notify a EventBridge",
+    );
+  });
+
+  it("refuses an EventBridge configuration that is not an object", async () => {
+    // Given a configuration whose EventBridgeConfiguration is a list.
+    // When the template is deployed.
+    const error = await deployConfiguration({ EventBridgeConfiguration: [] });
+
+    // Then the Stack fails on the shape before the destination is reached.
+    assertStringIncludes(
+      error.message,
+      "EventBridgeConfiguration must be an object",
+    );
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-template.factory.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-template.factory.ts
@@ -1,0 +1,156 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * What a test asks for when it wants the template CDK synthesizes for
+ * `bucket.addEventNotification(...)`.
+ *
+ * Four Resources stand between a test and a Bucket that notifies a function,
+ * and most tests about the custom Resource are about one property of one of
+ * them. `notificationProperties` is merged in last, so a test states the one
+ * property it is about rather than the whole template.
+ */
+export interface SimCdkBucketNotificationsTemplateInput {
+  readonly bucketName: string;
+  readonly functionName: string;
+  /** The inline function code the notification is delivered to. */
+  readonly handlerSource: string;
+  /** The configuration the custom Resource carries, in the SDK request shape. */
+  readonly notificationConfiguration: SimCfnTemplateValueRecord;
+  readonly notificationProperties: SimCfnTemplateValueRecord;
+  /**
+   * Whether the template grants S3 permission to invoke the function, which
+   * CDK always does alongside the notification.
+   */
+  readonly permitted: boolean;
+  readonly resources: SimCfnTemplateValueRecord;
+}
+
+/**
+ * The Resources and the `DependsOn` the permission contributes to the template.
+ */
+interface SimCdkBucketNotificationsPermission {
+  readonly resources: SimCfnTemplateValueRecord;
+  readonly dependsOn: SimCfnTemplateValueRecord;
+}
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * Builds the template CDK synthesizes for a Bucket event notification.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "uploads-stack",
+ *   template: simCdkBucketNotificationsTemplateFactory.make({
+ *     notificationProperties: { Managed: false },
+ *   }),
+ * });
+ * ```
+ *
+ * The `ServiceToken` points at nothing, as it does in the tests that matter:
+ * CDK's provider function is a Python function this simulator skips, and the
+ * factory reads the properties around the token rather than the token itself.
+ */
+export const simCdkBucketNotificationsTemplateFactory = new MappedFactory<
+  SimCdkBucketNotificationsTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    bucketName: "uploads",
+    functionName: "thumbnailer",
+    handlerSource: "exports.handler = async () => 'thumbnailed';",
+    notificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+        },
+      ],
+    },
+    notificationProperties: {},
+    permitted: true,
+    resources: {},
+  }),
+  (input) => ({
+    Resources: {
+      Bucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: input.bucketName },
+      },
+      HandlerRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: `${input.functionName}-role`,
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+        },
+      },
+      Handler: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: input.functionName,
+          Role: { "Fn::GetAtt": ["HandlerRole", "Arn"] },
+          Code: { ZipFile: input.handlerSource },
+          Handler: "index.handler",
+          Runtime: "nodejs20.x",
+        },
+      },
+      ...invokePermission(input).resources,
+      BucketNotifications: {
+        Type: "Custom::S3BucketNotifications",
+        ...invokePermission(input).dependsOn,
+        Properties: {
+          ServiceToken: "arn:aws:lambda:us-east-1:888888888888:function:cdk",
+          BucketName: { Ref: "Bucket" },
+          NotificationConfiguration: input.notificationConfiguration,
+          Managed: true,
+          SkipDestinationValidation: false,
+          ...input.notificationProperties,
+        },
+      },
+      ...input.resources,
+    },
+  }),
+);
+
+/**
+ * What the template carries for the `AWS::Lambda::Permission` CDK writes beside
+ * the notification, letting S3 invoke the function for events from this Bucket.
+ *
+ * The `DependsOn` comes with it, because it is what CDK writes to have the
+ * permission in place before S3 validates the destination naming the function.
+ */
+function invokePermission(
+  input: SimCdkBucketNotificationsTemplateInput,
+): SimCdkBucketNotificationsPermission {
+  if (!input.permitted) {
+    return { resources: {}, dependsOn: {} };
+  }
+
+  return {
+    dependsOn: { DependsOn: ["HandlerPermission"] },
+    resources: {
+      HandlerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:InvokeFunction",
+          FunctionName: { "Fn::GetAtt": ["Handler", "Arn"] },
+          Principal: "s3.amazonaws.com",
+          SourceAccount: { Ref: "AWS::AccountId" },
+          SourceArn: { "Fn::GetAtt": ["Bucket", "Arn"] },
+        },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
@@ -230,6 +230,7 @@ describe("CDK Bucket notifications CloudFormation Custom Resource", () => {
       );
     const configurations = output.LambdaFunctionConfigurations;
     assertNonNullable(configurations);
-    assertUndefined(configurations[0]?.Filter);
+    assertArrayLength(configurations, 1);
+    assertUndefined(configurations[0].Filter);
   });
 });

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
@@ -1,0 +1,235 @@
+import {
+  GetBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
+
+/**
+ * The part of the S3 event document these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: {
+        readonly configurationId: string;
+        readonly bucket: { readonly name: string };
+        readonly object: { readonly key: string };
+      };
+    },
+  ];
+}
+
+describe("CDK Bucket notifications CloudFormation Custom Resource", () => {
+  it("notifies the deployed function when an Object is created", async () => {
+    // Given the template CDK synthesizes for a Bucket event notification,
+    // with the function bound to a handler this test can watch.
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({}),
+      bindings: [
+        {
+          functionName: "thumbnailer",
+          handler: (event: S3EventDocument): string => {
+            received.push(event);
+
+            return "thumbnailed";
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then an Object put into the deployed Bucket reaches the deployed
+    // function.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(received, 1);
+    const record = received[0].Records[0];
+    assertIdentical(record.eventName, "ObjectCreated:Put");
+    assertIdentical(record.s3.bucket.name, "uploads");
+    assertIdentical(record.s3.object.key, "cat.jpg");
+  });
+
+  it("configures the Bucket as PutBucketNotificationConfiguration would", async () => {
+    // Given a template naming the configuration it applies.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "thumbnails",
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Bucket reports the configuration back as it would for an SDK
+    // caller who applied the same one.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.LambdaFunctionConfigurations;
+    assertNonNullable(configurations);
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "thumbnails");
+    assertIdentical(
+      configurations[0].LambdaFunctionArn,
+      `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`,
+    );
+    assertIdentical(
+      configurations[0].Filter?.Key?.FilterRules?.[0]?.Value,
+      "raw/",
+    );
+  });
+
+  it("delivers only the Object keys the prefix filter matches", async () => {
+    // Given a template whose notification filters on a prefix.
+    const simAws = new SimAws();
+    const received: S3EventDocument[] = [];
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+      bindings: [
+        {
+          functionName: "thumbnailer",
+          handler: (event: S3EventDocument): string => {
+            received.push(event);
+
+            return "thumbnailed";
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // When Objects are put on both sides of the filter.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "thumbs/cat.jpg",
+        Body: "thumbnail",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the matching key is delivered.
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].s3.object.key, "raw/cat.jpg");
+  });
+
+  it("reads Managed and SkipDestinationValidation as strings", async () => {
+    // Given a template whose flags are the strings CloudFormation hands a
+    // custom Resource provider, rather than JSON booleans.
+    const simAws = new SimAws();
+
+    // When the template is deployed, naming a function nothing permits S3 to
+    // invoke, with destination validation skipped.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        permitted: false,
+        notificationProperties: {
+          Managed: "true",
+          SkipDestinationValidation: "true",
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the configuration is applied without the destination being
+    // validated, as it is for an SDK caller who skipped it.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(output.LambdaFunctionConfigurations ?? [], 1);
+  });
+
+  it("applies a configuration that filters on nothing", async () => {
+    // Given a template carrying an empty filter, which is a configuration S3
+    // accepts and every Object key passes.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: { "Fn::GetAtt": ["Handler", "Arn"] },
+              Filter: { Key: {} },
+            },
+          ],
+          QueueConfigurations: [],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Bucket is configured, with no filter rules reported back.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.LambdaFunctionConfigurations;
+    assertNonNullable(configurations);
+    assertUndefined(configurations[0]?.Filter);
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.loc.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.loc.test.ts
@@ -1,0 +1,212 @@
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { buffer } from "node:stream/consumers";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the template
+ * for `bucket.addEventNotification(...)`, which CDK writes as a
+ * Custom::S3BucketNotifications Resource rather than as a Bucket property.
+ */
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * The Account and Region the CDK app synthesizes for.
+ *
+ * The simulated scope has to match, because the `SourceAccount` on the
+ * `AWS::Lambda::Permission` CDK writes beside the notification is a synth-time
+ * literal. A Stack deployed into another Account leaves S3 unable to validate
+ * the destination.
+ */
+const cdkAccountId = "111111111111";
+const cdkRegionName = "eu-west-2";
+
+/**
+ * The part of the S3 event document these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    { readonly s3: { readonly object: { readonly key: string } } },
+  ];
+}
+
+/**
+ * A handler that writes a marker Object into the second Bucket of the Stack,
+ * as the deployed function code rather than as a binding.
+ */
+const thumbnailHandlerSource = `
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+const s3Client = new S3Client({});
+exports.handler = async (event) => {
+  const record = event.Records[0];
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: "cdk-notification-thumbs",
+      Key: record.s3.object.key + ".thumb",
+      Body: record.eventName,
+    }),
+  );
+};
+`;
+
+describe("Sim CDK Bucket notification local integration", () => {
+  it("delivers a created Object to the function the CDK app notified", async () => {
+    // Given a CDK stack whose Bucket notifies a function on Object creation,
+    // where the function writes a marker Object into a second Bucket.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3n from "aws-cdk-lib/aws-s3-notifications";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "${cdkAccountId}", region: "${cdkRegionName}" },
+});
+
+const uploadsBucket = new s3.Bucket(stack, "UploadsBucket", {
+  bucketName: "cdk-notification-uploads",
+});
+const thumbsBucket = new s3.Bucket(stack, "ThumbsBucket", {
+  bucketName: "cdk-notification-thumbs",
+});
+
+const thumbnailer = new lambda.Function(stack, "Thumbnailer", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(thumbnailHandlerSource)}),
+});
+
+thumbsBucket.grantPut(thumbnailer);
+
+uploadsBucket.addEventNotification(
+  s3.EventType.OBJECT_CREATED,
+  new s3n.LambdaDestination(thumbnailer),
+);
+
+app.synth();
+      `,
+    );
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed into a matching scope.
+    const simAws = new SimAws();
+    const scope = simAws.account(cdkAccountId).region(cdkRegionName);
+    const stack = await scope
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+
+    // Then putting an Object into the deployed Bucket runs the deployed
+    // function.
+    await scope.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "cdk-notification-uploads",
+        Key: "cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const marker = await scope.s3().getObject(
+      new GetObjectCommand({
+        Bucket: "cdk-notification-thumbs",
+        Key: "cat.jpg.thumb",
+      }),
+    );
+    assertNonNullable(marker.Body);
+    const markerBytes = await buffer(marker.Body);
+    assertIdentical(markerBytes.toString(), "ObjectCreated:Put");
+  });
+
+  it("delivers only the keys the CDK filter matches", async () => {
+    // Given a CDK stack whose notification filters on a prefix, with the
+    // function bound to a handler this test can watch.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3n from "aws-cdk-lib/aws-s3-notifications";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "${cdkAccountId}", region: "${cdkRegionName}" },
+});
+
+const uploadsBucket = new s3.Bucket(stack, "UploadsBucket", {
+  bucketName: "cdk-filtered-uploads",
+});
+
+const thumbnailer = new lambda.Function(stack, "Thumbnailer", {
+  functionName: "cdk-filtered-thumbnailer",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline("exports.handler = async () => 'replaced';"),
+});
+
+uploadsBucket.addEventNotification(
+  s3.EventType.OBJECT_CREATED,
+  new s3n.LambdaDestination(thumbnailer),
+  { prefix: "raw/" },
+);
+
+app.synth();
+      `,
+    );
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed into a matching scope.
+    const simAws = new SimAws();
+    const scope = simAws.account(cdkAccountId).region(cdkRegionName);
+    const received: S3EventDocument[] = [];
+    await scope.cloudFormation().deployTemplateFile({
+      templatePath: path.join(cdkOutDirectory, "TestStack.template.json"),
+      bindings: [
+        {
+          functionName: "cdk-filtered-thumbnailer",
+          handler: (event: S3EventDocument): string => {
+            received.push(event);
+
+            return "thumbnailed";
+          },
+        },
+      ],
+    });
+    await simAws.backgroundTasksComplete();
+
+    // And Objects are put on both sides of the filter.
+    await scope.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "cdk-filtered-uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await scope.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "cdk-filtered-uploads",
+        Key: "thumbs/cat.jpg",
+        Body: "thumbnail",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the matching key reaches the function.
+    assertArrayLength(received, 1);
+    assertIdentical(received[0].Records[0].s3.object.key, "raw/cat.jpg");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
@@ -1,0 +1,71 @@
+import type { SimCfnServiceResourceFactory } from "../../../resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../../resource/sim-cfn-resource.js";
+import { SimCdkBucketNotificationConfiguration } from "./configuration/sim-cdk-bucket-notification-configuration.js";
+import { bucketNotificationsError } from "./error/sim-cdk-bucket-notification-error.js";
+import { SimCdkBucketNotificationProperties } from "./property/sim-cdk-bucket-notification-properties.js";
+
+/**
+ * CloudFormation Resource factory for CDK Bucket event notifications.
+ *
+ * CDK never emits the `AWS::S3::Bucket` `NotificationConfiguration` property.
+ * Every `bucket.addEventNotification(...)` becomes a
+ * `Custom::S3BucketNotifications` Resource backed by a Python provider function
+ * whose only job is one PutBucketNotificationConfiguration call. The Resource
+ * therefore already carries the SDK request shape, and this factory makes that
+ * call through the ordinary command path, so a CDK app and an SDK caller are
+ * validated identically.
+ *
+ * `ServiceToken` is ignored. The provider function it names is skipped on its
+ * runtime, as CDK's BucketDeployment provider already is.
+ */
+export class SimCdkBucketNotificationsResourceFactory implements SimCfnServiceResourceFactory {
+  /**
+   * Apply a CDK Bucket notification configuration to the simulated Bucket.
+   *
+   * Nothing is returned as the Resource's simulated object. A notification
+   * configuration has no existence of its own in S3, so there is nothing for
+   * `Ref` or `Fn::GetAtt` to answer with, and CDK references neither.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<undefined> {
+    /* v8 ignore if -- defensive catch; the resolver routes on this name */
+    if (resourceTypeName !== "S3BucketNotifications") {
+      throw bucketNotificationsError(
+        resource.logicalId,
+        `${resourceTypeName} is not a Resource type this factory creates`,
+      );
+    }
+
+    const properties = new SimCdkBucketNotificationProperties(
+      resource.logicalId,
+      context.resolvedProperties ?? resource.properties,
+    );
+    properties.assertManaged();
+
+    const configuration = new SimCdkBucketNotificationConfiguration(
+      resource.logicalId,
+    ).read(properties.notificationConfiguration);
+
+    await context.simAws
+      .accountRegionScope(
+        resource.accountRegionScope.accountId,
+        resource.accountRegionScope.regionName,
+      )
+      .s3()
+      .putBucketNotificationConfiguration({
+        input: {
+          Bucket: properties.bucketName,
+          NotificationConfiguration: configuration,
+          SkipDestinationValidation: properties.skipDestinationValidation,
+        },
+      });
+
+    return undefined;
+  }
+}

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-custom-resource-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-custom-resource-factories.ts
@@ -1,0 +1,39 @@
+import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
+import { SimCdkBucketDeploymentResourceFactory } from "../../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
+import { SimCdkBucketNotificationsResourceFactory } from "../../../cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.js";
+
+/**
+ * How one CDK custom Resource hands over its factory.
+ *
+ * Nothing is passed in, because a custom Resource names the Bucket or the
+ * function it acts on in its own properties and reads the Account and Region
+ * scope off the Resource being created.
+ */
+type SimCdkCustomResourceFactory = () => SimCfnServiceResourceFactory;
+
+/**
+ * The CDK custom Resource types this simulator creates.
+ *
+ * CDK reaches several features through a `Custom::` Resource backed by its own
+ * Lambda function rather than through a CloudFormation Resource type, so a
+ * synthesized template contains them whether or not the app mentions a custom
+ * resource. Each entry here replaces the work that function would have done.
+ *
+ * A `Custom::` type with no entry is not created, which is what the resolver
+ * turns into an unsupported-Resource error.
+ */
+export const simCdkCustomResourceFactories: ReadonlyMap<
+  string,
+  SimCdkCustomResourceFactory
+> = new Map([
+  [
+    "CDKBucketDeployment",
+    (): SimCfnServiceResourceFactory =>
+      new SimCdkBucketDeploymentResourceFactory(),
+  ],
+  [
+    "S3BucketNotifications",
+    (): SimCfnServiceResourceFactory =>
+      new SimCdkBucketNotificationsResourceFactory(),
+  ],
+]);

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-resolver.ts
@@ -4,7 +4,7 @@ import type {
   SimCloudFormationParsedResourceType,
   SimCfnServiceResourceFactory,
 } from "../../factory/sim-cfn-resource-factory.type.js";
-import { SimCdkBucketDeploymentResourceFactory } from "../../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
+import { simCdkCustomResourceFactories } from "./sim-cfn-custom-resource-factories.js";
 import { simCfnServiceResourceFactories } from "./sim-cfn-service-factories.js";
 
 /**
@@ -15,18 +15,8 @@ export function resolveSimCloudFormationServiceResourceFactory(
   accountRegionScope: SimAwsAccountRegionScope,
   resourceType: SimCloudFormationParsedResourceType,
 ): SimCfnServiceResourceFactory {
-  if (
-    resourceType.providerName === "Custom" &&
-    resourceType.serviceName === "Custom" &&
-    resourceType.resourceTypeName === "CDKBucketDeployment"
-  ) {
-    return new SimCdkBucketDeploymentResourceFactory();
-  }
-
   if (resourceType.providerName === "Custom") {
-    throw new Error(
-      `Unsupported sim CloudFormation Custom Resource ${resourceType.resourceTypeName}`,
-    );
+    return resolveSimCdkCustomResourceFactory(resourceType);
   }
 
   if (resourceType.providerName !== "AWS") {
@@ -50,5 +40,30 @@ export function resolveSimCloudFormationServiceResourceFactory(
       accountRegionScope.accountId,
       accountRegionScope.regionName,
     ),
+  );
+}
+
+/**
+ * Resolve the factory for a CDK custom Resource type.
+ *
+ * A custom Resource type is two parts, `Custom::<name>`, which the parser reads
+ * as a service name of `Custom`. Anything carrying a service name of its own is
+ * a type this simulator has not been told about, whatever it ends with.
+ */
+function resolveSimCdkCustomResourceFactory(
+  resourceType: SimCloudFormationParsedResourceType,
+): SimCfnServiceResourceFactory {
+  if (resourceType.serviceName === "Custom") {
+    const customResourceFactory = simCdkCustomResourceFactories.get(
+      resourceType.resourceTypeName,
+    );
+
+    if (customResourceFactory !== undefined) {
+      return customResourceFactory();
+    }
+  }
+
+  throw new Error(
+    `Unsupported sim CloudFormation Custom Resource ${resourceType.resourceTypeName}`,
   );
 }


### PR DESCRIPTION
CDK writes every event notification as a Custom::S3BucketNotifications Resource carrying the PutBucketNotificationConfiguration request, so sim CloudFormation applies it through the ordinary command path. Managed: false is refused by name rather than approximated, as are the destination groups simulated S3 cannot deliver to.

Resolves https://github.com/KensioSoftware/yulin/issues/332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deploying CDK S3 bucket notifications through simulated CloudFormation.
  - S3 event notifications can now trigger Lambda handlers, including prefix filtering and destination validation.
  - Added support for CDK custom resources for bucket deployment and S3 notifications.
  - Added an end-to-end example demonstrating object uploads and event delivery.

- **Documentation**
  - Documented deployment requirements, supported configurations, limitations, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->