### PR TITLE
feat: simulated CloudFormation template conditions Fn::If

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -516,6 +516,102 @@ The value a lookup returns does not have to be a string. A list value is returne
 used in resource properties and in `Outputs`. A map name or key that is not in `Mappings` fails the
 deployment with an error naming the path that could not be found.
 
+## Conditions
+
+A template `Conditions` section names boolean expressions over the stack's parameter values. A
+condition decides whether a resource is created, and which value `Fn::If` gives a property or an
+output.
+
+```typescript sim-cloudformation-conditions
+/**
+ * Choosing resources and property values by condition in a simulated CFN template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "conditions-stack",
+  template: {
+    Parameters: {
+      EnvName: { Type: "String" },
+    },
+    Conditions: {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+    },
+    Resources: {
+      Backups: {
+        Type: "AWS::S3::Bucket",
+        Condition: "IsProd",
+        Properties: { BucketName: "site-backups" },
+      },
+      Site: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            // eslint-disable-next-line no-template-curly-in-string
+            "Fn::If": ["IsProd", "site", { "Fn::Sub": "site-${EnvName}" }],
+          },
+        },
+      },
+    },
+  },
+  parameters: { EnvName: "dev" },
+});
+
+await stack.waitForDeployComplete();
+
+// site-dev
+console.log(simAws.s3().getSimBucketByName("site-dev")?.bucketName);
+
+// false, because IsProd is false
+console.log(stack.resources.has("Backups"));
+```
+
+### Writing a condition
+
+A condition is built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`. `Fn::And` and `Fn::Or`
+take a list of at least two conditions, and `Fn::Not` takes a list of exactly one. A condition can
+name another condition with `{ "Condition": "OtherCondition" }`, in any order, so a condition may
+name one written below it in the section.
+
+```json
+{
+  "IsProd": { "Fn::Equals": [{ "Ref": "EnvName" }, "prod"] },
+  "IsStaging": { "Fn::Equals": [{ "Ref": "EnvName" }, "staging"] },
+  "IsDeployed": {
+    "Fn::Or": [{ "Condition": "IsProd" }, { "Condition": "IsStaging" }]
+  }
+}
+```
+
+`Fn::Equals` compares its two values as strings, as CloudFormation does, so a JSON number in the
+template matches the string a parameter carries.
+
+The whole section is evaluated once per deployment, before any resource is created, so a condition
+can read parameters and pseudo parameters and nothing else. A comparison that would need a created
+resource, such as an `Fn::GetAtt`, fails the deployment rather than reading as false.
+
+### `Fn::If`
+
+`Fn::If` takes a condition name, a value to use when it is true, and a value to use when it is
+false. It works anywhere a resource property or an output value is read.
+
+Only the branch the condition selects is resolved. The other branch is left alone, so it can name a
+resource this deployment does not create.
+
+### The resource `Condition` attribute
+
+A resource carrying a `Condition` attribute whose condition is false is not created at all. It is
+absent from `stack.resources`, which is different from a resource sim CloudFormation skips: a
+skipped resource stays in the stack and answers `Ref` and `Fn::GetAtt` with
+[stand-in values](#values-from-a-skipped-resource).
+
+Because the resource does not exist, another resource naming it with `Ref` or `Fn::GetAtt` fails the
+deployment, with an error naming both resources and the condition. A `Condition` attribute naming a
+condition the template does not define fails the same way.
+
 ## Resource dependencies
 
 Resources can depend on each other explicitly with `DependsOn`.
@@ -1163,7 +1259,9 @@ Sim CloudFormation currently supports:
 - Template `Parameters` with supplied values and defaults
 - Template `Outputs`, resolved after resource creation and read from `stack.outputs`
 - Template `Mappings`, read with `Fn::FindInMap`
-- The `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub` and `Fn::FindInMap` intrinsic functions
+- Template `Conditions`, built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`
+- The resource `Condition` attribute, which decides whether a resource is created
+- The `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::FindInMap` and `Fn::If` intrinsic functions
 - Explicit resource dependencies with `DependsOn`
 - Implicit dependencies from resource `Ref` expressions
 
@@ -1207,4 +1305,9 @@ Each service's own docs describe what its resource types support.
   resource with a "could not find map" error rather than being resolved. Real CloudFormation allows
   only `Ref` and a nested `Fn::FindInMap` inside `Fn::FindInMap`, so this only affects templates real
   CloudFormation would reject as well, but the simulator does not reject them up front.
-- Conditions and many advanced CloudFormation features are not supported.
+- `Fn::If` is not supported inside the `Conditions` section itself. It is rejected there rather than
+  read against a half-evaluated section.
+- The `Condition` attribute is read on resources but not on outputs. An output carrying one is
+  resolved and present in `stack.outputs` whichever way its condition falls, where real
+  CloudFormation would leave it out.
+- Many advanced CloudFormation features are not supported.

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -371,7 +371,7 @@ A stand-in is deliberately not ARN-shaped, so it fails closed wherever the simul
 - In a property that is parsed as an ARN it is refused as malformed, and that Resource fails.
   Handing `Fn::GetAtt: ["Orders", "StreamArn"]` from a skipped DynamoDB table to an
   `AWS::Lambda::EventSourceMapping` fails with
-  `EventSourceArn Orders.StreamArn is not an SQS queue ARN`.
+  `EventSourceArn Orders.StreamArn names no simulated Lambda event source`.
 - Handed to a Lambda function through its environment, it names something that is not there, so the
   function's own SDK call fails as a call for a missing resource does. A `PutItem` naming the
   skipped table gets `ResourceNotFoundException: No DynamoDB Table named Orders`.

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -572,7 +572,7 @@ console.log(stack.resources.has("Backups"));
 ### Writing a condition
 
 A condition is built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`. `Fn::And` and `Fn::Or`
-take a list of at least two conditions, and `Fn::Not` takes a list of exactly one. A condition can
+take a list of two to ten conditions, and `Fn::Not` takes a list of exactly one. A condition can
 name another condition with `{ "Condition": "OtherCondition" }`, in any order, so a condition may
 name one written below it in the section.
 
@@ -608,9 +608,12 @@ absent from `stack.resources`, which is different from a resource sim CloudForma
 skipped resource stays in the stack and answers `Ref` and `Fn::GetAtt` with
 [stand-in values](#values-from-a-skipped-resource).
 
-Because the resource does not exist, another resource naming it with `Ref` or `Fn::GetAtt` fails the
-deployment, with an error naming both resources and the condition. A `Condition` attribute naming a
-condition the template does not define fails the same way.
+Because the resource does not exist, another resource naming it fails the deployment, with an error
+naming both resources and the condition. That covers a `Ref` or `Fn::GetAtt` that is actually
+reached, and a `DependsOn`. A name carried only by the branch of an `Fn::If` the condition did not
+select is not reached, so it does not fail.
+
+A `Condition` attribute naming a condition the template does not define fails the same way.
 
 ## Resource dependencies
 

--- a/docs/services/cloudformation/sim-cloudformation-conditions.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-conditions.example.ts
@@ -1,0 +1,44 @@
+/**
+ * Choosing resources and property values by condition in a simulated CFN template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "conditions-stack",
+  template: {
+    Parameters: {
+      EnvName: { Type: "String" },
+    },
+    Conditions: {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+    },
+    Resources: {
+      Backups: {
+        Type: "AWS::S3::Bucket",
+        Condition: "IsProd",
+        Properties: { BucketName: "site-backups" },
+      },
+      Site: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            // eslint-disable-next-line no-template-curly-in-string
+            "Fn::If": ["IsProd", "site", { "Fn::Sub": "site-${EnvName}" }],
+          },
+        },
+      },
+    },
+  },
+  parameters: { EnvName: "dev" },
+});
+
+await stack.waitForDeployComplete();
+
+// site-dev
+console.log(simAws.s3().getSimBucketByName("site-dev")?.bucketName);
+
+// false, because IsProd is false
+console.log(stack.resources.has("Backups"));

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -238,8 +238,11 @@ condition that reads false when it should read true silently deploys the wrong s
 resource is dropped before the resource map is built, so it never becomes a `SimCfnResource`. This
 is deliberately not the skipped-resource path used for unsupported resource types: a skipped
 resource stays in `stack.resources` and answers `Ref` and `Fn::GetAtt` with stand-in values, where a
-conditioned-out resource does not exist at all, and naming it from another resource fails the
-deployment.
+conditioned-out resource does not exist at all.
+
+Naming a conditioned-out resource from another resource fails the deployment. The names that count
+are those left in the resolved resource template, plus `DependsOn`. Because `Fn::If` has already
+picked its branch by then, a name carried only by the branch that was not selected does not count.
 
 This two-phase design is one of the most important simulated CloudFormation implementation details.
 It allows the stack to build a complete runtime resource graph before any service resources exist,

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -26,7 +26,7 @@ familiar CloudFormation/CDK outputs.
 - `deploy/` contains convenience helpers for deploying already-parsed templates or synthesized
   template files.
 - `template/` contains template body validation, template value parsing, intrinsic-function nodes,
-  and value resolution.
+  condition evaluation, and value resolution.
 - `parameters/` contains parameter input/default handling.
 - `resource/` contains the runtime CloudFormation resource model, resource type parsing, dependency
   extraction, property resolution, and service factory resolution.
@@ -163,7 +163,8 @@ Template responsibilities are limited:
 
 - validate broad template body shape
 - attach parameter definitions
-- expose resource template entries
+- evaluate the `Conditions` section
+- expose resource template entries, leaving out those a false `Condition` excludes
 - resolve parameters and parameter-only intrinsic functions before resources are created
 
 Resource-to-resource references are not fully resolved during initial template processing. Those
@@ -199,6 +200,7 @@ Supported intrinsic-function areas currently include:
 - `Fn::Join`
 - `Fn::Sub`
 - `Fn::FindInMap`
+- `Fn::If`
 
 Resolution happens in two phases:
 
@@ -206,6 +208,7 @@ Resolution happens in two phases:
 
 - Parameters and parameter-only expressions can be resolved.
 - The template `Mappings` section is available here, so `Fn::FindInMap` lookups resolve.
+- The evaluated `Conditions` are available here, so `Fn::If` picks its branch.
 - Resource references are preserved if the referenced resource does not exist yet.
 
 2. **Resource creation phase**
@@ -214,6 +217,29 @@ Resolution happens in two phases:
 - `Ref` and `Fn::GetAtt` can read values from resources whose dependencies have completed.
 - `Mappings` are not in this context, so a `Fn::FindInMap` left unresolved by the first phase fails
   here.
+- `Conditions` are not in this context either. The first phase always resolves `Fn::If` away, so
+  nothing reaching this phase needs them.
+
+## Conditions
+
+`SimCfnConditionEvaluator` turns the template `Conditions` section into a `SimCfnConditions` map of
+plain booleans, held under `template/condition/`.
+
+A condition can only read parameters and pseudo parameters, so the whole section is evaluated once
+per deployment, before any resource is created. `SimCfnTemplate` memoizes the result and passes it
+into every resolve context it builds, the same way it passes `Mappings`.
+
+Conditions are not written in dependency order, so each name is evaluated on demand and remembered,
+carrying the chain of names being evaluated to catch a condition that refers back to itself. A
+comparison that would need a created resource fails rather than reading as false, because a
+condition that reads false when it should read true silently deploys the wrong stack.
+
+`SimCfnResourceConditions` applies the resource-level `Condition` attribute. A conditioned-out
+resource is dropped before the resource map is built, so it never becomes a `SimCfnResource`. This
+is deliberately not the skipped-resource path used for unsupported resource types: a skipped
+resource stays in `stack.resources` and answers `Ref` and `Fn::GetAtt` with stand-in values, where a
+conditioned-out resource does not exist at all, and naming it from another resource fails the
+deployment.
 
 This two-phase design is one of the most important simulated CloudFormation implementation details.
 It allows the stack to build a complete runtime resource graph before any service resources exist,
@@ -548,7 +574,12 @@ Useful areas:
   - `Fn::Join`
   - `Fn::Sub`
   - `Fn::FindInMap`
+  - `Fn::If`
   - literal/list/object node resolution
+
+- `template/condition/*.iso.test.ts`
+  - condition evaluation and the condition functions it refuses
+  - the resource `Condition` attribute
 
 - `parameters/*.iso.test.ts`
   - parameter input/default behaviour

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-comparison.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-comparison.ts
@@ -1,0 +1,66 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+import type { SimCfnTemplateValueResolver } from "../value/sim-cfn-template-value-resolver.js";
+import {
+  SimCfnValueShape,
+  type SimCfnValueShapeErrorBuilder,
+} from "../value/sim-cfn-value-shape.js";
+
+interface SimCfnConditionComparisonProperties {
+  readonly valueResolver: SimCfnTemplateValueResolver;
+  readonly error: SimCfnValueShapeErrorBuilder;
+}
+
+/**
+ * Answers the `Fn::Equals` a Condition is built from.
+ *
+ * Both sides are resolved from Parameters and pseudo parameters, then compared
+ * as the strings CloudFormation compares, so a JSON number in the template
+ * matches the string a Parameter carries.
+ */
+export class SimCfnConditionComparison {
+  private readonly valueResolver: SimCfnTemplateValueResolver;
+  private readonly error: SimCfnValueShapeErrorBuilder;
+  private readonly shape: SimCfnValueShape;
+
+  constructor(properties: SimCfnConditionComparisonProperties) {
+    this.valueResolver = properties.valueResolver;
+    this.error = properties.error;
+    this.shape = new SimCfnValueShape(properties.error);
+  }
+
+  /**
+   * Whether the two values an Fn::Equals carries are the same.
+   */
+  equals(label: string, value: SimCfnTemplateValue): boolean {
+    const operands = this.shape.list(value, `${label} Fn::Equals`);
+
+    if (operands.length !== 2) {
+      throw this.error(
+        `${label} Fn::Equals must be a list of exactly two values`,
+      );
+    }
+
+    const left = operands[0];
+    const right = operands[1];
+    assertDefined(left, `${label} Fn::Equals left value`);
+    assertDefined(right, `${label} Fn::Equals right value`);
+
+    return this.comparable(label, left) === this.comparable(label, right);
+  }
+
+  private comparable(label: string, value: SimCfnTemplateValue): string {
+    const resolved = this.valueResolver.resolve(value);
+
+    if (isRecord(resolved) || Array.isArray(resolved)) {
+      throw this.error(
+        `${label} Fn::Equals cannot compare ${jsonStringify(resolved)}, ` +
+          "which does not resolve from Parameters alone",
+      );
+    }
+
+    return String(resolved);
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-evaluator.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-evaluator.ts
@@ -1,0 +1,103 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+import type { SimCfnTemplateValueResolver } from "../value/sim-cfn-template-value-resolver.js";
+import { SimCfnConditionComparison } from "./sim-cfn-condition-comparison.js";
+import { SimCfnConditionExpression } from "./sim-cfn-condition-expression.js";
+import {
+  SimCfnConditions,
+  type SimCfnConditionsSection,
+} from "./sim-cfn-conditions.js";
+
+interface SimCfnConditionEvaluatorProperties {
+  readonly conditions?: SimCfnConditionsSection | undefined;
+  readonly valueResolver: SimCfnTemplateValueResolver;
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * Evaluates a template's Conditions section into plain booleans.
+ *
+ * The section is not written in dependency order, so each name is evaluated on
+ * demand and remembered, with the chain of names being evaluated carried along
+ * to catch a Condition that refers back to itself.
+ *
+ * Every leaf comes from the Parameters and pseudo parameters the Stack was
+ * given, so the answers are the same however often they are read. A comparison
+ * that would need a created Resource fails the deployment instead of quietly
+ * answering false, because a Condition that reads false when it should read
+ * true silently deploys the wrong Stack.
+ */
+export class SimCfnConditionEvaluator {
+  private readonly expressions: ReadonlyMap<string, SimCfnTemplateValue>;
+  private readonly stackName: string | undefined;
+  private readonly comparison: SimCfnConditionComparison;
+  private readonly values = new Map<string, boolean>();
+
+  constructor(properties: SimCfnConditionEvaluatorProperties) {
+    this.expressions = new Map(Object.entries(properties.conditions ?? {}));
+    this.stackName = properties.stackName;
+    this.comparison = new SimCfnConditionComparison({
+      valueResolver: properties.valueResolver,
+      error: (reason): Error => this.error(reason),
+    });
+  }
+
+  /**
+   * Evaluate every Condition the template defines.
+   */
+  evaluate(): SimCfnConditions {
+    for (const conditionName of this.expressions.keys()) {
+      this.evaluateNamed(conditionName, []);
+    }
+
+    return new SimCfnConditions(this.values);
+  }
+
+  private evaluateNamed(
+    conditionName: string,
+    resolving: readonly string[],
+  ): boolean {
+    const known = this.values.get(conditionName);
+
+    if (known !== undefined) {
+      return known;
+    }
+
+    const chain = [...resolving, conditionName];
+
+    if (resolving.includes(conditionName)) {
+      const route = chain.join(" -> ");
+
+      throw this.error(
+        `Condition ${conditionName} refers to itself through ${route}`,
+      );
+    }
+
+    const expression = this.expressions.get(conditionName);
+    assertDefined(
+      expression,
+      this.message(
+        `Condition ${conditionName} is not defined in the template Conditions`,
+      ),
+    );
+
+    const value = new SimCfnConditionExpression({
+      label: `Condition ${conditionName}`,
+      error: (reason): Error => this.error(reason),
+      comparison: this.comparison,
+      named: (name): boolean => this.evaluateNamed(name, chain),
+    }).evaluate(expression);
+
+    this.values.set(conditionName, value);
+
+    return value;
+  }
+
+  private error(detail: string): Error {
+    return new Error(this.message(detail));
+  }
+
+  private message(detail: string): string {
+    return `Sim CloudFormation Stack ${this.stackName ?? "unknown"} ${detail}`;
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
@@ -28,7 +28,10 @@ interface SimCfnConditionExpressionProperties {
  * here.
  *
  * A function name this simulation has no behaviour for is refused rather than
- * read as false, which would deploy a Stack the template did not describe.
+ * read as false, which would deploy a Stack the template did not describe. The
+ * two to ten operands CloudFormation allows `Fn::And` and `Fn::Or` are held to
+ * for the same reason: a template this accepted and CloudFormation did not is a
+ * test that passes and a deployment that fails.
  */
 export class SimCfnConditionExpression {
   private readonly label: string;
@@ -99,9 +102,9 @@ export class SimCfnConditionExpression {
   ): boolean[] {
     const listed = this.shape.list(value, `${this.label} ${functionName}`);
 
-    if (listed.length < 2) {
+    if (listed.length < 2 || listed.length > 10) {
       throw this.error(
-        `${this.label} ${functionName} must be a list of at least two conditions`,
+        `${this.label} ${functionName} must be a list of two to ten conditions`,
       );
     }
 

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
@@ -1,0 +1,125 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+import {
+  SimCfnValueShape,
+  type SimCfnValueShapeErrorBuilder,
+} from "../value/sim-cfn-value-shape.js";
+import type { SimCfnConditionComparison } from "./sim-cfn-condition-comparison.js";
+
+/**
+ * Answers a Condition this expression names, by whatever route that takes.
+ */
+export type SimCfnNamedConditionReader = (conditionName: string) => boolean;
+
+interface SimCfnConditionExpressionProperties {
+  readonly label: string;
+  readonly error: SimCfnValueShapeErrorBuilder;
+  readonly comparison: SimCfnConditionComparison;
+  readonly named: SimCfnNamedConditionReader;
+}
+
+/**
+ * Evaluates the expression tree of one named Condition.
+ *
+ * The tree is `Fn::Equals` at the leaves and `Fn::And`, `Fn::Or` and `Fn::Not`
+ * above them, with `{ "Condition": "OtherCondition" }` handing off to the
+ * Condition of that name. Where that other Condition comes from is the
+ * evaluator's business, so it arrives as a reader rather than being looked up
+ * here.
+ *
+ * A function name this simulation has no behaviour for is refused rather than
+ * read as false, which would deploy a Stack the template did not describe.
+ */
+export class SimCfnConditionExpression {
+  private readonly label: string;
+  private readonly error: SimCfnValueShapeErrorBuilder;
+  private readonly comparison: SimCfnConditionComparison;
+  private readonly named: SimCfnNamedConditionReader;
+  private readonly shape: SimCfnValueShape;
+
+  constructor(properties: SimCfnConditionExpressionProperties) {
+    this.label = properties.label;
+    this.error = properties.error;
+    this.comparison = properties.comparison;
+    this.named = properties.named;
+    this.shape = new SimCfnValueShape(properties.error);
+  }
+
+  /**
+   * Evaluate one condition function object.
+   */
+  evaluate(expression: SimCfnTemplateValue): boolean {
+    const record = this.shape.record(expression, this.label);
+    const entries = Object.entries(record);
+
+    if (entries.length !== 1) {
+      throw this.error(
+        `${this.label} must be a single condition function object`,
+      );
+    }
+
+    const entry = entries[0];
+    assertDefined(entry, `${this.label} function entry`);
+
+    return this.apply(entry[0], entry[1]);
+  }
+
+  private apply(functionName: string, value: SimCfnTemplateValue): boolean {
+    if (functionName === "Fn::Equals") {
+      return this.comparison.equals(this.label, value);
+    }
+
+    if (functionName === "Fn::And") {
+      return this.operands(functionName, value).every(Boolean);
+    }
+
+    if (functionName === "Fn::Or") {
+      return this.operands(functionName, value).includes(true);
+    }
+
+    if (functionName === "Fn::Not") {
+      return this.negated(value);
+    }
+
+    if (functionName === "Condition") {
+      return this.named(
+        this.shape.string(value, `${this.label} Condition reference`),
+      );
+    }
+
+    throw this.error(
+      `${this.label} uses ${functionName}, which is not a condition function ` +
+        "this simulation evaluates",
+    );
+  }
+
+  private operands(
+    functionName: string,
+    value: SimCfnTemplateValue,
+  ): boolean[] {
+    const listed = this.shape.list(value, `${this.label} ${functionName}`);
+
+    if (listed.length < 2) {
+      throw this.error(
+        `${this.label} ${functionName} must be a list of at least two conditions`,
+      );
+    }
+
+    return listed.map((operand) => this.evaluate(operand));
+  }
+
+  private negated(value: SimCfnTemplateValue): boolean {
+    const listed = this.shape.list(value, `${this.label} Fn::Not`);
+
+    if (listed.length !== 1) {
+      throw this.error(
+        `${this.label} Fn::Not must be a list of exactly one condition`,
+      );
+    }
+
+    const operand = listed[0];
+    assertDefined(operand, `${this.label} Fn::Not condition`);
+
+    return !this.evaluate(operand);
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
@@ -1,0 +1,279 @@
+import { assertIdentical, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
+import { SimCfnTemplate } from "../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Conditions refusals", () => {
+  it("refuses a Condition that only a created Resource could evaluate", () => {
+    // Given a Condition comparing a Resource attribute.
+    const conditions = {
+      IsNamed: {
+        "Fn::Equals": [{ "Fn::GetAtt": ["SiteBucket", "Arn"] }, "arn:aws:s3"],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the Condition fails rather than quietly reading false.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsNamed " +
+        'Fn::Equals cannot compare {"Fn::GetAtt":["SiteBucket","Arn"]}, ' +
+        "which does not resolve from Parameters alone",
+    );
+  });
+
+  it("refuses a Condition that refers back to itself", () => {
+    // Given two Conditions that name each other.
+    const conditions = {
+      IsProd: { "Fn::Not": [{ Condition: "IsNotProd" }] },
+      IsNotProd: { "Fn::Not": [{ Condition: "IsProd" }] },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the cycle is named rather than recursing.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd refers to " +
+        "itself through IsProd -> IsNotProd -> IsProd",
+    );
+  });
+
+  it("refuses a Condition naming one the template does not define", () => {
+    // Given a Condition naming a Condition that is not in the section.
+    const conditions = { IsProd: { "Fn::Not": [{ Condition: "IsStaging" }] } };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the missing Condition is named.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsStaging is not " +
+        "defined in the template Conditions",
+    );
+  });
+
+  it("refuses a condition function it does not evaluate", () => {
+    // Given a Condition built from an unsupported function.
+    const conditions = { IsProd: { "Fn::Contains": [["prod"], "prod"] } };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the function is named rather than ignored.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd uses " +
+        "Fn::Contains, which is not a condition function this simulation " +
+        "evaluates",
+    );
+  });
+
+  it("refuses a Condition that is not a single function object", () => {
+    // Given a Condition carrying two functions at once.
+    const conditions = {
+      IsProd: {
+        "Fn::Equals": [{ Ref: "EnvName" }, "prod"],
+        "Fn::Not": [{ "Fn::Equals": [{ Ref: "EnvName" }, "dev"] }],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the Condition is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd must be a " +
+        "single condition function object",
+    );
+  });
+
+  it("refuses an Fn::Equals that does not compare exactly two values", () => {
+    // Given an Fn::Equals with three values.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod", "staging"] },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::Equals " +
+        "must be a list of exactly two values",
+    );
+  });
+
+  it("refuses an Fn::And with fewer than two conditions", () => {
+    // Given an Fn::And over one condition.
+    const conditions = {
+      IsProd: { "Fn::And": [{ "Fn::Equals": [{ Ref: "EnvName" }, "prod"] }] },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::And " +
+        "must be a list of at least two conditions",
+    );
+  });
+
+  it("refuses an Fn::Not over more than one condition", () => {
+    // Given an Fn::Not over two conditions.
+    const conditions = {
+      IsProd: {
+        "Fn::Not": [
+          { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+          { "Fn::Equals": [{ Ref: "EnvName" }, "dev"] },
+        ],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::Not " +
+        "must be a list of exactly one condition",
+    );
+  });
+
+  it("refuses an Fn::Equals that is not a list", () => {
+    // Given an Fn::Equals carrying an object.
+    const conditions = { IsProd: { "Fn::Equals": { Ref: "EnvName" } } };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::Equals " +
+        "must be a list",
+    );
+  });
+
+  it("refuses a Condition that is not an object", () => {
+    // Given a Condition written as a bare string.
+    const conditions = { IsProd: "prod" };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd must be an " +
+        "object",
+    );
+  });
+
+  it("refuses a Condition reference that is not a string", () => {
+    // Given a Condition reference carrying an object.
+    const conditions = {
+      IsProd: { "Fn::Not": [{ Condition: { Ref: "EnvName" } }] },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Condition " +
+        "reference must be a string",
+    );
+  });
+
+  it("refuses Fn::If inside the Conditions section", () => {
+    // Given a Condition built from Fn::If, which needs the very Conditions
+    // being evaluated.
+    const conditions = {
+      IsProd: {
+        "Fn::Equals": [{ "Fn::If": ["IsProd", "a", "b"] }, "a"],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then it is refused rather than reading a half-evaluated section.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::If IsProd cannot be resolved where the " +
+        "template Conditions are not available",
+    );
+  });
+
+  it("refuses a Conditions section that is not an object", () => {
+    // Given a template whose Conditions section is a list.
+    // When the template is read.
+    const error = assertThrowsError(
+      () =>
+        new SimCfnTemplate({
+          stackName: "conditions-stack",
+          template: {
+            Conditions: [] as unknown as Record<string, SimCfnTemplateValue>,
+            Resources: {},
+          },
+        }),
+    );
+
+    // Then the section is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Conditions must be an object",
+    );
+  });
+});
+
+/**
+ * Evaluate a Conditions section against one EnvName Parameter value.
+ */
+function evaluateWith(conditions: Record<string, SimCfnTemplateValue>): void {
+  new SimCfnTemplate({
+    stackName: "conditions-stack",
+    template: {
+      Parameters: { EnvName: { Type: "String" } },
+      Conditions: conditions,
+      Resources: {},
+    },
+    parameters: SimCfnParameters.fromValues({ EnvName: "prod" }),
+  }).conditions();
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
@@ -138,7 +138,26 @@ describe("SimCfnTemplate Conditions refusals", () => {
     assertIdentical(
       error.message,
       "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::And " +
-        "must be a list of at least two conditions",
+        "must be a list of two to ten conditions",
+    );
+  });
+
+  it("refuses an Fn::Or with more than ten conditions", () => {
+    // Given an Fn::Or over eleven conditions, one past what CloudFormation
+    // accepts.
+    const conditions = { IsProd: { "Fn::Or": equalsConditions(11) } };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused rather than deploying a template real
+    // CloudFormation would reject.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::Or " +
+        "must be a list of two to ten conditions",
     );
   });
 
@@ -276,4 +295,13 @@ function evaluateWith(conditions: Record<string, SimCfnTemplateValue>): void {
     },
     parameters: SimCfnParameters.fromValues({ EnvName: "prod" }),
   }).conditions();
+}
+
+/**
+ * A list of the given number of distinct Fn::Equals conditions.
+ */
+function equalsConditions(count: number): SimCfnTemplateValue[] {
+  return Array.from({ length: count }, (_, index) => ({
+    "Fn::Equals": [{ Ref: "EnvName" }, `env-${String(index)}`],
+  }));
 }

--- a/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
@@ -131,6 +131,24 @@ describe("SimCfnTemplate Conditions", () => {
     assertFalse(evaluateWith(conditions, "dev").value("IsDeployed"));
   });
 
+  it("composes the ten conditions Fn::Or accepts", () => {
+    // Given an Fn::Or over the most conditions CloudFormation allows, the last
+    // of which matches.
+    const conditions = {
+      IsKnownEnv: {
+        "Fn::Or": Array.from({ length: 10 }, (_, index) => ({
+          "Fn::Equals": [{ Ref: "EnvName" }, `env-${String(index)}`],
+        })),
+      },
+    };
+
+    // When the Stack is deployed with that value.
+    const evaluated = evaluateWith(conditions, "env-9");
+
+    // Then the Condition is true.
+    assertTrue(evaluated.value("IsKnownEnv"));
+  });
+
   it("evaluates a Condition named before the one it depends on", () => {
     // Given a Condition named ahead of the Condition it reads, as a template
     // section carries no ordering.

--- a/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
@@ -1,0 +1,178 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { DEFAULT_SIM_AWS_REGION_NAME } from "../../../aws/sim-aws-region.js";
+import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
+import { SimCfnTemplate } from "../sim-cfn-template.js";
+import type {
+  SimCfnConditions,
+  SimCfnConditionsSection,
+} from "./sim-cfn-conditions.js";
+
+describe("SimCfnTemplate Conditions", () => {
+  it("evaluates Fn::Equals over a Parameter as true", () => {
+    // Given a Condition comparing a Parameter to a literal.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+    };
+
+    // When the Stack is deployed with the value it compares against.
+    const evaluated = evaluateWith(conditions, "prod");
+
+    // Then the Condition is true.
+    assertTrue(evaluated.value("IsProd"));
+  });
+
+  it("evaluates Fn::Equals over a Parameter as false", () => {
+    // Given a Condition comparing a Parameter to a literal.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+    };
+
+    // When the Stack is deployed with a different value.
+    const evaluated = evaluateWith(conditions, "dev");
+
+    // Then the Condition is false.
+    assertFalse(evaluated.value("IsProd"));
+  });
+
+  it("compares a Parameter against a pseudo parameter", () => {
+    // Given a Condition comparing the Stack Region to a Parameter.
+    const conditions = {
+      IsHomeRegion: {
+        "Fn::Equals": [{ Ref: "AWS::Region" }, { Ref: "EnvName" }],
+      },
+    };
+
+    // When the Stack is deployed with the Region it runs in.
+    const evaluated = evaluateWith(conditions, DEFAULT_SIM_AWS_REGION_NAME);
+
+    // Then the Condition is true.
+    assertTrue(evaluated.value("IsHomeRegion"));
+  });
+
+  it("compares a template number against a Parameter string", () => {
+    // Given a Condition comparing a Parameter to a JSON number.
+    const conditions = { IsTwo: { "Fn::Equals": [{ Ref: "EnvName" }, 2] } };
+
+    // When the Stack is deployed with that number as a Parameter value.
+    const evaluated = evaluateWith(conditions, "2");
+
+    // Then the Condition is true, as CloudFormation compares template values
+    // as the strings they arrive as.
+    assertTrue(evaluated.value("IsTwo"));
+  });
+
+  it("inverts a Condition with Fn::Not", () => {
+    // Given a Condition negating a comparison.
+    const conditions = {
+      IsNotProd: {
+        "Fn::Not": [{ "Fn::Equals": [{ Ref: "EnvName" }, "prod"] }],
+      },
+    };
+
+    // When the Stack is deployed with a different value.
+    const evaluated = evaluateWith(conditions, "dev");
+
+    // Then the Condition is true.
+    assertTrue(evaluated.value("IsNotProd"));
+  });
+
+  it("composes Conditions by name with Fn::And", () => {
+    // Given a Condition that names two other Conditions.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+      IsNamed: { "Fn::Not": [{ "Fn::Equals": [{ Ref: "EnvName" }, ""] }] },
+      IsNamedProd: {
+        "Fn::And": [{ Condition: "IsProd" }, { Condition: "IsNamed" }],
+      },
+    };
+
+    // When the Stack is deployed with a value both agree on.
+    const evaluated = evaluateWith(conditions, "prod");
+
+    // Then the composed Condition is true.
+    assertTrue(evaluated.value("IsNamedProd"));
+  });
+
+  it("evaluates Fn::And as false when one named Condition is false", () => {
+    // Given a Condition that names two other Conditions.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+      IsStaging: { "Fn::Equals": [{ Ref: "EnvName" }, "staging"] },
+      IsBoth: {
+        "Fn::And": [{ Condition: "IsProd" }, { Condition: "IsStaging" }],
+      },
+    };
+
+    // When the Stack is deployed with a value only one of them agrees on.
+    const evaluated = evaluateWith(conditions, "prod");
+
+    // Then the composed Condition is false.
+    assertFalse(evaluated.value("IsBoth"));
+  });
+
+  it("composes Conditions by name with Fn::Or", () => {
+    // Given a Condition that accepts either of two other Conditions.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+      IsStaging: { "Fn::Equals": [{ Ref: "EnvName" }, "staging"] },
+      IsDeployed: {
+        "Fn::Or": [{ Condition: "IsProd" }, { Condition: "IsStaging" }],
+      },
+    };
+
+    // When the Stack is deployed with a value one of them agrees on.
+    const evaluated = evaluateWith(conditions, "staging");
+
+    // Then the composed Condition is true.
+    assertTrue(evaluated.value("IsDeployed"));
+
+    // And a value neither agrees on leaves it false.
+    assertFalse(evaluateWith(conditions, "dev").value("IsDeployed"));
+  });
+
+  it("evaluates a Condition named before the one it depends on", () => {
+    // Given a Condition named ahead of the Condition it reads, as a template
+    // section carries no ordering.
+    const conditions = {
+      IsNotProd: { "Fn::Not": [{ Condition: "IsProd" }] },
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+    };
+
+    // When the Stack is deployed.
+    const evaluated = evaluateWith(conditions, "dev");
+
+    // Then both Conditions are evaluated.
+    assertTrue(evaluated.value("IsNotProd"));
+    assertFalse(evaluated.value("IsProd"));
+  });
+
+  it("reads a template with no Conditions section", () => {
+    // Given a template with no Conditions.
+    const template = new SimCfnTemplate({ template: { Resources: {} } });
+
+    // When its Conditions are read.
+    const evaluated = template.conditions();
+
+    // Then nothing is defined.
+    assertFalse(evaluated.has("IsProd"));
+  });
+});
+
+/**
+ * Evaluate a Conditions section against one EnvName Parameter value.
+ */
+function evaluateWith(
+  conditions: SimCfnConditionsSection,
+  environmentName: string,
+): SimCfnConditions {
+  return new SimCfnTemplate({
+    stackName: "conditions-stack",
+    template: {
+      Parameters: { EnvName: { Type: "String" } },
+      Conditions: conditions,
+      Resources: {},
+    },
+    parameters: SimCfnParameters.fromValues({ EnvName: environmentName }),
+  }).conditions();
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-conditions.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-conditions.ts
@@ -1,0 +1,45 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+
+/**
+ * The Conditions section of a CloudFormation template body.
+ *
+ * Each entry is a condition function expression, which is only evaluated once
+ * the Stack's Parameter values are known.
+ */
+export type SimCfnConditionsSection = Record<string, SimCfnTemplateValue>;
+
+/**
+ * A template's Conditions section, already evaluated to booleans.
+ *
+ * A Condition can only read Parameters and pseudo parameters, so the whole
+ * section is evaluated once per deployment, before any Resource is created.
+ * Everything downstream reads these answers rather than the expressions.
+ */
+export class SimCfnConditions {
+  private readonly values: ReadonlyMap<string, boolean>;
+
+  constructor(values: ReadonlyMap<string, boolean> = new Map()) {
+    this.values = values;
+  }
+
+  /**
+   * Whether the template defines a Condition with this name.
+   */
+  has(conditionName: string): boolean {
+    return this.values.has(conditionName);
+  }
+
+  /**
+   * The evaluated value of a Condition the template defines.
+   */
+  value(conditionName: string): boolean {
+    const value = this.values.get(conditionName);
+    assertDefined(
+      value,
+      `Sim CloudFormation Condition ${conditionName} is not defined in the template Conditions`,
+    );
+
+    return value;
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
@@ -1,0 +1,208 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../sim-cfn-template.js";
+
+describe("SimCfnStack Resource Condition", () => {
+  it("does not create a Resource whose Condition is false", async () => {
+    // Given a Stack with a Bucket only production gets.
+    const simAws = new SimAws();
+
+    // When it is deployed as dev.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "resource-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "dev" },
+    });
+
+    // Then that Resource is not in the Stack at all, unlike a skipped one.
+    assertFalse(stack.resources.has("Backups"));
+    assertArrayLength(stack.skippedResources, 0);
+
+    // And the Resource the Condition kept is created and named for dev.
+    const site = stack.resources.get("Site");
+    assertNonNullable(site, "Site Resource");
+    assertTrue(site.deployed);
+    assertIdentical(
+      simAws.s3().getSimBucketByName("site-dev")?.bucketName,
+      "site-dev",
+    );
+  });
+
+  it("creates a Resource whose Condition is true", async () => {
+    // Given the same Stack.
+    const simAws = new SimAws();
+
+    // When it is deployed as prod.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "resource-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "prod" },
+    });
+
+    // Then both Buckets are created, and the Fn::If took its true branch.
+    assertTrue(stack.resources.has("Backups"));
+    assertIdentical(simAws.s3().getSimBucketByName("site")?.bucketName, "site");
+  });
+
+  it("refuses a Resource naming a Condition the template does not define", async () => {
+    // Given a Resource whose Condition is not in the Conditions section.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "resource-condition-stack",
+        template: {
+          Conditions: { IsProd: { "Fn::Equals": ["a", "b"] } },
+          Resources: {
+            Backups: { Type: "AWS::S3::Bucket", Condition: "IsStaging" },
+          },
+        },
+      });
+    });
+
+    // Then the error names the Resource and the Condition.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack resource-condition-stack Resource Backups " +
+        "names Condition IsStaging, which the template does not define",
+    );
+  });
+
+  it("refuses a Resource Condition that is not a string", async () => {
+    // Given a Resource whose Condition is an expression.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "resource-condition-stack",
+        template: {
+          Conditions: { IsProd: { "Fn::Equals": ["a", "b"] } },
+          Resources: {
+            Backups: {
+              Type: "AWS::S3::Bucket",
+              Condition: { Ref: "IsProd" },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack resource-condition-stack Resource Backups " +
+        "Condition must be a string",
+    );
+  });
+
+  it("allows an unselected Fn::If branch to name a Resource that is not created", async () => {
+    // Given a property whose true branch reads the Bucket only prod creates.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed as dev.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "resource-condition-stack",
+      template: {
+        Parameters: { EnvName: { Type: "String" } },
+        Conditions: {
+          IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+        },
+        Resources: {
+          Backups: { Type: "AWS::S3::Bucket", Condition: "IsProd" },
+          Site: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: {
+                "Fn::If": ["IsProd", { Ref: "Backups" }, "site-dev"],
+              },
+            },
+          },
+        },
+      },
+      parameters: { EnvName: "dev" },
+    });
+
+    // Then the branch that was not taken never had to resolve.
+    assertIdentical(stack.lifecycle.status, "CREATE_COMPLETE");
+    assertIdentical(
+      simAws.s3().getSimBucketByName("site-dev")?.bucketName,
+      "site-dev",
+    );
+  });
+
+  it("refuses a Ref to a Resource the Stack does not create", async () => {
+    // Given a Resource property naming a conditioned-out Resource outright,
+    // rather than inside the branch of an Fn::If.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed as dev.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "resource-condition-stack",
+        template: {
+          Parameters: { EnvName: { Type: "String" } },
+          Conditions: {
+            IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+          },
+          Resources: {
+            Backups: { Type: "AWS::S3::Bucket", Condition: "IsProd" },
+            Site: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: { Ref: "Backups" } },
+            },
+          },
+        },
+        parameters: { EnvName: "dev" },
+      });
+    });
+
+    // Then it is refused, rather than deploying a Bucket named after an
+    // expression that will never resolve.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack resource-condition-stack Resource Site names " +
+        "Resource Backups, which the Stack does not create because its " +
+        "Condition IsProd is false",
+    );
+  });
+});
+
+/**
+ * A Stack whose Backups Bucket and Site Bucket name both follow EnvName.
+ */
+function conditionedTemplate(): CfnTemplateBodyRecord {
+  return {
+    Parameters: { EnvName: { Type: "String" } },
+    Conditions: { IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] } },
+    Resources: {
+      Backups: {
+        Type: "AWS::S3::Bucket",
+        Condition: "IsProd",
+        Properties: { BucketName: "site-backups" },
+      },
+      Site: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            "Fn::If": [
+              "IsProd",
+              "site",
+              // eslint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+              { "Fn::Sub": ["site-${Env}", { Env: { Ref: "EnvName" } }] },
+            ],
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
@@ -140,6 +140,42 @@ describe("SimCfnStack Resource Condition", () => {
     );
   });
 
+  it("refuses a DependsOn to a Resource the Stack does not create", async () => {
+    // Given a Resource that waits on a conditioned-out Resource.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed as dev.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "resource-condition-stack",
+        template: {
+          Parameters: { EnvName: { Type: "String" } },
+          Conditions: {
+            IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+          },
+          Resources: {
+            Backups: { Type: "AWS::S3::Bucket", Condition: "IsProd" },
+            Site: {
+              Type: "AWS::S3::Bucket",
+              DependsOn: ["Backups"],
+              Properties: { BucketName: "site-dev" },
+            },
+          },
+        },
+        parameters: { EnvName: "dev" },
+      });
+    });
+
+    // Then the Condition is named, rather than the deployment waiting on a
+    // Resource that is never coming and failing as an unresolvable dependency.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack resource-condition-stack Resource Site names " +
+        "Resource Backups, which the Stack does not create because its " +
+        "Condition IsProd is false",
+    );
+  });
+
   it("refuses a Ref to a Resource the Stack does not create", async () => {
     // Given a Resource property naming a conditioned-out Resource outright,
     // rather than inside the branch of an Fn::If.

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.ts
@@ -1,0 +1,135 @@
+import { isCfnTemplateValueRecord } from "../../resource/template/sim-cfn-templ-value-record.js";
+import { parseSimCfnNode } from "../parse/node/sim-cfn-node-parser.js";
+import type { SimCfnResourceTemplateRecord } from "../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+import type { SimCfnConditions } from "./sim-cfn-conditions.js";
+
+interface SimCfnResourceConditionsProperties {
+  readonly resources: Record<string, SimCfnTemplateValue>;
+  readonly conditions: SimCfnConditions;
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * Applies the Resource-level `Condition` attribute to a template's Resources.
+ *
+ * A Resource whose Condition is false is not created at all, so it never
+ * reaches the Stack Resource map. That is deliberately not the skipped-Resource
+ * path used for a Resource type this simulation cannot create: a skipped
+ * Resource is still in the Stack and still answers `Ref` and `Fn::GetAtt` with
+ * stand-in values, where a Resource the template conditioned out does not
+ * exist, and naming it is a template mistake CloudFormation refuses.
+ */
+export class SimCfnResourceConditions {
+  private readonly stackName: string | undefined;
+  private readonly conditionedOut: ReadonlyMap<string, string>;
+
+  constructor(properties: SimCfnResourceConditionsProperties) {
+    this.stackName = properties.stackName;
+    this.conditionedOut = this.readConditionedOut(
+      properties.resources,
+      properties.conditions,
+    );
+  }
+
+  /**
+   * Whether the template asked for this Resource but its Condition is false.
+   */
+  excludes(logicalId: string): boolean {
+    return this.conditionedOut.has(logicalId);
+  }
+
+  /**
+   * Refuse a template where a Resource that is created names one that is not.
+   *
+   * The templates given here are already resolved, so an `Fn::If` has picked
+   * its branch: a name only the branch that was not taken carries never gets
+   * this far.
+   */
+  assertNotReferenced(
+    resourceTemplates: readonly SimCfnResourceTemplateRecord[],
+  ): void {
+    if (this.conditionedOut.size === 0) {
+      return;
+    }
+
+    for (const { logicalId, template } of resourceTemplates) {
+      this.assertNamesOnlyCreated(
+        logicalId,
+        new Set(parseSimCfnNode(template).referencedNames()),
+      );
+    }
+  }
+
+  private assertNamesOnlyCreated(
+    logicalId: string,
+    referenced: ReadonlySet<string>,
+  ): void {
+    for (const [excludedId, conditionName] of this.conditionedOut) {
+      if (!referenced.has(excludedId)) {
+        continue;
+      }
+
+      throw this.error(
+        `Resource ${logicalId} names Resource ${excludedId}, which the ` +
+          `Stack does not create because its Condition ${conditionName} ` +
+          "is false",
+      );
+    }
+  }
+
+  private readConditionedOut(
+    resources: Record<string, SimCfnTemplateValue>,
+    conditions: SimCfnConditions,
+  ): ReadonlyMap<string, string> {
+    const conditionedOut = new Map<string, string>();
+
+    for (const [logicalId, resourceTemplate] of Object.entries(resources)) {
+      const conditionName = this.conditionName(logicalId, resourceTemplate);
+
+      if (conditionName === undefined) {
+        continue;
+      }
+
+      if (!conditions.has(conditionName)) {
+        throw this.error(
+          `Resource ${logicalId} names Condition ${conditionName}, which the ` +
+            "template does not define",
+        );
+      }
+
+      if (!conditions.value(conditionName)) {
+        conditionedOut.set(logicalId, conditionName);
+      }
+    }
+
+    return conditionedOut;
+  }
+
+  private conditionName(
+    logicalId: string,
+    resourceTemplate: SimCfnTemplateValue,
+  ): string | undefined {
+    if (!isCfnTemplateValueRecord(resourceTemplate)) {
+      return undefined;
+    }
+
+    const conditionName = resourceTemplate["Condition"];
+
+    if (conditionName === undefined) {
+      return undefined;
+    }
+
+    if (typeof conditionName !== "string") {
+      throw this.error(`Resource ${logicalId} Condition must be a string`);
+    }
+
+    return conditionName;
+  }
+
+  private error(detail: string): Error {
+    return new Error(
+      `Sim CloudFormation Stack ${this.stackName ?? "unknown"} ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.ts
@@ -1,3 +1,4 @@
+import { parseSimCfnResourceDependencies } from "../../resource/dependency/sim-cfn-resource-dependencies.js";
 import { isCfnTemplateValueRecord } from "../../resource/template/sim-cfn-templ-value-record.js";
 import { parseSimCfnNode } from "../parse/node/sim-cfn-node-parser.js";
 import type { SimCfnResourceTemplateRecord } from "../sim-cfn-template.js";
@@ -42,6 +43,11 @@ export class SimCfnResourceConditions {
   /**
    * Refuse a template where a Resource that is created names one that is not.
    *
+   * Both the intrinsic expressions and `DependsOn` count. A `DependsOn` on a
+   * Resource the Stack never creates would otherwise leave the deployment
+   * waiting on it and fail as an unresolvable dependency, which says nothing
+   * about the Condition that caused it.
+   *
    * The templates given here are already resolved, so an `Fn::If` has picked
    * its branch: a name only the branch that was not taken carries never gets
    * this far.
@@ -56,7 +62,10 @@ export class SimCfnResourceConditions {
     for (const { logicalId, template } of resourceTemplates) {
       this.assertNamesOnlyCreated(
         logicalId,
-        new Set(parseSimCfnNode(template).referencedNames()),
+        new Set([
+          ...parseSimCfnNode(template).referencedNames(),
+          ...parseSimCfnResourceDependencies(template["DependsOn"]),
+        ]),
       );
     }
   }

--- a/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import { SimCfnTemplate } from "../../../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Fn::If", () => {
+  it("resolves the branch the Condition selects in a Resource property", () => {
+    // Given a Resource property choosing a Bucket name by Condition.
+    const template = templateWithBucketName({
+      // eslint-disable-next-line no-template-curly-in-string -- Fn::Sub syntax, not a JavaScript template.
+      "Fn::If": ["IsProd", "site", { "Fn::Sub": "site-${EnvName}" }],
+    });
+
+    // When the Resource templates are read with EnvName left at dev.
+    const resourceTemplate = template.resourceTemplates()[0];
+    assertNonNullable(resourceTemplate, "Site Resource template");
+
+    // Then the false branch is the one that resolved.
+    assertObjectMatches(resourceTemplate.template, {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "site-dev" },
+    });
+  });
+
+  it("leaves the branch the Condition does not select unresolved", () => {
+    // Given a true branch that would fail if it were resolved.
+    const template = templateWithBucketName({
+      "Fn::If": [
+        "IsProd",
+        { "Fn::FindInMap": ["RegionMap", "us-east-1", "MissingAMI"] },
+        "site-dev",
+      ],
+    });
+
+    // When the Resource templates are read with the Condition false.
+    const resourceTemplate = template.resourceTemplates()[0];
+    assertNonNullable(resourceTemplate, "Site Resource template");
+
+    // Then the deployment is unaffected by what the unused branch names.
+    assertObjectMatches(resourceTemplate.template, {
+      Properties: { BucketName: "site-dev" },
+    });
+  });
+
+  it("resolves a nested Fn::If", () => {
+    // Given a branch that is itself an Fn::If.
+    const template = templateWithBucketName({
+      "Fn::If": [
+        "IsProd",
+        "site",
+        { "Fn::If": ["IsProd", "unreachable", { Ref: "EnvName" }] },
+      ],
+    });
+
+    // When the Resource templates are read.
+    const resourceTemplate = template.resourceTemplates()[0];
+    assertNonNullable(resourceTemplate, "Site Resource template");
+
+    // Then the inner Fn::If resolved too.
+    assertObjectMatches(resourceTemplate.template, {
+      Properties: { BucketName: "dev" },
+    });
+  });
+
+  it("resolves Fn::If in an Output", async () => {
+    // Given a Stack whose Output picks between a literal and a Resource Ref.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed with the Condition false.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "fn-if-stack",
+      template: {
+        Parameters: { EnvName: { Type: "String", Default: "dev" } },
+        Conditions: {
+          IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+        },
+        Resources: {
+          Site: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "fn-if-site-dev" },
+          },
+        },
+        Outputs: {
+          SiteName: {
+            Value: { "Fn::If": ["IsProd", "production-site", { Ref: "Site" }] },
+          },
+        },
+      },
+    });
+
+    // Then the false branch resolved against the created Resource.
+    assertIdentical(stack.outputs.get("SiteName")?.value, "fn-if-site-dev");
+  });
+
+  it("refuses an Fn::If naming a Condition the template does not define", () => {
+    // Given an Fn::If naming an unknown Condition.
+    const template = templateWithBucketName({
+      "Fn::If": ["IsStaging", "site", "site-dev"],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the Condition is named rather than read as false.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::If names Condition IsStaging, which the " +
+        "template does not define",
+    );
+  });
+
+  it("refuses an Fn::If that is not a three-item list", () => {
+    // Given an Fn::If with no false branch.
+    const template = templateWithBucketName({
+      "Fn::If": ["IsProd", "site"],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then a clear validation error is thrown.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::If value must be [conditionName, valueIfTrue, valueIfFalse]",
+    );
+  });
+
+  it("refuses an Fn::If whose Condition name is not a string", () => {
+    // Given an Fn::If naming its Condition with an expression.
+    const template = templateWithBucketName({
+      "Fn::If": [{ Ref: "EnvName" }, "site", "site-dev"],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then a clear validation error is thrown.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::If condition name must be a string",
+    );
+  });
+});
+
+/**
+ * A one-Bucket template whose name is the given expression, with an IsProd
+ * Condition that is false for the default EnvName.
+ */
+function templateWithBucketName(
+  bucketName: SimCfnTemplateValue,
+): SimCfnTemplate {
+  return new SimCfnTemplate({
+    stackName: "fn-if-stack",
+    template: {
+      Parameters: { EnvName: { Type: "String", Default: "dev" } },
+      Conditions: { IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] } },
+      Mappings: { RegionMap: { "us-east-1": { AMI: "ami-00000000" } } },
+      Resources: {
+        Site: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: bucketName },
+        },
+      },
+    },
+  });
+}

--- a/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.ts
+++ b/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.ts
@@ -1,0 +1,61 @@
+import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { SimCfnNode } from "../../sim-cfn-node.js";
+
+/**
+ * Simulated CloudFormation `Fn::If` intrinsic function.
+ *
+ * The Condition it names is already evaluated by the time a template value is
+ * resolved, so this only picks a branch. Only the branch it picks is resolved:
+ * the other one is left alone, as CloudFormation leaves it alone, so it can
+ * name something that the Stack being deployed does not have.
+ */
+export class SimCfnFnIf extends SimCfnNode {
+  constructor(
+    private readonly conditionName: string,
+    private readonly whenTrue: SimCfnNode,
+    private readonly whenFalse: SimCfnNode,
+  ) {
+    super();
+  }
+
+  /**
+   * Resolve only the branch the named Condition selects.
+   */
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const conditions = context.conditions;
+
+    if (conditions === undefined) {
+      throw new Error(
+        `Sim CloudFormation Fn::If ${this.conditionName} cannot be resolved ` +
+          "where the template Conditions are not available",
+      );
+    }
+
+    if (!conditions.has(this.conditionName)) {
+      throw new Error(
+        `Sim CloudFormation Fn::If names Condition ${this.conditionName}, ` +
+          "which the template does not define",
+      );
+    }
+
+    return conditions.value(this.conditionName)
+      ? this.whenTrue.resolve(context)
+      : this.whenFalse.resolve(context);
+  }
+
+  /**
+   * Collect referenced names from both branches.
+   *
+   * Which branch is taken is not known while the dependency graph is being
+   * built, so both contribute. Ordering against a Resource that is never
+   * created costs nothing, where a missed dependency would create a Resource
+   * before the one it reads.
+   */
+  override referencedNames(): string[] {
+    return [
+      ...this.whenTrue.referencedNames(),
+      ...this.whenFalse.referencedNames(),
+    ];
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/if/sim-cfn-fn-if-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/if/sim-cfn-fn-if-parser.ts
@@ -1,0 +1,45 @@
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+import { SimCfnFnIf as SimCfnFunctionIf } from "../../../node/fn/if/sim-cfn-fn-if.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
+
+/**
+ * Parses CloudFormation Fn::If values.
+ */
+export class SimCfnFnIfParser {
+  constructor(private readonly valueParser: SimCfnValueParser) {}
+
+  /**
+   * Parse and validate the value inside a Fn::If expression.
+   *
+   * Both branches are parsed, because a branch that is not valid template
+   * syntax is a template mistake whichever way the Condition falls. Only
+   * resolving is deferred to the branch the Condition selects.
+   */
+  parse(value: SimCfnTemplateValue): SimCfnFunctionIf {
+    if (!Array.isArray(value) || value.length !== 3) {
+      throw new Error(
+        "Sim CloudFormation Fn::If value must be [conditionName, valueIfTrue, valueIfFalse]",
+      );
+    }
+
+    const conditionName = value[0];
+    const whenTrue = value[1];
+    const whenFalse = value[2];
+
+    assertDefined(whenTrue, "Fn::If value if true");
+    assertDefined(whenFalse, "Fn::If value if false");
+
+    if (typeof conditionName !== "string") {
+      throw new TypeError(
+        "Sim CloudFormation Fn::If condition name must be a string",
+      );
+    }
+
+    return new SimCfnFunctionIf(
+      conditionName,
+      this.valueParser.parse(whenTrue),
+      this.valueParser.parse(whenFalse),
+    );
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
@@ -5,6 +5,7 @@ import { SimCfnFnJoinParser as SimCfnFunctionJoinParser } from "./join/sim-cfn-f
 import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
 import { SimCfnFnSubParser as SimCfnFunctionSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
 import { SimCfnFnFindInMapParser as SimCfnFunctionFindInMapParser } from "./find-in-map/sim-cfn-fn-find-in-map-parser.js";
+import { SimCfnFnIfParser as SimCfnFunctionIfParser } from "./if/sim-cfn-fn-if-parser.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
@@ -26,12 +27,14 @@ export class SimCfnFunctionParser {
   private readonly fnFindInMapParser: SimCfnFunctionFindInMapParser;
   private readonly fnJoinParser: SimCfnFunctionJoinParser;
   private readonly fnSubParser: SimCfnFunctionSubParser;
+  private readonly fnIfParser: SimCfnFunctionIfParser;
 
   constructor(valueParser: SimCfnValueParser) {
     this.fnGetAttParser = new SimCfnFunctionGetAttParser();
     this.fnFindInMapParser = new SimCfnFunctionFindInMapParser(valueParser);
     this.fnJoinParser = new SimCfnFunctionJoinParser(valueParser);
     this.fnSubParser = new SimCfnFunctionSubParser(valueParser);
+    this.fnIfParser = new SimCfnFunctionIfParser(valueParser);
   }
 
   /**
@@ -79,6 +82,10 @@ export class SimCfnFunctionParser {
 
     if (functionName === "Fn::FindInMap") {
       return this.fnFindInMapParser.parse(value);
+    }
+
+    if (functionName === "Fn::If") {
+      return this.fnIfParser.parse(value);
     }
 
     throw new Error(

--- a/src/service/cloudformation/template/parse/node/sim-cfn-node-parser.iso.test.ts
+++ b/src/service/cloudformation/template/parse/node/sim-cfn-node-parser.iso.test.ts
@@ -92,10 +92,13 @@ describe("SimCfnNodeParser", () => {
     const parameters = SimCfnParameters.fromValues({});
     assertIdentical(
       node.resolve(
-        new SimCfnResolveContext(parameters, undefined, undefined, {
-          RegionMap: {
-            "us-east-1": {
-              AMI: "ami-1234567890abcdef0",
+        new SimCfnResolveContext({
+          parameters,
+          mappings: {
+            RegionMap: {
+              "us-east-1": {
+                AMI: "ami-1234567890abcdef0",
+              },
             },
           },
         }),
@@ -280,5 +283,5 @@ describe("SimCfnNodeParser", () => {
 });
 
 function emptyContext(): SimCfnResolveContext {
-  return new SimCfnResolveContext(new SimCfnParameters());
+  return new SimCfnResolveContext({ parameters: new SimCfnParameters() });
 }

--- a/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
+++ b/src/service/cloudformation/template/resolve/sim-cfn-resolve-context.ts
@@ -2,15 +2,31 @@ import type { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
 import type { SimCfnResourceRefResolver as SimCfnResourceReferenceResolver } from "./sim-cfn-resource-ref-resolver.js";
 import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
+import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
+
+interface SimCfnResolveContextProperties {
+  readonly parameters: SimCfnParameters;
+  readonly resources?: SimCfnResourceReferenceResolver | undefined;
+  readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
+  readonly mappings?: SimCfnMappings | undefined;
+  readonly conditions?: SimCfnConditions | undefined;
+}
 
 /**
  * Context available while resolving a parsed CloudFormation node tree.
  */
 export class SimCfnResolveContext {
-  constructor(
-    readonly parameters: SimCfnParameters,
-    readonly resources?: SimCfnResourceReferenceResolver | undefined,
-    readonly pseudoParameters?: SimCfnPseudoParameters | undefined,
-    readonly mappings?: SimCfnMappings | undefined,
-  ) {}
+  public readonly parameters: SimCfnParameters;
+  public readonly resources: SimCfnResourceReferenceResolver | undefined;
+  public readonly pseudoParameters: SimCfnPseudoParameters | undefined;
+  public readonly mappings: SimCfnMappings | undefined;
+  public readonly conditions: SimCfnConditions | undefined;
+
+  constructor(properties: SimCfnResolveContextProperties) {
+    this.parameters = properties.parameters;
+    this.resources = properties.resources;
+    this.pseudoParameters = properties.pseudoParameters;
+    this.mappings = properties.mappings;
+    this.conditions = properties.conditions;
+  }
 }

--- a/src/service/cloudformation/template/sim-cfn-template-body-validator.ts
+++ b/src/service/cloudformation/template/sim-cfn-template-body-validator.ts
@@ -43,6 +43,13 @@ export class SimCfnTemplateBodyValidator {
     ) {
       throw this.error("Parameters must be an object");
     }
+
+    if (
+      this.template.Conditions !== undefined &&
+      !isRecord(this.template.Conditions)
+    ) {
+      throw this.error("Conditions must be an object");
+    }
   }
 
   private error(detail: string): Error {

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -11,6 +11,12 @@ import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import { SimCfnPseudoParameters } from "../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import type { SimCfnMappings } from "./mapping/sim-cfn-mappings.js";
+import { SimCfnConditionEvaluator } from "./condition/sim-cfn-condition-evaluator.js";
+import type {
+  SimCfnConditions,
+  SimCfnConditionsSection,
+} from "./condition/sim-cfn-conditions.js";
+import { SimCfnResourceConditions } from "./condition/sim-cfn-resource-conditions.js";
 
 /**
  * Parsed CloudFormation template body accepted by the simulator.
@@ -20,6 +26,7 @@ import type { SimCfnMappings } from "./mapping/sim-cfn-mappings.js";
 export interface CfnTemplateBodyRecord {
   readonly Parameters?: Record<string, SimCfnParameterDefinition> | undefined;
   readonly Mappings?: SimCfnMappings | undefined;
+  readonly Conditions?: SimCfnConditionsSection | undefined;
   readonly Resources: Record<string, SimCfnTemplateValue>;
   readonly Outputs?: Record<string, SimCfnTemplateValue> | undefined;
   readonly [sectionName: string]:
@@ -62,6 +69,7 @@ export class SimCfnTemplate {
   public readonly stackName: string | undefined;
   public readonly parameters: SimCfnParameters;
   private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
+  private evaluatedConditions: SimCfnConditions | undefined;
 
   constructor(properties: SimCfnTemplateProperties) {
     const { template, parameters, stackName, accountRegionScope } = properties;
@@ -111,22 +119,31 @@ export class SimCfnTemplate {
    *
    * Parameters and parameter-only intrinsic functions are resolved here.
    * Refs to other Resources are left unresolved because the referenced Resources do not exist yet; they are resolved at Resource creation time.
+   *
+   * A Resource whose `Condition` attribute is false is left out entirely, so
+   * the Stack never has a Resource the template conditioned out.
    */
   resourceTemplates(): SimCfnResourceTemplateRecord[] {
-    const valueResolver = new SimCfnTemplateValueResolver({
-      parameters: this.parameters,
-      pseudoParameters: this.pseudoParameters(),
-      mappings: this.template.Mappings,
+    const valueResolver = this.valueResolver();
+    const resourceConditions = new SimCfnResourceConditions({
+      resources: this.template.Resources,
+      conditions: this.conditions(),
+      stackName: this.stackName,
     });
 
-    return Object.entries(this.template.Resources)
+    const resourceTemplates = Object.entries(this.template.Resources)
       .filter((entry): entry is [string, SimCfnTemplateValueRecord] => {
         return isRecord(entry[1]);
       })
+      .filter(([logicalId]) => !resourceConditions.excludes(logicalId))
       .map(([logicalId, resourceTemplate]) => ({
         logicalId,
         template: valueResolver.resolveRecord(resourceTemplate),
       }));
+
+    resourceConditions.assertNotReferenced(resourceTemplates);
+
+    return resourceTemplates;
   }
 
   /**
@@ -136,11 +153,7 @@ export class SimCfnTemplate {
    * Outputs are resolved after Resource creation.
    */
   outputTemplates(): SimCfnOutputTemplateRecord[] {
-    const valueResolver = new SimCfnTemplateValueResolver({
-      parameters: this.parameters,
-      pseudoParameters: this.pseudoParameters(),
-      mappings: this.template.Mappings,
-    });
+    const valueResolver = this.valueResolver();
 
     return Object.entries(this.template.Outputs ?? {})
       .filter((entry): entry is [string, SimCfnTemplateValueRecord] => {
@@ -161,6 +174,35 @@ export class SimCfnTemplate {
     return new SimCfnPseudoParameters({
       accountRegionScope: this.accountRegionScope,
       stackName: this.stackName,
+    });
+  }
+
+  /**
+   * Get the template Conditions, evaluated against this Stack's Parameters.
+   *
+   * A Condition reads only Parameters and pseudo parameters, so the section is
+   * evaluated once and the answers reused by every Resource and Output.
+   */
+  conditions(): SimCfnConditions {
+    this.evaluatedConditions ??= new SimCfnConditionEvaluator({
+      conditions: this.template.Conditions,
+      stackName: this.stackName,
+      valueResolver: new SimCfnTemplateValueResolver({
+        parameters: this.parameters,
+        pseudoParameters: this.pseudoParameters(),
+        mappings: this.template.Mappings,
+      }),
+    }).evaluate();
+
+    return this.evaluatedConditions;
+  }
+
+  private valueResolver(): SimCfnTemplateValueResolver {
+    return new SimCfnTemplateValueResolver({
+      parameters: this.parameters,
+      pseudoParameters: this.pseudoParameters(),
+      mappings: this.template.Mappings,
+      conditions: this.conditions(),
     });
   }
 }

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -8,12 +8,14 @@ import type { SimCfnResourceRefResolver as SimCfnResourceReferenceResolver } fro
 import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
+import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
 
 interface SimCfnTemplateValueResolverProperties {
   readonly parameters: SimCfnParameters;
   readonly resources?: SimCfnResourceReferenceResolver | undefined;
   readonly pseudoParameters?: SimCfnPseudoParameters | undefined;
   readonly mappings?: SimCfnMappings | undefined;
+  readonly conditions?: SimCfnConditions | undefined;
 }
 
 /**
@@ -23,12 +25,13 @@ export class SimCfnTemplateValueResolver {
   private readonly context: SimCfnResolveContext;
 
   constructor(properties: SimCfnTemplateValueResolverProperties) {
-    this.context = new SimCfnResolveContext(
-      properties.parameters,
-      properties.resources,
-      properties.pseudoParameters,
-      properties.mappings,
-    );
+    this.context = new SimCfnResolveContext({
+      parameters: properties.parameters,
+      resources: properties.resources,
+      pseudoParameters: properties.pseudoParameters,
+      mappings: properties.mappings,
+      conditions: properties.conditions,
+    });
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-storage.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-storage.ts
@@ -1,0 +1,138 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
+import { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
+import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
+import type { SimDynamoDbTableDefinition } from "./sim-dynamodb-table-definition.js";
+import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
+import { simDynamoDbTableReadView } from "./sim-dynamodb-table-read-view.js";
+import { SimDynamoDbTableWrites } from "./sim-dynamodb-table-writes.js";
+import type { DynamoDbTableName } from "./sim-dynamodb-table-name.js";
+
+interface SimDynamoDbTableStorageProperties {
+  readonly tableName: DynamoDbTableName;
+  readonly definition: SimDynamoDbTableDefinition;
+  readonly indexes: SimDynamoDbSecondaryIndexes;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What one simulated table holds, and everything that reaches its items.
+ *
+ * The items, the key they are held under, the writes that put them there and
+ * the time to live that takes them away are all one thing, because none of them
+ * is any use without the others: a key is read to write an item, and a write is
+ * what gives an item its deletion window. Holding them together is what leaves
+ * the table itself as what a request asks about rather than where its items
+ * live.
+ *
+ * This is built from a definition rather than from a key schema, so the key an
+ * item is stored under follows an UpdateTable that changed which attributes the
+ * table declares, without the storage having to be told about the update.
+ */
+export class SimDynamoDbTableStorage {
+  /**
+   * The table's time to live, and the item removals it drives.
+   */
+  public readonly timeToLive: SimDynamoDbTableTimeToLive;
+
+  /**
+   * How the table takes a write, as a check and then a commit, which is what
+   * lets a transaction prepare all of its writes before committing any.
+   */
+  public readonly writes: SimDynamoDbTableWrites;
+
+  private readonly tableName: DynamoDbTableName;
+  private readonly definition: SimDynamoDbTableDefinition;
+  private readonly indexes: SimDynamoDbSecondaryIndexes;
+  private readonly items = new SimDynamoDbTableItems();
+
+  constructor(properties: SimDynamoDbTableStorageProperties) {
+    this.tableName = properties.tableName;
+    this.definition = properties.definition;
+    this.indexes = properties.indexes;
+    this.timeToLive = new SimDynamoDbTableTimeToLive({
+      tableName: properties.tableName,
+      items: this.items,
+      background: properties.background,
+    });
+    this.writes = new SimDynamoDbTableWrites({
+      items: this.items,
+      timeToLive: this.timeToLive,
+      definition: properties.definition,
+      indexes: properties.indexes,
+    });
+  }
+
+  /**
+   * Put an item into the table, and answer with whatever it replaced. The item
+   * is there by the time this returns, since real DynamoDB acknowledges a write
+   * once it is durable.
+   */
+  putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
+    return this.writes.prepareItem(item).commit();
+  }
+
+  /**
+   * The item already stored under the same primary key as this one.
+   *
+   * A conditional write is checked against what is there before it, and what is
+   * there is found by the key inside the item rather than by a Key of its own.
+   * The key is read the same way a write reads it, so an item that could not be
+   * written does not quietly find nothing here either.
+   */
+  itemUnder(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
+    return this.items.get(this.definition.itemKey.of(item));
+  }
+
+  /**
+   * The primary key an item is stored under, as the table marshals it.
+   *
+   * A batch write tells two operations on the same item apart by comparing
+   * these, which is why the key is readable rather than only usable. Reading it
+   * checks the item against the key schema, so a key a write would refuse is
+   * refused here too.
+   */
+  keyOfItem(item: SimDynamoDbItem): string {
+    return this.definition.itemKey.of(item);
+  }
+
+  /**
+   * The primary key a request's Key names, as the table marshals it.
+   */
+  keyOfKey(key: SimDynamoDbItem): string {
+    return this.definition.itemKey.ofKey(key);
+  }
+
+  /**
+   * Read the item a primary key names, if the table holds one.
+   *
+   * Every write has landed by the time it returns, so this reads the latest
+   * one. That is what real DynamoDB gives a strongly consistent read.
+   */
+  getItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
+    return this.items.get(this.definition.itemKey.ofKey(key));
+  }
+
+  /**
+   * Remove the item a primary key names, and answer with whatever was removed.
+   */
+  deleteItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
+    return this.writes.prepareRemoval(key).commit();
+  }
+
+  /**
+   * What a Query or a Scan reads: the table, or one of its indexes.
+   */
+  view(indexName: string | undefined): SimDynamoDbReadView {
+    return simDynamoDbTableReadView({
+      tableName: this.tableName,
+      indexName,
+      items: this.items.entries().values().toArray(),
+      keySchema: this.definition.keySchema,
+      attributeDefinitions: this.definition.attributeDefinitions,
+      indexes: this.indexes,
+      itemKey: this.definition.itemKey,
+    });
+  }
+}

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -10,16 +10,15 @@ import type {
   SimDynamoDbTableStatus,
 } from "../command/table/table.types.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
-import { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
+import type { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
 import { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
 import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
 import { describeSimDynamoDbTable } from "./sim-dynamodb-table-description.js";
 import { SimDynamoDbTableDefinition } from "./sim-dynamodb-table-definition.js";
-import { SimDynamoDbTableItems } from "./sim-dynamodb-table-items.js";
 import { SimDynamoDbTableLifecycle } from "./sim-dynamodb-table-lifecycle.js";
-import { simDynamoDbTableReadView } from "./sim-dynamodb-table-read-view.js";
+import { SimDynamoDbTableStorage } from "./sim-dynamodb-table-storage.js";
 import { SimDynamoDbTableTags } from "./sim-dynamodb-table-tags.js";
-import { SimDynamoDbTableWrites } from "./sim-dynamodb-table-writes.js";
+import type { SimDynamoDbTableWrites } from "./sim-dynamodb-table-writes.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -74,20 +73,9 @@ export class SimDynamoDbTable {
    */
   public readonly tags: SimDynamoDbTableTags;
 
-  /**
-   * This table's time to live, and the item removals it drives.
-   */
-  public readonly timeToLive: SimDynamoDbTableTimeToLive;
-
-  /**
-   * How this table takes a write, as a check and then a commit, which is what
-   * lets a transaction prepare all of its writes before committing any.
-   */
-  public readonly writes: SimDynamoDbTableWrites;
-
-  private readonly items = new SimDynamoDbTableItems();
   private readonly definition: SimDynamoDbTableDefinition;
   private readonly lifecycle: SimDynamoDbTableLifecycle;
+  private readonly storage: SimDynamoDbTableStorage;
 
   constructor(properties: SimDynamoDbTableProperties) {
     const {
@@ -117,53 +105,48 @@ export class SimDynamoDbTable {
       tableName: name.value,
       deletionProtectionEnabled,
     });
-    this.timeToLive = new SimDynamoDbTableTimeToLive({
+    this.storage = new SimDynamoDbTableStorage({
       tableName: name.value,
-      items: this.items,
-      background,
-    });
-    this.writes = new SimDynamoDbTableWrites({
-      items: this.items,
-      timeToLive: this.timeToLive,
       definition: this.definition,
       indexes: this.indexes,
+      background,
     });
     this.creationDateTime = background.now();
   }
 
-  /**
-   * Get the current table status.
-   */
+  /** Get the current table status. */
   public get status(): SimDynamoDbTableStatus {
     return this.lifecycle.status;
   }
 
-  /**
-   * The attributes this table's keys are made of.
-   */
+  /** The attributes this table's keys are made of. */
   public get attributeDefinitions(): SimDynamoDbAttributeDefinitions {
     return this.definition.attributeDefinitions;
   }
 
-  /**
-   * How this table is billed, and what it is provisioned for.
-   */
+  /** How this table is billed, and what it is provisioned for. */
   public get billing(): SimDynamoDbTableBilling {
     return this.definition.billing;
   }
 
-  /**
-   * The class this table is stored under, when it was given one.
-   */
+  /** The class this table is stored under, when it was given one. */
   public get tableClass(): SimDynamoDbTableClass | undefined {
     return this.definition.tableClass;
   }
 
-  /**
-   * Whether this table is protected from deletion.
-   */
+  /** Whether this table is protected from deletion. */
   public get deletionProtectionEnabled(): boolean {
     return this.lifecycle.deletionProtectionEnabled;
+  }
+
+  /** This table's time to live, and the item removals it drives. */
+  public get timeToLive(): SimDynamoDbTableTimeToLive {
+    return this.storage.timeToLive;
+  }
+
+  /** How this table takes a write, as a check and then a commit. */
+  public get writes(): SimDynamoDbTableWrites {
+    return this.storage.writes;
   }
 
   /**
@@ -182,9 +165,7 @@ export class SimDynamoDbTable {
     return Promise.resolve();
   }
 
-  /**
-   * Refuse an update this table is not in a state to take.
-   */
+  /** Refuse an update this table is not in a state to take. */
   assertUpdatable(): void {
     this.lifecycle.assertUpdatable();
   }
@@ -202,9 +183,7 @@ export class SimDynamoDbTable {
     this.lifecycle.applyUpdate(update);
   }
 
-  /**
-   * Refuse a delete this table is not in a state to take.
-   */
+  /** Refuse a delete this table is not in a state to take. */
   assertDeletable(): void {
     this.lifecycle.assertDeletable();
   }
@@ -219,82 +198,43 @@ export class SimDynamoDbTable {
     this.lifecycle.beginDeletion();
   }
 
-  /**
-   * Describe this table the way DynamoDB reports it.
-   */
+  /** Describe this table the way DynamoDB reports it. */
   toDescription(): SimDynamoDbTableDescription {
     return describeSimDynamoDbTable(this);
   }
 
-  /**
-   * Put an item into the table, and answer with whatever it replaced. The item
-   * is there by the time this returns, since real DynamoDB acknowledges a write
-   * once it is durable.
-   */
+  /** Put an item into the table, and answer with whatever it replaced. */
   public putItem(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.writes.prepareItem(item).commit();
+    return this.storage.putItem(item);
   }
 
-  /**
-   * The item already stored under the same primary key as this one.
-   *
-   * A conditional write is checked against what is there before it, and what is
-   * there is found by the key inside the item rather than by a Key of its own.
-   * The key is read the same way a write reads it, so an item that could not be
-   * written does not quietly find nothing here either.
-   */
+  /** The item already stored under the same primary key as this one. */
   public itemUnder(item: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.items.get(this.definition.itemKey.of(item));
+    return this.storage.itemUnder(item);
   }
 
-  /**
-   * The primary key an item is stored under, as this table marshals it.
-   *
-   * A batch write tells two operations on the same item apart by comparing
-   * these, which is why the key is readable rather than only usable. Reading it
-   * checks the item against the key schema, so a key a write would refuse is
-   * refused here too.
-   */
+  /** The primary key an item is stored under, as this table marshals it. */
   public keyOfItem(item: SimDynamoDbItem): string {
-    return this.definition.itemKey.of(item);
+    return this.storage.keyOfItem(item);
   }
 
-  /**
-   * The primary key a request's Key names, as this table marshals it.
-   */
+  /** The primary key a request's Key names, as this table marshals it. */
   public keyOfKey(key: SimDynamoDbItem): string {
-    return this.definition.itemKey.ofKey(key);
+    return this.storage.keyOfKey(key);
   }
 
-  /**
-   * Read the item a primary key names, if the table holds one.
-   *
-   * Every write has landed by the time it returns, so this reads the latest
-   * one. That is what real DynamoDB gives a strongly consistent read.
-   */
+  /** Read the item a primary key names, if the table holds one. */
   public getItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.items.get(this.definition.itemKey.ofKey(key));
+    return this.storage.getItem(key);
   }
 
-  /**
-   * Remove the item a primary key names, and answer with whatever was removed.
-   */
+  /** Remove the item a primary key names, and what was removed with it. */
   public deleteItem(key: SimDynamoDbItem): SimDynamoDbItem | undefined {
-    return this.writes.prepareRemoval(key).commit();
+    return this.storage.deleteItem(key);
   }
 
-  /**
-   * What a Query or a Scan reads: this table, or one of its indexes.
-   */
+  /** What a Query or a Scan reads: this table, or one of its indexes. */
   public view(indexName: string | undefined): SimDynamoDbReadView {
-    return simDynamoDbTableReadView({
-      tableName: this.tableName,
-      indexName,
-      items: this.items.entries().values().toArray(),
-      keySchema: this.keySchema,
-      attributeDefinitions: this.attributeDefinitions,
-      indexes: this.indexes,
-      itemKey: this.definition.itemKey,
-    });
+    return this.storage.view(indexName);
   }
 }

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -255,10 +255,18 @@ owner, keeping its ambient callers isolated.
 
 `event-source/` owns delivery from a simulated SQS queue to a function.
 
+SQS is the only source there is so far, but the machinery around it is split by event source kind
+rather than assuming one. `sim-lambda-event-source-arn.ts` reads the ARN a mapping names into a
+union discriminated by `kind`, and that value carries what the rest of the machinery would otherwise
+have had to assume: the service label a refusal names, the `{action, resource}` permissions the
+execution role is checked for, and the batch size rules the request is measured against
+(`SimLambdaEventSourceBatchRules`). It is also the one place that decides which sources a mapping
+may name, so a refusal anywhere lists the same supported set.
+
 Real Lambda polls a queue continuously, and nothing in this simulation runs continuously, so the
 queue says when there is something to poll for. `SimSqsQueueActivity` (in sim SQS) holds the
 watchers on a queue, `SimSqsQueue.add` tells them a message has arrived, and
-`SimLambdaEventSourcePoller` schedules a poll in response. A message moved to a dead-letter queue
+`SimLambdaSqsEventSourcePoller` schedules a poll in response. A message moved to a dead-letter queue
 arrives the same way, so a mapping on a dead-letter queue is polled too.
 
 `SimLambdaEventSourcePollSchedule` decides when that poll happens. A message that is receivable now
@@ -277,21 +285,30 @@ were all in flight when the mapping was made.
 `SimSqsEventSourceQueues` implements it over the ordinary SQS commands, as the function's execution
 role, so simulated IAM authorizes each poll the way real IAM does. A standalone `SimLambda` has no
 sim SQS, and `SimLambdaNoEventSourceQueues` refuses with guidance rather than silently delivering
-nothing. `SimLambdaSqsEventSourceArn` reads a queue ARN into the URL requests name it by and the
-Region event records report.
+nothing. `SimLambdaSqsEventSourceArn` is the SQS member of the event source ARN union: it reads a
+queue ARN into the URL requests name it by and the Region event records report, and carries the
+queue's own polling permissions and batch size rules.
 
-Creating a mapping checks what real Lambda checks before it will make one: that the queue exists,
-and that the execution role may call `ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes` on
-it (`SimLambdaEventSourceRolePermissions`). Both failures are the mapping's, not the poller's: a
-mapping that cannot poll looks like a working subscription and delivers nothing.
+Creating a mapping checks what real Lambda checks before it will make one: that the event source
+exists, and that the execution role may perform the operations polling it takes
+(`SimLambdaEventSourceRolePermissions`, which reads those operations off the ARN — for a queue,
+`ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes`). Both failures are the mapping's, not
+the poller's: a mapping that cannot poll looks like a working subscription and delivers nothing.
 
-`poll/` holds what one poll does. `SimLambdaEventSourceDelivery` invokes the function directly
-rather than through the Invoke command, because the handler error has to be seen: the asynchronous
-invoke path drops it, and this is what decides whether the batch goes back on the queue.
-`SimLambdaSqsBatchResponse` reads what the function said about the batch, including a
+`poll/` holds what one poll does. `SimLambdaEventSourcePoller` is the three-method interface
+(`watch`, `pollNow`, `stop`) the mapping's pollers are held behind, and
+`makeSimLambdaEventSourcePoller` picks the one for the kind of source the ARN names.
+`SimLambdaEventSourceDelivery` invokes the function directly rather than through the Invoke command,
+because the handler error has to be seen: the asynchronous invoke path drops it, and this is what
+decides whether the batch goes back on the source. It is handed the event builder and the batch
+response rather than building them, since both are the source's own.
+
+`SimLambdaSqsBatchResponse` reads what the function said about a batch of messages, including a
 `batchItemFailures` report when the mapping was told to expect one, and returns the whole batch for
-a report it cannot trust. `SimLambdaSqsEventBuilder` turns a batch into the event's own shape,
-which is the lower-case record naming and the base64 binary attribute values real AWS uses.
+a report it cannot trust. Reading the report itself is shared in `SimLambdaBatchItemFailures`, which
+is also where a malformed entry becomes an id no message has. `SimLambdaSqsEventBuilder` turns a
+batch into the event's own shape, which is the lower-case record naming and the base64 binary
+attribute values real AWS uses.
 
 ## Function URLs
 

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -207,6 +207,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
         functionName: "order-consumer",
         functionArn:
           "arn:aws:lambda:eu-west-2:111111111111:function:order-consumer",
+        batchSize: 10,
         createdAt: new Date(0),
       }),
     });

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -1,18 +1,23 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import {
+  type SimLambdaEventSourceArn,
+  simLambdaEventSourceArnOf,
+} from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
 import {
-  batchSizeIn,
   functionResponseTypesIn,
   requiredString,
 } from "./create-event-source-mapping-values.js";
-import { refuseUnsimulatedInput } from "./create-event-source-mapping-refusals.js";
+import {
+  refuseUnsimulatedInput,
+  refuseUnsupportedEventSourceInput,
+} from "./create-event-source-mapping-refusals.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 interface SimLambdaEventSourceMappingInputProperties {
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly eventSourceArn: SimLambdaEventSourceArn;
   readonly functionName: string;
   readonly batchSize: number;
   readonly enabled: boolean;
@@ -25,9 +30,12 @@ interface SimLambdaEventSourceMappingInputProperties {
  * Everything the request is refused for is decided here, before a mapping
  * exists: a mapping that cannot poll the way it was asked to would look like a
  * working subscription and deliver nothing.
+ *
+ * The event source ARN is read first, because what a mapping may ask for
+ * depends on the kind of source it names.
  */
 export class SimLambdaEventSourceMappingInput {
-  public readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  public readonly eventSourceArn: SimLambdaEventSourceArn;
   public readonly functionName: string;
   public readonly batchSize: number;
   public readonly enabled: boolean;
@@ -49,14 +57,17 @@ export class SimLambdaEventSourceMappingInput {
     input: SimCreateEventSourceMappingCommandInput,
     scope: SimAwsAccountRegionScope,
   ): SimLambdaEventSourceMappingInput {
+    const eventSourceArn = eventSourceArnIn(input, scope);
+
+    refuseUnsupportedEventSourceInput(input);
     refuseUnsimulatedInput(input);
 
     return new this({
-      eventSourceArn: eventSourceArnIn(input, scope),
+      eventSourceArn,
       functionName: simLambdaFunctionNameOf(
         requiredString(input.FunctionName, "functionName"),
       ),
-      batchSize: batchSizeIn(input),
+      batchSize: eventSourceArn.batchRules.sizeIn(input.BatchSize),
       enabled: input.Enabled ?? true,
       functionResponseTypes: functionResponseTypesIn(input),
     });
@@ -64,14 +75,14 @@ export class SimLambdaEventSourceMappingInput {
 }
 
 /**
- * The queue an event source ARN names, refusing one this simulated Lambda
- * cannot poll.
+ * The event source an ARN names, refusing one this simulated Lambda cannot
+ * poll.
  */
 function eventSourceArnIn(
   input: SimCreateEventSourceMappingCommandInput,
   scope: SimAwsAccountRegionScope,
-): SimLambdaSqsEventSourceArn {
-  const eventSourceArn = SimLambdaSqsEventSourceArn.of(
+): SimLambdaEventSourceArn {
+  const eventSourceArn = simLambdaEventSourceArnOf(
     requiredString(input.EventSourceArn, "eventSourceArn"),
   );
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -1,8 +1,10 @@
+import { simulatedEventSourcesDescription } from "../../event-source/sim-lambda-event-source-arn.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 /**
- * The inputs a mapping cannot be created with here, and why each is refused.
+ * The inputs no simulated event source has behaviour for, and why each is
+ * refused.
  *
  * Every one of them changes what a function sees or when it sees it, so
  * accepting and ignoring one would let a test pass on behaviour the deployment
@@ -18,26 +20,6 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["BisectBatchOnFunctionError", "batch bisection is not simulated"],
   ["ParallelizationFactor", "polling concurrency is not simulated"],
   ["TumblingWindowInSeconds", "tumbling windows are not simulated"],
-  ["StartingPosition", "SQS queues are the only simulated event source"],
-  [
-    "StartingPositionTimestamp",
-    "SQS queues are the only simulated event source",
-  ],
-  ["Topics", "SQS queues are the only simulated event source"],
-  ["Queues", "SQS queues are the only simulated event source"],
-  ["SelfManagedEventSource", "SQS queues are the only simulated event source"],
-  [
-    "SelfManagedKafkaEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
-  [
-    "AmazonManagedKafkaEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
-  [
-    "DocumentDBEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
   [
     "SourceAccessConfigurations",
     "event source authentication is not simulated",
@@ -45,6 +27,25 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["MetricsConfig", "event source metrics are not simulated"],
   ["KMSKeyArn", "filter criteria encryption is not simulated"],
   ["Tags", "tags are not simulated"],
+]);
+
+/**
+ * The inputs that only mean something for an event source this simulation does
+ * not have.
+ *
+ * None of them is a thing that is missing from the sources here. Each one
+ * configures a source the ARN dispatcher refuses outright, so naming one is a
+ * request for a different kind of mapping rather than for a feature.
+ */
+const unsupportedEventSourceInputs: ReadonlySet<string> = new Set([
+  "StartingPosition",
+  "StartingPositionTimestamp",
+  "Topics",
+  "Queues",
+  "SelfManagedEventSource",
+  "SelfManagedKafkaEventSourceConfig",
+  "AmazonManagedKafkaEventSourceConfig",
+  "DocumentDBEventSourceConfig",
 ]);
 
 /**
@@ -72,5 +73,21 @@ export function refuseUnsimulatedInput(
         "simulated as 0: a partial batch is delivered as soon as anything is " +
         "on the queue, so a batching window would have nothing to wait for",
     );
+  }
+}
+
+/**
+ * Refuse an input belonging to an event source this simulation does not have.
+ */
+export function refuseUnsupportedEventSourceInput(
+  input: SimCreateEventSourceMappingCommandInput,
+): void {
+  for (const [name, value] of Object.entries(input)) {
+    if (value !== undefined && unsupportedEventSourceInputs.has(name)) {
+      throw new SimLambdaInvalidParameterValueException(
+        `${name} on an event source mapping is for an event source this ` +
+          `simulation does not have: ${simulatedEventSourcesDescription}`,
+      );
+    }
   }
 }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -81,19 +81,48 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "functionName");
   });
 
-  it("refuses an event source that is not an SQS queue", async () => {
+  it("refuses an event source this simulation does not poll", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();
 
-    // When a mapping names a DynamoDB stream.
+    // When a mapping names a Kinesis stream.
     const error = await refusedMapping(ready, {
-      EventSourceArn:
-        "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-07-30T00:00:00.000",
+      EventSourceArn: "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
     });
 
-    // Then it is refused rather than accepted and never delivered from.
+    // Then it is refused rather than accepted and never delivered from, and
+    // the refusal says what a mapping may name instead.
     assertIdentical(error.name, "InvalidParameterValueException");
-    assertStringIncludes(error.message, "is not an SQS queue ARN");
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda event source",
+    );
+    assertStringIncludes(
+      error.message,
+      "SQS queues are the only simulated event source",
+    );
+    assertStringIncludes(
+      error.message,
+      "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+    );
+  });
+
+  it("refuses an input belonging to an event source this simulation does not have", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for a starting position, which only a stream has.
+    const error = await refusedMapping(ready, {
+      StartingPosition: "LATEST",
+    });
+
+    // Then it is refused, naming the sources there are instead.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "StartingPosition");
+    assertStringIncludes(
+      error.message,
+      "SQS queues are the only simulated event source",
+    );
   });
 
   it("refuses a queue in another Account or Region", async () => {

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -1,43 +1,6 @@
-import {
-  DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE,
-  type SimLambdaFunctionResponseType,
-} from "../../event-source/sim-lambda-event-source-mapping.js";
-import {
-  SimLambdaInvalidParameterValueException,
-  SimLambdaValidationException,
-} from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
-
-/**
- * The largest batch real Lambda delivers from a standard queue without a
- * batching window to fill it.
- */
-const maximumBatchSize = 10;
-
-/**
- * The batch size a mapping delivers with, refusing one a queue with no
- * batching window would never fill.
- */
-export function batchSizeIn(
-  input: SimCreateEventSourceMappingCommandInput,
-): number {
-  const batchSize =
-    input.BatchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
-
-  if (
-    !Number.isSafeInteger(batchSize) ||
-    batchSize < 1 ||
-    batchSize > maximumBatchSize
-  ) {
-    throw new SimLambdaInvalidParameterValueException(
-      `BatchSize ${String(batchSize)} is out of range: a queue with no ` +
-        `batching window delivers a whole number of messages between 1 and ` +
-        `${String(maximumBatchSize)} at a time`,
-    );
-  }
-
-  return batchSize;
-}
 
 /**
  * The response types the function reports, refusing one Lambda does not have.

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -4,7 +4,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimLambdaEventSourceQueues } from "../../event-source/queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceArn } from "../../event-source/sim-lambda-event-source-arn.js";
 import { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
 import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
@@ -94,7 +94,8 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
   }
 
   /**
-   * Refuse a mapping whose queue cannot be polled as the execution role.
+   * Refuse a mapping whose event source cannot be polled as the execution
+   * role.
    *
    * The role's permission is checked before the queue is read, so a role with
    * no access is told what it is missing rather than being told the queue does
@@ -102,12 +103,9 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
    */
   private async assertPollable(
     simFunction: SimLambdaFunction,
-    eventSourceArn: SimLambdaSqsEventSourceArn,
+    eventSourceArn: SimLambdaEventSourceArn,
   ): Promise<void> {
-    this.rolePermissions.assertMayPoll(
-      simFunction.roleArn,
-      eventSourceArn.value,
-    );
+    this.rolePermissions.assertMayPoll(simFunction.roleArn, eventSourceArn);
 
     // Reading the queue's attributes as the role is how the mapping finds out
     // the queue is there at all, exactly as the poller will.

--- a/src/service/lambda/event-source/poll/sim-lambda-batch-item-failures.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-batch-item-failures.ts
@@ -1,0 +1,55 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+/**
+ * The batch item failure report a function may send back.
+ *
+ * Reading the report is the same for every event source that accepts one: the
+ * mapping has to have been told to expect it, and the entries have to name
+ * something. What is done with the ids it names belongs to the source, so that
+ * stays with the source's own batch response.
+ */
+export class SimLambdaBatchItemFailures {
+  private readonly reportsBatchItemFailures: boolean;
+
+  constructor(reportsBatchItemFailures: boolean) {
+    this.reportsBatchItemFailures = reportsBatchItemFailures;
+  }
+
+  /**
+   * The item ids a report names, or undefined when the function reported none.
+   */
+  idsIn(result: unknown): readonly string[] | undefined {
+    if (!this.reportsBatchItemFailures || !isRecord(result)) {
+      return undefined;
+    }
+
+    const reported = result["batchItemFailures"];
+
+    if (!Array.isArray(reported) || reported.length === 0) {
+      return undefined;
+    }
+
+    return reported.map((failure: unknown) => itemIdentifier(failure));
+  }
+}
+
+/**
+ * The item id one reported failure names.
+ *
+ * An entry naming nothing is reported as an empty id, which no item has, so the
+ * whole batch goes back. That is what real Lambda does with a malformed report
+ * rather than dropping the entry.
+ */
+function itemIdentifier(failure: unknown): string {
+  if (!isRecord(failure)) {
+    return "";
+  }
+
+  const identifier = failure["itemIdentifier"];
+
+  if (typeof identifier !== "string") {
+    return "";
+  }
+
+  return identifier;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-batch-response.ts
@@ -1,0 +1,59 @@
+import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+
+/**
+ * What became of one batch handed to a function.
+ *
+ * A batch is either deleted from the source or left on it to be delivered
+ * again. Partial batch responses split it, which is the only reason this is a
+ * pair of lists rather than a yes or no.
+ */
+export class SimLambdaEventSourceBatchOutcome {
+  public readonly handled: readonly SimLambdaEventSourceMessage[];
+  public readonly returned: readonly SimLambdaEventSourceMessage[];
+
+  constructor(
+    handled: readonly SimLambdaEventSourceMessage[],
+    returned: readonly SimLambdaEventSourceMessage[],
+  ) {
+    this.handled = handled;
+    this.returned = returned;
+  }
+
+  /**
+   * The receipt handles of the messages to delete from the source.
+   */
+  get handledReceiptHandles(): readonly string[] {
+    return this.handled.map((message) => message.ReceiptHandle);
+  }
+
+  /**
+   * Whether anything was left behind to be delivered again.
+   */
+  get hasReturnedMessages(): boolean {
+    return this.returned.length > 0;
+  }
+}
+
+/**
+ * Reads what a function said about the batch it was given.
+ *
+ * One per kind of event source, because what a function may say about a batch,
+ * and what becomes of the part it did not handle, are the source's rules rather
+ * than the delivery's.
+ */
+export interface SimLambdaEventSourceBatchResponse {
+  /**
+   * What became of a batch the function returned from.
+   */
+  handled(
+    messages: readonly SimLambdaEventSourceMessage[],
+    result: unknown,
+  ): SimLambdaEventSourceBatchOutcome;
+
+  /**
+   * What becomes of a batch the function threw on.
+   */
+  failed(
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): SimLambdaEventSourceBatchOutcome;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
@@ -1,16 +1,43 @@
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
-import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import {
-  type SimLambdaSqsBatchOutcome,
-  SimLambdaSqsBatchResponse,
-} from "./sim-lambda-sqs-batch-response.js";
-import { SimLambdaSqsEventBuilder } from "./sim-lambda-sqs-event.js";
+import type {
+  SimLambdaEventSourceBatchOutcome,
+  SimLambdaEventSourceBatchResponse,
+} from "./sim-lambda-event-source-batch-response.js";
+
+/**
+ * One record of an event source event.
+ *
+ * Every source's records name where they came from, whatever else they carry,
+ * which is as much as delivery needs to know about the shape.
+ */
+export interface SimLambdaEventSourceEventRecord {
+  readonly eventSource: string;
+  readonly eventSourceARN: string;
+}
+
+/**
+ * The event one batch is delivered as.
+ */
+export interface SimLambdaEventSourceEvent {
+  readonly Records: readonly SimLambdaEventSourceEventRecord[];
+}
+
+/**
+ * Builds the event a batch is handed to the function as.
+ *
+ * The shape is the event source's own, so the poller that made the delivery
+ * decides which builder it gets.
+ */
+export interface SimLambdaEventSourceEventBuilder {
+  of(
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): SimLambdaEventSourceEvent;
+}
 
 interface SimLambdaEventSourceDeliveryProperties {
-  readonly mapping: SimLambdaEventSourceMapping;
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly eventBuilder: SimLambdaEventSourceEventBuilder;
+  readonly batchResponse: SimLambdaEventSourceBatchResponse;
 }
 
 /**
@@ -18,17 +45,18 @@ interface SimLambdaEventSourceDeliveryProperties {
  *
  * The batch is invoked directly rather than through the Invoke command because
  * the handler's error has to be seen: an asynchronous invocation drops it, and
- * this is what decides whether the messages go back on the queue.
+ * this is what decides whether the messages go back on the source.
+ *
+ * What the event looks like and what a return value means are the source's
+ * business, so both are handed in rather than built here.
  */
 export class SimLambdaEventSourceDelivery {
-  private readonly eventBuilder: SimLambdaSqsEventBuilder;
-  private readonly batchResponse: SimLambdaSqsBatchResponse;
+  private readonly eventBuilder: SimLambdaEventSourceEventBuilder;
+  private readonly batchResponse: SimLambdaEventSourceBatchResponse;
 
   constructor(properties: SimLambdaEventSourceDeliveryProperties) {
-    this.eventBuilder = new SimLambdaSqsEventBuilder(properties.eventSourceArn);
-    this.batchResponse = new SimLambdaSqsBatchResponse(
-      properties.mapping.reportsBatchItemFailures,
-    );
+    this.eventBuilder = properties.eventBuilder;
+    this.batchResponse = properties.batchResponse;
   }
 
   /**
@@ -37,7 +65,7 @@ export class SimLambdaEventSourceDelivery {
   async to(
     simFunction: SimLambdaFunction,
     messages: readonly SimLambdaEventSourceMessage[],
-  ): Promise<SimLambdaSqsBatchOutcome> {
+  ): Promise<SimLambdaEventSourceBatchOutcome> {
     try {
       return this.batchResponse.handled(
         messages,
@@ -46,7 +74,7 @@ export class SimLambdaEventSourceDelivery {
     } catch {
       // As on real Lambda, the handler error goes to the function's logs and
       // not to whoever sent the message. What the sender sees is the batch
-      // coming back to the queue.
+      // coming back to the source.
       return this.batchResponse.failed(messages);
     }
   }

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
@@ -1,0 +1,33 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceQueues } from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceArn } from "../sim-lambda-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
+import { SimLambdaSqsEventSourcePoller } from "./sim-lambda-sqs-event-source-poller.js";
+
+export interface SimLambdaEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The poller for the kind of event source a mapping names.
+ *
+ * Which poller a mapping gets is decided here rather than by whoever starts
+ * one, so adding a kind of source is a change here rather than a change to
+ * everything a poller touches. There is one kind so far, so this hands the ARN
+ * straight to the queue poller: the queue poller only accepts a queue ARN, so a
+ * second kind of source fails to compile here rather than being polled as a
+ * queue.
+ */
+export function makeSimLambdaEventSourcePoller(
+  properties: SimLambdaEventSourcePollerProperties,
+): SimLambdaEventSourcePoller {
+  const { eventSourceArn } = properties;
+
+  return new SimLambdaSqsEventSourcePoller({ ...properties, eventSourceArn });
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
@@ -1,183 +1,26 @@
-import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
-import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
-import type {
-  SimLambdaEventSourceQueueRequest,
-  SimLambdaEventSourceQueues,
-  SimLambdaEventSourceQueueWatcher,
-} from "../queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
-import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
-import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
-import type { SimLambdaSqsBatchOutcome } from "./sim-lambda-sqs-batch-response.js";
-
-interface SimLambdaEventSourcePollerProperties {
-  readonly mapping: SimLambdaEventSourceMapping;
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
-  readonly functions: SimLambdaFunctionLookup;
-  readonly queues: SimLambdaEventSourceQueues;
-  readonly background: BackgroundScheduler;
-}
-
 /**
- * Polls one event source mapping's queue and invokes its function.
+ * The running side of one event source mapping.
  *
- * Real Lambda polls a queue continuously. Nothing in this simulation runs
- * continuously, so the queue says when a message has arrived and a poll is
- * scheduled in response. A test that awaits the simulation settling has
- * therefore watched the whole delivery happen, rather than having waited a
- * while and hoped.
- *
- * A batch the function returns from is deleted from the queue. A batch it
- * throws on is left there, which hides it for the visibility timeout and hands
- * it back afterwards, so a redrive policy eventually gives up on it exactly as
- * it would for any other failing consumer. That is why the poller invokes the
- * function directly rather than through the Invoke command: an asynchronous
- * invocation drops its handler error, and this one has to be seen.
+ * A mapping is state a request can read; a poller is the thing behind it that
+ * actually delivers. Each kind of event source has its own poller, and this is
+ * all `SimLambdaEventSourcePollers` needs from any of them: start watching,
+ * poll now, stop.
  */
-export class SimLambdaEventSourcePoller implements SimLambdaEventSourceQueueWatcher {
-  private readonly properties: SimLambdaEventSourcePollerProperties;
-  private readonly delivery: SimLambdaEventSourceDelivery;
-  private readonly schedule: SimLambdaEventSourcePollSchedule;
-
-  private stopped = false;
-
-  constructor(properties: SimLambdaEventSourcePollerProperties) {
-    this.properties = properties;
-    this.delivery = new SimLambdaEventSourceDelivery(properties);
-    this.schedule = new SimLambdaEventSourcePollSchedule({
-      background: properties.background,
-      poll: async (): Promise<void> => {
-        await this.run();
-      },
-    });
-  }
-
+export interface SimLambdaEventSourcePoller {
   /**
-   * Watch the queue this mapping polls.
-   *
-   * Watching starts as soon as the mapping is created, before it has finished
-   * creating, so a message sent in between is not missed. The poll it wakes
-   * finds a mapping that is not polling yet and does nothing, and the poll that
-   * follows activation picks the message up.
+   * Watch the event source this mapping polls, so something arriving on it
+   * wakes a poll.
    */
-  watch(): void {
-    this.properties.queues.watch(this.properties.eventSourceArn.value, this);
-  }
+  watch(): void;
 
   /**
    * Poll as soon as the simulation gets to it, which is what a newly enabled
-   * mapping does with whatever is already on its queue.
+   * mapping does with whatever is already waiting.
    */
-  pollNow(): void {
-    this.schedule.now();
-  }
+  pollNow(): void;
 
   /**
    * Stop polling, as deleting the mapping does.
    */
-  stop(): void {
-    this.stopped = true;
-    this.properties.queues.unwatch(this.properties.eventSourceArn.value, this);
-  }
-
-  /**
-   * Take a message arriving on the queue as something to poll for.
-   */
-  messageAvailable(availableFrom: Date): void {
-    this.schedule.at(availableFrom);
-  }
-
-  /**
-   * Poll once: one batch, delivered and then deleted or left behind.
-   */
-  private async run(): Promise<void> {
-    const simFunction = this.pollingFunction();
-
-    if (simFunction === undefined) {
-      return;
-    }
-
-    // Polling is done as the function's execution role, as on real Lambda, so
-    // simulated IAM decides whether this mapping may read its queue.
-    const request = {
-      queueArn: this.properties.eventSourceArn.value,
-      caller: { kind: "arn", arn: simFunction.roleArn },
-    } as const satisfies SimLambdaEventSourceQueueRequest;
-    const visibilityTimeoutSeconds =
-      await this.properties.queues.visibilityTimeoutSeconds(request);
-    const messages = await this.properties.queues.receive({
-      ...request,
-      batchSize: this.properties.mapping.batchSize,
-    });
-
-    if (messages.length === 0) {
-      this.pollWhenSomethingComesBack();
-
-      return;
-    }
-
-    const outcome = await this.delivery.to(simFunction, messages);
-
-    await this.properties.queues.deleteMessages({
-      ...request,
-      receiptHandles: outcome.handledReceiptHandles,
-    });
-
-    this.pollAgainAfter(outcome, messages.length, visibilityTimeoutSeconds);
-  }
-
-  /**
-   * The function this mapping delivers to, while it should be delivering.
-   *
-   * A mapping still being created is not polling yet, and a disabled one never
-   * is. A function that is not there is not an error here: the mapping simply
-   * has nothing to deliver to.
-   */
-  private pollingFunction(): SimLambdaFunction | undefined {
-    if (this.stopped || !this.properties.mapping.isPolling) {
-      return undefined;
-    }
-
-    return this.properties.functions.find(this.properties.mapping.functionName);
-  }
-
-  /**
-   * Look again when a message the queue could not hand out becomes
-   * receivable.
-   *
-   * A mapping created while every message on its queue is in flight, or one
-   * whose queue holds only delayed messages, has nothing to wake it otherwise.
-   */
-  private pollWhenSomethingComesBack(): void {
-    const availableFrom = this.properties.queues.nextAvailability(
-      this.properties.eventSourceArn.value,
-    );
-
-    if (availableFrom !== undefined) {
-      this.schedule.at(availableFrom);
-    }
-  }
-
-  /**
-   * Decide when this mapping polls again: when a returned batch becomes
-   * visible again, or straight away when a batch filled the request and there
-   * may be more waiting.
-   */
-  private pollAgainAfter(
-    outcome: SimLambdaSqsBatchOutcome,
-    receivedCount: number,
-    visibilityTimeoutSeconds: number,
-  ): void {
-    if (outcome.hasReturnedMessages) {
-      this.schedule.afterSeconds(visibilityTimeoutSeconds);
-
-      return;
-    }
-
-    if (receivedCount >= this.properties.mapping.batchSize) {
-      this.schedule.now();
-    }
-  }
+  stop(): void;
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
@@ -1,42 +1,12 @@
-import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+import { SimLambdaBatchItemFailures } from "./sim-lambda-batch-item-failures.js";
+import {
+  SimLambdaEventSourceBatchOutcome,
+  type SimLambdaEventSourceBatchResponse,
+} from "./sim-lambda-event-source-batch-response.js";
 
 /**
- * What became of one batch handed to a function.
- *
- * A batch is either deleted from the queue or left on it to become visible
- * again. Partial batch responses split it, which is the only reason this is a
- * pair of lists rather than a yes or no.
- */
-export class SimLambdaSqsBatchOutcome {
-  public readonly handled: readonly SimLambdaEventSourceMessage[];
-  public readonly returned: readonly SimLambdaEventSourceMessage[];
-
-  constructor(
-    handled: readonly SimLambdaEventSourceMessage[],
-    returned: readonly SimLambdaEventSourceMessage[],
-  ) {
-    this.handled = handled;
-    this.returned = returned;
-  }
-
-  /**
-   * The receipt handles of the messages to delete from the queue.
-   */
-  get handledReceiptHandles(): readonly string[] {
-    return this.handled.map((message) => message.ReceiptHandle);
-  }
-
-  /**
-   * Whether anything was left on the queue to be delivered again.
-   */
-  get hasReturnedMessages(): boolean {
-    return this.returned.length > 0;
-  }
-}
-
-/**
- * Reads what a function said about the batch it was given.
+ * Reads what a function said about the batch of messages it was given.
  *
  * A function that returns normally has handled the whole batch, unless the
  * mapping was told to expect a batch item failure report and the function sent
@@ -44,11 +14,13 @@ export class SimLambdaSqsBatchOutcome {
  * as on real Lambda: the alternative is to guess which messages the function
  * meant, and guessing wrong loses a message.
  */
-export class SimLambdaSqsBatchResponse {
-  private readonly reportsBatchItemFailures: boolean;
+export class SimLambdaSqsBatchResponse implements SimLambdaEventSourceBatchResponse {
+  private readonly batchItemFailures: SimLambdaBatchItemFailures;
 
   constructor(reportsBatchItemFailures: boolean) {
-    this.reportsBatchItemFailures = reportsBatchItemFailures;
+    this.batchItemFailures = new SimLambdaBatchItemFailures(
+      reportsBatchItemFailures,
+    );
   }
 
   /**
@@ -57,18 +29,18 @@ export class SimLambdaSqsBatchResponse {
   handled(
     messages: readonly SimLambdaEventSourceMessage[],
     result: unknown,
-  ): SimLambdaSqsBatchOutcome {
-    const failedIds = this.reportedFailureIds(result);
+  ): SimLambdaEventSourceBatchOutcome {
+    const failedIds = this.batchItemFailures.idsIn(result);
 
     if (failedIds === undefined) {
-      return new SimLambdaSqsBatchOutcome(messages, []);
+      return new SimLambdaEventSourceBatchOutcome(messages, []);
     }
 
     if (!this.namesBatchMessages(failedIds, messages)) {
       return this.failed(messages);
     }
 
-    return new SimLambdaSqsBatchOutcome(
+    return new SimLambdaEventSourceBatchOutcome(
       messages.filter((message) => !failedIds.includes(message.MessageId)),
       messages.filter((message) => failedIds.includes(message.MessageId)),
     );
@@ -79,26 +51,8 @@ export class SimLambdaSqsBatchResponse {
    */
   failed(
     messages: readonly SimLambdaEventSourceMessage[],
-  ): SimLambdaSqsBatchOutcome {
-    return new SimLambdaSqsBatchOutcome([], messages);
-  }
-
-  /**
-   * The message ids a batch item failure report names, or undefined when the
-   * function reported none.
-   */
-  private reportedFailureIds(result: unknown): readonly string[] | undefined {
-    if (!this.reportsBatchItemFailures || !isRecord(result)) {
-      return undefined;
-    }
-
-    const reported = result["batchItemFailures"];
-
-    if (!Array.isArray(reported) || reported.length === 0) {
-      return undefined;
-    }
-
-    return reported.map((failure: unknown) => itemIdentifier(failure));
+  ): SimLambdaEventSourceBatchOutcome {
+    return new SimLambdaEventSourceBatchOutcome([], messages);
   }
 
   private namesBatchMessages(
@@ -109,25 +63,4 @@ export class SimLambdaSqsBatchResponse {
       messages.some((message) => message.MessageId === failedId),
     );
   }
-}
-
-/**
- * The message id one reported failure names.
- *
- * An entry naming nothing is reported as an empty id, which no message has, so
- * the whole batch goes back. That is what real Lambda does with a malformed
- * report rather than dropping the entry.
- */
-function itemIdentifier(failure: unknown): string {
-  if (!isRecord(failure)) {
-    return "";
-  }
-
-  const identifier = failure["itemIdentifier"];
-
-  if (typeof identifier !== "string") {
-    return "";
-  }
-
-  return identifier;
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
@@ -1,0 +1,28 @@
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
+import { SimLambdaSqsBatchResponse } from "./sim-lambda-sqs-batch-response.js";
+import { SimLambdaSqsEventBuilder } from "./sim-lambda-sqs-event.js";
+
+interface SimLambdaSqsDeliveryProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+}
+
+/**
+ * The delivery an SQS mapping hands its batches over with.
+ *
+ * What the event looks like and what the function's return value means are both
+ * the queue's, so they are put together here and handed to the delivery, which
+ * knows neither.
+ */
+export function makeSimLambdaSqsDelivery(
+  properties: SimLambdaSqsDeliveryProperties,
+): SimLambdaEventSourceDelivery {
+  return new SimLambdaEventSourceDelivery({
+    eventBuilder: new SimLambdaSqsEventBuilder(properties.eventSourceArn),
+    batchResponse: new SimLambdaSqsBatchResponse(
+      properties.mapping.reportsBatchItemFailures,
+    ),
+  });
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-poller.ts
@@ -1,0 +1,182 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type {
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+} from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceBatchOutcome } from "./sim-lambda-event-source-batch-response.js";
+import type { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
+import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
+import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
+import { makeSimLambdaSqsDelivery } from "./sim-lambda-sqs-delivery.js";
+import { SimLambdaSqsPolledQueue } from "./sim-lambda-sqs-polled-queue.js";
+
+interface SimLambdaSqsEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one event source mapping's queue and invokes its function.
+ *
+ * Real Lambda polls a queue continuously. Nothing in this simulation runs
+ * continuously, so the queue says when a message has arrived and a poll is
+ * scheduled in response. A test that awaits the simulation settling has
+ * therefore watched the whole delivery happen, rather than having waited a
+ * while and hoped.
+ *
+ * A batch the function returns from is deleted from the queue. A batch it
+ * throws on is left there, which hides it for the visibility timeout and hands
+ * it back afterwards, so a redrive policy eventually gives up on it exactly as
+ * it would for any other failing consumer. That is why the poller invokes the
+ * function directly rather than through the Invoke command: an asynchronous
+ * invocation drops its handler error, and this one has to be seen.
+ */
+export class SimLambdaSqsEventSourcePoller
+  implements SimLambdaEventSourcePoller, SimLambdaEventSourceQueueWatcher
+{
+  private readonly mapping: SimLambdaEventSourceMapping;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly queue: SimLambdaSqsPolledQueue;
+  private readonly delivery: SimLambdaEventSourceDelivery;
+  private readonly schedule: SimLambdaEventSourcePollSchedule;
+
+  private stopped = false;
+
+  constructor(properties: SimLambdaSqsEventSourcePollerProperties) {
+    this.mapping = properties.mapping;
+    this.functions = properties.functions;
+    this.queue = new SimLambdaSqsPolledQueue(
+      properties.queues,
+      properties.eventSourceArn.value,
+    );
+    this.delivery = makeSimLambdaSqsDelivery(properties);
+    this.schedule = new SimLambdaEventSourcePollSchedule({
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.run();
+      },
+    });
+  }
+
+  /**
+   * Watch the queue this mapping polls.
+   *
+   * Watching starts as soon as the mapping is created, before it has finished
+   * creating, so a message sent in between is not missed. The poll it wakes
+   * finds a mapping that is not polling yet and does nothing, and the poll that
+   * follows activation picks the message up.
+   */
+  watch(): void {
+    this.queue.watch(this);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, which is what a newly enabled
+   * mapping does with whatever is already on its queue.
+   */
+  pollNow(): void {
+    this.schedule.now();
+  }
+
+  /**
+   * Stop polling, as deleting the mapping does.
+   */
+  stop(): void {
+    this.stopped = true;
+    this.queue.unwatch(this);
+  }
+
+  /**
+   * Take a message arriving on the queue as something to poll for.
+   */
+  messageAvailable(availableFrom: Date): void {
+    this.schedule.at(availableFrom);
+  }
+
+  /**
+   * Poll once: one batch, delivered and then deleted or left behind.
+   */
+  private async run(): Promise<void> {
+    const simFunction = this.pollingFunction();
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    // Polling is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its queue.
+    const { roleArn } = simFunction;
+    const timeout = await this.queue.visibilityTimeoutSeconds(roleArn);
+    const messages = await this.queue.receive(roleArn, this.mapping.batchSize);
+
+    if (messages.length === 0) {
+      this.pollWhenSomethingComesBack();
+
+      return;
+    }
+
+    const outcome = await this.delivery.to(simFunction, messages);
+
+    await this.queue.deleteMessages(roleArn, outcome.handledReceiptHandles);
+
+    this.pollAgainAfter(outcome, messages.length, timeout);
+  }
+
+  /**
+   * The function this mapping delivers to, while it should be delivering.
+   *
+   * A mapping still being created is not polling yet, and a disabled one never
+   * is. A function that is not there is not an error here: the mapping simply
+   * has nothing to deliver to.
+   */
+  private pollingFunction(): SimLambdaFunction | undefined {
+    if (this.stopped || !this.mapping.isPolling) {
+      return undefined;
+    }
+
+    return this.functions.find(this.mapping.functionName);
+  }
+
+  /**
+   * Look again when a message the queue could not hand out becomes
+   * receivable.
+   *
+   * A mapping created while every message on its queue is in flight, or one
+   * whose queue holds only delayed messages, has nothing to wake it otherwise.
+   */
+  private pollWhenSomethingComesBack(): void {
+    const availableFrom = this.queue.nextAvailability();
+
+    if (availableFrom !== undefined) {
+      this.schedule.at(availableFrom);
+    }
+  }
+
+  /**
+   * Decide when this mapping polls again: when a returned batch becomes
+   * visible again, or straight away when a batch filled the request and there
+   * may be more waiting.
+   */
+  private pollAgainAfter(
+    outcome: SimLambdaEventSourceBatchOutcome,
+    receivedCount: number,
+    visibilityTimeoutSeconds: number,
+  ): void {
+    if (outcome.hasReturnedMessages) {
+      this.schedule.afterSeconds(visibilityTimeoutSeconds);
+
+      return;
+    }
+
+    if (receivedCount >= this.mapping.batchSize) {
+      this.schedule.now();
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-polled-queue.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-polled-queue.ts
@@ -1,0 +1,80 @@
+import type {
+  SimLambdaEventSourceMessage,
+  SimLambdaEventSourceQueueRequest,
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+} from "../queue/sim-lambda-event-source-queues.js";
+
+/**
+ * The one queue a mapping polls.
+ *
+ * Every call names the same queue, and the ones a poll makes are all made as
+ * the function's execution role, so both are fixed here rather than written out
+ * at each call. Simulated IAM still decides each one, exactly as real IAM does.
+ */
+export class SimLambdaSqsPolledQueue {
+  private readonly queues: SimLambdaEventSourceQueues;
+  private readonly queueArn: string;
+
+  constructor(queues: SimLambdaEventSourceQueues, queueArn: string) {
+    this.queues = queues;
+    this.queueArn = queueArn;
+  }
+
+  /**
+   * Watch for messages arriving on the queue.
+   */
+  watch(watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.queues.watch(this.queueArn, watcher);
+  }
+
+  /**
+   * Stop watching the queue.
+   */
+  unwatch(watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.queues.unwatch(this.queueArn, watcher);
+  }
+
+  /**
+   * When the earliest message the queue cannot hand out yet becomes
+   * receivable.
+   */
+  nextAvailability(): Date | undefined {
+    return this.queues.nextAvailability(this.queueArn);
+  }
+
+  /**
+   * How long a received message stays hidden, and by asking, whether the queue
+   * is there to be polled at all.
+   */
+  async visibilityTimeoutSeconds(roleArn: string): Promise<number> {
+    return await this.queues.visibilityTimeoutSeconds(this.requestAs(roleArn));
+  }
+
+  /**
+   * Take up to a batch of messages off the queue.
+   */
+  async receive(
+    roleArn: string,
+    batchSize: number,
+  ): Promise<readonly SimLambdaEventSourceMessage[]> {
+    return await this.queues.receive({ ...this.requestAs(roleArn), batchSize });
+  }
+
+  /**
+   * Delete the messages the function handled.
+   */
+  async deleteMessages(
+    roleArn: string,
+    receiptHandles: readonly string[],
+  ): Promise<void> {
+    await this.queues.deleteMessages({
+      ...this.requestAs(roleArn),
+      receiptHandles,
+    });
+  }
+
+  private requestAs(roleArn: string): SimLambdaEventSourceQueueRequest {
+    return { queueArn: this.queueArn, caller: { kind: "arn", arn: roleArn } };
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.iso.test.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.iso.test.ts
@@ -1,0 +1,80 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaSqsEventSourceArn } from "./sim-lambda-sqs-event-source-arn.js";
+
+describe("sim Lambda SQS event source ARNs", () => {
+  it("reads the queue a mapping polls out of its ARN", () => {
+    // Given a queue ARN.
+    const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+
+    // When it is read.
+    const eventSourceArn = SimLambdaSqsEventSourceArn.of(queueArn);
+
+    // Then it knows what kind of source it is, and both halves of what a
+    // poller needs come out of it.
+    assertIdentical(eventSourceArn.kind, "sqs");
+    assertIdentical(eventSourceArn.serviceLabel, "SQS");
+    assertIdentical(eventSourceArn.regionName, "eu-west-2");
+    assertIdentical(
+      eventSourceArn.queueUrl,
+      "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+    );
+  });
+
+  it("names the operations a poller has to be allowed to call", () => {
+    // Given a queue ARN.
+    const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+
+    // When its polling permissions are read.
+    const permissions =
+      SimLambdaSqsEventSourceArn.of(queueArn).pollingPermissions;
+
+    // Then they are the three SQS operations real Lambda checks, on the queue,
+    // each naming the operation the way a refusal reports it.
+    assertIdentical(
+      permissions.map((permission) => permission.action).join(","),
+      "sqs:ReceiveMessage,sqs:DeleteMessage,sqs:GetQueueAttributes",
+    );
+    assertIdentical(
+      permissions.map((permission) => permission.operationName).join(","),
+      "ReceiveMessage,DeleteMessage,GetQueueAttributes",
+    );
+    assertIdentical(
+      permissions.map((permission) => permission.resource).join(","),
+      [queueArn, queueArn, queueArn].join(","),
+    );
+  });
+
+  it("answers with nothing for an ARN that is not a queue", () => {
+    // Given an ARN naming something other than a queue.
+    // When it is parsed.
+    const parsed = SimLambdaSqsEventSourceArn.parse(
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+    );
+
+    // Then the dispatcher is left to decide what to say about it.
+    assertUndefined(parsed);
+  });
+
+  it("refuses an ARN that is not a queue when read directly", () => {
+    // Given an ARN naming something other than a queue.
+    // When it is read as a queue ARN.
+    const error = assertThrowsError(() => {
+      SimLambdaSqsEventSourceArn.of("arn:aws:sqs:eu-west-2:orders");
+    });
+
+    // Then it says what a queue ARN looks like.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "is not an SQS queue ARN");
+    assertStringIncludes(
+      error.message,
+      "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+    );
+  });
+});

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,8 +1,36 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { sqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-arn.js";
+import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
 
 const queueArnPattern =
   /^arn:aws:sqs:(?<region>[a-z0-9-]+):(?<account>\d{12}):(?<name>[\w-]{1,80})$/u;
+
+/**
+ * What a function's execution role has to be allowed to do on a queue for
+ * Lambda to poll it.
+ *
+ * These are the three operations real Lambda checks when an SQS event source
+ * mapping is created, and the three its poller performs afterwards.
+ */
+const queuePollingOperations = [
+  "ReceiveMessage",
+  "DeleteMessage",
+  "GetQueueAttributes",
+] as const;
+
+/**
+ * The batch sizes an SQS event source delivers with.
+ *
+ * Ten is both the batch real Lambda uses when the mapping names none, and the
+ * largest batch it delivers from a standard queue without a batching window to
+ * fill a bigger one.
+ */
+const queueBatchRules = new SimLambdaEventSourceBatchRules({
+  defaultSize: 10,
+  maximumSize: 10,
+  sourceDescription: "a queue with no batching window",
+});
 
 /**
  * The queue ARN an event source mapping is created for.
@@ -13,37 +41,69 @@ const queueArnPattern =
  * report.
  */
 export class SimLambdaSqsEventSourceArn {
+  /**
+   * How an ARN naming this kind of event source is written, for a refusal to
+   * say what it wanted instead.
+   */
+  static readonly arnShape =
+    "An SQS queue ARN is arn:aws:sqs:<region>:<account-id>:<queue-name>";
+
+  public readonly kind = "sqs" as const;
+  public readonly serviceLabel = "SQS";
   public readonly value: string;
   public readonly regionName: string;
   public readonly accountId: string;
   public readonly queueName: string;
+  public readonly pollingPermissions: readonly SimLambdaEventSourcePollingPermission[];
 
   private constructor(value: string, parts: Record<string, string>) {
     this.value = value;
     this.regionName = parts["region"] ?? "";
     this.accountId = parts["account"] ?? "";
     this.queueName = parts["name"] ?? "";
+    this.pollingPermissions = queuePollingOperations.map(
+      (operation) =>
+        new SimLambdaEventSourcePollingPermission(`sqs:${operation}`, value),
+    );
   }
 
   /**
-   * Read an event source ARN, refusing one that names no simulated event
-   * source.
+   * Read a queue ARN, answering with nothing when the ARN names something
+   * else.
    *
-   * SQS queues are the only event source this simulation polls, so an ARN for
-   * any other one is refused rather than accepted and never delivered from.
+   * This is what the event source ARN dispatcher asks, so that deciding what a
+   * mapping may name stays in one place rather than in each parser.
    */
-  static of(eventSourceArn: string): SimLambdaSqsEventSourceArn {
-    const parts = queueArnPattern.exec(eventSourceArn)?.groups;
+  static parse(queueArn: string): SimLambdaSqsEventSourceArn | undefined {
+    const parts = queueArnPattern.exec(queueArn)?.groups;
 
     if (parts === undefined) {
+      return undefined;
+    }
+
+    return new this(queueArn, parts);
+  }
+
+  /**
+   * Read a queue ARN, refusing one that is not a queue ARN at all.
+   */
+  static of(queueArn: string): SimLambdaSqsEventSourceArn {
+    const parsed = this.parse(queueArn);
+
+    if (parsed === undefined) {
       throw new SimLambdaInvalidParameterValueException(
-        `EventSourceArn ${eventSourceArn} is not an SQS queue ARN. SQS queues ` +
-          "are the only simulated Lambda event source, and a queue ARN is " +
-          "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+        `${queueArn} is not an SQS queue ARN. ${this.arnShape}`,
       );
     }
 
-    return new this(eventSourceArn, parts);
+    return parsed;
+  }
+
+  /**
+   * The batch sizes a mapping on this queue may deliver with.
+   */
+  get batchRules(): SimLambdaEventSourceBatchRules {
+    return queueBatchRules;
   }
 
   /**

--- a/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
@@ -1,0 +1,49 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+import { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+
+/**
+ * The ARN of an event source a mapping can name.
+ *
+ * A union discriminated by `kind`, so the poller a mapping gets, the
+ * permissions its execution role is checked for and the batch sizes it may ask
+ * for all come from the source the mapping names rather than being assumed.
+ */
+export type SimLambdaEventSourceArn = SimLambdaSqsEventSourceArn;
+
+/**
+ * What this simulation polls, said in one place so every refusal that mentions
+ * it says the same thing.
+ */
+export const simulatedEventSourcesDescription =
+  "SQS queues are the only simulated event source";
+
+/**
+ * The ARN shapes those event sources are named by.
+ */
+const simulatedEventSourceArnShapes: readonly string[] = [
+  SimLambdaSqsEventSourceArn.arnShape,
+];
+
+/**
+ * Read an event source ARN, refusing one that names no simulated event source.
+ *
+ * This is the one place that decides which sources a mapping may name. A source
+ * this simulation cannot poll is refused rather than accepted and never
+ * delivered from.
+ */
+export function simLambdaEventSourceArnOf(
+  eventSourceArn: string,
+): SimLambdaEventSourceArn {
+  const queueArn = SimLambdaSqsEventSourceArn.parse(eventSourceArn);
+
+  if (queueArn === undefined) {
+    const arnShapes = simulatedEventSourceArnShapes.join(" ");
+
+    throw new SimLambdaInvalidParameterValueException(
+      `EventSourceArn ${eventSourceArn} names no simulated Lambda event ` +
+        `source. ${simulatedEventSourcesDescription}. ${arnShapes}`,
+    );
+  }
+
+  return queueArn;
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
@@ -1,0 +1,50 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+interface SimLambdaEventSourceBatchRulesProperties {
+  readonly defaultSize: number;
+  readonly maximumSize: number;
+  readonly sourceDescription: string;
+}
+
+/**
+ * The batch sizes one kind of event source delivers with.
+ *
+ * The default and the maximum belong to the source rather than to the mapping:
+ * how much a queue hands out in one receive is not how much another kind of
+ * source would, and neither is what makes a larger request pointless. The
+ * source description is the clause a refusal explains the range with.
+ */
+export class SimLambdaEventSourceBatchRules {
+  public readonly defaultSize: number;
+  public readonly maximumSize: number;
+
+  private readonly sourceDescription: string;
+
+  constructor(properties: SimLambdaEventSourceBatchRulesProperties) {
+    this.defaultSize = properties.defaultSize;
+    this.maximumSize = properties.maximumSize;
+    this.sourceDescription = properties.sourceDescription;
+  }
+
+  /**
+   * The batch size a mapping delivers with, refusing one this source would
+   * never fill.
+   */
+  sizeIn(requested: number | undefined): number {
+    const batchSize = requested ?? this.defaultSize;
+
+    if (
+      !Number.isSafeInteger(batchSize) ||
+      batchSize < 1 ||
+      batchSize > this.maximumSize
+    ) {
+      throw new SimLambdaInvalidParameterValueException(
+        `BatchSize ${String(batchSize)} is out of range: ` +
+          `${this.sourceDescription} delivers a whole number of messages ` +
+          `between 1 and ${String(this.maximumSize)} at a time`,
+      );
+    }
+
+    return batchSize;
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -10,12 +10,6 @@ export type SimLambdaEventSourceMappingArn =
   `arn:aws:lambda:${string}:${string}:event-source-mapping:${string}`;
 
 /**
- * The batch size real Lambda uses for an SQS event source when the mapping
- * does not name one.
- */
-export const DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE = 10;
-
-/**
  * The response types a mapping can be told the function reports.
  *
  * Only the batch item failure one exists on real Lambda.
@@ -37,7 +31,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly eventSourceArn: string;
   readonly functionName: string;
   readonly functionArn: SimLambdaFunctionArn;
-  readonly batchSize?: number | undefined;
+  readonly batchSize: number;
   readonly enabled?: boolean | undefined;
   readonly functionResponseTypes?:
     readonly SimLambdaFunctionResponseType[] | undefined;
@@ -63,11 +57,14 @@ export interface SimLambdaEventSourceMappingConfiguration {
 }
 
 /**
- * One simulated Lambda event source mapping, from an SQS queue to a function.
+ * One simulated Lambda event source mapping, from an event source to a
+ * function.
  *
  * The mapping holds what polling is done with rather than doing the polling: a
  * poller reads the batch size and the response types from here, and the mapping
- * stays the piece of state a Get or List reports.
+ * stays the piece of state a Get or List reports. What a batch size may be is
+ * the event source's rule, so the mapping is given one rather than defaulting
+ * it.
  */
 export class SimLambdaEventSourceMapping {
   public readonly uuid: string = randomUUID();
@@ -87,8 +84,7 @@ export class SimLambdaEventSourceMapping {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
     this.functionArn = properties.functionArn;
-    this.batchSize =
-      properties.batchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
+    this.batchSize = properties.batchSize;
     // Copied rather than held, so a caller keeping the list it passed in
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];

--- a/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
@@ -1,8 +1,9 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimLambdaFunctionLookup } from "../function/url/sim-lambda-function-lookup.js";
-import { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller.js";
+import { makeSimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller-factory.js";
+import type { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller.js";
 import type { SimLambdaEventSourceQueues } from "./queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
 
 interface SimLambdaEventSourcePollersProperties {
@@ -30,15 +31,15 @@ export class SimLambdaEventSourcePollers {
    * Start polling for a newly created mapping.
    *
    * The mapping finishes creating in the background, as it does on real Lambda,
-   * and starts polling once it does. Whatever is already on the queue is polled
-   * for then, because real Lambda does not only deliver what arrives after the
-   * mapping was made.
+   * and starts polling once it does. Whatever is already waiting on the event
+   * source is polled for then, because real Lambda does not only deliver what
+   * arrives after the mapping was made.
    */
   start(
     mapping: SimLambdaEventSourceMapping,
-    eventSourceArn: SimLambdaSqsEventSourceArn,
+    eventSourceArn: SimLambdaEventSourceArn,
   ): void {
-    const poller = new SimLambdaEventSourcePoller({
+    const poller = makeSimLambdaEventSourcePoller({
       ...this.properties,
       mapping,
       eventSourceArn,

--- a/src/service/lambda/event-source/sim-lambda-event-source-polling-permission.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-polling-permission.ts
@@ -1,0 +1,24 @@
+/**
+ * One thing a function's execution role has to be allowed to do for Lambda to
+ * poll an event source.
+ *
+ * The action carries its service prefix, because that is what simulated IAM is
+ * asked. The operation name is read back out of it for a refusal, which names
+ * the operation the way AWS names it.
+ */
+export class SimLambdaEventSourcePollingPermission {
+  public readonly action: string;
+  public readonly resource: string;
+
+  constructor(action: string, resource: string) {
+    this.action = action;
+    this.resource = resource;
+  }
+
+  /**
+   * The operation this permission names, without its service prefix.
+   */
+  get operationName(): string {
+    return this.action.slice(this.action.indexOf(":") + 1);
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
@@ -1,31 +1,22 @@
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
-
-/**
- * What a function's execution role has to be allowed to do on a queue for
- * Lambda to poll it.
- *
- * These are the three operations real Lambda checks when an SQS event source
- * mapping is created, and the three its poller performs afterwards.
- */
-const requiredQueueOperations = [
-  "ReceiveMessage",
-  "DeleteMessage",
-  "GetQueueAttributes",
-] as const;
+import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 
 interface SimLambdaEventSourceRolePermissionsProperties {
   readonly iam: SimIamInterServiceAuthZ;
 }
 
 /**
- * Checks that a function's execution role may poll the queue a mapping names.
+ * Checks that a function's execution role may poll the source a mapping names.
  *
  * Real Lambda refuses to create the mapping at all when the role cannot poll,
  * rather than creating one that silently delivers nothing, so this is checked
  * up front here too. The poller's own calls go through simulated IAM again
  * afterwards, as they do on AWS: this check is about failing early, not about
  * standing in for authorization.
+ *
+ * What has to be allowed comes from the event source, since the operations a
+ * poller performs are the source's own.
  */
 export class SimLambdaEventSourceRolePermissions {
   private readonly iam: SimIamInterServiceAuthZ;
@@ -35,21 +26,25 @@ export class SimLambdaEventSourceRolePermissions {
   }
 
   /**
-   * Refuse a mapping whose execution role cannot poll the queue.
+   * Refuse a mapping whose execution role cannot poll the event source.
    */
-  assertMayPoll(roleArn: string, queueArn: string): void {
-    for (const operation of requiredQueueOperations) {
+  assertMayPoll(
+    roleArn: string,
+    eventSourceArn: SimLambdaEventSourceArn,
+  ): void {
+    for (const permission of eventSourceArn.pollingPermissions) {
       const decision = this.iam.authorize({
-        action: `sqs:${operation}`,
-        resource: queueArn,
+        action: permission.action,
+        resource: permission.resource,
         caller: { kind: "arn", arn: roleArn },
       });
 
       if (decision.isDenied) {
         throw new SimLambdaInvalidParameterValueException(
-          `The provided execution role does not have permissions to call ` +
-            `${operation} on SQS. Role ${roleArn} has no policy allowing ` +
-            `sqs:${operation} on ${queueArn}`,
+          "The provided execution role does not have permissions to call " +
+            `${permission.operationName} on ${eventSourceArn.serviceLabel}. ` +
+            `Role ${roleArn} has no policy allowing ` +
+            `${permission.action} on ${permission.resource}`,
         );
       }
     }


### PR DESCRIPTION
Resolves #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CloudFormation conditions, including `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`, and named condition references.
  * Added `Fn::If` support for conditional resource properties and outputs.
  * Resources with false conditions are excluded, with validation for references to omitted resources.
* **Documentation**
  * Added CloudFormation condition guidance, limitations, evaluation behavior, and an example deployment.
* **Bug Fixes**
  * Added validation and clear errors for malformed, undefined, cyclic, or unsupported conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->