### PR TITLE
refactor: split the simulated Lambda event source machinery by source…

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -371,7 +371,7 @@ A stand-in is deliberately not ARN-shaped, so it fails closed wherever the simul
 - In a property that is parsed as an ARN it is refused as malformed, and that Resource fails.
   Handing `Fn::GetAtt: ["Orders", "StreamArn"]` from a skipped DynamoDB table to an
   `AWS::Lambda::EventSourceMapping` fails with
-  `EventSourceArn Orders.StreamArn is not an SQS queue ARN`.
+  `EventSourceArn Orders.StreamArn names no simulated Lambda event source`.
 - Handed to a Lambda function through its environment, it names something that is not there, so the
   function's own SDK call fails as a call for a missing resource does. A `PutItem` naming the
   skipped table gets `ResourceNotFoundException: No DynamoDB Table named Orders`.

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -255,10 +255,18 @@ owner, keeping its ambient callers isolated.
 
 `event-source/` owns delivery from a simulated SQS queue to a function.
 
+SQS is the only source there is so far, but the machinery around it is split by event source kind
+rather than assuming one. `sim-lambda-event-source-arn.ts` reads the ARN a mapping names into a
+union discriminated by `kind`, and that value carries what the rest of the machinery would otherwise
+have had to assume: the service label a refusal names, the `{action, resource}` permissions the
+execution role is checked for, and the batch size rules the request is measured against
+(`SimLambdaEventSourceBatchRules`). It is also the one place that decides which sources a mapping
+may name, so a refusal anywhere lists the same supported set.
+
 Real Lambda polls a queue continuously, and nothing in this simulation runs continuously, so the
 queue says when there is something to poll for. `SimSqsQueueActivity` (in sim SQS) holds the
 watchers on a queue, `SimSqsQueue.add` tells them a message has arrived, and
-`SimLambdaEventSourcePoller` schedules a poll in response. A message moved to a dead-letter queue
+`SimLambdaSqsEventSourcePoller` schedules a poll in response. A message moved to a dead-letter queue
 arrives the same way, so a mapping on a dead-letter queue is polled too.
 
 `SimLambdaEventSourcePollSchedule` decides when that poll happens. A message that is receivable now
@@ -277,21 +285,30 @@ were all in flight when the mapping was made.
 `SimSqsEventSourceQueues` implements it over the ordinary SQS commands, as the function's execution
 role, so simulated IAM authorizes each poll the way real IAM does. A standalone `SimLambda` has no
 sim SQS, and `SimLambdaNoEventSourceQueues` refuses with guidance rather than silently delivering
-nothing. `SimLambdaSqsEventSourceArn` reads a queue ARN into the URL requests name it by and the
-Region event records report.
+nothing. `SimLambdaSqsEventSourceArn` is the SQS member of the event source ARN union: it reads a
+queue ARN into the URL requests name it by and the Region event records report, and carries the
+queue's own polling permissions and batch size rules.
 
-Creating a mapping checks what real Lambda checks before it will make one: that the queue exists,
-and that the execution role may call `ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes` on
-it (`SimLambdaEventSourceRolePermissions`). Both failures are the mapping's, not the poller's: a
-mapping that cannot poll looks like a working subscription and delivers nothing.
+Creating a mapping checks what real Lambda checks before it will make one: that the event source
+exists, and that the execution role may perform the operations polling it takes
+(`SimLambdaEventSourceRolePermissions`, which reads those operations off the ARN — for a queue,
+`ReceiveMessage`, `DeleteMessage` and `GetQueueAttributes`). Both failures are the mapping's, not
+the poller's: a mapping that cannot poll looks like a working subscription and delivers nothing.
 
-`poll/` holds what one poll does. `SimLambdaEventSourceDelivery` invokes the function directly
-rather than through the Invoke command, because the handler error has to be seen: the asynchronous
-invoke path drops it, and this is what decides whether the batch goes back on the queue.
-`SimLambdaSqsBatchResponse` reads what the function said about the batch, including a
+`poll/` holds what one poll does. `SimLambdaEventSourcePoller` is the three-method interface
+(`watch`, `pollNow`, `stop`) the mapping's pollers are held behind, and
+`makeSimLambdaEventSourcePoller` picks the one for the kind of source the ARN names.
+`SimLambdaEventSourceDelivery` invokes the function directly rather than through the Invoke command,
+because the handler error has to be seen: the asynchronous invoke path drops it, and this is what
+decides whether the batch goes back on the source. It is handed the event builder and the batch
+response rather than building them, since both are the source's own.
+
+`SimLambdaSqsBatchResponse` reads what the function said about a batch of messages, including a
 `batchItemFailures` report when the mapping was told to expect one, and returns the whole batch for
-a report it cannot trust. `SimLambdaSqsEventBuilder` turns a batch into the event's own shape,
-which is the lower-case record naming and the base64 binary attribute values real AWS uses.
+a report it cannot trust. Reading the report itself is shared in `SimLambdaBatchItemFailures`, which
+is also where a malformed entry becomes an id no message has. `SimLambdaSqsEventBuilder` turns a
+batch into the event's own shape, which is the lower-case record naming and the base64 binary
+attribute values real AWS uses.
 
 ## Function URLs
 

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -207,6 +207,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
         functionName: "order-consumer",
         functionArn:
           "arn:aws:lambda:eu-west-2:111111111111:function:order-consumer",
+        batchSize: 10,
         createdAt: new Date(0),
       }),
     });

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -1,18 +1,23 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import {
+  type SimLambdaEventSourceArn,
+  simLambdaEventSourceArnOf,
+} from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
 import {
-  batchSizeIn,
   functionResponseTypesIn,
   requiredString,
 } from "./create-event-source-mapping-values.js";
-import { refuseUnsimulatedInput } from "./create-event-source-mapping-refusals.js";
+import {
+  refuseUnsimulatedInput,
+  refuseUnsupportedEventSourceInput,
+} from "./create-event-source-mapping-refusals.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 interface SimLambdaEventSourceMappingInputProperties {
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly eventSourceArn: SimLambdaEventSourceArn;
   readonly functionName: string;
   readonly batchSize: number;
   readonly enabled: boolean;
@@ -25,9 +30,12 @@ interface SimLambdaEventSourceMappingInputProperties {
  * Everything the request is refused for is decided here, before a mapping
  * exists: a mapping that cannot poll the way it was asked to would look like a
  * working subscription and deliver nothing.
+ *
+ * The event source ARN is read first, because what a mapping may ask for
+ * depends on the kind of source it names.
  */
 export class SimLambdaEventSourceMappingInput {
-  public readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  public readonly eventSourceArn: SimLambdaEventSourceArn;
   public readonly functionName: string;
   public readonly batchSize: number;
   public readonly enabled: boolean;
@@ -49,14 +57,17 @@ export class SimLambdaEventSourceMappingInput {
     input: SimCreateEventSourceMappingCommandInput,
     scope: SimAwsAccountRegionScope,
   ): SimLambdaEventSourceMappingInput {
+    const eventSourceArn = eventSourceArnIn(input, scope);
+
+    refuseUnsupportedEventSourceInput(input);
     refuseUnsimulatedInput(input);
 
     return new this({
-      eventSourceArn: eventSourceArnIn(input, scope),
+      eventSourceArn,
       functionName: simLambdaFunctionNameOf(
         requiredString(input.FunctionName, "functionName"),
       ),
-      batchSize: batchSizeIn(input),
+      batchSize: eventSourceArn.batchRules.sizeIn(input.BatchSize),
       enabled: input.Enabled ?? true,
       functionResponseTypes: functionResponseTypesIn(input),
     });
@@ -64,14 +75,14 @@ export class SimLambdaEventSourceMappingInput {
 }
 
 /**
- * The queue an event source ARN names, refusing one this simulated Lambda
- * cannot poll.
+ * The event source an ARN names, refusing one this simulated Lambda cannot
+ * poll.
  */
 function eventSourceArnIn(
   input: SimCreateEventSourceMappingCommandInput,
   scope: SimAwsAccountRegionScope,
-): SimLambdaSqsEventSourceArn {
-  const eventSourceArn = SimLambdaSqsEventSourceArn.of(
+): SimLambdaEventSourceArn {
+  const eventSourceArn = simLambdaEventSourceArnOf(
     requiredString(input.EventSourceArn, "eventSourceArn"),
   );
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -1,8 +1,10 @@
+import { simulatedEventSourcesDescription } from "../../event-source/sim-lambda-event-source-arn.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 /**
- * The inputs a mapping cannot be created with here, and why each is refused.
+ * The inputs no simulated event source has behaviour for, and why each is
+ * refused.
  *
  * Every one of them changes what a function sees or when it sees it, so
  * accepting and ignoring one would let a test pass on behaviour the deployment
@@ -18,26 +20,6 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["BisectBatchOnFunctionError", "batch bisection is not simulated"],
   ["ParallelizationFactor", "polling concurrency is not simulated"],
   ["TumblingWindowInSeconds", "tumbling windows are not simulated"],
-  ["StartingPosition", "SQS queues are the only simulated event source"],
-  [
-    "StartingPositionTimestamp",
-    "SQS queues are the only simulated event source",
-  ],
-  ["Topics", "SQS queues are the only simulated event source"],
-  ["Queues", "SQS queues are the only simulated event source"],
-  ["SelfManagedEventSource", "SQS queues are the only simulated event source"],
-  [
-    "SelfManagedKafkaEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
-  [
-    "AmazonManagedKafkaEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
-  [
-    "DocumentDBEventSourceConfig",
-    "SQS queues are the only simulated event source",
-  ],
   [
     "SourceAccessConfigurations",
     "event source authentication is not simulated",
@@ -45,6 +27,25 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["MetricsConfig", "event source metrics are not simulated"],
   ["KMSKeyArn", "filter criteria encryption is not simulated"],
   ["Tags", "tags are not simulated"],
+]);
+
+/**
+ * The inputs that only mean something for an event source this simulation does
+ * not have.
+ *
+ * None of them is a thing that is missing from the sources here. Each one
+ * configures a source the ARN dispatcher refuses outright, so naming one is a
+ * request for a different kind of mapping rather than for a feature.
+ */
+const unsupportedEventSourceInputs: ReadonlySet<string> = new Set([
+  "StartingPosition",
+  "StartingPositionTimestamp",
+  "Topics",
+  "Queues",
+  "SelfManagedEventSource",
+  "SelfManagedKafkaEventSourceConfig",
+  "AmazonManagedKafkaEventSourceConfig",
+  "DocumentDBEventSourceConfig",
 ]);
 
 /**
@@ -72,5 +73,21 @@ export function refuseUnsimulatedInput(
         "simulated as 0: a partial batch is delivered as soon as anything is " +
         "on the queue, so a batching window would have nothing to wait for",
     );
+  }
+}
+
+/**
+ * Refuse an input belonging to an event source this simulation does not have.
+ */
+export function refuseUnsupportedEventSourceInput(
+  input: SimCreateEventSourceMappingCommandInput,
+): void {
+  for (const [name, value] of Object.entries(input)) {
+    if (value !== undefined && unsupportedEventSourceInputs.has(name)) {
+      throw new SimLambdaInvalidParameterValueException(
+        `${name} on an event source mapping is for an event source this ` +
+          `simulation does not have: ${simulatedEventSourcesDescription}`,
+      );
+    }
   }
 }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -81,19 +81,48 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "functionName");
   });
 
-  it("refuses an event source that is not an SQS queue", async () => {
+  it("refuses an event source this simulation does not poll", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();
 
-    // When a mapping names a DynamoDB stream.
+    // When a mapping names a Kinesis stream.
     const error = await refusedMapping(ready, {
-      EventSourceArn:
-        "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-07-30T00:00:00.000",
+      EventSourceArn: "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
     });
 
-    // Then it is refused rather than accepted and never delivered from.
+    // Then it is refused rather than accepted and never delivered from, and
+    // the refusal says what a mapping may name instead.
     assertIdentical(error.name, "InvalidParameterValueException");
-    assertStringIncludes(error.message, "is not an SQS queue ARN");
+    assertStringIncludes(
+      error.message,
+      "names no simulated Lambda event source",
+    );
+    assertStringIncludes(
+      error.message,
+      "SQS queues are the only simulated event source",
+    );
+    assertStringIncludes(
+      error.message,
+      "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+    );
+  });
+
+  it("refuses an input belonging to an event source this simulation does not have", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for a starting position, which only a stream has.
+    const error = await refusedMapping(ready, {
+      StartingPosition: "LATEST",
+    });
+
+    // Then it is refused, naming the sources there are instead.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "StartingPosition");
+    assertStringIncludes(
+      error.message,
+      "SQS queues are the only simulated event source",
+    );
   });
 
   it("refuses a queue in another Account or Region", async () => {

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -1,43 +1,6 @@
-import {
-  DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE,
-  type SimLambdaFunctionResponseType,
-} from "../../event-source/sim-lambda-event-source-mapping.js";
-import {
-  SimLambdaInvalidParameterValueException,
-  SimLambdaValidationException,
-} from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
-
-/**
- * The largest batch real Lambda delivers from a standard queue without a
- * batching window to fill it.
- */
-const maximumBatchSize = 10;
-
-/**
- * The batch size a mapping delivers with, refusing one a queue with no
- * batching window would never fill.
- */
-export function batchSizeIn(
-  input: SimCreateEventSourceMappingCommandInput,
-): number {
-  const batchSize =
-    input.BatchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
-
-  if (
-    !Number.isSafeInteger(batchSize) ||
-    batchSize < 1 ||
-    batchSize > maximumBatchSize
-  ) {
-    throw new SimLambdaInvalidParameterValueException(
-      `BatchSize ${String(batchSize)} is out of range: a queue with no ` +
-        `batching window delivers a whole number of messages between 1 and ` +
-        `${String(maximumBatchSize)} at a time`,
-    );
-  }
-
-  return batchSize;
-}
 
 /**
  * The response types the function reports, refusing one Lambda does not have.

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -4,7 +4,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimLambdaEventSourceQueues } from "../../event-source/queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../../event-source/queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceArn } from "../../event-source/sim-lambda-event-source-arn.js";
 import { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
 import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
@@ -94,7 +94,8 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
   }
 
   /**
-   * Refuse a mapping whose queue cannot be polled as the execution role.
+   * Refuse a mapping whose event source cannot be polled as the execution
+   * role.
    *
    * The role's permission is checked before the queue is read, so a role with
    * no access is told what it is missing rather than being told the queue does
@@ -102,12 +103,9 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
    */
   private async assertPollable(
     simFunction: SimLambdaFunction,
-    eventSourceArn: SimLambdaSqsEventSourceArn,
+    eventSourceArn: SimLambdaEventSourceArn,
   ): Promise<void> {
-    this.rolePermissions.assertMayPoll(
-      simFunction.roleArn,
-      eventSourceArn.value,
-    );
+    this.rolePermissions.assertMayPoll(simFunction.roleArn, eventSourceArn);
 
     // Reading the queue's attributes as the role is how the mapping finds out
     // the queue is there at all, exactly as the poller will.

--- a/src/service/lambda/event-source/poll/sim-lambda-batch-item-failures.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-batch-item-failures.ts
@@ -1,0 +1,55 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+/**
+ * The batch item failure report a function may send back.
+ *
+ * Reading the report is the same for every event source that accepts one: the
+ * mapping has to have been told to expect it, and the entries have to name
+ * something. What is done with the ids it names belongs to the source, so that
+ * stays with the source's own batch response.
+ */
+export class SimLambdaBatchItemFailures {
+  private readonly reportsBatchItemFailures: boolean;
+
+  constructor(reportsBatchItemFailures: boolean) {
+    this.reportsBatchItemFailures = reportsBatchItemFailures;
+  }
+
+  /**
+   * The item ids a report names, or undefined when the function reported none.
+   */
+  idsIn(result: unknown): readonly string[] | undefined {
+    if (!this.reportsBatchItemFailures || !isRecord(result)) {
+      return undefined;
+    }
+
+    const reported = result["batchItemFailures"];
+
+    if (!Array.isArray(reported) || reported.length === 0) {
+      return undefined;
+    }
+
+    return reported.map((failure: unknown) => itemIdentifier(failure));
+  }
+}
+
+/**
+ * The item id one reported failure names.
+ *
+ * An entry naming nothing is reported as an empty id, which no item has, so the
+ * whole batch goes back. That is what real Lambda does with a malformed report
+ * rather than dropping the entry.
+ */
+function itemIdentifier(failure: unknown): string {
+  if (!isRecord(failure)) {
+    return "";
+  }
+
+  const identifier = failure["itemIdentifier"];
+
+  if (typeof identifier !== "string") {
+    return "";
+  }
+
+  return identifier;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-batch-response.ts
@@ -1,0 +1,59 @@
+import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+
+/**
+ * What became of one batch handed to a function.
+ *
+ * A batch is either deleted from the source or left on it to be delivered
+ * again. Partial batch responses split it, which is the only reason this is a
+ * pair of lists rather than a yes or no.
+ */
+export class SimLambdaEventSourceBatchOutcome {
+  public readonly handled: readonly SimLambdaEventSourceMessage[];
+  public readonly returned: readonly SimLambdaEventSourceMessage[];
+
+  constructor(
+    handled: readonly SimLambdaEventSourceMessage[],
+    returned: readonly SimLambdaEventSourceMessage[],
+  ) {
+    this.handled = handled;
+    this.returned = returned;
+  }
+
+  /**
+   * The receipt handles of the messages to delete from the source.
+   */
+  get handledReceiptHandles(): readonly string[] {
+    return this.handled.map((message) => message.ReceiptHandle);
+  }
+
+  /**
+   * Whether anything was left behind to be delivered again.
+   */
+  get hasReturnedMessages(): boolean {
+    return this.returned.length > 0;
+  }
+}
+
+/**
+ * Reads what a function said about the batch it was given.
+ *
+ * One per kind of event source, because what a function may say about a batch,
+ * and what becomes of the part it did not handle, are the source's rules rather
+ * than the delivery's.
+ */
+export interface SimLambdaEventSourceBatchResponse {
+  /**
+   * What became of a batch the function returned from.
+   */
+  handled(
+    messages: readonly SimLambdaEventSourceMessage[],
+    result: unknown,
+  ): SimLambdaEventSourceBatchOutcome;
+
+  /**
+   * What becomes of a batch the function threw on.
+   */
+  failed(
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): SimLambdaEventSourceBatchOutcome;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
@@ -1,16 +1,43 @@
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
-import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import {
-  type SimLambdaSqsBatchOutcome,
-  SimLambdaSqsBatchResponse,
-} from "./sim-lambda-sqs-batch-response.js";
-import { SimLambdaSqsEventBuilder } from "./sim-lambda-sqs-event.js";
+import type {
+  SimLambdaEventSourceBatchOutcome,
+  SimLambdaEventSourceBatchResponse,
+} from "./sim-lambda-event-source-batch-response.js";
+
+/**
+ * One record of an event source event.
+ *
+ * Every source's records name where they came from, whatever else they carry,
+ * which is as much as delivery needs to know about the shape.
+ */
+export interface SimLambdaEventSourceEventRecord {
+  readonly eventSource: string;
+  readonly eventSourceARN: string;
+}
+
+/**
+ * The event one batch is delivered as.
+ */
+export interface SimLambdaEventSourceEvent {
+  readonly Records: readonly SimLambdaEventSourceEventRecord[];
+}
+
+/**
+ * Builds the event a batch is handed to the function as.
+ *
+ * The shape is the event source's own, so the poller that made the delivery
+ * decides which builder it gets.
+ */
+export interface SimLambdaEventSourceEventBuilder {
+  of(
+    messages: readonly SimLambdaEventSourceMessage[],
+  ): SimLambdaEventSourceEvent;
+}
 
 interface SimLambdaEventSourceDeliveryProperties {
-  readonly mapping: SimLambdaEventSourceMapping;
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly eventBuilder: SimLambdaEventSourceEventBuilder;
+  readonly batchResponse: SimLambdaEventSourceBatchResponse;
 }
 
 /**
@@ -18,17 +45,18 @@ interface SimLambdaEventSourceDeliveryProperties {
  *
  * The batch is invoked directly rather than through the Invoke command because
  * the handler's error has to be seen: an asynchronous invocation drops it, and
- * this is what decides whether the messages go back on the queue.
+ * this is what decides whether the messages go back on the source.
+ *
+ * What the event looks like and what a return value means are the source's
+ * business, so both are handed in rather than built here.
  */
 export class SimLambdaEventSourceDelivery {
-  private readonly eventBuilder: SimLambdaSqsEventBuilder;
-  private readonly batchResponse: SimLambdaSqsBatchResponse;
+  private readonly eventBuilder: SimLambdaEventSourceEventBuilder;
+  private readonly batchResponse: SimLambdaEventSourceBatchResponse;
 
   constructor(properties: SimLambdaEventSourceDeliveryProperties) {
-    this.eventBuilder = new SimLambdaSqsEventBuilder(properties.eventSourceArn);
-    this.batchResponse = new SimLambdaSqsBatchResponse(
-      properties.mapping.reportsBatchItemFailures,
-    );
+    this.eventBuilder = properties.eventBuilder;
+    this.batchResponse = properties.batchResponse;
   }
 
   /**
@@ -37,7 +65,7 @@ export class SimLambdaEventSourceDelivery {
   async to(
     simFunction: SimLambdaFunction,
     messages: readonly SimLambdaEventSourceMessage[],
-  ): Promise<SimLambdaSqsBatchOutcome> {
+  ): Promise<SimLambdaEventSourceBatchOutcome> {
     try {
       return this.batchResponse.handled(
         messages,
@@ -46,7 +74,7 @@ export class SimLambdaEventSourceDelivery {
     } catch {
       // As on real Lambda, the handler error goes to the function's logs and
       // not to whoever sent the message. What the sender sees is the batch
-      // coming back to the queue.
+      // coming back to the source.
       return this.batchResponse.failed(messages);
     }
   }

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
@@ -1,0 +1,33 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceQueues } from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceArn } from "../sim-lambda-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
+import { SimLambdaSqsEventSourcePoller } from "./sim-lambda-sqs-event-source-poller.js";
+
+export interface SimLambdaEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * The poller for the kind of event source a mapping names.
+ *
+ * Which poller a mapping gets is decided here rather than by whoever starts
+ * one, so adding a kind of source is a change here rather than a change to
+ * everything a poller touches. There is one kind so far, so this hands the ARN
+ * straight to the queue poller: the queue poller only accepts a queue ARN, so a
+ * second kind of source fails to compile here rather than being polled as a
+ * queue.
+ */
+export function makeSimLambdaEventSourcePoller(
+  properties: SimLambdaEventSourcePollerProperties,
+): SimLambdaEventSourcePoller {
+  const { eventSourceArn } = properties;
+
+  return new SimLambdaSqsEventSourcePoller({ ...properties, eventSourceArn });
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller.ts
@@ -1,183 +1,26 @@
-import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
-import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
-import type {
-  SimLambdaEventSourceQueueRequest,
-  SimLambdaEventSourceQueues,
-  SimLambdaEventSourceQueueWatcher,
-} from "../queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
-import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
-import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
-import type { SimLambdaSqsBatchOutcome } from "./sim-lambda-sqs-batch-response.js";
-
-interface SimLambdaEventSourcePollerProperties {
-  readonly mapping: SimLambdaEventSourceMapping;
-  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
-  readonly functions: SimLambdaFunctionLookup;
-  readonly queues: SimLambdaEventSourceQueues;
-  readonly background: BackgroundScheduler;
-}
-
 /**
- * Polls one event source mapping's queue and invokes its function.
+ * The running side of one event source mapping.
  *
- * Real Lambda polls a queue continuously. Nothing in this simulation runs
- * continuously, so the queue says when a message has arrived and a poll is
- * scheduled in response. A test that awaits the simulation settling has
- * therefore watched the whole delivery happen, rather than having waited a
- * while and hoped.
- *
- * A batch the function returns from is deleted from the queue. A batch it
- * throws on is left there, which hides it for the visibility timeout and hands
- * it back afterwards, so a redrive policy eventually gives up on it exactly as
- * it would for any other failing consumer. That is why the poller invokes the
- * function directly rather than through the Invoke command: an asynchronous
- * invocation drops its handler error, and this one has to be seen.
+ * A mapping is state a request can read; a poller is the thing behind it that
+ * actually delivers. Each kind of event source has its own poller, and this is
+ * all `SimLambdaEventSourcePollers` needs from any of them: start watching,
+ * poll now, stop.
  */
-export class SimLambdaEventSourcePoller implements SimLambdaEventSourceQueueWatcher {
-  private readonly properties: SimLambdaEventSourcePollerProperties;
-  private readonly delivery: SimLambdaEventSourceDelivery;
-  private readonly schedule: SimLambdaEventSourcePollSchedule;
-
-  private stopped = false;
-
-  constructor(properties: SimLambdaEventSourcePollerProperties) {
-    this.properties = properties;
-    this.delivery = new SimLambdaEventSourceDelivery(properties);
-    this.schedule = new SimLambdaEventSourcePollSchedule({
-      background: properties.background,
-      poll: async (): Promise<void> => {
-        await this.run();
-      },
-    });
-  }
-
+export interface SimLambdaEventSourcePoller {
   /**
-   * Watch the queue this mapping polls.
-   *
-   * Watching starts as soon as the mapping is created, before it has finished
-   * creating, so a message sent in between is not missed. The poll it wakes
-   * finds a mapping that is not polling yet and does nothing, and the poll that
-   * follows activation picks the message up.
+   * Watch the event source this mapping polls, so something arriving on it
+   * wakes a poll.
    */
-  watch(): void {
-    this.properties.queues.watch(this.properties.eventSourceArn.value, this);
-  }
+  watch(): void;
 
   /**
    * Poll as soon as the simulation gets to it, which is what a newly enabled
-   * mapping does with whatever is already on its queue.
+   * mapping does with whatever is already waiting.
    */
-  pollNow(): void {
-    this.schedule.now();
-  }
+  pollNow(): void;
 
   /**
    * Stop polling, as deleting the mapping does.
    */
-  stop(): void {
-    this.stopped = true;
-    this.properties.queues.unwatch(this.properties.eventSourceArn.value, this);
-  }
-
-  /**
-   * Take a message arriving on the queue as something to poll for.
-   */
-  messageAvailable(availableFrom: Date): void {
-    this.schedule.at(availableFrom);
-  }
-
-  /**
-   * Poll once: one batch, delivered and then deleted or left behind.
-   */
-  private async run(): Promise<void> {
-    const simFunction = this.pollingFunction();
-
-    if (simFunction === undefined) {
-      return;
-    }
-
-    // Polling is done as the function's execution role, as on real Lambda, so
-    // simulated IAM decides whether this mapping may read its queue.
-    const request = {
-      queueArn: this.properties.eventSourceArn.value,
-      caller: { kind: "arn", arn: simFunction.roleArn },
-    } as const satisfies SimLambdaEventSourceQueueRequest;
-    const visibilityTimeoutSeconds =
-      await this.properties.queues.visibilityTimeoutSeconds(request);
-    const messages = await this.properties.queues.receive({
-      ...request,
-      batchSize: this.properties.mapping.batchSize,
-    });
-
-    if (messages.length === 0) {
-      this.pollWhenSomethingComesBack();
-
-      return;
-    }
-
-    const outcome = await this.delivery.to(simFunction, messages);
-
-    await this.properties.queues.deleteMessages({
-      ...request,
-      receiptHandles: outcome.handledReceiptHandles,
-    });
-
-    this.pollAgainAfter(outcome, messages.length, visibilityTimeoutSeconds);
-  }
-
-  /**
-   * The function this mapping delivers to, while it should be delivering.
-   *
-   * A mapping still being created is not polling yet, and a disabled one never
-   * is. A function that is not there is not an error here: the mapping simply
-   * has nothing to deliver to.
-   */
-  private pollingFunction(): SimLambdaFunction | undefined {
-    if (this.stopped || !this.properties.mapping.isPolling) {
-      return undefined;
-    }
-
-    return this.properties.functions.find(this.properties.mapping.functionName);
-  }
-
-  /**
-   * Look again when a message the queue could not hand out becomes
-   * receivable.
-   *
-   * A mapping created while every message on its queue is in flight, or one
-   * whose queue holds only delayed messages, has nothing to wake it otherwise.
-   */
-  private pollWhenSomethingComesBack(): void {
-    const availableFrom = this.properties.queues.nextAvailability(
-      this.properties.eventSourceArn.value,
-    );
-
-    if (availableFrom !== undefined) {
-      this.schedule.at(availableFrom);
-    }
-  }
-
-  /**
-   * Decide when this mapping polls again: when a returned batch becomes
-   * visible again, or straight away when a batch filled the request and there
-   * may be more waiting.
-   */
-  private pollAgainAfter(
-    outcome: SimLambdaSqsBatchOutcome,
-    receivedCount: number,
-    visibilityTimeoutSeconds: number,
-  ): void {
-    if (outcome.hasReturnedMessages) {
-      this.schedule.afterSeconds(visibilityTimeoutSeconds);
-
-      return;
-    }
-
-    if (receivedCount >= this.properties.mapping.batchSize) {
-      this.schedule.now();
-    }
-  }
+  stop(): void;
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-batch-response.ts
@@ -1,42 +1,12 @@
-import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimLambdaEventSourceMessage } from "../queue/sim-lambda-event-source-queues.js";
+import { SimLambdaBatchItemFailures } from "./sim-lambda-batch-item-failures.js";
+import {
+  SimLambdaEventSourceBatchOutcome,
+  type SimLambdaEventSourceBatchResponse,
+} from "./sim-lambda-event-source-batch-response.js";
 
 /**
- * What became of one batch handed to a function.
- *
- * A batch is either deleted from the queue or left on it to become visible
- * again. Partial batch responses split it, which is the only reason this is a
- * pair of lists rather than a yes or no.
- */
-export class SimLambdaSqsBatchOutcome {
-  public readonly handled: readonly SimLambdaEventSourceMessage[];
-  public readonly returned: readonly SimLambdaEventSourceMessage[];
-
-  constructor(
-    handled: readonly SimLambdaEventSourceMessage[],
-    returned: readonly SimLambdaEventSourceMessage[],
-  ) {
-    this.handled = handled;
-    this.returned = returned;
-  }
-
-  /**
-   * The receipt handles of the messages to delete from the queue.
-   */
-  get handledReceiptHandles(): readonly string[] {
-    return this.handled.map((message) => message.ReceiptHandle);
-  }
-
-  /**
-   * Whether anything was left on the queue to be delivered again.
-   */
-  get hasReturnedMessages(): boolean {
-    return this.returned.length > 0;
-  }
-}
-
-/**
- * Reads what a function said about the batch it was given.
+ * Reads what a function said about the batch of messages it was given.
  *
  * A function that returns normally has handled the whole batch, unless the
  * mapping was told to expect a batch item failure report and the function sent
@@ -44,11 +14,13 @@ export class SimLambdaSqsBatchOutcome {
  * as on real Lambda: the alternative is to guess which messages the function
  * meant, and guessing wrong loses a message.
  */
-export class SimLambdaSqsBatchResponse {
-  private readonly reportsBatchItemFailures: boolean;
+export class SimLambdaSqsBatchResponse implements SimLambdaEventSourceBatchResponse {
+  private readonly batchItemFailures: SimLambdaBatchItemFailures;
 
   constructor(reportsBatchItemFailures: boolean) {
-    this.reportsBatchItemFailures = reportsBatchItemFailures;
+    this.batchItemFailures = new SimLambdaBatchItemFailures(
+      reportsBatchItemFailures,
+    );
   }
 
   /**
@@ -57,18 +29,18 @@ export class SimLambdaSqsBatchResponse {
   handled(
     messages: readonly SimLambdaEventSourceMessage[],
     result: unknown,
-  ): SimLambdaSqsBatchOutcome {
-    const failedIds = this.reportedFailureIds(result);
+  ): SimLambdaEventSourceBatchOutcome {
+    const failedIds = this.batchItemFailures.idsIn(result);
 
     if (failedIds === undefined) {
-      return new SimLambdaSqsBatchOutcome(messages, []);
+      return new SimLambdaEventSourceBatchOutcome(messages, []);
     }
 
     if (!this.namesBatchMessages(failedIds, messages)) {
       return this.failed(messages);
     }
 
-    return new SimLambdaSqsBatchOutcome(
+    return new SimLambdaEventSourceBatchOutcome(
       messages.filter((message) => !failedIds.includes(message.MessageId)),
       messages.filter((message) => failedIds.includes(message.MessageId)),
     );
@@ -79,26 +51,8 @@ export class SimLambdaSqsBatchResponse {
    */
   failed(
     messages: readonly SimLambdaEventSourceMessage[],
-  ): SimLambdaSqsBatchOutcome {
-    return new SimLambdaSqsBatchOutcome([], messages);
-  }
-
-  /**
-   * The message ids a batch item failure report names, or undefined when the
-   * function reported none.
-   */
-  private reportedFailureIds(result: unknown): readonly string[] | undefined {
-    if (!this.reportsBatchItemFailures || !isRecord(result)) {
-      return undefined;
-    }
-
-    const reported = result["batchItemFailures"];
-
-    if (!Array.isArray(reported) || reported.length === 0) {
-      return undefined;
-    }
-
-    return reported.map((failure: unknown) => itemIdentifier(failure));
+  ): SimLambdaEventSourceBatchOutcome {
+    return new SimLambdaEventSourceBatchOutcome([], messages);
   }
 
   private namesBatchMessages(
@@ -109,25 +63,4 @@ export class SimLambdaSqsBatchResponse {
       messages.some((message) => message.MessageId === failedId),
     );
   }
-}
-
-/**
- * The message id one reported failure names.
- *
- * An entry naming nothing is reported as an empty id, which no message has, so
- * the whole batch goes back. That is what real Lambda does with a malformed
- * report rather than dropping the entry.
- */
-function itemIdentifier(failure: unknown): string {
-  if (!isRecord(failure)) {
-    return "";
-  }
-
-  const identifier = failure["itemIdentifier"];
-
-  if (typeof identifier !== "string") {
-    return "";
-  }
-
-  return identifier;
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
@@ -1,0 +1,28 @@
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
+import { SimLambdaSqsBatchResponse } from "./sim-lambda-sqs-batch-response.js";
+import { SimLambdaSqsEventBuilder } from "./sim-lambda-sqs-event.js";
+
+interface SimLambdaSqsDeliveryProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+}
+
+/**
+ * The delivery an SQS mapping hands its batches over with.
+ *
+ * What the event looks like and what the function's return value means are both
+ * the queue's, so they are put together here and handed to the delivery, which
+ * knows neither.
+ */
+export function makeSimLambdaSqsDelivery(
+  properties: SimLambdaSqsDeliveryProperties,
+): SimLambdaEventSourceDelivery {
+  return new SimLambdaEventSourceDelivery({
+    eventBuilder: new SimLambdaSqsEventBuilder(properties.eventSourceArn),
+    batchResponse: new SimLambdaSqsBatchResponse(
+      properties.mapping.reportsBatchItemFailures,
+    ),
+  });
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-event-source-poller.ts
@@ -1,0 +1,182 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type {
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+} from "../queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceBatchOutcome } from "./sim-lambda-event-source-batch-response.js";
+import type { SimLambdaEventSourceDelivery } from "./sim-lambda-event-source-delivery.js";
+import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
+import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
+import { makeSimLambdaSqsDelivery } from "./sim-lambda-sqs-delivery.js";
+import { SimLambdaSqsPolledQueue } from "./sim-lambda-sqs-polled-queue.js";
+
+interface SimLambdaSqsEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaSqsEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one event source mapping's queue and invokes its function.
+ *
+ * Real Lambda polls a queue continuously. Nothing in this simulation runs
+ * continuously, so the queue says when a message has arrived and a poll is
+ * scheduled in response. A test that awaits the simulation settling has
+ * therefore watched the whole delivery happen, rather than having waited a
+ * while and hoped.
+ *
+ * A batch the function returns from is deleted from the queue. A batch it
+ * throws on is left there, which hides it for the visibility timeout and hands
+ * it back afterwards, so a redrive policy eventually gives up on it exactly as
+ * it would for any other failing consumer. That is why the poller invokes the
+ * function directly rather than through the Invoke command: an asynchronous
+ * invocation drops its handler error, and this one has to be seen.
+ */
+export class SimLambdaSqsEventSourcePoller
+  implements SimLambdaEventSourcePoller, SimLambdaEventSourceQueueWatcher
+{
+  private readonly mapping: SimLambdaEventSourceMapping;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly queue: SimLambdaSqsPolledQueue;
+  private readonly delivery: SimLambdaEventSourceDelivery;
+  private readonly schedule: SimLambdaEventSourcePollSchedule;
+
+  private stopped = false;
+
+  constructor(properties: SimLambdaSqsEventSourcePollerProperties) {
+    this.mapping = properties.mapping;
+    this.functions = properties.functions;
+    this.queue = new SimLambdaSqsPolledQueue(
+      properties.queues,
+      properties.eventSourceArn.value,
+    );
+    this.delivery = makeSimLambdaSqsDelivery(properties);
+    this.schedule = new SimLambdaEventSourcePollSchedule({
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.run();
+      },
+    });
+  }
+
+  /**
+   * Watch the queue this mapping polls.
+   *
+   * Watching starts as soon as the mapping is created, before it has finished
+   * creating, so a message sent in between is not missed. The poll it wakes
+   * finds a mapping that is not polling yet and does nothing, and the poll that
+   * follows activation picks the message up.
+   */
+  watch(): void {
+    this.queue.watch(this);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, which is what a newly enabled
+   * mapping does with whatever is already on its queue.
+   */
+  pollNow(): void {
+    this.schedule.now();
+  }
+
+  /**
+   * Stop polling, as deleting the mapping does.
+   */
+  stop(): void {
+    this.stopped = true;
+    this.queue.unwatch(this);
+  }
+
+  /**
+   * Take a message arriving on the queue as something to poll for.
+   */
+  messageAvailable(availableFrom: Date): void {
+    this.schedule.at(availableFrom);
+  }
+
+  /**
+   * Poll once: one batch, delivered and then deleted or left behind.
+   */
+  private async run(): Promise<void> {
+    const simFunction = this.pollingFunction();
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    // Polling is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its queue.
+    const { roleArn } = simFunction;
+    const timeout = await this.queue.visibilityTimeoutSeconds(roleArn);
+    const messages = await this.queue.receive(roleArn, this.mapping.batchSize);
+
+    if (messages.length === 0) {
+      this.pollWhenSomethingComesBack();
+
+      return;
+    }
+
+    const outcome = await this.delivery.to(simFunction, messages);
+
+    await this.queue.deleteMessages(roleArn, outcome.handledReceiptHandles);
+
+    this.pollAgainAfter(outcome, messages.length, timeout);
+  }
+
+  /**
+   * The function this mapping delivers to, while it should be delivering.
+   *
+   * A mapping still being created is not polling yet, and a disabled one never
+   * is. A function that is not there is not an error here: the mapping simply
+   * has nothing to deliver to.
+   */
+  private pollingFunction(): SimLambdaFunction | undefined {
+    if (this.stopped || !this.mapping.isPolling) {
+      return undefined;
+    }
+
+    return this.functions.find(this.mapping.functionName);
+  }
+
+  /**
+   * Look again when a message the queue could not hand out becomes
+   * receivable.
+   *
+   * A mapping created while every message on its queue is in flight, or one
+   * whose queue holds only delayed messages, has nothing to wake it otherwise.
+   */
+  private pollWhenSomethingComesBack(): void {
+    const availableFrom = this.queue.nextAvailability();
+
+    if (availableFrom !== undefined) {
+      this.schedule.at(availableFrom);
+    }
+  }
+
+  /**
+   * Decide when this mapping polls again: when a returned batch becomes
+   * visible again, or straight away when a batch filled the request and there
+   * may be more waiting.
+   */
+  private pollAgainAfter(
+    outcome: SimLambdaEventSourceBatchOutcome,
+    receivedCount: number,
+    visibilityTimeoutSeconds: number,
+  ): void {
+    if (outcome.hasReturnedMessages) {
+      this.schedule.afterSeconds(visibilityTimeoutSeconds);
+
+      return;
+    }
+
+    if (receivedCount >= this.mapping.batchSize) {
+      this.schedule.now();
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-polled-queue.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-polled-queue.ts
@@ -1,0 +1,80 @@
+import type {
+  SimLambdaEventSourceMessage,
+  SimLambdaEventSourceQueueRequest,
+  SimLambdaEventSourceQueues,
+  SimLambdaEventSourceQueueWatcher,
+} from "../queue/sim-lambda-event-source-queues.js";
+
+/**
+ * The one queue a mapping polls.
+ *
+ * Every call names the same queue, and the ones a poll makes are all made as
+ * the function's execution role, so both are fixed here rather than written out
+ * at each call. Simulated IAM still decides each one, exactly as real IAM does.
+ */
+export class SimLambdaSqsPolledQueue {
+  private readonly queues: SimLambdaEventSourceQueues;
+  private readonly queueArn: string;
+
+  constructor(queues: SimLambdaEventSourceQueues, queueArn: string) {
+    this.queues = queues;
+    this.queueArn = queueArn;
+  }
+
+  /**
+   * Watch for messages arriving on the queue.
+   */
+  watch(watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.queues.watch(this.queueArn, watcher);
+  }
+
+  /**
+   * Stop watching the queue.
+   */
+  unwatch(watcher: SimLambdaEventSourceQueueWatcher): void {
+    this.queues.unwatch(this.queueArn, watcher);
+  }
+
+  /**
+   * When the earliest message the queue cannot hand out yet becomes
+   * receivable.
+   */
+  nextAvailability(): Date | undefined {
+    return this.queues.nextAvailability(this.queueArn);
+  }
+
+  /**
+   * How long a received message stays hidden, and by asking, whether the queue
+   * is there to be polled at all.
+   */
+  async visibilityTimeoutSeconds(roleArn: string): Promise<number> {
+    return await this.queues.visibilityTimeoutSeconds(this.requestAs(roleArn));
+  }
+
+  /**
+   * Take up to a batch of messages off the queue.
+   */
+  async receive(
+    roleArn: string,
+    batchSize: number,
+  ): Promise<readonly SimLambdaEventSourceMessage[]> {
+    return await this.queues.receive({ ...this.requestAs(roleArn), batchSize });
+  }
+
+  /**
+   * Delete the messages the function handled.
+   */
+  async deleteMessages(
+    roleArn: string,
+    receiptHandles: readonly string[],
+  ): Promise<void> {
+    await this.queues.deleteMessages({
+      ...this.requestAs(roleArn),
+      receiptHandles,
+    });
+  }
+
+  private requestAs(roleArn: string): SimLambdaEventSourceQueueRequest {
+    return { queueArn: this.queueArn, caller: { kind: "arn", arn: roleArn } };
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.iso.test.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.iso.test.ts
@@ -1,0 +1,80 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaSqsEventSourceArn } from "./sim-lambda-sqs-event-source-arn.js";
+
+describe("sim Lambda SQS event source ARNs", () => {
+  it("reads the queue a mapping polls out of its ARN", () => {
+    // Given a queue ARN.
+    const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+
+    // When it is read.
+    const eventSourceArn = SimLambdaSqsEventSourceArn.of(queueArn);
+
+    // Then it knows what kind of source it is, and both halves of what a
+    // poller needs come out of it.
+    assertIdentical(eventSourceArn.kind, "sqs");
+    assertIdentical(eventSourceArn.serviceLabel, "SQS");
+    assertIdentical(eventSourceArn.regionName, "eu-west-2");
+    assertIdentical(
+      eventSourceArn.queueUrl,
+      "https://sqs.eu-west-2.amazonaws.com/111111111111/orders",
+    );
+  });
+
+  it("names the operations a poller has to be allowed to call", () => {
+    // Given a queue ARN.
+    const queueArn = "arn:aws:sqs:eu-west-2:111111111111:orders";
+
+    // When its polling permissions are read.
+    const permissions =
+      SimLambdaSqsEventSourceArn.of(queueArn).pollingPermissions;
+
+    // Then they are the three SQS operations real Lambda checks, on the queue,
+    // each naming the operation the way a refusal reports it.
+    assertIdentical(
+      permissions.map((permission) => permission.action).join(","),
+      "sqs:ReceiveMessage,sqs:DeleteMessage,sqs:GetQueueAttributes",
+    );
+    assertIdentical(
+      permissions.map((permission) => permission.operationName).join(","),
+      "ReceiveMessage,DeleteMessage,GetQueueAttributes",
+    );
+    assertIdentical(
+      permissions.map((permission) => permission.resource).join(","),
+      [queueArn, queueArn, queueArn].join(","),
+    );
+  });
+
+  it("answers with nothing for an ARN that is not a queue", () => {
+    // Given an ARN naming something other than a queue.
+    // When it is parsed.
+    const parsed = SimLambdaSqsEventSourceArn.parse(
+      "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+    );
+
+    // Then the dispatcher is left to decide what to say about it.
+    assertUndefined(parsed);
+  });
+
+  it("refuses an ARN that is not a queue when read directly", () => {
+    // Given an ARN naming something other than a queue.
+    // When it is read as a queue ARN.
+    const error = assertThrowsError(() => {
+      SimLambdaSqsEventSourceArn.of("arn:aws:sqs:eu-west-2:orders");
+    });
+
+    // Then it says what a queue ARN looks like.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "is not an SQS queue ARN");
+    assertStringIncludes(
+      error.message,
+      "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+    );
+  });
+});

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,8 +1,36 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { sqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-arn.js";
+import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
 
 const queueArnPattern =
   /^arn:aws:sqs:(?<region>[a-z0-9-]+):(?<account>\d{12}):(?<name>[\w-]{1,80})$/u;
+
+/**
+ * What a function's execution role has to be allowed to do on a queue for
+ * Lambda to poll it.
+ *
+ * These are the three operations real Lambda checks when an SQS event source
+ * mapping is created, and the three its poller performs afterwards.
+ */
+const queuePollingOperations = [
+  "ReceiveMessage",
+  "DeleteMessage",
+  "GetQueueAttributes",
+] as const;
+
+/**
+ * The batch sizes an SQS event source delivers with.
+ *
+ * Ten is both the batch real Lambda uses when the mapping names none, and the
+ * largest batch it delivers from a standard queue without a batching window to
+ * fill a bigger one.
+ */
+const queueBatchRules = new SimLambdaEventSourceBatchRules({
+  defaultSize: 10,
+  maximumSize: 10,
+  sourceDescription: "a queue with no batching window",
+});
 
 /**
  * The queue ARN an event source mapping is created for.
@@ -13,37 +41,69 @@ const queueArnPattern =
  * report.
  */
 export class SimLambdaSqsEventSourceArn {
+  /**
+   * How an ARN naming this kind of event source is written, for a refusal to
+   * say what it wanted instead.
+   */
+  static readonly arnShape =
+    "An SQS queue ARN is arn:aws:sqs:<region>:<account-id>:<queue-name>";
+
+  public readonly kind = "sqs" as const;
+  public readonly serviceLabel = "SQS";
   public readonly value: string;
   public readonly regionName: string;
   public readonly accountId: string;
   public readonly queueName: string;
+  public readonly pollingPermissions: readonly SimLambdaEventSourcePollingPermission[];
 
   private constructor(value: string, parts: Record<string, string>) {
     this.value = value;
     this.regionName = parts["region"] ?? "";
     this.accountId = parts["account"] ?? "";
     this.queueName = parts["name"] ?? "";
+    this.pollingPermissions = queuePollingOperations.map(
+      (operation) =>
+        new SimLambdaEventSourcePollingPermission(`sqs:${operation}`, value),
+    );
   }
 
   /**
-   * Read an event source ARN, refusing one that names no simulated event
-   * source.
+   * Read a queue ARN, answering with nothing when the ARN names something
+   * else.
    *
-   * SQS queues are the only event source this simulation polls, so an ARN for
-   * any other one is refused rather than accepted and never delivered from.
+   * This is what the event source ARN dispatcher asks, so that deciding what a
+   * mapping may name stays in one place rather than in each parser.
    */
-  static of(eventSourceArn: string): SimLambdaSqsEventSourceArn {
-    const parts = queueArnPattern.exec(eventSourceArn)?.groups;
+  static parse(queueArn: string): SimLambdaSqsEventSourceArn | undefined {
+    const parts = queueArnPattern.exec(queueArn)?.groups;
 
     if (parts === undefined) {
+      return undefined;
+    }
+
+    return new this(queueArn, parts);
+  }
+
+  /**
+   * Read a queue ARN, refusing one that is not a queue ARN at all.
+   */
+  static of(queueArn: string): SimLambdaSqsEventSourceArn {
+    const parsed = this.parse(queueArn);
+
+    if (parsed === undefined) {
       throw new SimLambdaInvalidParameterValueException(
-        `EventSourceArn ${eventSourceArn} is not an SQS queue ARN. SQS queues ` +
-          "are the only simulated Lambda event source, and a queue ARN is " +
-          "arn:aws:sqs:<region>:<account-id>:<queue-name>",
+        `${queueArn} is not an SQS queue ARN. ${this.arnShape}`,
       );
     }
 
-    return new this(eventSourceArn, parts);
+    return parsed;
+  }
+
+  /**
+   * The batch sizes a mapping on this queue may deliver with.
+   */
+  get batchRules(): SimLambdaEventSourceBatchRules {
+    return queueBatchRules;
   }
 
   /**

--- a/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
@@ -1,0 +1,49 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+import { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+
+/**
+ * The ARN of an event source a mapping can name.
+ *
+ * A union discriminated by `kind`, so the poller a mapping gets, the
+ * permissions its execution role is checked for and the batch sizes it may ask
+ * for all come from the source the mapping names rather than being assumed.
+ */
+export type SimLambdaEventSourceArn = SimLambdaSqsEventSourceArn;
+
+/**
+ * What this simulation polls, said in one place so every refusal that mentions
+ * it says the same thing.
+ */
+export const simulatedEventSourcesDescription =
+  "SQS queues are the only simulated event source";
+
+/**
+ * The ARN shapes those event sources are named by.
+ */
+const simulatedEventSourceArnShapes: readonly string[] = [
+  SimLambdaSqsEventSourceArn.arnShape,
+];
+
+/**
+ * Read an event source ARN, refusing one that names no simulated event source.
+ *
+ * This is the one place that decides which sources a mapping may name. A source
+ * this simulation cannot poll is refused rather than accepted and never
+ * delivered from.
+ */
+export function simLambdaEventSourceArnOf(
+  eventSourceArn: string,
+): SimLambdaEventSourceArn {
+  const queueArn = SimLambdaSqsEventSourceArn.parse(eventSourceArn);
+
+  if (queueArn === undefined) {
+    const arnShapes = simulatedEventSourceArnShapes.join(" ");
+
+    throw new SimLambdaInvalidParameterValueException(
+      `EventSourceArn ${eventSourceArn} names no simulated Lambda event ` +
+        `source. ${simulatedEventSourcesDescription}. ${arnShapes}`,
+    );
+  }
+
+  return queueArn;
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
@@ -1,0 +1,50 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+interface SimLambdaEventSourceBatchRulesProperties {
+  readonly defaultSize: number;
+  readonly maximumSize: number;
+  readonly sourceDescription: string;
+}
+
+/**
+ * The batch sizes one kind of event source delivers with.
+ *
+ * The default and the maximum belong to the source rather than to the mapping:
+ * how much a queue hands out in one receive is not how much another kind of
+ * source would, and neither is what makes a larger request pointless. The
+ * source description is the clause a refusal explains the range with.
+ */
+export class SimLambdaEventSourceBatchRules {
+  public readonly defaultSize: number;
+  public readonly maximumSize: number;
+
+  private readonly sourceDescription: string;
+
+  constructor(properties: SimLambdaEventSourceBatchRulesProperties) {
+    this.defaultSize = properties.defaultSize;
+    this.maximumSize = properties.maximumSize;
+    this.sourceDescription = properties.sourceDescription;
+  }
+
+  /**
+   * The batch size a mapping delivers with, refusing one this source would
+   * never fill.
+   */
+  sizeIn(requested: number | undefined): number {
+    const batchSize = requested ?? this.defaultSize;
+
+    if (
+      !Number.isSafeInteger(batchSize) ||
+      batchSize < 1 ||
+      batchSize > this.maximumSize
+    ) {
+      throw new SimLambdaInvalidParameterValueException(
+        `BatchSize ${String(batchSize)} is out of range: ` +
+          `${this.sourceDescription} delivers a whole number of messages ` +
+          `between 1 and ${String(this.maximumSize)} at a time`,
+      );
+    }
+
+    return batchSize;
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -10,12 +10,6 @@ export type SimLambdaEventSourceMappingArn =
   `arn:aws:lambda:${string}:${string}:event-source-mapping:${string}`;
 
 /**
- * The batch size real Lambda uses for an SQS event source when the mapping
- * does not name one.
- */
-export const DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE = 10;
-
-/**
  * The response types a mapping can be told the function reports.
  *
  * Only the batch item failure one exists on real Lambda.
@@ -37,7 +31,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly eventSourceArn: string;
   readonly functionName: string;
   readonly functionArn: SimLambdaFunctionArn;
-  readonly batchSize?: number | undefined;
+  readonly batchSize: number;
   readonly enabled?: boolean | undefined;
   readonly functionResponseTypes?:
     readonly SimLambdaFunctionResponseType[] | undefined;
@@ -63,11 +57,14 @@ export interface SimLambdaEventSourceMappingConfiguration {
 }
 
 /**
- * One simulated Lambda event source mapping, from an SQS queue to a function.
+ * One simulated Lambda event source mapping, from an event source to a
+ * function.
  *
  * The mapping holds what polling is done with rather than doing the polling: a
  * poller reads the batch size and the response types from here, and the mapping
- * stays the piece of state a Get or List reports.
+ * stays the piece of state a Get or List reports. What a batch size may be is
+ * the event source's rule, so the mapping is given one rather than defaulting
+ * it.
  */
 export class SimLambdaEventSourceMapping {
   public readonly uuid: string = randomUUID();
@@ -87,8 +84,7 @@ export class SimLambdaEventSourceMapping {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
     this.functionArn = properties.functionArn;
-    this.batchSize =
-      properties.batchSize ?? DEFAULT_SIM_LAMBDA_EVENT_SOURCE_BATCH_SIZE;
+    this.batchSize = properties.batchSize;
     // Copied rather than held, so a caller keeping the list it passed in
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];

--- a/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
@@ -1,8 +1,9 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimLambdaFunctionLookup } from "../function/url/sim-lambda-function-lookup.js";
-import { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller.js";
+import { makeSimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller-factory.js";
+import type { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-poller.js";
 import type { SimLambdaEventSourceQueues } from "./queue/sim-lambda-event-source-queues.js";
-import type { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
 
 interface SimLambdaEventSourcePollersProperties {
@@ -30,15 +31,15 @@ export class SimLambdaEventSourcePollers {
    * Start polling for a newly created mapping.
    *
    * The mapping finishes creating in the background, as it does on real Lambda,
-   * and starts polling once it does. Whatever is already on the queue is polled
-   * for then, because real Lambda does not only deliver what arrives after the
-   * mapping was made.
+   * and starts polling once it does. Whatever is already waiting on the event
+   * source is polled for then, because real Lambda does not only deliver what
+   * arrives after the mapping was made.
    */
   start(
     mapping: SimLambdaEventSourceMapping,
-    eventSourceArn: SimLambdaSqsEventSourceArn,
+    eventSourceArn: SimLambdaEventSourceArn,
   ): void {
-    const poller = new SimLambdaEventSourcePoller({
+    const poller = makeSimLambdaEventSourcePoller({
       ...this.properties,
       mapping,
       eventSourceArn,

--- a/src/service/lambda/event-source/sim-lambda-event-source-polling-permission.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-polling-permission.ts
@@ -1,0 +1,24 @@
+/**
+ * One thing a function's execution role has to be allowed to do for Lambda to
+ * poll an event source.
+ *
+ * The action carries its service prefix, because that is what simulated IAM is
+ * asked. The operation name is read back out of it for a refusal, which names
+ * the operation the way AWS names it.
+ */
+export class SimLambdaEventSourcePollingPermission {
+  public readonly action: string;
+  public readonly resource: string;
+
+  constructor(action: string, resource: string) {
+    this.action = action;
+    this.resource = resource;
+  }
+
+  /**
+   * The operation this permission names, without its service prefix.
+   */
+  get operationName(): string {
+    return this.action.slice(this.action.indexOf(":") + 1);
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-role-permissions.ts
@@ -1,31 +1,22 @@
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
-
-/**
- * What a function's execution role has to be allowed to do on a queue for
- * Lambda to poll it.
- *
- * These are the three operations real Lambda checks when an SQS event source
- * mapping is created, and the three its poller performs afterwards.
- */
-const requiredQueueOperations = [
-  "ReceiveMessage",
-  "DeleteMessage",
-  "GetQueueAttributes",
-] as const;
+import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 
 interface SimLambdaEventSourceRolePermissionsProperties {
   readonly iam: SimIamInterServiceAuthZ;
 }
 
 /**
- * Checks that a function's execution role may poll the queue a mapping names.
+ * Checks that a function's execution role may poll the source a mapping names.
  *
  * Real Lambda refuses to create the mapping at all when the role cannot poll,
  * rather than creating one that silently delivers nothing, so this is checked
  * up front here too. The poller's own calls go through simulated IAM again
  * afterwards, as they do on AWS: this check is about failing early, not about
  * standing in for authorization.
+ *
+ * What has to be allowed comes from the event source, since the operations a
+ * poller performs are the source's own.
  */
 export class SimLambdaEventSourceRolePermissions {
   private readonly iam: SimIamInterServiceAuthZ;
@@ -35,21 +26,25 @@ export class SimLambdaEventSourceRolePermissions {
   }
 
   /**
-   * Refuse a mapping whose execution role cannot poll the queue.
+   * Refuse a mapping whose execution role cannot poll the event source.
    */
-  assertMayPoll(roleArn: string, queueArn: string): void {
-    for (const operation of requiredQueueOperations) {
+  assertMayPoll(
+    roleArn: string,
+    eventSourceArn: SimLambdaEventSourceArn,
+  ): void {
+    for (const permission of eventSourceArn.pollingPermissions) {
       const decision = this.iam.authorize({
-        action: `sqs:${operation}`,
-        resource: queueArn,
+        action: permission.action,
+        resource: permission.resource,
         caller: { kind: "arn", arn: roleArn },
       });
 
       if (decision.isDenied) {
         throw new SimLambdaInvalidParameterValueException(
-          `The provided execution role does not have permissions to call ` +
-            `${operation} on SQS. Role ${roleArn} has no policy allowing ` +
-            `sqs:${operation} on ${queueArn}`,
+          "The provided execution role does not have permissions to call " +
+            `${permission.operationName} on ${eventSourceArn.serviceLabel}. ` +
+            `Role ${roleArn} has no policy allowing ` +
+            `${permission.action} on ${permission.resource}`,
         );
       }
     }


### PR DESCRIPTION
… kind

An event source ARN is read into a discriminated union carrying the kind, a service label, the polling permissions and the batch size rules, so the poller, the role permission check and the batch size check ask the source rather than assuming a queue. SQS behaviour, refusal messages and EventSourceMappingConfiguration output are unchanged.

Resolves https://github.com/KensioSoftware/yulin/issues/338