### PR TITLE
feat: resolve Fn::Select and Fn::Split in simulated CFN templates

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -516,6 +516,94 @@ The value a lookup returns does not have to be a string. A list value is returne
 used in resource properties and in `Outputs`. A map name or key that is not in `Mappings` fails the
 deployment with an error naming the path that could not be found.
 
+### `Fn::Split` and `Fn::Select`
+
+`Fn::Split` cuts a string into a list on a delimiter. `Fn::Select` reads one value out of a list by
+its zero-based index. They are usually written together, to pull one part out of a string another
+resource gave.
+
+```typescript sim-cloudformation-fn-select-split
+/**
+ * Naming a bucket after part of another bucket's domain name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "select-split-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      LogsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            "Fn::Join": [
+              "-",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        ".",
+                        { "Fn::GetAtt": ["SiteBucket", "DomainName"] },
+                      ],
+                    },
+                  ],
+                },
+                "logs",
+              ],
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// site-bucket-logs, from the first part of site-bucket.s3.amazonaws.com
+console.log(simAws.s3().getSimBucketByName("site-bucket-logs")?.bucketName);
+```
+
+The delimiter is a literal string. The string being split can be any expression that resolves to a
+string, including a `Ref`, an `Fn::GetAtt` or another function. A delimiter the string does not
+contain gives a one-element list, and a delimiter at the start or end of the string gives an empty
+element there, as CloudFormation does.
+
+`Fn::Select` takes its list from a literal list, from `Fn::Split`, or from anything else that
+resolves to a list, such as an `Fn::FindInMap` of a list value. The index is a number or a string of
+digits, so a `Ref` to a parameter can supply it.
+
+That pair is how a host is read out of a URL. CDK writes this shape when a CloudFront origin points
+at a Lambda function URL:
+
+```json
+{
+  "DomainName": {
+    "Fn::Select": [
+      2,
+      { "Fn::Split": ["/", { "Fn::GetAtt": ["Url", "FunctionUrl"] }] }
+    ]
+  }
+}
+```
+
+`https://abc123.lambda-url.eu-west-2.on.aws/` splits into
+`["https:", "", "abc123.lambda-url.eu-west-2.on.aws", ""]`, so index 2 is the host.
+
+An index past the end of the list, a negative or fractional index, and a second argument that is not
+a list all fail the deployment, as they are all templates AWS rejects. The error names the resource
+and the property path the value sat at, for example
+`Sim CloudFormation Resource LogsBucket value at Properties.BucketName`.
+
 ## Conditions
 
 A template `Conditions` section names boolean expressions over the stack's parameter values. A
@@ -1264,7 +1352,8 @@ Sim CloudFormation currently supports:
 - Template `Mappings`, read with `Fn::FindInMap`
 - Template `Conditions`, built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`
 - The resource `Condition` attribute, which decides whether a resource is created
-- The `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::FindInMap` and `Fn::If` intrinsic functions
+- The `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::FindInMap`, `Fn::If`, `Fn::Split` and
+  `Fn::Select` intrinsic functions
 - Explicit resource dependencies with `DependsOn`
 - Implicit dependencies from resource `Ref` expressions
 
@@ -1310,6 +1399,9 @@ Each service's own docs describe what its resource types support.
   CloudFormation would reject as well, but the simulator does not reject them up front.
 - `Fn::If` is not supported inside the `Conditions` section itself. It is rejected there rather than
   read against a half-evaluated section.
+- `Fn::Split` and `Fn::Select` accept any argument that resolves to the type they need. Real
+  CloudFormation allows only a named set of functions inside each of them, so a template the
+  simulator resolves may still be one CloudFormation rejects.
 - The `Condition` attribute is read on resources but not on outputs. An output carrying one is
   resolved and present in `stack.outputs` whichever way its condition falls, where real
   CloudFormation would leave it out.

--- a/docs/services/cloudformation/sim-cloudformation-fn-select-split.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-fn-select-split.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Naming a bucket after part of another bucket's domain name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "select-split-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      LogsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            "Fn::Join": [
+              "-",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        ".",
+                        { "Fn::GetAtt": ["SiteBucket", "DomainName"] },
+                      ],
+                    },
+                  ],
+                },
+                "logs",
+              ],
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// site-bucket-logs, from the first part of site-bucket.s3.amazonaws.com
+console.log(simAws.s3().getSimBucketByName("site-bucket-logs")?.bucketName);

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -201,6 +201,8 @@ Supported intrinsic-function areas currently include:
 - `Fn::Sub`
 - `Fn::FindInMap`
 - `Fn::If`
+- `Fn::Split`
+- `Fn::Select`
 
 Resolution happens in two phases:
 
@@ -219,6 +221,30 @@ Resolution happens in two phases:
   here.
 - `Conditions` are not in this context either. The first phase always resolves `Fn::If` away, so
   nothing reaching this phase needs them.
+
+A function whose arguments have not all resolved re-emits itself in template form rather than
+failing, so the second phase parses it again and finishes it. `Fn::Split` over an `Fn::GetAtt` is
+the common case: the first phase leaves `{ "Fn::Split": ["/", { "Fn::GetAtt": [...] }] }` in the
+resource template, which also keeps the logical ID visible to implicit dependency discovery.
+
+Most intrinsic functions resolve to a string. `Fn::Split` resolves to a list, and `Fn::Select`
+resolves to whatever the list entry it picks holds, which may be a list or an object.
+
+### Naming the value that failed
+
+A resolution failure says what was wrong with the expression but not where it sat.
+`template/value/sim-cfn-value-path.ts` fills that in: `SimCfnObject` and `SimCfnList` catch what a
+child throws and add their own key or list position to a path held beside the error, and
+`SimCfnTemplateValueResolver.resolveRecordFor` adds the resource or output name at the top. The
+error object itself is kept, so its type and stack survive, and only its message changes:
+
+```
+Sim CloudFormation Resource LogsBucket value at Properties.BucketName: Sim CloudFormation Fn::Select
+index 9 is out of range for a list of 4 values
+```
+
+Only resolution goes through this. A value that does not parse is left alone, because its message
+already quotes the expression at fault.
 
 ## Conditions
 
@@ -578,6 +604,8 @@ Useful areas:
   - `Fn::Sub`
   - `Fn::FindInMap`
   - `Fn::If`
+  - `Fn::Split`
+  - `Fn::Select`
   - literal/list/object node resolution
 
 - `template/condition/*.iso.test.ts`

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
@@ -197,7 +197,8 @@ describe("SimCfnTemplate Fn::FindInMap Resources", () => {
     // Then a clear missing Mapping value error is thrown.
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::FindInMap could not find map RegionMap.us-east-1.MissingAMI",
+      "Sim CloudFormation Resource TestInstance value at Properties.ImageId: " +
+        "Sim CloudFormation Fn::FindInMap could not find map RegionMap.us-east-1.MissingAMI",
     );
   });
 });

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
@@ -3,6 +3,7 @@ import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-cont
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import { isRecord } from "../../../../../../util/type-guard/record.js";
 import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
 
 /**
  * Simulated CloudFormation `Fn::FindInMap` intrinsic function.
@@ -76,7 +77,7 @@ export class SimCfnFnFindInMap extends SimCfnNode {
       return value;
     }
 
-    if (this.isUnresolvedIntrinsicExpression(value)) {
+    if (isSimCfnUnresolvedExpression(value)) {
       return value;
     }
 
@@ -84,26 +85,6 @@ export class SimCfnFnFindInMap extends SimCfnNode {
     throw new TypeError(
       `Sim CloudFormation Fn::FindInMap keys must each resolve to a string, got ${typeof value}`,
     );
-  }
-
-  private isUnresolvedIntrinsicExpression(
-    value: SimCfnTemplateValue,
-  ): value is Record<string, SimCfnTemplateValue> {
-    /* v8 ignore if */
-    if (!isRecord(value) || Array.isArray(value)) {
-      return false;
-    }
-
-    const entries = Object.entries(value);
-
-    /* v8 ignore if */
-    if (entries.length !== 1) {
-      return false;
-    }
-
-    const functionName = entries[0]?.[0];
-
-    return functionName === "Ref" || functionName?.startsWith("Fn::") === true;
   }
 
   private isResolvedKey(value: SimCfnTemplateValue): value is string {

--- a/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/if/sim-cfn-fn-if.iso.test.ts
@@ -110,7 +110,8 @@ describe("SimCfnTemplate Fn::If", () => {
     // Then the Condition is named rather than read as false.
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::If names Condition IsStaging, which the " +
+      "Sim CloudFormation Resource Site value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::If names Condition IsStaging, which the " +
         "template does not define",
     );
   });

--- a/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/join/sim-cfn-fn-join.iso.test.ts
@@ -240,7 +240,8 @@ describe("CloudFormation Fn::Join Resource value", () => {
     assertInstanceOf(error, TypeError);
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::Join values must each resolve to a string, got number",
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Join values must each resolve to a string, got number",
     );
   });
 });

--- a/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select-refusals.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select-refusals.iso.test.ts
@@ -1,0 +1,212 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import { SimCfnTemplate } from "../../../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Fn::Select refusals", () => {
+  it("refuses an index past the end of the list", () => {
+    // Given an index the list has no value for.
+    const template = templateWithBucketName({
+      "Fn::Select": [2, ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the refusal names the Resource, the property and the range.
+    assertInstanceOf(error, RangeError);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Select index 2 is out of range for a list of 2 values",
+    );
+  });
+
+  it("refuses an index that is not a whole number", () => {
+    // Given a fractional index.
+    const template = templateWithBucketName({
+      "Fn::Select": [1.5, ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the value it was given is quoted back.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Select index must be a whole number, got 1.5",
+    );
+  });
+
+  it("refuses a negative index", () => {
+    // Given an index below the start of the list.
+    const template = templateWithBucketName({
+      "Fn::Select": [-1, ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then it is refused rather than counted from the end.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Select index must be a whole number, got -1",
+    );
+  });
+
+  it("refuses an index string that is not a whole number", () => {
+    // Given an index that is a string of something other than digits.
+    const template = templateWithBucketName({
+      "Fn::Select": ["two", ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the string it was given is quoted back.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        'Sim CloudFormation Fn::Select index must be a whole number, got "two"',
+    );
+  });
+
+  it("refuses values that do not resolve to a list", () => {
+    // Given a second argument that is a single string.
+    const template = templateWithBucketName({
+      "Fn::Select": [0, "first-bucket"],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the refusal names the Resource and the property.
+    assertInstanceOf(error, TypeError);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Select values must resolve to a list, got string",
+    );
+  });
+
+  it("refuses a list with a null entry", () => {
+    // Given a list carrying a null, which CloudFormation rejects.
+    const template = templateWithBucketName({
+      "Fn::Select": [0, ["first-bucket", null]],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the list is refused, even though the index picks a real value.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Select values must not contain null",
+    );
+  });
+
+  it("names the list position a failing Fn::Select sat at", () => {
+    // Given a failing Fn::Select inside a list property.
+    const template = templateWithBucketName("test-bucket", {
+      Tags: ["site", { "Fn::Select": [4, ["first", "second"]] }],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the position in the list is part of the path.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.Tags[1]: " +
+        "Sim CloudFormation Fn::Select index 4 is out of range for a list of 2 values",
+    );
+  });
+
+  it("refuses an Fn::Select that is not a two-item list", () => {
+    // Given an Fn::Select missing its list.
+    const template = templateWithBucketName({ "Fn::Select": [0] });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the expected shape is named.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Select value must be [index, values]",
+    );
+  });
+
+  it("refuses an out-of-range index found at Resource creation time", async () => {
+    // Given a list only a created Resource can supply, selected past its end.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "fn-select-stack",
+        template: {
+          Resources: {
+            SiteBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "site-bucket" },
+            },
+            LogsBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: {
+                BucketName: {
+                  "Fn::Select": [
+                    9,
+                    {
+                      "Fn::Split": [
+                        ".",
+                        { "Fn::GetAtt": ["SiteBucket", "DomainName"] },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the deployment fails naming the Resource and the property.
+    assertStringIncludes(
+      error.message,
+      "Sim CloudFormation Resource LogsBucket creation failed: " +
+        "value at BucketName: Sim CloudFormation Fn::Select index 9 is out " +
+        "of range for a list of 4 values",
+    );
+  });
+});
+
+/**
+ * A template whose Bucket name property is the value under test.
+ */
+function templateWithBucketName(
+  bucketName: SimCfnTemplateValue,
+  otherProperties: Record<string, SimCfnTemplateValue> = {},
+): SimCfnTemplate {
+  return new SimCfnTemplate({
+    stackName: "test-stack",
+    template: {
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: bucketName, ...otherProperties },
+        },
+      },
+    },
+  });
+}

--- a/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.iso.test.ts
@@ -1,0 +1,249 @@
+import {
+  assertArrayEquals,
+  assertNonNullable,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import { SimCfnTemplate } from "../../../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Fn::Select", () => {
+  it("picks a value from a literal list", () => {
+    // Given a Resource property selecting from a list written in the template.
+    const template = templateWithBucketName({
+      "Fn::Select": [1, ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the value at the zero-based index is the property value.
+    assertObjectMatches(properties, { BucketName: "second-bucket" });
+  });
+
+  it("picks a host out of a URL with Fn::Split", () => {
+    // Given the URL-splitting shape CDK writes for a Function URL origin.
+    const template = templateWithBucketName({
+      "Fn::Select": [
+        2,
+        {
+          "Fn::Split": ["/", "https://abc123.lambda-url.eu-west-2.on.aws/"],
+        },
+      ],
+    });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the host is what the property resolves to.
+    assertObjectMatches(properties, {
+      BucketName: "abc123.lambda-url.eu-west-2.on.aws",
+    });
+  });
+
+  it("accepts an index written as a string", () => {
+    // Given an index in the string form a JSON template often carries.
+    const template = templateWithBucketName({
+      "Fn::Select": ["0", ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then it selects the same value the number form would.
+    assertObjectMatches(properties, { BucketName: "first-bucket" });
+  });
+
+  it("accepts an index read from a Parameter", () => {
+    // Given an index supplied as a Parameter, which is always a string.
+    const template = templateWithBucketName(
+      { "Fn::Select": [{ Ref: "Index" }, ["first-bucket", "second-bucket"]] },
+      { Index: { Type: "String", Default: "1" } },
+    );
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the Parameter value is read as the index.
+    assertObjectMatches(properties, { BucketName: "second-bucket" });
+  });
+
+  it("picks a value out of a Mapping list", () => {
+    // Given a Mappings entry holding a list.
+    const template = new SimCfnTemplate({
+      stackName: "test-stack",
+      template: {
+        Mappings: {
+          EnvironmentMap: { staging: { Buckets: ["staging-a", "staging-b"] } },
+        },
+        Resources: {
+          TestBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: {
+                "Fn::Select": [
+                  1,
+                  { "Fn::FindInMap": ["EnvironmentMap", "staging", "Buckets"] },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the list the Mapping gave is selected from.
+    assertObjectMatches(properties, { BucketName: "staging-b" });
+  });
+
+  it("leaves an unresolved list for the Resource creation pass", () => {
+    // Given a list that cannot be built until a Resource exists.
+    const template = templateWithBucketName({
+      "Fn::Select": [
+        2,
+        {
+          "Fn::Split": ["/", { "Fn::GetAtt": ["SiteBucket", "WebsiteURL"] }],
+        },
+      ],
+    });
+
+    // When the Resource templates are read, before any Resource exists.
+    const properties = resolvedProperties(template);
+
+    // Then both functions are re-emitted for the later pass to finish.
+    assertObjectMatches(properties, {
+      BucketName: {
+        "Fn::Select": [
+          2,
+          {
+            "Fn::Split": ["/", { "Fn::GetAtt": ["SiteBucket", "WebsiteURL"] }],
+          },
+        ],
+      },
+    });
+  });
+
+  it("leaves an unresolved index for the Resource creation pass", () => {
+    // Given an index that Refs a Resource rather than a Parameter.
+    const template = templateWithBucketName({
+      "Fn::Select": [{ Ref: "SiteBucket" }, ["first-bucket", "second-bucket"]],
+    });
+
+    // When the Resource templates are read, before any Resource exists.
+    const properties = resolvedProperties(template);
+
+    // Then the whole function waits rather than reading the Ref as an index.
+    assertObjectMatches(properties, {
+      BucketName: {
+        "Fn::Select": [
+          { Ref: "SiteBucket" },
+          ["first-bucket", "second-bucket"],
+        ],
+      },
+    });
+  });
+
+  it("selects an unresolved list entry for the Resource creation pass", () => {
+    // Given a literal list whose selected entry names a Resource attribute.
+    const template = templateWithBucketName({
+      "Fn::Select": [1, ["site", { "Fn::GetAtt": ["SiteBucket", "Arn"] }]],
+    });
+
+    // When the Resource templates are read, before any Resource exists.
+    const properties = resolvedProperties(template);
+
+    // Then the entry itself is what is left to resolve later.
+    assertObjectMatches(properties, {
+      BucketName: { "Fn::GetAtt": ["SiteBucket", "Arn"] },
+    });
+  });
+
+  it("resolves against a Resource once that Resource has been created", async () => {
+    // Given a Bucket named after a part of another Bucket's domain name.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "fn-select-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "site-bucket" },
+          },
+          LogsBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Fn::Select": [
+                        0,
+                        {
+                          "Fn::Split": [
+                            ".",
+                            { "Fn::GetAtt": ["SiteBucket", "DomainName"] },
+                          ],
+                        },
+                      ],
+                    },
+                    "logs",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack has finished deploying.
+    await stack.waitForDeployComplete();
+
+    // Then the Fn::GetAtt inside made the read Resource a dependency.
+    assertArrayEquals(stack.getResource("LogsBucket")?.dependencies(), [
+      "SiteBucket",
+    ]);
+
+    // And the Bucket was created with the selected part of the domain name.
+    assertNonNullable(
+      simAws.s3().getSimBucketByName("site-bucket-logs"),
+      "site-bucket-logs Bucket",
+    );
+  });
+});
+
+/**
+ * A template whose Bucket name property is the value under test.
+ */
+function templateWithBucketName(
+  bucketName: SimCfnTemplateValue,
+  parameters: Record<string, { Type: string; Default: string }> = {},
+): SimCfnTemplate {
+  return new SimCfnTemplate({
+    stackName: "test-stack",
+    template: {
+      Parameters: parameters,
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: bucketName },
+        },
+      },
+    },
+  });
+}
+
+function resolvedProperties(template: SimCfnTemplate): SimCfnTemplateValue {
+  const resourceTemplate = template.resourceTemplates()[0];
+  assertNonNullable(resourceTemplate, "TestBucket Resource template");
+
+  const properties = resourceTemplate.template["Properties"];
+  assertNonNullable(properties, "TestBucket Resource Properties");
+
+  return properties;
+}

--- a/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.ts
+++ b/src/service/cloudformation/template/node/fn/select/sim-cfn-fn-select.ts
@@ -1,0 +1,114 @@
+import { SimCfnNode } from "../../sim-cfn-node.js";
+import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+
+/** A whole number written as a string, as JSON templates often write it. */
+const wholeNumber = /^\d+$/u;
+
+/**
+ * Simulated CloudFormation `Fn::Select` intrinsic function.
+ *
+ * Standard shape:
+ *
+ * {
+ *   "Fn::Select": [2, { "Fn::Split": ["/", "https://example.com/path"] }]
+ * }
+ */
+export class SimCfnFnSelect extends SimCfnNode {
+  constructor(
+    private readonly index: SimCfnNode,
+    private readonly values: SimCfnNode,
+  ) {
+    super();
+  }
+
+  /**
+   * Pick the value at the zero-based index.
+   *
+   * An index or a list that is still an unresolved expression re-emits this
+   * function in template form, so a later resolution pass can finish it once
+   * the Resources it reads exist. The picked value itself may be unresolved,
+   * which the same later pass resolves.
+   */
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const index = this.index.resolve(context);
+    const values = this.values.resolve(context);
+
+    if (
+      isSimCfnUnresolvedExpression(index) ||
+      isSimCfnUnresolvedExpression(values)
+    ) {
+      return { "Fn::Select": [index, values] };
+    }
+
+    if (!Array.isArray(values)) {
+      throw new TypeError(
+        `Sim CloudFormation Fn::Select values must resolve to a list, got ${typeof values}`,
+      );
+    }
+
+    // CloudFormation rejects a list with a null in it, whichever value the
+    // index picks, so this is refused rather than selected from.
+    if (values.includes(null)) {
+      throw new TypeError(
+        "Sim CloudFormation Fn::Select values must not contain null",
+      );
+    }
+
+    return this.valueAt(this.position(index), values);
+  }
+
+  /**
+   * Collect referenced names from the index and the list.
+   */
+  override referencedNames(): string[] {
+    return [...this.index.referencedNames(), ...this.values.referencedNames()];
+  }
+
+  private valueAt(
+    position: number,
+    values: readonly SimCfnTemplateValue[],
+  ): SimCfnTemplateValue {
+    if (position >= values.length) {
+      throw new RangeError(
+        `Sim CloudFormation Fn::Select index ${String(position)} is out of ` +
+          `range for a list of ${String(values.length)} values`,
+      );
+    }
+
+    // eslint-disable-next-line security/detect-object-injection -- checked above
+    const value = values[position];
+    assertDefined(
+      value,
+      `Sim CloudFormation Fn::Select found no value at index ${String(position)}`,
+    );
+
+    return value;
+  }
+
+  /**
+   * The list position an index argument names.
+   *
+   * CloudFormation accepts the index as a JSON number or as a string, because
+   * a `Ref` to a Parameter can only give a string.
+   */
+  private position(index: SimCfnTemplateValue): number {
+    if (
+      typeof index === "number" &&
+      Number.isSafeInteger(index) &&
+      index >= 0
+    ) {
+      return index;
+    }
+
+    if (typeof index === "string" && wholeNumber.test(index)) {
+      return Number(index);
+    }
+
+    throw new TypeError(
+      `Sim CloudFormation Fn::Select index must be a whole number, got ${JSON.stringify(index)}`,
+    );
+  }
+}

--- a/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnTemplate } from "../../../sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Fn::Split", () => {
+  it("splits a literal string on the delimiter", () => {
+    // Given a Resource property splitting a URL on slashes.
+    const template = templateWithTags({
+      "Fn::Split": ["/", "https://example.com/site/index.html"],
+    });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the property is the list of parts, empty parts included.
+    assertObjectMatches(properties, {
+      Tags: ["https:", "", "example.com", "site", "index.html"],
+    });
+  });
+
+  it("splits a value read from a Parameter", () => {
+    // Given a delimiter-separated Parameter value.
+    const template = templateWithTags(
+      { "Fn::Split": [",", { Ref: "Names" }] },
+      { Names: { Type: "String", Default: "alpha,beta" } },
+    );
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the Parameter value is split.
+    assertObjectMatches(properties, { Tags: ["alpha", "beta"] });
+  });
+
+  it("splits on a delimiter the string does not contain", () => {
+    // Given a string with no delimiter in it.
+    const template = templateWithTags({ "Fn::Split": ["|", "one-value"] });
+
+    // When the Resource templates are read.
+    const properties = resolvedProperties(template);
+
+    // Then the whole string is the only element, as CloudFormation gives it.
+    assertObjectMatches(properties, { Tags: ["one-value"] });
+  });
+
+  it("leaves an Fn::GetAtt source for the Resource creation pass", () => {
+    // Given a source that names a Resource attribute.
+    const template = templateWithTags({
+      "Fn::Split": ["/", { "Fn::GetAtt": ["SiteBucket", "WebsiteURL"] }],
+    });
+
+    // When the Resource templates are read, before any Resource exists.
+    const properties = resolvedProperties(template);
+
+    // Then the function is re-emitted for the later pass to finish.
+    assertObjectMatches(properties, {
+      Tags: {
+        "Fn::Split": ["/", { "Fn::GetAtt": ["SiteBucket", "WebsiteURL"] }],
+      },
+    });
+  });
+
+  it("leaves a Resource Ref source for the Resource creation pass", () => {
+    // Given a source that Refs a Resource rather than a Parameter.
+    const template = templateWithTags({
+      "Fn::Split": ["/", { Ref: "SiteBucket" }],
+    });
+
+    // When the Resource templates are read, before any Resource exists.
+    const properties = resolvedProperties(template);
+
+    // Then the unresolved Ref is kept inside the re-emitted function.
+    assertObjectMatches(properties, {
+      Tags: { "Fn::Split": ["/", { Ref: "SiteBucket" }] },
+    });
+  });
+
+  it("refuses a source that does not resolve to a string", () => {
+    // Given a source that is a number.
+    const template = templateWithTags({ "Fn::Split": ["/", 42] });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the refusal names the Resource and the property.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.Tags: " +
+        "Sim CloudFormation Fn::Split source must resolve to a string, got number",
+    );
+  });
+
+  it("refuses a source that resolves to an object", () => {
+    // Given a source that is an object rather than an expression.
+    const template = templateWithTags({
+      "Fn::Split": ["/", { Name: "site", Region: "eu-west-2" }],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then it is refused rather than treated as unresolved work.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.Tags: " +
+        "Sim CloudFormation Fn::Split source must resolve to a string, got object",
+    );
+  });
+
+  it("refuses a single-key object source that is not an intrinsic", () => {
+    // Given a one-key object, which has the shape of an unresolved function.
+    const template = templateWithTags({
+      "Fn::Split": ["/", { Name: "site" }],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the key is what decides it, so this is still the wrong type.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource TestBucket value at Properties.Tags: " +
+        "Sim CloudFormation Fn::Split source must resolve to a string, got object",
+    );
+  });
+
+  it("refuses an Fn::Split that is not a two-item list", () => {
+    // Given an Fn::Split missing its source string.
+    const template = templateWithTags({ "Fn::Split": ["/"] });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the expected shape is named.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Split value must be [delimiter, sourceString]",
+    );
+  });
+
+  it("refuses an Fn::Split delimiter that is not a string", () => {
+    // Given a delimiter that is not a literal string.
+    const template = templateWithTags({
+      "Fn::Split": [{ Ref: "Delimiter" }, "a-b"],
+    });
+
+    // When the Resource templates are read.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then it is refused, as CloudFormation requires a literal delimiter.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::Split delimiter must be a string",
+    );
+  });
+});
+
+/**
+ * A template whose Bucket Tags property is the value under test.
+ */
+function templateWithTags(
+  tags: SimCfnTemplateValue,
+  parameters: Record<string, { Type: string; Default: string }> = {},
+): SimCfnTemplate {
+  return new SimCfnTemplate({
+    stackName: "test-stack",
+    template: {
+      Parameters: parameters,
+      Resources: {
+        TestBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "test-bucket", Tags: tags },
+        },
+      },
+    },
+  });
+}
+
+function resolvedProperties(template: SimCfnTemplate): SimCfnTemplateValue {
+  const resourceTemplate = template.resourceTemplates()[0];
+  assertNonNullable(resourceTemplate, "TestBucket Resource template");
+
+  const properties = resourceTemplate.template["Properties"];
+  assertNonNullable(properties, "TestBucket Resource Properties");
+
+  return properties;
+}

--- a/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
+++ b/src/service/cloudformation/template/node/fn/split/sim-cfn-fn-split.ts
@@ -1,0 +1,53 @@
+import { SimCfnNode } from "../../sim-cfn-node.js";
+import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
+
+/**
+ * Simulated CloudFormation `Fn::Split` intrinsic function.
+ *
+ * Standard shape:
+ *
+ * {
+ *   "Fn::Split": ["/", { "Fn::GetAtt": ["Url", "FunctionUrl"] }]
+ * }
+ */
+export class SimCfnFnSplit extends SimCfnNode {
+  constructor(
+    private readonly delimiter: string,
+    private readonly source: SimCfnNode,
+  ) {
+    super();
+  }
+
+  /**
+   * Split the resolved source string on the delimiter.
+   *
+   * Splitting happens only once the source has resolved to a string. A source
+   * that is still an unresolved expression, such as an `Fn::GetAtt` read
+   * before Resources exist, re-emits this function in template form for a
+   * later resolution pass to finish.
+   */
+  resolve(context: SimCfnResolveContext): SimCfnTemplateValue {
+    const source = this.source.resolve(context);
+
+    if (typeof source === "string") {
+      return source.split(this.delimiter);
+    }
+
+    if (isSimCfnUnresolvedExpression(source)) {
+      return { "Fn::Split": [this.delimiter, source] };
+    }
+
+    throw new TypeError(
+      `Sim CloudFormation Fn::Split source must resolve to a string, got ${typeof source}`,
+    );
+  }
+
+  /**
+   * Collect referenced names from the source expression.
+   */
+  override referencedNames(): string[] {
+    return this.source.referencedNames();
+  }
+}

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-literal.iso.test.ts
@@ -138,7 +138,8 @@ describe("CloudFormation Fn::Sub literals", () => {
     assertInstanceOf(error, TypeError);
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::Sub variable Name must resolve to a string, got number",
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Sub variable Name must resolve to a string, got number",
     );
   });
 });

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
@@ -257,7 +257,8 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertInstanceOf(error, Error);
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::Sub variable UnusedName was not resolved",
+      "Sim CloudFormation Resource DerivedBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::Sub variable UnusedName was not resolved",
     );
   });
 
@@ -286,7 +287,8 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertInstanceOf(error, Error);
     assertIdentical(
       error.message,
-      "Logical ID in CFN Fn::Sub variable .AttributeName must be non-empty",
+      "Sim CloudFormation Resource DerivedBucket value at Properties.BucketName: " +
+        "Logical ID in CFN Fn::Sub variable .AttributeName must be non-empty",
     );
   });
 });

--- a/src/service/cloudformation/template/node/sim-cfn-list.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-list.ts
@@ -1,6 +1,7 @@
 import { SimCfnNode } from "./sim-cfn-node.js";
 import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
 import type { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
+import { resolveSimCfnValueAt } from "../value/sim-cfn-value-path.js";
 
 /**
  * A CloudFormation template array of nodes.
@@ -11,10 +12,12 @@ export class SimCfnList extends SimCfnNode {
   }
 
   /**
-   * Resolve each item in the list.
+   * Resolve each item in the list, naming the position of one that fails.
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValue[] {
-    return this.items.map((item) => item.resolve(context));
+    return this.items.map((item, position) =>
+      resolveSimCfnValueAt(position, () => item.resolve(context)),
+    );
   }
 
   /**

--- a/src/service/cloudformation/template/node/sim-cfn-object.ts
+++ b/src/service/cloudformation/template/node/sim-cfn-object.ts
@@ -1,6 +1,7 @@
 import { SimCfnNode } from "./sim-cfn-node.js";
 import type { SimCfnTemplateValueRecord } from "../value/sim-cfn-template-value.js";
 import type { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
+import { resolveSimCfnValueAt } from "../value/sim-cfn-value-path.js";
 
 /**
  * A plain CloudFormation template object (one that is not an intrinsic function).
@@ -15,7 +16,10 @@ export class SimCfnObject extends SimCfnNode {
    */
   resolve(context: SimCfnResolveContext): SimCfnTemplateValueRecord {
     return Object.fromEntries(
-      [...this.entries].map(([key, node]) => [key, node.resolve(context)]),
+      [...this.entries].map(([key, node]) => [
+        key,
+        resolveSimCfnValueAt(key, () => node.resolve(context)),
+      ]),
     );
   }
 

--- a/src/service/cloudformation/template/parse/fn/select/sim-cfn-fn-select-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/select/sim-cfn-fn-select-parser.ts
@@ -1,0 +1,43 @@
+import { SimCfnFnSelect as SimCfnFunctionSelect } from "../../../node/fn/select/sim-cfn-fn-select.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+
+/**
+ * Parses CloudFormation Fn::Select values.
+ *
+ * Fn::Select has the shape:
+ *
+ * {
+ *   "Fn::Select": [2, { "Fn::Split": ["/", "https://example.com/path"] }]
+ * }
+ *
+ * Both arguments go through the recursive value parser. The index may be a Ref
+ * to a Parameter, and the list may be a literal list or another intrinsic
+ * function that yields one. Whether they resolve to a whole number and a list
+ * is a resolution-time question, so it belongs to the node rather than here.
+ */
+export class SimCfnFnSelectParser {
+  constructor(private readonly valueParser: SimCfnValueParser) {}
+
+  /**
+   * Parse and validate the value inside a Fn::Select expression.
+   */
+  parse(value: SimCfnTemplateValue): SimCfnFunctionSelect {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error(
+        "Sim CloudFormation Fn::Select value must be [index, values]",
+      );
+    }
+
+    const [index, values] = value;
+
+    assertDefined(index, "Fn::Select index");
+    assertDefined(values, "Fn::Select values");
+
+    return new SimCfnFunctionSelect(
+      this.valueParser.parse(index),
+      this.valueParser.parse(values),
+    );
+  }
+}

--- a/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/sim-cfn-function-parser.ts
@@ -6,6 +6,8 @@ import type { SimCfnValueParser } from "../value/sim-cfn-value-parser.type.js";
 import { SimCfnFnSubParser as SimCfnFunctionSubParser } from "./sub/sim-cfn-fn-sub-parser.js";
 import { SimCfnFnFindInMapParser as SimCfnFunctionFindInMapParser } from "./find-in-map/sim-cfn-fn-find-in-map-parser.js";
 import { SimCfnFnIfParser as SimCfnFunctionIfParser } from "./if/sim-cfn-fn-if-parser.js";
+import { SimCfnFnSplitParser as SimCfnFunctionSplitParser } from "./split/sim-cfn-fn-split-parser.js";
+import { SimCfnFnSelectParser as SimCfnFunctionSelectParser } from "./select/sim-cfn-fn-select-parser.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 
 /**
@@ -28,6 +30,8 @@ export class SimCfnFunctionParser {
   private readonly fnJoinParser: SimCfnFunctionJoinParser;
   private readonly fnSubParser: SimCfnFunctionSubParser;
   private readonly fnIfParser: SimCfnFunctionIfParser;
+  private readonly fnSplitParser: SimCfnFunctionSplitParser;
+  private readonly fnSelectParser: SimCfnFunctionSelectParser;
 
   constructor(valueParser: SimCfnValueParser) {
     this.fnGetAttParser = new SimCfnFunctionGetAttParser();
@@ -35,6 +39,8 @@ export class SimCfnFunctionParser {
     this.fnJoinParser = new SimCfnFunctionJoinParser(valueParser);
     this.fnSubParser = new SimCfnFunctionSubParser(valueParser);
     this.fnIfParser = new SimCfnFunctionIfParser(valueParser);
+    this.fnSplitParser = new SimCfnFunctionSplitParser(valueParser);
+    this.fnSelectParser = new SimCfnFunctionSelectParser(valueParser);
   }
 
   /**
@@ -86,6 +92,14 @@ export class SimCfnFunctionParser {
 
     if (functionName === "Fn::If") {
       return this.fnIfParser.parse(value);
+    }
+
+    if (functionName === "Fn::Split") {
+      return this.fnSplitParser.parse(value);
+    }
+
+    if (functionName === "Fn::Select") {
+      return this.fnSelectParser.parse(value);
     }
 
     throw new Error(

--- a/src/service/cloudformation/template/parse/fn/split/sim-cfn-fn-split-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/split/sim-cfn-fn-split-parser.ts
@@ -1,0 +1,44 @@
+import { SimCfnFnSplit as SimCfnFunctionSplit } from "../../../node/fn/split/sim-cfn-fn-split.js";
+import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
+import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+
+/**
+ * Parses CloudFormation Fn::Split values.
+ *
+ * Fn::Split has the shape:
+ *
+ * {
+ *   "Fn::Split": ["/", { "Fn::GetAtt": ["Url", "FunctionUrl"] }]
+ * }
+ *
+ * The delimiter is a literal string, as CloudFormation requires. The source
+ * string goes through the recursive value parser, because it may be a literal,
+ * a Ref, or another intrinsic function.
+ */
+export class SimCfnFnSplitParser {
+  constructor(private readonly valueParser: SimCfnValueParser) {}
+
+  /**
+   * Parse and validate the value inside a Fn::Split expression.
+   */
+  parse(value: SimCfnTemplateValue): SimCfnFunctionSplit {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error(
+        "Sim CloudFormation Fn::Split value must be [delimiter, sourceString]",
+      );
+    }
+
+    const [delimiter, source] = value;
+
+    if (typeof delimiter !== "string") {
+      throw new TypeError(
+        "Sim CloudFormation Fn::Split delimiter must be a string",
+      );
+    }
+
+    assertDefined(source, "Fn::Split source string");
+
+    return new SimCfnFunctionSplit(delimiter, this.valueParser.parse(source));
+  }
+}

--- a/src/service/cloudformation/template/sim-cfn-template-parameters.iso.test.ts
+++ b/src/service/cloudformation/template/sim-cfn-template-parameters.iso.test.ts
@@ -242,7 +242,8 @@ describe("SimCfnTemplate params", () => {
 
     assertIdentical(
       error.message,
-      "Sim CloudFormation Stack TestStack parameter BucketName is missing a value",
+      "Sim CloudFormation Resource TestBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Stack TestStack parameter BucketName is missing a value",
     );
   });
 

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -138,7 +138,10 @@ export class SimCfnTemplate {
       .filter(([logicalId]) => !resourceConditions.excludes(logicalId))
       .map(([logicalId, resourceTemplate]) => ({
         logicalId,
-        template: valueResolver.resolveRecord(resourceTemplate),
+        template: valueResolver.resolveRecordFor(
+          `Sim CloudFormation Resource ${logicalId}`,
+          resourceTemplate,
+        ),
       }));
 
     resourceConditions.assertNotReferenced(resourceTemplates);
@@ -161,7 +164,10 @@ export class SimCfnTemplate {
       })
       .map(([outputKey, outputTemplate]) => ({
         outputKey,
-        template: valueResolver.resolveRecord(outputTemplate),
+        template: valueResolver.resolveRecordFor(
+          `Sim CloudFormation Output ${outputKey}`,
+          outputTemplate,
+        ),
       }));
   }
 

--- a/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-template-value-resolver.ts
@@ -9,6 +9,10 @@ import type { SimCfnPseudoParameters } from "../../parameters/pseudo/sim-cfn-pse
 import { SimCfnResolveContext } from "../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnMappings } from "../mapping/sim-cfn-mappings.js";
 import type { SimCfnConditions } from "../condition/sim-cfn-conditions.js";
+import {
+  resolveSimCfnValueAt,
+  resolveSimCfnValueIn,
+} from "./sim-cfn-value-path.js";
 
 interface SimCfnTemplateValueResolverProperties {
   readonly parameters: SimCfnParameters;
@@ -43,13 +47,45 @@ export class SimCfnTemplateValueResolver {
 
   /**
    * Resolve every value in a CloudFormation template object.
+   *
+   * A value that cannot be resolved carries the name it was stored under, so
+   * the caller can say which property of which Resource was at fault.
    */
   resolveRecord(value: SimCfnTemplateValueRecord): SimCfnTemplateValueRecord {
     return Object.fromEntries(
       Object.entries(value).map(([key, entryValue]) => [
         key,
-        this.resolve(entryValue),
+        this.resolveEntry(key, entryValue),
       ]),
     );
+  }
+
+  /**
+   * Resolve every value in a template object belonging to a named subject.
+   *
+   * The subject is the Resource or Output the object came from, which this
+   * resolver has no way to know. A value that fails to resolve is named with
+   * both, so a template author is told where to look.
+   */
+  resolveRecordFor(
+    subject: string,
+    value: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValueRecord {
+    return resolveSimCfnValueIn(subject, () => this.resolveRecord(value));
+  }
+
+  /**
+   * Resolve one entry, naming it if the value underneath fails.
+   *
+   * Parsing happens outside the catch, because a value that does not parse
+   * fails with a message that already quotes the expression at fault.
+   */
+  private resolveEntry(
+    key: string,
+    value: SimCfnTemplateValue,
+  ): SimCfnTemplateValue {
+    const node = parseSimCfnNode(value);
+
+    return resolveSimCfnValueAt(key, () => node.resolve(this.context));
   }
 }

--- a/src/service/cloudformation/template/value/sim-cfn-unresolved-expression.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-unresolved-expression.ts
@@ -1,0 +1,28 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnTemplateValue } from "./sim-cfn-template-value.js";
+
+/**
+ * Whether a resolved value is still an unresolved intrinsic expression.
+ *
+ * Resolution runs in two phases, so a node can resolve to a `Ref` or an
+ * `Fn::*` object that a later phase finishes. A function reading that value
+ * has to tell it apart from a value the template really carries: an object
+ * with one intrinsic key is deferred work, anything else is the wrong type.
+ */
+export function isSimCfnUnresolvedExpression(
+  value: SimCfnTemplateValue,
+): value is Record<string, SimCfnTemplateValue> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const entries = Object.entries(value);
+
+  if (entries.length !== 1) {
+    return false;
+  }
+
+  const functionName = entries[0]?.[0];
+
+  return functionName === "Ref" || functionName?.startsWith("Fn::") === true;
+}

--- a/src/service/cloudformation/template/value/sim-cfn-value-path.ts
+++ b/src/service/cloudformation/template/value/sim-cfn-value-path.ts
@@ -1,0 +1,128 @@
+/** A key or a list position on the way down to a template value. */
+export type SimCfnValuePathSegment = string | number;
+
+interface SimCfnValuePath {
+  readonly segments: readonly SimCfnValuePathSegment[];
+  readonly reason: string;
+}
+
+/**
+ * Where in the template each failed value sat.
+ *
+ * The path is held beside the error rather than on it, so the error thrown by
+ * a node keeps its own type and stack while it travels back up.
+ */
+const valuePaths = new WeakMap<Error, SimCfnValuePath>();
+
+/**
+ * Resolve a value, naming the key it sat under if it fails.
+ *
+ * A failure on its own says what was wrong with the expression but not which
+ * property held it, which is the part a template author needs. Each container
+ * node adds its own key or list position as the failure passes back up, so the
+ * path is built without any node having to know where it sits.
+ *
+ * Only resolution runs in here. A value that does not parse is left alone,
+ * because its message already quotes the expression at fault.
+ */
+export function resolveSimCfnValueAt<T>(
+  segment: SimCfnValuePathSegment,
+  resolve: () => T,
+): T {
+  try {
+    return resolve();
+  } catch (error) {
+    rethrowSimCfnValueAt(segment, error);
+  }
+}
+
+/**
+ * Resolve a template object, naming the subject it belongs to if it fails.
+ *
+ * The subject is the Resource or Output the values belong to, which the
+ * template value resolver has no way to know.
+ */
+export function resolveSimCfnValueIn<T>(subject: string, resolve: () => T): T {
+  try {
+    return resolve();
+  } catch (error) {
+    rethrowSimCfnValueIn(subject, error);
+  }
+}
+
+function rethrowSimCfnValueAt(
+  segment: SimCfnValuePathSegment,
+  error: unknown,
+): never {
+  /* v8 ignore next 3 -- defensive: resolution throws Errors */
+  if (!(error instanceof Error)) {
+    throw error;
+  }
+
+  const path = extendedValuePath(segment, error);
+  valuePaths.set(error, path);
+  error.message = `value at ${formatSimCfnValuePath(path.segments)}: ${path.reason}`;
+
+  throw error;
+}
+
+/**
+ * A failure carrying no path is rethrown as it is: it comes from reading the
+ * template rather than from one value inside it.
+ */
+function rethrowSimCfnValueIn(subject: string, error: unknown): never {
+  if (!(error instanceof Error)) {
+    /* v8 ignore next -- defensive: resolution throws Errors */
+    throw error;
+  }
+
+  const path = valuePaths.get(error);
+
+  if (path === undefined) {
+    throw error;
+  }
+
+  error.message = `${subject} value at ${formatSimCfnValuePath(path.segments)}: ${path.reason}`;
+
+  throw error;
+}
+
+function extendedValuePath(
+  segment: SimCfnValuePathSegment,
+  error: Error,
+): SimCfnValuePath {
+  const path = valuePaths.get(error);
+
+  if (path === undefined) {
+    return { segments: [segment], reason: error.message };
+  }
+
+  return { segments: [segment, ...path.segments], reason: path.reason };
+}
+
+/**
+ * Write a value path the way a template author reads it, e.g.
+ * `Properties.Origins[0].DomainName`.
+ */
+function formatSimCfnValuePath(
+  segments: readonly SimCfnValuePathSegment[],
+): string {
+  return segments
+    .map((segment, position) => formatSimCfnValuePathSegment(segment, position))
+    .join("");
+}
+
+function formatSimCfnValuePathSegment(
+  segment: SimCfnValuePathSegment,
+  position: number,
+): string {
+  if (typeof segment === "number") {
+    return `[${String(segment)}]`;
+  }
+
+  if (position === 0) {
+    return segment;
+  }
+
+  return `.${segment}`;
+}


### PR DESCRIPTION
Fn::Split cuts a resolved string into a list on a literal delimiter, and Fn::Select reads one entry out of a list by a zero-based index. Both defer to the resource creation pass when an argument is still an unresolved expression, so the Fn::Select over Fn::Split over Fn::GetAtt shape CDK writes for a Function URL origin resolves.

A resolution failure now names the resource and the property path the value sat at, which applies to the existing intrinsics too.

Resolves https://github.com/KensioSoftware/yulin/issues/358