### PR TITLE
feat: route simulated CloudFront custom origins to sim services

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -140,6 +140,174 @@ try {
 The Distribution domain is adapted through `server.localUrl(...)` so that the request is sent to the
 local Yulin server while preserving the simulated CloudFront hostname.
 
+## Custom Origins
+
+An Origin with a `CustomOriginConfig` is one CloudFront reaches over HTTP rather than as an S3
+Bucket. Sim CloudFront resolves its `DomainName` in the simulated environment and serves the request
+in process, so a Distribution can front a simulated HTTP API endpoint
+(`<api-id>.execute-api.<region>.amazonaws.com`), a simulated Lambda Function URL
+(`<url-id>.lambda-url.<region>.on.aws`), or anything a simulated Route53 record points at one of
+those.
+
+That covers the common arrangement of one Distribution serving static assets from a Bucket and
+sending `/api/*` to an API:
+
+```typescript sim-cloudfront-distribution-custom-origin
+/**
+ * A simulated CloudFront Distribution fronting a simulated HTTP API.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+// A Bucket holding the site.
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "site",
+    Key: "index.html",
+    Body: "<h1>Site</h1>",
+  }),
+);
+
+// An HTTP API serving /api/things from a function.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "things",
+    Role: "arn:aws:iam::111111111111:role/ThingsRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ things: ["kettle"] })) },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "things", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /api/things",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "things",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// One Distribution serving the site, with /api/* going to the API.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "site-and-api",
+      Comment: "Site and API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "site.s3.amazonaws.com",
+            S3OriginConfig: { OriginAccessIdentity: "" },
+          },
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/api/*",
+            TargetOriginId: "api-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const page = await fetch(srv.localUrl(`http://${distroHostname}/index.html`));
+  const things = await fetch(
+    srv.localUrl(`http://${distroHostname}/api/things`),
+  );
+
+  console.log(await page.text());
+  console.log(await things.text());
+} finally {
+  srv.close();
+}
+```
+
+The Origin domain is resolved when a request is served rather than when the Distribution is created,
+so the Distribution and the service behind its Origin can be created in either order, whichever way
+round a CloudFormation template happens to declare them.
+
+`OriginPath` is prefixed to the request path, as it is for an S3 Origin, so an Origin path of `/v1`
+sends a request for `/things` on to `/v1/things`.
+
+A few things follow from the request never leaving the process:
+
+- A domain that names nothing in the simulation fails with an error naming the Origin and the
+  domain, rather than a real request being made to it. External HTTP Origins are not supported.
+- The settings inside `CustomOriginConfig` describe how CloudFront connects over the network, so
+  the protocol policy, ports, SSL protocols and timeouts are accepted and ignored.
+- The Origin is reached anonymously, as CloudFront reaches an Origin with no Origin Access Control.
+  A Function URL or an HTTP API route authorizing with `AWS_IAM` therefore refuses the request.
+
 ## Viewer certificates
 
 A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only
@@ -392,6 +560,7 @@ Sim CloudFront currently supports:
 
 - `CreateDistributionCommand` and `GetDistributionCommand`
 - S3 Origins backed by sim S3 Buckets
+- Custom Origins reaching sim HTTP APIs and sim Lambda Function URLs in process
 - CloudFront Distribution hostnames such as `distro123.cloudfront.net`
 - Default cache Behavior and path-based cache Behaviors
 - `viewer-request` and `viewer-response` CloudFront Functions

--- a/docs/services/cloudfront/sim-cloudfront-distribution-custom-origin.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-distribution-custom-origin.example.ts
@@ -1,0 +1,137 @@
+/**
+ * A simulated CloudFront Distribution fronting a simulated HTTP API.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+// A Bucket holding the site.
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "site",
+    Key: "index.html",
+    Body: "<h1>Site</h1>",
+  }),
+);
+
+// An HTTP API serving /api/things from a function.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "things",
+    Role: "arn:aws:iam::111111111111:role/ThingsRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => ({ things: ["kettle"] })) },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "things", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /api/things",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "things",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// One Distribution serving the site, with /api/* going to the API.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "site-and-api",
+      Comment: "Site and API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "site.s3.amazonaws.com",
+            S3OriginConfig: { OriginAccessIdentity: "" },
+          },
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/api/*",
+            TargetOriginId: "api-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const page = await fetch(srv.localUrl(`http://${distroHostname}/index.html`));
+  const things = await fetch(
+    srv.localUrl(`http://${distroHostname}/api/things`),
+  );
+
+  console.log(await page.text());
+  console.log(await things.text());
+} finally {
+  srv.close();
+}

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -7,6 +7,7 @@ import type { SimAws } from "../sim-aws.js";
 import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import type { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
+import { makeSimCfCustomOriginDispatcher } from "../../cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.factory.js";
 import { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import { SimRoute53 } from "../../route53/index.js";
 import type { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
@@ -92,6 +93,7 @@ export class SimAwsAccountServiceCache {
           accountRegionScope: scope.accountRegionScope,
           cloudFrontRegistry: this.cloudFrontRegistry,
           s3OriginResolver: makeSimCfS3OriginResolver(this.simAws, scope),
+          customOriginDispatcher: makeSimCfCustomOriginDispatcher(this.simAws),
           iam,
           acmRegistry: this.acmRegistry,
           background: this.background,

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -88,7 +88,9 @@ HTTP request behaviour is split across a few directories:
 - `router/` resolves an incoming `Request` to a simulated Distribution by CloudFront hostname or
   alternate domain name.
 - `resolver/` chooses the matching Cache Behavior for a request path.
-- `origin/` adapts CloudFront Origin requests/responses, including S3 Origins.
+- `origin/` adapts CloudFront Origin requests/responses. `origin/s3/` reaches a sim S3 Bucket
+  directly, while `origin/custom/` turns the Origin request back into an HTTP request and sends it
+  into the wider simulated environment.
 
 When a sim AWS is served on localhost, CloudFront requests are routed through this layer to find the
 right sim Distribution, Origin and Behavior.
@@ -117,6 +119,11 @@ The key integration points are:
   information across the broader simulated AWS instance.
 - S3 Origin resolution, which lets CloudFront Distributions fetch from simulated S3 buckets and S3
   website Origins.
+- `SimCfCustomOriginDispatcher`, which resolves a custom Origin domain through simulated Route53 and
+  serves the request over the same in-process HTTP entry point as a request arriving on localhost.
+  CloudFront therefore needs no per-service knowledge: an HTTP API endpoint, a Lambda Function URL
+  and a hosted-zone record pointing at either all reach their service the same way. A standalone
+  `SimCloudFront` has no dispatcher, and refuses a custom Origin rather than reaching the network.
 - `SimAcmRegistry`, which resolves the ACM Certificate a Distribution's viewer certificate ARN
   names, wherever in the simulated AWS instance it lives.
 

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-custom-origin.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-custom-origin.iso.test.ts
@@ -1,0 +1,73 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+describe("CloudFormation CloudFront Distribution custom Origin", () => {
+  it("serves a simulated HTTP API declared as a template Origin", async () => {
+    // Given an HTTP API serving a route.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => ({ things: ["kettle"] }),
+        routeKeys: ["GET /things"],
+      },
+      simAws,
+    );
+
+    // When a template declares a Distribution fronting that API.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "api-distribution-stack",
+      template: {
+        Resources: {
+          ApiDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [
+                  {
+                    Id: "ApiOrigin",
+                    DomainName: new URL(api.apiEndpoint).hostname,
+                    CustomOriginConfig: {
+                      OriginProtocolPolicy: "https-only",
+                    },
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "ApiOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the deployed Distribution serves the API's responses.
+    const resource = stack.getResource("ApiDistribution");
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    const distributionId = resource.simResource.distributionId.toLowerCase();
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({
+        input: `https://${distributionId}.cloudfront.net/things`,
+      }).toString(),
+    );
+
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), '{"things":["kettle"]}');
+  });
+});

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -82,12 +82,19 @@ export interface SimCloudFrontViewerCertificate {
 
 /**
  * Minimal structural sim CloudFront Origin config.
+ *
+ * An Origin is an S3 Origin or a custom Origin, as it is in CloudFront, and
+ * which one it is decides how the simulator reaches it. The settings inside
+ * `CustomOriginConfig` describe how CloudFront connects to the Origin over the
+ * network, which an in-process fetch has no use for, so they are accepted and
+ * ignored.
  */
 export interface SimCloudFrontOriginConfig {
   readonly Id?: string | undefined;
   readonly DomainName?: string | undefined;
   readonly OriginPath?: string | undefined;
   readonly S3OriginConfig?: object | undefined;
+  readonly CustomOriginConfig?: object | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -11,6 +11,7 @@ import {
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { SimCloudFrontOriginConfigurator } from "../../distribution/configurator/sim-cloud-front-origin-configurator.js";
 import { SimCloudFrontBehaviorConfigurator } from "../../distribution/configurator/sim-cloud-front-behavior-configurator.js";
@@ -33,6 +34,7 @@ interface CreateDistributionCommandHandlerProperties {
   >;
   readonly cloudFrontRegistry: SimCloudFrontRegistry;
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background: BackgroundScheduler;
@@ -67,7 +69,10 @@ export class CreateDistributionCommandHandler implements CommandHandler<
     this.distributions = properties.distributions;
     this.cloudFrontRegistry = properties.cloudFrontRegistry;
     this.distributionConfigurator = new SimCloudFrontDistributionConfigurator(
-      new SimCloudFrontOriginConfigurator(properties.s3OriginResolver),
+      new SimCloudFrontOriginConfigurator(
+        properties.s3OriginResolver,
+        properties.customOriginDispatcher,
+      ),
       new SimCloudFrontBehaviorConfigurator(),
     );
     this.authorizer = new CreateDistributionAuthorizer({

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -5,13 +5,23 @@ import {
   SimCloudFrontS3Origin,
   type SimCloudFrontS3OriginResolver,
 } from "../../origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
+import { SimCloudFrontCustomOrigin } from "../../origin/custom/sim-cloudfront-custom-origin.js";
 
 /**
  * Applies Origin configuration to a sim CloudFront Distribution.
+ *
+ * An Origin is an S3 Origin or a custom Origin, as it is in CloudFront, and
+ * which one it is decides how the simulator reaches it. A custom Origin domain
+ * is not resolved here, because a Distribution and the service behind its
+ * Origin are routinely created in either order, and a CloudFormation template
+ * says nothing about which comes first. Resolution happens when a request is
+ * served, by which time both exist.
  */
 export class SimCloudFrontOriginConfigurator {
   constructor(
     private readonly s3OriginResolver: SimCloudFrontS3OriginResolver,
+    private readonly customOriginDispatcher?: SimCfCustomOriginDispatcher,
   ) {}
 
   /**
@@ -35,6 +45,24 @@ export class SimCloudFrontOriginConfigurator {
       distribution.addOrigin(
         origin.Id,
         new SimCloudFrontS3Origin({ bucket, originPath: origin.OriginPath }),
+      );
+      return;
+    }
+
+    if (origin.CustomOriginConfig !== undefined) {
+      assertDefined(
+        this.customOriginDispatcher,
+        `Simulated AWS environment for sim CloudFront custom Origin ${origin.Id}, which a standalone SimCloudFront has no way to reach`,
+      );
+
+      distribution.addOrigin(
+        origin.Id,
+        new SimCloudFrontCustomOrigin({
+          originId: origin.Id,
+          domainName: origin.DomainName,
+          originPath: origin.OriginPath,
+          dispatcher: this.customOriginDispatcher,
+        }),
       );
       return;
     }

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.factory.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.factory.ts
@@ -1,0 +1,47 @@
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfCustomOriginDispatcher } from "./sim-cf-custom-origin-dispatcher.js";
+
+/**
+ * Dispatches sim CloudFront custom Origin requests into a simulated AWS
+ * environment, over the same in-process HTTP entry point everything else
+ * addressed to a simulated hostname goes through.
+ *
+ * Reusing that entry point is what keeps CloudFront free of per-service
+ * knowledge: an Origin domain is resolved by simulated Route53, so an HTTP
+ * API, a Lambda Function URL, and a hosted-zone record pointing at either all
+ * work without CloudFront knowing which is which.
+ */
+class SimCfSimAwsOriginDispatcher implements SimCfCustomOriginDispatcher {
+  private readonly simAws: SimAws;
+  private http: SimAwsHttp | undefined;
+
+  constructor(simAws: SimAws) {
+    this.simAws = simAws;
+  }
+
+  /**
+   * Whether simulated Route53 resolves the Origin hostname to a service.
+   */
+  resolves(originHostname: string): boolean {
+    return this.simAws.route53().resolveHttpHost(originHostname) !== undefined;
+  }
+
+  /**
+   * Serve the Origin request from the simulated environment.
+   */
+  async fetch(request: Request): Promise<Response> {
+    this.http ??= new SimAwsHttp({ simAws: this.simAws });
+
+    return await this.http.handleRequest(request);
+  }
+}
+
+/**
+ * Create a custom Origin dispatcher backed by a simulated AWS environment.
+ */
+export function makeSimCfCustomOriginDispatcher(
+  simAws: SimAws,
+): SimCfCustomOriginDispatcher {
+  return new SimCfSimAwsOriginDispatcher(simAws);
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-dispatcher.ts
@@ -1,0 +1,24 @@
+/**
+ * Sends a sim CloudFront custom Origin request into the simulated AWS
+ * environment the Distribution belongs to.
+ *
+ * A custom Origin is reached over HTTP, and Yulin does no real networking, so
+ * the request never leaves the process: the Origin hostname names another
+ * simulated service, which serves the request the same way it serves one
+ * arriving on localhost.
+ *
+ * This is the seam between CloudFront and that wider environment. A
+ * standalone `SimCloudFront` has no environment to reach, and so has no
+ * dispatcher, rather than reaching the network.
+ */
+export interface SimCfCustomOriginDispatcher {
+  /**
+   * Whether a Yulin-local Origin hostname names a simulated service.
+   */
+  resolves(originHostname: string): boolean;
+
+  /**
+   * Send an Origin request to the simulated service its hostname names.
+   */
+  fetch(request: Request): Promise<Response>;
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -1,0 +1,53 @@
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+
+interface SimCfCustomOriginRequestProperties {
+  readonly domainName: string;
+  readonly originPath: string;
+  readonly request: Request;
+}
+
+/**
+ * Build the request sim CloudFront sends on to a custom Origin.
+ *
+ * CloudFront keeps the viewer's method, headers, query string and body, sends
+ * the Origin's own domain as the host, and prefixes the Origin path to the
+ * request path. The Origin domain is rewritten to its Yulin-local form here,
+ * so that an AWS endpoint hostname is resolved by the same host handling that
+ * serves the simulated environment on localhost.
+ */
+export function simCfCustomOriginRequest(
+  properties: SimCfCustomOriginRequestProperties,
+): Request {
+  const { request } = properties;
+  const viewerUrl = new URL(request.url);
+
+  const originUrl = new SimAwsLocalUrl({
+    input: `https://${properties.domainName}`,
+  }).toURL();
+  originUrl.pathname = originRequestPath(
+    properties.originPath,
+    viewerUrl.pathname,
+  );
+  originUrl.search = viewerUrl.search;
+
+  const headers = new Headers(request.headers);
+  headers.set("host", originUrl.host);
+
+  const isBodyAllowed = !/^(?:get|head)$/iu.test(request.method);
+
+  return new Request(originUrl, {
+    method: request.method,
+    headers,
+    body: isBodyAllowed ? request.clone().body : null,
+    duplex: "half",
+    redirect: request.redirect,
+    signal: request.signal,
+  });
+}
+
+/**
+ * Prefix the Origin path to the request path, as CloudFront does.
+ */
+function originRequestPath(originPath: string, viewerPath: string): string {
+  return `/${originPath}/${viewerPath}`.replaceAll(/\/{2,}/gu, "/");
+}

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.iso.test.ts
@@ -1,0 +1,383 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateDistributionCommand,
+  type Origin,
+} from "@aws-sdk/client-cloudfront";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+import { SimCloudFront } from "../../sim-cloudfront.js";
+
+/**
+ * Create a Distribution sending everything to one custom Origin, and return
+ * the hostname a viewer reaches it on.
+ */
+async function distributionForOrigin(
+  simAws: SimAws,
+  origin: Origin,
+): Promise<string> {
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "custom-origin",
+        Comment: "Custom Origin CDN",
+        Enabled: true,
+        Origins: { Quantity: 1, Items: [origin] },
+        DefaultCacheBehavior: {
+          TargetOriginId: origin.Id,
+          ViewerProtocolPolicy: "allow-all",
+          AllowedMethods: {
+            Quantity: 3,
+            Items: ["GET", "HEAD", "POST"],
+            CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+          },
+        },
+      },
+    }),
+  );
+
+  const distroHostname = creation.Distribution?.DomainName;
+  assertNonNullable(distroHostname);
+
+  return distroHostname;
+}
+
+function viewerUrl(distroHostname: string, path: string): string {
+  return new SimAwsLocalUrl({
+    input: `https://${distroHostname}${path}`,
+  }).toString();
+}
+
+describe("Simulated CloudFront custom Origin", () => {
+  it("serves a simulated HTTP API through the Distribution", async () => {
+    // Given an HTTP API serving a route.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => ({ things: ["kettle"] }),
+        routeKeys: ["GET /things"],
+      },
+      simAws,
+    );
+
+    // And a Distribution with the API's endpoint as a custom Origin.
+    const distroHostname = await distributionForOrigin(simAws, {
+      Id: "api-origin",
+      DomainName: new URL(api.apiEndpoint).hostname,
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: "https-only",
+      },
+    });
+
+    // When the route is requested through the Distribution.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      viewerUrl(distroHostname, "/things"),
+    );
+
+    // Then the API's response is what the viewer sees.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), '{"things":["kettle"]}');
+  });
+
+  it("serves a simulated Lambda Function URL through the Distribution", async () => {
+    // Given a function served at a public Function URL.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => ({
+            statusCode: 200,
+            headers: { "content-type": "text/plain" },
+            body: "Hello from behind CloudFront",
+          })),
+        },
+      }),
+    );
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+    assertNonNullable(functionUrl);
+
+    // And a Distribution with the Function URL as a custom Origin.
+    const distroHostname = await distributionForOrigin(simAws, {
+      Id: "function-origin",
+      DomainName: new URL(functionUrl).hostname,
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: "https-only",
+      },
+    });
+
+    // When the Distribution is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      viewerUrl(distroHostname, "/greeting"),
+    );
+
+    // Then the function's response is what the viewer sees.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "Hello from behind CloudFront");
+  });
+
+  it("prepends the Origin path to the request path", async () => {
+    // Given an API whose routes all sit under a prefix.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): unknown => ({
+          rawPath: event.rawPath,
+          query: event.rawQueryString,
+        }),
+        routeKeys: ["GET /v1/things"],
+      },
+      simAws,
+    );
+
+    // And a Distribution whose Origin adds that prefix.
+    const distroHostname = await distributionForOrigin(simAws, {
+      Id: "api-origin",
+      DomainName: new URL(api.apiEndpoint).hostname,
+      OriginPath: "/v1",
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: "https-only",
+      },
+    });
+
+    // When a request is made without the prefix.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      viewerUrl(distroHostname, "/things?colour=copper"),
+    );
+
+    // Then the Origin saw the prefixed path, and the query string with it.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(
+      await response.text(),
+      '{"rawPath":"/v1/things","query":"colour=copper"}',
+    );
+  });
+
+  it("passes the request method and body on to the Origin", async () => {
+    // Given an API echoing what it was sent.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): unknown => ({
+          method: event.requestContext.http.method,
+          body: event.body,
+        }),
+        routeKeys: ["POST /things"],
+      },
+      simAws,
+    );
+    const distroHostname = await distributionForOrigin(simAws, {
+      Id: "api-origin",
+      DomainName: new URL(api.apiEndpoint).hostname,
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: "https-only",
+      },
+    });
+
+    // When a POST with a body goes through the Distribution.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      viewerUrl(distroHostname, "/things"),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"name":"kettle"}',
+      },
+    );
+
+    // Then the Origin was sent both.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(
+      await response.text(),
+      String.raw`{"method":"POST","body":"{\"name\":\"kettle\"}"}`,
+    );
+  });
+
+  it("sends one path pattern to the API and the rest to the Bucket", async () => {
+    // Given an API and a Bucket holding a page.
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): unknown => ({ things: ["kettle"] }),
+        routeKeys: ["GET /api/things"],
+      },
+      simAws,
+    );
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: "index.html",
+        Body: "<h1>Site</h1>",
+      }),
+    );
+
+    // And a Distribution serving the site, with /api/* going to the API.
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "site-and-api",
+          Comment: "Site and API CDN",
+          Enabled: true,
+          Origins: {
+            Quantity: 2,
+            Items: [
+              {
+                Id: "site-origin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+              {
+                Id: "api-origin",
+                DomainName: new URL(api.apiEndpoint).hostname,
+                CustomOriginConfig: {
+                  HTTPPort: 80,
+                  HTTPSPort: 443,
+                  OriginProtocolPolicy: "https-only",
+                },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+          CacheBehaviors: {
+            Quantity: 1,
+            Items: [
+              {
+                PathPattern: "/api/*",
+                TargetOriginId: "api-origin",
+                ViewerProtocolPolicy: "allow-all",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const distroHostname = creation.Distribution?.DomainName;
+    assertNonNullable(distroHostname);
+
+    // When both a page and an API route are requested.
+    const http = new SimAwsHttp({ simAws });
+    const pageResponse = await http.fetch(
+      viewerUrl(distroHostname, "/index.html"),
+    );
+    const apiResponse = await http.fetch(
+      viewerUrl(distroHostname, "/api/things"),
+    );
+
+    // Then each Behavior served from its own Origin.
+    assertResponseStatus(
+      pageResponse,
+      200,
+      await describeResponse(pageResponse),
+    );
+    assertIdentical(await pageResponse.text(), "<h1>Site</h1>");
+    assertResponseStatus(apiResponse, 200, await describeResponse(apiResponse));
+    assertIdentical(await apiResponse.text(), '{"things":["kettle"]}');
+  });
+
+  it("fails an Origin domain naming nothing in the simulation", async () => {
+    // Given a Distribution with a custom Origin outside the simulation.
+    const simAws = new SimAws();
+    const distroHostname = await distributionForOrigin(simAws, {
+      Id: "api-origin",
+      DomainName: "api.example.test",
+      CustomOriginConfig: {
+        HTTPPort: 80,
+        HTTPSPort: 443,
+        OriginProtocolPolicy: "https-only",
+      },
+    });
+
+    // When it is requested.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      viewerUrl(distroHostname, "/things"),
+    );
+
+    // Then the failure names the Origin and its domain, rather than the
+    // request being sent to the real domain.
+    assertResponseStatus(response, 500, await describeResponse(response));
+    assertStringIncludes(
+      await response.text(),
+      "Sim CloudFront Origin api-origin domain name api.example.test does not resolve to a simulated AWS service",
+    );
+  });
+
+  it("refuses a custom Origin on a standalone sim CloudFront", async () => {
+    // Given a sim CloudFront with no simulated environment around it.
+    const simCloudFront = new SimCloudFront();
+
+    // When a Distribution declares a custom Origin.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: {
+            CallerReference: "standalone",
+            Comment: "Standalone CDN",
+            Enabled: true,
+            Origins: {
+              Quantity: 1,
+              Items: [
+                {
+                  Id: "api-origin",
+                  DomainName: "abc123.execute-api.eu-west-2.amazonaws.com",
+                  CustomOriginConfig: {
+                    HTTPPort: 80,
+                    HTTPSPort: 443,
+                    OriginProtocolPolicy: "https-only",
+                  },
+                },
+              ],
+            },
+            DefaultCacheBehavior: {
+              TargetOriginId: "api-origin",
+              ViewerProtocolPolicy: "allow-all",
+            },
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, because there is nothing for it to reach.
+    assertStringIncludes(
+      error.message,
+      "Simulated AWS environment for sim CloudFront custom Origin api-origin",
+    );
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
@@ -1,0 +1,94 @@
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { serveSimAws } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+
+describe("Serving a sim CloudFront custom Origin on localhost", () => {
+  it("reaches the Origin in process for a real localhost request", async () => {
+    // Given a function behind a public Function URL.
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(
+            (event: { rawPath?: string; body?: string }) => ({
+              statusCode: 200,
+              headers: { "content-type": "text/plain" },
+              body: `${event.rawPath ?? ""} ${event.body ?? ""}`.trim(),
+            }),
+          ),
+        },
+      }),
+    );
+    const { FunctionUrl: functionUrl } = await simAws
+      .lambda()
+      .createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+        }),
+      );
+    assertNonNullable(functionUrl);
+
+    // And a Distribution fronting it as a custom Origin.
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "localhost-custom-origin",
+          Comment: "Localhost custom Origin CDN",
+          Enabled: true,
+          Origins: {
+            Quantity: 1,
+            Items: [
+              {
+                Id: "function-origin",
+                DomainName: new URL(functionUrl).hostname,
+                CustomOriginConfig: {
+                  HTTPPort: 80,
+                  HTTPSPort: 443,
+                  OriginProtocolPolicy: "https-only",
+                },
+              },
+            ],
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "function-origin",
+            ViewerProtocolPolicy: "allow-all",
+            AllowedMethods: {
+              Quantity: 3,
+              Items: ["GET", "HEAD", "POST"],
+              CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+            },
+          },
+        },
+      }),
+    );
+    const distroHostname = creation.Distribution?.DomainName;
+    assertNonNullable(distroHostname);
+
+    const srv = await serveSimAws({ simAws });
+
+    try {
+      // When the Distribution is requested over localhost.
+      const response = await fetch(
+        srv.localUrl(`http://${distroHostname}/greet`),
+        { method: "POST", body: "Yulin" },
+      );
+
+      // Then the Origin served it, over the same request path and body.
+      assertIdentical(response.status, 200);
+      assertIdentical(await response.text(), "/greet Yulin");
+    } finally {
+      srv.close();
+    }
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -1,0 +1,62 @@
+import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
+import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+import type { SimCfCustomOriginDispatcher } from "./sim-cf-custom-origin-dispatcher.js";
+import { simCfCustomOriginRequest } from "./sim-cf-custom-origin-request.js";
+
+interface SimCloudFrontCustomOriginProperties {
+  readonly originId: string;
+  readonly domainName: string;
+  readonly originPath?: string | undefined;
+  readonly dispatcher: SimCfCustomOriginDispatcher;
+}
+
+/**
+ * Simulated CloudFront custom Origin.
+ *
+ * A custom Origin is any Origin CloudFront reaches over HTTP rather than as an
+ * S3 Bucket. In a simulated environment that means another simulated service
+ * with an endpoint of its own: an HTTP API or a Lambda Function URL, or
+ * anything a simulated Route53 record points at one of those.
+ *
+ * The Origin is reached anonymously, as CloudFront reaches an Origin it has no
+ * Origin Access Control for, so a Function URL or route that authorizes with
+ * `AWS_IAM` refuses the request.
+ */
+export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
+  private readonly originId: string;
+  private readonly domainName: string;
+  private readonly originPath: string;
+  private readonly dispatcher: SimCfCustomOriginDispatcher;
+
+  constructor(properties: SimCloudFrontCustomOriginProperties) {
+    this.originId = properties.originId;
+    this.domainName = properties.domainName;
+    this.originPath = properties.originPath ?? "";
+    this.dispatcher = properties.dispatcher;
+  }
+
+  /**
+   * Fetch the request from the simulated service behind this Origin.
+   *
+   * An Origin domain naming nothing in the simulation fails here rather than
+   * being sent to the real domain, because a simulated Distribution reaching
+   * out to the internet is never what a test meant.
+   */
+  async fetch(request: SimCloudFrontOriginRequest): Promise<Response> {
+    const originRequest = simCfCustomOriginRequest({
+      domainName: this.domainName,
+      originPath: this.originPath,
+      request: request.req,
+    });
+
+    const { hostname } = new URL(originRequest.url);
+
+    if (!this.dispatcher.resolves(hostname)) {
+      throw new Error(
+        `Sim CloudFront Origin ${this.originId} domain name ${this.domainName} does not resolve to a simulated AWS service`,
+      );
+    }
+
+    return await this.dispatcher.fetch(originRequest);
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -13,6 +13,7 @@ import {
   emptyCloudFrontS3OriginResolver,
   type SimCloudFrontS3OriginResolver,
 } from "./origin/s3/sim-cloudfront-s3-origin.js";
+import type { SimCfCustomOriginDispatcher } from "./origin/custom/sim-cf-custom-origin-dispatcher.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -53,6 +54,7 @@ interface SimCloudFrontProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly cloudFrontRegistry?: SimCloudFrontRegistry;
   readonly s3OriginResolver?: SimCloudFrontS3OriginResolver;
+  readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;
   readonly background?: BackgroundScheduler;
@@ -74,6 +76,8 @@ export class SimCloudFront {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly cloudFrontRegistry: SimCloudFrontRegistry;
   private readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
+  private readonly customOriginDispatcher:
+    SimCfCustomOriginDispatcher | undefined;
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly acmRegistry: SimAcmRegistry | undefined;
   private readonly background: BackgroundScheduler;
@@ -87,6 +91,7 @@ export class SimCloudFront {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       cloudFrontRegistry = new SimCloudFrontRegistry(),
       s3OriginResolver = emptyCloudFrontS3OriginResolver,
+      customOriginDispatcher,
       iam = new SimIamAllowAllAuth(),
       acmRegistry,
       background = new BackgroundTasks(),
@@ -95,6 +100,7 @@ export class SimCloudFront {
     this.accountRegionScope = accountRegionScope;
     this.cloudFrontRegistry = cloudFrontRegistry;
     this.s3OriginResolver = s3OriginResolver;
+    this.customOriginDispatcher = customOriginDispatcher;
     this.iam = iam;
     this.acmRegistry = acmRegistry;
     this.background = background;
@@ -133,6 +139,7 @@ export class SimCloudFront {
       distributions: this.distributions,
       cloudFrontRegistry: this.cloudFrontRegistry,
       s3OriginResolver: this.s3OriginResolver,
+      customOriginDispatcher: this.customOriginDispatcher,
       iam: this.iam,
       acmRegistry: this.acmRegistry,
       background: this.background,


### PR DESCRIPTION
An Origin with a CustomOriginConfig resolves its domain through simulated Route53 and is fetched in process, so a Distribution can front a sim HTTP API or Lambda Function URL. A domain naming nothing in the simulation fails with an error naming the Origin and the domain.

Resolves #357