### PR TITLE
feat: read simulated DynamoDB stream records with the Streams API

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -243,8 +243,8 @@ which descriptors is in
 ## Supported services and Commands
 
 All simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
-Cognito, DynamoDB, IAM, KMS, Lambda, Route53, S3, Secrets Manager, SQS, SSM and STS. Each service's
-own docs under
+Cognito, DynamoDB, DynamoDB Streams, IAM, KMS, Lambda, Route53, S3, Secrets Manager, SQS, SSM and
+STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2576,8 +2576,129 @@ cancelled transaction, a delete of a key holding nothing, or a request the table
 the table takes its items with it rather than removing them one at a time, so nothing is captured
 for that either.
 
-Reading the records back is the DynamoDB Streams API, which is not simulated yet, so for now a
-stream is captured rather than consumed.
+## Reading a stream's records
+
+Reading the records back is the DynamoDB Streams API, which AWS puts behind a client of its own.
+`simAws.dynamoDbStreams()` is that API here, with `ListStreams`, `DescribeStream`,
+`GetShardIterator` and `GetRecords`.
+
+Reading a stream takes four calls the first time. `ListStreams` finds the stream ARN for a table,
+`DescribeStream` reports the shard, `GetShardIterator` says where on that shard to start, and
+`GetRecords` reads from there and hands back the iterator to carry on with.
+
+```typescript sim-dynamodb-stream-records
+/**
+ * Reading a table's captured changes back off its stream.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+const dynamoDbStreams = simAws.dynamoDbStreams();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+const listed = await dynamoDbStreams.listStreams(
+  new ListStreamsCommand({ TableName: "OrdersTable" }),
+);
+const streamArn = listed.Streams?.[0]?.StreamArn;
+
+const described = await dynamoDbStreams.describeStream(
+  new DescribeStreamCommand({ StreamArn: streamArn }),
+);
+const shardId = described.StreamDescription?.Shards?.[0]?.ShardId;
+
+console.log(described.StreamDescription?.StreamStatus); // "ENABLED"
+
+const iterator = await dynamoDbStreams.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamArn: streamArn,
+    ShardId: shardId,
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const read = await dynamoDbStreams.getRecords(
+  new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+);
+
+console.log(read.Records?.[0]?.eventName); // "INSERT"
+console.log(read.Records?.[0]?.dynamodb?.NewImage?.["total"]?.N); // "101"
+
+// The iterator to poll with next, which is there while the stream is open.
+console.log(read.NextShardIterator !== undefined); // true
+```
+
+A record carries `eventID`, `eventName`, `eventSource`, `awsRegion` and a `dynamodb` body holding
+`Keys`, the images the view type selects, `SequenceNumber`, `SizeBytes` and
+`ApproximateCreationDateTime`. A time to live removal carries
+`userIdentity: { PrincipalId: "dynamodb.amazonaws.com", Type: "Service" }`. The Streams API
+capitalizes those two fields where the Lambda event carries the same values as `principalId` and
+`type`, so a consumer written against one shape does not read the other.
+
+### Where to start reading
+
+`ShardIteratorType` picks the place on the shard an iterator starts at.
+
+| `ShardIteratorType`     | Starts at                                |
+| ----------------------- | ---------------------------------------- |
+| `TRIM_HORIZON`          | the oldest record the stream still holds |
+| `LATEST`                | just after the newest record on it       |
+| `AT_SEQUENCE_NUMBER`    | the record the `SequenceNumber` names    |
+| `AFTER_SEQUENCE_NUMBER` | the record following the one it names    |
+
+`AT_SEQUENCE_NUMBER` and `AFTER_SEQUENCE_NUMBER` need a `SequenceNumber`, and the other two are
+refused if given one, since an iterator asking for both is saying two different things about where
+to start.
+
+### Polling with NextShardIterator
+
+`GetRecords` answers with the iterator to use for the next call. Reading a stream to the end and
+polling it is the same loop either way: pass each `NextShardIterator` to the following `GetRecords`.
+
+An empty `Records` array alongside a `NextShardIterator` is the ordinary answer for a reader that
+has caught up, and means to look again rather than that anything is wrong. `NextShardIterator` is
+absent only when the shard is closed and the reader has reached the end of it, which happens once
+the table has switched the stream off and everything on it has been read.
+
+### The 24 hour retention window
+
+A stream keeps its records for 24 hours on the simulated clock, and the trim is applied when the
+stream is read. Reading from a position the stream no longer holds raises a
+`TrimmedDataAccessException`, whether the sequence number was named in a `GetShardIterator` call or
+carried in an iterator that was still good when it was handed out. `TRIM_HORIZON` never raises it:
+it means the oldest record still there, whatever has gone.
+
+A stream stays listable and readable after its table switches it off, and after everything on it has
+been trimmed. A trimmed stream reads as empty rather than as missing.
 
 ## Numbers
 
@@ -3111,11 +3232,16 @@ nothing is written.
   record with the images its `StreamViewType` selects, a time to live expiry carrying a `Service`
   `userIdentity`, and `StreamSpecification`, `LatestStreamArn` and `LatestStreamLabel` reported by
   `DescribeTable`.
+- The DynamoDB Streams API through `simAws.dynamoDbStreams()`, with `ListStreams`, `DescribeStream`,
+  `GetShardIterator` and `GetRecords`, all four shard iterator types, a `NextShardIterator` that is
+  absent only for a closed and drained shard, and the 24 hour retention window with
+  `TrimmedDataAccessException` past the trim point.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
   expires items, `Tags` deploying a tagged table, and `GlobalSecondaryIndexes` and
   `LocalSecondaryIndexes` deploying a table whose indexes are then queried and scanned.
-- SDK interception, so an intercepted `DynamoDBClient` reaches the simulation.
+- SDK interception, so an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
+  simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
   `UpdateCommand`, `BatchWriteCommand` and `BatchGetCommand` converting native JavaScript values on
   the way in and out.
@@ -3199,13 +3325,20 @@ nothing is written.
   elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
   is until something moves the clock. A simulated DynamoDB constructed standalone as
   `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
-- A stream's records cannot be read back. `ListStreams`, `DescribeStream`, `GetShardIterator` and
-  `GetRecords` are not simulated yet, so a table with a `StreamSpecification` captures its changes
-  and nothing can consume them. Nor can a Lambda event source mapping read one.
+- A Lambda event source mapping cannot read a stream yet. A test polls one with `GetRecords` itself.
 - A `StreamSpecification` in a CloudFormation template still skips the table, so a streamed table
   has to be created through `CreateTable`.
-- Records are kept for as long as the simulation runs. Real DynamoDB trims a stream at 24 hours,
-  which arrives with the read path.
+- A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
+  `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
+  number it last checkpointed. Nothing here refuses an iterator for being old.
+- `DescribeStream` takes `Limit` and `ExclusiveStartShardId` and neither changes the answer, since a
+  simulated stream has one shard and a page of shards is always all of them. `ShardFilter` is
+  refused by name rather than ignored, since there is no shard lineage for it to walk.
+- A stream is never dropped once everything on it has been trimmed. Real DynamoDB eventually stops
+  listing a disabled stream whose records have all aged out, where the ARN a test is holding goes on
+  resolving here and reads as empty.
+- The two readers per shard throughput limit and the `DescribeStream` rate limit are not applied.
+  Both are throughput protections a single-process simulation cannot produce honestly.
 - The five year time to live eligibility rule counts 1825 days rather than five calendar years, so
   an item whose timestamp sits within a couple of days of the boundary may be treated differently
   here to how AWS treats it.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2684,6 +2684,10 @@ to start.
 `GetRecords` answers with the iterator to use for the next call. Reading a stream to the end and
 polling it is the same loop either way: pass each `NextShardIterator` to the following `GetRecords`.
 
+One `GetRecords` hands back at most 1000 records, so a reader with more than that behind it stays
+behind until it polls again. `Limit` asks for fewer, and a `Limit` above 1000 is a
+`ValidationException` rather than being quietly reduced.
+
 An empty `Records` array alongside a `NextShardIterator` is the ordinary answer for a reader that
 has caught up, and means to look again rather than that anything is wrong. `NextShardIterator` is
 absent only when the shard is closed and the reader has reached the end of it, which happens once
@@ -3331,9 +3335,9 @@ nothing is written.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
   `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
   number it last checkpointed. Nothing here refuses an iterator for being old.
-- `DescribeStream` takes `Limit` and `ExclusiveStartShardId` and neither changes the answer, since a
-  simulated stream has one shard and a page of shards is always all of them. `ShardFilter` is
-  refused by name rather than ignored, since there is no shard lineage for it to walk.
+- `DescribeStream` never reports a `LastEvaluatedShardId`, since a simulated stream has one shard
+  and a page of shards is always all of them. `ShardFilter` is refused by name rather than ignored,
+  since there is no shard lineage for it to walk.
 - A stream is never dropped once everything on it has been trimmed. Real DynamoDB eventually stops
   listing a disabled stream whose records have all aged out, where the ARN a test is holding goes on
   resolving here and reads as empty.

--- a/docs/services/dynamodb/sim-dynamodb-stream-records.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-stream-records.example.ts
@@ -1,0 +1,68 @@
+/**
+ * Reading a table's captured changes back off its stream.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+const dynamoDbStreams = simAws.dynamoDbStreams();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+const listed = await dynamoDbStreams.listStreams(
+  new ListStreamsCommand({ TableName: "OrdersTable" }),
+);
+const streamArn = listed.Streams?.[0]?.StreamArn;
+
+const described = await dynamoDbStreams.describeStream(
+  new DescribeStreamCommand({ StreamArn: streamArn }),
+);
+const shardId = described.StreamDescription?.Shards?.[0]?.ShardId;
+
+console.log(described.StreamDescription?.StreamStatus); // "ENABLED"
+
+const iterator = await dynamoDbStreams.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamArn: streamArn,
+    ShardId: shardId,
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const read = await dynamoDbStreams.getRecords(
+  new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+);
+
+console.log(read.Records?.[0]?.eventName); // "INSERT"
+console.log(read.Records?.[0]?.dynamodb?.NewImage?.["total"]?.N); // "101"
+
+// The iterator to poll with next, which is there while the stream is open.
+console.log(read.NextShardIterator !== undefined); // true

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "@aws-sdk/client-cloudfront": "^3.1101.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1101.0",
     "@aws-sdk/client-dynamodb": "^3.1101.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.1101.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1101.0
         version: 3.1101.0
+      '@aws-sdk/client-dynamodb-streams':
+        specifier: ^3.1101.0
+        version: 3.1101.0
       '@aws-sdk/client-iam':
         specifier: ^3.1101.0
         version: 3.1101.0
@@ -210,6 +213,10 @@ packages:
 
   '@aws-sdk/client-cognito-identity-provider@3.1101.0':
     resolution: {integrity: sha512-iINP4bJzVeCN1UDDQ5aRIEaGOCUUf8esOkHp7P7q/mBB+X8icJUitDsCcf4F1poymUO5YK4ArARGF45dH74rSg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-dynamodb-streams@3.1101.0':
+    resolution: {integrity: sha512-j/VjMkhZPpnSO+DLjf22ZzxBnzbH86dtWrh+wV0AJkZvDT3bZNQXEPAj0ioqhPTWHARB9jYa6bLTtKCa1zZw1A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-dynamodb@3.1101.0':
@@ -1176,6 +1183,7 @@ packages:
 
   constructs@10.8.0:
     resolution: {integrity: sha512-pJHp2CxvTG0ttp52rZvQfkbspPLZzttWPooIRLBwlZK8rV7ZhkjIkyZWJhIfBDC4YdcwIDmXyUFr1ieJaqjBbg==}
+    deprecated: This version has a bug that breaks downstream jsii consumers
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2013,6 +2021,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-cognito-identity-provider@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-dynamodb-streams@3.1101.0':
     dependencies:
       '@aws-sdk/core': 3.977.4
       '@aws-sdk/credential-provider-node': 3.972.76

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -41,6 +41,9 @@ export function resolveSimSdkCommandRouter(
     case "DynamoDB": {
       return scoped.dynamoDb().sdkCommandRouter();
     }
+    case "DynamoDB Streams": {
+      return scoped.dynamoDbStreams().sdkCommandRouter();
+    }
     case "IAM": {
       return scoped.iam().sdkCommandRouter();
     }

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -4,7 +4,10 @@ import { Memo } from "../../util/memo/memo.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
-import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
+import type {
+  SimDynamoDb as SimDynamoDatabase,
+  SimDynamoDbStreams,
+} from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
 import type { SimRoute53 } from "../route53/index.js";
@@ -107,6 +110,17 @@ export class SimAwsAccountRegionContainer {
     return this.memo.getOrCreate("dynamoDb", () =>
       this.simAws.serviceFactory.createDynamoDb(this),
     );
+  }
+
+  /**
+   * Get simulated DynamoDB Streams for this account and region.
+   *
+   * It is not made here, unlike the services around it. The streams it reads
+   * are the ones this scope's DynamoDB tables captured onto, so it belongs to
+   * that service and is reached through it.
+   */
+  dynamoDbStreams(): SimDynamoDbStreams {
+    return this.dynamoDb().streams();
   }
 
   /**

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -4,7 +4,10 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import { faker } from "@faker-js/faker";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
-import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
+import type {
+  SimDynamoDb as SimDynamoDatabase,
+  SimDynamoDbStreams,
+} from "../dynamodb/index.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
@@ -84,6 +87,13 @@ export class SimAwsAccount {
    */
   dynamoDb(): SimDynamoDatabase {
     return this.region().dynamoDb();
+  }
+
+  /**
+   * Get simulated DynamoDB Streams for this Account's default Region.
+   */
+  dynamoDbStreams(): SimDynamoDbStreams {
+    return this.region().dynamoDbStreams();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -3,7 +3,10 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import { faker } from "@faker-js/faker";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
-import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
+import type {
+  SimDynamoDb as SimDynamoDatabase,
+  SimDynamoDbStreams,
+} from "../dynamodb/index.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
@@ -149,6 +152,13 @@ export class SimAwsRegion {
    */
   dynamoDb(): SimDynamoDatabase {
     return this.account().dynamoDb();
+  }
+
+  /**
+   * Get simulated DynamoDB Streams for this Region's default Account.
+   */
+  dynamoDbStreams(): SimDynamoDbStreams {
+    return this.account().dynamoDbStreams();
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -4,7 +4,10 @@ import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
-import type { SimDynamoDb as SimDynamoDatabase } from "../dynamodb/index.js";
+import type {
+  SimDynamoDb as SimDynamoDatabase,
+  SimDynamoDbStreams,
+} from "../dynamodb/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
@@ -57,6 +60,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated DynamoDB in the default Account Region scope. */
   dynamoDb(): SimDynamoDatabase {
     return this.defaultAccountRegionScope().dynamoDb();
+  }
+
+  /** Get simulated DynamoDB Streams in the default Account Region scope. */
+  dynamoDbStreams(): SimDynamoDbStreams {
+    return this.defaultAccountRegionScope().dynamoDbStreams();
   }
 
   /** Get simulated IAM in the default Account scope. */

--- a/src/service/aws/sim-aws.iso.test.ts
+++ b/src/service/aws/sim-aws.iso.test.ts
@@ -71,6 +71,15 @@ describe("SimAws", () => {
     assertIdentical(simAws.dynamoDb(), simAws.region().account().dynamoDb());
   });
 
+  it("returns the Streams API of the DynamoDB in the same scope", () => {
+    const simAws = new SimAws();
+    const streams = simAws.dynamoDb().streams();
+
+    assertIdentical(simAws.dynamoDbStreams(), streams);
+    assertIdentical(simAws.account().dynamoDbStreams(), streams);
+    assertIdentical(simAws.region().dynamoDbStreams(), streams);
+  });
+
   describe("simulated time", () => {
     const instant = new Date("2026-07-26T09:30:00.000Z");
 

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -55,6 +55,8 @@ Current command areas include:
 - `transact/` (TransactWriteItems and TransactGetItems)
 - `tag/` (TagResource, UntagResource and ListTagsOfResource)
 - `time-to-live/` (UpdateTimeToLive and DescribeTimeToLive)
+- `stream/` (the DynamoDB Streams API: ListStreams, DescribeStream, GetShardIterator and GetRecords,
+  one directory per operation)
 
 The `@aws-sdk/lib-dynamodb` document client's Commands are handled under `document/` rather than
 here, since they are the same operations with a conversion around them.
@@ -1115,6 +1117,53 @@ state rather than request handling.
 - `SimDynamoDbStreamActivity` is the twin of `SimSqsQueueActivity`: it is how a consumer that cannot
   poll continuously finds out there is something to read. There is no instant on the notification,
   unlike the queue's, because a stream record is readable the moment it is written.
+
+The read path is the other half of `stream/`, and none of it is state:
+
+- `SimDynamoDbStreamPosition` is where a reader is on a shard: the start of it, at a sequence
+  number, or after one. The four shard iterator types come down to those three, and a position is a
+  place rather than an index so it survives the shard being trimmed underneath it.
+- `simDynamoDbShardIteratorToken` and `readSimDynamoDbShardIteratorToken` encode a stream ARN, a
+  shard identifier and a position into the opaque string a caller passes back. Nothing remembers an
+  iterator, which is also why there is no 15 minute expiry: an iterator is a value rather than a
+  handle. That is under Limitations.
+- `simDynamoDbStreamRead` is one `GetRecords` against a shard, and `drained` is what
+  `NextShardIterator` being absent means. An open shard is never drained however empty it is.
+- `simDynamoDbStreamTrimPoint` and `SimDynamoDbStreamShard.trim` are the 24 hour retention window.
+  Trimming is applied on read rather than scheduled, following `SimSqsQueue.applyLifecycle`, and it
+  is the one place in this service where that pattern genuinely fits: what a read finds is a
+  function of the instant of that read alone. The shard remembers the sequence number it trimmed
+  through once the records are gone, which is the difference between a position the shard never
+  reached and one it has already dropped.
+
+## Streams API commands
+
+The four DynamoDB Streams operations are under `command/stream/`, one directory per operation, and
+`SimDynamoDbStreams` is the facade over them. It is a second API over one simulated DynamoDB's
+state rather than a service of its own: `SimDynamoDb` builds it and hands it the same
+`SimDynamoDbStreamStore` its tables capture onto, and `simAws.dynamoDbStreams()` reaches it through
+`simAws.dynamoDb()` rather than through the service factory.
+
+`SimDynamoDbStreamAccess` is the stream side of `SimDynamoDbTableAccess`: apply retention, authorize
+against the ARN the request carries, then look the stream up, always in that order.
+`SimDynamoDbAuthorizer.authorizeStream` is what it authorizes with, and the resource is the stream's
+own ARN rather than its table's, so a statement naming `table/Orders` does not reach
+`table/Orders/stream/<label>`. Nothing in simulated IAM needed changing for that: statement matching
+is wildcard matching on the raw ARN, and the matcher already treats everything past the fifth colon
+as one segment. `ListStreams` names no stream, so it goes through `authorizeAnyTable` the way
+`ListTables` does.
+
+`simDynamoDbStreamsApiRecord` renders a captured record the way the Streams API carries it, and is
+deliberately a renderer over the stored domain object rather than the stored shape itself. The
+Streams API declares `Identity` as `PrincipalId`/`Type` and `ApproximateCreationDateTime` as a
+timestamp, where the Lambda event uses `principalId`/`type` and epoch seconds. Sharing one payload
+between the two surfaces would leave one of them quietly wrong, so the Lambda event builder gets a
+projection of its own rather than reshaping this one.
+
+`@aws-sdk/client-dynamodb-streams` is a client with a service identity of its own, so
+`SimDynamoDbStreamsSdkCommandRouter` is a second router registered under `DynamoDB Streams` in
+`resolveSimSdkCommandRouter`. A DynamoDB client cannot reach it and a Streams client cannot reach
+the table commands, which is what AWS does too.
 
 Capture happens in `SimDynamoDbTableItems`, on `put`, `remove` and `expire`. That pair of writes and
 removals is the only place every item mutation passes through exactly once, and both already read

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
@@ -51,6 +51,24 @@ export class SimDynamoDbAuthorizer {
   }
 
   /**
+   * Ensure the caller may perform an action on a table's stream.
+   *
+   * The resource is the stream's own ARN, which is the table's ARN and then
+   * the stream's label, so a statement naming only the table does not reach it.
+   * The ARN comes from the request rather than being built here: a stream is
+   * named by an ARN a caller was handed, and one naming no stream is refused
+   * before anything looks it up, as real IAM refuses a request before the
+   * service sees it.
+   */
+  authorizeStream(
+    action: string,
+    streamArn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, streamArn, caller);
+  }
+
+  /**
    * Ensure the caller may perform an action that names no particular table.
    *
    * Authorization applies to the whole operation. A denied caller receives

--- a/src/service/dynamodb/command/stream/describe-stream/describe-stream.command.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/describe-stream.command.ts
@@ -27,8 +27,9 @@ export interface SimDescribeStreamCommand {
  * Minimal structural sim DynamoDB Streams DescribeStream input.
  *
  * `Limit` and `ExclusiveStartShardId` page through a stream's shards. A
- * simulated stream has exactly one, so a page of them is never cut short and
- * neither parameter can change what comes back.
+ * simulated stream has exactly one, so a `Limit` of at least one never cuts a
+ * page short, and `ExclusiveStartShardId` naming that shard leaves a page with
+ * nothing on it.
  */
 export interface SimDescribeStreamCommandInput {
   readonly StreamArn?: string | undefined;

--- a/src/service/dynamodb/command/stream/describe-stream/describe-stream.command.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/describe-stream.command.ts
@@ -1,0 +1,46 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb-streams/command/DescribeStreamCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../../aws/metadata/response-metadata.type.js";
+import type { SimDynamoDbStreamDescription } from "../stream.types.js";
+
+/**
+ * Minimal structural sim DynamoDB Streams shard filter.
+ *
+ * Declared so a request asking for one is refused by name. A simulated stream
+ * has one shard and never splits, so there is no lineage for a filter to walk.
+ */
+export interface SimDynamoDbShardFilter {
+  readonly Type?: string | undefined;
+  readonly ShardId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams DescribeStream command.
+ */
+export interface SimDescribeStreamCommand {
+  readonly input: SimDescribeStreamCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams DescribeStream input.
+ *
+ * `Limit` and `ExclusiveStartShardId` page through a stream's shards. A
+ * simulated stream has exactly one, so a page of them is never cut short and
+ * neither parameter can change what comes back.
+ */
+export interface SimDescribeStreamCommandInput {
+  readonly StreamArn?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartShardId?: string | undefined;
+  readonly ShardFilter?: SimDynamoDbShardFilter | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams DescribeStream output.
+ */
+export interface SimDescribeStreamCommandOutput {
+  readonly StreamDescription?: SimDynamoDbStreamDescription | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.iso.test.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.iso.test.ts
@@ -16,6 +16,7 @@ import { SimIamAccessDenied } from "../../../../iam/error/sim-iam.error.js";
 import {
   SimDynamoDbResourceNotFoundException,
   SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
 } from "../../../error/dynamodb.error.js";
 import { simDynamoDbStreamedTableFactory } from "../../../stream/sim-dynamodb-streamed-table.factory.js";
 
@@ -139,6 +140,39 @@ describe("DynamoDB Streams DescribeStream", () => {
     assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
   });
 
+  it("pages the one shard a stream has", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+    const first = await simAws
+      .dynamoDbStreams()
+      .describeStream(new DescribeStreamCommand({ StreamArn: streamArn }));
+    const shardId = first.StreamDescription?.Shards?.[0]?.ShardId;
+
+    // When the shards are asked for again from after the one that came back.
+    const second = await simAws.dynamoDbStreams().describeStream(
+      new DescribeStreamCommand({
+        StreamArn: streamArn,
+        ExclusiveStartShardId: shardId,
+      }),
+    );
+
+    // Then there is nothing left to report, rather than the same shard over
+    // again.
+    assertArrayLength(second.StreamDescription?.Shards, 0);
+
+    // And a page size DynamoDB would not take is refused.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().describeStream(
+        new DescribeStreamCommand({
+          StreamArn: streamArn,
+          Limit: 0,
+        }),
+      ),
+    );
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
   it("denies a caller without dynamodb:DescribeStream on the stream ARN", async () => {
     // Given a Role with no DynamoDB permissions.
     const simAws = new SimAws();
@@ -171,5 +205,18 @@ describe("DynamoDB Streams DescribeStream", () => {
     assertInstanceOf(error, SimIamAccessDenied);
     assertIdentical(error.action, "dynamodb:DescribeStream");
     assertIdentical(error.resource, streamArn);
+
+    // And a request the simulation would refuse anyway is still refused for
+    // the caller first, so what is and is not simulated stays behind IAM.
+    const filtered = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().describeStream(
+        new DescribeStreamCommand({
+          StreamArn: streamArn,
+          ShardFilter: { Type: "CHILD_SHARDS" },
+        }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+    assertInstanceOf(filtered, SimIamAccessDenied);
   });
 });

--- a/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.iso.test.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.iso.test.ts
@@ -1,0 +1,175 @@
+import { PutItemCommand, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import { DescribeStreamCommand } from "@aws-sdk/client-dynamodb-streams";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../../iam/error/sim-iam.error.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbUnsupportedOperation,
+} from "../../../error/dynamodb.error.js";
+import { simDynamoDbStreamedTableFactory } from "../../../stream/sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The ARN of the stream a streamed table is capturing onto.
+ */
+async function streamArnOf(simAws: SimAws): Promise<string> {
+  const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+  const arn = table.stream.latest?.arn;
+  assertDefined(arn, "DynamoDB table stream ARN");
+
+  return arn;
+}
+
+describe("DynamoDB Streams DescribeStream", () => {
+  it("reports the shard, the view type and the stream status", async () => {
+    // Given a stream with one record on it.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // When the stream is described.
+    const output = await simAws
+      .dynamoDbStreams()
+      .describeStream(new DescribeStreamCommand({ StreamArn: streamArn }));
+
+    // Then it reports itself as enabled, with the images its records carry and
+    // the key schema they are cut with.
+    const description = output.StreamDescription;
+    assertNonNullable(description);
+    assertIdentical(description.StreamArn, streamArn);
+    assertIdentical(description.StreamStatus, "ENABLED");
+    assertIdentical(description.StreamViewType, "NEW_AND_OLD_IMAGES");
+    assertIdentical(description.TableName, "orders");
+    assertArrayLength(description.KeySchema, 1);
+    assertIdentical(description.KeySchema[0].AttributeName, "orderId");
+
+    // And its one open shard starts at the record on it and has no end.
+    assertArrayLength(description.Shards, 1);
+    const range = description.Shards[0].SequenceNumberRange;
+    assertNonNullable(range);
+    assertIdentical(range.StartingSequenceNumber, "100000000000000000000");
+    assertUndefined(range.EndingSequenceNumber);
+    assertUndefined(description.LastEvaluatedShardId);
+  });
+
+  it("closes the shard of a stream its table has switched off", async () => {
+    // Given a stream with a record on it that is then disabled.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the disabled stream is described.
+    const output = await simAws
+      .dynamoDbStreams()
+      .describeStream(new DescribeStreamCommand({ StreamArn: streamArn }));
+
+    // Then it is off, and its shard ends at the last record it took.
+    const description = output.StreamDescription;
+    assertNonNullable(description);
+    assertIdentical(description.StreamStatus, "DISABLED");
+    assertArrayLength(description.Shards, 1);
+    const range = description.Shards[0].SequenceNumberRange;
+    assertNonNullable(range);
+    assertIdentical(range.EndingSequenceNumber, "100000000000000000000");
+  });
+
+  it("reports no stream for an ARN naming none", async () => {
+    // Given a simulated DynamoDB with one stream on it.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+
+    // When a stream nobody was ever handed is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().describeStream(
+        new DescribeStreamCommand({
+          StreamArn: `${streamArn}-not-a-stream`,
+        }),
+      ),
+    );
+
+    // Then it is simply not found.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("refuses a ShardFilter it cannot honour", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+
+    // When it is described with a shard filter.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().describeStream(
+        new DescribeStreamCommand({
+          StreamArn: streamArn,
+          ShardFilter: { Type: "CHILD_SHARDS", ShardId: "shardId-0" },
+        }),
+      ),
+    );
+
+    // Then it is refused by name rather than answered with an unfiltered
+    // shard list, since a simulated stream has no shard lineage.
+    assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
+  });
+
+  it("denies a caller without dynamodb:DescribeStream on the stream ARN", async () => {
+    // Given a Role with no DynamoDB permissions.
+    const simAws = new SimAws();
+    const streamArn = await streamArnOf(simAws);
+
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoDescribeStreamRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When that Role describes the stream.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .describeStream(new DescribeStreamCommand({ StreamArn: streamArn }), {
+          caller: { kind: "arn", arn: roleCreation.Role.Arn },
+        }),
+    );
+
+    // Then it is refused against the stream's own ARN rather than the table's.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:DescribeStream");
+    assertIdentical(error.resource, streamArn);
+  });
+});

--- a/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.ts
@@ -1,5 +1,8 @@
 import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
-import { SimDynamoDbUnsupportedOperation } from "../../../error/dynamodb.error.js";
+import {
+  SimDynamoDbUnsupportedOperation,
+  SimDynamoDbValidationException,
+} from "../../../error/dynamodb.error.js";
 import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
 import type { SimDynamoDbStreamShardDescription } from "../stream.types.js";
 import type { SimDynamoDbStreamAccess } from "../sim-dynamodb-stream-access.js";
@@ -17,16 +20,51 @@ interface SimDynamoDbDescribeStreamOptions {
 }
 
 /**
- * The one shard of a stream, as DescribeStream reports it.
+ * The greatest number of shards one DescribeStream reports.
  */
-function shardOf(stream: SimDynamoDbStream): SimDynamoDbStreamShardDescription {
-  return {
-    ShardId: stream.shard.shardId,
-    SequenceNumberRange: {
-      StartingSequenceNumber: stream.shard.startingSequenceNumber,
-      EndingSequenceNumber: stream.shard.endingSequenceNumber,
+const greatestLimit = 100;
+
+/**
+ * Refuse a page size DynamoDB would not take.
+ */
+function assertLimit(limit: number | undefined): void {
+  if (limit === undefined) {
+    return;
+  }
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > greatestLimit) {
+    throw new SimDynamoDbValidationException(
+      `Limit ${limit.toString()} is invalid. It is a whole number between 1 ` +
+        `and ${greatestLimit.toString()}.`,
+    );
+  }
+}
+
+/**
+ * The shards of a stream a request asks for, which is its one shard or none.
+ *
+ * A simulated stream has one shard, so a `Limit` of at least one never cuts the
+ * page short. `ExclusiveStartShardId` naming that shard does leave nothing to
+ * report, which is what a caller resuming from it means, so it is honoured
+ * rather than ignored.
+ */
+function shardsOf(
+  stream: SimDynamoDbStream,
+  exclusiveStartShardId: string | undefined,
+): readonly SimDynamoDbStreamShardDescription[] {
+  if (exclusiveStartShardId === stream.shard.shardId) {
+    return [];
+  }
+
+  return [
+    {
+      ShardId: stream.shard.shardId,
+      SequenceNumberRange: {
+        StartingSequenceNumber: stream.shard.startingSequenceNumber,
+        EndingSequenceNumber: stream.shard.endingSequenceNumber,
+      },
     },
-  };
+  ];
 }
 
 /**
@@ -50,6 +88,12 @@ export class SimDynamoDbDescribeStream {
     command: SimDescribeStreamCommand,
     options?: SimDynamoDbDescribeStreamOptions,
   ): SimDescribeStreamCommandOutput {
+    const stream = this.access.required(
+      "dynamodb:DescribeStream",
+      command.input.StreamArn,
+      options?.caller,
+    );
+
     if (command.input.ShardFilter !== undefined) {
       throw new SimDynamoDbUnsupportedOperation(
         "DescribeStream ShardFilter is not simulated: a simulated stream has " +
@@ -57,11 +101,7 @@ export class SimDynamoDbDescribeStream {
       );
     }
 
-    const stream = this.access.required(
-      "dynamodb:DescribeStream",
-      command.input.StreamArn,
-      options?.caller,
-    );
+    assertLimit(command.input.Limit);
 
     return {
       StreamDescription: {
@@ -72,7 +112,7 @@ export class SimDynamoDbDescribeStream {
         CreationRequestDateTime: stream.enabledAt,
         TableName: stream.tableName,
         KeySchema: stream.keySchemaElements,
-        Shards: [shardOf(stream)],
+        Shards: shardsOf(stream, command.input.ExclusiveStartShardId),
       },
       $metadata: {},
     };

--- a/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.ts
+++ b/src/service/dynamodb/command/stream/describe-stream/sim-dynamodb-describe-stream.ts
@@ -1,0 +1,80 @@
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import { SimDynamoDbUnsupportedOperation } from "../../../error/dynamodb.error.js";
+import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
+import type { SimDynamoDbStreamShardDescription } from "../stream.types.js";
+import type { SimDynamoDbStreamAccess } from "../sim-dynamodb-stream-access.js";
+import type {
+  SimDescribeStreamCommand,
+  SimDescribeStreamCommandOutput,
+} from "./describe-stream.command.js";
+
+interface SimDynamoDbDescribeStreamProperties {
+  readonly access: SimDynamoDbStreamAccess;
+}
+
+interface SimDynamoDbDescribeStreamOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The one shard of a stream, as DescribeStream reports it.
+ */
+function shardOf(stream: SimDynamoDbStream): SimDynamoDbStreamShardDescription {
+  return {
+    ShardId: stream.shard.shardId,
+    SequenceNumberRange: {
+      StartingSequenceNumber: stream.shard.startingSequenceNumber,
+      EndingSequenceNumber: stream.shard.endingSequenceNumber,
+    },
+  };
+}
+
+/**
+ * The command that reports a stream, its shard and what its records carry.
+ */
+export class SimDynamoDbDescribeStream {
+  private readonly access: SimDynamoDbStreamAccess;
+
+  constructor(properties: SimDynamoDbDescribeStreamProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Describe the stream an ARN names.
+   *
+   * `LastEvaluatedShardId` is never reported: there is one shard, so a page of
+   * them is always the whole of them, and a token would send a caller round a
+   * loop for a shard that does not exist.
+   */
+  handle(
+    command: SimDescribeStreamCommand,
+    options?: SimDynamoDbDescribeStreamOptions,
+  ): SimDescribeStreamCommandOutput {
+    if (command.input.ShardFilter !== undefined) {
+      throw new SimDynamoDbUnsupportedOperation(
+        "DescribeStream ShardFilter is not simulated: a simulated stream has " +
+          "one shard and never splits, so it has no shard lineage to filter",
+      );
+    }
+
+    const stream = this.access.required(
+      "dynamodb:DescribeStream",
+      command.input.StreamArn,
+      options?.caller,
+    );
+
+    return {
+      StreamDescription: {
+        StreamArn: stream.arn,
+        StreamLabel: stream.label,
+        StreamStatus: stream.status,
+        StreamViewType: stream.viewType,
+        CreationRequestDateTime: stream.enabledAt,
+        TableName: stream.tableName,
+        KeySchema: stream.keySchemaElements,
+        Shards: [shardOf(stream)],
+      },
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/stream/get-records/get-records.command.ts
+++ b/src/service/dynamodb/command/stream/get-records/get-records.command.ts
@@ -1,0 +1,35 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb-streams/command/GetRecordsCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../../aws/metadata/response-metadata.type.js";
+import type { SimDynamoDbStreamsRecord } from "../stream.types.js";
+
+/**
+ * Minimal structural sim DynamoDB Streams GetRecords command.
+ */
+export interface SimGetRecordsCommand {
+  readonly input: SimGetRecordsCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams GetRecords input.
+ */
+export interface SimGetRecordsCommandInput {
+  readonly ShardIterator?: string | undefined;
+  readonly Limit?: number | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams GetRecords output.
+ *
+ * An empty `Records` with a `NextShardIterator` is the ordinary answer for a
+ * reader that has caught up, and is not smoothed away into anything else.
+ * `NextShardIterator` is absent only when the shard is closed and the reader
+ * has reached the end of it, which is how a consumer knows to stop.
+ */
+export interface SimGetRecordsCommandOutput {
+  readonly Records?: readonly SimDynamoDbStreamsRecord[] | undefined;
+  readonly NextShardIterator?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records-iam.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records-iam.iso.test.ts
@@ -1,0 +1,129 @@
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../../iam/error/sim-iam.error.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../../error/dynamodb.error.js";
+import { simDynamoDbStreamStart } from "../../../stream/sim-dynamodb-stream-position.js";
+import { simDynamoDbShardIteratorToken } from "../../../stream/sim-dynamodb-stream-shard-iterator.js";
+import { simDynamoDbStreamedOrdersFactory } from "../../../stream/sim-dynamodb-streamed-orders.factory.js";
+
+describe("DynamoDB Streams GetRecords request checking", () => {
+  it("refuses a Limit above the batch cap", async () => {
+    // Given a stream with a record on it, and an iterator for its shard.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+    const iterator = await simAws.dynamoDbStreams().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamArn: stream.arn,
+        ShardId: stream.shard.shardId,
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+
+    // When more than one batch of records is asked for at once.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getRecords(
+        new GetRecordsCommand({
+          ShardIterator: iterator.ShardIterator,
+          Limit: 1001,
+        }),
+      ),
+    );
+
+    // Then the request is refused rather than quietly given fewer, which a
+    // consumer could not tell from having caught up.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("refuses a shard iterator it never handed out", async () => {
+    // Given a stream.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When something that is not one of its iterators is read from.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .getRecords(new GetRecordsCommand({ ShardIterator: "not-one" })),
+    );
+
+    // Then it is refused as invalid input.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("reports no shard for an iterator naming one the stream has not got", async () => {
+    // Given an iterator built for a shard this stream never had, which is what
+    // an iterator kept across a stream being switched off and on again is.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+    const iterator = simDynamoDbShardIteratorToken({
+      streamArn: stream.arn,
+      shardId: "shardId-00000000000000000000-deadbeef",
+      position: simDynamoDbStreamStart,
+    });
+
+    // When it is read from.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .getRecords(new GetRecordsCommand({ ShardIterator: iterator })),
+    );
+
+    // Then the shard is simply not found.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("denies a caller without dynamodb:GetRecords on the stream ARN", async () => {
+    // Given a Role with no DynamoDB permissions, and an iterator to read with.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+    const iterator = await simAws.dynamoDbStreams().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamArn: stream.arn,
+        ShardId: stream.shard.shardId,
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoGetRecordsRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When that Role reads the shard.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .getRecords(
+          new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+          { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+        ),
+    );
+
+    // Then it is refused against the stream the iterator belongs to, which the
+    // request never named separately.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:GetRecords");
+    assertIdentical(error.resource, stream.arn);
+  });
+});

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records.iso.test.ts
@@ -1,0 +1,140 @@
+import { PutItemCommand, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
+import { simDynamoDbStreamedOrdersFactory } from "../../../stream/sim-dynamodb-streamed-orders.factory.js";
+
+/**
+ * A TRIM_HORIZON iterator for the one shard of a stream.
+ */
+async function trimHorizonIterator(
+  simAws: SimAws,
+  stream: SimDynamoDbStream,
+): Promise<string | undefined> {
+  const output = await simAws.dynamoDbStreams().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamArn: stream.arn,
+      ShardId: stream.shard.shardId,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+
+  return output.ShardIterator;
+}
+
+describe("DynamoDB Streams GetRecords", () => {
+  it("walks the whole log and then answers empty without ending", async () => {
+    // Given a stream with three records on it, read one at a time.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 3 },
+      simAws,
+    );
+    let iterator = await trimHorizonIterator(simAws, stream);
+    const read: string[] = [];
+
+    // When each successive NextShardIterator is followed four times: three
+    // that have a record for them and one that has caught up.
+    for (let poll = 0; poll < 4; poll += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const output = await simAws
+        .dynamoDbStreams()
+        .getRecords(
+          new GetRecordsCommand({ ShardIterator: iterator, Limit: 1 }),
+        );
+
+      read.push(
+        ...(output.Records ?? []).map(
+          (record) => record.dynamodb?.Keys?.["orderId"]?.S ?? "",
+        ),
+      );
+      iterator = output.NextShardIterator;
+    }
+
+    // Then every record was read once, and the caught-up reader was handed an
+    // iterator to carry on with rather than being told the shard had ended.
+    assertIdentical(read.join(","), "order-1,order-2,order-3");
+    assertNonNullable(iterator);
+  });
+
+  it("hands back an empty batch and a live iterator when caught up", async () => {
+    // Given a stream that has been read to the end.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+    const iterator = await trimHorizonIterator(simAws, stream);
+    const first = await simAws
+      .dynamoDbStreams()
+      .getRecords(new GetRecordsCommand({ ShardIterator: iterator }));
+
+    // When the reader polls again with nothing new written.
+    const second = await simAws
+      .dynamoDbStreams()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: first.NextShardIterator }),
+      );
+
+    // Then the empty batch is the ordinary answer, and the reader can go on.
+    assertArrayLength(second.Records, 0);
+    assertNonNullable(second.NextShardIterator);
+
+    // And a record written afterwards is read from that same iterator.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-2" } },
+      }),
+    );
+    const third = await simAws
+      .dynamoDbStreams()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: second.NextShardIterator }),
+      );
+    assertArrayLength(third.Records, 1);
+  });
+
+  it("drops NextShardIterator once a disabled stream is drained", async () => {
+    // Given a stream with two records on it whose table has switched it off.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 2 },
+      simAws,
+    );
+    const iterator = await trimHorizonIterator(simAws, stream);
+
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the closed shard is read one record at a time.
+    const first = await simAws
+      .dynamoDbStreams()
+      .getRecords(new GetRecordsCommand({ ShardIterator: iterator, Limit: 1 }));
+
+    // Then there is still somewhere to go while records remain.
+    assertArrayLength(first.Records, 1);
+    assertNonNullable(first.NextShardIterator);
+
+    // And the read that empties the shard ends it.
+    const second = await simAws
+      .dynamoDbStreams()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: first.NextShardIterator }),
+      );
+    assertArrayLength(second.Records, 1);
+    assertUndefined(second.NextShardIterator);
+  });
+});

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-get-records.ts
@@ -1,0 +1,106 @@
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../../error/dynamodb.error.js";
+import { simDynamoDbStreamRead } from "../../../stream/sim-dynamodb-stream-read.js";
+import {
+  readSimDynamoDbShardIteratorToken,
+  simDynamoDbShardIteratorToken,
+} from "../../../stream/sim-dynamodb-stream-shard-iterator.js";
+import type { SimDynamoDbStreamAccess } from "../sim-dynamodb-stream-access.js";
+import { simDynamoDbStreamsApiRecord } from "./sim-dynamodb-streams-api-record.js";
+import type {
+  SimGetRecordsCommand,
+  SimGetRecordsCommandOutput,
+} from "./get-records.command.js";
+
+/**
+ * The most records one GetRecords hands back, whatever the request asks for.
+ */
+const greatestLimit = 1000;
+
+interface SimDynamoDbGetRecordsProperties {
+  readonly access: SimDynamoDbStreamAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+interface SimDynamoDbGetRecordsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Read the batch size a request asks for.
+ *
+ * A request asking for more than the cap is refused rather than quietly given
+ * fewer, since a consumer that thinks it asked for 5000 and got 1000 has no way
+ * of telling that from having caught up.
+ */
+function readLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return greatestLimit;
+  }
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > greatestLimit) {
+    throw new SimDynamoDbValidationException(
+      `Limit ${limit.toString()} is invalid. It is a whole number between 1 ` +
+        `and ${greatestLimit.toString()}.`,
+    );
+  }
+
+  return limit;
+}
+
+/**
+ * The command that reads records off a shard.
+ */
+export class SimDynamoDbGetRecords {
+  private readonly access: SimDynamoDbStreamAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimDynamoDbGetRecordsProperties) {
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read from where a shard iterator points, and say where to carry on.
+   *
+   * The iterator carries the stream it belongs to, so the caller is authorized
+   * against that stream's ARN rather than against anything the request names
+   * separately.
+   */
+  handle(
+    command: SimGetRecordsCommand,
+    options?: SimDynamoDbGetRecordsOptions,
+  ): SimGetRecordsCommandOutput {
+    const iterator = readSimDynamoDbShardIteratorToken(
+      command.input.ShardIterator,
+    );
+    const limit = readLimit(command.input.Limit);
+    const stream = this.access.required(
+      "dynamodb:GetRecords",
+      iterator.streamArn,
+      options?.caller,
+    );
+
+    if (iterator.shardId !== stream.shard.shardId) {
+      throw new SimDynamoDbResourceNotFoundException(
+        `Stream ${stream.arn} has no shard ${iterator.shardId}`,
+      );
+    }
+
+    const read = simDynamoDbStreamRead(stream.shard, iterator.position, limit);
+
+    return {
+      Records: read.records.map((record) =>
+        simDynamoDbStreamsApiRecord(record, this.accountRegionScope.regionName),
+      ),
+      NextShardIterator: read.drained
+        ? undefined
+        : simDynamoDbShardIteratorToken({ ...iterator, position: read.next }),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-stream-retention.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-stream-retention.iso.test.ts
@@ -1,4 +1,6 @@
+import { UpdateTableCommand } from "@aws-sdk/client-dynamodb";
 import {
+  DescribeStreamCommand,
   GetRecordsCommand,
   GetShardIteratorCommand,
   ListStreamsCommand,
@@ -123,6 +125,34 @@ describe("DynamoDB Streams 24 hour retention", () => {
     assertIdentical(listed.Streams[0].StreamArn, aged.stream.arn);
     assertArrayLength(output.Records, 0);
     assertNonNullable(output.NextShardIterator);
+  });
+
+  it("goes on reporting the range of a shard whose records have gone", async () => {
+    // Given a closed shard whose records have all aged out.
+    const aged = await agedStream();
+    await aged.simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await aged.simAws.backgroundTasksComplete();
+    await aged.simAws.clock().advanceBy({ hours: 25 });
+
+    // When the stream is described.
+    const output = await aged.simAws
+      .dynamoDbStreams()
+      .describeStream(
+        new DescribeStreamCommand({ StreamArn: aged.stream.arn }),
+      );
+
+    // Then the shard still says where it began and where it ended. A shard's
+    // range is fixed as its records go on, and trimming takes records away
+    // rather than moving it.
+    const range = output.StreamDescription?.Shards?.[0]?.SequenceNumberRange;
+    assertNonNullable(range);
+    assertIdentical(range.StartingSequenceNumber, sequenceNumberAt(0));
+    assertIdentical(range.EndingSequenceNumber, sequenceNumberAt(1));
   });
 
   it("keeps records that are still inside the retention window", async () => {

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-stream-retention.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-stream-retention.iso.test.ts
@@ -1,0 +1,150 @@
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+  type ShardIteratorType,
+} from "@aws-sdk/client-dynamodb-streams";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimDynamoDbTrimmedDataAccessException } from "../../../error/dynamodb.error.js";
+import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
+import { simDynamoDbStreamedOrdersFactory } from "../../../stream/sim-dynamodb-streamed-orders.factory.js";
+
+/**
+ * The instant these tests start from.
+ */
+const startedAt = new Date("2026-08-04T09:00:00.000Z");
+
+/**
+ * The sequence number the record at a position on a fresh stream carries.
+ */
+function sequenceNumberAt(position: number): string {
+  return (100_000_000_000_000_000_000n + BigInt(position)).toString();
+}
+
+interface AgedStream {
+  readonly simAws: SimAws;
+  readonly stream: SimDynamoDbStream;
+}
+
+/**
+ * A stream with two records on it, written on a clock a test can move.
+ */
+async function agedStream(): Promise<AgedStream> {
+  const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+
+  return {
+    simAws,
+    stream: await simDynamoDbStreamedOrdersFactory.make({ orders: 2 }, simAws),
+  };
+}
+
+/**
+ * An iterator for the one shard of a stream, of a type and at a place.
+ */
+async function iteratorFor(
+  aged: AgedStream,
+  iteratorType: ShardIteratorType,
+  sequenceNumber?: string,
+): Promise<string | undefined> {
+  const output = await aged.simAws.dynamoDbStreams().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamArn: aged.stream.arn,
+      ShardId: aged.stream.shard.shardId,
+      ShardIteratorType: iteratorType,
+      SequenceNumber: sequenceNumber,
+    }),
+  );
+
+  return output.ShardIterator;
+}
+
+describe("DynamoDB Streams 24 hour retention", () => {
+  it("raises TrimmedDataAccessException for a position past the trim point", async () => {
+    // Given an iterator taken at the first record, held while a day passes.
+    const aged = await agedStream();
+    const iterator = await iteratorFor(
+      aged,
+      "AT_SEQUENCE_NUMBER",
+      sequenceNumberAt(0),
+    );
+    await aged.simAws.clock().advanceBy({ hours: 25 });
+
+    // When the reader comes back with the iterator it was holding.
+    const error = await assertThrowsErrorAsync(async () =>
+      aged.simAws
+        .dynamoDbStreams()
+        .getRecords(new GetRecordsCommand({ ShardIterator: iterator })),
+    );
+
+    // Then it is told the records it wanted have been trimmed, rather than
+    // being quietly given whatever is left.
+    assertInstanceOf(error, SimDynamoDbTrimmedDataAccessException);
+  });
+
+  it("refuses a sequence number that has already been trimmed", async () => {
+    // Given a stream whose records have all aged out.
+    const aged = await agedStream();
+    await aged.simAws.clock().advanceBy({ hours: 25 });
+
+    // When an iterator is asked for at one of them.
+    const error = await assertThrowsErrorAsync(async () =>
+      iteratorFor(aged, "AT_SEQUENCE_NUMBER", sequenceNumberAt(1)),
+    );
+
+    // Then it is refused at the call that asked, rather than one call later.
+    assertInstanceOf(error, SimDynamoDbTrimmedDataAccessException);
+  });
+
+  it("leaves a trimmed stream listable and readable from TRIM_HORIZON", async () => {
+    // Given a stream whose records have all aged out.
+    const aged = await agedStream();
+    await aged.simAws.clock().advanceBy({ hours: 25 });
+
+    // When it is listed and then read from the oldest record it still holds.
+    const listed = await aged.simAws
+      .dynamoDbStreams()
+      .listStreams(new ListStreamsCommand({ TableName: "orders" }));
+    const iterator = await iteratorFor(aged, "TRIM_HORIZON");
+    const output = await aged.simAws
+      .dynamoDbStreams()
+      .getRecords(new GetRecordsCommand({ ShardIterator: iterator }));
+
+    // Then the stream is still there and still readable, with nothing on it.
+    assertArrayLength(listed.Streams, 1);
+    assertIdentical(listed.Streams[0].StreamArn, aged.stream.arn);
+    assertArrayLength(output.Records, 0);
+    assertNonNullable(output.NextShardIterator);
+  });
+
+  it("keeps records that are still inside the retention window", async () => {
+    // Given a stream read part of the way through, less than a day ago.
+    const aged = await agedStream();
+    await aged.simAws.clock().advanceBy({ hours: 23 });
+
+    // When it is read from the second record.
+    const iterator = await iteratorFor(
+      aged,
+      "AT_SEQUENCE_NUMBER",
+      sequenceNumberAt(1),
+    );
+    const output = await aged.simAws
+      .dynamoDbStreams()
+      .getRecords(new GetRecordsCommand({ ShardIterator: iterator }));
+
+    // Then it is still there.
+    assertArrayLength(output.Records, 1);
+    assertIdentical(
+      output.Records[0].dynamodb?.Keys?.["orderId"]?.S,
+      "order-2",
+    );
+  });
+});

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-streams-api-record.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-streams-api-record.iso.test.ts
@@ -1,0 +1,143 @@
+import {
+  PutItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimDynamoDbStreamsRecord } from "../stream.types.js";
+import { simDynamoDbStreamedTableFactory } from "../../../stream/sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * The instant these tests start from, and the epoch seconds of it.
+ */
+const startedAt = new Date("2026-08-04T09:00:00.000Z");
+const startedAtSeconds = String(Math.floor(startedAt.getTime() / 1000));
+
+/**
+ * Read everything a streamed table's stream holds, oldest first.
+ */
+async function recordsOf(
+  simAws: SimAws,
+): Promise<readonly SimDynamoDbStreamsRecord[]> {
+  const table = simAws.dynamoDb().findTable("orders");
+  const stream = table?.stream.latest;
+  assertDefined(stream, "DynamoDB table stream");
+
+  const iterator = await simAws.dynamoDbStreams().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamArn: stream.arn,
+      ShardId: stream.shard.shardId,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+  const output = await simAws
+    .dynamoDbStreams()
+    .getRecords(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+  return output.Records ?? [];
+}
+
+describe("DynamoDB Streams record rendering", () => {
+  it("renders a captured change the way the Streams API carries it", async () => {
+    // Given a streamed table whose item has been written twice.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    for (const total of ["101", "202"]) {
+      // eslint-disable-next-line no-await-in-loop
+      await simAws.dynamoDb().putItem(
+        new PutItemCommand({
+          TableName: "orders",
+          Item: { orderId: { S: "order-1" }, total: { N: total } },
+        }),
+      );
+    }
+
+    // When the stream is read.
+    const records = await recordsOf(simAws);
+
+    // Then the second record carries both images, under the names and the
+    // capitalization the Streams API uses.
+    assertArrayLength(records, 2);
+    const record = records[1];
+    assertIdentical(record.eventName, "MODIFY");
+    assertIdentical(record.eventSource, "aws:dynamodb");
+    assertIdentical(record.awsRegion, simAws.defaultRegionName);
+    assertIdentical(record.eventVersion, "1.1");
+    assertIdentical(record.eventID?.length, 32);
+
+    const body = record.dynamodb;
+    assertNonNullable(body);
+    assertObjectEquals(body.Keys, { orderId: { S: "order-1" } });
+    assertObjectEquals(body.NewImage, {
+      orderId: { S: "order-1" },
+      total: { N: "202" },
+    });
+    assertObjectEquals(body.OldImage, {
+      orderId: { S: "order-1" },
+      total: { N: "101" },
+    });
+    assertIdentical(body.StreamViewType, "NEW_AND_OLD_IMAGES");
+    assertIdentical(body.SequenceNumber, "100000000000000000001");
+
+    // And the creation time is a Date, which is what the SDK deserializes a
+    // timestamp into, rather than the epoch seconds a Lambda event carries.
+    assertInstanceOf(body.ApproximateCreationDateTime, Date);
+    assertIdentical(
+      body.ApproximateCreationDateTime.toISOString(),
+      startedAt.toISOString(),
+    );
+
+    // And nothing but DynamoDB itself gets an identity.
+    assertUndefined(record.userIdentity);
+  });
+
+  it("capitalizes the identity of a time to live removal", async () => {
+    // Given a streamed table expiring its items, holding one that is due.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: "orders",
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" }, expiresAt: { N: startedAtSeconds } },
+      }),
+    );
+
+    // When the clock passes the deletion window, far enough that the write
+    // itself has aged out of the retention window.
+    await simAws.clock().advanceBy({ hours: 49 });
+
+    // Then the removal that is left says DynamoDB made it, under the names the
+    // Streams API uses rather than the ones the Lambda event uses.
+    const records = await recordsOf(simAws);
+    assertArrayLength(records, 1);
+    assertIdentical(records[0].eventName, "REMOVE");
+    assertObjectEquals(records[0].userIdentity, {
+      PrincipalId: "dynamodb.amazonaws.com",
+      Type: "Service",
+    });
+  });
+});

--- a/src/service/dynamodb/command/stream/get-records/sim-dynamodb-streams-api-record.ts
+++ b/src/service/dynamodb/command/stream/get-records/sim-dynamodb-streams-api-record.ts
@@ -1,0 +1,66 @@
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import type { SimDynamoDbStreamRecord } from "../../../stream/sim-dynamodb-stream-record.js";
+import type {
+  SimDynamoDbStreamsIdentity,
+  SimDynamoDbStreamsRecord,
+} from "../stream.types.js";
+
+/**
+ * The record format version the Streams API reports.
+ *
+ * AWS documents this as subject to change and tells clients not to depend on
+ * a particular value. It is here because a record carries it, not because
+ * anything should be read from it.
+ */
+const eventVersion = "1.1";
+
+/**
+ * Who made a change, as the Streams API capitalizes it.
+ *
+ * The Lambda event carries the same two values under `principalId` and `type`,
+ * which is why the stored record keeps them in its own terms and each surface
+ * renders its own. Sharing one payload between the two would leave one of them
+ * quietly wrong.
+ */
+function identityOf(
+  record: SimDynamoDbStreamRecord,
+): SimDynamoDbStreamsIdentity | undefined {
+  if (record.userIdentity === undefined) {
+    return undefined;
+  }
+
+  return {
+    PrincipalId: record.userIdentity.principalId,
+    Type: record.userIdentity.type,
+  };
+}
+
+/**
+ * Render a captured record the way the DynamoDB Streams API hands it back.
+ *
+ * `ApproximateCreationDateTime` is a Date here, where the Lambda event has
+ * epoch seconds in the same place. The SDK deserializes a timestamp into a
+ * Date, so this is what an application reading GetRecords already expects.
+ */
+export function simDynamoDbStreamsApiRecord(
+  record: SimDynamoDbStreamRecord,
+  awsRegion: AwsRegionName,
+): SimDynamoDbStreamsRecord {
+  return {
+    eventID: record.eventId,
+    eventName: record.eventName,
+    eventVersion,
+    eventSource: "aws:dynamodb",
+    awsRegion,
+    dynamodb: {
+      ApproximateCreationDateTime: record.approximateCreationDateTime,
+      Keys: record.keys.toAttributeValues(),
+      NewImage: record.newImage?.toAttributeValues(),
+      OldImage: record.oldImage?.toAttributeValues(),
+      SequenceNumber: record.sequenceNumber,
+      SizeBytes: record.sizeBytes,
+      StreamViewType: record.streamViewType,
+    },
+    userIdentity: identityOf(record),
+  };
+}

--- a/src/service/dynamodb/command/stream/get-shard-iterator/get-shard-iterator.command.ts
+++ b/src/service/dynamodb/command/stream/get-shard-iterator/get-shard-iterator.command.ts
@@ -1,0 +1,34 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb-streams/command/GetShardIteratorCommand/
+ */
+
+import type { SimResponseMetadata } from "../../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim DynamoDB Streams GetShardIterator command.
+ */
+export interface SimGetShardIteratorCommand {
+  readonly input: SimGetShardIteratorCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams GetShardIterator input.
+ *
+ * `SequenceNumber` belongs with the two iterator types that name a record, and
+ * is refused with the two that do not, so a request cannot half-say where it
+ * means to start.
+ */
+export interface SimGetShardIteratorCommandInput {
+  readonly StreamArn?: string | undefined;
+  readonly ShardId?: string | undefined;
+  readonly ShardIteratorType?: string | undefined;
+  readonly SequenceNumber?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams GetShardIterator output.
+ */
+export interface SimGetShardIteratorCommandOutput {
+  readonly ShardIterator?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator-validation.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator-validation.iso.test.ts
@@ -1,0 +1,167 @@
+import { GetShardIteratorCommand } from "@aws-sdk/client-dynamodb-streams";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../../iam/error/sim-iam.error.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../../error/dynamodb.error.js";
+import { simDynamoDbStreamedOrdersFactory } from "../../../stream/sim-dynamodb-streamed-orders.factory.js";
+
+/**
+ * The sequence number the first record on a fresh stream carries.
+ */
+const firstSequenceNumber = "100000000000000000000";
+
+describe("DynamoDB Streams GetShardIterator request checking", () => {
+  it("refuses a sequence number given with LATEST", async () => {
+    // Given a stream with a record on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When an iterator asks for LATEST and names a record as well.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamArn: stream.arn,
+          ShardId: stream.shard.shardId,
+          ShardIteratorType: "LATEST",
+          SequenceNumber: firstSequenceNumber,
+        }),
+      ),
+    );
+
+    // Then the request is refused rather than one of the two being dropped.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("refuses AT_SEQUENCE_NUMBER with no sequence number", async () => {
+    // Given a stream with a record on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When an iterator names a record without saying which.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamArn: stream.arn,
+          ShardId: stream.shard.shardId,
+          ShardIteratorType: "AT_SEQUENCE_NUMBER",
+        }),
+      ),
+    );
+
+    // Then the request is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("refuses a shard iterator type it does not know", async () => {
+    // Given a stream with a record on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When an iterator asks to start somewhere DynamoDB has no name for.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator({
+        input: {
+          StreamArn: stream.arn,
+          ShardId: stream.shard.shardId,
+          ShardIteratorType: "OLDEST",
+        },
+      }),
+    );
+
+    // Then the request is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("refuses a request naming no stream and one naming no shard", async () => {
+    // Given a stream with a record on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When an iterator is asked for without a stream to read.
+    const withoutStream = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .getShardIterator({ input: { ShardIteratorType: "TRIM_HORIZON" } }),
+    );
+
+    // And when one is asked for without a shard to read.
+    const withoutShard = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator({
+        input: {
+          StreamArn: stream.arn,
+          ShardIteratorType: "TRIM_HORIZON",
+        },
+      }),
+    );
+
+    // Then both are refused as incomplete requests rather than as anything
+    // being missing from the simulation.
+    assertInstanceOf(withoutStream, SimDynamoDbValidationException);
+    assertInstanceOf(withoutShard, SimDynamoDbValidationException);
+  });
+
+  it("reports no shard for a shard identifier the stream has not got", async () => {
+    // Given a stream with a record on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+
+    // When an iterator is asked for on another shard.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamArn: stream.arn,
+          ShardId: "shardId-00000000000000000000-deadbeef",
+          ShardIteratorType: "TRIM_HORIZON",
+        }),
+      ),
+    );
+
+    // Then the shard is simply not found.
+    assertInstanceOf(error, SimDynamoDbResourceNotFoundException);
+  });
+
+  it("denies a caller without dynamodb:GetShardIterator on the stream ARN", async () => {
+    // Given a Role with no DynamoDB permissions.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make({}, simAws);
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoIteratorRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When that Role asks for an iterator.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().getShardIterator(
+        new GetShardIteratorCommand({
+          StreamArn: stream.arn,
+          ShardId: stream.shard.shardId,
+          ShardIteratorType: "TRIM_HORIZON",
+        }),
+        { caller: { kind: "arn", arn: roleCreation.Role.Arn } },
+      ),
+    );
+
+    // Then it is refused against the stream's own ARN.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:GetShardIterator");
+    assertIdentical(error.resource, stream.arn);
+  });
+});

--- a/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator.iso.test.ts
+++ b/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator.iso.test.ts
@@ -1,0 +1,139 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  type ShardIteratorType,
+} from "@aws-sdk/client-dynamodb-streams";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
+import { simDynamoDbStreamedOrdersFactory } from "../../../stream/sim-dynamodb-streamed-orders.factory.js";
+
+/**
+ * The sequence number the record at a position on a fresh stream carries.
+ */
+function sequenceNumberAt(position: number): string {
+  return (100_000_000_000_000_000_000n + BigInt(position)).toString();
+}
+
+/**
+ * The order identifiers an iterator of a type reads, oldest first, as one
+ * string.
+ */
+async function readFrom(
+  simAws: SimAws,
+  stream: SimDynamoDbStream,
+  iteratorType: ShardIteratorType,
+  sequenceNumber?: string,
+): Promise<string> {
+  const iterator = await simAws.dynamoDbStreams().getShardIterator(
+    new GetShardIteratorCommand({
+      StreamArn: stream.arn,
+      ShardId: stream.shard.shardId,
+      ShardIteratorType: iteratorType,
+      SequenceNumber: sequenceNumber,
+    }),
+  );
+  const output = await simAws
+    .dynamoDbStreams()
+    .getRecords(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+  return (output.Records ?? [])
+    .map((record) => record.dynamodb?.Keys?.["orderId"]?.S ?? "")
+    .join(",");
+}
+
+describe("DynamoDB Streams GetShardIterator", () => {
+  it("reads from the oldest record with TRIM_HORIZON", async () => {
+    // Given a stream with three records on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 3 },
+      simAws,
+    );
+
+    // When a TRIM_HORIZON iterator is read from.
+    // Then it starts at the first record the stream took.
+    assertIdentical(
+      await readFrom(simAws, stream, "TRIM_HORIZON"),
+      "order-1,order-2,order-3",
+    );
+  });
+
+  it("skips what is already there with LATEST", async () => {
+    // Given a stream with three records on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 3 },
+      simAws,
+    );
+
+    // When a LATEST iterator is taken and then another record is written.
+    const iterator = await simAws.dynamoDbStreams().getShardIterator(
+      new GetShardIteratorCommand({
+        StreamArn: stream.arn,
+        ShardId: stream.shard.shardId,
+        ShardIteratorType: "LATEST",
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-4" } },
+      }),
+    );
+    const output = await simAws
+      .dynamoDbStreams()
+      .getRecords(
+        new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+      );
+
+    // Then only the record written afterwards is read.
+    assertIdentical(
+      (output.Records ?? [])
+        .map((record) => record.dynamodb?.Keys?.["orderId"]?.S ?? "")
+        .join(","),
+      "order-4",
+    );
+  });
+
+  it("includes the record it names with AT_SEQUENCE_NUMBER", async () => {
+    // Given a stream with three records on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 3 },
+      simAws,
+    );
+
+    // When an iterator is taken at the second record's sequence number.
+    // Then the record it names is the first one read.
+    assertIdentical(
+      await readFrom(simAws, stream, "AT_SEQUENCE_NUMBER", sequenceNumberAt(1)),
+      "order-2,order-3",
+    );
+  });
+
+  it("excludes the record it names with AFTER_SEQUENCE_NUMBER", async () => {
+    // Given a stream with three records on it.
+    const simAws = new SimAws();
+    const stream = await simDynamoDbStreamedOrdersFactory.make(
+      { orders: 3 },
+      simAws,
+    );
+
+    // When an iterator is taken after the second record's sequence number.
+    // Then reading starts at the record following the one it named.
+    assertIdentical(
+      await readFrom(
+        simAws,
+        stream,
+        "AFTER_SEQUENCE_NUMBER",
+        sequenceNumberAt(1),
+      ),
+      "order-3",
+    );
+  });
+});

--- a/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator.ts
+++ b/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator.ts
@@ -1,0 +1,79 @@
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../../error/dynamodb.error.js";
+import { assertSimDynamoDbStreamPositionReadable } from "../../../stream/sim-dynamodb-stream-read.js";
+import { simDynamoDbShardIteratorToken } from "../../../stream/sim-dynamodb-stream-shard-iterator.js";
+import type { SimDynamoDbStreamAccess } from "../sim-dynamodb-stream-access.js";
+import { simDynamoDbShardIteratorPosition } from "./sim-dynamodb-shard-iterator-position.js";
+import type {
+  SimGetShardIteratorCommand,
+  SimGetShardIteratorCommandOutput,
+} from "./get-shard-iterator.command.js";
+
+interface SimDynamoDbGetShardIteratorProperties {
+  readonly access: SimDynamoDbStreamAccess;
+}
+
+interface SimDynamoDbGetShardIteratorOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The command that hands out a place to start reading a shard from.
+ */
+export class SimDynamoDbGetShardIterator {
+  private readonly access: SimDynamoDbStreamAccess;
+
+  constructor(properties: SimDynamoDbGetShardIteratorProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * Get an iterator for a shard of a stream.
+   *
+   * A sequence number the retention window has already outlived is refused
+   * here rather than at the GetRecords that would have used the iterator, so a
+   * consumer resuming from a checkpoint it kept too long finds out at the call
+   * that asked.
+   */
+  handle(
+    command: SimGetShardIteratorCommand,
+    options?: SimDynamoDbGetShardIteratorOptions,
+  ): SimGetShardIteratorCommandOutput {
+    const stream = this.access.required(
+      "dynamodb:GetShardIterator",
+      command.input.StreamArn,
+      options?.caller,
+    );
+
+    const shardId = command.input.ShardId;
+    if (shardId === undefined) {
+      throw new SimDynamoDbValidationException(
+        "GetShardIterator requires a ShardId",
+      );
+    }
+
+    if (shardId !== stream.shard.shardId) {
+      throw new SimDynamoDbResourceNotFoundException(
+        `Stream ${stream.arn} has no shard ${shardId}`,
+      );
+    }
+
+    const position = simDynamoDbShardIteratorPosition(
+      command.input,
+      stream.shard,
+    );
+    assertSimDynamoDbStreamPositionReadable(stream.shard, position);
+
+    return {
+      ShardIterator: simDynamoDbShardIteratorToken({
+        streamArn: stream.arn,
+        shardId: stream.shard.shardId,
+        position,
+      }),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-shard-iterator-position.ts
+++ b/src/service/dynamodb/command/stream/get-shard-iterator/sim-dynamodb-shard-iterator-position.ts
@@ -1,0 +1,83 @@
+import { SimDynamoDbValidationException } from "../../../error/dynamodb.error.js";
+import {
+  simDynamoDbStreamAfter,
+  type SimDynamoDbStreamPosition,
+  simDynamoDbStreamStart,
+} from "../../../stream/sim-dynamodb-stream-position.js";
+import { readSimDynamoDbSequenceNumber } from "../../../stream/sim-dynamodb-stream-sequence-numbers.js";
+import type { SimDynamoDbStreamShard } from "../../../stream/sim-dynamodb-stream-shard.js";
+import type { SimGetShardIteratorCommandInput } from "./get-shard-iterator.command.js";
+
+/**
+ * The iterator types that name a record, and so carry a sequence number.
+ */
+const sequenceNumberTypes = new Set([
+  "AT_SEQUENCE_NUMBER",
+  "AFTER_SEQUENCE_NUMBER",
+]);
+
+/**
+ * Refuse a sequence number given with an iterator type that has no place for
+ * one.
+ *
+ * TRIM_HORIZON and LATEST are both ends of the shard rather than a record on
+ * it, so a request that gives one of them a sequence number is saying two
+ * different things about where to start. Taking the type and dropping the
+ * number would silently read from somewhere the caller did not ask for.
+ */
+function assertNoSequenceNumber(
+  input: SimGetShardIteratorCommandInput,
+  iteratorType: string,
+): void {
+  if (input.SequenceNumber !== undefined) {
+    throw new SimDynamoDbValidationException(
+      `GetShardIterator takes no SequenceNumber with the ShardIteratorType ${
+        iteratorType
+      }`,
+    );
+  }
+}
+
+/**
+ * Where on a shard the iterator type a request asks for starts reading.
+ *
+ * LATEST on an empty shard is the start of it, which is the same place: an
+ * empty shard has nothing before its end either.
+ */
+export function simDynamoDbShardIteratorPosition(
+  input: SimGetShardIteratorCommandInput,
+  shard: SimDynamoDbStreamShard,
+): SimDynamoDbStreamPosition {
+  const iteratorType = input.ShardIteratorType;
+
+  if (iteratorType === "TRIM_HORIZON") {
+    assertNoSequenceNumber(input, iteratorType);
+
+    return simDynamoDbStreamStart;
+  }
+
+  if (iteratorType === "LATEST") {
+    assertNoSequenceNumber(input, iteratorType);
+    const newest = shard.records.at(-1);
+
+    return newest === undefined
+      ? simDynamoDbStreamStart
+      : simDynamoDbStreamAfter(newest.sequenceNumber);
+  }
+
+  if (iteratorType === undefined || !sequenceNumberTypes.has(iteratorType)) {
+    throw new SimDynamoDbValidationException(
+      `GetShardIterator needs a ShardIteratorType of TRIM_HORIZON, LATEST, ` +
+        `AT_SEQUENCE_NUMBER or AFTER_SEQUENCE_NUMBER`,
+    );
+  }
+
+  const sequenceNumber = readSimDynamoDbSequenceNumber(
+    input.SequenceNumber,
+    `GetShardIterator with the ShardIteratorType ${iteratorType}`,
+  );
+
+  return iteratorType === "AT_SEQUENCE_NUMBER"
+    ? { kind: "at", sequenceNumber }
+    : simDynamoDbStreamAfter(sequenceNumber);
+}

--- a/src/service/dynamodb/command/stream/list-streams/list-streams.command.ts
+++ b/src/service/dynamodb/command/stream/list-streams/list-streams.command.ts
@@ -1,0 +1,36 @@
+/**
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb-streams/command/ListStreamsCommand/
+ */
+
+import type { SimArn } from "../../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../../aws/metadata/response-metadata.type.js";
+import type { SimDynamoDbStreamSummary } from "../stream.types.js";
+
+/**
+ * Minimal structural sim DynamoDB Streams ListStreams command.
+ */
+export interface SimListStreamsCommand {
+  readonly input: SimListStreamsCommandInput;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams ListStreams input.
+ *
+ * `TableName` narrows the answer to one table's streams. Real DynamoDB takes
+ * the table's name here rather than its ARN, unlike the DynamoDB API's own
+ * `TableName` parameters.
+ */
+export interface SimListStreamsCommandInput {
+  readonly TableName?: string | undefined;
+  readonly Limit?: number | undefined;
+  readonly ExclusiveStartStreamArn?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams ListStreams output.
+ */
+export interface SimListStreamsCommandOutput {
+  readonly Streams?: readonly SimDynamoDbStreamSummary[] | undefined;
+  readonly LastEvaluatedStreamArn?: SimArn | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.iso.test.ts
+++ b/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.iso.test.ts
@@ -121,20 +121,26 @@ describe("DynamoDB Streams ListStreams", () => {
     assertUndefined(second.LastEvaluatedStreamArn);
   });
 
-  it("refuses a Limit above the page size cap", async () => {
+  it("refuses a Limit outside the page size DynamoDB takes", async () => {
     // Given a table with a stream.
     const simAws = new SimAws();
     await simDynamoDbStreamedTableFactory.make({}, simAws);
 
-    // When more streams than one page holds are asked for at once.
-    const error = await assertThrowsErrorAsync(async () =>
+    // When a page of no streams, and one of more than a page, are asked for.
+    const tooFew = await assertThrowsErrorAsync(async () =>
       simAws
         .dynamoDbStreams()
         .listStreams(new ListStreamsCommand({ Limit: 0 })),
     );
+    const tooMany = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .listStreams(new ListStreamsCommand({ Limit: 101 })),
+    );
 
-    // Then the request is refused.
-    assertInstanceOf(error, SimDynamoDbValidationException);
+    // Then both are refused.
+    assertInstanceOf(tooFew, SimDynamoDbValidationException);
+    assertInstanceOf(tooMany, SimDynamoDbValidationException);
   });
 
   it("denies a caller without dynamodb:ListStreams", async () => {

--- a/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.iso.test.ts
+++ b/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  CreateTableCommand,
+  UpdateTableCommand,
+} from "@aws-sdk/client-dynamodb";
+import { ListStreamsCommand } from "@aws-sdk/client-dynamodb-streams";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../../iam/error/sim-iam.error.js";
+import { SimDynamoDbValidationException } from "../../../error/dynamodb.error.js";
+import { simDynamoDbStreamedTableFactory } from "../../../stream/sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * Create a table with no stream on it at all.
+ */
+async function createPlainTable(
+  simAws: SimAws,
+  tableName: string,
+): Promise<void> {
+  await simAws.dynamoDb().createTable(
+    new CreateTableCommand({
+      TableName: tableName,
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("DynamoDB Streams ListStreams", () => {
+  it("reports a streamed table's stream", async () => {
+    // Given a table with a stream switched on.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    // When the streams of that table are listed.
+    const output = await simAws
+      .dynamoDbStreams()
+      .listStreams(new ListStreamsCommand({ TableName: "orders" }));
+
+    // Then the stream the table is capturing onto is the one reported.
+    assertArrayLength(output.Streams, 1);
+    assertIdentical(output.Streams[0].StreamArn, table.stream.latest?.arn);
+    assertIdentical(output.Streams[0].TableName, "orders");
+    assertIdentical(output.Streams[0].StreamLabel, table.stream.latest?.label);
+  });
+
+  it("reports nothing for a table with no stream", async () => {
+    // Given one streamed table and one without a stream.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+    await createPlainTable(simAws, "invoices");
+
+    // When the streams of the table with no stream are listed.
+    const output = await simAws
+      .dynamoDbStreams()
+      .listStreams(new ListStreamsCommand({ TableName: "invoices" }));
+
+    // Then it has none, rather than the table being reported as missing.
+    assertArrayLength(output.Streams, 0);
+  });
+
+  it("goes on listing a stream its table has switched off", async () => {
+    // Given a table whose stream has been disabled.
+    const simAws = new SimAws();
+    const table = await simDynamoDbStreamedTableFactory.make({}, simAws);
+    const disabledArn = table.stream.latest?.arn;
+
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: "orders",
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the table's streams are listed.
+    const output = await simAws
+      .dynamoDbStreams()
+      .listStreams(new ListStreamsCommand({ TableName: "orders" }));
+
+    // Then the disabled stream is still there to be read within its retention
+    // window.
+    assertArrayLength(output.Streams, 1);
+    assertIdentical(output.Streams[0].StreamArn, disabledArn);
+  });
+
+  it("pages by stream ARN", async () => {
+    // Given two tables, each with a stream.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make({ tableName: "alpha" }, simAws);
+    await simDynamoDbStreamedTableFactory.make({ tableName: "beta" }, simAws);
+
+    // When a page of one stream is asked for.
+    const first = await simAws
+      .dynamoDbStreams()
+      .listStreams(new ListStreamsCommand({ Limit: 1 }));
+
+    // Then the page carries the ARN to resume from.
+    assertArrayLength(first.Streams, 1);
+    assertIdentical(first.LastEvaluatedStreamArn, first.Streams[0].StreamArn);
+
+    // And resuming from it gives the other stream, and no token to go on with.
+    const second = await simAws.dynamoDbStreams().listStreams(
+      new ListStreamsCommand({
+        Limit: 1,
+        ExclusiveStartStreamArn: first.LastEvaluatedStreamArn,
+      }),
+    );
+
+    assertArrayLength(second.Streams, 1);
+    assertIdentical(second.Streams[0].TableName, "beta");
+    assertUndefined(second.LastEvaluatedStreamArn);
+  });
+
+  it("refuses a Limit above the page size cap", async () => {
+    // Given a table with a stream.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    // When more streams than one page holds are asked for at once.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDbStreams()
+        .listStreams(new ListStreamsCommand({ Limit: 0 })),
+    );
+
+    // Then the request is refused.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+  });
+
+  it("denies a caller without dynamodb:ListStreams", async () => {
+    // Given a Role with no DynamoDB permissions at all.
+    const simAws = new SimAws();
+    await simDynamoDbStreamedTableFactory.make({}, simAws);
+
+    const roleCreation = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "NoStreamsRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    // When that Role lists streams.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDbStreams().listStreams(new ListStreamsCommand({}), {
+        caller: { kind: "arn", arn: roleCreation.Role.Arn },
+      }),
+    );
+
+    // Then it is refused rather than given an empty listing, since the action
+    // names no particular stream.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "dynamodb:ListStreams");
+    assertIdentical(error.resource, "*");
+  });
+});

--- a/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.ts
+++ b/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-list-streams.ts
@@ -1,0 +1,51 @@
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import type { SimDynamoDbStreamAccess } from "../sim-dynamodb-stream-access.js";
+import { SimDynamoDbStreamPage } from "./sim-dynamodb-stream-page.js";
+import type {
+  SimListStreamsCommand,
+  SimListStreamsCommandOutput,
+} from "./list-streams.command.js";
+
+interface SimDynamoDbListStreamsProperties {
+  readonly access: SimDynamoDbStreamAccess;
+}
+
+interface SimDynamoDbListStreamsOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The command that lists the streams of this Account and Region.
+ *
+ * A stream stays listed once its table has switched it off, since a disabled
+ * stream is readable for the rest of its retention window and a consumer has to
+ * be able to find it.
+ */
+export class SimDynamoDbListStreams {
+  private readonly access: SimDynamoDbStreamAccess;
+
+  constructor(properties: SimDynamoDbListStreamsProperties) {
+    this.access = properties.access;
+  }
+
+  /**
+   * List the streams here, optionally only one table's.
+   */
+  handle(
+    command: SimListStreamsCommand,
+    options?: SimDynamoDbListStreamsOptions,
+  ): SimListStreamsCommandOutput {
+    const streams = this.access.all("dynamodb:ListStreams", options?.caller);
+    const page = new SimDynamoDbStreamPage(streams, command.input);
+
+    return {
+      Streams: page.streams.map((stream) => ({
+        StreamArn: stream.arn,
+        TableName: stream.tableName,
+        StreamLabel: stream.label,
+      })),
+      LastEvaluatedStreamArn: page.lastEvaluatedStreamArn,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-stream-page.ts
+++ b/src/service/dynamodb/command/stream/list-streams/sim-dynamodb-stream-page.ts
@@ -1,0 +1,85 @@
+import type { SimArn } from "../../../../aws/arn.js";
+import { SimDynamoDbValidationException } from "../../../error/dynamodb.error.js";
+import type { SimDynamoDbStream } from "../../../stream/sim-dynamodb-stream.js";
+import type { SimListStreamsCommandInput } from "./list-streams.command.js";
+
+const defaultLimit = 100;
+const greatestLimit = 100;
+
+/**
+ * Read the page size a ListStreams request asks for.
+ */
+function readLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return defaultLimit;
+  }
+
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > greatestLimit) {
+    throw new SimDynamoDbValidationException(
+      `Limit ${limit.toString()} is invalid. It is a whole number between 1 ` +
+        `and ${greatestLimit.toString()}.`,
+    );
+  }
+
+  return limit;
+}
+
+/**
+ * One page of streams, as ListStreams hands them out.
+ *
+ * The token is a stream ARN rather than an opaque cursor, matching the way
+ * ListTables pages by table name, so a page resumes at the first ARN after it.
+ */
+export class SimDynamoDbStreamPage {
+  public readonly streams: readonly SimDynamoDbStream[];
+  public readonly lastEvaluatedStreamArn: SimArn | undefined;
+
+  constructor(
+    streams: readonly SimDynamoDbStream[],
+    input: SimListStreamsCommandInput,
+  ) {
+    const named = this.ofTable(streams, input.TableName);
+    const remaining = this.after(named, input.ExclusiveStartStreamArn);
+
+    this.streams = remaining.slice(0, readLimit(input.Limit));
+    this.lastEvaluatedStreamArn =
+      this.streams.length === remaining.length
+        ? undefined
+        : this.streams.at(-1)?.arn;
+  }
+
+  /**
+   * The streams of the table a request named, or all of them when it named
+   * none.
+   *
+   * A table with no stream, and a name no table ever had, both list nothing.
+   * Real DynamoDB does not refuse either: ListStreams reports what is there
+   * rather than checking that the table is.
+   */
+  private ofTable(
+    streams: readonly SimDynamoDbStream[],
+    tableName: string | undefined,
+  ): readonly SimDynamoDbStream[] {
+    if (tableName === undefined) {
+      return streams;
+    }
+
+    return streams.filter((stream) => stream.tableName === tableName);
+  }
+
+  /**
+   * The streams left to list after the ARN a request resumes from.
+   */
+  private after(
+    streams: readonly SimDynamoDbStream[],
+    exclusiveStartStreamArn: string | undefined,
+  ): readonly SimDynamoDbStream[] {
+    if (exclusiveStartStreamArn === undefined) {
+      return streams;
+    }
+
+    return streams.filter(
+      (stream) => stream.arn.localeCompare(exclusiveStartStreamArn) > 0,
+    );
+  }
+}

--- a/src/service/dynamodb/command/stream/sim-dynamodb-stream-access.ts
+++ b/src/service/dynamodb/command/stream/sim-dynamodb-stream-access.ts
@@ -1,0 +1,85 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  SimDynamoDbResourceNotFoundException,
+  SimDynamoDbValidationException,
+} from "../../error/dynamodb.error.js";
+import type { SimDynamoDbStream } from "../../stream/sim-dynamodb-stream.js";
+import type { SimDynamoDbStreamStore } from "../../stream/sim-dynamodb-stream-store.js";
+import type { SimDynamoDbAuthorizer } from "../authorize/sim-dynamodb-authorizer.js";
+
+interface SimDynamoDbStreamAccessProperties {
+  readonly streams: SimDynamoDbStreamStore;
+  readonly authorizer: SimDynamoDbAuthorizer;
+  readonly clock: SimClock;
+}
+
+/**
+ * How a Streams command reaches the stream a request names.
+ *
+ * Every one of them goes through the same three steps in the same order: bring
+ * the streams up to date for the retention window, authorize the caller
+ * against the ARN the request carries, then look the stream up. Keeping them
+ * here is what makes that order the same for all of them, so no command can
+ * tell an unauthorized caller which stream ARNs are real.
+ */
+export class SimDynamoDbStreamAccess {
+  private readonly streams: SimDynamoDbStreamStore;
+  private readonly authorizer: SimDynamoDbAuthorizer;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimDynamoDbStreamAccessProperties) {
+    this.streams = properties.streams;
+    this.authorizer = properties.authorizer;
+    this.clock = properties.clock;
+  }
+
+  /**
+   * Find the stream an ARN names, refusing the caller before looking it up.
+   *
+   * A request with no `StreamArn` at all is refused before authorization,
+   * since there is no resource to authorize it against. Everything past that
+   * is authorized first, so an unauthorized caller cannot find out which ARNs
+   * name a real stream.
+   */
+  required(
+    action: string,
+    streamArn: string | undefined,
+    caller: SimAwsCaller | undefined,
+  ): SimDynamoDbStream {
+    if (streamArn === undefined || streamArn === "") {
+      throw new SimDynamoDbValidationException(
+        `${action.replace("dynamodb:", "")} requires a StreamArn`,
+      );
+    }
+
+    this.streams.applyRetention(this.clock.now());
+    this.authorizer.authorizeStream(action, streamArn, caller);
+
+    const stream = this.streams.findByArn(streamArn);
+    if (stream === undefined) {
+      throw new SimDynamoDbResourceNotFoundException(
+        `No DynamoDB Stream with ARN ${streamArn}`,
+      );
+    }
+
+    return stream;
+  }
+
+  /**
+   * Every stream in this scope, once the caller is allowed to list them.
+   *
+   * ListStreams names no stream, so it authorizes the way ListTables does:
+   * against every resource, and without filtering the answer by what the caller
+   * could go on to read.
+   */
+  all(
+    action: string,
+    caller: SimAwsCaller | undefined,
+  ): readonly SimDynamoDbStream[] {
+    this.streams.applyRetention(this.clock.now());
+    this.authorizer.authorizeAnyTable(action, caller);
+
+    return this.streams.inArnOrder();
+  }
+}

--- a/src/service/dynamodb/command/stream/sim-dynamodb-stream-command.types.ts
+++ b/src/service/dynamodb/command/stream/sim-dynamodb-stream-command.types.ts
@@ -1,0 +1,23 @@
+/**
+ * The sim DynamoDB Streams Command types, gathered for the service facade.
+ */
+export type {
+  SimListStreamsCommand,
+  SimListStreamsCommandInput,
+  SimListStreamsCommandOutput,
+} from "./list-streams/list-streams.command.js";
+export type {
+  SimDescribeStreamCommand,
+  SimDescribeStreamCommandInput,
+  SimDescribeStreamCommandOutput,
+} from "./describe-stream/describe-stream.command.js";
+export type {
+  SimGetShardIteratorCommand,
+  SimGetShardIteratorCommandInput,
+  SimGetShardIteratorCommandOutput,
+} from "./get-shard-iterator/get-shard-iterator.command.js";
+export type {
+  SimGetRecordsCommand,
+  SimGetRecordsCommandInput,
+  SimGetRecordsCommandOutput,
+} from "./get-records/get-records.command.js";

--- a/src/service/dynamodb/command/stream/stream.types.ts
+++ b/src/service/dynamodb/command/stream/stream.types.ts
@@ -1,0 +1,94 @@
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
+import type { SimDynamoDbKeySchemaElement } from "../table/table.types.js";
+import type { SimDynamoDbStreamViewType } from "../../stream/sim-dynamodb-stream.types.js";
+
+/**
+ * Minimal structural sim DynamoDB Streams stream summary, as ListStreams
+ * reports one.
+ */
+export interface SimDynamoDbStreamSummary {
+  readonly StreamArn?: SimArn | undefined;
+  readonly TableName?: string | undefined;
+  readonly StreamLabel?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams sequence number range.
+ *
+ * `EndingSequenceNumber` is absent from an open shard, which is how a reader
+ * tells a shard still taking changes from one it can finish with.
+ */
+export interface SimDynamoDbStreamSequenceNumberRange {
+  readonly StartingSequenceNumber?: string | undefined;
+  readonly EndingSequenceNumber?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams shard.
+ *
+ * A simulated stream has one shard and never splits, so no shard here has a
+ * `ParentShardId`.
+ */
+export interface SimDynamoDbStreamShardDescription {
+  readonly ShardId?: string | undefined;
+  readonly SequenceNumberRange?:
+    SimDynamoDbStreamSequenceNumberRange | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams stream description.
+ */
+export interface SimDynamoDbStreamDescription {
+  readonly StreamArn?: SimArn | undefined;
+  readonly StreamLabel?: string | undefined;
+  readonly StreamStatus?: string | undefined;
+  readonly StreamViewType?: SimDynamoDbStreamViewType | undefined;
+  readonly CreationRequestDateTime?: Date | undefined;
+  readonly TableName?: string | undefined;
+  readonly KeySchema?: readonly SimDynamoDbKeySchemaElement[] | undefined;
+  readonly Shards?: readonly SimDynamoDbStreamShardDescription[] | undefined;
+  readonly LastEvaluatedShardId?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams identity.
+ *
+ * The Streams API capitalizes these, where the Lambda event that carries the
+ * same records does not. That is the whole reason a captured record is kept as
+ * a domain object with a renderer over it rather than as one payload shared
+ * between the two surfaces.
+ */
+export interface SimDynamoDbStreamsIdentity {
+  readonly PrincipalId?: string | undefined;
+  readonly Type?: string | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams stream record body.
+ */
+export interface SimDynamoDbStreamsRecordBody {
+  readonly ApproximateCreationDateTime?: Date | undefined;
+  readonly Keys?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly NewImage?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly OldImage?:
+    Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined;
+  readonly SequenceNumber?: string | undefined;
+  readonly SizeBytes?: number | undefined;
+  readonly StreamViewType?: SimDynamoDbStreamViewType | undefined;
+}
+
+/**
+ * Minimal structural sim DynamoDB Streams record, as GetRecords hands one back.
+ */
+export interface SimDynamoDbStreamsRecord {
+  readonly eventID?: string | undefined;
+  readonly eventName?: string | undefined;
+  readonly eventVersion?: string | undefined;
+  readonly eventSource?: string | undefined;
+  readonly awsRegion?: string | undefined;
+  readonly dynamodb?: SimDynamoDbStreamsRecordBody | undefined;
+  readonly userIdentity?: SimDynamoDbStreamsIdentity | undefined;
+}

--- a/src/service/dynamodb/error/dynamodb.error.ts
+++ b/src/service/dynamodb/error/dynamodb.error.ts
@@ -144,6 +144,27 @@ export class SimDynamoDbDocumentValueError extends SimDynamoDbError {
 }
 
 /**
+ * Simulated DynamoDB Streams TrimmedDataAccessException error.
+ *
+ * A stream keeps its records for 24 hours and then drops them. This is what a
+ * read of a position the stream no longer holds fails with, whether the caller
+ * named the position itself or is holding a shard iterator that was still good
+ * when it was handed out.
+ *
+ * It is not a ResourceNotFoundException: the stream and the shard are both
+ * still there, and everything after the trim point is still readable, so a
+ * consumer that catches this knows to start again from TRIM_HORIZON rather
+ * than that its stream has gone.
+ */
+export class SimDynamoDbTrimmedDataAccessException extends SimDynamoDbError {
+  public override readonly name = "TrimmedDataAccessException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated DynamoDB UnsupportedOperation error.
  *
  * Real DynamoDB has no error of this name. It is what simulated DynamoDB

--- a/src/service/dynamodb/index.ts
+++ b/src/service/dynamodb/index.ts
@@ -1,1 +1,2 @@
 export { SimDynamoDb } from "./sim-dynamodb.js";
+export { SimDynamoDbStreams } from "./sim-dynamodb-streams.js";

--- a/src/service/dynamodb/sdk/sim-dynamodb-streams-sdk-command-router.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-streams-sdk-command-router.ts
@@ -1,0 +1,74 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimDescribeStreamCommand } from "../command/stream/describe-stream/describe-stream.command.js";
+import type { SimGetRecordsCommand } from "../command/stream/get-records/get-records.command.js";
+import type { SimGetShardIteratorCommand } from "../command/stream/get-shard-iterator/get-shard-iterator.command.js";
+import type { SimListStreamsCommand } from "../command/stream/list-streams/list-streams.command.js";
+import type { SimDynamoDbStreams } from "../sim-dynamodb-streams.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated DynamoDB Streams.
+ *
+ * A second router rather than more entries on the DynamoDB one, because
+ * `@aws-sdk/client-dynamodb-streams` is a client of its own with a service
+ * identity of its own. Interception resolves the router from that identity, so
+ * a Streams client reaches this and a DynamoDB client cannot.
+ */
+export class SimDynamoDbStreamsSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simDynamoDbStreams: SimDynamoDbStreams) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "ListStreamsCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDbStreams.listStreams(
+            command as SimListStreamsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeStreamCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDbStreams.describeStream(
+            command as SimDescribeStreamCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetShardIteratorCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDbStreams.getShardIterator(
+            command as SimGetShardIteratorCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetRecordsCommand",
+        async (command, context): Promise<unknown> =>
+          await simDynamoDbStreams.getRecords(
+            command as SimGetRecordsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated DynamoDB Streams can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated DynamoDB Streams
+   * supports it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/dynamodb/sdk/sim-dynamodb-streams-sdk-routing.iso.test.ts
+++ b/src/service/dynamodb/sdk/sim-dynamodb-streams-sdk-routing.iso.test.ts
@@ -1,0 +1,114 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  DynamoDBStreamsClient,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * A streamed table written to through an intercepted DynamoDB client.
+ */
+async function streamedTable(simSdk: SimSdk): Promise<void> {
+  const client = new DynamoDBClient({ region: "eu-west-2" });
+  simSdk.intercept(client);
+
+  await client.send(
+    new CreateTableCommand({
+      TableName: "orders",
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+      StreamSpecification: {
+        StreamEnabled: true,
+        StreamViewType: "NEW_IMAGE",
+      },
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  await client.send(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: "order-1" } },
+    }),
+  );
+}
+
+describe("simulated DynamoDB Streams SDK Command routing", () => {
+  it("reads a table's captured changes through an intercepted Streams client", async () => {
+    // Given a streamed table and an intercepted DynamoDB Streams client, which
+    // is a client of its own with a service identity of its own.
+    const simSdk = new SimSdk();
+    await streamedTable(simSdk);
+
+    const streamsClient = new DynamoDBStreamsClient({ region: "eu-west-2" });
+    simSdk.intercept(streamsClient);
+
+    // When the four Streams operations are used the way an application would.
+    const listed = await streamsClient.send(
+      new ListStreamsCommand({ TableName: "orders" }),
+    );
+    const streamArn = listed.Streams?.[0]?.StreamArn;
+    assertNonNullable(streamArn);
+
+    const described = await streamsClient.send(
+      new DescribeStreamCommand({ StreamArn: streamArn }),
+    );
+    const shardId = described.StreamDescription?.Shards?.[0]?.ShardId;
+    assertNonNullable(shardId);
+
+    const iterator = await streamsClient.send(
+      new GetShardIteratorCommand({
+        StreamArn: streamArn,
+        ShardId: shardId,
+        ShardIteratorType: "TRIM_HORIZON",
+      }),
+    );
+    const records = await streamsClient.send(
+      new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+    );
+
+    // Then the change the DynamoDB client made comes back off the stream.
+    assertIdentical(described.StreamDescription?.StreamViewType, "NEW_IMAGE");
+    assertArrayLength(records.Records, 1);
+    assertIdentical(records.Records[0].eventName, "INSERT");
+    assertIdentical(
+      records.Records[0].dynamodb?.NewImage?.["orderId"]?.S,
+      "order-1",
+    );
+    assertIdentical(records.Records[0].awsRegion, "eu-west-2");
+  });
+
+  it("names every Command simulated DynamoDB Streams handles", () => {
+    // Given a scoped simulated DynamoDB Streams.
+    const simAws = new SimAws();
+    const router = simAws.dynamoDbStreams().sdkCommandRouter();
+
+    // When its supported Command names are asked for.
+    // Then the four Streams operations are routable by SDK Command name, and
+    // nothing the DynamoDB client sends is.
+    assertArrayEquals(router.supportedCommandNames(), [
+      "ListStreamsCommand",
+      "DescribeStreamCommand",
+      "GetShardIteratorCommand",
+      "GetRecordsCommand",
+    ]);
+    assertUndefined(router.route("PutItemCommand"));
+  });
+});

--- a/src/service/dynamodb/sim-dynamodb-streams.ts
+++ b/src/service/dynamodb/sim-dynamodb-streams.ts
@@ -1,0 +1,119 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/index.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimDynamoDbAuthorizer } from "./command/authorize/sim-dynamodb-authorizer.js";
+import type * as simStreamCommands from "./command/stream/sim-dynamodb-stream-command.types.js";
+import { SimDynamoDbDescribeStream } from "./command/stream/describe-stream/sim-dynamodb-describe-stream.js";
+import { SimDynamoDbGetRecords } from "./command/stream/get-records/sim-dynamodb-get-records.js";
+import { SimDynamoDbGetShardIterator } from "./command/stream/get-shard-iterator/sim-dynamodb-get-shard-iterator.js";
+import { SimDynamoDbListStreams } from "./command/stream/list-streams/sim-dynamodb-list-streams.js";
+import { SimDynamoDbStreamAccess } from "./command/stream/sim-dynamodb-stream-access.js";
+import { SimDynamoDbStreamsSdkCommandRouter } from "./sdk/sim-dynamodb-streams-sdk-command-router.js";
+import type { SimDynamoDbStreamStore } from "./stream/sim-dynamodb-stream-store.js";
+import type { SimDynamoDbRequestOptions } from "./sim-dynamodb.types.js";
+
+/**
+ * What one simulated DynamoDB Streams is built with.
+ *
+ * It is never built alone. The streams it reads are the ones the tables of one
+ * simulated DynamoDB captured onto, so the store comes from there rather than
+ * being made here.
+ */
+export interface SimDynamoDbStreamsProperties {
+  readonly streams: SimDynamoDbStreamStore;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated DynamoDB Streams. Handles SDK commands from the separate DynamoDB
+ * Streams client.
+ *
+ * This is a second API over one simulated DynamoDB's state rather than a
+ * service of its own, which is what AWS has too: the streams here are the ones
+ * this Account and Region's tables captured onto, and a stream ARN is a table
+ * ARN with a label after it.
+ *
+ * It is deliberately shaped as SDK commands rather than as a Yulin accessor,
+ * even though nobody writes GetRecords loops in application code. A Lambda
+ * event source mapping polling a stream has to authorize as its execution role
+ * through the same path a user's own call takes, so a bespoke internal read
+ * interface would be GetRecords under another name plus a second thing to
+ * learn. It is also the only way a failing delivery test can tell "nothing was
+ * captured" from "the poller did not deliver".
+ */
+export class SimDynamoDbStreams {
+  private readonly background: BackgroundScheduler;
+  private readonly streamListing: SimDynamoDbListStreams;
+  private readonly streamDescriptions: SimDynamoDbDescribeStream;
+  private readonly shardIterators: SimDynamoDbGetShardIterator;
+  private readonly recordReads: SimDynamoDbGetRecords;
+  private readonly sdkRouter = new SimDynamoDbStreamsSdkCommandRouter(this);
+
+  constructor(properties: SimDynamoDbStreamsProperties) {
+    const { accountRegionScope, background } = properties;
+    const access = new SimDynamoDbStreamAccess({
+      streams: properties.streams,
+      authorizer: new SimDynamoDbAuthorizer({
+        iam: properties.iam,
+        accountRegionScope,
+      }),
+      clock: background,
+    });
+
+    this.background = background;
+    this.streamListing = new SimDynamoDbListStreams({ access });
+    this.streamDescriptions = new SimDynamoDbDescribeStream({ access });
+    this.shardIterators = new SimDynamoDbGetShardIterator({ access });
+    this.recordReads = new SimDynamoDbGetRecords({
+      access,
+      accountRegionScope,
+    });
+  }
+
+  /** Handle a List Streams Command from the SDK. */
+  async listStreams(
+    command: simStreamCommands.SimListStreamsCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simStreamCommands.SimListStreamsCommandOutput> {
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+    return this.streamListing.handle(command, options);
+  }
+
+  /** Handle a Describe Stream Command from the SDK. */
+  async describeStream(
+    command: simStreamCommands.SimDescribeStreamCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simStreamCommands.SimDescribeStreamCommandOutput> {
+    await this.background.sequence();
+    return this.streamDescriptions.handle(command, options);
+  }
+
+  /** Handle a Get Shard Iterator Command from the SDK. */
+  async getShardIterator(
+    command: simStreamCommands.SimGetShardIteratorCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simStreamCommands.SimGetShardIteratorCommandOutput> {
+    await this.background.sequence();
+    return this.shardIterators.handle(command, options);
+  }
+
+  /** Handle a Get Records Command from the SDK. */
+  async getRecords(
+    command: simStreamCommands.SimGetRecordsCommand,
+    options?: SimDynamoDbRequestOptions,
+  ): Promise<simStreamCommands.SimGetRecordsCommandOutput> {
+    await this.background.sequence();
+    return this.recordReads.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -7,6 +7,7 @@ import type * as simDynamoDbCommands from "./command/sim-dynamodb-command.types.
 import { SimDynamoDbStreamActivity } from "./stream/sim-dynamodb-stream-activity.js";
 import { SimDynamoDbStreamStore } from "./stream/sim-dynamodb-stream-store.js";
 import type { SimDynamoDbStream } from "./stream/sim-dynamodb-stream.js";
+import { SimDynamoDbStreams } from "./sim-dynamodb-streams.js";
 import { SimDynamoDbTableStore } from "./table/sim-dynamodb-table-store.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
@@ -29,10 +30,11 @@ import type {
  */
 export class SimDynamoDb {
   private readonly tables = new SimDynamoDbTableStore();
-  private readonly streams = new SimDynamoDbStreamStore();
+  private readonly streamStore = new SimDynamoDbStreamStore();
   private readonly activity = new SimDynamoDbStreamActivity();
   private readonly background: BackgroundScheduler;
   private readonly commands: SimDynamoDbCommandHandlers;
+  private readonly streamsApi: SimDynamoDbStreams;
   private readonly sdkRouter = new SimDynamoDatabaseSdkCommandRouter(this);
   private readonly cfnFactory = new SimDynamoDbCfnResourceFactory({
     dynamoDb: this,
@@ -48,8 +50,14 @@ export class SimDynamoDb {
     this.background = background;
     this.commands = new SimDynamoDbCommandHandlers({
       tables: this.tables,
-      streams: this.streams,
+      streams: this.streamStore,
       streamActivity: this.activity,
+      accountRegionScope,
+      iam,
+      background,
+    });
+    this.streamsApi = new SimDynamoDbStreams({
+      streams: this.streamStore,
       accountRegionScope,
       iam,
       background,
@@ -253,11 +261,15 @@ export class SimDynamoDb {
    * Find a stream by ARN, if there is one here.
    *
    * Not a DynamoDB API operation. A stream outlives being enabled, so this
-   * finds one whose table has since switched it off, which is what reading a
-   * disabled stream within its retention window needs.
+   * finds one whose table has since switched it off.
    */
   findStream(streamArn: string): SimDynamoDbStream | undefined {
-    return this.streams.findByArn(streamArn);
+    return this.streamStore.findByArn(streamArn);
+  }
+
+  /** Get the DynamoDB Streams API over this service's streams. */
+  streams(): SimDynamoDbStreams {
+    return this.streamsApi;
   }
 
   /**

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-position.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-position.ts
@@ -1,0 +1,33 @@
+/**
+ * Where on a shard a reader is, between one GetRecords and the next.
+ *
+ * The three kinds are what the four shard iterator types come down to.
+ * TRIM_HORIZON is the start of whatever the shard still holds; LATEST is after
+ * the newest record on it; AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER are the
+ * two ways of naming a record, and the difference between them is whether that
+ * record is handed back or stepped over.
+ *
+ * A position is a place rather than an index, so it survives the shard being
+ * trimmed underneath it. That is what lets a read tell "you are asking for
+ * records that have aged out" from "there is nothing new yet".
+ */
+export type SimDynamoDbStreamPosition =
+  | { readonly kind: "start" }
+  | { readonly kind: "at"; readonly sequenceNumber: string }
+  | { readonly kind: "after"; readonly sequenceNumber: string };
+
+/**
+ * The position a reader starting from the oldest record it can reach is at.
+ */
+export const simDynamoDbStreamStart: SimDynamoDbStreamPosition = {
+  kind: "start",
+};
+
+/**
+ * The position a reader that has just taken a record is at.
+ */
+export function simDynamoDbStreamAfter(
+  sequenceNumber: string,
+): SimDynamoDbStreamPosition {
+  return { kind: "after", sequenceNumber };
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-read.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-read.ts
@@ -1,0 +1,124 @@
+import { SimDynamoDbTrimmedDataAccessException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import {
+  simDynamoDbStreamAfter,
+  type SimDynamoDbStreamPosition,
+} from "./sim-dynamodb-stream-position.js";
+import { compareSimDynamoDbSequenceNumbers } from "./sim-dynamodb-stream-sequence-numbers.js";
+import type { SimDynamoDbStreamShard } from "./sim-dynamodb-stream-shard.js";
+
+/**
+ * What one read of a shard came back with.
+ *
+ * `drained` is only true of a closed shard a reader has reached the end of. An
+ * open shard is never drained, however empty it is: more may yet be written to
+ * it, and that is the difference between a reader that should look again and
+ * one that is finished.
+ */
+export interface SimDynamoDbStreamRead {
+  readonly records: readonly SimDynamoDbStreamRecord[];
+  readonly next: SimDynamoDbStreamPosition;
+  readonly drained: boolean;
+}
+
+/**
+ * Whether a shard has dropped the record a position names.
+ *
+ * `at` a trimmed sequence number is gone: that record is what was asked for.
+ * `after` one is not, as long as the record following it survived, which is why
+ * the two comparisons differ by the equal case.
+ */
+function isTrimmed(
+  shard: SimDynamoDbStreamShard,
+  sequenceNumber: string,
+  inclusive: boolean,
+): boolean {
+  const trimmedThrough = shard.trimmedThrough;
+
+  if (trimmedThrough === undefined) {
+    return false;
+  }
+
+  const order = compareSimDynamoDbSequenceNumbers(
+    sequenceNumber,
+    trimmedThrough,
+  );
+
+  return inclusive ? order <= 0 : order < 0;
+}
+
+/**
+ * Ensure a shard still holds the position a reader is asking for.
+ *
+ * Checked when an iterator is handed out as well as when one is used, because a
+ * caller can name a sequence number the retention window has already outlived
+ * and should find that out at the request rather than one call later.
+ */
+export function assertSimDynamoDbStreamPositionReadable(
+  shard: SimDynamoDbStreamShard,
+  position: SimDynamoDbStreamPosition,
+): void {
+  if (
+    position.kind === "start" ||
+    !isTrimmed(shard, position.sequenceNumber, position.kind === "at")
+  ) {
+    return;
+  }
+
+  throw new SimDynamoDbTrimmedDataAccessException(
+    `Stream record with sequence number ${position.sequenceNumber} on shard ` +
+      `${shard.shardId} is past the 24 hour trim point`,
+  );
+}
+
+/**
+ * Where in the records a position starts reading from.
+ */
+function startIndexOf(
+  records: readonly SimDynamoDbStreamRecord[],
+  position: SimDynamoDbStreamPosition,
+): number {
+  if (position.kind === "start") {
+    return 0;
+  }
+
+  const wanted = position.kind === "at" ? 0 : 1;
+  const found = records.findIndex(
+    (record) =>
+      compareSimDynamoDbSequenceNumbers(
+        record.sequenceNumber,
+        position.sequenceNumber,
+      ) >= wanted,
+  );
+
+  return found === -1 ? records.length : found;
+}
+
+/**
+ * Read up to a limit of records from a shard, starting at a position.
+ *
+ * An empty result is an ordinary answer rather than a problem: a reader that
+ * has caught up with an open shard gets nothing back and the position it
+ * already had, which is what makes polling each successive iterator work.
+ */
+export function simDynamoDbStreamRead(
+  shard: SimDynamoDbStreamShard,
+  position: SimDynamoDbStreamPosition,
+  limit: number,
+): SimDynamoDbStreamRead {
+  assertSimDynamoDbStreamPositionReadable(shard, position);
+
+  const available = shard.records;
+  const start = startIndexOf(available, position);
+  const records = available.slice(start, start + limit);
+  const last = records.at(-1);
+
+  return {
+    records,
+    next:
+      last === undefined
+        ? position
+        : simDynamoDbStreamAfter(last.sequenceNumber),
+    drained: !shard.isOpen && start + records.length >= available.length,
+  };
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-retention.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-retention.ts
@@ -1,0 +1,25 @@
+/**
+ * How long DynamoDB Streams keeps a record before trimming it.
+ */
+const retentionHours = 24;
+
+const millisecondsPerHour = 60 * 60 * 1000;
+
+/**
+ * The instant a stream's records have to be newer than to still be readable.
+ *
+ * Trimming is applied when a stream is read rather than scheduled, because it
+ * is a pure function of the current time: whatever a read finds is what the
+ * retention window holds at the instant of that read, and nothing has to have
+ * run in between for that to be true. Compare `SimSqsQueue.applyLifecycle`,
+ * which is the same shape for the same reason.
+ *
+ * A stream itself is not dropped once everything on it has been trimmed. Real
+ * DynamoDB eventually stops listing a disabled stream whose records have all
+ * aged out, which is a divergence in a test's favour: the ARN a test is holding
+ * goes on resolving, and reading it gives an empty result rather than a
+ * resource that has silently disappeared.
+ */
+export function simDynamoDbStreamTrimPoint(now: Date): Date {
+  return new Date(now.getTime() - retentionHours * millisecondsPerHour);
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-sequence-numbers.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-sequence-numbers.ts
@@ -1,3 +1,5 @@
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+
 /**
  * The number the first record on a stream is given.
  *
@@ -31,4 +33,49 @@ export class SimDynamoDbStreamSequenceNumbers {
 
     return taken.toString();
   }
+}
+
+/**
+ * A sequence number is digits and nothing else.
+ */
+const digitsOnly = /^\d+$/u;
+
+/**
+ * Read a sequence number a request carries.
+ *
+ * Real DynamoDB refuses anything that is not a run of digits, so a caller that
+ * passes a shard identifier or a truncated value here finds out at the request
+ * rather than reading from a position nothing could ever be at.
+ */
+export function readSimDynamoDbSequenceNumber(
+  value: string | undefined,
+  operationName: string,
+): string {
+  if (value === undefined || !digitsOnly.test(value)) {
+    throw new SimDynamoDbValidationException(
+      `${operationName} needs a numeric SequenceNumber`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Order two sequence numbers, as a comparator does.
+ *
+ * These are compared as numbers rather than as text. The ones a simulated
+ * stream hands out are a fixed width, where the two orders agree, but one a
+ * request carries came from outside and need not be.
+ */
+export function compareSimDynamoDbSequenceNumbers(
+  left: string,
+  right: string,
+): number {
+  const difference = BigInt(left) - BigInt(right);
+
+  if (difference === 0n) {
+    return 0;
+  }
+
+  return difference > 0n ? 1 : -1;
 }

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-shard-iterator.iso.test.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-shard-iterator.iso.test.ts
@@ -1,0 +1,96 @@
+import {
+  assertInstanceOf,
+  assertObjectEquals,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import {
+  readSimDynamoDbShardIteratorToken,
+  type SimDynamoDbShardIterator,
+  simDynamoDbShardIteratorToken,
+} from "./sim-dynamodb-stream-shard-iterator.js";
+
+/**
+ * The place a token in these tests stands for.
+ */
+const iterator: SimDynamoDbShardIterator = {
+  streamArn: "arn:aws:dynamodb:eu-west-2:666666666666:table/orders/stream/x",
+  shardId: "shardId-00000000000000000000-2bac9cd2",
+  position: { kind: "after", sequenceNumber: "100000000000000000000" },
+};
+
+/**
+ * A token carrying whatever a caller has made of it.
+ */
+function tokenOf(contents: unknown): string {
+  return Buffer.from(JSON.stringify(contents), "utf8").toString("base64url");
+}
+
+/**
+ * A token whose position is whatever a caller has made of it.
+ */
+function positionToken(position: unknown): string {
+  return tokenOf({ streamArn: "arn", shardId: "shard", position });
+}
+
+/**
+ * Read a token, which every test here expects to be refused.
+ */
+function refuse(token: string | undefined): void {
+  const error = assertThrowsError(() =>
+    readSimDynamoDbShardIteratorToken(token),
+  );
+
+  assertInstanceOf(error, SimDynamoDbValidationException);
+}
+
+describe("DynamoDB stream shard iterator tokens", () => {
+  it("reads back the place it was made from", () => {
+    // Given a token for a place on a shard.
+    const token = simDynamoDbShardIteratorToken(iterator);
+
+    // When it is read back.
+    const read = readSimDynamoDbShardIteratorToken(token);
+
+    // Then it stands for the place it was made from.
+    assertObjectEquals({ ...read }, { ...iterator });
+  });
+
+  it("carries each of the three positions", () => {
+    // Given a token for each position a reader can be at.
+    for (const position of [
+      { kind: "start" },
+      { kind: "at", sequenceNumber: "100000000000000000001" },
+      { kind: "after", sequenceNumber: "100000000000000000002" },
+    ] as const) {
+      // When it is read back.
+      const read = readSimDynamoDbShardIteratorToken(
+        simDynamoDbShardIteratorToken({ ...iterator, position }),
+      );
+
+      // Then the position is the one it was made with.
+      assertObjectEquals(read.position, position);
+    }
+  });
+
+  it("refuses a token with nothing readable in it", () => {
+    // Given tokens with no readable contents at all.
+    // When each is read.
+    // Then every one is refused rather than read as a position.
+    refuse(undefined);
+    refuse("");
+    refuse("not-base64url-json");
+    refuse(tokenOf(["not", "an", "object"]));
+    refuse(tokenOf({ shardId: "shard", position: { kind: "start" } }));
+  });
+
+  it("refuses a token whose position is not one it makes", () => {
+    // Given tokens carrying a position this never wrote.
+    // When each is read.
+    // Then every one is refused.
+    refuse(positionToken("start"));
+    refuse(positionToken({ kind: "middle" }));
+    refuse(positionToken({ kind: "at" }));
+  });
+});

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-shard-iterator.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-shard-iterator.ts
@@ -1,0 +1,104 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
+import type { SimDynamoDbStreamPosition } from "./sim-dynamodb-stream-position.js";
+
+/**
+ * What a shard iterator stands for: one place on one shard of one stream.
+ */
+export interface SimDynamoDbShardIterator {
+  readonly streamArn: string;
+  readonly shardId: string;
+  readonly position: SimDynamoDbStreamPosition;
+}
+
+/**
+ * The three position kinds, as a value read back out of a token has to be one
+ * of them before it is trusted.
+ */
+const positionKinds = new Set(["start", "at", "after"]);
+
+/**
+ * Refuse a shard iterator a request carries that this simulation never made.
+ */
+function refuse(): never {
+  throw new SimDynamoDbValidationException(
+    "The provided ShardIterator is not valid",
+  );
+}
+
+/**
+ * Read a position back out of a decoded token.
+ */
+function readPosition(value: unknown): SimDynamoDbStreamPosition {
+  if (!isRecord(value) || typeof value["kind"] !== "string") {
+    refuse();
+  }
+
+  const kind = value["kind"];
+  if (!positionKinds.has(kind)) {
+    refuse();
+  }
+
+  if (kind === "start") {
+    return { kind: "start" };
+  }
+
+  const sequenceNumber = value["sequenceNumber"];
+  if (typeof sequenceNumber !== "string") {
+    refuse();
+  }
+
+  return kind === "at"
+    ? { kind: "at", sequenceNumber }
+    : { kind: "after", sequenceNumber };
+}
+
+/**
+ * The opaque token a caller is handed to read on from a place.
+ *
+ * Real shard iterators are opaque strings a caller passes back unread, and this
+ * one is the same shape: the place it stands for travels inside it rather than
+ * in a table of handed-out iterators. That is what lets an iterator be used
+ * against the stream it names without the stream having to remember it, which
+ * is also why the 15 minute expiry is deliberately absent here rather than
+ * approximated.
+ */
+export function simDynamoDbShardIteratorToken(
+  iterator: SimDynamoDbShardIterator,
+): string {
+  return Buffer.from(JSON.stringify(iterator), "utf8").toString("base64url");
+}
+
+/**
+ * Read the place a shard iterator a request carries stands for.
+ */
+export function readSimDynamoDbShardIteratorToken(
+  token: string | undefined,
+): SimDynamoDbShardIterator {
+  if (token === undefined || token === "") {
+    throw new SimDynamoDbValidationException(
+      "GetRecords requires a ShardIterator",
+    );
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(token, "base64url").toString("utf8"));
+  } catch {
+    refuse();
+  }
+
+  if (
+    !isRecord(decoded) ||
+    typeof decoded["streamArn"] !== "string" ||
+    typeof decoded["shardId"] !== "string"
+  ) {
+    refuse();
+  }
+
+  return {
+    streamArn: decoded["streamArn"],
+    shardId: decoded["shardId"],
+    position: readPosition(decoded["position"]),
+  };
+}

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
@@ -36,6 +36,7 @@ export class SimDynamoDbStreamShard {
 
   private readonly written: SimDynamoDbStreamRecord[] = [];
   private open = true;
+  private trimmed: string | undefined;
 
   constructor(at: Date) {
     this.shardId = shardId(at);
@@ -56,10 +57,56 @@ export class SimDynamoDbStreamShard {
   }
 
   /**
+   * The sequence number of the last record trimmed off this shard, when the
+   * retention window has outlived one.
+   */
+  get trimmedThrough(): string | undefined {
+    return this.trimmed;
+  }
+
+  /**
+   * The sequence number of the oldest record still on this shard.
+   */
+  get startingSequenceNumber(): string | undefined {
+    return this.written.at(0)?.sequenceNumber;
+  }
+
+  /**
+   * The sequence number this shard ends at, which only a closed one has.
+   *
+   * An open shard has no ending sequence number, since the next record written
+   * would move it. That absence is how a reader tells a shard that is still
+   * taking changes from one it can finish with.
+   */
+  get endingSequenceNumber(): string | undefined {
+    return this.open ? undefined : this.written.at(-1)?.sequenceNumber;
+  }
+
+  /**
    * Write a record to this shard.
    */
   append(record: SimDynamoDbStreamRecord): void {
     this.written.push(record);
+  }
+
+  /**
+   * Drop the records written before an instant, remembering how far that got.
+   *
+   * The trim point is kept once the records themselves are gone, because it is
+   * the difference between a reader that asked for a position this shard never
+   * reached and one that asked for a position it has already dropped.
+   */
+  trim(before: Date): void {
+    let oldest = this.written.at(0);
+
+    while (
+      oldest !== undefined &&
+      oldest.approximateCreationDateTime.getTime() < before.getTime()
+    ) {
+      this.trimmed = oldest.sequenceNumber;
+      this.written.shift();
+      oldest = this.written.at(0);
+    }
   }
 
   /**

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-shard.ts
@@ -37,6 +37,8 @@ export class SimDynamoDbStreamShard {
   private readonly written: SimDynamoDbStreamRecord[] = [];
   private open = true;
   private trimmed: string | undefined;
+  private first: string | undefined;
+  private last: string | undefined;
 
   constructor(at: Date) {
     this.shardId = shardId(at);
@@ -65,10 +67,15 @@ export class SimDynamoDbStreamShard {
   }
 
   /**
-   * The sequence number of the oldest record still on this shard.
+   * The sequence number this shard starts at.
+   *
+   * This is the first record ever written to it rather than the oldest one it
+   * still holds. A shard's range is fixed as the records go on: trimming takes
+   * records away without moving where the shard began, and TRIM_HORIZON is what
+   * a reader uses to find the oldest record it can still reach.
    */
   get startingSequenceNumber(): string | undefined {
-    return this.written.at(0)?.sequenceNumber;
+    return this.first;
   }
 
   /**
@@ -79,7 +86,7 @@ export class SimDynamoDbStreamShard {
    * taking changes from one it can finish with.
    */
   get endingSequenceNumber(): string | undefined {
-    return this.open ? undefined : this.written.at(-1)?.sequenceNumber;
+    return this.open ? undefined : this.last;
   }
 
   /**
@@ -87,6 +94,8 @@ export class SimDynamoDbStreamShard {
    */
   append(record: SimDynamoDbStreamRecord): void {
     this.written.push(record);
+    this.first ??= record.sequenceNumber;
+    this.last = record.sequenceNumber;
   }
 
   /**
@@ -97,16 +106,18 @@ export class SimDynamoDbStreamShard {
    * reached and one that asked for a position it has already dropped.
    */
   trim(before: Date): void {
-    let oldest = this.written.at(0);
+    const surviving = this.written.findIndex(
+      (record) =>
+        record.approximateCreationDateTime.getTime() >= before.getTime(),
+    );
+    const outlived = surviving === -1 ? this.written.length : surviving;
 
-    while (
-      oldest !== undefined &&
-      oldest.approximateCreationDateTime.getTime() < before.getTime()
-    ) {
-      this.trimmed = oldest.sequenceNumber;
-      this.written.shift();
-      oldest = this.written.at(0);
+    if (outlived === 0) {
+      return;
     }
+
+    this.trimmed = this.written[outlived - 1]?.sequenceNumber ?? this.trimmed;
+    this.written.splice(0, outlived);
   }
 
   /**

--- a/src/service/dynamodb/stream/sim-dynamodb-stream-store.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream-store.ts
@@ -29,4 +29,31 @@ export class SimDynamoDbStreamStore {
   findByArn(streamArn: string): SimDynamoDbStream | undefined {
     return this.streams.get(streamArn);
   }
+
+  /**
+   * Every stream here, in ARN order.
+   *
+   * ListStreams pages by ARN, so the order a page is cut out of has to be the
+   * order the paging parameter walks. A stream's ARN is its table's ARN and
+   * then the instant it was enabled, so this also groups a table's streams
+   * together, oldest first.
+   */
+  inArnOrder(): readonly SimDynamoDbStream[] {
+    return this.streams
+      .values()
+      .toArray()
+      .toSorted((left, right) => left.arn.localeCompare(right.arn));
+  }
+
+  /**
+   * Bring every stream here up to date at an instant.
+   *
+   * All of them rather than the one being read, so that what a test sees of one
+   * stream does not depend on which other streams it happened to read first.
+   */
+  applyRetention(instant: Date): void {
+    for (const stream of this.streams.values()) {
+      stream.applyRetention(instant);
+    }
+  }
 }

--- a/src/service/dynamodb/stream/sim-dynamodb-stream.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-stream.ts
@@ -1,12 +1,14 @@
 import type { SimArn } from "../../aws/arn.js";
 import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
 import type { SimDynamoDbKeySchema } from "../table/sim-dynamodb-key-schema.js";
+import type { SimDynamoDbKeySchemaElement } from "../command/table/table.types.js";
 import type { SimDynamoDbItemChange } from "./sim-dynamodb-item-change.js";
 import {
   simDynamoDbStreamArn,
   simDynamoDbStreamLabel,
 } from "./sim-dynamodb-stream-arn.js";
 import { SimDynamoDbStreamRecord } from "./sim-dynamodb-stream-record.js";
+import { simDynamoDbStreamTrimPoint } from "./sim-dynamodb-stream-retention.js";
 import { SimDynamoDbStreamSequenceNumbers } from "./sim-dynamodb-stream-sequence-numbers.js";
 import { SimDynamoDbStreamShard } from "./sim-dynamodb-stream-shard.js";
 
@@ -73,6 +75,25 @@ export class SimDynamoDbStream {
    */
   get records(): readonly SimDynamoDbStreamRecord[] {
     return this.shard.records;
+  }
+
+  /**
+   * The key schema of the table this stream belongs to, as DescribeStream
+   * reports it.
+   */
+  get keySchemaElements(): readonly SimDynamoDbKeySchemaElement[] {
+    return this.keySchema.elements;
+  }
+
+  /**
+   * Drop whatever the 24 hour retention window has outlived.
+   *
+   * This is applied when the stream is read rather than scheduled, which is
+   * what `simDynamoDbStreamTrimPoint` explains. Running it twice at one instant
+   * does nothing the second time.
+   */
+  applyRetention(instant: Date): void {
+    this.shard.trim(simDynamoDbStreamTrimPoint(instant));
   }
 
   /**

--- a/src/service/dynamodb/stream/sim-dynamodb-streamed-orders.factory.ts
+++ b/src/service/dynamodb/stream/sim-dynamodb-streamed-orders.factory.ts
@@ -1,0 +1,62 @@
+import { AsyncMappedFactory } from "@kensio/part-factory";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbStreamViewType } from "./sim-dynamodb-stream.types.js";
+import type { SimDynamoDbStream } from "./sim-dynamodb-stream.js";
+import { simDynamoDbStreamedTableFactory } from "./sim-dynamodb-streamed-table.factory.js";
+
+/**
+ * What a test asks for when it wants a stream with records already on it.
+ */
+export interface SimDynamoDbStreamedOrdersInput {
+  readonly tableName: string;
+  readonly viewType: SimDynamoDbStreamViewType;
+
+  /**
+   * How many orders to write, which is how many records the stream takes.
+   */
+  readonly orders: number;
+}
+
+/**
+ * Creates a stream that has already captured a number of item writes.
+ *
+ * The orders are written one at a time through PutItem, so the stream takes
+ * them in the order their identifiers count up and a test can name the record
+ * it means by position.
+ *
+ * ```typescript
+ * const stream = await simDynamoDbStreamedOrdersFactory.make(
+ *   { orders: 3 },
+ *   simAws,
+ * );
+ * ```
+ */
+export const simDynamoDbStreamedOrdersFactory = new AsyncMappedFactory<
+  SimDynamoDbStreamedOrdersInput,
+  SimDynamoDbStream,
+  SimAws
+>(
+  () => ({ tableName: "orders", viewType: "NEW_AND_OLD_IMAGES", orders: 1 }),
+  async (input, simAws) => {
+    const table = await simDynamoDbStreamedTableFactory.make(
+      { tableName: input.tableName, viewType: input.viewType },
+      simAws,
+    );
+
+    for (let order = 1; order <= input.orders; order += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await simAws.dynamoDb().putItem({
+        input: {
+          TableName: input.tableName,
+          Item: { orderId: { S: `order-${order.toString()}` } },
+        },
+      });
+    }
+
+    const stream = table.stream.latest;
+    assertDefined(stream, "DynamoDB table stream");
+
+    return stream;
+  },
+);


### PR DESCRIPTION
ListStreams, DescribeStream, GetShardIterator and GetRecords over a table's captured changes, reached through simAws.dynamoDbStreams() or an intercepted DynamoDBStreamsClient. All four shard iterator types, an opaque self-describing iterator, and the 24 hour retention trim applied on read with TrimmedDataAccessException past the trim point.

Resolves #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated DynamoDB Streams support with stream discovery, description, shard iterators, and record retrieval.
  * Added support for stream read positions, record rendering, IAM authorization, shard closure, and 24-hour retention behavior.
  * Added access through the SDK and standard simulation entry points.
* **Documentation**
  * Added comprehensive DynamoDB Streams usage documentation and an example workflow.
* **Tests**
  * Added coverage for stream operations, validation, authorization, retention, pagination, and record formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->