### PR TITLE
feat: capture item changes on a simulated DynamoDB table stream

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2476,6 +2476,109 @@ inert while it was off. A removal already scheduled is checked again when it com
 overwritten with a later timestamp, or one on a table whose time to live has since been switched
 off, stays where it is.
 
+## Capturing changes with a stream
+
+A `StreamSpecification` on `CreateTable` gives a table a stream, and every change to an item is
+captured on it as a record: an `INSERT` for the first write of an item, a `MODIFY` for a write over
+one that was there, and a `REMOVE` for a deletion. `DescribeTable` reports the specification back
+along with `LatestStreamArn` and `LatestStreamLabel`.
+
+Which images a record carries is what `StreamViewType` chooses, and every record carries the keys of
+the item that changed whichever one it is:
+
+| `StreamViewType`     | `INSERT`        | `MODIFY`          | `REMOVE`        |
+| -------------------- | --------------- | ----------------- | --------------- |
+| `KEYS_ONLY`          | keys            | keys              | keys            |
+| `NEW_IMAGE`          | keys, new image | keys, new image   | keys            |
+| `OLD_IMAGE`          | keys            | keys, old image   | keys, old image |
+| `NEW_AND_OLD_IMAGES` | keys, new image | keys, both images | keys, old image |
+
+A `REMOVE` under `NEW_IMAGE` and an `INSERT` under `OLD_IMAGE` are keys and nothing else, because
+neither has the image the view type asks for. The record is still written: it is how a reader learns
+that the change happened at all.
+
+```typescript sim-dynamodb-stream-specification
+/**
+ * A table capturing its item changes on a stream.
+ */
+
+import {
+  CreateTableCommand,
+  DescribeTableCommand,
+  PutItemCommand,
+  UpdateTableCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const described = await dynamoDb.describeTable(
+  new DescribeTableCommand({ TableName: "OrdersTable" }),
+);
+
+console.log(described.Table?.StreamSpecification?.StreamViewType); // "NEW_AND_OLD_IMAGES"
+console.log(described.Table?.LatestStreamArn?.includes("/stream/")); // true
+
+// Every write from here is captured on the stream.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+// Switching the stream off keeps what it captured, and keeps naming it.
+await dynamoDb.updateTable(
+  new UpdateTableCommand({
+    TableName: "OrdersTable",
+    StreamSpecification: { StreamEnabled: false },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const withoutStream = await dynamoDb.describeTable(
+  new DescribeTableCommand({ TableName: "OrdersTable" }),
+);
+
+console.log(withoutStream.Table?.StreamSpecification?.StreamEnabled); // false
+console.log(withoutStream.Table?.LatestStreamArn !== undefined); // true
+```
+
+`UpdateTable` switches a stream on for a table that has none and off for one that has one. A
+`StreamViewType` belongs to the stream rather than to the table, so there is no changing it in
+place: switching the stream off and on again is what AWS makes an application do, and gives the
+table a stream with a fresh label and ARN. Asking to switch on a stream that is already on, or off
+one that is not there, is a `ValidationException` either way.
+
+A time to live expiry is captured as a `REMOVE` carrying
+`userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" }`, where a deletion the
+application asked for carries none. That is how a stream consumer tells an item it deleted from one
+DynamoDB collected.
+
+Nothing is captured for a write that never reached the item: a refused conditional write, a
+cancelled transaction, a delete of a key holding nothing, or a request the table refused. Deleting
+the table takes its items with it rather than removing them one at a time, so nothing is captured
+for that either.
+
+Reading the records back is the DynamoDB Streams API, which is not simulated yet, so for now a
+stream is captured rather than consumed.
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -2791,8 +2894,9 @@ that, which a template cannot predict either way. Two stacks deploying the same 
 differently named tables. The generated name is trimmed to the 255 characters a table name allows,
 ending in a hash of the untrimmed name so two long names that start the same stay apart.
 
-`Fn::GetAtt … StreamArn` on a table that was created is refused by name. Streams are not simulated,
-and an invented stream ARN would read as a working stream to whatever the template handed it to.
+`Fn::GetAtt … StreamArn` on a table that was created is refused by name. A template cannot declare a
+streamed table yet, so a table CloudFormation created never has a stream, and an invented stream ARN
+would read as a working stream to whatever the template handed it to.
 
 A table declaring `StreamSpecification` is skipped rather than created, though, and a skipped
 Resource never reaches that refusal. `Fn::GetAtt … StreamArn` on it resolves to the CloudFormation
@@ -3003,6 +3107,10 @@ nothing is written.
 - `UpdateTimeToLive` and `DescribeTimeToLive`, moving through `ENABLING` and `DISABLING` to settle,
   with the one update per hour rule measured on the simulated clock. Items expire as the clock moves
   past their deletion window, with no sweep for a test to call.
+- `StreamSpecification` on `CreateTable` and `UpdateTable`, capturing every item change as a stream
+  record with the images its `StreamViewType` selects, a time to live expiry carrying a `Service`
+  `userIdentity`, and `StreamSpecification`, `LatestStreamArn` and `LatestStreamLabel` reported by
+  `DescribeTable`.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
   expires items, `Tags` deploying a tagged table, and `GlobalSecondaryIndexes` and
@@ -3091,15 +3199,29 @@ nothing is written.
   elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
   is until something moves the clock. A simulated DynamoDB constructed standalone as
   `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
-- Time to live deletions publish no stream records. Real DynamoDB writes one with a `userIdentity`
-  of type `Service`, which is how an application tells a TTL deletion from an application's own, and
-  streams are not simulated here.
+- A stream's records cannot be read back. `ListStreams`, `DescribeStream`, `GetShardIterator` and
+  `GetRecords` are not simulated yet, so a table with a `StreamSpecification` captures its changes
+  and nothing can consume them. Nor can a Lambda event source mapping read one.
+- A `StreamSpecification` in a CloudFormation template still skips the table, so a streamed table
+  has to be created through `CreateTable`.
+- Records are kept for as long as the simulation runs. Real DynamoDB trims a stream at 24 hours,
+  which arrives with the read path.
 - The five year time to live eligibility rule counts 1825 days rather than five calendar years, so
   an item whose timestamp sits within a couple of days of the boundary may be treated differently
   here to how AWS treats it.
-- DynamoDB streams are not simulated. A `StreamSpecification` with `StreamEnabled` set is refused,
-  so a table whose changes nothing is publishing cannot be created by accident. One that switches
-  streams off describes the table this simulation already makes, so it is accepted.
+- A stream has one shard, which never splits. AWS documents an open shard as corresponding to one
+  table partition, and a simulated table is always one partition, so this is accurate rather than a
+  shortcut. It does mean the records come out in one total order across every key, which is stronger
+  than the per-key order AWS guarantees. A consumer relying on it here would be relying on something
+  real DynamoDB does not promise.
+- Stream sequence numbers are a counter rendered at a fixed 21 digits, where real AWS varies the
+  width between 21 and 40. That makes comparing them as text always agree with comparing them as
+  numbers, which is a divergence in a reader's favour. They are not derived from the clock, because
+  several items commonly change inside one millisecond and a clock cannot tell those apart.
+- A stream record's `SizeBytes` counts the text of each value, summed over the keys and every image
+  the record carries. That is the rule AWS's own published sample records follow, and it is not the
+  rule the 400 KB item limit uses, where a number costs about half its digits.
+- `KinesisStreamSpecification` is not simulated. A table's changes go to its own stream or nowhere.
 - Encryption at rest is not simulated. An `SSESpecification` with `Enabled` set is refused rather
   than reported back against items held in the clear. `Enabled: false` asks for the AWS owned key
   real DynamoDB uses by default, so it is accepted.
@@ -3211,5 +3333,5 @@ nothing is written.
 - Item sizes follow the figures AWS documents for its 400 KB limit, which AWS itself describes as
   approximate. An item near the limit here is near the limit there, but the byte counts are not
   identical.
-- DynamoDB Streams and PartiQL are not simulated, and are not on the roadmap for this service.
+- PartiQL is not simulated, and is not on the roadmap for this service.
 - DynamoDB is not served as an HTTP API by `serveSimAws`.

--- a/docs/services/dynamodb/sim-dynamodb-stream-specification.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-stream-specification.example.ts
@@ -1,0 +1,60 @@
+/**
+ * A table capturing its item changes on a stream.
+ */
+
+import {
+  CreateTableCommand,
+  DescribeTableCommand,
+  PutItemCommand,
+  UpdateTableCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const described = await dynamoDb.describeTable(
+  new DescribeTableCommand({ TableName: "OrdersTable" }),
+);
+
+console.log(described.Table?.StreamSpecification?.StreamViewType); // "NEW_AND_OLD_IMAGES"
+console.log(described.Table?.LatestStreamArn?.includes("/stream/")); // true
+
+// Every write from here is captured on the stream.
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+// Switching the stream off keeps what it captured, and keeps naming it.
+await dynamoDb.updateTable(
+  new UpdateTableCommand({
+    TableName: "OrdersTable",
+    StreamSpecification: { StreamEnabled: false },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+const withoutStream = await dynamoDb.describeTable(
+  new DescribeTableCommand({ TableName: "OrdersTable" }),
+);
+
+console.log(withoutStream.Table?.StreamSpecification?.StreamEnabled); // false
+console.log(withoutStream.Table?.LatestStreamArn !== undefined); // true

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -95,6 +95,7 @@ Table state lives under `table/`.
 - billing mode, provisioned throughput, table class and deletion protection
 - tags
 - in-memory items
+- its stream, and the item changes captured on it
 
 A table is built from values that have already been checked, not from a command object. Anything
 that can produce those values can make one, which is what will let CloudFormation create a table
@@ -106,7 +107,8 @@ The parts of that state UpdateTable can change are held together in
 key that is built from the definitions. The key schema is there too and never changes. Holding them
 together is what lets an update replace them in one step, while everything already holding the table
 goes on reading the table. `SimDynamoDbTableTimeToLive` holds the other mutable part, the time to
-live setting and the item removals it drives.
+live setting and the item removals it drives, and `SimDynamoDbTableStream` holds the third, the
+stream setting and what is captured onto it.
 
 Tables start in `CREATING` status. `SimDynamoDbCreateTable` schedules a background task that later
 activates the table by changing its status to `ACTIVE`.
@@ -205,6 +207,15 @@ The parts an index is made of are a file each, since each has rules of its own:
 Which items an index holds is worked out when the index is read rather than maintained on every
 write, following the precedent `SimSqsQueue.applyLifecycle` sets. So PutItem, UpdateItem and
 DeleteItem stay unaware of indexes apart from one check.
+
+Stream capture is the deliberate exception, and the reason it is one is worth keeping in view when
+reaching for the lazy pattern again. An index is a function of the table's current state, so
+deriving it on read is free. A stream is a log of transitions, and the transitions are not
+recoverable from the state they left behind: putting A, then B, then A leaves state A while owing
+two `MODIFY` records, and an insert followed by a delete leaves the table empty while owing an
+`INSERT` and a `REMOVE`. So a change is written to the stream as it happens, commented at the choke
+point in `SimDynamoDbStream.capture`. The one part of a stream that is genuinely a function of the
+current time, the 24 hour retention trim, will be lazy when it arrives with the reader.
 
 ## Read views
 
@@ -362,7 +373,9 @@ The returned `TableDescription` reports the table back: `TableName`, `TableArn`,
 `KeySchema`, `AttributeDefinitions`, `TableStatus`, `CreationDateTime`, `ProvisionedThroughput`,
 `DeletionProtectionEnabled`, and `BillingModeSummary` or `TableClassSummary` when the request named
 a billing mode or a table class. `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` are each
-there when the table has any of that kind, and left out altogether when it has none. `ItemCount` and `TableSizeBytes` stay at 0.
+there when the table has any of that kind, and left out altogether when it has none.
+`StreamSpecification`, `LatestStreamArn` and `LatestStreamLabel` are there once the table has ever
+had a stream. `ItemCount` and `TableSizeBytes` stay at 0.
 
 Unsimulated inputs are refused with `SimDynamoDbUnsupportedOperation` rather than dropped. Each one
 is listed in the Limitations section of
@@ -374,8 +387,8 @@ is listed in the Limitations section of
 
 The order it works in mirrors CreateTable's:
 
-1. `refuseUnsimulatedUpdateInput` refuses streams, encryption, replicas and the throughput settings
-   beyond provisioned capacity, before anything else looks at the request.
+1. `refuseUnsimulatedUpdateInput` refuses encryption, replicas and the throughput settings beyond
+   provisioned capacity, before anything else looks at the request.
 2. `SimDynamoDbTableAccess` reads the table reference and authorizes `dynamodb:UpdateTable` against
    it.
 3. `table.assertUpdatable()` refuses a table that is not ACTIVE, which is how a second update while
@@ -393,7 +406,14 @@ holds those three privately so they can be replaced, where the rest of a table i
 `SimDynamoDbIndexUpdate` reads `GlobalSecondaryIndexUpdates` into at most one creation or one
 deletion, since that is AWS's limit. `SimDynamoDbTableUpdate` then enforces the wider rule: a billing
 and throughput change, an index creation and an index deletion are one thing at a time, while a
-table class or deletion protection change rides along with any of them.
+table class, deletion protection or stream change rides along with any of them.
+
+`readSimDynamoDbStreamUpdate` is where a `StreamSpecification` is read against the stream the table
+already has, in step 4 with the rest. Switching on a stream that is already on, switching off one
+that is not there, and asking for a different `StreamViewType` on a live stream are all refused with
+a `ValidationException`, as they are on AWS. The third is the same request shape as the first, and
+gets a refusal of its own saying what to do instead: a view type belongs to the stream rather than
+to the table, so a different one means switching the stream off and on again.
 
 A new index has no backfill to run, because which items an index holds is worked out when it is read.
 The CREATING window is a status the scheduler advances rather than work being done, which is
@@ -704,7 +724,7 @@ A batch write takes no `ConditionExpression`, as a real one does not. `SimDynamo
 `SimDynamoDbDeleteRequest` declare one anyway, so a request carrying it is refused by name rather
 than written unconditionally.
 
-Streams are not implemented. Billing mode and provisioned capacity are read and stored by
+Billing mode and provisioned capacity are read and stored by
 CreateTable, for the table and for each global secondary index, but nothing enforces them: no write
 is ever throttled. A local secondary index has no capacity of its own to store, since it is read and
 written out of the table's.
@@ -1057,6 +1077,48 @@ Which object a user intercepts is settled: the document client itself.
 reach it. It does share the base client's `config`, so `serviceId` and `region` resolve the same way
 for both.
 
+## Stream model
+
+Streams live under `stream/`, away from the commands that switch one on, because a stream is table
+state rather than request handling.
+
+- `SimDynamoDbTableStream` is the table's one public field, alongside `timeToLive`. It holds the
+  stream that is on, if any, and the last one the table had, which is what `LatestStreamArn` and
+  `LatestStreamLabel` keep reporting after a stream has been switched off. It is also what the item
+  store reports changes to, so the store never learns whether the table has a stream at all.
+- `SimDynamoDbStream` is one stream: its label, ARN, view type, status, sequence numbers and its
+  shard. Switching a stream off and on again makes a second stream rather than reusing this one,
+  because the label and the ARN are the instant it was enabled.
+- `SimDynamoDbStreamShard` is the one shard a stream has. AWS documents an open shard as one table
+  partition, and a simulated table is always one partition, so this is accurate rather than a
+  shortcut. Nothing splits. The total order it gives across every key is stronger than the per-key
+  order AWS guarantees, which is under Limitations.
+- `SimDynamoDbStreamRecord` is one change as the stream carries it, built from the images, the key
+  schema, the view type and a sequence number. `simDynamoDbStreamImages` is the view type matrix,
+  including the degenerate shapes: a `REMOVE` on a `NEW_IMAGE` stream and an `INSERT` on an
+  `OLD_IMAGE` stream are keys only, and are still written.
+- `simDynamoDbStreamRecordSize` is `SizeBytes`, which is **not** `SimDynamoDbItem.sizeInBytes()`.
+  That one implements the 400 KB item rule, where a number costs about half its digits. The stream
+  rule is the text length of each value, summed over `Keys` and every image the record carries
+  together. The two agree on AWS's published samples only because `101` is three characters either
+  way, and a test reproduces those samples exactly.
+- `SimDynamoDbStreamSequenceNumbers` is a counter, not a clock. Tests write several items inside one
+  millisecond, which a clock cannot tell apart. The numbers are rendered at 21 digits with no
+  leading zero, so comparing them as text gives the same answer as comparing them as numbers. Real
+  AWS varies the width between 21 and 40 digits, which is under Limitations.
+- `SimDynamoDbStreamStore` holds every stream one simulated DynamoDB has made, keyed by ARN, since a
+  stream outlives being switched off and the table has already moved on from naming it.
+- `SimDynamoDbStreamActivity` is the twin of `SimSqsQueueActivity`: it is how a consumer that cannot
+  poll continuously finds out there is something to read. There is no instant on the notification,
+  unlike the queue's, because a stream record is readable the moment it is written.
+
+Capture happens in `SimDynamoDbTableItems`, on `put`, `remove` and `expire`. That pair of writes and
+removals is the only place every item mutation passes through exactly once, and both already read
+the old value to answer with, so the old image costs nothing. It is deliberately not
+`SimDynamoDbTable.putItem` and `deleteItem`: a time to live removal calls `items.expire` directly,
+and that is the one record carrying a `userIdentity`. `expire` is a separate call rather than a flag
+on `remove` so a caller has to decide which of the two it is making.
+
 ## Time to live
 
 Time to live lives under `time-to-live/`, away from the commands that switch it on, because it is
@@ -1076,8 +1138,11 @@ table state rather than request handling.
   under the key now, so one check covers a deleted item, an overwrite with a later TTL, a TTL
   attribute that has gone or changed type, and time to live having been switched off.
 
-`SimDynamoDbTableWrite.commit()` is the single hook. Every write in the service goes through it,
-including batch and transactional ones, so nothing needs a scheduling call of its own.
+`SimDynamoDbTableWrite.commit()` is the single hook for scheduling a removal. Every write in the
+service goes through it, including batch and transactional ones, so nothing needs a scheduling call
+of its own. It is not the hook a stream capture hangs off, because a time to live removal does not
+go through it: that reaches `SimDynamoDbTableItems.expire` directly, which is why capture lives one
+level further in.
 
 Tests that need eventual state should call the broader sim AWS background-drain helper, for example:
 

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -1107,7 +1107,11 @@ state rather than request handling.
   leading zero, so comparing them as text gives the same answer as comparing them as numbers. Real
   AWS varies the width between 21 and 40 digits, which is under Limitations.
 - `SimDynamoDbStreamStore` holds every stream one simulated DynamoDB has made, keyed by ARN, since a
-  stream outlives being switched off and the table has already moved on from naming it.
+  stream outlives being switched off and the table has already moved on from naming it. A table
+  reaches it through `SimDynamoDbTableStream.publishTo`, which `SimDynamoDbCreateTable` calls once
+  the table is in the table store. Registering when the table is built instead would leave a
+  resolvable stream behind for a table refused for a name already in use, since CreateTable checks
+  the name after it has built the table.
 - `SimDynamoDbStreamActivity` is the twin of `SimSqsQueueActivity`: it is how a consumer that cannot
   poll continuously finds out there is something to read. There is no instant on the notification,
   unlike the queue's, because a stream record is readable the moment it is written.

--- a/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
+++ b/src/service/dynamodb/command/sim-dynamodb-command-handlers.ts
@@ -1,6 +1,8 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimDynamoDbStreamActivity } from "../stream/sim-dynamodb-stream-activity.js";
+import type { SimDynamoDbStreamStore } from "../stream/sim-dynamodb-stream-store.js";
 import type { SimDynamoDbTableStore } from "../table/sim-dynamodb-table-store.js";
 import { SimDynamoDbAuthorizer } from "./authorize/sim-dynamodb-authorizer.js";
 import { SimDynamoDbBatchGetItem } from "./batch/sim-dynamodb-batch-get-item.js";
@@ -22,6 +24,8 @@ import { SimDynamoDbTransactWriteItems } from "./transact/sim-dynamodb-transact-
 
 interface SimDynamoDbCommandHandlersProperties {
   readonly tables: SimDynamoDbTableStore;
+  readonly streams: SimDynamoDbStreamStore;
+  readonly streamActivity: SimDynamoDbStreamActivity;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
@@ -68,6 +72,8 @@ export class SimDynamoDbCommandHandlers {
     this.access = access;
     this.tableCreation = new SimDynamoDbCreateTable({
       tables,
+      streams: properties.streams,
+      streamActivity: properties.streamActivity,
       authorizer,
       accountRegionScope,
       background,

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
@@ -3,6 +3,9 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimDynamoDbResourceInUseException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbSecondaryIndexes } from "../../secondary-index/sim-dynamodb-secondary-indexes.js";
+import type { SimDynamoDbStreamActivity } from "../../stream/sim-dynamodb-stream-activity.js";
+import { readSimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream-specification.js";
+import type { SimDynamoDbStreamStore } from "../../stream/sim-dynamodb-stream-store.js";
 import { SimDynamoDbAttributeDefinitions } from "../../table/sim-dynamodb-attribute-definitions.js";
 import { SimDynamoDbKeySchema } from "../../table/sim-dynamodb-key-schema.js";
 import { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
@@ -22,6 +25,8 @@ import { refuseUnsimulatedTableInput } from "./sim-dynamodb-unsimulated-table-in
 
 interface SimDynamoDbCreateTableProperties {
   readonly tables: SimDynamoDbTableStore;
+  readonly streams: SimDynamoDbStreamStore;
+  readonly streamActivity: SimDynamoDbStreamActivity;
   readonly authorizer: SimDynamoDbAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
@@ -46,12 +51,16 @@ interface SimDynamoDbCreateTableOptions {
  */
 export class SimDynamoDbCreateTable {
   private readonly tables: SimDynamoDbTableStore;
+  private readonly streams: SimDynamoDbStreamStore;
+  private readonly streamActivity: SimDynamoDbStreamActivity;
   private readonly authorizer: SimDynamoDbAuthorizer;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
 
   constructor(properties: SimDynamoDbCreateTableProperties) {
     this.tables = properties.tables;
+    this.streams = properties.streams;
+    this.streamActivity = properties.streamActivity;
     this.authorizer = properties.authorizer;
     this.accountRegionScope = properties.accountRegionScope;
     this.background = properties.background;
@@ -140,6 +149,9 @@ export class SimDynamoDbCreateTable {
       tableClass: readSimDynamoDbTableClass(input.TableClass),
       deletionProtectionEnabled: input.DeletionProtectionEnabled,
       tags: SimDynamoDbTableTags.fromInput(input.Tags),
+      stream: readSimDynamoDbStreamSpecification(input.StreamSpecification),
+      streams: this.streams,
+      streamActivity: this.streamActivity,
       background: this.background,
     });
   }

--- a/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-create-table.ts
@@ -110,6 +110,11 @@ export class SimDynamoDbCreateTable {
     }
 
     this.tables.add(table);
+
+    // Only now is the table real, so only now can its stream be resolved by
+    // ARN. A table refused above made its stream while it was being checked,
+    // and that stream goes nowhere with it.
+    table.stream.publishTo(this.streams);
     this.background.schedule(() => table.activate());
 
     return table;
@@ -150,7 +155,6 @@ export class SimDynamoDbCreateTable {
       deletionProtectionEnabled: input.DeletionProtectionEnabled,
       tags: SimDynamoDbTableTags.fromInput(input.Tags),
       stream: readSimDynamoDbStreamSpecification(input.StreamSpecification),
-      streams: this.streams,
       streamActivity: this.streamActivity,
       background: this.background,
     });

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.iso.test.ts
@@ -48,21 +48,6 @@ async function refusedCreateTable(
 }
 
 describe("DynamoDB CreateTableCommand unsimulated input", () => {
-  it("refuses a stream specification", async () => {
-    // When a table is created with a stream.
-    const error = await refusedCreateTable({
-      ...tableInput,
-      StreamSpecification: {
-        StreamEnabled: true,
-        StreamViewType: "NEW_AND_OLD_IMAGES",
-      },
-    });
-
-    // Then the stream is refused.
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-    assertStringIncludes(error.message, "DynamoDB streams");
-  });
-
   it("refuses an encryption specification", async () => {
     // When a table is created with encryption at rest.
     const error = await refusedCreateTable({

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-table-input.ts
@@ -8,17 +8,17 @@ import type { SimDynamoDbSecondaryIndexInput } from "./table.types.js";
  * Each of these changes what the table does, so accepting one and ignoring it
  * would leave a test passing against a table that is not the table the request
  * asked for: items would outlive a time to live that was never applied, and
- * changes would be published to a stream that was never made. Refusing is the
- * louder failure, and the one that happens here rather than in a deployment.
+ * reads would be served from a table left open to callers a resource policy
+ * would have kept out. Refusing is the louder failure, and the one that happens
+ * here rather than in a deployment.
  *
- * Only input that asks for something is refused. A stream or encryption
- * specification that is switched off describes the table this simulation
- * already makes, so it is let through.
+ * Only input that asks for something is refused. An encryption specification
+ * that is switched off describes the table this simulation already makes, so it
+ * is let through.
  */
 export function refuseUnsimulatedTableInput(
   input: SimCreateTableCommandInput,
 ): void {
-  refuseStreams(input);
   refuseEncryption(input);
   refuseThroughputExtras(input);
 
@@ -27,19 +27,6 @@ export function refuseUnsimulatedTableInput(
       "A table ResourcePolicy is not simulated, so CreateTable refuses one " +
         "rather than leaving the table open to callers the policy would have " +
         "kept out",
-    );
-  }
-}
-
-/**
- * Refuse the stream a table's changes would be published to.
- */
-function refuseStreams(input: SimCreateTableCommandInput): void {
-  if (input.StreamSpecification?.StreamEnabled === true) {
-    throw new SimDynamoDbUnsupportedOperation(
-      "DynamoDB streams are not simulated, so CreateTable refuses a " +
-        "StreamSpecification rather than creating a table whose changes are " +
-        "published nowhere",
     );
   }
 }

--- a/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-update-input.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-unsimulated-update-input.ts
@@ -6,24 +6,16 @@ import type { SimUpdateTableCommandInput } from "./table.command.js";
  *
  * Each of these changes what the table does or where it lives, so accepting one
  * and ignoring it would leave a test passing against a table that is not the
- * table the request asked for: changes published to a stream that was never
- * made, or reads served from a region the table was never replicated to.
+ * table the request asked for: items held under an encryption key nothing is
+ * using, or reads served from a region the table was never replicated to.
  *
- * As with CreateTable, only input that asks for something is refused. A stream
- * or encryption specification that is switched off describes the table this
+ * As with CreateTable, only input that asks for something is refused. An
+ * encryption specification that is switched off describes the table this
  * simulation already has.
  */
 export function refuseUnsimulatedUpdateInput(
   input: SimUpdateTableCommandInput,
 ): void {
-  if (input.StreamSpecification?.StreamEnabled === true) {
-    throw new SimDynamoDbUnsupportedOperation(
-      "DynamoDB streams are not simulated, so UpdateTable refuses a " +
-        "StreamSpecification rather than reporting a stream whose changes go " +
-        "nowhere",
-    );
-  }
-
   if (input.SSESpecification?.Enabled === true) {
     throw new SimDynamoDbUnsupportedOperation(
       "Table encryption at rest is not simulated, so UpdateTable refuses an " +

--- a/src/service/dynamodb/command/table/sim-dynamodb-update-table-unsimulated.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-update-table-unsimulated.iso.test.ts
@@ -28,16 +28,6 @@ async function refusedUpdate(
 }
 
 describe("DynamoDB UpdateTableCommand unsimulated settings", () => {
-  it("refuses switching a stream on", async () => {
-    // Given a table, when a stream is switched on, then it is refused rather
-    // than reported as a stream whose changes go nowhere.
-    const error = await refusedUpdate({
-      StreamSpecification: { StreamEnabled: true, StreamViewType: "NEW_IMAGE" },
-    });
-
-    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-  });
-
   it("refuses a customer managed encryption key", async () => {
     // Given a table, when encryption at rest is asked for, then it is refused.
     const error = await refusedUpdate({

--- a/src/service/dynamodb/command/table/table.command.ts
+++ b/src/service/dynamodb/command/table/table.command.ts
@@ -8,11 +8,11 @@ import type {
   SimDynamoDbReplicaUpdateInput,
   SimDynamoDbSecondaryIndexInput,
   SimDynamoDbSseSpecification,
-  SimDynamoDbStreamSpecification,
   SimDynamoDbTableDescription,
   SimDynamoDbTagInput,
   SimDynamoDbWarmThroughput,
 } from "./table.types.js";
+import type { SimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream.types.js";
 
 /**
  * Minimal structural sim DynamoDB CreateTable command.

--- a/src/service/dynamodb/command/table/table.types.ts
+++ b/src/service/dynamodb/command/table/table.types.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../../aws/arn.js";
+import type { SimDynamoDbStreamSpecificationDescription } from "../../stream/sim-dynamodb-stream.types.js";
 
 /**
  * Minimal structural sim DynamoDB table description.
@@ -23,6 +24,10 @@ export interface SimDynamoDbTableDescription {
     readonly SimDynamoDbGlobalSecondaryIndexDescription[] | undefined;
   readonly LocalSecondaryIndexes?:
     readonly SimDynamoDbLocalSecondaryIndexDescription[] | undefined;
+  readonly StreamSpecification?:
+    SimDynamoDbStreamSpecificationDescription | undefined;
+  readonly LatestStreamArn?: SimArn | undefined;
+  readonly LatestStreamLabel?: string | undefined;
 }
 
 /**
@@ -168,14 +173,6 @@ export interface SimDynamoDbReplicaRegionInput {
 export interface SimDynamoDbProjectionInput {
   readonly ProjectionType?: string | undefined;
   readonly NonKeyAttributes?: readonly string[] | undefined;
-}
-
-/**
- * Minimal structural sim DynamoDB stream specification.
- */
-export interface SimDynamoDbStreamSpecification {
-  readonly StreamEnabled?: boolean | undefined;
-  readonly StreamViewType?: string | undefined;
 }
 
 /**

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -4,6 +4,9 @@ import {
 } from "../../util/background/background.js";
 import { SimDynamoDbCommandHandlers } from "./command/sim-dynamodb-command-handlers.js";
 import type * as simDynamoDbCommands from "./command/sim-dynamodb-command.types.js";
+import { SimDynamoDbStreamActivity } from "./stream/sim-dynamodb-stream-activity.js";
+import { SimDynamoDbStreamStore } from "./stream/sim-dynamodb-stream-store.js";
+import type { SimDynamoDbStream } from "./stream/sim-dynamodb-stream.js";
 import { SimDynamoDbTableStore } from "./table/sim-dynamodb-table-store.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
@@ -18,9 +21,16 @@ import type {
 
 /**
  * Simulated DynamoDB. Handles SDK commands. Emulates AWS behaviour and state.
+ *
+ * Each command below carries a one line doc comment rather than a block. This
+ * file grows by one delegating method per simulated operation and is close to
+ * the max-lines limit, which is the same reason `SimAwsServiceAccessors` reads
+ * that way.
  */
 export class SimDynamoDb {
   private readonly tables = new SimDynamoDbTableStore();
+  private readonly streams = new SimDynamoDbStreamStore();
+  private readonly activity = new SimDynamoDbStreamActivity();
   private readonly background: BackgroundScheduler;
   private readonly commands: SimDynamoDbCommandHandlers;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
@@ -38,15 +48,15 @@ export class SimDynamoDb {
     this.background = background;
     this.commands = new SimDynamoDbCommandHandlers({
       tables: this.tables,
+      streams: this.streams,
+      streamActivity: this.activity,
       accountRegionScope,
       iam,
       background,
     });
   }
 
-  /**
-   * Handle a Create Table Command from the SDK.
-   */
+  /** Handle a Create Table Command from the SDK. */
   async createTable(
     command: simDynamoDbCommands.SimCreateTableCommand,
     options?: SimDynamoDbRequestOptions,
@@ -56,9 +66,7 @@ export class SimDynamoDb {
     return this.commands.tableCreation.handle(command, options);
   }
 
-  /**
-   * Handle a Describe Table Command from the SDK.
-   */
+  /** Handle a Describe Table Command from the SDK. */
   async describeTable(
     command: simDynamoDbCommands.SimDescribeTableCommand,
     options?: SimDynamoDbRequestOptions,
@@ -67,9 +75,7 @@ export class SimDynamoDb {
     return this.commands.tables.describeTable(command, options);
   }
 
-  /**
-   * Handle an Update Table Command from the SDK.
-   */
+  /** Handle an Update Table Command from the SDK. */
   async updateTable(
     command: simDynamoDbCommands.SimUpdateTableCommand,
     options?: SimDynamoDbRequestOptions,
@@ -78,9 +84,7 @@ export class SimDynamoDb {
     return this.commands.tableUpdates.handle(command, options);
   }
 
-  /**
-   * Handle a List Tables Command from the SDK.
-   */
+  /** Handle a List Tables Command from the SDK. */
   async listTables(
     command: simDynamoDbCommands.SimListTablesCommand,
     options?: SimDynamoDbRequestOptions,
@@ -89,9 +93,7 @@ export class SimDynamoDb {
     return this.commands.tables.listTables(command, options);
   }
 
-  /**
-   * Handle a Delete Table Command from the SDK.
-   */
+  /** Handle a Delete Table Command from the SDK. */
   async deleteTable(
     command: simDynamoDbCommands.SimDeleteTableCommand,
     options?: SimDynamoDbRequestOptions,
@@ -100,9 +102,7 @@ export class SimDynamoDb {
     return this.commands.tables.deleteTable(command, options);
   }
 
-  /**
-   * Handle a Put Item Command from the SDK.
-   */
+  /** Handle a Put Item Command from the SDK. */
   async putItem(
     command: simDynamoDbCommands.SimPutItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -111,9 +111,7 @@ export class SimDynamoDb {
     return this.commands.itemWrites.handle(command, options);
   }
 
-  /**
-   * Handle a Get Item Command from the SDK.
-   */
+  /** Handle a Get Item Command from the SDK. */
   async getItem(
     command: simDynamoDbCommands.SimGetItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -122,9 +120,7 @@ export class SimDynamoDb {
     return this.commands.itemReads.handle(command, options);
   }
 
-  /**
-   * Handle a Delete Item Command from the SDK.
-   */
+  /** Handle a Delete Item Command from the SDK. */
   async deleteItem(
     command: simDynamoDbCommands.SimDeleteItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -133,9 +129,7 @@ export class SimDynamoDb {
     return this.commands.itemDeletions.handle(command, options);
   }
 
-  /**
-   * Handle an Update Item Command from the SDK.
-   */
+  /** Handle an Update Item Command from the SDK. */
   async updateItem(
     command: simDynamoDbCommands.SimUpdateItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -144,9 +138,7 @@ export class SimDynamoDb {
     return this.commands.itemUpdates.handle(command, options);
   }
 
-  /**
-   * Handle a Query Command from the SDK.
-   */
+  /** Handle a Query Command from the SDK. */
   async query(
     command: simDynamoDbCommands.SimQueryCommand,
     options?: SimDynamoDbRequestOptions,
@@ -155,9 +147,7 @@ export class SimDynamoDb {
     return this.commands.itemQueries.handle(command, options);
   }
 
-  /**
-   * Handle a Scan Command from the SDK.
-   */
+  /** Handle a Scan Command from the SDK. */
   async scan(
     command: simDynamoDbCommands.SimScanCommand,
     options?: SimDynamoDbRequestOptions,
@@ -166,9 +156,7 @@ export class SimDynamoDb {
     return this.commands.itemScans.handle(command, options);
   }
 
-  /**
-   * Handle a Batch Write Item Command from the SDK.
-   */
+  /** Handle a Batch Write Item Command from the SDK. */
   async batchWriteItem(
     command: simDynamoDbCommands.SimBatchWriteItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -177,9 +165,7 @@ export class SimDynamoDb {
     return this.commands.itemBatchWrites.handle(command, options);
   }
 
-  /**
-   * Handle a Batch Get Item Command from the SDK.
-   */
+  /** Handle a Batch Get Item Command from the SDK. */
   async batchGetItem(
     command: simDynamoDbCommands.SimBatchGetItemCommand,
     options?: SimDynamoDbRequestOptions,
@@ -188,9 +174,7 @@ export class SimDynamoDb {
     return this.commands.itemBatchReads.handle(command, options);
   }
 
-  /**
-   * Handle a Transact Write Items Command from the SDK.
-   */
+  /** Handle a Transact Write Items Command from the SDK. */
   async transactWriteItems(
     command: simDynamoDbCommands.SimTransactWriteItemsCommand,
     options?: SimDynamoDbRequestOptions,
@@ -199,9 +183,7 @@ export class SimDynamoDb {
     return this.commands.itemTransactWrites.handle(command, options);
   }
 
-  /**
-   * Handle a Transact Get Items Command from the SDK.
-   */
+  /** Handle a Transact Get Items Command from the SDK. */
   async transactGetItems(
     command: simDynamoDbCommands.SimTransactGetItemsCommand,
     options?: SimDynamoDbRequestOptions,
@@ -210,9 +192,7 @@ export class SimDynamoDb {
     return this.commands.itemTransactReads.handle(command, options);
   }
 
-  /**
-   * Handle a Tag Resource Command from the SDK.
-   */
+  /** Handle a Tag Resource Command from the SDK. */
   async tagResource(
     command: simDynamoDbCommands.SimTagResourceCommand,
     options?: SimDynamoDbRequestOptions,
@@ -221,9 +201,7 @@ export class SimDynamoDb {
     return this.commands.tags.tagResource(command, options);
   }
 
-  /**
-   * Handle an Untag Resource Command from the SDK.
-   */
+  /** Handle an Untag Resource Command from the SDK. */
   async untagResource(
     command: simDynamoDbCommands.SimUntagResourceCommand,
     options?: SimDynamoDbRequestOptions,
@@ -232,9 +210,7 @@ export class SimDynamoDb {
     return this.commands.tags.untagResource(command, options);
   }
 
-  /**
-   * Handle a List Tags Of Resource Command from the SDK.
-   */
+  /** Handle a List Tags Of Resource Command from the SDK. */
   async listTagsOfResource(
     command: simDynamoDbCommands.SimListTagsOfResourceCommand,
     options?: SimDynamoDbRequestOptions,
@@ -243,9 +219,7 @@ export class SimDynamoDb {
     return this.commands.tags.listTagsOfResource(command, options);
   }
 
-  /**
-   * Handle an Update Time To Live Command from the SDK.
-   */
+  /** Handle an Update Time To Live Command from the SDK. */
   async updateTimeToLive(
     command: simDynamoDbCommands.SimUpdateTimeToLiveCommand,
     options?: SimDynamoDbRequestOptions,
@@ -254,9 +228,7 @@ export class SimDynamoDb {
     return this.commands.timeToLive.updateTimeToLive(command, options);
   }
 
-  /**
-   * Handle a Describe Time To Live Command from the SDK.
-   */
+  /** Handle a Describe Time To Live Command from the SDK. */
   async describeTimeToLive(
     command: simDynamoDbCommands.SimDescribeTimeToLiveCommand,
     options?: SimDynamoDbRequestOptions,
@@ -275,6 +247,25 @@ export class SimDynamoDb {
    */
   findTable(name: string): SimDynamoDbTable | undefined {
     return this.tables.findByName(name);
+  }
+
+  /**
+   * Find a stream by ARN, if there is one here.
+   *
+   * Not a DynamoDB API operation. A stream outlives being enabled, so this
+   * finds one whose table has since switched it off, which is what reading a
+   * disabled stream within its retention window needs.
+   */
+  findStream(streamArn: string): SimDynamoDbStream | undefined {
+    return this.streams.findByArn(streamArn);
+  }
+
+  /**
+   * Get the streams of this service, for a consumer that cannot poll them
+   * continuously.
+   */
+  streamActivity(): SimDynamoDbStreamActivity {
+    return this.activity;
   }
 
   /**

--- a/src/service/dynamodb/stream/sim-dynamodb-item-change.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-item-change.ts
@@ -1,0 +1,36 @@
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+
+/**
+ * One change to one item of a table, as the item store saw it happen.
+ *
+ * This is a transition rather than a state: what was under the key before, and
+ * what is under it now. A change with no new image is a removal, one with no
+ * old image is an insertion, and one with neither never happened and is never
+ * reported.
+ */
+export interface SimDynamoDbItemChange {
+  readonly oldImage: SimDynamoDbItem | undefined;
+  readonly newImage: SimDynamoDbItem | undefined;
+
+  /**
+   * Whether time to live took the item, rather than a request.
+   *
+   * This is the one thing a stream record cannot work out from the images. It
+   * is what `userIdentity` reports, and it is how an application tells its own
+   * deletions from the ones it never asked for.
+   */
+  readonly expired: boolean;
+}
+
+/**
+ * Something told about every change to a table's items.
+ *
+ * The item store reports to this rather than to a stream, so the store stays
+ * unaware of whether the table it holds items for has a stream at all.
+ */
+export interface SimDynamoDbItemChanges {
+  /**
+   * Take a change that has already happened to the table's items.
+   */
+  capture(change: SimDynamoDbItemChange): void;
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-activity.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-activity.iso.test.ts
@@ -1,0 +1,85 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbStreamWatcher } from "./sim-dynamodb-stream-activity.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * A consumer that counts how often it was told to look.
+ */
+class CountingWatcher implements SimDynamoDbStreamWatcher {
+  public count = 0;
+
+  recordsAvailable(): void {
+    this.count += 1;
+  }
+}
+
+/**
+ * Write an order onto the streamed table.
+ */
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+}
+
+describe("DynamoDB stream activity", () => {
+  it("tells a watcher when a record is written", async () => {
+    // Given something watching a table's stream.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    const streamArn = table.stream.current?.arn;
+    assertDefined(streamArn, "stream ARN");
+    const watcher = new CountingWatcher();
+    simAws.dynamoDb().streamActivity().watch(streamArn, watcher);
+
+    // When two items are written.
+    await putOrder(simAws, "order-1");
+    await putOrder(simAws, "order-2");
+
+    // Then it was told about each, which is what stands in for the continuous
+    // polling nothing here can do.
+    assertIdentical(watcher.count, 2);
+  });
+
+  it("stops telling a watcher that has stopped watching", async () => {
+    // Given a watcher that has been told about one record and stopped.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    const streamArn = table.stream.current?.arn;
+    assertDefined(streamArn, "stream ARN");
+    const watcher = new CountingWatcher();
+    const activity = simAws.dynamoDb().streamActivity();
+    activity.watch(streamArn, watcher);
+    await putOrder(simAws, "order-1");
+    activity.unwatch(streamArn, watcher);
+
+    // When another item is written.
+    await putOrder(simAws, "order-2");
+
+    // Then it hears nothing more.
+    assertIdentical(watcher.count, 1);
+  });
+
+  it("finds a stream by the ARN a table reports", async () => {
+    // Given a table with a stream.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    const streamArn = table.stream.current?.arn;
+    assertDefined(streamArn, "stream ARN");
+
+    // Then the service resolves that ARN to the stream it names, and an ARN
+    // naming nothing to nothing.
+    assertIdentical(
+      simAws.dynamoDb().findStream(streamArn),
+      table.stream.current,
+    );
+    assertUndefined(simAws.dynamoDb().findStream(`${streamArn}-other`));
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-activity.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-activity.iso.test.ts
@@ -1,7 +1,12 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
-import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimDynamoDbStreamWatcher } from "./sim-dynamodb-stream-activity.js";
 import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
@@ -65,6 +70,27 @@ describe("DynamoDB stream activity", () => {
 
     // Then it hears nothing more.
     assertIdentical(watcher.count, 1);
+  });
+
+  it("holds no stream for a table that was refused", async () => {
+    // Given a streamed table, and an hour later a second create for the same
+    // name, which is built and checked before the name is found to be taken.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-04T09:00:00.000Z")),
+    });
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await simAws.clock().advanceBy({ hours: 1 });
+    await assertThrowsErrorAsync(async () =>
+      simDynamoDbStreamedTableFactory.make({}, simAws),
+    );
+
+    // Then the stream the refused table made while it was being checked is not
+    // resolvable, since its ARN names a table that was never created.
+    assertUndefined(
+      simAws
+        .dynamoDb()
+        .findStream(`${table.arn}/stream/2026-08-04T10:00:00.000`),
+    );
   });
 
   it("finds a stream by the ARN a table reports", async () => {

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-activity.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-activity.ts
@@ -1,0 +1,59 @@
+/**
+ * Something outside DynamoDB waiting for changes on a table's stream.
+ *
+ * A Lambda event source mapping is the one this exists for: real Lambda polls a
+ * stream continuously, and nothing in this simulation runs continuously, so the
+ * stream says when there is something to poll for instead.
+ */
+export interface SimDynamoDbStreamWatcher {
+  /**
+   * A record has been written, and can be read now.
+   *
+   * There is no instant here, unlike the queue watcher this mirrors. A stream
+   * record is readable the moment it is written: nothing delays one, and
+   * nothing hides one that has been handed out.
+   */
+  recordsAvailable(): void;
+}
+
+/**
+ * What a consumer that cannot poll continuously needs from the streams of one
+ * simulated DynamoDB: to be told when a record has been written.
+ *
+ * Watchers are held by stream ARN rather than on the stream itself, so a
+ * watcher survives whatever the stream does, and so the stream model stays a
+ * log rather than a subscription list.
+ */
+export class SimDynamoDbStreamActivity {
+  private readonly watchers = new Map<string, SimDynamoDbStreamWatcher[]>();
+
+  /**
+   * Watch a stream for the records written to it.
+   */
+  watch(streamArn: string, watcher: SimDynamoDbStreamWatcher): void {
+    this.watchers.set(streamArn, [...this.watchersOf(streamArn), watcher]);
+  }
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimDynamoDbStreamWatcher): void {
+    this.watchers.set(
+      streamArn,
+      this.watchersOf(streamArn).filter((held) => held !== watcher),
+    );
+  }
+
+  /**
+   * Tell a stream's watchers that there is something to read.
+   */
+  recordsAvailable(streamArn: string): void {
+    for (const watcher of this.watchersOf(streamArn)) {
+      watcher.recordsAvailable();
+    }
+  }
+
+  private watchersOf(streamArn: string): readonly SimDynamoDbStreamWatcher[] {
+    return this.watchers.get(streamArn) ?? [];
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-arn.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-arn.ts
@@ -1,0 +1,37 @@
+import type { SimArn } from "../../aws/arn.js";
+
+/**
+ * The instant a stream being enabled now takes its label from.
+ *
+ * A label is the instant the stream was enabled, and two streams on one table
+ * cannot share one: the label is what tells them apart in the ARN. Simulated
+ * time can stand still, so a stream enabled at an instant a previous one
+ * already took is moved on by a millisecond rather than colliding with it.
+ */
+export function simDynamoDbStreamLabelInstant(
+  now: Date,
+  previous: Date | undefined,
+): Date {
+  if (previous === undefined || now.getTime() > previous.getTime()) {
+    return now;
+  }
+
+  return new Date(previous.getTime() + 1);
+}
+
+/**
+ * The label a stream enabled at an instant carries.
+ *
+ * DynamoDB labels a stream with the instant it was enabled, to the
+ * millisecond and without the trailing zone marker: `2026-08-04T09:00:00.000`.
+ */
+export function simDynamoDbStreamLabel(at: Date): string {
+  return at.toISOString().replace("Z", "");
+}
+
+/**
+ * The ARN a table's stream has, which is the table's own ARN and the label.
+ */
+export function simDynamoDbStreamArn(tableArn: SimArn, label: string): SimArn {
+  return `${tableArn}/stream/${label}`;
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-capture-nothing.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-capture-nothing.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  DeleteItemCommand,
+  DeleteTableCommand,
+  PutItemCommand,
+  TransactWriteItemsCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * What a table's stream captured, oldest first.
+ */
+function capturedBy(
+  table: SimDynamoDbTable,
+): readonly SimDynamoDbStreamRecord[] {
+  return table.stream.latest?.records ?? [];
+}
+
+/**
+ * Write an order onto a streamed table.
+ */
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: orderId }, total: { N: "101" } },
+    }),
+  );
+}
+
+describe("DynamoDB stream capture of what did not happen", () => {
+  it("captures nothing on a table with no stream", async () => {
+    // Given a table created without a StreamSpecification.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "orders", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When items are written and deleted.
+    await putOrder(simAws, "order-1");
+    await simAws.dynamoDb().deleteItem(
+      new DeleteItemCommand({
+        TableName: "orders",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then the table never made a stream to capture any of it onto, and says
+    // so rather than reporting one that is switched off.
+    assertUndefined(table.stream.latest);
+    assertUndefined(table.stream.specification());
+  });
+
+  it("captures nothing for a failed conditional write", async () => {
+    // Given an item on a streamed table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When a write guarded by a condition that does not hold is refused.
+    await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().putItem(
+        new PutItemCommand({
+          TableName: "orders",
+          Item: { orderId: { S: "order-1" }, total: { N: "202" } },
+          ConditionExpression: "attribute_not_exists(orderId)",
+        }),
+      ),
+    );
+
+    // Then only the write that happened is on the stream.
+    assertArrayLength(capturedBy(table), 1);
+  });
+
+  it("captures nothing for a write the table refused", async () => {
+    // Given a streamed table holding one item.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When a write is refused for a key of the wrong type, which is checked
+    // before anything reaches the items.
+    await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().putItem(
+        new PutItemCommand({
+          TableName: "orders",
+          Item: { orderId: { N: "1" }, total: { N: "202" } },
+        }),
+      ),
+    );
+
+    // Then nothing was captured for it, since nothing changed.
+    assertArrayLength(capturedBy(table), 1);
+  });
+
+  it("captures nothing for a cancelled transaction", async () => {
+    // Given a streamed table holding one item.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When a transaction whose second action cannot be applied is cancelled.
+    await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().transactWriteItems(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "orders",
+                Item: { orderId: { S: "order-2" }, total: { N: "1" } },
+              },
+            },
+            {
+              Put: {
+                TableName: "orders",
+                Item: { orderId: { S: "order-1" }, total: { N: "2" } },
+                ConditionExpression: "attribute_not_exists(orderId)",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    // Then neither action reached the items, so neither is on the stream.
+    assertArrayLength(capturedBy(table), 1);
+  });
+
+  it("captures nothing for a delete of a key holding nothing", async () => {
+    // Given a streamed table holding nothing.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    // When a key that was never written is deleted, which DynamoDB accepts.
+    await simAws.dynamoDb().deleteItem(
+      new DeleteItemCommand({
+        TableName: "orders",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then nothing was removed, so there is no removal to report.
+    assertArrayLength(capturedBy(table), 0);
+  });
+
+  it("captures nothing for the items a deleted table was holding", async () => {
+    // Given a streamed table holding an item.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, "order-1");
+
+    // When the table itself is deleted.
+    await simAws
+      .dynamoDb()
+      .deleteTable(new DeleteTableCommand({ TableName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the items go with the table rather than being removed one at a
+    // time, so only the write that happened is on the stream.
+    assertArrayLength(capturedBy(table), 1);
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-capture.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-capture.iso.test.ts
@@ -1,0 +1,136 @@
+import {
+  DeleteItemCommand,
+  PutItemCommand,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The keys every record here carries.
+ */
+const keys = { orderId: { S: "order-1" } };
+
+/**
+ * The item as it is written, and as it is written again.
+ */
+const firstOrder = { ...keys, total: { N: "101" } };
+const secondOrder = { ...keys, total: { N: "202" } };
+
+/**
+ * What a table's stream captured, oldest first.
+ */
+function capturedBy(
+  table: SimDynamoDbTable,
+): readonly SimDynamoDbStreamRecord[] {
+  return table.stream.latest?.records ?? [];
+}
+
+/**
+ * The record a change left at a position, which is always there.
+ */
+function recordAt(
+  table: SimDynamoDbTable,
+  position: number,
+): SimDynamoDbStreamRecord {
+  const record = capturedBy(table).at(position);
+  assertDefined(record, "DynamoDB stream record");
+
+  return record;
+}
+
+/**
+ * Write an item onto the streamed table.
+ */
+async function putOrder(
+  simAws: SimAws,
+  item: Record<string, { S: string } | { N: string }>,
+): Promise<void> {
+  await simAws
+    .dynamoDb()
+    .putItem(new PutItemCommand({ TableName: "orders", Item: item }));
+}
+
+describe("DynamoDB stream capture", () => {
+  it("captures an INSERT for the first write of an item", async () => {
+    // Given a table with a stream.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    // When an item is written for the first time.
+    await putOrder(simAws, firstOrder);
+
+    // Then the change is on the stream as an insertion, carrying the keys and
+    // the item that was written and nothing before it.
+    const record = recordAt(table, 0);
+    assertIdentical(record.eventName, "INSERT");
+    assertObjectEquals(record.keys.toAttributeValues(), keys);
+    assertObjectEquals(record.newImage?.toAttributeValues(), firstOrder);
+    assertUndefined(record.oldImage);
+    assertUndefined(record.userIdentity);
+  });
+
+  it("captures a MODIFY with both images for a second write", async () => {
+    // Given an item that has been written once.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, firstOrder);
+
+    // When the same key is written again.
+    await putOrder(simAws, secondOrder);
+
+    // Then the second change is a modification carrying what the item was and
+    // what it became.
+    const record = recordAt(table, 1);
+    assertIdentical(record.eventName, "MODIFY");
+    assertObjectEquals(record.oldImage?.toAttributeValues(), firstOrder);
+    assertObjectEquals(record.newImage?.toAttributeValues(), secondOrder);
+  });
+
+  it("captures a REMOVE carrying the old image and no new one", async () => {
+    // Given an item on a streamed table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, firstOrder);
+
+    // When the application deletes it.
+    await simAws
+      .dynamoDb()
+      .deleteItem(new DeleteItemCommand({ TableName: "orders", Key: keys }));
+
+    // Then the removal carries what was taken away, and no identity: the
+    // application asked for this one itself.
+    const record = recordAt(table, 1);
+    assertIdentical(record.eventName, "REMOVE");
+    assertObjectEquals(record.oldImage?.toAttributeValues(), firstOrder);
+    assertUndefined(record.newImage);
+    assertUndefined(record.userIdentity);
+  });
+
+  it("captures a MODIFY for an update that changes nothing", async () => {
+    // Given an item on a streamed table.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await putOrder(simAws, firstOrder);
+
+    // When UpdateItem is called with no UpdateExpression, which stores the
+    // item that was already there.
+    await simAws
+      .dynamoDb()
+      .updateItem(new UpdateItemCommand({ TableName: "orders", Key: keys }));
+
+    // Then the write is captured anyway. Real DynamoDB writes a record for
+    // that request too, so comparing the images to decide would report less
+    // than AWS does.
+    assertIdentical(recordAt(table, 1).eventName, "MODIFY");
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-images.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-images.ts
@@ -1,0 +1,41 @@
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbItemChange } from "./sim-dynamodb-item-change.js";
+
+/**
+ * The images one stream record carries beyond its keys.
+ */
+export interface SimDynamoDbStreamImages {
+  readonly newImage: SimDynamoDbItem | undefined;
+  readonly oldImage: SimDynamoDbItem | undefined;
+}
+
+/**
+ * Which images a record carries, which is the whole of what a view type does.
+ *
+ * The degenerate shapes are the point of reading this as a matrix rather than
+ * as a choice per record: a removal on a `NEW_IMAGE` stream has no new image to
+ * carry, and an insertion on an `OLD_IMAGE` stream has no old one, so both come
+ * out as keys and nothing else. Real DynamoDB still writes those records, and
+ * so does this, since the record is how a reader learns the change happened at
+ * all.
+ */
+export function simDynamoDbStreamImages(
+  change: SimDynamoDbItemChange,
+  viewType: SimDynamoDbStreamViewType,
+): SimDynamoDbStreamImages {
+  switch (viewType) {
+    case "KEYS_ONLY": {
+      return { newImage: undefined, oldImage: undefined };
+    }
+    case "NEW_IMAGE": {
+      return { newImage: change.newImage, oldImage: undefined };
+    }
+    case "OLD_IMAGE": {
+      return { newImage: undefined, oldImage: change.oldImage };
+    }
+    case "NEW_AND_OLD_IMAGES": {
+      return { newImage: change.newImage, oldImage: change.oldImage };
+    }
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-lifecycle.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-lifecycle.iso.test.ts
@@ -192,6 +192,7 @@ describe("DynamoDB stream lifecycle", () => {
     await simDynamoDbStreamedTableFactory.make({}, simAws);
     const before = await describeOrders(simAws);
     const first = before.LatestStreamArn;
+    const firstLabel = before.LatestStreamLabel;
     await simAws.dynamoDb().updateTable(
       new UpdateTableCommand({
         TableName: "orders",
@@ -222,6 +223,12 @@ describe("DynamoDB stream lifecycle", () => {
     assertDefined(first, "first stream ARN");
     assertDefined(description.LatestStreamArn, "second stream ARN");
     assertFalse(description.LatestStreamArn === first);
+
+    // The label is what tells them apart inside the ARN, and it is the instant
+    // the stream was enabled, which the clock has not moved past.
+    assertDefined(firstLabel, "first stream label");
+    assertDefined(description.LatestStreamLabel, "second stream label");
+    assertFalse(description.LatestStreamLabel === firstLabel);
   });
 
   it("refuses switching on a stream the table already has", async () => {

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-lifecycle.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-lifecycle.iso.test.ts
@@ -1,0 +1,352 @@
+import {
+  DescribeTableCommand,
+  PutItemCommand,
+  UpdateTableCommand,
+} from "@aws-sdk/client-dynamodb";
+import type { UpdateTableCommandInput } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+import type { SimDynamoDbTableDescription } from "../command/table/table.types.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * Describe the table every test here works on.
+ */
+async function describeOrders(
+  simAws: SimAws,
+): Promise<SimDynamoDbTableDescription> {
+  const described = await simAws
+    .dynamoDb()
+    .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+  assertDefined(described.Table, "DynamoDB table description");
+
+  return described.Table;
+}
+
+/**
+ * Update the table every test here works on, and answer with what it refused.
+ */
+async function refusedUpdate(
+  simAws: SimAws,
+  input: Omit<UpdateTableCommandInput, "TableName">,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await simAws
+      .dynamoDb()
+      .updateTable(new UpdateTableCommand({ TableName: "orders", ...input }));
+  });
+}
+
+describe("DynamoDB stream lifecycle", () => {
+  it("reports the stream a table was created with", async () => {
+    // Given a table created with a stream.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make(
+      { viewType: "NEW_AND_OLD_IMAGES" },
+      simAws,
+    );
+
+    // When the table is described.
+    const description = await describeOrders(simAws);
+
+    // Then it reports the specification, and the ARN and label of the stream
+    // that specification made, which is on and taking changes.
+    assertObjectEquals(description.StreamSpecification, {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    });
+    assertIdentical(table.stream.current?.status, "ENABLED");
+    assertStringStartsWith(
+      description.LatestStreamArn ?? "",
+      "arn:aws:dynamodb:",
+    );
+    assertDefined(description.LatestStreamLabel, "latest stream label");
+    assertStringIncludes(
+      description.LatestStreamArn ?? "",
+      `:table/orders/stream/${description.LatestStreamLabel}`,
+    );
+  });
+
+  it("reports nothing for a table that never had a stream", async () => {
+    // Given a table created without one.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "orders", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // Then it reports no specification at all, rather than one that is off.
+    const description = await describeOrders(simAws);
+    assertUndefined(description.StreamSpecification);
+    assertUndefined(description.LatestStreamArn);
+    assertUndefined(description.LatestStreamLabel);
+  });
+
+  it("switches a stream on for a table that has none", async () => {
+    // Given a table with no stream, holding an item written before it had one.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "orders", partitionKeyName: "orderId" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When a stream is switched on and another item is written.
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: {
+          StreamEnabled: true,
+          StreamViewType: "NEW_IMAGE",
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-2" } },
+      }),
+    );
+
+    // Then the stream carries what changed after it was switched on, and
+    // nothing from before: a stream is a log of transitions rather than a
+    // view of the table.
+    assertArrayLength(table.stream.latest?.records ?? [], 1);
+    assertObjectEquals(
+      table.stream.latest?.records[0]?.newImage?.toAttributeValues(),
+      { orderId: { S: "order-2" } },
+    );
+  });
+
+  it("switches a stream off, keeping what it captured", async () => {
+    // Given a streamed table holding an item.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When the stream is switched off and another item is written.
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-2" } },
+      }),
+    );
+
+    // Then the table reports the stream as off while still naming it, since
+    // AWS keeps the last stream's ARN on a table that has switched it off.
+    const description = await describeOrders(simAws);
+    assertObjectEquals(description.StreamSpecification, {
+      StreamEnabled: false,
+    });
+    assertDefined(description.LatestStreamArn, "latest stream ARN");
+
+    // And the stream kept the record it had already taken, and took no more.
+    // Its shard is closed, which is how a reader finds out there will be no
+    // more coming.
+    assertArrayLength(table.stream.latest?.records ?? [], 1);
+    assertUndefined(table.stream.current);
+    assertIdentical(table.stream.latest?.status, "DISABLED");
+    assertFalse(table.stream.latest.shard.isOpen);
+  });
+
+  it("gives a re-enabled stream an ARN of its own", async () => {
+    // Given a streamed table whose stream has been switched off, on a clock
+    // that has not moved since it was switched on. A label is the instant the
+    // stream was enabled, so this is the case where two of them would collide.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-04T09:00:00.000Z")),
+    });
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+    const before = await describeOrders(simAws);
+    const first = before.LatestStreamArn;
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a stream is switched on again, with a different view type.
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: {
+          StreamEnabled: true,
+          StreamViewType: "KEYS_ONLY",
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then it is a new stream, with a label and an ARN of its own, and
+    // anything holding the old ARN is holding the old stream.
+    const description = await describeOrders(simAws);
+    assertObjectEquals(description.StreamSpecification, {
+      StreamEnabled: true,
+      StreamViewType: "KEYS_ONLY",
+    });
+    assertDefined(first, "first stream ARN");
+    assertDefined(description.LatestStreamArn, "second stream ARN");
+    assertFalse(description.LatestStreamArn === first);
+  });
+
+  it("refuses switching on a stream the table already has", async () => {
+    // Given a table whose stream is already on.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    // When the same stream is asked for again.
+    const error = await refusedUpdate(simAws, {
+      StreamSpecification: {
+        StreamEnabled: true,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+    });
+
+    // Then it is refused rather than quietly replacing the stream.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "already has an enabled stream");
+  });
+
+  it("refuses changing a stream's view type in place", async () => {
+    // Given a table whose stream is on with one view type.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make(
+      { viewType: "NEW_IMAGE" },
+      simAws,
+    );
+
+    // When another view type is asked for on the same stream.
+    const error = await refusedUpdate(simAws, {
+      StreamSpecification: {
+        StreamEnabled: true,
+        StreamViewType: "OLD_IMAGE",
+      },
+    });
+
+    // Then it is refused, saying what to do instead: a view type belongs to
+    // the stream, so a different one means a different stream.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "cannot be changed in place");
+  });
+
+  it("refuses switching off a stream the table does not have", async () => {
+    // Given a table with no stream.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "orders", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When the stream is switched off.
+    const error = await refusedUpdate(simAws, {
+      StreamSpecification: { StreamEnabled: false },
+    });
+
+    // Then it is refused rather than accepted as a request for the state the
+    // table is already in.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "does not have an enabled stream");
+  });
+
+  it("refuses switching a stream on without a view type", async () => {
+    // Given a table with no stream.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "orders", partitionKeyName: "orderId" },
+      simAws,
+    );
+
+    // When a stream is asked for without saying which images it carries.
+    const error = await refusedUpdate(simAws, {
+      StreamSpecification: { StreamEnabled: true },
+    });
+
+    // Then it is refused, since a record with no view type would have no rule
+    // about which images it carries.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "StreamViewType is required");
+  });
+
+  it("refuses a view type DynamoDB does not have", async () => {
+    // When a table is created asking for a view type that is not one.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().createTable({
+        input: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: {
+            StreamEnabled: true,
+            StreamViewType: "BOTH_IMAGES",
+          },
+        },
+      }),
+    );
+
+    // Then it is refused naming what was asked for.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "Unknown StreamViewType BOTH_IMAGES");
+  });
+
+  it("refuses a stream specification that does not say whether it is on", async () => {
+    // When a table is created with a specification carrying only a view type.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().createTable({
+        input: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_IMAGE" },
+        },
+      }),
+    );
+
+    // Then it is refused, rather than making a table with no stream out of a
+    // request that plainly asked for one.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(error.message, "StreamEnabled is required");
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-record-fields.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-record-fields.iso.test.ts
@@ -1,0 +1,60 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertSetSize,
+  assertStringLength,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The instant this test starts from.
+ */
+const startedAt = new Date("2026-08-04T09:00:00.000Z");
+
+/**
+ * Write an order onto the streamed table.
+ */
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+}
+
+describe("DynamoDB stream record numbering", () => {
+  it("numbers records in order at one width, on the simulated clock", async () => {
+    // Given several items written inside one millisecond of simulated time.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await simAws.clock().advanceBy({ hours: 1 });
+    await Promise.all([
+      putOrder(simAws, "order-1"),
+      putOrder(simAws, "order-2"),
+      putOrder(simAws, "order-3"),
+    ]);
+
+    // Then each record has its own sequence number, and the numbers sort the
+    // same way as text and as numbers: a clock could not have told these apart
+    // at all. What the clock does say is when the change happened.
+    const records = table.stream.latest?.records ?? [];
+    const numbers = records.map((record) => record.sequenceNumber);
+    assertArrayLength(numbers, 3);
+    assertSetSize(new Set(numbers), 3);
+
+    for (const [position, number] of numbers.entries()) {
+      assertStringLength(number, 21);
+      assertTrue(position === 0 || number > (numbers[position - 1] ?? ""));
+      assertIdentical(
+        records.at(position)?.approximateCreationDateTime.toISOString(),
+        "2026-08-04T10:00:00.000Z",
+      );
+    }
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-record-keys.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-record-keys.ts
@@ -1,0 +1,33 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+
+/**
+ * The `Keys` of a stream record, cut from the item that changed.
+ *
+ * Every record carries these, whatever view type the stream was enabled with,
+ * because a reader that cannot say which item changed cannot do anything with
+ * the record. A `KEYS_ONLY` stream is that and nothing else.
+ *
+ * The item is whichever image the change has: an insertion and a modification
+ * have a new one, a removal has only the old one, and the key attributes are
+ * the same in either since an update cannot move an item's primary key.
+ */
+export function simDynamoDbStreamRecordKeys(
+  item: SimDynamoDbItem,
+  keySchema: SimDynamoDbKeySchema,
+): SimDynamoDbItem {
+  const attributes = new Map<string, SimDynamoDbValue>();
+
+  for (const attributeName of keySchema.attributeNames()) {
+    const value = item.attribute(attributeName);
+
+    // An item is stored under its primary key, so one that changed carries
+    // every key attribute. Missing one would be the simulator's own fault.
+    assertDefined(value, `DynamoDB key attribute ${attributeName}`);
+    attributes.set(attributeName, value);
+  }
+
+  return SimDynamoDbItem.ofAttributes(attributes);
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-record-size.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-record-size.iso.test.ts
@@ -1,0 +1,88 @@
+import { DeleteItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { simDynamoDbStreamRecordSize } from "./sim-dynamodb-stream-record-size.js";
+
+/**
+ * The table AWS's own published stream records were written against: a Number
+ * partition key named `Id`, and a String `Message` alongside it.
+ */
+async function messageTable(simAws: SimAws): Promise<void> {
+  await simAws.dynamoDb().createTable({
+    input: {
+      TableName: "messages",
+      KeySchema: [{ AttributeName: "Id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "Id", AttributeType: "N" }],
+      BillingMode: "PAY_PER_REQUEST",
+      StreamSpecification: {
+        StreamEnabled: true,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+    },
+  });
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * Write a message under the key AWS's samples use.
+ */
+async function putMessage(simAws: SimAws, message: string): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "messages",
+      Item: { Id: { N: "101" }, Message: { S: message } },
+    }),
+  );
+}
+
+/**
+ * The three records AWS publishes as a worked example of a table's stream.
+ */
+async function publishedRecords(): Promise<readonly SimDynamoDbStreamRecord[]> {
+  const simAws = new SimAws();
+  await messageTable(simAws);
+
+  await putMessage(simAws, "New item!");
+  await putMessage(simAws, "This item has changed");
+  await simAws.dynamoDb().deleteItem(
+    new DeleteItemCommand({
+      TableName: "messages",
+      Key: { Id: { N: "101" } },
+    }),
+  );
+
+  const table = simAws.dynamoDb().findTable("messages");
+  assertDefined(table, "messages table");
+
+  return table.stream.latest?.records ?? [];
+}
+
+describe("DynamoDB stream record size", () => {
+  it("measures AWS's own published records exactly", async () => {
+    // When the three changes AWS publishes as a worked example are made.
+    const records = await publishedRecords();
+
+    // Then each record is the size AWS reports for it: the keys plus every
+    // image the record carries, counted as the text each value is written as.
+    assertIdentical(records[0]?.sizeBytes, 26);
+    assertIdentical(records[1]?.sizeBytes, 59);
+    assertIdentical(records[2]?.sizeBytes, 38);
+  });
+
+  it("counts a number as its digits, unlike the item size rule", () => {
+    // Given an item carrying an eight digit number.
+    const item = SimDynamoDbItem.fromAttributeValues({
+      n: { N: "12345678" },
+    });
+
+    // Then the stream counts the name and every digit, where the 400 KB item
+    // rule counts a number as roughly half its digits. The two agree on AWS's
+    // published samples only because `101` is three characters either way.
+    assertIdentical(simDynamoDbStreamRecordSize([item]), 9);
+    assertIdentical(item.sizeInBytes(), 6);
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-record-size.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-record-size.ts
@@ -1,0 +1,101 @@
+import { simDynamoDbBinaryText } from "../item/sim-dynamodb-binary.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { simDynamoDbTextSize } from "../item/sim-dynamodb-value-size.js";
+import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+
+/**
+ * The bytes one value counts towards a stream record's size.
+ *
+ * This is not `simDynamoDbValueSize`, and the difference is deliberate. That
+ * one implements the 400 KB item rule, where a number costs
+ * `ceil(significantDigits / 2) + 1` and a list or a map carries three bytes of
+ * overhead. A stream record is measured as the text it carries instead, so an
+ * eight digit number costs 8 here and 5 there. The two agree on AWS's own
+ * published samples only because `101` is three characters either way.
+ *
+ * A boolean and a null are the text the record carries them as, `true` or
+ * `false`, and a collection is its elements with no overhead. AWS publishes no
+ * sample covering those, so they follow the same rule the rest do rather than
+ * inventing a second one.
+ */
+function streamValueSize(value: SimDynamoDbValue): number {
+  switch (value.kind) {
+    case "S": {
+      return simDynamoDbTextSize(value.text);
+    }
+    case "N": {
+      return simDynamoDbTextSize(value.number.text);
+    }
+    case "B": {
+      return simDynamoDbTextSize(simDynamoDbBinaryText(value.bytes));
+    }
+    case "BOOL": {
+      return simDynamoDbTextSize(String(value.boolean));
+    }
+    case "NULL": {
+      return simDynamoDbTextSize("true");
+    }
+    case "SS": {
+      return value.texts.reduce(
+        (total, text) => total + simDynamoDbTextSize(text),
+        0,
+      );
+    }
+    case "NS": {
+      return value.numbers.reduce(
+        (total, number) => total + simDynamoDbTextSize(number.text),
+        0,
+      );
+    }
+    case "BS": {
+      return value.bytes.reduce(
+        (total, bytes) =>
+          total + simDynamoDbTextSize(simDynamoDbBinaryText(bytes)),
+        0,
+      );
+    }
+    case "L": {
+      return value.values.reduce(
+        (total, element) => total + streamValueSize(element),
+        0,
+      );
+    }
+    case "M": {
+      return value.entries
+        .entries()
+        .reduce(
+          (total, [name, element]) =>
+            total + simDynamoDbTextSize(name) + streamValueSize(element),
+          0,
+        );
+    }
+  }
+}
+
+/**
+ * The bytes one image counts towards a stream record's size.
+ */
+function streamImageSize(image: SimDynamoDbItem): number {
+  return image
+    .entries()
+    .entries()
+    .reduce(
+      (total, [name, value]) =>
+        total + simDynamoDbTextSize(name) + streamValueSize(value),
+      0,
+    );
+}
+
+/**
+ * The `SizeBytes` of a stream record carrying these images.
+ *
+ * Every image the record carries counts, together rather than one at a time:
+ * the keys, and then whichever of the old and new images the view type
+ * selected. A record carrying both images is close to twice the size of one
+ * carrying either, which is what AWS's published samples show.
+ */
+export function simDynamoDbStreamRecordSize(
+  images: readonly SimDynamoDbItem[],
+): number {
+  return images.reduce((total, image) => total + streamImageSize(image), 0);
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-record.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-record.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbItemChange } from "./sim-dynamodb-item-change.js";
+import { simDynamoDbStreamImages } from "./sim-dynamodb-stream-images.js";
+import { simDynamoDbStreamRecordKeys } from "./sim-dynamodb-stream-record-keys.js";
+import { simDynamoDbStreamRecordSize } from "./sim-dynamodb-stream-record-size.js";
+
+/**
+ * What kind of change one stream record reports.
+ */
+export type SimDynamoDbStreamEventName = "INSERT" | "MODIFY" | "REMOVE";
+
+/**
+ * Who made the change a record reports, when it was not the application.
+ *
+ * Only a time to live deletion carries one. It is how an application tells a
+ * deletion it never asked for from one of its own, which matters because the
+ * two want completely different handling downstream.
+ */
+export interface SimDynamoDbStreamUserIdentity {
+  readonly type: "Service";
+  readonly principalId: "dynamodb.amazonaws.com";
+}
+
+/**
+ * The identity a time to live deletion is written under.
+ */
+const timeToLiveIdentity: SimDynamoDbStreamUserIdentity = {
+  type: "Service",
+  principalId: "dynamodb.amazonaws.com",
+};
+
+interface SimDynamoDbStreamRecordProperties {
+  readonly change: SimDynamoDbItemChange;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly viewType: SimDynamoDbStreamViewType;
+  readonly sequenceNumber: string;
+  readonly at: Date;
+}
+
+/**
+ * Which of the three kinds of change these images are.
+ */
+function eventNameOf(
+  change: SimDynamoDbItemChange,
+): SimDynamoDbStreamEventName {
+  if (change.newImage === undefined) {
+    return "REMOVE";
+  }
+
+  return change.oldImage === undefined ? "INSERT" : "MODIFY";
+}
+
+/**
+ * One record on a table's stream: one change, as the stream carries it.
+ *
+ * A record is fixed once it is written. The images it holds are the items as
+ * they were at the moment of the change, rather than references to whatever the
+ * table holds now, which is what makes a stream a log of transitions rather
+ * than a view of the table.
+ */
+export class SimDynamoDbStreamRecord {
+  public readonly eventId: string;
+  public readonly eventName: SimDynamoDbStreamEventName;
+  public readonly sequenceNumber: string;
+  public readonly approximateCreationDateTime: Date;
+  public readonly streamViewType: SimDynamoDbStreamViewType;
+  public readonly keys: SimDynamoDbItem;
+  public readonly newImage: SimDynamoDbItem | undefined;
+  public readonly oldImage: SimDynamoDbItem | undefined;
+  public readonly sizeBytes: number;
+  public readonly userIdentity: SimDynamoDbStreamUserIdentity | undefined;
+
+  constructor(properties: SimDynamoDbStreamRecordProperties) {
+    const { change, viewType } = properties;
+
+    // A change with neither image never happened, and the stream is never told
+    // about one, so the item the keys are cut from is always there.
+    const changed = change.newImage ?? change.oldImage;
+    assertDefined(changed, "DynamoDB stream record item image");
+
+    const images = simDynamoDbStreamImages(change, viewType);
+
+    this.eventId = randomUUID().replaceAll("-", "");
+    this.eventName = eventNameOf(change);
+    this.sequenceNumber = properties.sequenceNumber;
+    this.approximateCreationDateTime = properties.at;
+    this.streamViewType = viewType;
+    this.keys = simDynamoDbStreamRecordKeys(changed, properties.keySchema);
+    this.newImage = images.newImage;
+    this.oldImage = images.oldImage;
+    this.sizeBytes = simDynamoDbStreamRecordSize(
+      [this.keys, images.newImage, images.oldImage].filter(
+        (image) => image !== undefined,
+      ),
+    );
+    this.userIdentity = change.expired ? timeToLiveIdentity : undefined;
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-sequence-numbers.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-sequence-numbers.ts
@@ -1,0 +1,34 @@
+/**
+ * The number the first record on a stream is given.
+ *
+ * A sequence number is compared as text by anything reading a stream, so the
+ * width has to be fixed and the first digit has to be something other than a
+ * zero. Starting at 10^20 gives 21 digits of room, which is a hundred billion
+ * billion records before the width changes.
+ */
+const firstSequenceNumber = 100_000_000_000_000_000_000n;
+
+/**
+ * The sequence numbers one stream hands out.
+ *
+ * This is a counter rather than a clock. Records are commonly written inside
+ * one millisecond, and a clock cannot tell those apart, so a clock-derived
+ * sequence number would leave two records claiming the same position on the
+ * stream. Real DynamoDB varies the width between 21 and 40 digits, where these
+ * stay at 21, which is a divergence in a reader's favour: lexicographic order
+ * is numeric order here whatever two numbers are compared.
+ */
+export class SimDynamoDbStreamSequenceNumbers {
+  private next = firstSequenceNumber;
+
+  /**
+   * Take the next sequence number, as the text a record carries.
+   */
+  take(): string {
+    const taken = this.next;
+
+    this.next += 1n;
+
+    return taken.toString();
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+
+/**
+ * How many digits DynamoDB pads a shard identifier's instant to.
+ */
+const shardInstantDigits = 20;
+
+/**
+ * The identifier a shard opened at an instant carries.
+ *
+ * DynamoDB shapes these as `shardId-00000001414562045508-2bac9cd2`: the instant
+ * the shard opened, padded, and then something to tell two shards opened at one
+ * instant apart.
+ */
+function shardId(at: Date): string {
+  const opened = at.getTime().toString().padStart(shardInstantDigits, "0");
+
+  return `shardId-${opened}-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * The one shard of one stream, and the records written to it.
+ *
+ * AWS documents an open shard as corresponding to one table partition, and a
+ * simulated table is always one partition, so one shard per stream is accurate
+ * rather than a shortcut. Nothing here splits: a shard is opened when the
+ * stream is enabled and closed when it is disabled.
+ *
+ * The total order that gives across every key is stronger than the per-key
+ * order AWS guarantees. A consumer relying on it here would be relying on
+ * something real DynamoDB does not promise.
+ */
+export class SimDynamoDbStreamShard {
+  public readonly shardId: string;
+
+  private readonly written: SimDynamoDbStreamRecord[] = [];
+  private open = true;
+
+  constructor(at: Date) {
+    this.shardId = shardId(at);
+  }
+
+  /**
+   * Whether this shard is still taking records.
+   */
+  get isOpen(): boolean {
+    return this.open;
+  }
+
+  /**
+   * The records written to this shard, oldest first.
+   */
+  get records(): readonly SimDynamoDbStreamRecord[] {
+    return this.written;
+  }
+
+  /**
+   * Write a record to this shard.
+   */
+  append(record: SimDynamoDbStreamRecord): void {
+    this.written.push(record);
+  }
+
+  /**
+   * Close this shard to further records.
+   *
+   * What is already on it stays readable: disabling a stream stops it taking
+   * changes rather than throwing away the ones it took.
+   */
+  close(): void {
+    this.open = false;
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-specification.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-specification.ts
@@ -1,0 +1,53 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type {
+  SimDynamoDbStreamSpecification,
+  SimDynamoDbStreamViewType,
+} from "./sim-dynamodb-stream.types.js";
+import { readSimDynamoDbStreamViewType } from "./sim-dynamodb-stream-view-type.js";
+
+/**
+ * What a request asks a table's stream to be, once it has been checked.
+ *
+ * A view type is there when the stream is being switched on, and never when it
+ * is being switched off, since the view type belongs to the stream rather than
+ * to the table. The two shapes are one type rather than two so that a request
+ * carrying a StreamSpecification is one thing to read and one thing to apply.
+ */
+export type SimDynamoDbStreamRequest =
+  | { readonly enabled: true; readonly viewType: SimDynamoDbStreamViewType }
+  | { readonly enabled: false };
+
+/**
+ * Read the StreamSpecification a CreateTable or UpdateTable request carries.
+ *
+ * Nothing here knows about the table, so nothing here refuses a request for the
+ * stream the table already has. This is only the request read on its own: what
+ * it asks for, and whether it asks for it coherently.
+ *
+ * `StreamEnabled` is required whenever the specification is there at all, as it
+ * is on real DynamoDB. A specification carrying only a view type would read as
+ * a request for a stream while making a table with none.
+ */
+export function readSimDynamoDbStreamSpecification(
+  input: SimDynamoDbStreamSpecification | undefined,
+): SimDynamoDbStreamRequest | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (input.StreamEnabled === undefined) {
+    throw new SimDynamoDbValidationException(
+      "One or more parameter values were invalid: StreamEnabled is required " +
+        "in a StreamSpecification",
+    );
+  }
+
+  if (!input.StreamEnabled) {
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    viewType: readSimDynamoDbStreamViewType(input.StreamViewType),
+  };
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-store.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-store.ts
@@ -1,0 +1,32 @@
+import type { SimDynamoDbStream } from "./sim-dynamodb-stream.js";
+
+/**
+ * The streams one simulated DynamoDB holds, keyed by ARN.
+ *
+ * A stream outlives being enabled: disabling one leaves it readable for the
+ * rest of its retention window, and the table that made it has already moved on
+ * to reporting nothing or reporting a newer one. So the streams are held here
+ * rather than only on the tables, which is what lets an ARN be resolved to the
+ * stream it names however long ago the table stopped writing to it.
+ */
+export class SimDynamoDbStreamStore {
+  private readonly streams = new Map<string, SimDynamoDbStream>();
+
+  /**
+   * Hold a stream a table has just enabled.
+   */
+  add(stream: SimDynamoDbStream): void {
+    this.streams.set(stream.arn, stream);
+  }
+
+  /**
+   * Find the stream an ARN names, if there is one.
+   *
+   * An ARN naming no stream is simply not found. It reaches this from request
+   * input, where a value that names nothing is an ordinary case the caller
+   * reports in its own terms.
+   */
+  findByArn(streamArn: string): SimDynamoDbStream | undefined {
+    return this.streams.get(streamArn);
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-time-to-live.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-time-to-live.iso.test.ts
@@ -1,0 +1,53 @@
+import {
+  PutItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The instant this test starts from, and the epoch seconds of it.
+ */
+const startedAt = new Date("2026-08-04T09:00:00.000Z");
+const startedAtSeconds = String(Math.floor(startedAt.getTime() / 1000));
+
+describe("DynamoDB stream capture of a time to live expiry", () => {
+  it("says DynamoDB made the removal, not the application", async () => {
+    // Given a streamed table expiring its items, holding one that is due.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "orders",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: {
+          orderId: { S: "order-1" },
+          expiresAt: { N: startedAtSeconds },
+        },
+      }),
+    );
+
+    // When the clock passes the deletion window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the removal carries the identity that tells an expiry from a
+    // deletion the application asked for.
+    const record = table.stream.latest?.records.at(1);
+    assertDefined(record, "DynamoDB stream record");
+    assertIdentical(record.eventName, "REMOVE");
+    assertObjectEquals(record.userIdentity, {
+      type: "Service",
+      principalId: "dynamodb.amazonaws.com",
+    });
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-update.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-update.ts
@@ -1,0 +1,76 @@
+import type { SimUpdateTableCommandInput } from "../command/table/table.command.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import {
+  readSimDynamoDbStreamSpecification,
+  type SimDynamoDbStreamRequest,
+} from "./sim-dynamodb-stream-specification.js";
+import type { SimDynamoDbTableStream } from "./sim-dynamodb-table-stream.js";
+
+/**
+ * Refuse a request to switch on a stream the table already has.
+ *
+ * A stream's view type is fixed for the life of the stream, so there is no such
+ * thing as changing it in place: what an application wants is a new stream, and
+ * AWS makes it ask for one by switching this one off first. The refusal says so
+ * rather than leaving a reader to work out why the obvious request failed.
+ */
+function refuseSecondStream(
+  request: SimDynamoDbStreamRequest,
+  stream: SimDynamoDbTableStream,
+): void {
+  const current = stream.current;
+
+  if (current === undefined || !request.enabled) {
+    return;
+  }
+
+  if (request.viewType === current.viewType) {
+    throw new SimDynamoDbValidationException(
+      "Table already has an enabled stream",
+    );
+  }
+
+  throw new SimDynamoDbValidationException(
+    `Table already has an enabled stream, and a stream's StreamViewType ` +
+      `cannot be changed in place: switch the ${current.viewType} stream off ` +
+      `and on again to get a ${request.viewType} one`,
+  );
+}
+
+/**
+ * Refuse a request to switch off a stream the table does not have.
+ */
+function refuseAbsentStream(
+  request: SimDynamoDbStreamRequest,
+  stream: SimDynamoDbTableStream,
+): void {
+  if (!request.enabled && stream.current === undefined) {
+    throw new SimDynamoDbValidationException(
+      "Table does not have an enabled stream to disable",
+    );
+  }
+}
+
+/**
+ * Read the change an UpdateTable request asks a table's stream for.
+ *
+ * Unlike CreateTable, where a stream specification describes a table that does
+ * not exist yet, this is read against the stream the table already has. A
+ * request that asks for the state the table is already in is refused rather
+ * than accepted as a no-op, which is what real DynamoDB does with both of them.
+ */
+export function readSimDynamoDbStreamUpdate(
+  input: SimUpdateTableCommandInput,
+  stream: SimDynamoDbTableStream,
+): SimDynamoDbStreamRequest | undefined {
+  const request = readSimDynamoDbStreamSpecification(input.StreamSpecification);
+
+  if (request === undefined) {
+    return undefined;
+  }
+
+  refuseSecondStream(request, stream);
+  refuseAbsentStream(request, stream);
+
+  return request;
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-value-size.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-value-size.iso.test.ts
@@ -1,0 +1,48 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import { simDynamoDbStreamRecordSize } from "./sim-dynamodb-stream-record-size.js";
+
+/**
+ * Three bytes, which base64 writes as the four characters `AQID`.
+ */
+const bytes = new Uint8Array([1, 2, 3]);
+
+/**
+ * The `SizeBytes` an image of these attributes counts for.
+ */
+function sizeOf(values: Record<string, SimDynamoDbAttributeValue>): number {
+  return simDynamoDbStreamRecordSize([
+    SimDynamoDbItem.fromAttributeValues(values),
+  ]);
+}
+
+describe("DynamoDB stream record value sizes", () => {
+  it("counts binary as the base64 a record carries it as", () => {
+    // The name is one byte and the four base64 characters are one each,
+    // rather than the three bytes the value holds.
+    assertIdentical(sizeOf({ b: { B: bytes } }), 5);
+  });
+
+  it("counts a boolean and a null as the text they are written as", () => {
+    // `true` is four characters and `false` is five, and a null is the `true`
+    // its descriptor carries.
+    assertIdentical(sizeOf({ on: { BOOL: true } }), 6);
+    assertIdentical(sizeOf({ off: { BOOL: false } }), 8);
+    assertIdentical(sizeOf({ nil: { NULL: true } }), 7);
+  });
+
+  it("counts a set as its members", () => {
+    assertIdentical(sizeOf({ ss: { SS: ["a", "bb"] } }), 5);
+    assertIdentical(sizeOf({ ns: { NS: ["1", "22"] } }), 5);
+    assertIdentical(sizeOf({ bs: { BS: [bytes] } }), 6);
+  });
+
+  it("counts a list and a map with no overhead of their own", () => {
+    // The 400 KB item rule adds three bytes for each of these. The stream rule
+    // does not: a record is measured as the text it carries.
+    assertIdentical(sizeOf({ l: { L: [{ S: "ab" }, { N: "12" }] } }), 5);
+    assertIdentical(sizeOf({ m: { M: { k: { S: "v" } } } }), 3);
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-view-type.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-view-type.ts
@@ -1,0 +1,49 @@
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
+/**
+ * Every view type a stream can be enabled with.
+ *
+ * The keys of the changed item are on every record whichever of these a stream
+ * was enabled with, so `KEYS_ONLY` is the floor rather than an exception.
+ */
+const streamViewTypes: readonly SimDynamoDbStreamViewType[] = [
+  "KEYS_ONLY",
+  "NEW_IMAGE",
+  "OLD_IMAGE",
+  "NEW_AND_OLD_IMAGES",
+];
+
+/**
+ * Whether some text names a view type.
+ */
+function isStreamViewType(value: string): value is SimDynamoDbStreamViewType {
+  return streamViewTypes.includes(value as SimDynamoDbStreamViewType);
+}
+
+/**
+ * Read the view type a stream is being enabled with.
+ *
+ * A stream that is on has one: a record with no view type would be a record
+ * with no rule about which images it carries. Real DynamoDB requires it the
+ * same way, so a request leaving it out is refused rather than defaulted.
+ */
+export function readSimDynamoDbStreamViewType(
+  value: string | undefined,
+): SimDynamoDbStreamViewType {
+  if (value === undefined) {
+    throw new SimDynamoDbValidationException(
+      "One or more parameter values were invalid: StreamViewType is " +
+        "required when StreamEnabled is true",
+    );
+  }
+
+  if (!isStreamViewType(value)) {
+    throw new SimDynamoDbValidationException(
+      `One or more parameter values were invalid: Unknown StreamViewType ` +
+        `${value}, expected one of ${streamViewTypes.join(", ")}`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-view-types.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-view-types.iso.test.ts
@@ -1,0 +1,150 @@
+import { DeleteItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The item every test here writes.
+ */
+const order = { orderId: { S: "order-1" }, total: { N: "101" } };
+
+/**
+ * Write an order, change it and delete it on a stream of one view type, and
+ * answer with the three records that came out.
+ *
+ * Every test here is the same three changes read through a different view
+ * type, so the changes are made once and each test says what it expects to
+ * find on them.
+ */
+async function recordsUnder(
+  viewType: SimDynamoDbStreamViewType,
+): Promise<readonly SimDynamoDbStreamRecord[]> {
+  const simAws = new SimAws();
+  const table = await simDynamoDbStreamedTableFactory.make(
+    { viewType },
+    simAws,
+  );
+
+  await simAws
+    .dynamoDb()
+    .putItem(new PutItemCommand({ TableName: "orders", Item: order }));
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { ...order, total: { N: "202" } },
+    }),
+  );
+  await simAws.dynamoDb().deleteItem(
+    new DeleteItemCommand({
+      TableName: "orders",
+      Key: { orderId: { S: "order-1" } },
+    }),
+  );
+
+  return table.stream.latest?.records ?? [];
+}
+
+/**
+ * One of the three records, which are always all there.
+ */
+function recordAt(
+  records: readonly SimDynamoDbStreamRecord[],
+  position: number,
+): SimDynamoDbStreamRecord {
+  const record = records.at(position);
+  assertDefined(record, "DynamoDB stream record");
+
+  return record;
+}
+
+describe("DynamoDB stream view types", () => {
+  it("carries only the keys under KEYS_ONLY", async () => {
+    // When an insertion, a modification and a removal go onto a KEYS_ONLY
+    // stream.
+    const records = await recordsUnder("KEYS_ONLY");
+
+    // Then each says which item changed and how, and nothing else.
+    for (const position of [0, 1, 2]) {
+      const record = recordAt(records, position);
+      assertObjectEquals(record.keys.toAttributeValues(), {
+        orderId: { S: "order-1" },
+      });
+      assertUndefined(record.newImage);
+      assertUndefined(record.oldImage);
+      assertIdentical(record.streamViewType, "KEYS_ONLY");
+    }
+  });
+
+  it("carries the item as it is now under NEW_IMAGE", async () => {
+    // When the three changes go onto a NEW_IMAGE stream.
+    const records = await recordsUnder("NEW_IMAGE");
+
+    // Then the insertion and the modification carry what the item became.
+    assertObjectEquals(recordAt(records, 0).newImage?.toAttributeValues(), {
+      orderId: { S: "order-1" },
+      total: { N: "101" },
+    });
+    assertObjectEquals(recordAt(records, 1).newImage?.toAttributeValues(), {
+      orderId: { S: "order-1" },
+      total: { N: "202" },
+    });
+
+    // And the removal is keys only, since a removed item has nothing it is
+    // now. The record is still written: it is how a reader learns the item
+    // has gone.
+    const removal = recordAt(records, 2);
+    assertIdentical(removal.eventName, "REMOVE");
+    assertUndefined(removal.newImage);
+    assertUndefined(removal.oldImage);
+    assertObjectEquals(removal.keys.toAttributeValues(), {
+      orderId: { S: "order-1" },
+    });
+  });
+
+  it("carries the item as it was under OLD_IMAGE", async () => {
+    // When the three changes go onto an OLD_IMAGE stream.
+    const records = await recordsUnder("OLD_IMAGE");
+
+    // Then the insertion is keys only, since an inserted item was nothing
+    // before.
+    const insertion = recordAt(records, 0);
+    assertIdentical(insertion.eventName, "INSERT");
+    assertUndefined(insertion.oldImage);
+    assertUndefined(insertion.newImage);
+
+    // And the modification and the removal carry what the item was.
+    assertObjectEquals(recordAt(records, 1).oldImage?.toAttributeValues(), {
+      orderId: { S: "order-1" },
+      total: { N: "101" },
+    });
+    assertObjectEquals(recordAt(records, 2).oldImage?.toAttributeValues(), {
+      orderId: { S: "order-1" },
+      total: { N: "202" },
+    });
+    assertUndefined(recordAt(records, 1).newImage);
+  });
+
+  it("carries both images under NEW_AND_OLD_IMAGES", async () => {
+    // When the three changes go onto a NEW_AND_OLD_IMAGES stream.
+    const records = await recordsUnder("NEW_AND_OLD_IMAGES");
+
+    // Then each record carries whichever images its change has.
+    assertUndefined(recordAt(records, 0).oldImage);
+    assertDefined(recordAt(records, 0).newImage, "new image");
+    assertDefined(recordAt(records, 1).oldImage, "old image");
+    assertDefined(recordAt(records, 1).newImage, "new image");
+    assertObjectEquals(recordAt(records, 2).oldImage?.toAttributeValues(), {
+      orderId: { S: "order-1" },
+      total: { N: "202" },
+    });
+    assertUndefined(recordAt(records, 2).newImage);
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream.ts
@@ -1,0 +1,114 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbItemChange } from "./sim-dynamodb-item-change.js";
+import {
+  simDynamoDbStreamArn,
+  simDynamoDbStreamLabel,
+} from "./sim-dynamodb-stream-arn.js";
+import { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { SimDynamoDbStreamSequenceNumbers } from "./sim-dynamodb-stream-sequence-numbers.js";
+import { SimDynamoDbStreamShard } from "./sim-dynamodb-stream-shard.js";
+
+/**
+ * Where a stream is between being enabled and being disabled.
+ *
+ * Real DynamoDB also has `ENABLING` and `DISABLING`, which it passes through
+ * while it brings the stream up or takes it down. Nothing here takes any time
+ * over either, so a stream switches straight between the two settled states.
+ */
+export type SimDynamoDbStreamStatus = "ENABLED" | "DISABLED";
+
+interface SimDynamoDbStreamProperties {
+  readonly tableName: string;
+  readonly tableArn: SimArn;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly viewType: SimDynamoDbStreamViewType;
+  readonly enabledAt: Date;
+}
+
+/**
+ * One stream of one table: everything that changed while it was on.
+ *
+ * A stream is made when a stream is enabled and is never remade. Disabling one
+ * and enabling another gives the table a second stream with a label and an ARN
+ * of its own, which is why the table holds these rather than being one.
+ *
+ * The key schema is held here because a record's `Keys` are cut with it, and a
+ * table's key schema never changes, so the stream can be given it once.
+ */
+export class SimDynamoDbStream {
+  public readonly arn: SimArn;
+  public readonly label: string;
+  public readonly tableName: string;
+  public readonly tableArn: SimArn;
+  public readonly viewType: SimDynamoDbStreamViewType;
+  public readonly enabledAt: Date;
+  public readonly shard: SimDynamoDbStreamShard;
+
+  private readonly keySchema: SimDynamoDbKeySchema;
+  private readonly sequenceNumbers = new SimDynamoDbStreamSequenceNumbers();
+  private enabled = true;
+
+  constructor(properties: SimDynamoDbStreamProperties) {
+    this.label = simDynamoDbStreamLabel(properties.enabledAt);
+    this.arn = simDynamoDbStreamArn(properties.tableArn, this.label);
+    this.tableName = properties.tableName;
+    this.tableArn = properties.tableArn;
+    this.viewType = properties.viewType;
+    this.enabledAt = properties.enabledAt;
+    this.keySchema = properties.keySchema;
+    this.shard = new SimDynamoDbStreamShard(properties.enabledAt);
+  }
+
+  /**
+   * Whether this stream is still taking the table's changes.
+   */
+  get status(): SimDynamoDbStreamStatus {
+    return this.enabled ? "ENABLED" : "DISABLED";
+  }
+
+  /**
+   * The records this stream has taken, oldest first.
+   */
+  get records(): readonly SimDynamoDbStreamRecord[] {
+    return this.shard.records;
+  }
+
+  /**
+   * Take one change to the table's items.
+   *
+   * Capture is eager, and that is deliberately against the house style. An
+   * index is derived when it is read because an index is a function of the
+   * table's current state. A stream is not: put A, then B, then A leaves state
+   * A while owing two `MODIFY` records, and an insert followed by a delete
+   * leaves the table empty while owing an `INSERT` and a `REMOVE`. Nothing
+   * readable afterwards reconstructs either, so the transition is written down
+   * as it happens.
+   */
+  capture(change: SimDynamoDbItemChange, at: Date): SimDynamoDbStreamRecord {
+    const record = new SimDynamoDbStreamRecord({
+      change,
+      keySchema: this.keySchema,
+      viewType: this.viewType,
+      sequenceNumber: this.sequenceNumbers.take(),
+      at,
+    });
+
+    this.shard.append(record);
+
+    return record;
+  }
+
+  /**
+   * Stop this stream taking the table's changes.
+   *
+   * The records already on it stay where they are. Real DynamoDB keeps a
+   * disabled stream readable for the rest of its retention window, and closing
+   * the shard is how a reader finds out there will be no more.
+   */
+  disable(): void {
+    this.enabled = false;
+    this.shard.close();
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream.types.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream.types.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal structural sim DynamoDB stream specification, as a request carries
+ * it.
+ */
+export interface SimDynamoDbStreamSpecification {
+  readonly StreamEnabled?: boolean | undefined;
+  readonly StreamViewType?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB stream specification, as a table reports it.
+ *
+ * A table that has a stream reports the view type it was enabled with. One that
+ * had a stream and no longer does reports only that it is off, as real DynamoDB
+ * does, since the view type belonged to the stream rather than to the table.
+ */
+export interface SimDynamoDbStreamSpecificationDescription {
+  readonly StreamEnabled: boolean;
+  readonly StreamViewType?: SimDynamoDbStreamViewType | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB stream view type.
+ */
+export type SimDynamoDbStreamViewType =
+  "KEYS_ONLY" | "NEW_IMAGE" | "OLD_IMAGE" | "NEW_AND_OLD_IMAGES";

--- a/src/service/dynamodb/stream/sim-dynamodb-streamed-table.factory.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-streamed-table.factory.ts
@@ -1,0 +1,74 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
+
+/**
+ * What a test asks for when it wants a table that captures its changes.
+ */
+export interface SimDynamoDbStreamedTableInput {
+  readonly tableName: string;
+  readonly partitionKeyName: string;
+
+  /**
+   * Which images the stream's records carry.
+   */
+  readonly viewType: SimDynamoDbStreamViewType;
+}
+
+/**
+ * Creates a table with a stream already switched on, through CreateTable.
+ *
+ * The table went through the ordinary command, so it is the table an
+ * application would have rather than one built around the commands, and it is
+ * ACTIVE by the time this answers.
+ *
+ * ```typescript
+ * const table = await simDynamoDbStreamedTableFactory.make(
+ *   { tableName: "orders", viewType: "NEW_AND_OLD_IMAGES" },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbStreamedTableFactory = new AsyncMappedFactory<
+  SimDynamoDbStreamedTableInput,
+  SimDynamoDbTable,
+  SimAws
+>(
+  () => ({
+    tableName: "orders",
+    partitionKeyName: "orderId",
+    viewType: "NEW_AND_OLD_IMAGES",
+  }),
+  async (input, simAws) => {
+    const simDynamoDb = simAws.dynamoDb();
+
+    await simDynamoDb.createTable({
+      input: {
+        TableName: input.tableName,
+        KeySchema: [{ AttributeName: input.partitionKeyName, KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: input.partitionKeyName, AttributeType: "S" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        StreamSpecification: {
+          StreamEnabled: true,
+          StreamViewType: input.viewType,
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // A name CreateTable accepted is a table the store holds, so this is only
+    // missing if something is wrong with the simulator itself.
+    const table = simDynamoDb.findTable(input.tableName);
+    assertDefined(
+      table,
+      `Simulated DynamoDB created the table ${input.tableName} and then did ` +
+        `not hold it`,
+    );
+
+    return table;
+  },
+);

--- a/src/service/dynamodb/stream/sim-dynamodb-table-stream.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-table-stream.ts
@@ -1,0 +1,159 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type {
+  SimDynamoDbStreamSpecificationDescription,
+  SimDynamoDbStreamViewType,
+} from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type {
+  SimDynamoDbItemChange,
+  SimDynamoDbItemChanges,
+} from "./sim-dynamodb-item-change.js";
+import { SimDynamoDbStream } from "./sim-dynamodb-stream.js";
+import { SimDynamoDbStreamActivity } from "./sim-dynamodb-stream-activity.js";
+import { simDynamoDbStreamLabelInstant } from "./sim-dynamodb-stream-arn.js";
+import type { SimDynamoDbStreamRequest } from "./sim-dynamodb-stream-specification.js";
+import { SimDynamoDbStreamStore } from "./sim-dynamodb-stream-store.js";
+
+interface SimDynamoDbTableStreamProperties {
+  readonly tableName: string;
+  readonly tableArn: SimArn;
+  readonly keySchema: SimDynamoDbKeySchema;
+  readonly clock: SimClock;
+  readonly streams?: SimDynamoDbStreamStore | undefined;
+  readonly activity?: SimDynamoDbStreamActivity | undefined;
+}
+
+/**
+ * One table's stream: the setting, and what the changes are captured on.
+ *
+ * The setting and the log are held together for the same reason time to live
+ * holds the setting and the removals it drives: switching the setting on is
+ * what gives the table somewhere to write its changes, and switching it off is
+ * what stops it.
+ *
+ * A table can have had several streams over its life, since disabling one and
+ * enabling another makes a second with a label and an ARN of its own. Only one
+ * of them is ever taking changes. `latest` is the one `LatestStreamArn` names,
+ * which real DynamoDB goes on reporting after the stream has been switched off.
+ */
+export class SimDynamoDbTableStream implements SimDynamoDbItemChanges {
+  private readonly tableName: string;
+  private readonly tableArn: SimArn;
+  private readonly keySchema: SimDynamoDbKeySchema;
+  private readonly clock: SimClock;
+  private readonly streams: SimDynamoDbStreamStore;
+  private readonly activity: SimDynamoDbStreamActivity;
+  private enabled: SimDynamoDbStream | undefined;
+  private newest: SimDynamoDbStream | undefined;
+
+  constructor(properties: SimDynamoDbTableStreamProperties) {
+    this.tableName = properties.tableName;
+    this.tableArn = properties.tableArn;
+    this.keySchema = properties.keySchema;
+    this.clock = properties.clock;
+    this.streams = properties.streams ?? new SimDynamoDbStreamStore();
+    this.activity = properties.activity ?? new SimDynamoDbStreamActivity();
+  }
+
+  /**
+   * The stream taking this table's changes, when one is switched on.
+   */
+  get current(): SimDynamoDbStream | undefined {
+    return this.enabled;
+  }
+
+  /**
+   * The last stream this table had, switched on or not.
+   */
+  get latest(): SimDynamoDbStream | undefined {
+    return this.newest;
+  }
+
+  /**
+   * How this table reports its stream setting, when it has ever had one.
+   *
+   * A table that has never had a stream reports no `StreamSpecification` at
+   * all, rather than one saying it is off, which is how a caller tells a table
+   * that never had a stream from one whose stream was switched off.
+   */
+  specification(): SimDynamoDbStreamSpecificationDescription | undefined {
+    if (this.enabled !== undefined) {
+      return { StreamEnabled: true, StreamViewType: this.enabled.viewType };
+    }
+
+    return this.newest === undefined ? undefined : { StreamEnabled: false };
+  }
+
+  /**
+   * Apply a stream request that has already been checked against this table.
+   *
+   * Nothing here refuses anything. A request asking for the stream the table
+   * already has, or for the removal of one it does not have, was refused while
+   * the request was being read.
+   */
+  apply(request: SimDynamoDbStreamRequest | undefined): void {
+    if (request === undefined) {
+      return;
+    }
+
+    if (request.enabled) {
+      this.enable(request.viewType);
+
+      return;
+    }
+
+    this.disable();
+  }
+
+  /**
+   * Take one change to the table's items.
+   *
+   * This is the choke point every item mutation passes through exactly once. A
+   * table with no stream on captures nothing, which is the ordinary case and
+   * costs one comparison.
+   */
+  capture(change: SimDynamoDbItemChange): void {
+    const stream = this.enabled;
+
+    if (stream === undefined) {
+      return;
+    }
+
+    stream.capture(change, this.clock.now());
+    this.activity.recordsAvailable(stream.arn);
+  }
+
+  /**
+   * Switch a stream on, which makes a new one.
+   *
+   * The label and the ARN come from the instant it was enabled, so re-enabling
+   * a stream gives a different ARN to the one the table had before. Anything
+   * holding the old ARN is holding the old stream, as it would be on AWS.
+   */
+  private enable(viewType: SimDynamoDbStreamViewType): void {
+    const enabledAt = simDynamoDbStreamLabelInstant(
+      this.clock.now(),
+      this.newest?.enabledAt,
+    );
+    const stream = new SimDynamoDbStream({
+      tableName: this.tableName,
+      tableArn: this.tableArn,
+      keySchema: this.keySchema,
+      viewType,
+      enabledAt,
+    });
+
+    this.enabled = stream;
+    this.newest = stream;
+    this.streams.add(stream);
+  }
+
+  /**
+   * Switch the stream off, leaving what it captured where it is.
+   */
+  private disable(): void {
+    this.enabled?.disable();
+    this.enabled = undefined;
+  }
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-table-stream.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-table-stream.ts
@@ -20,7 +20,6 @@ interface SimDynamoDbTableStreamProperties {
   readonly tableArn: SimArn;
   readonly keySchema: SimDynamoDbKeySchema;
   readonly clock: SimClock;
-  readonly streams?: SimDynamoDbStreamStore | undefined;
   readonly activity?: SimDynamoDbStreamActivity | undefined;
 }
 
@@ -42,8 +41,8 @@ export class SimDynamoDbTableStream implements SimDynamoDbItemChanges {
   private readonly tableArn: SimArn;
   private readonly keySchema: SimDynamoDbKeySchema;
   private readonly clock: SimClock;
-  private readonly streams: SimDynamoDbStreamStore;
   private readonly activity: SimDynamoDbStreamActivity;
+  private streams = new SimDynamoDbStreamStore();
   private enabled: SimDynamoDbStream | undefined;
   private newest: SimDynamoDbStream | undefined;
 
@@ -52,7 +51,6 @@ export class SimDynamoDbTableStream implements SimDynamoDbItemChanges {
     this.tableArn = properties.tableArn;
     this.keySchema = properties.keySchema;
     this.clock = properties.clock;
-    this.streams = properties.streams ?? new SimDynamoDbStreamStore();
     this.activity = properties.activity ?? new SimDynamoDbStreamActivity();
   }
 
@@ -83,6 +81,24 @@ export class SimDynamoDbTableStream implements SimDynamoDbItemChanges {
     }
 
     return this.newest === undefined ? undefined : { StreamEnabled: false };
+  }
+
+  /**
+   * Hand this table's streams to the store that resolves one by ARN.
+   *
+   * A table is built before the name it is taking has been checked, so a table
+   * that is refused for a name already in use has still made its stream by
+   * then. Registering when the table becomes real rather than when it is built
+   * is what keeps that stream from being resolvable by an ARN nobody was ever
+   * given. Until this is called a table keeps its streams to itself, which is
+   * what a table built with no simulated DynamoDB holding it does for good.
+   */
+  publishTo(streams: SimDynamoDbStreamStore): void {
+    this.streams = streams;
+
+    if (this.enabled !== undefined) {
+      streams.add(this.enabled);
+    }
   }
 
   /**

--- a/src/service/dynamodb/table/sim-dynamodb-table-description.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-description.ts
@@ -42,6 +42,12 @@ export function describeSimDynamoDbTable(
     GlobalSecondaryIndexes: table.indexes.global.descriptions(table.status),
     LocalSecondaryIndexes: table.indexes.local.descriptions(),
     DeletionProtectionEnabled: table.deletionProtectionEnabled,
+    StreamSpecification: table.stream.specification(),
+    // These stay set once the table has had a stream, whether or not it still
+    // has one, since they name the last stream rather than the current
+    // setting. A table that has never had one reports neither.
+    LatestStreamArn: table.stream.latest?.arn,
+    LatestStreamLabel: table.stream.latest?.label,
     // Neither figure is tracked yet. Real DynamoDB updates both about every
     // six hours, so they lag behind the items anyway.
     ItemCount: 0,

--- a/src/service/dynamodb/table/sim-dynamodb-table-items.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-items.ts
@@ -1,4 +1,9 @@
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbItemChanges } from "../stream/sim-dynamodb-item-change.js";
+
+interface SimDynamoDbTableItemsProperties {
+  readonly changes: SimDynamoDbItemChanges;
+}
 
 /**
  * The items one simulated table holds, keyed by marshalled primary key.
@@ -7,17 +12,39 @@ import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
  * read-your-writes as real DynamoDB is for a strongly consistent read. Nothing
  * here is scheduled: an item that a request has been told was written is an
  * item that is there.
+ *
+ * This is also where every change to an item is reported from, because it is
+ * the one place all of them pass through exactly once: PutItem, UpdateItem,
+ * DeleteItem, the batch and transactional writes, and the time to live removal
+ * all end up here and nowhere else. The old value is already read to answer
+ * with, so reporting the transition costs nothing extra.
  */
 export class SimDynamoDbTableItems {
   private readonly items = new Map<string, SimDynamoDbItem>();
+  private readonly changes: SimDynamoDbItemChanges;
+
+  constructor(properties: SimDynamoDbTableItemsProperties) {
+    this.changes = properties.changes;
+  }
 
   /**
    * Write an item, and answer with whatever it replaced.
+   *
+   * A write is reported whether or not it changed anything. UpdateItem with no
+   * UpdateExpression stores the item that was already there, so the two images
+   * arrive here as the same object, and real DynamoDB writes a `MODIFY` record
+   * for that request too. Comparing the images to decide would report less than
+   * AWS does, so nothing here compares them.
    */
   put(key: string, item: SimDynamoDbItem): SimDynamoDbItem | undefined {
     const replaced = this.items.get(key);
 
     this.items.set(key, item);
+    this.changes.capture({
+      oldImage: replaced,
+      newImage: item,
+      expired: false,
+    });
 
     return replaced;
   }
@@ -44,12 +71,39 @@ export class SimDynamoDbTableItems {
    *
    * A key holding nothing is not a failure. DynamoDB deletes by key rather than
    * by item, so removing a key that is already free asks for the state it is
-   * already in.
+   * already in, and nothing happened for a change to be reported about.
    */
   remove(key: string): SimDynamoDbItem | undefined {
+    return this.removed(key, false);
+  }
+
+  /**
+   * Take the item held under a key because its time to live ran out.
+   *
+   * This is a removal by DynamoDB itself rather than by the application, which
+   * is the one thing about a change that cannot be worked out from the images.
+   * It is a separate call rather than a flag on `remove` so that a caller has
+   * to decide which it is making.
+   */
+  expire(key: string): SimDynamoDbItem | undefined {
+    return this.removed(key, true);
+  }
+
+  /**
+   * Take the item held under a key, however it came to be taken.
+   */
+  private removed(key: string, expired: boolean): SimDynamoDbItem | undefined {
     const removed = this.items.get(key);
 
     this.items.delete(key);
+
+    if (removed !== undefined) {
+      this.changes.capture({
+        oldImage: removed,
+        newImage: undefined,
+        expired,
+      });
+    }
 
     return removed;
   }

--- a/src/service/dynamodb/table/sim-dynamodb-table-storage.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-storage.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
+import type { SimDynamoDbTableStream } from "../stream/sim-dynamodb-table-stream.js";
 import { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
 import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
 import type { SimDynamoDbTableDefinition } from "./sim-dynamodb-table-definition.js";
@@ -13,6 +14,7 @@ interface SimDynamoDbTableStorageProperties {
   readonly tableName: DynamoDbTableName;
   readonly definition: SimDynamoDbTableDefinition;
   readonly indexes: SimDynamoDbSecondaryIndexes;
+  readonly stream: SimDynamoDbTableStream;
   readonly background: BackgroundScheduler;
 }
 
@@ -29,6 +31,10 @@ interface SimDynamoDbTableStorageProperties {
  * This is built from a definition rather than from a key schema, so the key an
  * item is stored under follows an UpdateTable that changed which attributes the
  * table declares, without the storage having to be told about the update.
+ *
+ * The stream is handed in rather than made here, because it outlives the
+ * items: a table's stream is switched on and off by UpdateTable and keeps what
+ * it captured, where the storage is only ever what the table holds now.
  */
 export class SimDynamoDbTableStorage {
   /**
@@ -45,9 +51,10 @@ export class SimDynamoDbTableStorage {
   private readonly tableName: DynamoDbTableName;
   private readonly definition: SimDynamoDbTableDefinition;
   private readonly indexes: SimDynamoDbSecondaryIndexes;
-  private readonly items = new SimDynamoDbTableItems();
+  private readonly items: SimDynamoDbTableItems;
 
   constructor(properties: SimDynamoDbTableStorageProperties) {
+    this.items = new SimDynamoDbTableItems({ changes: properties.stream });
     this.tableName = properties.tableName;
     this.definition = properties.definition;
     this.indexes = properties.indexes;

--- a/src/service/dynamodb/table/sim-dynamodb-table-update.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table-update.ts
@@ -2,6 +2,8 @@ import type { SimUpdateTableCommandInput } from "../command/table/table.command.
 import type { SimDynamoDbTableClass } from "../command/table/table.types.js";
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import type { SimDynamoDbGlobalSecondaryIndex } from "../secondary-index/sim-dynamodb-global-secondary-index.js";
+import type { SimDynamoDbStreamRequest } from "../stream/sim-dynamodb-stream-specification.js";
+import { readSimDynamoDbStreamUpdate } from "../stream/sim-dynamodb-stream-update.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import { SimDynamoDbIndexUpdate } from "./sim-dynamodb-index-update.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -20,15 +22,16 @@ interface SimDynamoDbTableUpdateProperties {
   readonly indexDeleted: string | undefined;
   readonly tableClass: SimDynamoDbTableClass | undefined;
   readonly deletionProtectionEnabled: boolean | undefined;
+  readonly stream: SimDynamoDbStreamRequest | undefined;
 }
 
 /**
  * Refuse a request asking for more than one thing at a time.
  *
  * AWS takes one of these per call: change what the table is billed and
- * provisioned as, add one global secondary index, or remove one. A table class
- * or deletion protection change is not one of them and rides along with any of
- * them.
+ * provisioned as, add one global secondary index, or remove one. A table class,
+ * a deletion protection or a stream change is not one of them and rides along
+ * with any of them.
  */
 function assertOneOperation(
   billing: SimDynamoDbTableBilling | undefined,
@@ -54,13 +57,14 @@ function assertAsksForSomething(
     properties.indexCreated !== undefined ||
     properties.indexDeleted !== undefined ||
     properties.tableClass !== undefined ||
-    properties.deletionProtectionEnabled !== undefined;
+    properties.deletionProtectionEnabled !== undefined ||
+    properties.stream !== undefined;
 
   if (!asks) {
     throw new SimDynamoDbValidationException(
       "An UpdateTable request changes the table's billing and throughput, " +
-        "its global secondary indexes, its table class or its deletion " +
-        "protection, and this one changes none of them",
+        "its global secondary indexes, its stream, its table class or its " +
+        "deletion protection, and this one changes none of them",
     );
   }
 }
@@ -79,6 +83,7 @@ export class SimDynamoDbTableUpdate {
   public readonly indexDeleted: string | undefined;
   public readonly tableClass: SimDynamoDbTableClass | undefined;
   public readonly deletionProtectionEnabled: boolean | undefined;
+  public readonly stream: SimDynamoDbStreamRequest | undefined;
 
   private constructor(properties: SimDynamoDbTableUpdateProperties) {
     assertAsksForSomething(properties);
@@ -89,6 +94,7 @@ export class SimDynamoDbTableUpdate {
     this.indexDeleted = properties.indexDeleted;
     this.tableClass = properties.tableClass;
     this.deletionProtectionEnabled = properties.deletionProtectionEnabled;
+    this.stream = properties.stream;
   }
 
   /**
@@ -121,6 +127,7 @@ export class SimDynamoDbTableUpdate {
       indexDeleted: simDynamoDbDeletedIndexName(indexUpdate, table),
       tableClass: readSimDynamoDbTableClass(input.TableClass),
       deletionProtectionEnabled: input.DeletionProtectionEnabled,
+      stream: readSimDynamoDbStreamUpdate(input, table.stream),
     });
   }
 }

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -12,7 +12,6 @@ import type {
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
 import type { SimDynamoDbStreamActivity } from "../stream/sim-dynamodb-stream-activity.js";
 import type { SimDynamoDbStreamRequest } from "../stream/sim-dynamodb-stream-specification.js";
-import type { SimDynamoDbStreamStore } from "../stream/sim-dynamodb-stream-store.js";
 import { SimDynamoDbTableStream } from "../stream/sim-dynamodb-table-stream.js";
 import type { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
 import { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
@@ -43,7 +42,6 @@ interface SimDynamoDbTableProperties {
   readonly deletionProtectionEnabled?: boolean | undefined;
   readonly tags?: SimDynamoDbTableTags;
   readonly stream?: SimDynamoDbStreamRequest | undefined;
-  readonly streams?: SimDynamoDbStreamStore;
   readonly streamActivity?: SimDynamoDbStreamActivity;
   readonly background?: BackgroundScheduler;
 }
@@ -126,7 +124,6 @@ export class SimDynamoDbTable {
       tableArn: this.arn,
       keySchema,
       clock: background,
-      streams: properties.streams,
       activity: properties.streamActivity,
     });
     this.stream.apply(properties.stream);

--- a/src/service/dynamodb/table/sim-dynamodb-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-table.ts
@@ -10,6 +10,10 @@ import type {
   SimDynamoDbTableStatus,
 } from "../command/table/table.types.js";
 import type { SimDynamoDbItem } from "../item/sim-dynamodb-item.js";
+import type { SimDynamoDbStreamActivity } from "../stream/sim-dynamodb-stream-activity.js";
+import type { SimDynamoDbStreamRequest } from "../stream/sim-dynamodb-stream-specification.js";
+import type { SimDynamoDbStreamStore } from "../stream/sim-dynamodb-stream-store.js";
+import { SimDynamoDbTableStream } from "../stream/sim-dynamodb-table-stream.js";
 import type { SimDynamoDbTableTimeToLive } from "../time-to-live/sim-dynamodb-table-time-to-live.js";
 import { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
 import type { SimDynamoDbReadView } from "./sim-dynamodb-read-view.js";
@@ -38,6 +42,9 @@ interface SimDynamoDbTableProperties {
   readonly tableClass?: SimDynamoDbTableClass | undefined;
   readonly deletionProtectionEnabled?: boolean | undefined;
   readonly tags?: SimDynamoDbTableTags;
+  readonly stream?: SimDynamoDbStreamRequest | undefined;
+  readonly streams?: SimDynamoDbStreamStore;
+  readonly streamActivity?: SimDynamoDbStreamActivity;
   readonly background?: BackgroundScheduler;
 }
 
@@ -73,6 +80,15 @@ export class SimDynamoDbTable {
    */
   public readonly tags: SimDynamoDbTableTags;
 
+  /**
+   * This table's stream, and the item changes captured on it.
+   *
+   * A table always has one of these, and it holds no stream until one is
+   * enabled. That is what lets the item store report every change to the same
+   * place whether or not anything is listening.
+   */
+  public readonly stream: SimDynamoDbTableStream;
+
   private readonly definition: SimDynamoDbTableDefinition;
   private readonly lifecycle: SimDynamoDbTableLifecycle;
   private readonly storage: SimDynamoDbTableStorage;
@@ -105,10 +121,20 @@ export class SimDynamoDbTable {
       tableName: name.value,
       deletionProtectionEnabled,
     });
+    this.stream = new SimDynamoDbTableStream({
+      tableName: name.value,
+      tableArn: this.arn,
+      keySchema,
+      clock: background,
+      streams: properties.streams,
+      activity: properties.streamActivity,
+    });
+    this.stream.apply(properties.stream);
     this.storage = new SimDynamoDbTableStorage({
       tableName: name.value,
       definition: this.definition,
       indexes: this.indexes,
+      stream: this.stream,
       background,
     });
     this.creationDateTime = background.now();
@@ -181,6 +207,7 @@ export class SimDynamoDbTable {
     this.definition.apply(update);
     this.indexes.global.applyUpdate(update);
     this.lifecycle.applyUpdate(update);
+    this.stream.apply(update.stream);
   }
 
   /** Refuse a delete this table is not in a state to take. */

--- a/src/service/dynamodb/table/sim-dynamodb-updatable-table.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-updatable-table.ts
@@ -1,5 +1,6 @@
 import type { SimArn } from "../../aws/arn.js";
 import type { SimDynamoDbSecondaryIndexes } from "../secondary-index/sim-dynamodb-secondary-indexes.js";
+import type { SimDynamoDbTableStream } from "../stream/sim-dynamodb-table-stream.js";
 import type { SimDynamoDbAttributeDefinitions } from "./sim-dynamodb-attribute-definitions.js";
 import type { SimDynamoDbKeySchema } from "./sim-dynamodb-key-schema.js";
 import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
@@ -7,9 +8,10 @@ import type { SimDynamoDbTableBilling } from "./sim-dynamodb-table-billing.js";
 /**
  * What an update needs to know about the table it is going to be applied to.
  *
- * An index is declared against the table that will carry it, and a capacity
- * change is read against the mode the table is already billed under, so the
- * request cannot be checked without it.
+ * An index is declared against the table that will carry it, a capacity change
+ * is read against the mode the table is already billed under, and a stream
+ * change is read against the stream the table already has, so the request
+ * cannot be checked without it.
  */
 export interface SimDynamoDbUpdatableTable {
   readonly tableName: string;
@@ -18,4 +20,5 @@ export interface SimDynamoDbUpdatableTable {
   readonly attributeDefinitions: SimDynamoDbAttributeDefinitions;
   readonly billing: SimDynamoDbTableBilling;
   readonly indexes: SimDynamoDbSecondaryIndexes;
+  readonly stream: SimDynamoDbTableStream;
 }

--- a/src/service/dynamodb/time-to-live/sim-dynamodb-table-time-to-live.ts
+++ b/src/service/dynamodb/time-to-live/sim-dynamodb-table-time-to-live.ts
@@ -138,6 +138,10 @@ export class SimDynamoDbTableTimeToLive {
       return;
     }
 
-    this.items.remove(key);
+    // Expiring an item is not the same as deleting one. A stream record for a
+    // removal DynamoDB made itself carries a `userIdentity`, which is how an
+    // application tells it from one it asked for, so the item store is told
+    // which of the two this is.
+    this.items.expire(key);
   }
 }


### PR DESCRIPTION
A table created or updated with a StreamSpecification captures every item change as a stream record, with the images its StreamViewType selects. DescribeTable reports the specification, the latest stream ARN and label.

Capture is eager and lives in SimDynamoDbTableItems put, remove and a new expire, the one place every item mutation passes through exactly once. A stream is a log of transitions rather than a function of current state, so the lazy derivation the secondary indexes follow cannot work here.

Resolves #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated DynamoDB Streams support for table creation, updates, descriptions, lifecycle management, and record capture.
  * Captures INSERT, MODIFY, REMOVE, and TTL expiration events with configurable item images, keys, sequence numbers, sizes, and metadata.
  * Added stream activity notifications and stream lookup capabilities.
* **Documentation**
  * Documented stream configuration, limitations, retention, ordering, CloudFormation behavior, and TTL interactions.
* **Tests**
  * Added comprehensive coverage for stream lifecycle, records, view types, TTL events, sizing, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->