### PR TITLE
feat: send a simulated S3 event notification to a simulated SQS queue

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -280,12 +280,14 @@ failures come back.
 
 ## Event notifications
 
-A simulated S3 Bucket can notify a simulated Lambda function when an Object is created or removed.
-The configuration is applied with `PutBucketNotificationConfigurationCommand` and read back with
+A simulated S3 Bucket can notify a simulated Lambda function or a simulated SQS queue when an Object
+is created or removed. The configuration is applied with
+`PutBucketNotificationConfigurationCommand` and read back with
 `GetBucketNotificationConfigurationCommand`.
 
-The function's resource policy decides whether S3 may invoke it. That is checked when the
-configuration is applied, and again for every event, as real S3 does.
+The destination's own policy decides whether S3 may reach it: the function's resource policy, or the
+queue's `Policy` attribute. That is checked when the configuration is applied, and again for every
+event, as real S3 does.
 
 ```typescript sim-s3-event-notifications
 /**
@@ -374,6 +376,8 @@ A configuration can filter on an object key prefix, a suffix, or both. Two confi
 an event type and whose filters could both match the same key are refused with `InvalidArgument`, as
 real S3 refuses them. Overlapping prefixes are fine when the suffixes do not overlap, so one function
 can take the `.jpg` files under a prefix while another takes the `.png` files under the same one.
+The rule applies across the destination groups, so a function and a queue that both want the same
+event are refused as readily as two functions.
 
 `PutBucketNotificationConfigurationCommand` replaces the whole configuration rather than adding to
 it. `GetBucketNotificationConfigurationCommand` answers an empty configuration for a Bucket that has
@@ -392,15 +396,173 @@ const configurations = read.LambdaFunctionConfigurations ?? [];
 The two commands are authorized as `s3:PutBucketNotification` and `s3:GetBucketNotification`. Those
 are the real IAM action names, and they do not match the API names.
 
+### To an SQS queue
+
+A `QueueConfigurations` entry names a queue by ARN. The whole `Records` document arrives as one
+message body, so a consumer parses `record.body` to get at the event. Put a Lambda event source
+mapping on the queue and the chain runs end to end after one `backgroundTasksComplete()`.
+
+The queue's `Policy` attribute has to allow `sqs:SendMessage` for the `s3.amazonaws.com` service
+principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`, so the `ArnLike` condition CDK's
+`SqsDestination` writes and the `StringEquals aws:SourceAccount` guard AWS documents are both
+satisfied.
+
+```typescript sim-s3-sqs-notification
+/**
+ * An Object event reaching a Lambda function through an SQS queue.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+
+// The queue policy is the whole of what admits S3, which owns no identity
+// policies anywhere.
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+        },
+      }),
+    },
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "UploadConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "UploadConsumerRole",
+    PolicyName: "ConsumeUploads",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "upload-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          // The S3 event document is the SQS message body, so it is parsed
+          // out of the record rather than being the event itself.
+          const document = JSON.parse(record.body) as S3EventDocument;
+
+          console.log(document.Records[0].s3.object.key); // "raw/cat.jpg"
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "upload-consumer",
+  }),
+);
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      QueueConfigurations: [
+        {
+          Id: "raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          QueueArn: queueArn,
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// One wait covers the delivery to the queue and the poll that follows it.
+await simAws.backgroundTasksComplete();
+```
+
+The queue has to be in the Bucket's Region, as real S3 requires. It can be in another Account, since
+its own policy and its own Account's IAM are what admit the Bucket. A FIFO queue is refused by name.
+
 ### From a CloudFormation template
 
 The `NotificationConfiguration` property of `AWS::S3::Bucket` deploys through the same
 `PutBucketNotificationConfiguration` path, so a template and an SDK caller get identical validation.
-CloudFormation names the same configuration differently in four places: `LambdaConfigurations` rather
-than `LambdaFunctionConfigurations`, a single `Event` string rather than an `Events` list, `Function`
-rather than `LambdaFunctionArn`, and `Filter.S3Key.Rules` rather than `Filter.Key.FilterRules`. Yulin
-reads the CloudFormation names and refuses the others, so a template using the SDK spelling fails the
-stack rather than deploying an unfiltered configuration.
+CloudFormation names the same configuration differently in several places: `LambdaConfigurations`
+rather than `LambdaFunctionConfigurations`, a single `Event` string rather than an `Events` list,
+`Function` rather than `LambdaFunctionArn`, `Queue` rather than `QueueArn`, and `Filter.S3Key.Rules`
+rather than `Filter.Key.FilterRules`. `QueueConfigurations` is the one name both spell the same way.
+Yulin reads the CloudFormation names and refuses the others, so a template using the SDK spelling
+fails the stack rather than deploying an unfiltered configuration.
 
 ```typescript sim-s3-cfn-event-notification
 /**
@@ -549,9 +711,10 @@ already on the Bucket instead of replacing them, and simulated S3 only replaces,
 written would drop configurations that survive on real AWS. Declare the Bucket in the same stack to
 get a managed notification configuration.
 
-### What arrives at the handler
+### What arrives at the destination
 
-The handler is invoked with the `Records` document real S3 sends. One event produces one record.
+A function is invoked with the `Records` document real S3 sends, and a queue gets the same document
+as one message body. One event produces one record.
 
 Creation records carry the Object's `size` and its `eTag`, which is the MD5 of the bytes as it is for
 an Object real S3 stored in one part. Removal records carry neither, because the Object they describe
@@ -583,8 +746,11 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 
 ### Limitations
 
-- Lambda is the only destination. An SQS queue, an SNS topic and EventBridge are each refused by
-  name.
+- A Lambda function and an SQS queue are the destinations. An SNS topic and EventBridge are each
+  refused by name.
+- A destination goes where the group it was declared in says, not where its ARN says: a queue ARN
+  under `LambdaFunctionConfigurations` is refused for not being a function ARN rather than delivered
+  to as a queue.
 - Only `s3:ObjectCreated:Put` and `s3:ObjectRemoved:Delete` are raised. `Copy`, `Post`,
   `CompleteMultipartUpload`, `DeleteMarkerCreated`, the `ObjectRestore:*`, `Replication:*`,
   `LifecycleExpiration:*` and `ObjectTagging:*` families, `LifecycleTransition`,
@@ -603,15 +769,23 @@ writes do not match it. Without that, the simulation stops after a thousand deli
 - A notification cannot be configured on a standalone `SimS3`. It has no other simulated services to
   notify, and no shared background scheduler for `backgroundTasksComplete()` to drain. Reach
   simulated S3 through `SimAws` instead.
-- A queue or topic destination in an `AWS::S3::Bucket` `NotificationConfiguration` is refused by
-  name, as it is for an SDK caller, and so is an `EventBridgeConfiguration`.
+- A topic destination in an `AWS::S3::Bucket` `NotificationConfiguration` is refused by name, as it
+  is for an SDK caller, and so is an `EventBridgeConfiguration`.
 - `Managed: false` on a `Custom::S3BucketNotifications` resource is refused rather than approximated,
-  and a queue, topic or EventBridge destination in one is refused by name as it is for an SDK caller.
+  and a topic or EventBridge destination in one is refused by name as it is for an SDK caller.
+- A FIFO queue destination is refused by name, as real S3 refuses one. Simulated SQS has no FIFO
+  queues either.
+- The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is not acted on.
+  Queue encryption is not simulated.
 - A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
   rather than putting Objects, so neither raises anything, whereas real CDK `BucketDeployment` fires
   one `ObjectCreated:Put` per file.
 - A function ARN naming a version or an alias is refused, since simulated Lambda has neither.
-- `s3:TestEvent` is not sent. It is an SQS and SNS mechanism.
+- `s3:TestEvent` is not sent. Real S3 puts one on a queue or topic when a configuration naming it is
+  applied, carrying a flat `{Service, Event, Time, Bucket, RequestId, HostId}` document with no
+  `Records` in it. Sending it here would make the simplest test two messages long and hand a
+  consumer a body it cannot parse as an event. What the message exists to prove, that S3 may reach
+  the destination, is simulated directly by the destination check.
 
 ## Buckets from CloudFormation
 
@@ -1370,7 +1544,7 @@ Sim S3 currently supports:
 - `PutObjectCommand`, `GetObjectCommand` and `ListObjectsCommand`
 - `DeleteObjectCommand` and `DeleteObjectsCommand`, authorized per Object by sim IAM
 - `PutBucketNotificationConfigurationCommand` and `GetBucketNotificationConfigurationCommand`, with
-  Object events delivered to a simulated Lambda function
+  Object events delivered to a simulated Lambda function or a simulated SQS queue
 - `PutBucketWebsiteCommand`, for static website hosting
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies

--- a/docs/services/s3/sim-s3-sqs-notification.example.ts
+++ b/docs/services/s3/sim-s3-sqs-notification.example.ts
@@ -1,0 +1,140 @@
+/**
+ * An Object event reaching a Lambda function through an SQS queue.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+interface S3EventDocument {
+  Records: [{ eventName: string; s3: { object: { key: string } } }];
+}
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+
+// The queue policy is the whole of what admits S3, which owns no identity
+// policies anywhere.
+await simAws.sqs().setQueueAttributes(
+  new SetQueueAttributesCommand({
+    QueueUrl,
+    Attributes: {
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "s3.amazonaws.com" },
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+          Condition: { ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" } },
+        },
+      }),
+    },
+  }),
+);
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "UploadConsumerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "UploadConsumerRole",
+    PolicyName: "ConsumeUploads",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "upload-consumer",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          // The S3 event document is the SQS message body, so it is parsed
+          // out of the record rather than being the event itself.
+          const document = JSON.parse(record.body) as S3EventDocument;
+
+          console.log(document.Records[0].s3.object.key); // "raw/cat.jpg"
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "upload-consumer",
+  }),
+);
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      QueueConfigurations: [
+        {
+          Id: "raw-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          QueueArn: queueArn,
+        },
+      ],
+    },
+  }),
+);
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/cat.jpg",
+    Body: "cat picture",
+  }),
+);
+
+// One wait covers the delivery to the queue and the poll that follows it.
+await simAws.backgroundTasksComplete();

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -614,9 +614,14 @@ try {
 }
 ```
 
-`sourceArn` is what a request says it is being made on behalf of. A request that does not carry one
-leaves the key out rather than supplying an empty string, so a statement conditioned on
-`aws:SourceArn` does not match it at all.
+`sourceArn` is what a request says it is being made on behalf of, and `sourceAccount` is the Account
+owning that resource, supplied as `aws:SourceAccount`. A request that does not carry one leaves the
+key out rather than supplying an empty string, so a statement conditioned on it does not match at
+all.
+
+A simulated S3 Bucket notifying a queue supplies both, so the `ArnLike aws:SourceArn` condition CDK
+writes and the `StringEquals aws:SourceAccount` guard AWS documents are each enough on their own.
+See [Event notifications](../s3/#event-notifications) on the S3 page for the whole chain.
 
 A caller from another account needs both sides to allow the request, as it does on real AWS: the
 queue policy naming the principal, and that principal's own account allowing the action. Either one
@@ -1108,7 +1113,8 @@ Sim SQS currently supports:
   `DeadLetterQueueSourceArn` system attributes
 - Authorization of every operation by simulated IAM, against the real IAM action and queue ARN
 - The `Policy` attribute as the queue's resource policy, admitting another account's principal or a
-  service principal, with `aws:SourceArn` conditions honoured
+  service principal, with `aws:SourceArn` and `aws:SourceAccount` conditions honoured
+- S3 event notifications sent to a queue, with the event document as the message body
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 - Lambda event source mappings, delivering messages to a simulated function and deleting the batches
   it handles

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -23,6 +23,8 @@ import { SimS3 } from "../../s3/sim-s3.js";
 import { SimAwsS3NotificationFunctions } from "../../s3/notification/destination/lambda/sim-aws-s3-notification-functions.js";
 import { SimS3LambdaNotificationDestination } from "../../s3/notification/destination/lambda/sim-s3-lambda-notification-destination.js";
 import { SimS3ServiceNotificationDestinations } from "../../s3/notification/destination/sim-s3-service-notification-destinations.js";
+import { SimAwsS3NotificationQueues } from "../../s3/notification/destination/sqs/sim-aws-s3-notification-queues.js";
+import { SimS3SqsNotificationDestination } from "../../s3/notification/destination/sqs/sim-s3-sqs-notification-destination.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -275,17 +277,18 @@ export class SimAwsAccountRegionServiceBuilder {
   /**
    * Where a simulated S3 Bucket can send its event notifications.
    *
-   * A notification configuration names a function by ARN, and that ARN can
-   * name any Account and Region, so the functions come from the whole
+   * A notification configuration names a destination by ARN, and that ARN can
+   * name any Account and Region, so the destinations come from the whole
    * simulation rather than from one scope.
    */
   private s3NotificationDestinations(): SimS3ServiceNotificationDestinations {
-    const functions = new SimAwsS3NotificationFunctions({
-      simAws: this.simAws,
-    });
-
     return new SimS3ServiceNotificationDestinations({
-      lambda: new SimS3LambdaNotificationDestination({ functions }),
+      lambda: new SimS3LambdaNotificationDestination({
+        functions: new SimAwsS3NotificationFunctions({ simAws: this.simAws }),
+      }),
+      sqs: new SimS3SqsNotificationDestination({
+        queues: new SimAwsS3NotificationQueues({ simAws: this.simAws }),
+      }),
     });
   }
 }

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/configuration/sim-cdk-bucket-notification-configuration.ts
@@ -1,6 +1,7 @@
 import type {
   SimS3LambdaFunctionConfigurationInput,
   SimS3NotificationConfigurationInput,
+  SimS3QueueConfigurationInput,
 } from "../../../../../s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import type { SimCfnTemplateValue } from "../../../../template/value/sim-cfn-template-value.js";
 import { SimCfnValueShape } from "../../../../template/value/sim-cfn-value-shape.js";
@@ -47,8 +48,7 @@ export class SimCdkBucketNotificationConfiguration {
       ),
       QueueConfigurations: this.shape.present(
         record["QueueConfigurations"],
-        (configurations) =>
-          this.shape.list(configurations, "QueueConfigurations"),
+        (configurations) => this.queueConfigurations(configurations),
       ),
       TopicConfigurations: this.shape.present(
         record["TopicConfigurations"],
@@ -84,6 +84,33 @@ export class SimCdkBucketNotificationConfiguration {
       LambdaFunctionArn: this.shape.present(
         record["LambdaFunctionArn"],
         (arn) => this.shape.string(arn, "LambdaFunctionArn"),
+      ),
+      Events: this.shape.present(record["Events"], (events) =>
+        this.events(events),
+      ),
+      Filter: this.shape.present(record["Filter"], (filter) =>
+        this.filter.read(filter),
+      ),
+    };
+  }
+
+  private queueConfigurations(
+    value: SimCfnTemplateValue,
+  ): readonly SimS3QueueConfigurationInput[] {
+    return this.shape
+      .list(value, "QueueConfigurations")
+      .map((configuration) => this.queueConfiguration(configuration));
+  }
+
+  private queueConfiguration(
+    value: SimCfnTemplateValue,
+  ): SimS3QueueConfigurationInput {
+    const record = this.shape.record(value, "QueueConfigurations entry");
+
+    return {
+      Id: this.shape.present(record["Id"], (id) => this.shape.string(id, "Id")),
+      QueueArn: this.shape.present(record["QueueArn"], (arn) =>
+        this.shape.string(arn, "QueueArn"),
       ),
       Events: this.shape.present(record["Events"], (events) =>
         this.events(events),

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-shape.iso.test.ts
@@ -163,9 +163,9 @@ describe("CDK Bucket notifications configuration shape", () => {
     );
   });
 
-  it("refuses a queue destination by name", async () => {
-    // Given the configuration CDK synthesizes for an SQS destination, which
-    // simulated S3 cannot deliver to.
+  it("refuses a queue destination that is not there", async () => {
+    // Given the configuration CDK synthesizes for an SQS destination, naming a
+    // queue no stack ever created.
     // When the template is deployed.
     const error = await deployConfiguration({
       QueueConfigurations: [
@@ -178,10 +178,7 @@ describe("CDK Bucket notifications configuration shape", () => {
 
     // Then the Stack fails, because a configuration that is accepted and never
     // delivered is worse than one that is refused.
-    assertStringIncludes(
-      error.message,
-      "Simulated S3 cannot notify a SQS queue",
-    );
+    assertStringIncludes(error.message, "is not a simulated SQS queue");
   });
 
   it("refuses a topic destination by name", async () => {

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.iso.test.ts
@@ -1,7 +1,13 @@
 import {
+  DeleteObjectCommand,
   GetBucketNotificationConfigurationCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
 import {
   assertArrayLength,
   assertIdentical,
@@ -11,6 +17,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
 import { simCdkBucketNotificationsTemplateFactory } from "./sim-cdk-bucket-notifications-template.factory.js";
 
 /**
@@ -110,6 +117,93 @@ describe("CDK Bucket notifications CloudFormation Custom Resource", () => {
       configurations[0].LambdaFunctionArn,
       `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:thumbnailer`,
     );
+    assertIdentical(
+      configurations[0].Filter?.Key?.FilterRules?.[0]?.Value,
+      "raw/",
+    );
+  });
+
+  it("notifies a queue the way CDK's SqsDestination configures one", async () => {
+    // Given a queue whose policy carries the ArnLike source ARN condition
+    // CDK's SqsDestination writes, and no source Account guard.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: {
+                ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    // When a template naming that queue alongside the function is deployed,
+    // which is what a CDK app adding two destinations for two event types
+    // synthesizes.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCdkBucketNotificationsTemplateFactory.make({
+        notificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "removals",
+              Events: ["s3:ObjectRemoved:*"],
+              QueueArn: queueArn,
+              Filter: {
+                Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then an Object removed from under the filtered prefix reaches the queue.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "raw/cat.jpg" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+      );
+    assertArrayLength(received.Messages ?? [], 1);
+
+    // And the Bucket reports the configuration back under QueueConfigurations.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.QueueConfigurations;
+    assertNonNullable(configurations);
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].Id, "removals");
+    assertIdentical(configurations[0].QueueArn, queueArn);
     assertIdentical(
       configurations[0].Filter?.Key?.FilterRules?.[0]?.Value,
       "raw/",

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,4 +1,5 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { sqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-arn.js";
 
 const queueArnPattern =
   /^arn:aws:sqs:(?<region>[a-z0-9-]+):(?<account>\d{12}):(?<name>[\w-]{1,80})$/u;
@@ -49,10 +50,11 @@ export class SimLambdaSqsEventSourceArn {
    * The URL SQS requests name this queue by.
    */
   get queueUrl(): string {
-    return (
-      `https://sqs.${this.regionName}.amazonaws.com/` +
-      `${this.accountId}/${this.queueName}`
-    );
+    return sqsQueueUrl({
+      regionName: this.regionName,
+      accountId: this.accountId,
+      name: this.queueName,
+    });
   }
 
   /**

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -352,10 +352,20 @@ Sim S3 usage docs:
 Notifications are split between the configuration, which is Bucket state, and delivery, which is not.
 
 `bucket/notification/` holds the configuration. `SimS3NotificationConfiguration` is what a Bucket
-stores, `SimS3LambdaNotification` is one destination in it, and `SimS3NotificationFilter` is the
-object key filter. `SimS3NotificationConfigurationReader` turns a
-`PutBucketNotificationConfiguration` request into one, refusing everything it cannot honour before
-anything is stored, so a refused request leaves the previous configuration alone.
+stores, and `SimS3NotificationFilter` is the object key filter. `SimS3Notification` is one
+destination in it, with `SimS3LambdaNotification` and `SimS3QueueNotification` as the two kinds.
+Everything a configuration is asked, which events reach a destination and whether two of them
+conflict, is the same question whatever the destination is, so only the ARN's property name and the
+kind of destination it wants differ between the subclasses. Each reads its own entries through
+`simS3NotificationProperties`, since the ARN is the only part the destination groups spell
+differently.
+
+`SimS3NotificationConfigurationReader` turns a `PutBucketNotificationConfiguration` request into a
+configuration, refusing everything it cannot honour before anything is stored, so a refused request
+leaves the previous configuration alone. What is left in the reader is the two rules that are about
+the configuration as a whole, `simS3AssertNotificationIdsAreUnique` and
+`simS3AssertNoNotificationOverlap`, and both look across the destination groups rather than within
+one, as real S3 does.
 
 Two rules in there are worth knowing about:
 
@@ -388,20 +398,39 @@ Two rules in there are worth knowing about:
 `notification/destination/` is the port. `SimS3NotificationDestination` owns both `validate` and
 `deliver`, because configuration-time validation and delivery-time re-check are the same
 per-destination question asked twice, as real S3 asks it.
-`SimS3ServiceNotificationDestinations` resolves a destination ARN through a `ReadonlyMap` keyed on
-the ARN's service segment. `SimS3NoNotificationDestinations` is what a standalone `SimS3` gets, and
-it refuses by name.
+`SimS3ServiceNotificationDestinations` answers with the destination of the kind a configuration was
+declared for, rather than reading the ARN to decide: a queue ARN under `LambdaFunctionConfigurations`
+then reaches the Lambda destination and is refused for not being a function, instead of quietly
+being delivered to as a queue. Each destination refuses an ARN that does not name what it delivers
+to. `SimS3NoNotificationDestinations` is what a standalone `SimS3` gets, and it refuses by name.
 
-`SimAwsS3NotificationFunctions` resolves and invokes the function. It resolves lazily from the
-`SimAws` it was built with, never at construction time: `createLambda` already reaches
-`scope.s3()` for function code, so an eager `scope.lambda()` in `createS3` would recurse, because the
-scope memo records a service only once its factory has returned. Whether S3 may invoke a function is
-Lambda's own rule, so the decision comes from `SimLambdaServiceInvokeAuthorizer` with the Bucket ARN
-and Account supplied as the source.
+Both destinations resolve lazily from the `SimAws` they were built with, never at construction time:
+`createLambda` already reaches `scope.s3()` for function code, so an eager `scope.lambda()` in
+`createS3` would recurse, because the scope memo records a service only once its factory has
+returned.
+
+`SimAwsS3NotificationFunctions` resolves and invokes the function. Whether S3 may invoke a function
+is Lambda's own rule, so the decision comes from `SimLambdaServiceInvokeAuthorizer` with the Bucket
+ARN and Account supplied as the source.
+
+`SimAwsS3NotificationQueues` does the same for a queue, and splits in two: it applies the one rule
+that is S3's, that the queue is in the Bucket's Region, and hands the rest to
+`SimS3NotificationQueue`, which is one queue in the Account and Region its ARN names. Everything
+there is asked of that Account, which is what makes a cross-Account queue work: its policy is the
+grant and its own IAM evaluates it, through `SimSqsServiceSendAuthorizer`. Delivery goes through the
+ordinary `SendMessage` path, so the message is the same thing an SDK caller would have sent and is
+authorized again on the way in. The refusal is asked for first all the same, so a queue policy saying
+no is recorded as a refusal rather than as a fault.
 
 The raise point is one call in `PutObjectCommandHandler` and one in each of the two deletion
 handlers, after the write and with the caller the authorizer resolved. Every write path funnels
 through those, so the SDK, an intercepted SDK client and the REST endpoint are all covered.
+
+`s3:TestEvent` is deliberately not sent. Real S3 puts one on a queue or topic when a configuration
+naming it is applied, carrying a flat document with no `Records` in it. Sending it would make the
+simplest possible test two messages long and hand a consumer a first body it cannot parse as an
+event, and what it exists to prove, that S3 can reach the destination, is what the destination check
+already does directly.
 
 ## Static website configuration
 

--- a/src/service/s3/bucket/notification/sim-s3-lambda-notification.ts
+++ b/src/service/s3/bucket/notification/sim-s3-lambda-notification.ts
@@ -1,50 +1,31 @@
 import type { SimS3LambdaFunctionConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
-import type { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
-import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
-
-interface SimS3LambdaNotificationProperties {
-  readonly id: string;
-  readonly functionArn: string;
-  readonly events: readonly string[];
-  readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
-  readonly filter: SimS3NotificationFilter;
-}
+import type { SimS3NotificationDestinationService } from "../../notification/destination/sim-s3-notification-destination.js";
+import { SimS3Notification } from "./sim-s3-notification.js";
+import { simS3NotificationProperties } from "./sim-s3-notification-properties.js";
 
 /**
  * One Lambda function destination in a Bucket's notification configuration.
- *
- * Both the configured event types and what they expand to are kept: the
- * configured ones are what GetBucketNotificationConfiguration reports back, and
- * the expanded ones are what delivery and the overlap rule work on.
  */
-export class SimS3LambdaNotification {
-  public readonly id: string;
-  public readonly functionArn: string;
-  public readonly events: readonly string[];
-  public readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
-  public readonly filter: SimS3NotificationFilter;
-
-  constructor(properties: SimS3LambdaNotificationProperties) {
-    this.id = properties.id;
-    this.functionArn = properties.functionArn;
-    this.events = properties.events;
-    this.concreteEvents = properties.concreteEvents;
-    this.filter = properties.filter;
-  }
+export class SimS3LambdaNotification extends SimS3Notification {
+  /**
+   * The kind of destination this configuration was declared for.
+   */
+  public readonly destinationService: SimS3NotificationDestinationService =
+    "lambda";
 
   /**
-   * Whether this configuration wants an event about an object key.
+   * Read one LambdaFunctionConfigurations entry.
    */
-  matches(event: SimS3NotificationEvent, key: string): boolean {
-    return this.concreteEvents.has(event) && this.filter.matches(key);
-  }
-
-  /**
-   * Whether this configuration and another cover any of the same events.
-   */
-  sharesEventsWith(other: SimS3LambdaNotification): boolean {
-    return [...this.concreteEvents].some((event) =>
-      other.concreteEvents.has(event),
+  static fromInput(
+    configuration: SimS3LambdaFunctionConfigurationInput,
+  ): SimS3LambdaNotification {
+    return new SimS3LambdaNotification(
+      simS3NotificationProperties(
+        configuration,
+        configuration.LambdaFunctionArn,
+        "A Lambda function notification configuration must name a " +
+          "LambdaFunctionArn.",
+      ),
     );
   }
 
@@ -52,13 +33,6 @@ export class SimS3LambdaNotification {
    * This configuration as GetBucketNotificationConfiguration reports it.
    */
   toOutput(): SimS3LambdaFunctionConfigurationInput {
-    const filter = this.filter.toOutput();
-
-    return {
-      Id: this.id,
-      LambdaFunctionArn: this.functionArn,
-      Events: [...this.events],
-      ...(filter !== undefined && { Filter: filter }),
-    };
+    return { ...this.reported(), LambdaFunctionArn: this.destinationArn };
   }
 }

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration-reader.ts
@@ -1,31 +1,20 @@
-import { randomUUID } from "node:crypto";
-import type {
-  SimS3LambdaFunctionConfigurationInput,
-  SimS3NotificationConfigurationInput,
-} from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
-import {
-  SimS3InvalidArgument,
-  SimS3NotImplemented,
-} from "../../error/sim-s3.error.js";
+import type { SimS3NotificationConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
 import { SimS3NotificationConfiguration } from "./sim-s3-notification-configuration.js";
-import { simS3ExpandNotificationEvent } from "./sim-s3-notification-event.js";
-import { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
+import { simS3AssertNotificationIdsAreUnique } from "./sim-s3-notification-ids.js";
 import { simS3AssertNoNotificationOverlap } from "./sim-s3-notification-overlap.js";
-
-/**
- * The destination groups a request can carry that this simulator does not
- * deliver to, and what to say about each.
- */
-const unsimulatedDestinations = new Map<string, string>([
-  ["QueueConfigurations", "SQS queue"],
-  ["TopicConfigurations", "SNS topic"],
-  ["EventBridgeConfiguration", "EventBridge"],
-]);
+import { SimS3QueueNotification } from "./sim-s3-queue-notification.js";
+import { simS3RefuseUnsimulatedDestinations } from "./sim-s3-unsimulated-notification-destinations.js";
 
 /**
  * Reads a PutBucketNotificationConfiguration request into a Bucket's stored
  * configuration.
+ *
+ * Each destination group reads its own entries, since the ARN is the only part
+ * they spell differently. What is left here is the pair of rules that are about
+ * the configuration as a whole rather than about one entry of it, and both look
+ * across the groups: real S3 refuses a function and a queue that share an id or
+ * want the same event as readily as it refuses two functions.
  *
  * Everything the request states is checked before anything is stored, so a
  * request the simulator refuses leaves the Bucket's previous configuration
@@ -38,95 +27,20 @@ export class SimS3NotificationConfigurationReader {
   read(
     input: SimS3NotificationConfigurationInput,
   ): SimS3NotificationConfiguration {
-    this.refuseUnsimulatedDestinations(input);
+    simS3RefuseUnsimulatedDestinations(input);
 
-    const notifications = (input.LambdaFunctionConfigurations ?? []).map(
-      (configuration) => this.readLambdaNotification(configuration),
-    );
-
-    this.refuseRepeatedIds(notifications);
-    simS3AssertNoNotificationOverlap(notifications);
-
-    return new SimS3NotificationConfiguration(notifications);
-  }
-
-  private readLambdaNotification(
-    configuration: SimS3LambdaFunctionConfigurationInput,
-  ): SimS3LambdaNotification {
-    const functionArn = configuration.LambdaFunctionArn;
-
-    if (functionArn === undefined || functionArn === "") {
-      throw new SimS3InvalidArgument(
-        "A Lambda function notification configuration must name a " +
-          "LambdaFunctionArn.",
-      );
-    }
-
-    const events = configuration.Events ?? [];
-
-    if (events.length === 0) {
-      throw new SimS3InvalidArgument(
-        `Notification configuration for ${functionArn} names no events.`,
-      );
-    }
-
-    return new SimS3LambdaNotification({
-      // S3 generates a configuration id for a configuration that omits one,
-      // and reports it back through GetBucketNotificationConfiguration.
-      id: configuration.Id ?? randomUUID(),
-      functionArn,
-      events,
-      concreteEvents: new Set(
-        events.flatMap((event) => simS3ExpandNotificationEvent(event)),
+    const configuration = new SimS3NotificationConfiguration({
+      lambdaNotifications: (input.LambdaFunctionConfigurations ?? []).map(
+        (entry) => SimS3LambdaNotification.fromInput(entry),
       ),
-      filter: SimS3NotificationFilter.fromInput(configuration.Filter),
+      queueNotifications: (input.QueueConfigurations ?? []).map((entry) =>
+        SimS3QueueNotification.fromInput(entry),
+      ),
     });
-  }
 
-  /**
-   * Refuse a destination group this simulator cannot deliver to.
-   *
-   * Naming the destination matters more than the refusal: a configuration
-   * quietly accepted and never delivered is the failure this feature exists to
-   * remove, so an SQS or SNS destination says so rather than being dropped.
-   */
-  private refuseUnsimulatedDestinations(
-    input: SimS3NotificationConfigurationInput,
-  ): void {
-    for (const [property, destination] of unsimulatedDestinations) {
-      // Read-only lookup of a fixed set of property names.
+    simS3AssertNotificationIdsAreUnique(configuration.all);
+    simS3AssertNoNotificationOverlap(configuration.all);
 
-      const configured = input[property as keyof typeof input];
-
-      if (configured === undefined) {
-        continue;
-      }
-
-      if (Array.isArray(configured) && configured.length === 0) {
-        continue;
-      }
-
-      throw new SimS3NotImplemented(
-        `Simulated S3 cannot notify a ${destination}. ${property} is not ` +
-          "simulated; use LambdaFunctionConfigurations.",
-      );
-    }
-  }
-
-  private refuseRepeatedIds(
-    notifications: readonly SimS3LambdaNotification[],
-  ): void {
-    const seen = new Set<string>();
-
-    for (const notification of notifications) {
-      if (seen.has(notification.id)) {
-        throw new SimS3InvalidArgument(
-          `Configuration id ${notification.id} is used more than once. ` +
-            "Configuration ids must be unique within a Bucket.",
-        );
-      }
-
-      seen.add(notification.id);
-    }
+    return configuration;
   }
 }

--- a/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-configuration.ts
@@ -1,6 +1,13 @@
 import type { SimS3NotificationConfigurationOutput } from "../../command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.js";
 import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
+import type { SimS3Notification } from "./sim-s3-notification.js";
 import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
+import type { SimS3QueueNotification } from "./sim-s3-queue-notification.js";
+
+interface SimS3NotificationConfigurationProperties {
+  readonly lambdaNotifications?: readonly SimS3LambdaNotification[];
+  readonly queueNotifications?: readonly SimS3QueueNotification[];
+}
 
 /**
  * The event notification configuration of one simulated S3 Bucket.
@@ -8,12 +15,19 @@ import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
  * A Bucket has one configuration rather than a list of them, which is why
  * PutBucketNotificationConfiguration replaces the whole thing: real S3 has no
  * way to add one destination without restating the others.
+ *
+ * The destination groups are held apart because that is how they go in and come
+ * back out. Everything that acts on a configuration, the overlap rule, the
+ * destination check and delivery, works on `all` instead, since none of them
+ * cares which kind of destination it is looking at.
  */
 export class SimS3NotificationConfiguration {
   public readonly lambdaNotifications: readonly SimS3LambdaNotification[];
+  public readonly queueNotifications: readonly SimS3QueueNotification[];
 
-  constructor(lambdaNotifications: readonly SimS3LambdaNotification[] = []) {
-    this.lambdaNotifications = lambdaNotifications;
+  constructor(properties: SimS3NotificationConfigurationProperties = {}) {
+    this.lambdaNotifications = properties.lambdaNotifications ?? [];
+    this.queueNotifications = properties.queueNotifications ?? [];
   }
 
   /**
@@ -24,10 +38,10 @@ export class SimS3NotificationConfiguration {
   }
 
   /**
-   * Whether this Bucket notifies anything at all.
+   * Every configured destination, whatever kind it is.
    */
-  get notifiesNothing(): boolean {
-    return this.lambdaNotifications.length === 0;
+  get all(): readonly SimS3Notification[] {
+    return [...this.lambdaNotifications, ...this.queueNotifications];
   }
 
   /**
@@ -36,10 +50,8 @@ export class SimS3NotificationConfiguration {
   matching(
     event: SimS3NotificationEvent,
     key: string,
-  ): readonly SimS3LambdaNotification[] {
-    return this.lambdaNotifications.filter((notification) =>
-      notification.matches(event, key),
-    );
+  ): readonly SimS3Notification[] {
+    return this.all.filter((notification) => notification.matches(event, key));
   }
 
   /**
@@ -49,14 +61,17 @@ export class SimS3NotificationConfiguration {
    * empty, which is what real S3 answers for a Bucket with no configuration.
    */
   toOutput(): SimS3NotificationConfigurationOutput {
-    if (this.notifiesNothing) {
-      return {};
-    }
-
     return {
-      LambdaFunctionConfigurations: this.lambdaNotifications.map(
-        (notification) => notification.toOutput(),
-      ),
+      ...(this.lambdaNotifications.length > 0 && {
+        LambdaFunctionConfigurations: this.lambdaNotifications.map(
+          (notification) => notification.toOutput(),
+        ),
+      }),
+      ...(this.queueNotifications.length > 0 && {
+        QueueConfigurations: this.queueNotifications.map((notification) =>
+          notification.toOutput(),
+        ),
+      }),
     };
   }
 }

--- a/src/service/s3/bucket/notification/sim-s3-notification-ids.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-ids.ts
@@ -1,0 +1,25 @@
+import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
+import type { SimS3Notification } from "./sim-s3-notification.js";
+
+/**
+ * Refuse a configuration that uses one id twice.
+ *
+ * Ids are unique within a Bucket rather than within a destination group, so a
+ * function and a queue cannot share one either.
+ */
+export function simS3AssertNotificationIdsAreUnique(
+  notifications: readonly SimS3Notification[],
+): void {
+  const seen = new Set<string>();
+
+  for (const notification of notifications) {
+    if (seen.has(notification.id)) {
+      throw new SimS3InvalidArgument(
+        `Configuration id ${notification.id} is used more than once. ` +
+          "Configuration ids must be unique within a Bucket.",
+      );
+    }
+
+    seen.add(notification.id);
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification-overlap.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-overlap.ts
@@ -1,5 +1,5 @@
 import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
-import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
+import type { SimS3Notification } from "./sim-s3-notification.js";
 
 /**
  * Refuse a configuration whose destinations would both want the same event.
@@ -12,10 +12,12 @@ import type { SimS3LambdaNotification } from "./sim-s3-lambda-notification.js";
  *
  * The comparison is on expanded event sets rather than on the configured event
  * strings, so `s3:ObjectCreated:*` conflicts with `s3:ObjectCreated:Put` as it
- * does on real S3.
+ * does on real S3. It is across every destination rather than within one group,
+ * because real S3 refuses a function and a queue that both want an event just
+ * as it refuses two functions.
  */
 export function simS3AssertNoNotificationOverlap(
-  notifications: readonly SimS3LambdaNotification[],
+  notifications: readonly SimS3Notification[],
 ): void {
   for (const [index, notification] of notifications.entries()) {
     const rest = notifications.slice(index + 1);

--- a/src/service/s3/bucket/notification/sim-s3-notification-properties.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification-properties.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import type { SimS3NotificationFilterInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
+import type { SimS3NotificationProperties } from "./sim-s3-notification.js";
+import { simS3ExpandNotificationEvent } from "./sim-s3-notification-event.js";
+import { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
+
+/**
+ * One destination group's shared shape on the way in.
+ *
+ * The destination ARN is the only part a group names differently, so it is
+ * passed alongside rather than read from here.
+ */
+export interface SimS3NotificationInput {
+  readonly Id?: string | undefined;
+  readonly Events?: readonly string[] | undefined;
+  readonly Filter?: SimS3NotificationFilterInput | undefined;
+}
+
+/**
+ * Read one destination configuration into the parts a stored notification is
+ * built from.
+ */
+export function simS3NotificationProperties(
+  configuration: SimS3NotificationInput,
+  destinationArn: string | undefined,
+  missingArnReason: string,
+): SimS3NotificationProperties {
+  if (destinationArn === undefined || destinationArn === "") {
+    throw new SimS3InvalidArgument(missingArnReason);
+  }
+
+  const events = configuration.Events ?? [];
+
+  if (events.length === 0) {
+    throw new SimS3InvalidArgument(
+      `Notification configuration for ${destinationArn} names no events.`,
+    );
+  }
+
+  return {
+    // S3 generates a configuration id for a configuration that omits one, and
+    // reports it back through GetBucketNotificationConfiguration.
+    id: configuration.Id ?? randomUUID(),
+    destinationArn,
+    events,
+    concreteEvents: new Set(
+      events.flatMap((event) => simS3ExpandNotificationEvent(event)),
+    ),
+    filter: SimS3NotificationFilter.fromInput(configuration.Filter),
+  };
+}

--- a/src/service/s3/bucket/notification/sim-s3-notification.ts
+++ b/src/service/s3/bucket/notification/sim-s3-notification.ts
@@ -1,0 +1,87 @@
+import type { SimS3NotificationFilterInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimS3NotificationDestinationService } from "../../notification/destination/sim-s3-notification-destination.js";
+import type { SimS3NotificationEvent } from "./sim-s3-notification-event.js";
+import type { SimS3NotificationFilter } from "./sim-s3-notification-filter.js";
+
+/**
+ * The parts of a stored configuration that are the same whatever the
+ * destination is.
+ */
+export interface SimS3NotificationProperties {
+  readonly id: string;
+  readonly destinationArn: string;
+  readonly events: readonly string[];
+  readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
+  readonly filter: SimS3NotificationFilter;
+}
+
+/**
+ * What a configuration reports back with, apart from its destination.
+ */
+interface SimS3NotificationOutput {
+  readonly Id: string;
+  readonly Events: string[];
+  readonly Filter?: SimS3NotificationFilterInput;
+}
+
+/**
+ * One destination in a Bucket's notification configuration.
+ *
+ * Which events reach a destination, and whether two configurations conflict,
+ * are the same questions whatever the destination is, so a Bucket holds them
+ * all as this. Only the ARN's property name differs on the way back out, which
+ * is what a subclass is for.
+ *
+ * Both the configured event types and what they expand to are kept: the
+ * configured ones are what GetBucketNotificationConfiguration reports back, and
+ * the expanded ones are what delivery and the overlap rule work on.
+ */
+export abstract class SimS3Notification {
+  /**
+   * The kind of destination this configuration was declared for.
+   */
+  abstract readonly destinationService: SimS3NotificationDestinationService;
+
+  public readonly id: string;
+  public readonly destinationArn: string;
+  public readonly events: readonly string[];
+  public readonly concreteEvents: ReadonlySet<SimS3NotificationEvent>;
+  public readonly filter: SimS3NotificationFilter;
+
+  constructor(properties: SimS3NotificationProperties) {
+    this.id = properties.id;
+    this.destinationArn = properties.destinationArn;
+    this.events = properties.events;
+    this.concreteEvents = properties.concreteEvents;
+    this.filter = properties.filter;
+  }
+
+  /**
+   * Whether this configuration wants an event about an object key.
+   */
+  matches(event: SimS3NotificationEvent, key: string): boolean {
+    return this.concreteEvents.has(event) && this.filter.matches(key);
+  }
+
+  /**
+   * Whether this configuration and another cover any of the same events.
+   */
+  sharesEventsWith(other: SimS3Notification): boolean {
+    return [...this.concreteEvents].some((event) =>
+      other.concreteEvents.has(event),
+    );
+  }
+
+  /**
+   * The parts GetBucketNotificationConfiguration reports for any destination.
+   */
+  protected reported(): SimS3NotificationOutput {
+    const filter = this.filter.toOutput();
+
+    return {
+      Id: this.id,
+      Events: [...this.events],
+      ...(filter !== undefined && { Filter: filter }),
+    };
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-queue-notification.ts
+++ b/src/service/s3/bucket/notification/sim-s3-queue-notification.ts
@@ -1,0 +1,37 @@
+import type { SimS3QueueConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type { SimS3NotificationDestinationService } from "../../notification/destination/sim-s3-notification-destination.js";
+import { SimS3Notification } from "./sim-s3-notification.js";
+import { simS3NotificationProperties } from "./sim-s3-notification-properties.js";
+
+/**
+ * One SQS queue destination in a Bucket's notification configuration.
+ */
+export class SimS3QueueNotification extends SimS3Notification {
+  /**
+   * The kind of destination this configuration was declared for.
+   */
+  public readonly destinationService: SimS3NotificationDestinationService =
+    "sqs";
+
+  /**
+   * Read one QueueConfigurations entry.
+   */
+  static fromInput(
+    configuration: SimS3QueueConfigurationInput,
+  ): SimS3QueueNotification {
+    return new SimS3QueueNotification(
+      simS3NotificationProperties(
+        configuration,
+        configuration.QueueArn,
+        "A queue notification configuration must name a QueueArn.",
+      ),
+    );
+  }
+
+  /**
+   * This configuration as GetBucketNotificationConfiguration reports it.
+   */
+  toOutput(): SimS3QueueConfigurationInput {
+    return { ...this.reported(), QueueArn: this.destinationArn };
+  }
+}

--- a/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-destinations.ts
+++ b/src/service/s3/bucket/notification/sim-s3-unsimulated-notification-destinations.ts
@@ -1,0 +1,41 @@
+import type { SimS3NotificationConfigurationInput } from "../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
+
+/**
+ * The destination groups a request can carry that this simulator does not
+ * deliver to, and what to say about each.
+ */
+const unsimulatedDestinations = new Map<string, string>([
+  ["TopicConfigurations", "SNS topic"],
+  ["EventBridgeConfiguration", "EventBridge"],
+]);
+
+/**
+ * Refuse a destination group this simulator cannot deliver to.
+ *
+ * Naming the destination matters more than the refusal: a configuration quietly
+ * accepted and never delivered is the failure this feature exists to remove, so
+ * an SNS topic destination says so rather than being dropped.
+ */
+export function simS3RefuseUnsimulatedDestinations(
+  input: SimS3NotificationConfigurationInput,
+): void {
+  for (const [property, destination] of unsimulatedDestinations) {
+    // Read-only lookup of a fixed set of property names.
+
+    const configured = input[property as keyof typeof input];
+
+    if (configured === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(configured) && configured.length === 0) {
+      continue;
+    }
+
+    throw new SimS3NotImplemented(
+      `Simulated S3 cannot notify a ${destination}. ${property} is not ` +
+        "simulated; use LambdaFunctionConfigurations or QueueConfigurations.",
+    );
+  }
+}

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-configuration.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-configuration.ts
@@ -3,6 +3,8 @@ import { SimCfnValueShape } from "../../../../cloudformation/template/value/sim-
 import type {
   SimS3LambdaFunctionConfigurationInput,
   SimS3NotificationConfigurationInput,
+  SimS3NotificationFilterInput,
+  SimS3QueueConfigurationInput,
 } from "../../../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 import { s3BucketNotificationError } from "../error/sim-cfn-s3-bucket-error.js";
 import { SimCfnS3BucketNotificationFilter } from "./sim-cfn-s3-bucket-notification-filter.js";
@@ -28,6 +30,27 @@ const lambdaConfigurationNames: ReadonlySet<string> = new Set([
   "Filter",
   "Function",
 ]);
+
+/**
+ * The names one CloudFormation QueueConfiguration carries.
+ *
+ * `Queue` is the queue's ARN, despite the name, which is the third place
+ * CloudFormation calls the same thing something else.
+ */
+const queueConfigurationNames: ReadonlySet<string> = new Set([
+  "Event",
+  "Filter",
+  "Queue",
+]);
+
+/**
+ * The parts of one CloudFormation destination configuration that are the same
+ * whichever destination it names.
+ */
+interface SimCfnS3BucketNotificationParts {
+  readonly Events?: readonly string[] | undefined;
+  readonly Filter?: SimS3NotificationFilterInput | undefined;
+}
 
 /**
  * Reads the `NotificationConfiguration` property of an AWS::S3::Bucket Resource
@@ -77,8 +100,7 @@ export class SimCfnS3BucketNotificationConfiguration {
       ),
       QueueConfigurations: this.shape.present(
         record["QueueConfigurations"],
-        (configurations) =>
-          this.shape.list(configurations, "QueueConfigurations"),
+        (configurations) => this.queueConfigurations(configurations),
       ),
       TopicConfigurations: this.shape.present(
         record["TopicConfigurations"],
@@ -112,9 +134,43 @@ export class SimCfnS3BucketNotificationConfiguration {
     );
 
     return {
+      ...this.notificationParts(record),
       LambdaFunctionArn: this.shape.present(record["Function"], (arn) =>
         this.shape.string(arn, "Function"),
       ),
+    };
+  }
+
+  private queueConfigurations(
+    value: SimCfnTemplateValue,
+  ): readonly SimS3QueueConfigurationInput[] {
+    return this.shape
+      .list(value, "QueueConfigurations")
+      .map((configuration) => this.queueConfiguration(configuration));
+  }
+
+  private queueConfiguration(
+    value: SimCfnTemplateValue,
+  ): SimS3QueueConfigurationInput {
+    const record = this.shape.record(value, "QueueConfigurations entry");
+    this.shape.knownKeys(
+      record,
+      queueConfigurationNames,
+      "QueueConfigurations entry",
+    );
+
+    return {
+      ...this.notificationParts(record),
+      QueueArn: this.shape.present(record["Queue"], (arn) =>
+        this.shape.string(arn, "Queue"),
+      ),
+    };
+  }
+
+  private notificationParts(
+    record: Readonly<Record<string, SimCfnTemplateValue>>,
+  ): SimCfnS3BucketNotificationParts {
+    return {
       // CloudFormation states one event per configuration, where the request
       // takes a list, so one configuration becomes a one-element Events list.
       Events: this.shape.present(record["Event"], (event) => [

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification-refusals.iso.test.ts
@@ -35,23 +35,23 @@ async function deployFailing(
 
 describe("AWS::S3::Bucket NotificationConfiguration refusals", () => {
   it("refuses a queue destination the command would refuse from an SDK caller", async () => {
-    // Given a template naming an SQS queue destination.
+    // Given a template naming a queue no stack ever created.
     const simAws = new SimAws();
 
     // When the template is deployed.
     const error = await deployFailing(simAws, {
       QueueConfigurations: [
-        { Event: "s3:ObjectCreated:*", Queue: "arn:aws:sqs:::uploads" },
+        {
+          Event: "s3:ObjectCreated:*",
+          Queue: "arn:aws:sqs:us-east-1:888888888888:uploads",
+        },
       ],
     });
 
     // Then the Stack fails with the refusal
     // PutBucketNotificationConfiguration gives, rather than deploying a Bucket
     // that notifies nothing.
-    assertStringIncludes(
-      error.message,
-      "Simulated S3 cannot notify a SQS queue",
-    );
+    assertStringIncludes(error.message, "is not a simulated SQS queue");
   });
 
   it("refuses an event type the command would refuse from an SDK caller", async () => {

--- a/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification.iso.test.ts
+++ b/src/service/s3/cfn/bucket/notification/sim-cfn-s3-bucket-notification.iso.test.ts
@@ -3,6 +3,11 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
@@ -10,6 +15,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
 import { simCfnS3BucketNotificationTemplateFactory } from "./sim-cfn-s3-bucket-notification-template.factory.js";
 
 /**
@@ -176,6 +182,75 @@ describe("AWS::S3::Bucket NotificationConfiguration", () => {
 
     assertArrayLength(received, 1);
     assertIdentical(received[0].Records[0].s3.object.key, "raw/cat.jpg");
+  });
+
+  it("notifies a queue a QueueConfigurations entry names", async () => {
+    // Given a queue admitting the Bucket the template deploys.
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: {
+                ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    // When a template naming it under CloudFormation's own property names is
+    // deployed: `Queue` rather than `QueueArn`, and one `Event` rather than an
+    // `Events` list.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "uploads-stack",
+      template: simCfnS3BucketNotificationTemplateFactory.make({
+        notificationConfiguration: {
+          QueueConfigurations: [
+            { Event: "s3:ObjectCreated:*", Queue: queueArn },
+          ],
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then an Object put into the deployed Bucket reaches the queue.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+      );
+    assertArrayLength(received.Messages ?? [], 1);
+
+    // And the Bucket reports it back in the SDK's names.
+    const output = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    const configurations = output.QueueConfigurations ?? [];
+    assertArrayLength(configurations, 1);
+    assertIdentical(configurations[0].QueueArn, queueArn);
+    assertIdentical(configurations[0].Events?.[0], "s3:ObjectCreated:*");
   });
 
   it("leaves a Bucket declaring no notifications unconfigured", async () => {

--- a/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.ts
@@ -1,5 +1,8 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-import type { SimS3LambdaFunctionConfigurationInput } from "../put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
+import type {
+  SimS3LambdaFunctionConfigurationInput,
+  SimS3QueueConfigurationInput,
+} from "../put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
 
 /**
  * Minimal structural sim S3 GetBucketNotificationConfiguration command.
@@ -28,6 +31,8 @@ export interface SimGetBucketNotificationConfigurationCommandInput {
 export interface SimS3NotificationConfigurationOutput {
   readonly LambdaFunctionConfigurations?:
     readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
+  readonly QueueConfigurations?:
+    readonly SimS3QueueConfigurationInput[] | undefined;
 }
 
 /**

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.ts
@@ -35,7 +35,8 @@ export interface SimPutBucketNotificationConfigurationCommandOutput {
 export interface SimS3NotificationConfigurationInput {
   readonly LambdaFunctionConfigurations?:
     readonly SimS3LambdaFunctionConfigurationInput[] | undefined;
-  readonly QueueConfigurations?: readonly unknown[] | undefined;
+  readonly QueueConfigurations?:
+    readonly SimS3QueueConfigurationInput[] | undefined;
   readonly TopicConfigurations?: readonly unknown[] | undefined;
   readonly EventBridgeConfiguration?: object | undefined;
 }
@@ -46,6 +47,16 @@ export interface SimS3NotificationConfigurationInput {
 export interface SimS3LambdaFunctionConfigurationInput {
   readonly Id?: string | undefined;
   readonly LambdaFunctionArn?: string | undefined;
+  readonly Events?: readonly string[] | undefined;
+  readonly Filter?: SimS3NotificationFilterInput | undefined;
+}
+
+/**
+ * Minimal structural sim S3 SQS queue notification configuration.
+ */
+export interface SimS3QueueConfigurationInput {
+  readonly Id?: string | undefined;
+  readonly QueueArn?: string | undefined;
   readonly Events?: readonly string[] | undefined;
   readonly Filter?: SimS3NotificationFilterInput | undefined;
 }

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination-refusals.iso.test.ts
@@ -16,14 +16,14 @@ const thumbnailerArn =
   "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
 
 describe("What a simulated S3 notification destination refuses", () => {
-  it("refuses an SQS queue destination by name", async () => {
+  it("refuses a FIFO queue destination by name", async () => {
     // Given a Bucket
     const simAws = new SimAws();
     await simAws
       .s3()
       .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
 
-    // When a configuration names a queue
+    // When a configuration names a FIFO queue
     const error = await assertThrowsErrorAsync(async () =>
       simAws.s3().putBucketNotificationConfiguration(
         new PutBucketNotificationConfigurationCommand({
@@ -32,7 +32,7 @@ describe("What a simulated S3 notification destination refuses", () => {
             QueueConfigurations: [
               {
                 Events: ["s3:ObjectCreated:*"],
-                QueueArn: "arn:aws:sqs:us-east-1:888888888888:uploads",
+                QueueArn: "arn:aws:sqs:us-east-1:888888888888:uploads.fifo",
               },
             ],
           },
@@ -40,9 +40,10 @@ describe("What a simulated S3 notification destination refuses", () => {
       ),
     );
 
-    // Then the destination it cannot deliver to is named
+    // Then the queue real S3 will not deliver to is named for what it is,
+    // rather than being reported as a queue that is not there.
     assertIdentical(error.name, "NotImplemented");
-    assertStringIncludes(error.message, "SQS queue");
+    assertStringIncludes(error.message, "FIFO queue");
   });
 
   it("refuses an SNS topic destination by name", async () => {

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-destination.iso.test.ts
@@ -170,7 +170,7 @@ describe("The destination a simulated S3 notification configuration names", () =
     assertStringIncludes(error.message, "versions or aliases");
   });
 
-  it("refuses a destination ARN naming another service", async () => {
+  it("refuses a Lambda destination ARN naming another service", async () => {
     // Given a Bucket
     const simAws = new SimAws();
     await simAws
@@ -194,8 +194,10 @@ describe("The destination a simulated S3 notification configuration names", () =
       ),
     );
 
-    // Then the destination it cannot notify is named
-    assertStringIncludes(error.message, "cannot notify");
+    // Then it is refused for not being a function, rather than delivered to as
+    // the queue it names: the destination group a configuration was declared
+    // in is what decides where it goes.
+    assertStringIncludes(error.message, "is not a Lambda function ARN");
   });
 
   it("stores without checking when the request asks it to", async () => {

--- a/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-notification-configuration/put-bucket-notification-refusals.iso.test.ts
@@ -202,8 +202,8 @@ describe("What a simulated S3 notification configuration refuses", () => {
       ),
     );
 
-    // Then there is no service segment to route it by, so it is refused
-    assertStringIncludes(error.message, "cannot notify");
+    // Then it is refused for not being a function ARN
+    assertStringIncludes(error.message, "is not a Lambda function ARN");
   });
 
   it("refuses a configuration carrying no events at all", async () => {

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.iso.test.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.iso.test.ts
@@ -27,6 +27,7 @@ describe("Simulated Lambda functions as S3 notification destinations", () => {
           destinationArn: thumbnailerArn,
           bucketArn: "arn:aws:s3:::uploads",
           bucketOwnerAccountId: simAws.defaultAccountId,
+          bucketRegionName: simAws.defaultRegionName,
         },
         { Records: [] },
       ),
@@ -48,6 +49,7 @@ describe("Simulated Lambda functions as S3 notification destinations", () => {
         destinationArn: "arn:aws:lambda:us-east-1:888888888888:layer:shared",
         bucketArn: "arn:aws:s3:::uploads",
         bucketOwnerAccountId: simAws.defaultAccountId,
+        bucketRegionName: simAws.defaultRegionName,
       });
     } catch (error) {
       raised = error;
@@ -87,6 +89,7 @@ describe("Simulated Lambda functions as S3 notification destinations", () => {
         destinationArn: thumbnailerArn,
         bucketArn: "arn:aws:s3:::uploads",
         bucketOwnerAccountId: simAws.defaultAccountId,
+        bucketRegionName: simAws.defaultRegionName,
       },
     );
 

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
@@ -3,13 +3,9 @@ import { SimLambdaServiceInvokeAuthorizer } from "../../../../lambda/command/aut
 import type { SimLambdaFunction } from "../../../../lambda/function/sim-lambda-function.js";
 import type { SimIamInterServiceAuthZ } from "../../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
 import { SimS3NotificationFunctionArn } from "./sim-s3-notification-function-arn.js";
 import type { SimS3NotificationFunctions } from "./sim-s3-notification-functions.js";
-
-/**
- * The service principal S3 invokes a Lambda function as.
- */
-export const simS3ServicePrincipal = "s3.amazonaws.com";
 
 interface SimAwsS3NotificationFunctionsProperties {
   readonly simAws: SimAws;

--- a/src/service/s3/notification/destination/sim-s3-notification-destination-check.ts
+++ b/src/service/s3/notification/destination/sim-s3-notification-destination-check.ts
@@ -25,15 +25,17 @@ export class SimS3NotificationDestinationCheck {
     bucket: SimS3Bucket,
     configuration: SimS3NotificationConfiguration,
   ): void {
+    const scope = bucket.getAccountRegionScope();
     const request = {
       bucketArn: simS3BucketArn(bucket.bucketName),
-      bucketOwnerAccountId: bucket.getAccountRegionScope().accountId,
+      bucketOwnerAccountId: scope.accountId,
+      bucketRegionName: scope.regionName,
     };
 
-    for (const notification of configuration.lambdaNotifications) {
+    for (const notification of configuration.all) {
       this.destinations
-        .resolve(notification.functionArn)
-        .validate({ ...request, destinationArn: notification.functionArn });
+        .resolve(notification.destinationService, notification.destinationArn)
+        .validate({ ...request, destinationArn: notification.destinationArn });
     }
   }
 }

--- a/src/service/s3/notification/destination/sim-s3-notification-destination.ts
+++ b/src/service/s3/notification/destination/sim-s3-notification-destination.ts
@@ -11,6 +11,14 @@ export interface SimS3NotificationDestinationRequest {
   readonly destinationArn: string;
   readonly bucketArn: string;
   readonly bucketOwnerAccountId: string;
+
+  /**
+   * The Region the Bucket is in, which a queue destination has to be in too.
+   *
+   * A Bucket ARN carries no Region, so it is passed alongside rather than read
+   * out of one.
+   */
+  readonly bucketRegionName: string;
 }
 
 /**
@@ -44,11 +52,26 @@ export interface SimS3NotificationDestination {
 }
 
 /**
+ * The kinds of destination a notification configuration can name.
+ *
+ * Which one a configuration wants comes from the destination group it was
+ * declared in rather than from the service segment of its ARN, so a queue ARN
+ * under `LambdaFunctionConfigurations` is refused for not being a function
+ * rather than quietly delivered to as a queue.
+ */
+export type SimS3NotificationDestinationService = "lambda" | "sqs";
+
+/**
  * The destinations one simulated S3 scope can reach.
  */
 export interface SimS3NotificationDestinations {
   /**
-   * The destination an ARN names, refusing an ARN S3 cannot notify.
+   * The destination of a kind, refusing one this simulated S3 cannot reach.
+   *
+   * The ARN is carried for the refusal to name rather than to be read.
    */
-  resolve(destinationArn: string): SimS3NotificationDestination;
+  resolve(
+    service: SimS3NotificationDestinationService,
+    destinationArn: string,
+  ): SimS3NotificationDestination;
 }

--- a/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
+++ b/src/service/s3/notification/destination/sim-s3-service-notification-destinations.ts
@@ -2,44 +2,45 @@ import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
 import type {
   SimS3NotificationDestination,
   SimS3NotificationDestinations,
+  SimS3NotificationDestinationService,
 } from "./sim-s3-notification-destination.js";
 
 interface SimS3ServiceNotificationDestinationsProperties {
   readonly lambda: SimS3NotificationDestination;
+  readonly sqs: SimS3NotificationDestination;
 }
 
 /**
- * The destinations of one simulated S3 scope, keyed on the service an ARN
- * names.
+ * The destinations of one simulated S3 scope, one per kind of destination.
  *
- * An ARN's service segment is the only thing that decides which destination
- * takes it, so the lookup is a map rather than a chain of checks, and a service
- * this simulator has no destination for is refused by name.
+ * A configuration says which kind it wants by the destination group it was
+ * declared in, so nothing here reads an ARN. The ARN is the destination's own
+ * business, and each of them refuses one that does not name a resource of the
+ * kind it delivers to.
  */
 export class SimS3ServiceNotificationDestinations implements SimS3NotificationDestinations {
-  private readonly byService: ReadonlyMap<string, SimS3NotificationDestination>;
+  private readonly lambda: SimS3NotificationDestination;
+  private readonly sqs: SimS3NotificationDestination;
 
   constructor(properties: SimS3ServiceNotificationDestinationsProperties) {
-    this.byService = new Map([["lambda", properties.lambda]]);
+    this.lambda = properties.lambda;
+    this.sqs = properties.sqs;
   }
 
   /**
-   * The destination an ARN names.
+   * The destination of a kind.
    */
-  resolve(destinationArn: string): SimS3NotificationDestination {
-    const service = destinationArn.split(":", 3)[2];
-    const destination =
-      service === undefined ? undefined : this.byService.get(service);
-
-    if (destination === undefined) {
-      throw new SimS3NotImplemented(
-        `Simulated S3 cannot notify ${destinationArn}. It notifies a Lambda ` +
-          "function; SQS queue, SNS topic and EventBridge destinations are " +
-          "not simulated.",
-      );
+  resolve(
+    service: SimS3NotificationDestinationService,
+  ): SimS3NotificationDestination {
+    switch (service) {
+      case "lambda": {
+        return this.lambda;
+      }
+      case "sqs": {
+        return this.sqs;
+      }
     }
-
-    return destination;
   }
 }
 
@@ -55,7 +56,10 @@ export class SimS3NoNotificationDestinations implements SimS3NotificationDestina
   /**
    * Refuse every destination, explaining how to get one.
    */
-  resolve(destinationArn: string): never {
+  resolve(
+    _service: SimS3NotificationDestinationService,
+    destinationArn: string,
+  ): never {
     throw new SimS3NotImplemented(
       `Cannot notify ${destinationArn}: this SimS3 was constructed on its ` +
         "own, so it has no other simulated services to notify and no shared " +

--- a/src/service/s3/notification/destination/sim-s3-service-principal.ts
+++ b/src/service/s3/notification/destination/sim-s3-service-principal.ts
@@ -1,0 +1,7 @@
+/**
+ * The service principal S3 reaches a notification destination as.
+ *
+ * Every destination's resource policy is written for this, so it lives beside
+ * the destinations rather than inside one of them.
+ */
+export const simS3ServicePrincipal = "s3.amazonaws.com";

--- a/src/service/s3/notification/destination/sqs/sim-aws-s3-notification-queues.ts
+++ b/src/service/s3/notification/destination/sqs/sim-aws-s3-notification-queues.ts
@@ -1,0 +1,74 @@
+import type { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { SimS3NotificationQueue } from "./sim-s3-notification-queue.js";
+import { SimS3NotificationQueueArn } from "./sim-s3-notification-queue-arn.js";
+import type { SimS3NotificationQueues } from "./sim-s3-notification-queues.js";
+
+interface SimAwsS3NotificationQueuesProperties {
+  readonly simAws: SimAws;
+}
+
+/**
+ * The simulated SQS queues of one simulated AWS instance, as S3 notification
+ * destinations.
+ *
+ * Queues are looked up when a configuration is applied or an event is
+ * delivered, never when this is built, for the same reason the Lambda
+ * destination does it that way: reaching another service while this one is
+ * being constructed is a cycle with no bottom to it.
+ *
+ * A queue in another Account is allowed, and evaluated against the IAM of the
+ * Account owning it. Real S3 asks only that the queue is in the Bucket's
+ * Region, which is why AWS's own documented destination queue policy carries an
+ * `aws:SourceAccount` guard: it would have no job if the two Accounts were
+ * always the same.
+ */
+export class SimAwsS3NotificationQueues implements SimS3NotificationQueues {
+  private readonly simAws: SimAws;
+
+  constructor(properties: SimAwsS3NotificationQueuesProperties) {
+    this.simAws = properties.simAws;
+  }
+
+  /**
+   * Why S3 may not send to the queue, or nothing when it may.
+   *
+   * The Region is this side's rule and the rest is the queue's own. What S3
+   * adds to the queue's decision is which Bucket is sending, so a policy
+   * granting one Bucket does not open the queue to another.
+   */
+  sendRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined {
+    const arn = SimS3NotificationQueueArn.parse(request.destinationArn);
+
+    if (!arn.isIn(request.bucketRegionName)) {
+      return (
+        `${request.destinationArn} is in ${arn.regionName}, and an S3 event ` +
+        "notification destination queue must be in the Bucket's Region, " +
+        `${request.bucketRegionName}.`
+      );
+    }
+
+    return this.queue(arn).sendRefusal(request);
+  }
+
+  /**
+   * Send the event document to the queue.
+   */
+  async send(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void> {
+    await this.queue(
+      SimS3NotificationQueueArn.parse(request.destinationArn),
+    ).send(request, body);
+  }
+
+  private queue(arn: SimS3NotificationQueueArn): SimS3NotificationQueue {
+    return new SimS3NotificationQueue({
+      arn,
+      scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),
+    });
+  }
+}

--- a/src/service/s3/notification/destination/sqs/sim-s3-notification-queue-arn.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-notification-queue-arn.ts
@@ -1,0 +1,89 @@
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { sqsQueueUrl } from "../../../../sqs/queue/sim-sqs-queue-arn.js";
+import {
+  SimS3InvalidArgument,
+  SimS3NotImplemented,
+} from "../../../error/sim-s3.error.js";
+
+/**
+ * The SQS queue ARN a notification configuration names.
+ *
+ * A queue ARN has no resource type segment, so the queue name follows the
+ * Account id directly and the shared ARN reader cannot read one.
+ */
+export class SimS3NotificationQueueArn {
+  public readonly regionName: AwsRegionName;
+  public readonly accountId: SimAwsAccountId;
+  public readonly queueName: string;
+
+  private constructor(
+    regionName: AwsRegionName,
+    accountId: SimAwsAccountId,
+    queueName: string,
+  ) {
+    this.regionName = regionName;
+    this.accountId = accountId;
+    this.queueName = queueName;
+  }
+
+  /**
+   * Read an SQS queue ARN, refusing anything else.
+   *
+   * A FIFO queue is refused by its name, as real S3 refuses one as an event
+   * notification destination. Simulated SQS has no FIFO queues either, so
+   * without this the refusal would be that the queue does not exist, which
+   * points at the wrong thing to fix.
+   */
+  static parse(arn: string): SimS3NotificationQueueArn {
+    const [prefix, partition, service, region, accountId, name, extra] =
+      arn.split(":");
+
+    if (
+      prefix !== "arn" ||
+      partition !== "aws" ||
+      service !== "sqs" ||
+      region === undefined ||
+      region === "" ||
+      accountId === undefined ||
+      accountId === "" ||
+      name === undefined ||
+      name === "" ||
+      extra !== undefined
+    ) {
+      throw new SimS3InvalidArgument(`${arn} is not an SQS queue ARN.`);
+    }
+
+    if (name.endsWith(".fifo")) {
+      throw new SimS3NotImplemented(
+        `Cannot notify ${arn}: a FIFO queue is not a valid S3 event ` +
+          "notification destination, and simulated SQS has no FIFO queues.",
+      );
+    }
+
+    return new SimS3NotificationQueueArn(
+      region as AwsRegionName,
+      accountId as SimAwsAccountId,
+      name,
+    );
+  }
+
+  /**
+   * The URL an SQS request names this queue by.
+   */
+  get queueUrl(): string {
+    return sqsQueueUrl({
+      regionName: this.regionName,
+      accountId: this.accountId,
+      name: this.queueName,
+    });
+  }
+
+  /**
+   * Whether this queue is in a Region, which a destination queue has to share
+   * with the Bucket notifying it.
+   */
+  isIn(regionName: string): boolean {
+    return this.regionName === regionName;
+  }
+}

--- a/src/service/s3/notification/destination/sqs/sim-s3-notification-queue.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-notification-queue.ts
@@ -1,0 +1,80 @@
+import type { SimAwsAccountRegionContainer } from "../../../../aws/sim-aws-account-region-scope.js";
+import { SimSqsServiceSendAuthorizer } from "../../../../sqs/command/authorize/sim-sqs-service-send-authorizer.js";
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
+import type { SimS3NotificationQueueArn } from "./sim-s3-notification-queue-arn.js";
+
+interface SimS3NotificationQueueProperties {
+  readonly arn: SimS3NotificationQueueArn;
+  readonly scope: SimAwsAccountRegionContainer;
+}
+
+/**
+ * One queue an S3 Bucket is notifying, in the Account and Region its ARN names.
+ *
+ * Everything here is asked of the queue's own Account, which is what makes a
+ * queue in another Account reachable: its policy is the grant, and its
+ * Account's IAM is what evaluates it.
+ */
+export class SimS3NotificationQueue {
+  private readonly arn: SimS3NotificationQueueArn;
+  private readonly scope: SimAwsAccountRegionContainer;
+
+  constructor(properties: SimS3NotificationQueueProperties) {
+    this.arn = properties.arn;
+    this.scope = properties.scope;
+  }
+
+  /**
+   * Why S3 may not send to this queue, or nothing when it may.
+   */
+  sendRefusal(
+    request: SimS3NotificationDestinationRequest,
+  ): string | undefined {
+    const queue = this.scope.sqs().findQueue(this.arn.queueName);
+
+    if (queue === undefined) {
+      return `${request.destinationArn} is not a simulated SQS queue.`;
+    }
+
+    const decision = new SimSqsServiceSendAuthorizer({
+      iam: this.scope.iam(),
+    }).authorize({
+      queue,
+      servicePrincipal: simS3ServicePrincipal,
+      sourceArn: request.bucketArn,
+      sourceAccount: request.bucketOwnerAccountId,
+    });
+
+    if (decision.isDenied) {
+      return (
+        `The queue policy of ${request.destinationArn} does not allow ` +
+        `${simS3ServicePrincipal} to send to it for ${request.bucketArn}. ` +
+        "Grant sqs:SendMessage with the queue's Policy attribute."
+      );
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Send one message body to this queue as the S3 service principal.
+   *
+   * This goes through the ordinary SendMessage path rather than putting a
+   * message on the queue directly, so a delivered event is the same thing an
+   * SDK caller would have sent, and is authorized again on the way in.
+   */
+  async send(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void> {
+    await this.scope.sqs().sendMessage(
+      { input: { QueueUrl: this.arn.queueUrl, MessageBody: body } },
+      {
+        caller: { kind: "service", service: simS3ServicePrincipal },
+        sourceArn: request.bucketArn,
+        sourceAccount: request.bucketOwnerAccountId,
+      },
+    );
+  }
+}

--- a/src/service/s3/notification/destination/sqs/sim-s3-notification-queues.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-notification-queues.ts
@@ -1,0 +1,27 @@
+import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
+
+/**
+ * The narrow slice of simulated SQS that S3 event notification needs.
+ *
+ * S3 asks two questions of a queue: whether it may send to it, and then to send
+ * to it. Both are asked by ARN, because a notification configuration names a
+ * queue by ARN and that ARN can name another Account.
+ */
+export interface SimS3NotificationQueues {
+  /**
+   * Why S3 may not send to the queue, or nothing when it may.
+   *
+   * A reason rather than a boolean, because both the configuration-time
+   * refusal and the delivery-time record repeat it back to whoever has to fix
+   * it.
+   */
+  sendRefusal(request: SimS3NotificationDestinationRequest): string | undefined;
+
+  /**
+   * Send one message body to the queue.
+   */
+  send(
+    request: SimS3NotificationDestinationRequest,
+    body: string,
+  ): Promise<void>;
+}

--- a/src/service/s3/notification/destination/sqs/sim-s3-queue-notification-refusals.iso.test.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-queue-notification-refusals.iso.test.ts
@@ -1,0 +1,281 @@
+import {
+  CreateBucketCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
+
+/**
+ * The policy statement AWS documents for an S3 event notification destination
+ * queue, which is what a Bucket has to be admitted by.
+ */
+function sendPolicyFor(queueArn: string, sourceArn: string): string {
+  return simIamPolicyDocumentFactory.make({
+    Statement: {
+      Principal: { Service: "s3.amazonaws.com" },
+      Action: "sqs:SendMessage",
+      Resource: queueArn,
+      Condition: { ArnLike: { "aws:SourceArn": sourceArn } },
+    },
+  });
+}
+
+describe("What a simulated SQS notification destination refuses", () => {
+  it("refuses a queue whose policy admits nothing", async () => {
+    // Given a queue with no policy at all, and a Bucket
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the Bucket is configured to notify it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              { Events: ["s3:ObjectCreated:*"], QueueArn: queueArn },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, since a service principal owns no identity policies
+    // and the queue policy is the whole decision
+    assertIdentical(error.name, "InvalidArgument");
+    assertStringIncludes(error.message, "does not allow s3.amazonaws.com");
+
+    // And nothing was stored
+    const stored = await simAws
+      .s3()
+      .getBucketNotificationConfiguration(
+        new GetBucketNotificationConfigurationCommand({ Bucket: "uploads" }),
+      );
+    assertArrayLength(stored.QueueConfigurations ?? [], 0);
+  });
+
+  it("refuses a queue whose policy admits another Bucket", async () => {
+    // Given a queue admitting S3 for a different Bucket
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: sendPolicyFor(queueArn, "arn:aws:s3:::reports"),
+        },
+      }),
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When this Bucket is configured to notify it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              { Events: ["s3:ObjectCreated:*"], QueueArn: queueArn },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the source ARN condition keeps it out, so a grant written for one
+    // Bucket does not open the queue to another
+    assertStringIncludes(error.message, "arn:aws:s3:::uploads");
+  });
+
+  it("refuses a queue in another Region", async () => {
+    // Given a queue in another Region, admitting the Bucket
+    const simAws = new SimAws();
+    const otherSqs = simAws
+      .account(simAws.defaultAccountId)
+      .region("eu-west-2")
+      .sqs();
+    const queueArn = `arn:aws:sqs:eu-west-2:${simAws.defaultAccountId}:uploads`;
+    const created = await otherSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "uploads" }),
+    );
+    await otherSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: sendPolicyFor(queueArn, "arn:aws:s3:::uploads"),
+        },
+      }),
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the Bucket is configured to notify it
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              { Events: ["s3:ObjectCreated:*"], QueueArn: queueArn },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused: real S3 requires the destination queue to be in the
+    // Bucket's own Region, whatever either side's policies say
+    assertStringIncludes(error.message, "must be in the Bucket's Region");
+  });
+
+  it("refuses a queue that is not there", async () => {
+    // Given a Bucket and no queue
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the Bucket is configured to notify one
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                QueueArn: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the missing queue is named rather than the configuration being
+    // stored and never delivered on
+    assertStringIncludes(error.message, "is not a simulated SQS queue");
+  });
+
+  it("refuses a destination ARN that is not a queue", async () => {
+    // Given a Bucket
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    // When the queue destination carries an SNS topic ARN
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.s3().putBucketNotificationConfiguration(
+        new PutBucketNotificationConfigurationCommand({
+          Bucket: "uploads",
+          NotificationConfiguration: {
+            QueueConfigurations: [
+              {
+                Events: ["s3:ObjectCreated:*"],
+                QueueArn: "arn:aws:sns:us-east-1:888888888888:uploads",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused for what it is
+    assertStringIncludes(error.message, "is not an SQS queue ARN");
+  });
+
+  it("stops delivering when the queue policy stops admitting the Bucket", async () => {
+    // Given a Bucket notifying a queue that admits it
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: sendPolicyFor(queueArn, "arn:aws:s3:::uploads"),
+        },
+      }),
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "uploads",
+              Events: ["s3:ObjectCreated:*"],
+              QueueArn: queueArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the queue policy is narrowed to another Bucket and an Object is put
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: sendPolicyFor(queueArn, "arn:aws:s3:::reports"),
+        },
+      }),
+    );
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing is delivered, and the refusal is recorded rather than the
+    // event simply disappearing
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+      );
+    assertArrayLength(received.Messages ?? [], 0);
+
+    const failures = simAws.s3().getNotificationDeliveryFailures();
+    assertArrayLength(failures, 1);
+    assertTrue(failures[0].wasRefused);
+    assertIdentical(failures[0].destinationArn, queueArn);
+  });
+});

--- a/src/service/s3/notification/destination/sqs/sim-s3-sqs-notification-destination.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-sqs-notification-destination.ts
@@ -1,0 +1,74 @@
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimS3InvalidArgument } from "../../../error/sim-s3.error.js";
+import { SimS3NotificationNotPermitted } from "../../../error/sim-s3-notification.error.js";
+import { simS3EventRecordsDocument } from "../../event/sim-s3-event-records.js";
+import type {
+  SimS3NotificationDeliveryRequest,
+  SimS3NotificationDestination,
+  SimS3NotificationDestinationRequest,
+} from "../sim-s3-notification-destination.js";
+import type { SimS3NotificationQueues } from "./sim-s3-notification-queues.js";
+
+interface SimS3SqsNotificationDestinationProperties {
+  readonly queues: SimS3NotificationQueues;
+}
+
+/**
+ * A simulated SQS queue as somewhere S3 sends Object events.
+ *
+ * The whole `Records` document goes on the queue as one message body, which is
+ * the double envelope a consumer has to reach through: the SQS message carries
+ * the S3 event document as text, so a handler parses `record.body` before it
+ * can read a key out of it.
+ *
+ * The same question is asked twice on purpose, as it is for a function
+ * destination. Real S3 checks the queue policy when the configuration is
+ * applied and checks it again for every event, so a permission removed
+ * afterwards stops delivery.
+ */
+export class SimS3SqsNotificationDestination implements SimS3NotificationDestination {
+  private readonly queues: SimS3NotificationQueues;
+
+  constructor(properties: SimS3SqsNotificationDestinationProperties) {
+    this.queues = properties.queues;
+  }
+
+  /**
+   * Refuse a queue the Bucket may not send to.
+   *
+   * Real S3 answers InvalidArgument for a destination it could not validate,
+   * which is what a queue policy that does not admit `s3.amazonaws.com`
+   * produces.
+   */
+  validate(request: SimS3NotificationDestinationRequest): void {
+    const refusal = this.queues.sendRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3InvalidArgument(
+        `Unable to validate the following destination configurations: ${refusal}`,
+      );
+    }
+  }
+
+  /**
+   * Put the event document on the queue, if it still admits this Bucket.
+   *
+   * The refusal is asked for before sending rather than left to the send,
+   * which authorizes the same way, so that a queue policy saying no is recorded
+   * as a refusal rather than as a fault in the simulation.
+   */
+  async deliver(request: SimS3NotificationDeliveryRequest): Promise<void> {
+    const refusal = this.queues.sendRefusal(request);
+
+    if (refusal !== undefined) {
+      throw new SimS3NotificationNotPermitted(refusal);
+    }
+
+    await this.queues.send(
+      request,
+      jsonStringify(
+        simS3EventRecordsDocument(request.event, request.configurationId),
+      ),
+    );
+  }
+}

--- a/src/service/s3/notification/sim-s3-notification-dispatcher.ts
+++ b/src/service/s3/notification/sim-s3-notification-dispatcher.ts
@@ -1,4 +1,4 @@
-import type { SimS3LambdaNotification } from "../bucket/notification/sim-s3-lambda-notification.js";
+import type { SimS3Notification } from "../bucket/notification/sim-s3-notification.js";
 import type { SimS3NotificationDestinations } from "./destination/sim-s3-notification-destination.js";
 import type { SimS3ObjectEvent } from "./event/sim-s3-object-event.js";
 import { SimS3NotificationCeiling } from "./sim-s3-notification-ceiling.js";
@@ -42,24 +42,27 @@ export class SimS3NotificationDispatcher {
    * Deliver one event to the destination one configuration names.
    */
   async deliver(
-    notification: SimS3LambdaNotification,
+    notification: SimS3Notification,
     event: SimS3ObjectEvent,
   ): Promise<void> {
     this.ceiling.take(event.bucketName);
 
     try {
-      await this.destinations.resolve(notification.functionArn).deliver({
-        destinationArn: notification.functionArn,
-        bucketArn: event.bucketArn,
-        bucketOwnerAccountId: event.ownerAccountId,
-        configurationId: notification.id,
-        event,
-      });
+      await this.destinations
+        .resolve(notification.destinationService, notification.destinationArn)
+        .deliver({
+          destinationArn: notification.destinationArn,
+          bucketArn: event.bucketArn,
+          bucketOwnerAccountId: event.ownerAccountId,
+          bucketRegionName: event.regionName,
+          configurationId: notification.id,
+          event,
+        });
     } catch (error) {
       this.failures.record(
         new SimS3NotificationDeliveryFailure({
           event,
-          destinationArn: notification.functionArn,
+          destinationArn: notification.destinationArn,
           configurationId: notification.id,
           error,
         }),

--- a/src/service/s3/notification/sim-s3-queue-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-queue-notification.iso.test.ts
@@ -94,13 +94,16 @@ describe("Notifying a simulated SQS queue of an Object event", () => {
     );
     await simAws.backgroundTasksComplete();
 
-    // Then the whole Records document is on the queue as one message body
-    const received = await simAws
-      .sqs()
-      .receiveMessage(
-        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
-      );
+    // Then the whole Records document is on the queue as one message body,
+    // with no message attributes beside it, as real S3 sends none
+    const received = await simAws.sqs().receiveMessage(
+      new ReceiveMessageCommand({
+        QueueUrl: created.QueueUrl,
+        MessageAttributeNames: ["All"],
+      }),
+    );
     assertArrayLength(received.Messages ?? [], 1);
+    assertUndefined(received.Messages?.[0]?.MessageAttributes);
     const body = received.Messages?.[0]?.Body;
     assertNonNullable(body);
     const document = JSON.parse(body) as S3EventDocument;

--- a/src/service/s3/notification/sim-s3-queue-notification.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-queue-notification.iso.test.ts
@@ -1,0 +1,317 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+
+/**
+ * The part of the S3 event document these tests read out of a message body.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventVersion: string;
+      readonly eventName: string;
+      readonly s3: {
+        readonly configurationId: string;
+        readonly bucket: { readonly name: string };
+        readonly object: { readonly key: string; readonly size?: number };
+      };
+    },
+  ];
+}
+
+describe("Notifying a simulated SQS queue of an Object event", () => {
+  it("puts the event document on the queue as a message body", async () => {
+    // Given a queue whose policy lets one Bucket's events onto it
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:uploads`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "uploads" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: {
+                ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    // And a Bucket configured to notify it
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "raw-uploads",
+              Events: ["s3:ObjectCreated:*"],
+              QueueArn: queueArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the whole Records document is on the queue as one message body
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+      );
+    assertArrayLength(received.Messages ?? [], 1);
+    const body = received.Messages?.[0]?.Body;
+    assertNonNullable(body);
+    const document = JSON.parse(body) as S3EventDocument;
+    assertArrayLength(document.Records, 1);
+    assertStringStartsWith(document.Records[0].eventVersion, "2.");
+    assertIdentical(document.Records[0].eventName, "ObjectCreated:Put");
+    assertIdentical(document.Records[0].s3.configurationId, "raw-uploads");
+    assertIdentical(document.Records[0].s3.bucket.name, "uploads");
+    const { key, size } = document.Records[0].s3.object;
+    assertIdentical(key, "raw/cat.jpg");
+    assertIdentical(size, 11);
+  });
+
+  it("notifies the queue of a removed Object", async () => {
+    // Given a queue admitting S3, and a Bucket notifying it of removals
+    const simAws = new SimAws();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:removals`;
+    const created = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "removals" }));
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+            },
+          }),
+        },
+      }),
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "removals",
+              Events: ["s3:ObjectRemoved:*"],
+              QueueArn: queueArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the Object is deleted
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "uploads", Key: "raw/cat.jpg" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the removal record is on the queue, carrying no size, as a real
+    // removal record carries none
+    const received = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+      );
+    const body = received.Messages?.[0]?.Body;
+    assertNonNullable(body);
+    const document = JSON.parse(body) as S3EventDocument;
+    assertIdentical(document.Records[0].eventName, "ObjectRemoved:Delete");
+    const { size } = document.Records[0].s3.object;
+    assertUndefined(size);
+  });
+
+  it("reaches a function through an event source mapping on the queue", async () => {
+    // Given a queue delivering to a function through an event source mapping
+    const source = await simAwsWithSqsEventSource();
+    const { simAws, queueArn, queueUrl, events } = source;
+
+    // And a queue policy letting a Bucket's events onto it
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: {
+                ArnLike: { "aws:SourceArn": "arn:aws:s3:::uploads" },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    // And a Bucket configured to notify the queue
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "uploads",
+              Events: ["s3:ObjectCreated:*"],
+              QueueArn: queueArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is put into the Bucket
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler was given the S3 event document inside an SQS record,
+    // which is the double envelope a consumer of this chain has to reach
+    // through
+    assertArrayLength(events, 1);
+    const records = events[0].Records;
+    assertArrayLength(records, 1);
+    const { body } = records[0];
+    assertNonNullable(body);
+    const document = JSON.parse(body) as S3EventDocument;
+    assertIdentical(document.Records[0].s3.object.key, "raw/cat.jpg");
+  });
+
+  it("notifies a queue in another Account that admits the Bucket", async () => {
+    // Given a queue in another Account, admitting this Bucket's Account
+    const simAws = new SimAws();
+    const otherAccountId = "222222222222";
+    const otherSqs = simAws
+      .account(otherAccountId)
+      .region(simAws.defaultRegionName)
+      .sqs();
+    const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${otherAccountId}:uploads`;
+    const created = await otherSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "uploads" }),
+    );
+    await otherSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: {
+          Policy: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: { Service: "s3.amazonaws.com" },
+              Action: "sqs:SendMessage",
+              Resource: queueArn,
+              Condition: {
+                StringEquals: { "aws:SourceAccount": simAws.defaultAccountId },
+              },
+            },
+          }),
+        },
+      }),
+    );
+
+    // And a Bucket in this Account configured to notify it
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          QueueConfigurations: [
+            {
+              Id: "uploads",
+              Events: ["s3:ObjectCreated:*"],
+              QueueArn: queueArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is put into it
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/cat.jpg",
+        Body: "cat picture",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the event reached the other Account's queue, since the source
+    // Account is what its policy asked about
+    const received = await otherSqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: created.QueueUrl }),
+    );
+    assertArrayLength(received.Messages ?? [], 1);
+  });
+});

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -29,7 +29,10 @@ received, how long it is kept, and how large it is allowed to be.
 `SimSqsQueueArn` builds both the ARN and the URL, since they carry the same three facts in two
 formats. A queue ARN has no resource type separator, so it is `arn:aws:sqs:region:account:name`
 rather than anything with a `queue/` in it. That is also why `parseSimArn` returns undefined for one,
-and why `SimSqsQueueUrl` does the URL parsing this service needs.
+and why `SimSqsQueueUrl` does the URL parsing this service needs. The URL format itself is
+`sqsQueueUrl`, which anything holding a queue ARN builds through rather than writing the format out
+again: an event source mapping polling a queue and a simulated service notifying one both mean the
+same URL.
 
 `SimSqsQueueUrl` reads a queue URL into its region, account and name. All three matter: a URL naming
 another account or region reaches nothing here rather than having its name read out and looked up
@@ -185,11 +188,17 @@ principal from another Account, or a service principal such as `s3.amazonaws.com
 identity policies anywhere. A queue with no policy contributes nothing and the decision is left to
 the caller's identity policies, as it is on real AWS.
 
-`SimSqsRequestOptions` carries a `sourceArn` alongside the caller, supplied to IAM as
-`aws:SourceArn`. A simulated service reaching a queue on a resource's behalf sets it, which is how a
-queue policy granting a service principal under an `ArnLike aws:SourceArn` condition tells one
-Bucket from another. A request that does not carry one leaves the key out rather than supplying an
-empty string, so a statement conditioned on it fails to match.
+`SimSqsRequestOptions` carries a `sourceArn` and a `sourceAccount` alongside the caller, supplied to
+IAM as `aws:SourceArn` and `aws:SourceAccount`. A simulated service reaching a queue on a resource's
+behalf sets both, which is how a queue policy granting a service principal tells one Bucket from
+another, and one Account's Buckets from another's. A request that does not carry one leaves the key
+out rather than supplying an empty string, so a statement conditioned on it fails to match.
+
+`SimSqsServiceSendAuthorizer` answers whether a service principal may send to a queue, as a decision
+rather than a thrown error. A service asks it before it has a message to send: simulated S3
+validates a notification destination when the configuration naming it is applied, and has to report
+the refusal as part of refusing the configuration. Sending later goes through `SendMessage` as
+usual, which authorizes the same way, so nothing is remembered from the earlier question.
 
 A request naming another Account as the queue owner is still refused rather than quietly answered
 with a local queue of the same name: a queue policy admits another Account's principal to a queue
@@ -218,5 +227,8 @@ here, it does not make another Account's queues reachable through this one.
   and starts its receive count again, which is not documented either way.
 - A Lambda event source mapping polls one batch at a time, where real Lambda runs several pollers and
   scales them with the queue.
+- An S3 event notification arrives as one ordinary message with no message attributes. The
+  `s3:TestEvent` real S3 puts on a queue when a configuration naming it is applied is not sent; see
+  the S3 service README for why.
 
 The full list is in [docs/services/sqs](../../../docs/services/sqs/).

--- a/src/service/sqs/command/authorize/sim-sqs-condition-context.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-condition-context.ts
@@ -1,5 +1,6 @@
 import type { SimIamConditionValue } from "../../../iam/policy/sim-iam-policy.js";
 import {
+  simSqsSourceAccountConditionKey,
   simSqsSourceArnConditionKey,
   type SimSqsRequestOptions,
 } from "../sim-sqs-request-options.js";
@@ -16,9 +17,12 @@ import {
 export function simSqsConditionContext(
   options: SimSqsRequestOptions | undefined,
 ): Readonly<Record<string, SimIamConditionValue>> {
-  if (options?.sourceArn === undefined) {
-    return {};
-  }
-
-  return { [simSqsSourceArnConditionKey]: options.sourceArn };
+  return {
+    ...(options?.sourceArn !== undefined && {
+      [simSqsSourceArnConditionKey]: options.sourceArn,
+    }),
+    ...(options?.sourceAccount !== undefined && {
+      [simSqsSourceAccountConditionKey]: options.sourceAccount,
+    }),
+  };
 }

--- a/src/service/sqs/command/authorize/sim-sqs-queue-policy-source-account.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-queue-policy-source-account.iso.test.ts
@@ -103,4 +103,34 @@ describe("SQS queue policy source Account conditions", () => {
     // admit another's.
     assertInstanceOf(error, SimIamAccessDenied);
   });
+
+  it("refuses a conditioned request that carries no source Account", async () => {
+    // Given a queue admitting S3 only for one Account's resources.
+    const simAws = new SimAws();
+    const simSqs = simAws.account(ownerAccountId).region(regionName).sqs();
+    const created = await simSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+    await simSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: { Policy: sourceAccountPolicy },
+      }),
+    );
+
+    // When S3 sends without saying which Account it is sending for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simSqs.sendMessage(
+        new SendMessageCommand({
+          QueueUrl: created.QueueUrl,
+          MessageBody: "order-1",
+        }),
+        { caller: s3ServicePrincipal, sourceArn: bucketArn },
+      );
+    });
+
+    // Then the condition has nothing to match, so the statement does not
+    // apply, which is the safe direction for a key the request left out.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
 });

--- a/src/service/sqs/command/authorize/sim-sqs-queue-policy-source-account.iso.test.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-queue-policy-source-account.iso.test.ts
@@ -1,0 +1,106 @@
+import {
+  CreateQueueCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const ownerAccountId = "111111111111";
+const sourceAccountId = "222222222222";
+const regionName = "us-east-1";
+const queueArn = `arn:aws:sqs:${regionName}:${ownerAccountId}:orders`;
+const bucketArn = "arn:aws:s3:::uploads";
+
+const s3ServicePrincipal = {
+  kind: "service",
+  service: "s3.amazonaws.com",
+} as const;
+
+/**
+ * The guard AWS documents on a destination queue policy, which only has a job
+ * when the queue and the resource sending to it are in different Accounts.
+ */
+const sourceAccountPolicy = simIamPolicyDocumentFactory.make({
+  Statement: {
+    Principal: { Service: "s3.amazonaws.com" },
+    Action: "sqs:SendMessage",
+    Resource: queueArn,
+    Condition: { StringEquals: { "aws:SourceAccount": sourceAccountId } },
+  },
+});
+
+describe("SQS queue policy source Account conditions", () => {
+  it("admits a service sending for a resource in the named Account", async () => {
+    // Given a queue admitting S3 only for one Account's resources.
+    const simAws = new SimAws();
+    const simSqs = simAws.account(ownerAccountId).region(regionName).sqs();
+    const created = await simSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+    await simSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: { Policy: sourceAccountPolicy },
+      }),
+    );
+
+    // When S3 sends on behalf of a Bucket in that Account.
+    const sent = await simSqs.sendMessage(
+      new SendMessageCommand({
+        QueueUrl: created.QueueUrl,
+        MessageBody: "order-1",
+      }),
+      {
+        caller: s3ServicePrincipal,
+        sourceArn: bucketArn,
+        sourceAccount: sourceAccountId,
+      },
+    );
+
+    // Then the condition matched.
+    assertNonNullable(sent.MessageId);
+  });
+
+  it("refuses a service sending for a resource in another Account", async () => {
+    // Given a queue admitting S3 only for one Account's resources.
+    const simAws = new SimAws();
+    const simSqs = simAws.account(ownerAccountId).region(regionName).sqs();
+    const created = await simSqs.createQueue(
+      new CreateQueueCommand({ QueueName: "orders" }),
+    );
+    await simSqs.setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: created.QueueUrl,
+        Attributes: { Policy: sourceAccountPolicy },
+      }),
+    );
+
+    // When S3 sends on behalf of a Bucket in a third Account.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simSqs.sendMessage(
+        new SendMessageCommand({
+          QueueUrl: created.QueueUrl,
+          MessageBody: "order-1",
+        }),
+        {
+          caller: s3ServicePrincipal,
+          sourceArn: bucketArn,
+          sourceAccount: "333333333333",
+        },
+      );
+    });
+
+    // Then it is denied, so a grant written for one Account's Buckets does not
+    // admit another's.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/sqs/command/authorize/sim-sqs-service-send-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-service-send-authorizer.ts
@@ -1,0 +1,69 @@
+import type {
+  SimIamAuthorizationDecision,
+  SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
+import { simSqsConditionContext } from "./sim-sqs-condition-context.js";
+import { simSqsQueueResourcePolicies } from "./sim-sqs-queue-resource-policies.js";
+
+interface SimSqsServiceSendAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+interface SimSqsServiceSendAuthorizationInput {
+  readonly queue: SimSqsQueue;
+
+  /** The service principal the sending service calls SQS as. */
+  readonly servicePrincipal: string;
+
+  /**
+   * What the service is sending for, such as the S3 Bucket an event came from.
+   */
+  readonly sourceArn?: string | undefined;
+
+  /** The Account the sending service's own resource belongs to. */
+  readonly sourceAccount?: string | undefined;
+}
+
+/**
+ * Decides whether a simulated AWS service may send a message to a queue.
+ *
+ * A service principal owns no identity policies anywhere, so the queue's own
+ * policy is the whole decision. The answer is a decision rather than a thrown
+ * error because a service asks this before it has a message to send: S3
+ * validates the destination when a notification configuration is applied, and
+ * has to report the refusal as part of refusing the configuration.
+ *
+ * A service with a message in hand sends it through `SendMessage` as usual,
+ * which authorizes the same way. Nothing is remembered from the earlier
+ * question, so a queue policy changed in between stops the delivery.
+ */
+export class SimSqsServiceSendAuthorizer {
+  private static readonly action = "sqs:SendMessage";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimSqsServiceSendAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Evaluate `sqs:SendMessage` for a service against the queue.
+   */
+  authorize(
+    input: SimSqsServiceSendAuthorizationInput,
+  ): SimIamAuthorizationDecision {
+    return this.iam.authorize({
+      action: SimSqsServiceSendAuthorizer.action,
+      resource: input.queue.arn.value,
+      caller: { kind: "service", service: input.servicePrincipal },
+      resourcePolicies: simSqsQueueResourcePolicies(input.queue),
+      conditionContext: simSqsConditionContext({
+        ...(input.sourceArn !== undefined && { sourceArn: input.sourceArn }),
+        ...(input.sourceAccount !== undefined && {
+          sourceAccount: input.sourceAccount,
+        }),
+      }),
+    });
+  }
+}

--- a/src/service/sqs/command/sim-sqs-request-options.ts
+++ b/src/service/sqs/command/sim-sqs-request-options.ts
@@ -11,6 +11,16 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 export const simSqsSourceArnConditionKey = "aws:SourceArn";
 
 /**
+ * The condition key naming the Account owning the resource a simulated service
+ * is reaching the queue for.
+ *
+ * It only has a job when that resource and the queue are in different Accounts,
+ * which is why AWS's own documented destination queue policies carry it
+ * alongside the source ARN.
+ */
+export const simSqsSourceAccountConditionKey = "aws:SourceAccount";
+
+/**
  * What an SQS request carries besides its command input.
  */
 export interface SimSqsRequestOptions {
@@ -30,4 +40,12 @@ export interface SimSqsRequestOptions {
    * match instead of matching an empty string.
    */
   readonly sourceArn?: string;
+
+  /**
+   * The Account owning the resource the caller is reaching the queue for,
+   * supplied to IAM as `aws:SourceAccount`.
+   *
+   * Left out the same way when the caller has no value for it.
+   */
+  readonly sourceAccount?: string;
 }

--- a/src/service/sqs/index.ts
+++ b/src/service/sqs/index.ts
@@ -1,5 +1,6 @@
 export { SimSqs } from "./sim-sqs.js";
 export {
+  simSqsSourceAccountConditionKey,
   simSqsSourceArnConditionKey,
   type SimSqsRequestOptions,
 } from "./command/sim-sqs-request-options.js";
@@ -11,8 +12,9 @@ export {
 export {
   sqsAnyQueueArn,
   SimSqsQueueArn,
+  type SimSqsQueueLocation,
   sqsQueueArnPrefix,
-  sqsQueueUrlPrefix,
+  sqsQueueUrl,
 } from "./queue/sim-sqs-queue-arn.js";
 export {
   type SimSqsQueueAttributeInput,

--- a/src/service/sqs/queue/sim-sqs-queue-arn.ts
+++ b/src/service/sqs/queue/sim-sqs-queue-arn.ts
@@ -30,14 +30,28 @@ export function sqsAnyQueueArn(
 }
 
 /**
- * The part of a queue URL that comes before the queue's own name.
+ * Where one queue is, in the three facts both its ARN and its URL carry.
+ *
+ * The strings are unbranded because the callers that have only read an ARN,
+ * rather than been handed a scope, have nothing but strings to offer.
  */
-export function sqsQueueUrlPrefix(
-  accountRegionScope: SimAwsAccountRegionScope,
-): string {
-  const { regionName, accountId } = accountRegionScope;
+export interface SimSqsQueueLocation {
+  readonly regionName: string;
+  readonly accountId: string;
+  readonly name: string;
+}
 
-  return `https://sqs.${regionName}.amazonaws.com/${accountId}/`;
+/**
+ * The URL SQS requests name a queue by.
+ *
+ * Anything holding a queue ARN builds the URL here rather than writing the
+ * format out again: a simulated service reaching a queue by ARN, an event
+ * source mapping polling one, and the queue itself all mean the same URL.
+ */
+export function sqsQueueUrl(location: SimSqsQueueLocation): string {
+  const { regionName, accountId, name } = location;
+
+  return `https://sqs.${regionName}.amazonaws.com/${accountId}/${name}`;
 }
 
 interface SimSqsQueueArnProperties {
@@ -62,6 +76,6 @@ export class SimSqsQueueArn {
 
     this.name = name.value;
     this.value = sqsQueueArnPrefix(accountRegionScope) + name.value;
-    this.url = sqsQueueUrlPrefix(accountRegionScope) + name.value;
+    this.url = sqsQueueUrl({ ...accountRegionScope, name: name.value });
   }
 }


### PR DESCRIPTION
A QueueConfigurations entry names a queue by ARN, and the Records document arrives as one message body, so an event source mapping on the queue carries it to a function with no further wiring.

The queue policy is the whole decision, checked when the configuration is applied and again at delivery, with aws:SourceArn and aws:SourceAccount both supplied. A cross-Account queue is allowed and a cross-Region one is not, as on real S3. A FIFO queue is refused by name.

Resolves https://github.com/KensioSoftware/yulin/issues/334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 event notifications to simulated SQS queues.
  * Added support for Lambda processing of S3 events delivered through SQS.
  * Added CloudFormation and CDK configuration support for queue destinations.
  * Added queue policy validation, region checks, cross-account authorization, and source-account conditions.
  * Added detailed S3-to-SQS documentation and executable examples.

* **Bug Fixes**
  * Improved validation and error messages for unsupported, missing, FIFO, cross-region, and unauthorized queue destinations.
  * Applied notification ID and filter-overlap checks across all destination types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->