### PR TITLE
feat: deliver simulated DynamoDB stream records to a simulated Lambda…

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2704,6 +2704,13 @@ it means the oldest record still there, whatever has gone.
 A stream stays listable and readable after its table switches it off, and after everything on it has
 been trimmed. A trimmed stream reads as empty rather than as missing.
 
+### Delivering a stream to a Lambda function
+
+Nobody writes `GetRecords` loops in application code. What most applications do with a stream is
+have a Lambda function run on it, which is a
+[Lambda event source mapping](../lambda/#triggering-a-function-from-a-dynamodb-stream "Simulated Lambda event source mapping docs"):
+create the mapping, write to the table, and the function is invoked with the changes.
+
 ## Numbers
 
 A DynamoDB number carries up to 38 significant digits, where a JavaScript number carries about 15.
@@ -3329,7 +3336,8 @@ nothing is written.
   elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
   is until something moves the clock. A simulated DynamoDB constructed standalone as
   `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
-- A Lambda event source mapping cannot read a stream yet. A test polls one with `GetRecords` itself.
+- A Lambda event source mapping delivers a stream to a function, but nothing else consumes one. A
+  Kinesis Data Streams destination is not simulated.
 - A `StreamSpecification` in a CloudFormation template still skips the table, so a streamed table
   has to be created through `CreateTable`.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2706,10 +2706,11 @@ been trimmed. A trimmed stream reads as empty rather than as missing.
 
 ### Delivering a stream to a Lambda function
 
-Nobody writes `GetRecords` loops in application code. What most applications do with a stream is
-have a Lambda function run on it, which is a
+Most applications consume a stream by having a Lambda function run on it rather than by polling it
+themselves, which is a
 [Lambda event source mapping](../lambda/#triggering-a-function-from-a-dynamodb-stream "Simulated Lambda event source mapping docs"):
-create the mapping, write to the table, and the function is invoked with the changes.
+create the mapping, write to the table, and the function is invoked with the changes. The
+`GetRecords` loop above is still there for a consumer that wants to read a stream directly.
 
 ## Numbers
 
@@ -3336,7 +3337,8 @@ nothing is written.
   elapsing. An item whose window goes by while a running-mode clock tracks the host stays where it
   is until something moves the clock. A simulated DynamoDB constructed standalone as
   `new SimDynamoDb()` has no clock control at all, so nothing there ever expires.
-- A Lambda event source mapping delivers a stream to a function, but nothing else consumes one. A
+- A Lambda event source mapping is the only simulated service integration that consumes a stream.
+  Anything else reads one through the Streams API itself. A
   Kinesis Data Streams destination is not simulated.
 - A `StreamSpecification` in a CloudFormation template still skips the table, so a streamed table
   has to be created through `CreateTable`.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -591,7 +591,11 @@ and region, as they do on real AWS.
  * Delivering a simulated table's changes to a simulated function.
  */
 
-import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateEventSourceMappingCommand,
@@ -622,7 +626,8 @@ const { TableDescription } = await simAws.dynamoDb().createTable(
 const streamArn = TableDescription?.LatestStreamArn;
 
 // The projection goes into a second table. A function writing back into the
-// table whose stream invoked it would be delivered its own writes forever.
+// table whose stream invoked it would be delivered its own writes, which the
+// simulator refuses rather than looping on.
 await simAws.dynamoDb().createTable(
   new CreateTableCommand({
     TableName: "order-totals",
@@ -633,7 +638,8 @@ await simAws.dynamoDb().createTable(
 );
 
 // The execution role needs the three stream actions Lambda reads a stream
-// with, plus ListStreams, which is on every stream rather than on one.
+// with, plus ListStreams, which is on every stream rather than on one, and
+// whatever the function itself does.
 const role = await simAws.iam().createRole(
   new CreateRoleCommand({
     RoleName: "OrderProjectorRole",
@@ -665,25 +671,38 @@ await simAws.iam().putRolePolicy(
           Resource: streamArn,
         },
         { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "dynamodb:PutItem",
+          Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/order-totals`,
+        },
       ],
     }),
   }),
 );
-
-const projected: string[] = [];
 
 await simAws.lambda().createFunction(
   new CreateFunctionCommand({
     FunctionName: "order-projector",
     Role: role.Role.Arn,
     Code: {
-      ZipFile: makeLambdaZipFileInput((event: SimLambdaDynamoDbStreamEvent) => {
-        for (const record of event.Records) {
-          projected.push(
-            `${record.eventName}:${record.dynamodb.Keys?.["orderId"]?.S ?? ""}`,
+      ZipFile: makeLambdaZipFileInput(
+        async (event: SimLambdaDynamoDbStreamEvent) => {
+          await Promise.all(
+            event.Records.map(async (record) =>
+              simAws.dynamoDb().putItem(
+                new PutItemCommand({
+                  TableName: "order-totals",
+                  Item: {
+                    orderId: { S: record.dynamodb.Keys?.["orderId"]?.S ?? "" },
+                    total: { N: record.dynamodb.NewImage?.["total"]?.N ?? "0" },
+                  },
+                }),
+              ),
+            ),
           );
-        }
-      }),
+        },
+      ),
     },
   }),
 );
@@ -706,7 +725,14 @@ await simAws.dynamoDb().putItem(
 // Delivery happens in the background, so wait for the simulation to settle.
 await simAws.backgroundTasksComplete();
 
-console.log(projected); // ["INSERT:order-1"]
+const projected = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "order-totals",
+    Key: { orderId: { S: "order-1" } },
+  }),
+);
+
+console.log(projected.Item?.["total"]?.N); // "42"
 ```
 
 Each record carries `eventID`, `eventName`, `eventVersion`, `eventSource`, `awsRegion`,
@@ -719,8 +745,14 @@ where [the Streams API capitalizes them](../dynamodb/#reading-a-streams-records 
 
 `SimLambdaDynamoDbStreamEvent` and `SimLambdaDynamoDbStreamEventRecord` are exported from
 `@kensio/yulin/lambda` for typing a handler, and are minimal structural equivalents of the
-`DynamoDBStreamEvent` and `DynamoDBRecord` types from the `aws-lambda` typings package. The images
-are attribute value maps, so `unmarshall` from `@aws-sdk/util-dynamodb` takes one unchanged.
+`DynamoDBStreamEvent` and `DynamoDBRecord` types from the `aws-lambda` typings package.
+
+A binary attribute reaches the handler as a base64 string rather than as bytes, which is what the
+event carries on AWS: it arrives as JSON, and JSON has no bytes. `Buffer.from(value.B, "base64")`
+therefore reads the same here as it does deployed. The
+[Streams API](../dynamodb/#reading-a-streams-records "Simulated DynamoDB Streams docs") hands out
+bytes for the same attribute, because its client decodes them. Nesting makes no difference: binary
+inside a list or a map is encoded too.
 
 Creating the mapping checks what real Lambda checks: that the stream exists, and that the function's
 execution role is allowed `dynamodb:DescribeStream`, `dynamodb:GetRecords` and
@@ -742,9 +774,9 @@ Advancing the simulation's clock is what hands the batch over again:
 await simAws.clock().advanceBy({ seconds: 30 });
 ```
 
-The batch is delivered five times in all, after 1, 2, 4, 8 and 16 seconds. Then it is discarded and
-the mapping carries on with the stream, which is what AWS does once a stream mapping's error
-handling has run out.
+The batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, so six deliveries in all.
+Then it is discarded and the mapping carries on with the stream, which is what AWS does once a
+stream mapping's error handling has run out.
 
 Both the cadence and the number of attempts are simulator constraints rather than AWS behaviour. AWS
 documents no delay between attempts and retries until the records age out of the stream, a day
@@ -765,6 +797,10 @@ to settle:
 ```typescript
 await simAws.backgroundTasksComplete(); // throws SimLambdaStreamCascadeError
 ```
+
+Only the handler's own writes count. Items written at the same time by the test, or by anything else
+in the simulation, are an ordinary batch however many of them there are, because the guard tells them
+apart by where the write came from rather than by when it landed.
 
 Writing the projection into a second table is what the guard is asking for, and is what a real
 aggregation or search index does anyway.
@@ -1583,7 +1619,8 @@ Current documented limitations:
   accepted and ignored. A stream retries a batch from the record a report names onward, where a
   queue takes back the messages it names, and a failing stream batch is retried whole here. That
   rule is [issue 342](https://github.com/KensioSoftware/yulin/issues/342).
-- A stream batch is delivered again after 1, 2, 4, 8 and 16 seconds and then discarded. AWS
+- A stream batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, and then
+  discarded. AWS
   documents no delay between attempts and retries until the records age out. Both differences are
   deliberate: a delay of zero falls due at the instant the clock already reads, so a handler that
   always throws would leave `advanceBy` with work falling due forever.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -571,6 +571,204 @@ or an empty `batchItemFailures` list, has handled the whole batch.
 `Fn::GetAtt` and `Ref` values a template gives them, `Ref` on the mapping returns its UUID, and
 `Fn::GetAtt` exposes `Id` and `EventSourceMappingArn`.
 
+## Triggering a function from a DynamoDB stream
+
+An event source mapping also connects a [simulated table's stream](../dynamodb/#capturing-changes-with-a-stream "Simulated DynamoDB streams docs")
+to a function. Changes to the table are delivered to the handler as a DynamoDB stream event, with
+the `Records` shape real Lambda uses.
+
+`StartingPosition` is required for a stream and is `TRIM_HORIZON` or `LATEST`. `TRIM_HORIZON` reads
+what the stream still holds, so changes made before the mapping existed are delivered too. `LATEST`
+reads only what the table changes from the moment the mapping starts reading. `AT_TIMESTAMP` is for
+a Kinesis stream and is refused by name.
+
+`BatchSize` says how many records one invocation may be given, and defaults to 100, which is what
+CDK's `DynamoEventSource` also asks for. The table and the function have to be in the same account
+and region, as they do on real AWS.
+
+```typescript sim-lambda-dynamodb-stream-event-source
+/**
+ * Delivering a simulated table's changes to a simulated function.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDynamoDbStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { TableDescription } = await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+
+const streamArn = TableDescription?.LatestStreamArn;
+
+// The projection goes into a second table. A function writing back into the
+// table whose stream invoked it would be delivered its own writes forever.
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "order-totals",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// The execution role needs the three stream actions Lambda reads a stream
+// with, plus ListStreams, which is on every stream rather than on one.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ProjectOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "dynamodb:DescribeStream",
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+const projected: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaDynamoDbStreamEvent) => {
+        for (const record of event.Records) {
+          projected.push(
+            `${record.eventName}:${record.dynamodb.Keys?.["orderId"]?.S ?? ""}`,
+          );
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+  }),
+);
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(projected); // ["INSERT:order-1"]
+```
+
+Each record carries `eventID`, `eventName`, `eventVersion`, `eventSource`, `awsRegion`,
+`eventSourceARN` and a `dynamodb` body holding `Keys`, the images the stream's view type selects,
+`SequenceNumber`, `SizeBytes`, `StreamViewType` and `ApproximateCreationDateTime` as whole seconds
+since the epoch. A time to live removal also carries
+`userIdentity: { type: "Service", principalId: "dynamodb.amazonaws.com" }`, which is how a handler
+tells an expiry from a deletion the application asked for. The event lower-cases those two fields
+where [the Streams API capitalizes them](../dynamodb/#reading-a-streams-records "Simulated DynamoDB Streams docs").
+
+`SimLambdaDynamoDbStreamEvent` and `SimLambdaDynamoDbStreamEventRecord` are exported from
+`@kensio/yulin/lambda` for typing a handler, and are minimal structural equivalents of the
+`DynamoDBStreamEvent` and `DynamoDBRecord` types from the `aws-lambda` typings package. The images
+are attribute value maps, so `unmarshall` from `@aws-sdk/util-dynamodb` takes one unchanged.
+
+Creating the mapping checks what real Lambda checks: that the stream exists, and that the function's
+execution role is allowed `dynamodb:DescribeStream`, `dynamodb:GetRecords` and
+`dynamodb:GetShardIterator` on it, plus `dynamodb:ListStreams` on `*`. Those four are what both the
+AWS managed policy and CDK's own grant give a stream consumer. A role missing one of them fails with
+`InvalidParameterValueException` naming the operation.
+
+### When the handler fails
+
+A stream is not a queue, and the difference shows here. A queue hands a message out and hides it, so
+a batch the handler threw on is the queue's problem afterwards. A stream hands out a place, and the
+mapping is the only thing that remembers it, so a batch the handler threw on is read again from
+exactly where it was and nothing behind it is delivered until it is through. That is what blocking a
+shard means.
+
+Advancing the simulation's clock is what hands the batch over again:
+
+```typescript
+await simAws.clock().advanceBy({ seconds: 30 });
+```
+
+The batch is delivered five times in all, after 1, 2, 4, 8 and 16 seconds. Then it is discarded and
+the mapping carries on with the stream, which is what AWS does once a stream mapping's error
+handling has run out.
+
+Both the cadence and the number of attempts are simulator constraints rather than AWS behaviour. AWS
+documents no delay between attempts and retries until the records age out of the stream, a day
+later. A delay of zero here would fall due at the instant the clock already reads, so a handler that
+always throws would leave `advanceBy` with work falling due forever, and waiting out a simulated day
+is the same problem with more steps.
+
+### Writing back to the source table
+
+A handler that writes into the table whose stream invoked it is delivered its own write, which
+writes again. Real Lambda runs that loop for as long as the account is willing to pay for it. The
+simulation refuses instead, with an error naming the function, the stream and the table, rather than
+going round until the test times out.
+
+The write itself succeeds; the refusal comes afterwards, from whatever is waiting for the simulation
+to settle:
+
+```typescript
+await simAws.backgroundTasksComplete(); // throws SimLambdaStreamCascadeError
+```
+
+Writing the projection into a second table is what the guard is asking for, and is what a real
+aggregation or search index does anyway.
+
 ## Function URLs
 
 A Function URL is an HTTP endpoint for one function. Creating one with
@@ -1310,11 +1508,14 @@ Sim Lambda currently supports:
   resolved from the request
 - `AddPermissionCommand`, `RemovePermissionCommand` and `GetPolicyCommand`, for resource-based
   policies evaluated alongside identity policies
-- SQS event source mappings, created with `CreateEventSourceMappingCommand` and read with
-  `GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
-  `DeleteEventSourceMappingCommand`, delivering real-shaped SQS events and honouring `BatchSize`
-- `FunctionResponseTypes: ["ReportBatchItemFailures"]`, returning only the message ids the handler
-  reported
+- SQS and DynamoDB stream event source mappings, created with `CreateEventSourceMappingCommand` and
+  read with `GetEventSourceMappingCommand`, `ListEventSourceMappingsCommand` and
+  `DeleteEventSourceMappingCommand`, delivering real-shaped SQS and DynamoDB stream events and
+  honouring `BatchSize`
+- `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, with a failing batch
+  blocking its shard until it is through or discarded
+- `FunctionResponseTypes: ["ReportBatchItemFailures"]` on a queue mapping, returning only the
+  message ids the handler reported
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
@@ -1373,17 +1574,35 @@ Current documented limitations:
   invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
 - `Event` invocations do not simulate retries or failure destinations; handler errors are dropped.
 - `Code.S3ObjectVersion` is accepted but ignored, as sim S3 has no object versioning yet.
-- SQS queues are the only event source. DynamoDB streams, Kinesis, Kafka and DocumentDB sources are
-  refused rather than accepted and never delivered from, and so are `FilterCriteria`, `ScalingConfig`,
-  `DestinationConfig`, `MaximumRetryAttempts` and the other mapping inputs this simulation has no
-  behaviour for.
+- SQS queues and DynamoDB streams are the only event sources. Kinesis, Kafka and DocumentDB sources
+  are refused rather than accepted and never delivered from, and so are `FilterCriteria`,
+  `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
+  `ParallelizationFactor`, `TumblingWindowInSeconds` and the other mapping inputs this simulation
+  has no behaviour for.
+- `FunctionResponseTypes: ["ReportBatchItemFailures"]` is refused on a stream mapping rather than
+  accepted and ignored. A stream retries a batch from the record a report names onward, where a
+  queue takes back the messages it names, and a failing stream batch is retried whole here. That
+  rule is [issue 342](https://github.com/KensioSoftware/yulin/issues/342).
+- A stream batch is delivered again after 1, 2, 4, 8 and 16 seconds and then discarded. AWS
+  documents no delay between attempts and retries until the records age out. Both differences are
+  deliberate: a delay of zero falls due at the instant the clock already reads, so a handler that
+  always throws would leave `advanceBy` with work falling due forever.
+- A handler writing into the table whose stream invoked it is refused with
+  `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
+  that loop.
+- A shard iterator never expires, where a real one is good for 15 minutes.
 - `MaximumBatchingWindowInSeconds` is only simulated as 0: a partial batch is delivered as soon as
-  anything is on the queue, so a batching window would have nothing to wait for. A non-zero value is
-  refused, which also caps `BatchSize` at 10.
+  anything is on the event source, so a batching window would have nothing to wait for. A non-zero
+  value is refused, which also caps a queue mapping's `BatchSize` at 10. The documented rule that a
+  `BatchSize` above 10 needs a batching window is not enforced, because the same AWS documentation
+  gives a stream mapping `BatchSize` 100 and window 0 as simultaneous defaults, and CDK emits
+  exactly that.
 - `UpdateEventSourceMapping` is not supported, so a mapping's batch size or enabled state is fixed
   once it is created. `Enabled: false` at creation is simulated.
 - One poll delivers one batch. Real Lambda runs several pollers at once and scales them with the
-  queue, so nothing here shows what concurrency does to ordering or to a downstream service.
+  event source, so nothing here shows what concurrency does to ordering or to a downstream service.
+  A simulated stream has one shard and never splits, so a stream mapping has one thing to read
+  either way.
 - CloudFormation resource types other than `AWS::Lambda::Function`, `AWS::Lambda::Url`,
   `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping` (`Version`, `Alias`, ...) are
   skipped with an "Unsupported" diagnostic.

--- a/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
@@ -1,0 +1,120 @@
+/**
+ * Delivering a simulated table's changes to a simulated function.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDynamoDbStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { TableDescription } = await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+
+const streamArn = TableDescription?.LatestStreamArn;
+
+// The projection goes into a second table. A function writing back into the
+// table whose stream invoked it would be delivered its own writes forever.
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "order-totals",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+// The execution role needs the three stream actions Lambda reads a stream
+// with, plus ListStreams, which is on every stream rather than on one.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ProjectOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "dynamodb:DescribeStream",
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+const projected: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaDynamoDbStreamEvent) => {
+        for (const record of event.Records) {
+          projected.push(
+            `${record.eventName}:${record.dynamodb.Keys?.["orderId"]?.S ?? ""}`,
+          );
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+  }),
+);
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);
+
+// Delivery happens in the background, so wait for the simulation to settle.
+await simAws.backgroundTasksComplete();
+
+console.log(projected); // ["INSERT:order-1"]

--- a/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
@@ -2,7 +2,11 @@
  * Delivering a simulated table's changes to a simulated function.
  */
 
-import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  CreateTableCommand,
+  GetItemCommand,
+  PutItemCommand,
+} from "@aws-sdk/client-dynamodb";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateEventSourceMappingCommand,
@@ -33,7 +37,8 @@ const { TableDescription } = await simAws.dynamoDb().createTable(
 const streamArn = TableDescription?.LatestStreamArn;
 
 // The projection goes into a second table. A function writing back into the
-// table whose stream invoked it would be delivered its own writes forever.
+// table whose stream invoked it would be delivered its own writes, which the
+// simulator refuses rather than looping on.
 await simAws.dynamoDb().createTable(
   new CreateTableCommand({
     TableName: "order-totals",
@@ -44,7 +49,8 @@ await simAws.dynamoDb().createTable(
 );
 
 // The execution role needs the three stream actions Lambda reads a stream
-// with, plus ListStreams, which is on every stream rather than on one.
+// with, plus ListStreams, which is on every stream rather than on one, and
+// whatever the function itself does.
 const role = await simAws.iam().createRole(
   new CreateRoleCommand({
     RoleName: "OrderProjectorRole",
@@ -76,25 +82,38 @@ await simAws.iam().putRolePolicy(
           Resource: streamArn,
         },
         { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "dynamodb:PutItem",
+          Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/order-totals`,
+        },
       ],
     }),
   }),
 );
-
-const projected: string[] = [];
 
 await simAws.lambda().createFunction(
   new CreateFunctionCommand({
     FunctionName: "order-projector",
     Role: role.Role.Arn,
     Code: {
-      ZipFile: makeLambdaZipFileInput((event: SimLambdaDynamoDbStreamEvent) => {
-        for (const record of event.Records) {
-          projected.push(
-            `${record.eventName}:${record.dynamodb.Keys?.["orderId"]?.S ?? ""}`,
+      ZipFile: makeLambdaZipFileInput(
+        async (event: SimLambdaDynamoDbStreamEvent) => {
+          await Promise.all(
+            event.Records.map(async (record) =>
+              simAws.dynamoDb().putItem(
+                new PutItemCommand({
+                  TableName: "order-totals",
+                  Item: {
+                    orderId: { S: record.dynamodb.Keys?.["orderId"]?.S ?? "" },
+                    total: { N: record.dynamodb.NewImage?.["total"]?.N ?? "0" },
+                  },
+                }),
+              ),
+            ),
           );
-        }
-      }),
+        },
+      ),
     },
   }),
 );
@@ -117,4 +136,11 @@ await simAws.dynamoDb().putItem(
 // Delivery happens in the background, so wait for the simulation to settle.
 await simAws.backgroundTasksComplete();
 
-console.log(projected); // ["INSERT:order-1"]
+const projected = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "order-totals",
+    Key: { orderId: { S: "order-1" } },
+  }),
+);
+
+console.log(projected.Item?.["total"]?.N); // "42"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:check": "tsc -p tsconfig.json --noEmit",
     "prepack": "pnpm build",
     "verify:pack": "pnpm tsx scripts/mts/verify-pack.mts",
-    "fmt": "eslint --cache --cache-location node_modules/.cache/eslint/main --fix . && prettier --cache --write .",
+    "fmt": "eslint --cache --cache-location node_modules/.cache/eslint/main --fix . && prettier --cache --write . && prettier --cache --cache-location node_modules/.cache/prettier/settled --check .",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint/main . && prettier --cache --check .",
     "test": "vitest run",
     "test:coverage": "rm -rf './.tmp/' && vitest run --coverage",

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -17,6 +17,7 @@ import type { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-ap
 import { SimLambda } from "../../lambda/index.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
 import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs-event-source-queues.js";
+import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
 import { SimS3 } from "../../s3/sim-s3.js";
@@ -180,8 +181,9 @@ export class SimAwsAccountRegionServiceBuilder {
    * packages intercepted into this SimAws, as the real Lambda runtime
    * provides the SDK.
    *
-   * Event source mappings poll the same scope's simulated SQS, as a queue can
-   * only be an event source for a function in its own Account and Region.
+   * Event source mappings poll the same scope's simulated SQS and DynamoDB, as
+   * a queue or a table's stream can only be an event source for a function in
+   * its own Account and Region.
    */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return new SimLambda({
@@ -192,6 +194,9 @@ export class SimAwsAccountRegionServiceBuilder {
       urlRegistry: this.lambdaUrlRegistry,
       codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
       eventSourceQueues: new SimSqsEventSourceQueues({ sqs: scope.sqs() }),
+      eventSourceStreams: new SimDynamoDbEventSourceStreams({
+        dynamoDb: scope.dynamoDb(),
+      }),
       vmSdkModuleProvider: new SimSdkLambdaVmModuleProvider({
         simAws: this.simAws,
         regionName: scope.accountRegionScope.regionName,

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -1116,7 +1116,10 @@ state rather than request handling.
   the name after it has built the table.
 - `SimDynamoDbStreamActivity` is the twin of `SimSqsQueueActivity`: it is how a consumer that cannot
   poll continuously finds out there is something to read. There is no instant on the notification,
-  unlike the queue's, because a stream record is readable the moment it is written.
+  unlike the queue's, because a stream record is readable the moment it is written. A simulated
+  Lambda event source mapping is the consumer it exists for, and it reaches this through
+  `SimDynamoDb.streamActivity()` and the Streams commands, matching interfaces simulated Lambda
+  declares for itself, so neither service imports the other.
 
 The read path is the other half of `stream/`, and none of it is state:
 

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -253,15 +253,17 @@ owner, keeping its ambient callers isolated.
 
 ## Event source mappings
 
-`event-source/` owns delivery from a simulated SQS queue to a function.
+`event-source/` owns delivery from a simulated SQS queue or DynamoDB stream to a function.
 
-SQS is the only source there is so far, but the machinery around it is split by event source kind
-rather than assuming one. `sim-lambda-event-source-arn.ts` reads the ARN a mapping names into a
-union discriminated by `kind`, and that value carries what the rest of the machinery would otherwise
-have had to assume: the service label a refusal names, the `{action, resource}` permissions the
-execution role is checked for, and the batch size rules the request is measured against
-(`SimLambdaEventSourceBatchRules`). It is also the one place that decides which sources a mapping
-may name, so a refusal anywhere lists the same supported set.
+The machinery is split by event source kind rather than assuming one.
+`sim-lambda-event-source-arn.ts` reads the ARN a mapping names into a union discriminated by `kind`,
+and that value carries what the rest of the machinery would otherwise have had to assume: the
+service label a refusal names, the `{action, resource}` permissions the execution role is checked
+for, the batch size rules the request is measured against (`SimLambdaEventSourceBatchRules`), and
+whether the source has a starting position at all
+(`SimLambdaEventSourceStartingPositionRules` — required for a stream, refused for a queue). It is
+also the one place that decides which sources a mapping may name, so a refusal anywhere lists the
+same supported set.
 
 Real Lambda polls a queue continuously, and nothing in this simulation runs continuously, so the
 queue says when there is something to poll for. `SimSqsQueueActivity` (in sim SQS) holds the
@@ -309,6 +311,45 @@ a report it cannot trust. Reading the report itself is shared in `SimLambdaBatch
 is also where a malformed entry becomes an id no message has. `SimLambdaSqsEventBuilder` turns a
 batch into the event's own shape, which is the lower-case record naming and the base64 binary
 attribute values real AWS uses.
+
+### DynamoDB streams
+
+`stream/` is the port onto simulated DynamoDB, and `SimLambdaDynamoDbStreamEventSourcePoller` is a
+sibling of the queue poller rather than a generalisation of it. Every step differs and the last one
+inverts: a queue mapping polls again when a batch came back, because the batch is on the queue
+waiting; a stream mapping polls again when a batch went through, because the records stay on the
+stream either way and it is the checkpoint that moved.
+
+`SimLambdaStreamProgress` holds that checkpoint (`SimLambdaStreamCheckpoint`, the shard iterator the
+last read handed back) alongside the retry backoff and the poll schedule, because they are one
+decision. A batch the function took moves the checkpoint and the mapping reads on. A batch it threw
+on leaves the checkpoint where it is, so the same records are read again and nothing behind them is
+delivered until they are through: that is a stream mapping blocking its shard.
+`SimLambdaStreamRetryBackoff` is why the wait is strictly positive and why the attempts are counted.
+A retry scheduled at the instant the clock already reads falls due inside every interval
+`advanceBy` walks, so a handler that always throws would never let it return, and both that trap and
+its guard tests are in
+[issue 341](https://github.com/KensioSoftware/yulin/issues/341).
+
+Two polls must never overlap, which a queue mapping does not have to care about: a received message
+is hidden and a read record is not, so a second poll from the same checkpoint would deliver the same
+records twice. `SimLambdaEventSourcePollTurn` is the one-at-a-time guard, and it reschedules from
+its `finally` block rather than dropping a poll that was asked for mid-turn, because
+`SimLambdaEventSourcePollSchedule` clears its own flag when the task starts.
+
+`SimLambdaStreamCascadeGuard` is what stops a function writing back into the table whose stream
+invoked it. The delivery runs inside an asynchronous context
+(`sim-lambda-event-source-delivery-context.ts`), so a record written by the handler is told apart
+from one written by anything else that happened to be running at the same time. Several items
+written in one `Promise.all` are an ordinary batch; a handler feeding its own source is a loop, and
+is refused with `SimLambdaStreamCascadeError` once the delivery is over rather than left to spin.
+
+`SimDynamoDbEventSourceStreams` implements the port over the DynamoDB Streams commands, as the
+execution role, and `SimDynamoDbEventSourceStreamShard` is the part that finds the table and the
+shard and reads records off it. The port is SDK-shaped for the same reason the Streams API exists at
+all: a bespoke read interface would be `GetRecords` under another name, and would not authorize.
+The `SimLambdaEventSourceStreamService` and `SimLambdaEventSourceStreamActivity` interfaces are
+declared here and satisfied structurally by `SimDynamoDb`, so neither service imports the other.
 
 ## Function URLs
 
@@ -459,8 +500,8 @@ the CloudFormation engine with an "Unsupported" diagnostic.
 
 - `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`,
   `AWS::Lambda::Url`, `AWS::Lambda::Permission` and `AWS::Lambda::EventSourceMapping`
-- event sources other than SQS queues, `FilterCriteria`, `UpdateEventSourceMapping`, and polling
-  concurrency
+- event sources other than SQS queues and DynamoDB streams, `FilterCriteria`,
+  `UpdateEventSourceMapping`, `ReportBatchItemFailures` for a stream, and polling concurrency
 - Function URL `Cors` configuration and OPTIONS preflight handling
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -341,8 +341,10 @@ its `finally` block rather than dropping a poll that was asked for mid-turn, bec
 invoked it. The delivery runs inside an asynchronous context
 (`sim-lambda-event-source-delivery-context.ts`), so a record written by the handler is told apart
 from one written by anything else that happened to be running at the same time. Several items
-written in one `Promise.all` are an ordinary batch; a handler feeding its own source is a loop, and
-is refused with `SimLambdaStreamCascadeError` once the delivery is over rather than left to spin.
+written in one `Promise.all` by a test, or by anything other than this mapping's own handler, are an
+ordinary batch. Writes the handler itself makes to its own source are the loop, however many of them
+it makes and however it makes them, and are refused with `SimLambdaStreamCascadeError` once the
+delivery is over rather than left to spin.
 
 `SimDynamoDbEventSourceStreams` implements the port over the DynamoDB Streams commands, as the
 execution role, and `SimDynamoDbEventSourceStreamShard` is the part that finds the table and the

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -4,6 +4,7 @@ import {
   simLambdaEventSourceArnOf,
 } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceStartingPosition } from "../../event-source/sim-lambda-event-source-starting-position.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { simLambdaFunctionNameOf } from "../../function/sim-lambda-function-name.js";
 import {
@@ -20,6 +21,7 @@ interface SimLambdaEventSourceMappingInputProperties {
   readonly eventSourceArn: SimLambdaEventSourceArn;
   readonly functionName: string;
   readonly batchSize: number;
+  readonly startingPosition: SimLambdaEventSourceStartingPosition | undefined;
   readonly enabled: boolean;
   readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 }
@@ -38,6 +40,8 @@ export class SimLambdaEventSourceMappingInput {
   public readonly eventSourceArn: SimLambdaEventSourceArn;
   public readonly functionName: string;
   public readonly batchSize: number;
+  public readonly startingPosition:
+    SimLambdaEventSourceStartingPosition | undefined;
   public readonly enabled: boolean;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
@@ -45,6 +49,7 @@ export class SimLambdaEventSourceMappingInput {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
     this.batchSize = properties.batchSize;
+    this.startingPosition = properties.startingPosition;
     this.enabled = properties.enabled;
     this.functionResponseTypes = properties.functionResponseTypes;
   }
@@ -68,8 +73,12 @@ export class SimLambdaEventSourceMappingInput {
         requiredString(input.FunctionName, "functionName"),
       ),
       batchSize: eventSourceArn.batchRules.sizeIn(input.BatchSize),
+      startingPosition: eventSourceArn.startingPositionRules.positionIn({
+        startingPosition: input.StartingPosition,
+        startingPositionTimestamp: input.StartingPositionTimestamp,
+      }),
       enabled: input.Enabled ?? true,
-      functionResponseTypes: functionResponseTypesIn(input),
+      functionResponseTypes: functionResponseTypesIn(input, eventSourceArn),
     });
   }
 }
@@ -91,7 +100,7 @@ function eventSourceArnIn(
       `EventSourceArn ${eventSourceArn.value} names Account ` +
         `${eventSourceArn.accountId} in ${eventSourceArn.regionName}, and a ` +
         `function in Account ${scope.accountId} in ${scope.regionName} can ` +
-        "only be mapped to a queue in its own Account and Region",
+        "only be mapped to an event source in its own Account and Region",
     );
   }
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -14,11 +14,26 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["FilterCriteria", "event filtering is not simulated"],
   ["ScalingConfig", "polling concurrency is not simulated"],
   ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
-  ["DestinationConfig", "failure destinations are not simulated"],
-  ["MaximumRetryAttempts", "retry limits are not simulated"],
+  [
+    "DestinationConfig",
+    "failure destinations are not simulated, so a stream batch that runs out " +
+      "of attempts is discarded rather than sent anywhere",
+  ],
+  [
+    "MaximumRetryAttempts",
+    "the number of times a stream batch is delivered again is fixed",
+  ],
   ["MaximumRecordAgeInSeconds", "record ages are not simulated"],
-  ["BisectBatchOnFunctionError", "batch bisection is not simulated"],
-  ["ParallelizationFactor", "polling concurrency is not simulated"],
+  [
+    "BisectBatchOnFunctionError",
+    "batch bisection is not simulated, so a failing stream batch is retried " +
+      "whole",
+  ],
+  [
+    "ParallelizationFactor",
+    "polling concurrency is not simulated, and a simulated stream has one " +
+      "shard",
+  ],
   ["TumblingWindowInSeconds", "tumbling windows are not simulated"],
   [
     "SourceAccessConfigurations",
@@ -36,10 +51,12 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
  * None of them is a thing that is missing from the sources here. Each one
  * configures a source the ARN dispatcher refuses outright, so naming one is a
  * request for a different kind of mapping rather than for a feature.
+ *
+ * `StartingPosition` is not among them, because whether a source has one is the
+ * source's own rule: a stream is refused without it and a queue is refused with
+ * it.
  */
 const unsupportedEventSourceInputs: ReadonlySet<string> = new Set([
-  "StartingPosition",
-  "StartingPositionTimestamp",
   "Topics",
   "Queues",
   "SelfManagedEventSource",
@@ -71,7 +88,8 @@ export function refuseUnsimulatedInput(
     throw new SimLambdaInvalidParameterValueException(
       "MaximumBatchingWindowInSeconds on an event source mapping is only " +
         "simulated as 0: a partial batch is delivered as soon as anything is " +
-        "on the queue, so a batching window would have nothing to wait for",
+        "on the event source, so a batching window would have nothing to " +
+        "wait for",
     );
   }
 }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -99,7 +99,7 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     );
     assertStringIncludes(
       error.message,
-      "SQS queues are the only simulated event source",
+      "SQS queues and DynamoDB streams are the simulated event sources",
     );
     assertStringIncludes(
       error.message,
@@ -111,17 +111,31 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();
 
-    // When a mapping asks for a starting position, which only a stream has.
-    const error = await refusedMapping(ready, {
-      StartingPosition: "LATEST",
-    });
+    // When a mapping names Kafka topics, which no simulated source has.
+    const error = await refusedMapping(ready, { Topics: ["orders"] });
 
     // Then it is refused, naming the sources there are instead.
     assertIdentical(error.name, "InvalidParameterValueException");
-    assertStringIncludes(error.message, "StartingPosition");
+    assertStringIncludes(error.message, "Topics");
     assertStringIncludes(
       error.message,
-      "SQS queues are the only simulated event source",
+      "SQS queues and DynamoDB streams are the simulated event sources",
+    );
+  });
+
+  it("refuses a starting position on a queue mapping", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks a queue where to start reading.
+    const error = await refusedMapping(ready, { StartingPosition: "LATEST" });
+
+    // Then it is refused: a queue only has a front, so where to start is not
+    // something a mapping on one can say.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(
+      error.message,
+      "StartingPosition is not valid for a queue",
     );
   });
 

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -1,12 +1,25 @@
+import type { SimLambdaEventSourceArn } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
-import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import {
+  SimLambdaInvalidParameterValueException,
+  SimLambdaValidationException,
+} from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 /**
- * The response types the function reports, refusing one Lambda does not have.
+ * The response types the function reports, refusing one Lambda does not have
+ * and one the event source has no simulated rule for.
+ *
+ * A batch item failure report means different things to the two sources. A
+ * queue takes back the messages a report names; a stream retries the batch from
+ * the record it names onward, and a failing stream batch is retried whole here.
+ * Accepting the flag on a stream mapping would be a mapping that says it does
+ * one thing and does another, which is
+ * https://github.com/KensioSoftware/yulin/issues/342.
  */
 export function functionResponseTypesIn(
   input: SimCreateEventSourceMappingCommandInput,
+  eventSourceArn: SimLambdaEventSourceArn,
 ): readonly SimLambdaFunctionResponseType[] {
   const responseTypes = input.FunctionResponseTypes ?? [];
 
@@ -17,6 +30,15 @@ export function functionResponseTypesIn(
           "function response type. ReportBatchItemFailures is the only one",
       );
     }
+  }
+
+  if (responseTypes.length > 0 && eventSourceArn.kind === "dynamodb-stream") {
+    throw new SimLambdaInvalidParameterValueException(
+      "FunctionResponseTypes on a DynamoDB stream event source mapping is " +
+        "not simulated: a stream retries a batch from the record a report " +
+        "names onward, rather than taking back the records it names, and a " +
+        "failing batch is retried whole here",
+    );
   }
 
   return responseTypes as readonly SimLambdaFunctionResponseType[];

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -8,7 +8,9 @@ import type { SimLambdaEventSourceArn } from "../../event-source/sim-lambda-even
 import { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
 import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
+import { SimLambdaEventSourceReachable } from "../../event-source/sim-lambda-event-source-reachable.js";
 import { SimLambdaEventSourceRolePermissions } from "../../event-source/sim-lambda-event-source-role-permissions.js";
+import type { SimLambdaEventSourceStreams } from "../../event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import { FunctionUrlAuthorizer } from "../function-url/function-url-authorizer.js";
@@ -23,6 +25,7 @@ interface CreateEventSourceMappingCommandHandlerProperties {
   readonly mappings: SimLambdaEventSourceMappingStore;
   readonly pollers: SimLambdaEventSourcePollers;
   readonly queues: SimLambdaEventSourceQueues;
+  readonly streams: SimLambdaEventSourceStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
@@ -49,6 +52,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
   private readonly properties: CreateEventSourceMappingCommandHandlerProperties;
   private readonly authorizer: FunctionUrlAuthorizer;
   private readonly rolePermissions: SimLambdaEventSourceRolePermissions;
+  private readonly reachable: SimLambdaEventSourceReachable;
 
   constructor(properties: CreateEventSourceMappingCommandHandlerProperties) {
     this.properties = properties;
@@ -58,6 +62,10 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
     });
     this.rolePermissions = new SimLambdaEventSourceRolePermissions({
       iam: properties.iam,
+    });
+    this.reachable = new SimLambdaEventSourceReachable({
+      queues: properties.queues,
+      streams: properties.streams,
     });
   }
 
@@ -97,8 +105,8 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
    * Refuse a mapping whose event source cannot be polled as the execution
    * role.
    *
-   * The role's permission is checked before the queue is read, so a role with
-   * no access is told what it is missing rather than being told the queue does
+   * The role's permission is checked before the source is read, so a role with
+   * no access is told what it is missing rather than being told the source does
    * not exist.
    */
   private async assertPollable(
@@ -107,12 +115,9 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
   ): Promise<void> {
     this.rolePermissions.assertMayPoll(simFunction.roleArn, eventSourceArn);
 
-    // Reading the queue's attributes as the role is how the mapping finds out
-    // the queue is there at all, exactly as the poller will.
-    await this.properties.queues.visibilityTimeoutSeconds({
-      queueArn: eventSourceArn.value,
-      caller: { kind: "arn", arn: simFunction.roleArn },
-    });
+    // Reading the source as the role is how the mapping finds out it is there
+    // at all, exactly as the poller will.
+    await this.reachable.assertReachable(simFunction.roleArn, eventSourceArn);
   }
 
   private created(
@@ -125,6 +130,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
       functionName: input.functionName,
       functionArn: simFunction.arn,
       batchSize: input.batchSize,
+      startingPosition: input.startingPosition,
       enabled: input.enabled,
       functionResponseTypes: input.functionResponseTypes,
       createdAt: this.properties.background.now(),

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
@@ -3,6 +3,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimLambdaEventSourceQueues } from "../../event-source/queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceStreams } from "../../event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import { SimLambdaEventSourceMappingStore } from "../../event-source/sim-lambda-event-source-mapping-store.js";
 import type { SimLambdaEventSourcePollers } from "../../event-source/sim-lambda-event-source-pollers.js";
@@ -28,6 +29,7 @@ interface SimLambdaEventSourceMappingCommandsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly pollers: SimLambdaEventSourcePollers;
   readonly queues: SimLambdaEventSourceQueues;
+  readonly streams: SimLambdaEventSourceStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
@@ -60,7 +62,7 @@ export class SimLambdaEventSourceMappingCommands {
   }
 
   /**
-   * Create an event source mapping from a queue to a function.
+   * Create an event source mapping from an event source to a function.
    */
   async create(
     command: SimCreateEventSourceMappingCommand,

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-event-image.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-event-image.ts
@@ -1,0 +1,83 @@
+import type {
+  SimLambdaDynamoDbAttributeValue,
+  SimLambdaDynamoDbImage,
+} from "../stream/sim-lambda-dynamodb-attribute-value.js";
+import type { SimLambdaEventSourceStreamRecordBody } from "../stream/sim-lambda-event-source-streams.js";
+import type {
+  SimLambdaDynamoDbEventAttributeValue,
+  SimLambdaDynamoDbEventImage,
+} from "./sim-lambda-dynamodb-stream-event.types.js";
+
+/**
+ * The images an event record carries, which are the ones the stream's view type
+ * gave the record and no others.
+ */
+export function simLambdaDynamoDbEventImages(
+  body: SimLambdaEventSourceStreamRecordBody | undefined,
+): {
+  readonly Keys?: SimLambdaDynamoDbEventImage;
+  readonly NewImage?: SimLambdaDynamoDbEventImage;
+  readonly OldImage?: SimLambdaDynamoDbEventImage;
+} {
+  return {
+    ...(body?.Keys !== undefined && {
+      Keys: simLambdaDynamoDbEventImage(body.Keys),
+    }),
+    ...(body?.NewImage !== undefined && {
+      NewImage: simLambdaDynamoDbEventImage(body.NewImage),
+    }),
+    ...(body?.OldImage !== undefined && {
+      OldImage: simLambdaDynamoDbEventImage(body.OldImage),
+    }),
+  };
+}
+
+/**
+ * The image a stream record's item becomes in the event.
+ *
+ * Everything but binary crosses unchanged. Binary does not: the Streams API
+ * hands out bytes, because its client decoded them, and a function receives the
+ * base64 the event was written with. A handler doing `Buffer.from(value.B,
+ * "base64")` works on AWS, so it has to work here, and bytes handed over
+ * instead would make that same line quietly produce something else.
+ */
+export function simLambdaDynamoDbEventImage(
+  image: SimLambdaDynamoDbImage,
+): SimLambdaDynamoDbEventImage {
+  return Object.fromEntries(
+    Object.entries(image).map(([name, value]) => [
+      name,
+      eventAttributeValue(value),
+    ]),
+  );
+}
+
+/**
+ * One value, with the binary inside it base64 encoded however deeply it is
+ * nested: a list or a map carries attribute values of its own.
+ */
+function eventAttributeValue(
+  value: SimLambdaDynamoDbAttributeValue,
+): SimLambdaDynamoDbEventAttributeValue {
+  if (value.B !== undefined) {
+    return { B: base64Of(value.B) };
+  }
+
+  if (value.BS !== undefined) {
+    return { BS: value.BS.map((member) => base64Of(member)) };
+  }
+
+  if (value.L !== undefined) {
+    return { L: value.L.map((member) => eventAttributeValue(member)) };
+  }
+
+  if (value.M !== undefined) {
+    return { M: simLambdaDynamoDbEventImage(value.M) };
+  }
+
+  return value;
+}
+
+function base64Of(value: Uint8Array): string {
+  return Buffer.from(value).toString("base64");
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-polled-stream.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-polled-stream.ts
@@ -1,0 +1,57 @@
+import type {
+  SimLambdaEventSourceStreamBatch,
+  SimLambdaEventSourceStreamPosition,
+  SimLambdaEventSourceStreamRequest,
+  SimLambdaEventSourceStreams,
+  SimLambdaEventSourceStreamWatcher,
+} from "../stream/sim-lambda-event-source-streams.js";
+
+/**
+ * The one stream a mapping polls.
+ *
+ * Every call names the same stream, and the ones a poll makes are all made as
+ * the function's execution role, so both are fixed here rather than written out
+ * at each call. Simulated IAM still decides each one, exactly as real IAM does.
+ */
+export class SimLambdaDynamoDbPolledStream {
+  private readonly streams: SimLambdaEventSourceStreams;
+  private readonly streamArn: string;
+
+  constructor(streams: SimLambdaEventSourceStreams, streamArn: string) {
+    this.streams = streams;
+    this.streamArn = streamArn;
+  }
+
+  /**
+   * Watch for records being written to the stream.
+   */
+  watch(watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.streams.watch(this.streamArn, watcher);
+  }
+
+  /**
+   * Stop watching the stream.
+   */
+  unwatch(watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.streams.unwatch(this.streamArn, watcher);
+  }
+
+  /**
+   * Read up to a batch of records from where the mapping left off.
+   */
+  async read(
+    roleArn: string,
+    position: SimLambdaEventSourceStreamPosition,
+    batchSize: number,
+  ): Promise<SimLambdaEventSourceStreamBatch> {
+    return await this.streams.read({
+      ...this.requestAs(roleArn),
+      position,
+      batchSize,
+    });
+  }
+
+  private requestAs(roleArn: string): SimLambdaEventSourceStreamRequest {
+    return { streamArn: this.streamArn, caller: { kind: "arn", arn: roleArn } };
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -1,0 +1,74 @@
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
+import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
+import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
+
+interface SimLambdaDynamoDbStreamDeliveryProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn;
+}
+
+/**
+ * Hands one batch of stream records to a function and says whether it took
+ * them.
+ *
+ * The batch is invoked directly rather than through the Invoke command because
+ * the handler's error has to be seen: an asynchronous invocation drops it, and
+ * this is what decides whether the mapping's checkpoint moves.
+ *
+ * There is no partial answer here, unlike a queue delivery. A function reading
+ * a stream either handled the batch or did not, until it is allowed to report
+ * its own batch item failures.
+ *
+ * What the function did with the table while it ran is part of the same
+ * question, so the cascade guard belongs here too: a handler writing back into
+ * its own source table is refused rather than handled.
+ */
+export class SimLambdaDynamoDbStreamDelivery {
+  private readonly eventBuilder: SimLambdaDynamoDbStreamEventBuilder;
+  private readonly cascade: SimLambdaStreamCascadeGuard;
+
+  constructor(properties: SimLambdaDynamoDbStreamDeliveryProperties) {
+    this.eventBuilder = new SimLambdaDynamoDbStreamEventBuilder(
+      properties.eventSourceArn,
+    );
+    this.cascade = new SimLambdaStreamCascadeGuard(properties);
+  }
+
+  /**
+   * Deliver a batch, answering with whether the function handled it.
+   */
+  async to(
+    simFunction: SimLambdaFunction,
+    records: readonly SimLambdaEventSourceStreamRecord[],
+  ): Promise<boolean> {
+    return await this.cascade.around(
+      async () => await this.handled(simFunction, records),
+    );
+  }
+
+  /**
+   * Note a record written to the polled stream, answering with whether this
+   * mapping's own function wrote it.
+   */
+  noteRecordWritten(): boolean {
+    return this.cascade.noteRecordWritten();
+  }
+
+  private async handled(
+    simFunction: SimLambdaFunction,
+    records: readonly SimLambdaEventSourceStreamRecord[],
+  ): Promise<boolean> {
+    try {
+      await simFunction.invoke(this.eventBuilder.of(records));
+
+      return true;
+    } catch {
+      // As on real Lambda, the handler error goes to the function's logs. What
+      // the table sees is the batch being tried again.
+      return false;
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
@@ -1,0 +1,158 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
+import type { SimLambdaEventSourceStreams } from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaDynamoDbPolledStream } from "./sim-lambda-dynamodb-polled-stream.js";
+import { SimLambdaDynamoDbStreamDelivery } from "./sim-lambda-dynamodb-stream-delivery.js";
+import {
+  type SimLambdaEventSourcePolls,
+  SimLambdaEventSourcePollTurn,
+} from "./sim-lambda-event-source-poll-turn.js";
+import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
+import { SimLambdaStreamProgress } from "./sim-lambda-stream-progress.js";
+
+interface SimLambdaDynamoDbStreamEventSourcePollerProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn;
+  readonly functions: SimLambdaFunctionLookup;
+  readonly streams: SimLambdaEventSourceStreams;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Polls one event source mapping's DynamoDB stream and invokes its function.
+ *
+ * A sibling of the queue poller rather than a variation on it. Every step
+ * differs, and the last one inverts: a queue mapping polls again when a batch
+ * came back, because the batch is on the queue waiting; a stream mapping polls
+ * again when a batch went through, because the records stay on the stream
+ * either way and it is the checkpoint that moved.
+ *
+ * That is also why nothing else may read while a delivery is in flight. A
+ * received message is hidden and a read record is not, so a second poll
+ * overlapping the first would hand the same records to the function twice.
+ */
+export class SimLambdaDynamoDbStreamEventSourcePoller
+  implements SimLambdaEventSourcePoller, SimLambdaEventSourcePolls
+{
+  private readonly mapping: SimLambdaEventSourceMapping;
+  private readonly functions: SimLambdaFunctionLookup;
+  private readonly stream: SimLambdaDynamoDbPolledStream;
+  private readonly delivery: SimLambdaDynamoDbStreamDelivery;
+  private readonly progress: SimLambdaStreamProgress;
+  private readonly turn = new SimLambdaEventSourcePollTurn(this);
+
+  private stopped = false;
+
+  constructor(properties: SimLambdaDynamoDbStreamEventSourcePollerProperties) {
+    const { eventSourceArn, mapping } = properties;
+
+    this.mapping = mapping;
+    this.functions = properties.functions;
+    this.stream = new SimLambdaDynamoDbPolledStream(
+      properties.streams,
+      eventSourceArn.value,
+    );
+    this.delivery = new SimLambdaDynamoDbStreamDelivery({
+      mapping,
+      eventSourceArn,
+    });
+    this.progress = new SimLambdaStreamProgress({
+      mapping,
+      background: properties.background,
+      poll: async (): Promise<void> => {
+        await this.turn.take();
+      },
+    });
+  }
+
+  /**
+   * Watch the stream this mapping polls.
+   *
+   * Watching starts as soon as the mapping is created, before it has finished
+   * creating, so a change made in between is not missed. The poll it wakes
+   * finds a mapping that is not polling yet and does nothing, and the poll that
+   * follows activation reads from the starting position.
+   */
+  watch(): void {
+    this.stream.watch(this);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it, which is what a newly enabled
+   * mapping does with whatever its stream already holds, and what a wake-up
+   * that arrived mid-poll comes back as.
+   */
+  pollNow(): void {
+    this.progress.pollNow();
+  }
+
+  /**
+   * Stop polling, as deleting the mapping does.
+   */
+  stop(): void {
+    this.stopped = true;
+    this.stream.unwatch(this);
+  }
+
+  /**
+   * Take a record arriving on the stream as something to poll for.
+   *
+   * A record written while this mapping's own function is running is the
+   * function writing back into its own source table. That never settles, so the
+   * mapping stops here and the delivery refuses once it is over.
+   */
+  recordsAvailable(): void {
+    if (this.delivery.noteRecordWritten()) {
+      this.stopped = true;
+
+      return;
+    }
+
+    this.progress.pollNow();
+  }
+
+  /**
+   * Read one batch, deliver it, and decide what happens next.
+   *
+   * Only ever called through the turn, which is what keeps two polls from
+   * reading the same records.
+   */
+  async poll(): Promise<void> {
+    const simFunction = this.pollingFunction();
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    const { progress } = this;
+    // Reading is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its stream.
+    const batch = await this.stream.read(
+      simFunction.roleArn,
+      progress.position,
+      this.mapping.batchSize,
+    );
+
+    if (batch.records.length === 0) {
+      progress.caughtUp(batch);
+
+      return;
+    }
+
+    progress.after(await this.delivery.to(simFunction, batch.records), batch);
+  }
+
+  /**
+   * The function this mapping delivers to, while it should be delivering.
+   */
+  private pollingFunction(): SimLambdaFunction | undefined {
+    if (this.stopped || !this.mapping.isPolling) {
+      return undefined;
+    }
+
+    return this.functions.find(this.mapping.functionName);
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertArrayEquals,
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
@@ -63,6 +64,41 @@ describe("sim Lambda DynamoDB stream event builder", () => {
     assertIdentical(built.dynamodb.SizeBytes, 0);
     assertIdentical(built.dynamodb.StreamViewType, "");
     assertUndefined(built.userIdentity);
+  });
+
+  it("base64 encodes binary, however deeply it is nested", () => {
+    // Given a record carrying bytes at the top level, in a set, and inside a
+    // list and a map, as the Streams API hands them out.
+    const record = {
+      dynamodb: {
+        NewImage: {
+          thumbnail: { B: Uint8Array.from([1, 2, 3]) },
+          fingerprints: { BS: [Uint8Array.from([4, 5]), Uint8Array.from([6])] },
+          history: { L: [{ B: Uint8Array.from([7]) }, { N: "1" }] },
+          meta: { M: { signature: { B: Uint8Array.from([8, 9]) } } },
+        },
+      },
+    };
+
+    // When it is built into an event.
+    const [built] = builder.of([record]).Records;
+
+    assertNonNullable(built);
+
+    // Then every one of them is the base64 the event is written with, so a
+    // handler decoding with `Buffer.from(value, "base64")` reads what it does
+    // on AWS.
+    const image = built.dynamodb.NewImage;
+
+    assertNonNullable(image);
+
+    const [nested, alongside] = image["history"]?.L ?? [];
+
+    assertIdentical(image["thumbnail"]?.B, "AQID");
+    assertArrayEquals([...(image["fingerprints"]?.BS ?? [])], ["BAU=", "Bg=="]);
+    assertIdentical(nested?.B, "Bw==");
+    assertIdentical(alongside?.N, "1");
+    assertIdentical(image["meta"]?.M?.["signature"]?.B, "CAk=");
   });
 
   it("lower-cases an identity the Streams API capitalizes", () => {

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.iso.test.ts
@@ -1,0 +1,84 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
+import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
+
+const eventSourceArn = SimLambdaDynamoDbStreamEventSourceArn.of(
+  "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-08-04T09:00:00.000",
+);
+
+const builder = new SimLambdaDynamoDbStreamEventBuilder(eventSourceArn);
+
+describe("sim Lambda DynamoDB stream event builder", () => {
+  it("carries only the images the stream's view type gave a record", () => {
+    // Given a record from a KEYS_ONLY stream, which has neither image.
+    const record = {
+      eventID: "1",
+      eventName: "INSERT",
+      eventVersion: "1.1",
+      awsRegion: "eu-west-2",
+      dynamodb: {
+        Keys: { orderId: { S: "order-1" } },
+        SequenceNumber: "100000000000000000001",
+        SizeBytes: 20,
+        StreamViewType: "KEYS_ONLY",
+      },
+    } as const;
+
+    // When it is built into an event.
+    const [built] = builder.of([record]).Records;
+
+    assertNonNullable(built);
+
+    // Then the images an image-less record never had are absent rather than
+    // present and empty.
+    assertObjectEquals(built.dynamodb.Keys, { orderId: { S: "order-1" } });
+    assertUndefined(built.dynamodb.NewImage);
+    assertUndefined(built.dynamodb.OldImage);
+    assertUndefined(built.dynamodb.ApproximateCreationDateTime);
+  });
+
+  it("falls back to what the mapping knows for a record that says nothing", () => {
+    // Given a record with none of its parts filled in, which nothing simulated
+    // DynamoDB answers with: the port is shaped as the SDK shapes it, where
+    // every part of a record is optional.
+    // When it is built into an event.
+    const [built] = builder.of([{}]).Records;
+
+    assertNonNullable(built);
+
+    // Then the event still has the shape a handler reads, with the Region
+    // taken from the stream the mapping polls.
+    assertIdentical(built.eventID, "");
+    assertIdentical(built.eventName, "");
+    assertIdentical(built.eventVersion, "");
+    assertIdentical(built.awsRegion, "eu-west-2");
+    assertIdentical(built.dynamodb.SequenceNumber, "");
+    assertIdentical(built.dynamodb.SizeBytes, 0);
+    assertIdentical(built.dynamodb.StreamViewType, "");
+    assertUndefined(built.userIdentity);
+  });
+
+  it("lower-cases an identity the Streams API capitalizes", () => {
+    // Given a record whose identity says only who made the change.
+    const record = { userIdentity: { Type: "Service" } };
+
+    // When it is built into an event.
+    const [built] = builder.of([record]).Records;
+
+    assertNonNullable(built);
+
+    // Then the event names the identity its own way, with nothing missing
+    // left undefined inside it.
+    assertObjectEquals(built.userIdentity, {
+      type: "Service",
+      principalId: "",
+    });
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
@@ -1,62 +1,16 @@
 import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
-import type { SimLambdaDynamoDbImage } from "../stream/sim-lambda-dynamodb-attribute-value.js";
+import { simLambdaDynamoDbEventImages } from "./sim-lambda-dynamodb-event-image.js";
+import type {
+  SimLambdaDynamoDbStreamEvent,
+  SimLambdaDynamoDbStreamEventRecord,
+  SimLambdaDynamoDbStreamEventRecordBody,
+} from "./sim-lambda-dynamodb-stream-event.types.js";
 import type {
   SimLambdaEventSourceStreamRecord,
   SimLambdaEventSourceStreamRecordBody,
 } from "../stream/sim-lambda-event-source-streams.js";
 
 const millisecondsPerSecond = 1000;
-
-/**
- * The change one record reports, as a DynamoDB stream event record carries it.
- *
- * The field names are the Streams API's, capital and all, because that is what
- * the event carries. `ApproximateCreationDateTime` is the exception: the API
- * gives an instant and the event gives whole seconds since the epoch.
- */
-export interface SimLambdaDynamoDbStreamEventRecordBody {
-  readonly ApproximateCreationDateTime?: number | undefined;
-  readonly Keys?: SimLambdaDynamoDbImage | undefined;
-  readonly NewImage?: SimLambdaDynamoDbImage | undefined;
-  readonly OldImage?: SimLambdaDynamoDbImage | undefined;
-  readonly SequenceNumber: string;
-  readonly SizeBytes: number;
-  readonly StreamViewType: string;
-}
-
-/**
- * Who made the change a record reports, when it was not the application.
- *
- * A time to live deletion is the one that carries this. The Streams API
- * capitalizes the same two fields; the event does not.
- */
-export interface SimLambdaDynamoDbStreamEventUserIdentity {
-  readonly type: string;
-  readonly principalId: string;
-}
-
-/**
- * One stream record as a DynamoDB stream event record.
- *
- * https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
- */
-export interface SimLambdaDynamoDbStreamEventRecord {
-  readonly eventID: string;
-  readonly eventName: string;
-  readonly eventVersion: string;
-  readonly eventSource: "aws:dynamodb";
-  readonly awsRegion: string;
-  readonly dynamodb: SimLambdaDynamoDbStreamEventRecordBody;
-  readonly eventSourceARN: string;
-  readonly userIdentity?: SimLambdaDynamoDbStreamEventUserIdentity | undefined;
-}
-
-/**
- * The event a DynamoDB stream event source mapping invokes a function with.
- */
-export interface SimLambdaDynamoDbStreamEvent {
-  readonly Records: readonly SimLambdaDynamoDbStreamEventRecord[];
-}
 
 /**
  * Builds the DynamoDB stream event for one batch of polled records.
@@ -106,8 +60,7 @@ export class SimLambdaDynamoDbStreamEventBuilder {
 }
 
 /**
- * The change block of an event record, with only the images the stream's view
- * type gave it.
+ * The change block of an event record.
  */
 function eventRecordBody(
   body: SimLambdaEventSourceStreamRecordBody | undefined,
@@ -120,9 +73,7 @@ function eventRecordBody(
         createdAt.getTime() / millisecondsPerSecond,
       ),
     }),
-    ...(body?.Keys !== undefined && { Keys: body.Keys }),
-    ...(body?.NewImage !== undefined && { NewImage: body.NewImage }),
-    ...(body?.OldImage !== undefined && { OldImage: body.OldImage }),
+    ...simLambdaDynamoDbEventImages(body),
     SequenceNumber: body?.SequenceNumber ?? "",
     SizeBytes: body?.SizeBytes ?? 0,
     StreamViewType: body?.StreamViewType ?? "",

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
@@ -1,0 +1,130 @@
+import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
+import type { SimLambdaDynamoDbImage } from "../stream/sim-lambda-dynamodb-attribute-value.js";
+import type {
+  SimLambdaEventSourceStreamRecord,
+  SimLambdaEventSourceStreamRecordBody,
+} from "../stream/sim-lambda-event-source-streams.js";
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * The change one record reports, as a DynamoDB stream event record carries it.
+ *
+ * The field names are the Streams API's, capital and all, because that is what
+ * the event carries. `ApproximateCreationDateTime` is the exception: the API
+ * gives an instant and the event gives whole seconds since the epoch.
+ */
+export interface SimLambdaDynamoDbStreamEventRecordBody {
+  readonly ApproximateCreationDateTime?: number | undefined;
+  readonly Keys?: SimLambdaDynamoDbImage | undefined;
+  readonly NewImage?: SimLambdaDynamoDbImage | undefined;
+  readonly OldImage?: SimLambdaDynamoDbImage | undefined;
+  readonly SequenceNumber: string;
+  readonly SizeBytes: number;
+  readonly StreamViewType: string;
+}
+
+/**
+ * Who made the change a record reports, when it was not the application.
+ *
+ * A time to live deletion is the one that carries this. The Streams API
+ * capitalizes the same two fields; the event does not.
+ */
+export interface SimLambdaDynamoDbStreamEventUserIdentity {
+  readonly type: string;
+  readonly principalId: string;
+}
+
+/**
+ * One stream record as a DynamoDB stream event record.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
+ */
+export interface SimLambdaDynamoDbStreamEventRecord {
+  readonly eventID: string;
+  readonly eventName: string;
+  readonly eventVersion: string;
+  readonly eventSource: "aws:dynamodb";
+  readonly awsRegion: string;
+  readonly dynamodb: SimLambdaDynamoDbStreamEventRecordBody;
+  readonly eventSourceARN: string;
+  readonly userIdentity?: SimLambdaDynamoDbStreamEventUserIdentity | undefined;
+}
+
+/**
+ * The event a DynamoDB stream event source mapping invokes a function with.
+ */
+export interface SimLambdaDynamoDbStreamEvent {
+  readonly Records: readonly SimLambdaDynamoDbStreamEventRecord[];
+}
+
+/**
+ * Builds the DynamoDB stream event for one batch of polled records.
+ *
+ * The casing here is the event's own and is not a tidy scheme: `eventID` has a
+ * capital ID, `dynamodb` has none, `eventSourceARN` has a capital ARN, the
+ * block inside `dynamodb` is capitalized and `userIdentity` is not. All of it
+ * is what a function actually receives, so all of it is written out.
+ */
+export class SimLambdaDynamoDbStreamEventBuilder {
+  private readonly eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn;
+
+  constructor(eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn) {
+    this.eventSourceArn = eventSourceArn;
+  }
+
+  /**
+   * The event for a batch of records.
+   */
+  of(
+    records: readonly SimLambdaEventSourceStreamRecord[],
+  ): SimLambdaDynamoDbStreamEvent {
+    return { Records: records.map((record) => this.record(record)) };
+  }
+
+  private record(
+    record: SimLambdaEventSourceStreamRecord,
+  ): SimLambdaDynamoDbStreamEventRecord {
+    const identity = record.userIdentity;
+
+    return {
+      eventID: record.eventID ?? "",
+      eventName: record.eventName ?? "",
+      eventVersion: record.eventVersion ?? "",
+      eventSource: "aws:dynamodb",
+      awsRegion: record.awsRegion ?? this.eventSourceArn.regionName,
+      dynamodb: eventRecordBody(record.dynamodb),
+      eventSourceARN: this.eventSourceArn.value,
+      ...(identity !== undefined && {
+        userIdentity: {
+          type: identity.Type ?? "",
+          principalId: identity.PrincipalId ?? "",
+        },
+      }),
+    };
+  }
+}
+
+/**
+ * The change block of an event record, with only the images the stream's view
+ * type gave it.
+ */
+function eventRecordBody(
+  body: SimLambdaEventSourceStreamRecordBody | undefined,
+): SimLambdaDynamoDbStreamEventRecordBody {
+  const createdAt = body?.ApproximateCreationDateTime;
+
+  return {
+    ...(createdAt !== undefined && {
+      ApproximateCreationDateTime: Math.floor(
+        createdAt.getTime() / millisecondsPerSecond,
+      ),
+    }),
+    ...(body?.Keys !== undefined && { Keys: body.Keys }),
+    ...(body?.NewImage !== undefined && { NewImage: body.NewImage }),
+    ...(body?.OldImage !== undefined && { OldImage: body.OldImage }),
+    SequenceNumber: body?.SequenceNumber ?? "",
+    SizeBytes: body?.SizeBytes ?? 0,
+    StreamViewType: body?.StreamViewType ?? "",
+  };
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.types.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.types.ts
@@ -1,0 +1,85 @@
+/**
+ * The shape of the event a DynamoDB stream event source mapping invokes a
+ * function with.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
+ */
+
+/**
+ * One attribute value as a DynamoDB stream event carries it.
+ *
+ * The tags are the ones DynamoDB names its types with, and every one of them is
+ * optional, which is how the `aws-lambda` typings declare a stream event's
+ * attribute values. Binary is a base64 string rather than bytes, because the
+ * event reaches a function as JSON, and JSON has no bytes.
+ */
+export interface SimLambdaDynamoDbEventAttributeValue {
+  readonly B?: string | undefined;
+  readonly BOOL?: boolean | undefined;
+  readonly BS?: readonly string[] | undefined;
+  readonly L?: readonly SimLambdaDynamoDbEventAttributeValue[] | undefined;
+  readonly M?: SimLambdaDynamoDbEventImage | undefined;
+  readonly N?: string | undefined;
+  readonly NS?: readonly string[] | undefined;
+  readonly NULL?: boolean | undefined;
+  readonly S?: string | undefined;
+  readonly SS?: readonly string[] | undefined;
+}
+
+/**
+ * One item image as a DynamoDB stream event carries it.
+ */
+export type SimLambdaDynamoDbEventImage = Readonly<
+  Record<string, SimLambdaDynamoDbEventAttributeValue>
+>;
+
+/**
+ * The change one record reports, as a DynamoDB stream event record carries it.
+ *
+ * The field names are the Streams API's, capital and all, because that is what
+ * the event carries. `ApproximateCreationDateTime` is the exception: the API
+ * gives an instant and the event gives whole seconds since the epoch.
+ */
+export interface SimLambdaDynamoDbStreamEventRecordBody {
+  readonly ApproximateCreationDateTime?: number | undefined;
+  readonly Keys?: SimLambdaDynamoDbEventImage | undefined;
+  readonly NewImage?: SimLambdaDynamoDbEventImage | undefined;
+  readonly OldImage?: SimLambdaDynamoDbEventImage | undefined;
+  readonly SequenceNumber: string;
+  readonly SizeBytes: number;
+  readonly StreamViewType: string;
+}
+
+/**
+ * Who made the change a record reports, when it was not the application.
+ *
+ * A time to live deletion is the one that carries this. The Streams API
+ * capitalizes the same two fields; the event does not.
+ */
+export interface SimLambdaDynamoDbStreamEventUserIdentity {
+  readonly type: string;
+  readonly principalId: string;
+}
+
+/**
+ * One stream record as a DynamoDB stream event record.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
+ */
+export interface SimLambdaDynamoDbStreamEventRecord {
+  readonly eventID: string;
+  readonly eventName: string;
+  readonly eventVersion: string;
+  readonly eventSource: "aws:dynamodb";
+  readonly awsRegion: string;
+  readonly dynamodb: SimLambdaDynamoDbStreamEventRecordBody;
+  readonly eventSourceARN: string;
+  readonly userIdentity?: SimLambdaDynamoDbStreamEventUserIdentity | undefined;
+}
+
+/**
+ * The event a DynamoDB stream event source mapping invokes a function with.
+ */
+export interface SimLambdaDynamoDbStreamEvent {
+  readonly Records: readonly SimLambdaDynamoDbStreamEventRecord[];
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.iso.test.ts
@@ -1,0 +1,70 @@
+import { assertArrayEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  type SimLambdaEventSourcePolls,
+  SimLambdaEventSourcePollTurn,
+} from "./sim-lambda-event-source-poll-turn.js";
+
+/**
+ * A poller recording what it was asked to do, and letting a test decide when a
+ * poll finishes.
+ */
+class RecordingPoller implements SimLambdaEventSourcePolls {
+  public readonly steps: string[] = [];
+  public readonly turn = new SimLambdaEventSourcePollTurn(this);
+
+  private finish: (() => void) | undefined;
+
+  async poll(): Promise<void> {
+    this.steps.push("polled");
+
+    await new Promise<void>((resolve) => {
+      this.finish = resolve;
+    });
+  }
+
+  pollNow(): void {
+    this.steps.push("asked again");
+  }
+
+  /**
+   * Let the poll that is in flight finish.
+   */
+  finishPoll(): void {
+    this.finish?.();
+  }
+}
+
+describe("sim Lambda event source poll turns", () => {
+  it("keeps a second poll from starting while one is in flight", async () => {
+    // Given a poller part way through a poll.
+    const poller = new RecordingPoller();
+    const inFlight = poller.turn.take();
+
+    // When another turn is taken before the first has finished.
+    const second = poller.turn.take();
+
+    // Then only one poll ran, and the second was remembered rather than
+    // dropped: records that arrived mid-poll would otherwise sit until an
+    // unrelated later write happened to wake the mapping.
+    await second;
+    poller.finishPoll();
+    await inFlight;
+
+    assertArrayEquals(poller.steps, ["polled", "asked again"]);
+  });
+
+  it("asks for nothing more when nothing arrived during a poll", async () => {
+    // Given a poller taking a turn with nothing else asking for one.
+    const poller = new RecordingPoller();
+    const inFlight = poller.turn.take();
+
+    // When the poll finishes.
+    poller.finishPoll();
+    await inFlight;
+
+    // Then the mapping waits to be woken rather than polling round again.
+    assertArrayEquals(poller.steps, ["polled"]);
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.iso.test.ts
@@ -22,6 +22,8 @@ class RecordingPoller implements SimLambdaEventSourcePolls {
     await new Promise<void>((resolve) => {
       this.finish = resolve;
     });
+
+    this.steps.push("finished");
   }
 
   pollNow(): void {
@@ -47,12 +49,14 @@ describe("sim Lambda event source poll turns", () => {
 
     // Then only one poll ran, and the second was remembered rather than
     // dropped: records that arrived mid-poll would otherwise sit until an
-    // unrelated later write happened to wake the mapping.
+    // unrelated later write happened to wake the mapping. The wake-up it was
+    // remembered as comes after the poll it arrived during, so the two never
+    // overlap.
     await second;
     poller.finishPoll();
     await inFlight;
 
-    assertArrayEquals(poller.steps, ["polled", "asked again"]);
+    assertArrayEquals(poller.steps, ["polled", "finished", "asked again"]);
   });
 
   it("asks for nothing more when nothing arrived during a poll", async () => {
@@ -65,6 +69,6 @@ describe("sim Lambda event source poll turns", () => {
     await inFlight;
 
     // Then the mapping waits to be woken rather than polling round again.
-    assertArrayEquals(poller.steps, ["polled"]);
+    assertArrayEquals(poller.steps, ["polled", "finished"]);
   });
 });

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poll-turn.ts
@@ -1,0 +1,64 @@
+/**
+ * What a turn is taken on behalf of.
+ */
+export interface SimLambdaEventSourcePolls {
+  /**
+   * Poll once.
+   */
+  poll(): Promise<void>;
+
+  /**
+   * Poll again as soon as the simulation gets to it.
+   */
+  pollNow(): void;
+}
+
+/**
+ * One poll at a time, remembering a wake-up that arrived during one.
+ *
+ * A stream mapping cannot have two polls overlapping. Reading a stream record
+ * leaves it where it is, unlike receiving a message, so a second poll reading
+ * from the same checkpoint would hand the same records to the function again.
+ *
+ * Dropping the second poll instead is not safe either. The poll schedule clears
+ * its own flag when the task starts rather than when it finishes, so a write
+ * landing mid-poll does schedule a further poll, and a poll that returned
+ * without noting it would leave those records sitting until an unrelated later
+ * write happened to wake the mapping.
+ */
+export class SimLambdaEventSourcePollTurn {
+  private readonly poller: SimLambdaEventSourcePolls;
+  private running = false;
+  private asked = false;
+
+  constructor(poller: SimLambdaEventSourcePolls) {
+    this.poller = poller;
+  }
+
+  /**
+   * Take a turn, or note that one was asked for while a turn is being taken.
+   *
+   * The poll asked for during a turn is scheduled once the turn is over rather
+   * than run here, so the two never overlap.
+   */
+  async take(): Promise<void> {
+    if (this.running) {
+      this.asked = true;
+
+      return;
+    }
+
+    this.running = true;
+
+    try {
+      await this.poller.poll();
+    } finally {
+      this.running = false;
+
+      if (this.asked) {
+        this.asked = false;
+        this.poller.pollNow();
+      }
+    }
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-poller-factory.ts
@@ -3,6 +3,8 @@ import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-func
 import type { SimLambdaEventSourceQueues } from "../queue/sim-lambda-event-source-queues.js";
 import type { SimLambdaEventSourceArn } from "../sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceStreams } from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaDynamoDbStreamEventSourcePoller } from "./sim-lambda-dynamodb-stream-event-source-poller.js";
 import type { SimLambdaEventSourcePoller } from "./sim-lambda-event-source-poller.js";
 import { SimLambdaSqsEventSourcePoller } from "./sim-lambda-sqs-event-source-poller.js";
 
@@ -11,6 +13,7 @@ export interface SimLambdaEventSourcePollerProperties {
   readonly eventSourceArn: SimLambdaEventSourceArn;
   readonly functions: SimLambdaFunctionLookup;
   readonly queues: SimLambdaEventSourceQueues;
+  readonly streams: SimLambdaEventSourceStreams;
   readonly background: BackgroundScheduler;
 }
 
@@ -19,15 +22,28 @@ export interface SimLambdaEventSourcePollerProperties {
  *
  * Which poller a mapping gets is decided here rather than by whoever starts
  * one, so adding a kind of source is a change here rather than a change to
- * everything a poller touches. There is one kind so far, so this hands the ARN
- * straight to the queue poller: the queue poller only accepts a queue ARN, so a
- * second kind of source fails to compile here rather than being polled as a
- * queue.
+ * everything a poller touches. Each poller only accepts the ARN of the source
+ * it polls, so a source given to the wrong one fails to compile here rather
+ * than being polled as something it is not.
  */
 export function makeSimLambdaEventSourcePoller(
   properties: SimLambdaEventSourcePollerProperties,
 ): SimLambdaEventSourcePoller {
   const { eventSourceArn } = properties;
 
-  return new SimLambdaSqsEventSourcePoller({ ...properties, eventSourceArn });
+  switch (eventSourceArn.kind) {
+    case "sqs": {
+      return new SimLambdaSqsEventSourcePoller({
+        ...properties,
+        eventSourceArn,
+      });
+    }
+
+    case "dynamodb-stream": {
+      return new SimLambdaDynamoDbStreamEventSourcePoller({
+        ...properties,
+        eventSourceArn,
+      });
+    }
+  }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
@@ -1,0 +1,34 @@
+import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+
+/**
+ * How far along its stream one mapping has got.
+ *
+ * This is the difference between a stream and a queue. A queue hands a message
+ * out and hides it, so a failed batch is the queue's problem afterwards. A
+ * stream hands out a place, and the reader is the only thing that remembers it,
+ * so a batch that failed is read again from exactly where it was. The
+ * checkpoint therefore only moves when a batch is finished with: handled, or
+ * discarded after its retries.
+ */
+export class SimLambdaStreamCheckpoint {
+  #position: SimLambdaEventSourceStreamPosition;
+
+  constructor(startingPosition: SimLambdaEventSourceStartingPosition) {
+    this.#position = { kind: "starting", startingPosition };
+  }
+
+  /**
+   * Where the next read starts.
+   */
+  get position(): SimLambdaEventSourceStreamPosition {
+    return this.#position;
+  }
+
+  /**
+   * Move past a batch that is finished with.
+   */
+  advanceTo(position: SimLambdaEventSourceStreamPosition): void {
+    this.#position = position;
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -1,0 +1,112 @@
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type {
+  SimLambdaEventSourceStreamBatch,
+  SimLambdaEventSourceStreamPosition,
+} from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
+import { SimLambdaStreamCheckpoint } from "./sim-lambda-stream-checkpoint.js";
+import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
+
+interface SimLambdaStreamProgressProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly background: BackgroundScheduler;
+  readonly poll: BackgroundTask;
+}
+
+/**
+ * How far along its stream one mapping has got, and what it does next.
+ *
+ * The two belong together because they are the same decision. A batch the
+ * function took moves the checkpoint and the mapping reads on; a batch it threw
+ * on leaves the checkpoint where it is and the mapping tries the same records
+ * again after a wait. Nothing behind a failing batch is read until it is
+ * through, which is what it means for a stream mapping to block its shard.
+ */
+export class SimLambdaStreamProgress {
+  private readonly checkpoint: SimLambdaStreamCheckpoint;
+  private readonly backoff = new SimLambdaStreamRetryBackoff();
+  private readonly schedule: SimLambdaEventSourcePollSchedule;
+
+  constructor(properties: SimLambdaStreamProgressProperties) {
+    // A stream mapping is refused at creation unless it names a starting
+    // position, so one that has got this far without one is the simulator
+    // having gone wrong rather than a request having been wrong.
+    const { startingPosition } = properties.mapping;
+    assertDefined(startingPosition, "DynamoDB stream mapping start position");
+
+    this.checkpoint = new SimLambdaStreamCheckpoint(startingPosition);
+    this.schedule = new SimLambdaEventSourcePollSchedule(properties);
+  }
+
+  /**
+   * Poll as soon as the simulation gets to it.
+   */
+  pollNow(): void {
+    this.schedule.now();
+  }
+
+  /**
+   * Where the next read starts.
+   */
+  get position(): SimLambdaEventSourceStreamPosition {
+    return this.checkpoint.position;
+  }
+
+  /**
+   * Take a read that came back with nothing.
+   *
+   * The place is still worth keeping: it is what a starting position of LATEST
+   * resolves to, so the mapping settles on one place to read on from rather
+   * than working out a new one each time.
+   */
+  caughtUp(batch: SimLambdaEventSourceStreamBatch): void {
+    this.checkpoint.advanceTo(batch.next);
+  }
+
+  /**
+   * Take what became of a batch: move past it, or wait and try it again.
+   */
+  after(handled: boolean, batch: SimLambdaEventSourceStreamBatch): void {
+    if (handled) {
+      this.handled(batch);
+
+      return;
+    }
+
+    this.failed(batch);
+  }
+
+  /**
+   * Move past a batch the function took, and read on.
+   */
+  handled(batch: SimLambdaEventSourceStreamBatch): void {
+    this.backoff.reset();
+    this.checkpoint.advanceTo(batch.next);
+
+    if (!batch.drained) {
+      this.schedule.now();
+    }
+  }
+
+  /**
+   * Wait and hand a failed batch over again, or give up on it.
+   *
+   * Giving up discards the records and carries on with the stream, which is
+   * what AWS does when a stream mapping's error handling runs out. Parking the
+   * shard instead would be a simulator invention.
+   */
+  failed(batch: SimLambdaEventSourceStreamBatch): void {
+    if (this.backoff.isExhausted) {
+      this.handled(batch);
+
+      return;
+    }
+
+    this.schedule.afterSeconds(this.backoff.nextSeconds());
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
@@ -1,0 +1,51 @@
+/**
+ * How many times one batch is delivered again before it is given up on.
+ */
+const attemptLimit = 5;
+
+/**
+ * How long a mapping waits before handing a failed batch to its function
+ * again, and when it stops trying.
+ *
+ * Both are simulator constraints rather than AWS behaviour, and both are
+ * deliberate.
+ *
+ * AWS documents no delay between attempts. A delay of zero here would be
+ * scheduled at the instant the clock already reads, and advancing the clock
+ * keeps dispatching whatever falls due inside the interval it is moving
+ * through, so a batch the function always throws on would leave `advanceBy`
+ * with work to do forever. The delay is therefore strictly positive and grows
+ * with each attempt, which is also what a consumer under load actually wants.
+ *
+ * AWS retries a stream batch until the records age out of the stream, which is
+ * a day. Waiting out a simulated day for a handler that is never going to
+ * succeed is the same hang with more steps, so the attempts are counted
+ * instead. What happens at the end is AWS's own behaviour: the records are
+ * discarded and the mapping carries on with the stream.
+ */
+export class SimLambdaStreamRetryBackoff {
+  private attempts = 0;
+
+  /**
+   * Whether this batch has had all the attempts it gets.
+   */
+  get isExhausted(): boolean {
+    return this.attempts >= attemptLimit;
+  }
+
+  /**
+   * How long to wait before the next attempt, in seconds.
+   */
+  nextSeconds(): number {
+    this.attempts += 1;
+
+    return 2 ** (this.attempts - 1);
+  }
+
+  /**
+   * Start counting again, which a batch that is finished with does.
+   */
+  reset(): void {
+    this.attempts = 0;
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,36 +1,16 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { sqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-arn.js";
-import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import type { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
 import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
+import type { SimLambdaEventSourceStartingPositionRules } from "../sim-lambda-event-source-starting-position.js";
+import {
+  sqsBatchRules,
+  sqsPollingOperations,
+  sqsStartingPositionRules,
+} from "./sim-lambda-sqs-event-source-rules.js";
 
 const queueArnPattern =
   /^arn:aws:sqs:(?<region>[a-z0-9-]+):(?<account>\d{12}):(?<name>[\w-]{1,80})$/u;
-
-/**
- * What a function's execution role has to be allowed to do on a queue for
- * Lambda to poll it.
- *
- * These are the three operations real Lambda checks when an SQS event source
- * mapping is created, and the three its poller performs afterwards.
- */
-const queuePollingOperations = [
-  "ReceiveMessage",
-  "DeleteMessage",
-  "GetQueueAttributes",
-] as const;
-
-/**
- * The batch sizes an SQS event source delivers with.
- *
- * Ten is both the batch real Lambda uses when the mapping names none, and the
- * largest batch it delivers from a standard queue without a batching window to
- * fill a bigger one.
- */
-const queueBatchRules = new SimLambdaEventSourceBatchRules({
-  defaultSize: 10,
-  maximumSize: 10,
-  sourceDescription: "a queue with no batching window",
-});
 
 /**
  * The queue ARN an event source mapping is created for.
@@ -61,7 +41,7 @@ export class SimLambdaSqsEventSourceArn {
     this.regionName = parts["region"] ?? "";
     this.accountId = parts["account"] ?? "";
     this.queueName = parts["name"] ?? "";
-    this.pollingPermissions = queuePollingOperations.map(
+    this.pollingPermissions = sqsPollingOperations.map(
       (operation) =>
         new SimLambdaEventSourcePollingPermission(`sqs:${operation}`, value),
     );
@@ -103,7 +83,15 @@ export class SimLambdaSqsEventSourceArn {
    * The batch sizes a mapping on this queue may deliver with.
    */
   get batchRules(): SimLambdaEventSourceBatchRules {
-    return queueBatchRules;
+    return sqsBatchRules;
+  }
+
+  /**
+   * The starting positions a mapping on this queue may be created with, which
+   * is none of them.
+   */
+  get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
+    return sqsStartingPositionRules;
   }
 
   /**

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-rules.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-rules.ts
@@ -1,0 +1,37 @@
+import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaNoStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+
+/**
+ * What a function's execution role has to be allowed to do on a queue for
+ * Lambda to poll it.
+ *
+ * These are the three operations real Lambda checks when an SQS event source
+ * mapping is created, and the three its poller performs afterwards.
+ */
+export const sqsPollingOperations = [
+  "ReceiveMessage",
+  "DeleteMessage",
+  "GetQueueAttributes",
+] as const;
+
+/**
+ * The batch sizes an SQS event source delivers with.
+ *
+ * Ten is both the batch real Lambda uses when the mapping names none, and the
+ * largest batch it delivers from a standard queue without a batching window to
+ * fill a bigger one.
+ */
+export const sqsBatchRules = new SimLambdaEventSourceBatchRules({
+  defaultSize: 10,
+  maximumSize: 10,
+  sourceDescription: "a queue with no batching window",
+  unitName: "messages",
+});
+
+/**
+ * A queue has no starting position: a mapping on one takes whatever is at the
+ * front of the queue, and there is nowhere else it could start from.
+ */
+export const sqsStartingPositionRules = new SimLambdaNoStartingPosition(
+  "a queue",
+);

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
@@ -1,0 +1,85 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  makeSourceStream,
+  simAwsWithStreamEventSource,
+} from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+
+describe("sim Lambda DynamoDB stream event source write cascades", () => {
+  it("refuses a function that writes back into its own source table", async () => {
+    // Given a function whose handler writes an aggregate into the table whose
+    // stream invoked it, which is a loop rather than a projection.
+    const simAws = new SimAws();
+    const { tableName } = await simAwsWithStreamEventSource({
+      simAws,
+      handlerResult: (event: SimLambdaDynamoDbStreamEvent): Promise<unknown> =>
+        simAws.dynamoDb().putItem(
+          new PutItemCommand({
+            TableName: "orders",
+            Item: {
+              orderId: { S: `total-${String(event.Records.length)}` },
+            },
+          }),
+        ),
+    });
+
+    // When a change is written to the table.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+
+    // Then the simulation refuses rather than going round forever, naming the
+    // function, the stream and the table.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.backgroundTasksComplete();
+    });
+
+    assertStringIncludes(error.message, "order-projector");
+    assertStringIncludes(error.message, "the table orders");
+    assertStringIncludes(error.message, "own stream");
+    assertStringIncludes(error.message, "Write the result to a different");
+  });
+
+  it("allows a function that writes into a second table", async () => {
+    // Given a function whose handler writes its projection somewhere else.
+    const simAws = new SimAws();
+    const projected = await makeSourceStream(simAws, {
+      tableName: "order-totals",
+    });
+    const { tableName } = await simAwsWithStreamEventSource({
+      simAws,
+      handlerResult: (event: SimLambdaDynamoDbStreamEvent): Promise<unknown> =>
+        simAws.dynamoDb().putItem(
+          new PutItemCommand({
+            TableName: projected.tableName,
+            Item: {
+              orderId: { S: `total-${String(event.Records.length)}` },
+            },
+          }),
+        ),
+    });
+
+    // When a change is written to the source table.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the projection was written, and nothing refused it.
+    const totals = await simAws
+      .dynamoDb()
+      .scan({ input: { TableName: projected.tableName } });
+
+    assertStringIncludes(JSON.stringify(totals.Items), "total-1");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
@@ -7,7 +7,7 @@ import {
   makeSourceStream,
   simAwsWithStreamEventSource,
 } from "../../../../test/lambda/stream-event-source-fixture.js";
-import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
 
 describe("sim Lambda DynamoDB stream event source write cascades", () => {
   it("refuses a function that writes back into its own source table", async () => {

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-blocking.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-blocking.iso.test.ts
@@ -1,0 +1,95 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+
+/**
+ * A stream mapping delivers one record at a time here, so a record that follows
+ * a failing one is a record that has to wait for it.
+ */
+const oneRecordAtATime = 1;
+
+describe("sim Lambda DynamoDB stream event source mapping blocking", () => {
+  it("holds back the record behind a failing batch until that batch is through", async () => {
+    // Given a mapping delivering one record at a time to a function that
+    // throws on the first order and handles the second.
+    const failed: string[] = [];
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      batchSize: oneRecordAtATime,
+      handlerResult: (event: SimLambdaDynamoDbStreamEvent): undefined => {
+        if (orderIdIn(event) === "order-1" && failed.length < 2) {
+          failed.push("order-1");
+
+          throw new Error("Projector could not handle order-1");
+        }
+
+        return undefined;
+      },
+    });
+
+    // When both orders are written.
+    await writeOrder(simAws, tableName, "order-1");
+    await writeOrder(simAws, tableName, "order-2");
+    await simAws.backgroundTasksComplete();
+
+    // Then only the failing one has been delivered: the second is behind it on
+    // the shard.
+    assertArrayLength(events, 1);
+    assertIdentical(orderIdIn(events[0]), "order-1");
+
+    // And it is delivered once the failing batch gets through.
+    await simAws.clock().advanceBy({ seconds: 5 });
+
+    assertIdentical(orderIdIn(events.at(-1)), "order-2");
+  });
+
+  it("discards a batch that runs out of attempts and carries on with the stream", async () => {
+    // Given a mapping delivering one record at a time, whose function can
+    // never handle the first order.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      batchSize: oneRecordAtATime,
+      handlerResult: (event: SimLambdaDynamoDbStreamEvent): undefined => {
+        if (orderIdIn(event) === "order-1") {
+          throw new Error("Projector could not handle order-1");
+        }
+
+        return undefined;
+      },
+    });
+
+    await writeOrder(simAws, tableName, "order-1");
+    await writeOrder(simAws, tableName, "order-2");
+    await simAws.backgroundTasksComplete();
+
+    // When the first order has had every attempt it gets.
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then it was given up on and the record behind it was delivered.
+    assertIdentical(orderIdIn(events.at(-1)), "order-2");
+  });
+});
+
+/**
+ * Write one order to the table, which is one record on its stream.
+ */
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+}
+
+function orderIdIn(
+  event: SimLambdaDynamoDbStreamEvent | undefined,
+): string | undefined {
+  return event?.Records[0]?.dynamodb.Keys?.["orderId"]?.S;
+}

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-blocking.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-blocking.iso.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "vitest";
 
 import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
 
 /**
  * A stream mapping delivers one record at a time here, so a record that follows

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
@@ -1,9 +1,5 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
-import {
-  assertArrayLength,
-  assertArrayMinLength,
-  assertTrue,
-} from "@kensio/smartass";
+import { assertArrayLength } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
@@ -42,10 +38,10 @@ describe("sim Lambda DynamoDB stream event source mapping failures", () => {
     // When an hour of simulated time passes.
     await simAws.clock().advanceBy({ hours: 1 });
 
-    // Then the mapping tried a bounded number of times and stopped, rather
-    // than leaving the clock with work falling due forever.
-    assertArrayMinLength(events, 2);
-    assertTrue(events.length <= 6, "the batch was not delivered forever");
+    // Then the batch was delivered again five times, after 1, 2, 4, 8 and 16
+    // seconds, and then given up on, rather than leaving the clock with work
+    // falling due forever.
+    assertArrayLength(events, 6);
   });
 });
 

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
@@ -1,0 +1,68 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertArrayMinLength,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+
+function throwing(): never {
+  throw new Error("Projector could not handle the batch");
+}
+
+describe("sim Lambda DynamoDB stream event source mapping failures", () => {
+  it("settles rather than spinning while a failed batch waits to be tried again", async () => {
+    // Given a stream mapped to a function that cannot handle what it is given.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+    });
+
+    // When a change is written and the handler throws on it.
+    await writeOrder(simAws, tableName, "order-1");
+
+    // Then the simulation settles: the batch is waiting on the clock rather
+    // than on anything still running.
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(events, 1);
+  });
+
+  it("gives up on a batch the function never handles rather than retrying forever", async () => {
+    // Given a stream mapped to a function that always throws.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+    });
+
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+
+    // When an hour of simulated time passes.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the mapping tried a bounded number of times and stopped, rather
+    // than leaving the clock with work falling due forever.
+    assertArrayMinLength(events, 2);
+    assertTrue(events.length <= 6, "the batch was not delivered forever");
+  });
+});
+
+/**
+ * Write one order to the table, which is one record on its stream.
+ */
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws
+    .dynamoDb()
+    .putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: orderId } },
+      }),
+    );
+}

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-failures.iso.test.ts
@@ -57,12 +57,10 @@ async function writeOrder(
   tableName: string,
   orderId: string,
 ): Promise<void> {
-  await simAws
-    .dynamoDb()
-    .putItem(
-      new PutItemCommand({
-        TableName: tableName,
-        Item: { orderId: { S: orderId } },
-      }),
-    );
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
 }

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-lifecycle.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-lifecycle.iso.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from "vitest";
 
 import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
 import type { SimAws } from "../../aws/sim-aws.js";
-import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
 
 /**
  * A stream mapping delivers one record at a time here, so a record that follows

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-lifecycle.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-lifecycle.iso.test.ts
@@ -1,0 +1,90 @@
+import { PutItemCommand, UpdateTableCommand } from "@aws-sdk/client-dynamodb";
+import { DeleteEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.js";
+
+/**
+ * A stream mapping delivers one record at a time here, so a record that follows
+ * a failing one is a record that has to wait for it.
+ */
+const oneRecordAtATime = 1;
+
+describe("sim Lambda DynamoDB stream event source mapping lifecycle", () => {
+  it("stops delivering once the mapping is deleted", async () => {
+    // Given a stream mapped to a function.
+    const { simAws, tableName, uuid, events } =
+      await simAwsWithStreamEventSource();
+
+    // When the mapping is deleted and the table changes afterwards.
+    await simAws
+      .lambda()
+      .deleteEventSourceMapping(
+        new DeleteEventSourceMappingCommand({ UUID: uuid }),
+      );
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing was delivered: the mapping stopped watching the stream.
+    assertArrayLength(events, 0);
+  });
+
+  it("stops reading once the table's stream is switched off", async () => {
+    // Given a mapping whose function threw on the batch it was given.
+    const failures: string[] = [];
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      batchSize: oneRecordAtATime,
+      handlerResult: (): undefined => {
+        if (failures.length === 0) {
+          failures.push("order-1");
+
+          throw new Error("Projector could not handle order-1");
+        }
+
+        return undefined;
+      },
+    });
+
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+
+    // When the table's stream is switched off before the batch is tried again.
+    await simAws.dynamoDb().updateTable(
+      new UpdateTableCommand({
+        TableName: tableName,
+        StreamSpecification: { StreamEnabled: false },
+      }),
+    );
+    await simAws.clock().advanceBy({ seconds: 5 });
+
+    // Then the batch was delivered again and read from a shard that is
+    // finished with, so the mapping has nothing left to come back for.
+    assertArrayLength(events, 2);
+    assertIdentical(orderIdIn(events[1]), "order-1");
+  });
+});
+
+/**
+ * Write one order to the table, which is one record on its stream.
+ */
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+}
+
+function orderIdIn(
+  event: SimLambdaDynamoDbStreamEvent | undefined,
+): string | undefined {
+  return event?.Records[0]?.dynamodb.Keys?.["orderId"]?.S;
+}

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-validation.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-validation.iso.test.ts
@@ -1,0 +1,192 @@
+import {
+  CreateEventSourceMappingCommand,
+  type EventSourcePosition,
+} from "@aws-sdk/client-lambda";
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  makeSourceStream,
+  makeStreamPollingRole,
+  simAwsWithStreamEventSource,
+  streamPollingActions,
+} from "../../../../test/lambda/stream-event-source-fixture.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+interface StreamMappingRequest {
+  readonly StartingPosition?: EventSourcePosition;
+  readonly StartingPositionTimestamp?: Date;
+  readonly BatchSize?: number;
+  readonly FunctionResponseTypes?: "ReportBatchItemFailures"[];
+}
+
+/**
+ * Try to create a stream mapping, with a role allowed to read the stream.
+ */
+async function createStreamMapping(
+  request: StreamMappingRequest,
+  roleActions: readonly string[] = streamPollingActions,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const { streamArn } = await makeSourceStream(simAws);
+  const roleArn = await makeStreamPollingRole(simAws, streamArn, roleActions);
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "order-projector",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput((): undefined => undefined) },
+    },
+  });
+
+  return await assertThrowsErrorAsync(async () => {
+    await simAws.lambda().createEventSourceMapping(
+      new CreateEventSourceMappingCommand({
+        EventSourceArn: streamArn,
+        FunctionName: "order-projector",
+        ...request,
+      }),
+    );
+  });
+}
+
+describe("sim Lambda DynamoDB stream event source mapping validation", () => {
+  it("refuses a stream mapping that says nothing about where to start", async () => {
+    // Given a stream and a function.
+    // When a mapping is created without a starting position.
+    const error = await createStreamMapping({});
+
+    // Then it is refused, because there is no sensible default between
+    // replaying the stream and taking only what happens next.
+    assertStringIncludes(
+      error.message,
+      "StartingPosition is required for a DynamoDB stream",
+    );
+  });
+
+  it("refuses AT_TIMESTAMP by name", async () => {
+    // Given a stream and a function.
+    // When a mapping asks to start at a timestamp.
+    const error = await createStreamMapping({
+      StartingPosition: "AT_TIMESTAMP",
+      StartingPositionTimestamp: new Date("2026-08-04T09:00:00.000Z"),
+    });
+
+    // Then it is refused, saying which source that position belongs to.
+    assertStringIncludes(error.message, "AT_TIMESTAMP is for a Kinesis stream");
+  });
+
+  it("refuses a starting position timestamp on its own", async () => {
+    // Given a stream and a function.
+    // When a mapping gives a timestamp with a position that has no use for one.
+    const error = await createStreamMapping({
+      StartingPosition: "LATEST",
+      StartingPositionTimestamp: new Date("2026-08-04T09:00:00.000Z"),
+    });
+
+    // Then it is refused rather than the timestamp being ignored.
+    assertStringIncludes(
+      error.message,
+      "StartingPositionTimestamp only goes with",
+    );
+  });
+
+  it("refuses a batch size larger than a stream delivers", async () => {
+    // Given a stream and a function.
+    // When a mapping asks for a batch bigger than a stream hands out.
+    const error = await createStreamMapping({
+      StartingPosition: "TRIM_HORIZON",
+      BatchSize: 10_001,
+    });
+
+    // Then it is refused, saying what a stream does deliver.
+    assertStringIncludes(error.message, "a DynamoDB stream delivers");
+  });
+
+  it("refuses a batch item failure report from a stream mapping", async () => {
+    // Given a stream and a function.
+    // When a mapping says the function reports its own batch item failures.
+    const error = await createStreamMapping({
+      StartingPosition: "TRIM_HORIZON",
+      FunctionResponseTypes: ["ReportBatchItemFailures"],
+    });
+
+    // Then it is refused rather than accepted and ignored: a stream retries
+    // from the record a report names, which is not what a failing batch does
+    // here.
+    assertStringIncludes(
+      error.message,
+      "FunctionResponseTypes on a DynamoDB stream event source mapping is " +
+        "not simulated",
+    );
+  });
+
+  it("refuses a mapping whose execution role cannot read the stream", async () => {
+    // Given a role allowed only to describe the stream.
+    // When a mapping is created for it.
+    const error = await createStreamMapping(
+      { StartingPosition: "TRIM_HORIZON" },
+      ["dynamodb:DescribeStream"],
+    );
+
+    // Then it is refused at creation, naming the operation it cannot call,
+    // rather than being created and delivering nothing.
+    assertStringIncludes(
+      error.message,
+      "does not have permissions to call GetRecords on DynamoDB Streams",
+    );
+  });
+
+  it("refuses a mapping to a stream that is not there", async () => {
+    // Given a table, and a role allowed to read any stream in the Account.
+    const simAws = new SimAws();
+    const { streamArn } = await makeSourceStream(simAws);
+    const roleArn = await makeStreamPollingRole(simAws, "*");
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "order-projector",
+        Role: roleArn,
+        Code: { ZipFile: makeLambdaZipFileInput((): undefined => undefined) },
+      },
+    });
+
+    // When a mapping names a stream label no table ever had.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn: streamArn.replace(/[^/]+$/u, "2020-01-01T00:00:00.0"),
+          FunctionName: "order-projector",
+          StartingPosition: "TRIM_HORIZON",
+        }),
+      );
+    });
+
+    // Then it is refused at creation rather than at the first poll.
+    assertStringIncludes(error.message, "No DynamoDB Stream with ARN");
+  });
+
+  it("refuses a mapping to a stream in another Account", async () => {
+    // Given a simulated AWS with a stream mapped to a function.
+    const { simAws, functionName } = await simAwsWithStreamEventSource();
+
+    // When a mapping names a stream belonging to a different Account.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.lambda().createEventSourceMapping(
+        new CreateEventSourceMappingCommand({
+          EventSourceArn:
+            "arn:aws:dynamodb:eu-west-2:222222222222:table/orders/stream/2026-08-04T09:00:00.000",
+          FunctionName: functionName,
+          StartingPosition: "TRIM_HORIZON",
+        }),
+      );
+    });
+
+    // Then it is refused, as it is on AWS.
+    assertStringIncludes(
+      error.message,
+      "only be mapped to an event source in its own Account and Region",
+    );
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  PutItemCommand,
+  UpdateTimeToLiveCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringLength,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimLambdaDynamoDbStreamEvent,
+  SimLambdaDynamoDbStreamEventRecord,
+} from "./poll/sim-lambda-dynamodb-stream-event.js";
+
+/**
+ * The orders a batch test writes at once.
+ */
+const orderIds = ["order-1", "order-2", "order-3", "order-4", "order-5"];
+
+/**
+ * The instant the time to live test starts from.
+ */
+const startedAt = new Date("2026-08-04T09:00:00.000Z");
+const startedAtSeconds = String(Math.floor(startedAt.getTime() / 1000));
+
+describe("sim Lambda DynamoDB stream event source mappings", () => {
+  it("delivers a written item to the function as a DynamoDB stream event", async () => {
+    // Given a table's stream mapped to a function.
+    const { simAws, tableName, streamArn, events } =
+      await simAwsWithStreamEventSource();
+
+    simAws.clock().freeze();
+
+    // When an item is written to the table.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler was given one real-shaped DynamoDB stream record.
+    assertArrayLength(events, 1);
+
+    const record = events[0].Records[0];
+
+    assertNonNullable(record);
+    assertIdentical(record.eventName, "INSERT");
+    assertIdentical(record.eventSource, "aws:dynamodb");
+    assertIdentical(record.eventSourceARN, streamArn);
+    assertIdentical(record.awsRegion, simAws.defaultRegionName);
+    assertIdentical(record.eventVersion, "1.1");
+    assertStringLength(record.eventID, 32);
+    assertObjectEquals(record.dynamodb.Keys, { orderId: { S: "order-1" } });
+    assertObjectEquals(record.dynamodb.NewImage, {
+      orderId: { S: "order-1" },
+      total: { N: "42" },
+    });
+    assertIdentical(record.dynamodb.StreamViewType, "NEW_AND_OLD_IMAGES");
+    assertIdentical(
+      record.dynamodb.ApproximateCreationDateTime,
+      Math.floor(simAws.now().getTime() / 1000),
+    );
+  });
+
+  it("names the parts of a record the way the event does", async () => {
+    // Given a table's stream mapped to a function.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource();
+
+    // When an item is written and the record is delivered.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the casing is the event's own rather than a tidy scheme: `eventID`
+    // with a capital ID, `dynamodb` with none, `eventSourceARN` with a capital
+    // ARN, and the block inside `dynamodb` capitalized.
+    const record = events[0]?.Records[0];
+
+    assertNonNullable(record);
+    assertArrayEquals(Object.keys(events[0] ?? {}), ["Records"]);
+    assertArrayEquals(Object.keys(record), [
+      "eventID",
+      "eventName",
+      "eventVersion",
+      "eventSource",
+      "awsRegion",
+      "dynamodb",
+      "eventSourceARN",
+    ]);
+    assertArrayEquals(Object.keys(record.dynamodb), [
+      "ApproximateCreationDateTime",
+      "Keys",
+      "NewImage",
+      "SequenceNumber",
+      "SizeBytes",
+      "StreamViewType",
+    ]);
+  });
+
+  it("delivers each of a set of items written at once exactly once", async () => {
+    // Given a table's stream mapped to a function.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource();
+
+    // When several items are written at the same time.
+    await Promise.all(
+      orderIds.map(async (orderId) =>
+        simAws.dynamoDb().putItem(
+          new PutItemCommand({
+            TableName: tableName,
+            Item: { orderId: { S: orderId } },
+          }),
+        ),
+      ),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then every change reached the function, and none of them twice.
+    const delivered = deliveredOrderIds(events).toSorted((left, right) =>
+      left.localeCompare(right),
+    );
+
+    assertArrayEquals(delivered, [...orderIds]);
+  });
+
+  it("delivers what the stream already holds to a TRIM_HORIZON mapping", async () => {
+    // Given a table whose stream already holds a change.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource();
+
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When a change is made after the mapping caught up.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-2" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then both are delivered, oldest first.
+    assertArrayEquals(deliveredOrderIds(events), ["order-1", "order-2"]);
+  });
+
+  it("delivers only what happens next to a LATEST mapping", async () => {
+    // Given a mapping created to read only what the table changes from now on.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      startingPosition: "LATEST",
+    });
+
+    // When a change the stream already holds is followed by a new one.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-2" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the one made after the mapping started reading is delivered.
+    assertArrayEquals(deliveredOrderIds(events), ["order-2"]);
+  });
+
+  it("says DynamoDB made a time to live removal, in the event's own casing", async () => {
+    // Given a streamed table expiring its items, mapped to a function.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const { tableName, events } = await simAwsWithStreamEventSource({ simAws });
+
+    await simAws.dynamoDb().updateTimeToLive(
+      new UpdateTimeToLiveCommand({
+        TableName: tableName,
+        TimeToLiveSpecification: { Enabled: true, AttributeName: "expiresAt" },
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          orderId: { S: "order-1" },
+          expiresAt: { N: startedAtSeconds },
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the clock passes the deletion window.
+    await simAws.clock().advanceBy({ days: 3 });
+
+    // Then the removal reached the function with the identity that tells an
+    // expiry from a deletion the application asked for, lower-cased the way
+    // the event has it rather than the way the Streams API has it.
+    const removal = events.at(-1)?.Records[0];
+
+    assertNonNullable(removal);
+    assertIdentical(removal.eventName, "REMOVE");
+    assertObjectEquals(removal.userIdentity, {
+      type: "Service",
+      principalId: "dynamodb.amazonaws.com",
+    });
+  });
+
+  it("reports the starting position a stream mapping was created with", async () => {
+    // Given a table's stream mapped to a function.
+    const { simAws, uuid } = await simAwsWithStreamEventSource();
+
+    // When the mapping is read back.
+    const mapping = await simAws
+      .lambda()
+      .getEventSourceMapping({ input: { UUID: uuid } });
+
+    // Then it says where it started reading, and with the batch size a
+    // DynamoDB stream mapping takes when the request names none.
+    assertIdentical(mapping.StartingPosition, "TRIM_HORIZON");
+    assertIdentical(mapping.BatchSize, 100);
+  });
+});
+
+function deliveredOrderIds(
+  events: readonly SimLambdaDynamoDbStreamEvent[],
+): string[] {
+  return events.flatMap((event) =>
+    event.Records.map((record) => orderIdOf(record)),
+  );
+}
+
+function orderIdOf(record: SimLambdaDynamoDbStreamEventRecord): string {
+  return record.dynamodb.Keys?.["orderId"]?.S ?? "";
+}

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source.iso.test.ts
@@ -18,7 +18,7 @@ import { SimAws } from "../../aws/sim-aws.js";
 import type {
   SimLambdaDynamoDbStreamEvent,
   SimLambdaDynamoDbStreamEventRecord,
-} from "./poll/sim-lambda-dynamodb-stream-event.js";
+} from "./poll/sim-lambda-dynamodb-stream-event.types.js";
 
 /**
  * The orders a batch test writes at once.
@@ -159,6 +159,31 @@ describe("sim Lambda DynamoDB stream event source mappings", () => {
 
     // Then both are delivered, oldest first.
     assertArrayEquals(deliveredOrderIds(events), ["order-1", "order-2"]);
+  });
+
+  it("delivers a binary attribute as the base64 the event carries", async () => {
+    // Given a table's stream mapped to a function.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource();
+
+    // When an item with bytes in it is written.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: {
+          orderId: { S: "order-1" },
+          receipt: { B: Uint8Array.from([1, 2, 3]) },
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler was given base64 rather than bytes, because the event
+    // reaches a function as JSON, so decoding it reads the same here as it
+    // does on AWS.
+    const receipt = events[0]?.Records[0]?.dynamodb.NewImage?.["receipt"]?.B;
+
+    assertIdentical(receipt, "AQID");
+    assertIdentical(Buffer.from(receipt, "base64").toString("hex"), "010203");
   });
 
   it("delivers only what happens next to a LATEST mapping", async () => {

--- a/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-arn.ts
@@ -1,27 +1,31 @@
 import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
 import { SimLambdaSqsEventSourceArn } from "./queue/sim-lambda-sqs-event-source-arn.js";
+import { SimLambdaDynamoDbStreamEventSourceArn } from "./stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 
 /**
  * The ARN of an event source a mapping can name.
  *
  * A union discriminated by `kind`, so the poller a mapping gets, the
- * permissions its execution role is checked for and the batch sizes it may ask
- * for all come from the source the mapping names rather than being assumed.
+ * permissions its execution role is checked for, the batch sizes it may ask
+ * for and whether it has a starting position at all come from the source the
+ * mapping names rather than being assumed.
  */
-export type SimLambdaEventSourceArn = SimLambdaSqsEventSourceArn;
+export type SimLambdaEventSourceArn =
+  SimLambdaSqsEventSourceArn | SimLambdaDynamoDbStreamEventSourceArn;
 
 /**
  * What this simulation polls, said in one place so every refusal that mentions
  * it says the same thing.
  */
 export const simulatedEventSourcesDescription =
-  "SQS queues are the only simulated event source";
+  "SQS queues and DynamoDB streams are the simulated event sources";
 
 /**
  * The ARN shapes those event sources are named by.
  */
 const simulatedEventSourceArnShapes: readonly string[] = [
   SimLambdaSqsEventSourceArn.arnShape,
+  SimLambdaDynamoDbStreamEventSourceArn.arnShape,
 ];
 
 /**
@@ -34,10 +38,12 @@ const simulatedEventSourceArnShapes: readonly string[] = [
 export function simLambdaEventSourceArnOf(
   eventSourceArn: string,
 ): SimLambdaEventSourceArn {
-  const queueArn = SimLambdaSqsEventSourceArn.parse(eventSourceArn);
+  const parsed =
+    SimLambdaSqsEventSourceArn.parse(eventSourceArn) ??
+    SimLambdaDynamoDbStreamEventSourceArn.parse(eventSourceArn);
 
-  if (queueArn === undefined) {
-    const arnShapes = simulatedEventSourceArnShapes.join(" ");
+  if (parsed === undefined) {
+    const arnShapes = simulatedEventSourceArnShapes.join(". ");
 
     throw new SimLambdaInvalidParameterValueException(
       `EventSourceArn ${eventSourceArn} names no simulated Lambda event ` +
@@ -45,5 +51,5 @@ export function simLambdaEventSourceArnOf(
     );
   }
 
-  return queueArn;
+  return parsed;
 }

--- a/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-batch-rules.ts
@@ -4,6 +4,7 @@ interface SimLambdaEventSourceBatchRulesProperties {
   readonly defaultSize: number;
   readonly maximumSize: number;
   readonly sourceDescription: string;
+  readonly unitName: string;
 }
 
 /**
@@ -12,18 +13,22 @@ interface SimLambdaEventSourceBatchRulesProperties {
  * The default and the maximum belong to the source rather than to the mapping:
  * how much a queue hands out in one receive is not how much another kind of
  * source would, and neither is what makes a larger request pointless. The
- * source description is the clause a refusal explains the range with.
+ * source description is the clause a refusal explains the range with, and the
+ * unit name is what that source hands out: a queue has messages, a stream has
+ * records.
  */
 export class SimLambdaEventSourceBatchRules {
   public readonly defaultSize: number;
   public readonly maximumSize: number;
 
   private readonly sourceDescription: string;
+  private readonly unitName: string;
 
   constructor(properties: SimLambdaEventSourceBatchRulesProperties) {
     this.defaultSize = properties.defaultSize;
     this.maximumSize = properties.maximumSize;
     this.sourceDescription = properties.sourceDescription;
+    this.unitName = properties.unitName;
   }
 
   /**
@@ -40,8 +45,9 @@ export class SimLambdaEventSourceBatchRules {
     ) {
       throw new SimLambdaInvalidParameterValueException(
         `BatchSize ${String(batchSize)} is out of range: ` +
-          `${this.sourceDescription} delivers a whole number of messages ` +
-          `between 1 and ${String(this.maximumSize)} at a time`,
+          `${this.sourceDescription} delivers a whole number of ` +
+          `${this.unitName} between 1 and ${String(this.maximumSize)} at a ` +
+          "time",
       );
     }
 

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimLambdaFunctionArn } from "../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceStartingPosition } from "./sim-lambda-event-source-starting-position.js";
 
 /**
  * Event source mapping ARNs address the mapping by its UUID.
@@ -32,6 +33,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly functionName: string;
   readonly functionArn: SimLambdaFunctionArn;
   readonly batchSize: number;
+  readonly startingPosition?: SimLambdaEventSourceStartingPosition | undefined;
   readonly enabled?: boolean | undefined;
   readonly functionResponseTypes?:
     readonly SimLambdaFunctionResponseType[] | undefined;
@@ -49,6 +51,7 @@ export interface SimLambdaEventSourceMappingConfiguration {
   readonly EventSourceArn: string;
   readonly FunctionArn: SimLambdaFunctionArn;
   readonly BatchSize: number;
+  readonly StartingPosition?: SimLambdaEventSourceStartingPosition | undefined;
   readonly MaximumBatchingWindowInSeconds: number;
   readonly FunctionResponseTypes: readonly SimLambdaFunctionResponseType[];
   readonly State: SimLambdaEventSourceMappingState;
@@ -72,6 +75,13 @@ export class SimLambdaEventSourceMapping {
   public readonly functionName: string;
   public readonly functionArn: SimLambdaFunctionArn;
   public readonly batchSize: number;
+  /**
+   * Where this mapping started reading, for a source that has a choice.
+   *
+   * A queue mapping has none, because a queue only has a front.
+   */
+  public readonly startingPosition:
+    SimLambdaEventSourceStartingPosition | undefined;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -85,6 +95,7 @@ export class SimLambdaEventSourceMapping {
     this.functionName = properties.functionName;
     this.functionArn = properties.functionArn;
     this.batchSize = properties.batchSize;
+    this.startingPosition = properties.startingPosition;
     // Copied rather than held, so a caller keeping the list it passed in
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];
@@ -144,6 +155,7 @@ export class SimLambdaEventSourceMapping {
       EventSourceArn: this.eventSourceArn,
       FunctionArn: this.functionArn,
       BatchSize: this.batchSize,
+      StartingPosition: this.startingPosition,
       // Partial batches are delivered as soon as anything is available, so the
       // batching window is always zero. Anything else is refused at creation.
       MaximumBatchingWindowInSeconds: 0,

--- a/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-pollers.ts
@@ -5,10 +5,12 @@ import type { SimLambdaEventSourcePoller } from "./poll/sim-lambda-event-source-
 import type { SimLambdaEventSourceQueues } from "./queue/sim-lambda-event-source-queues.js";
 import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
 import type { SimLambdaEventSourceMapping } from "./sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceStreams } from "./stream/sim-lambda-event-source-streams.js";
 
 interface SimLambdaEventSourcePollersProperties {
   readonly functions: SimLambdaFunctionLookup;
   readonly queues: SimLambdaEventSourceQueues;
+  readonly streams: SimLambdaEventSourceStreams;
   readonly background: BackgroundScheduler;
 }
 

--- a/src/service/lambda/event-source/sim-lambda-event-source-reachable.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-reachable.ts
@@ -1,0 +1,57 @@
+import type { SimLambdaEventSourceQueues } from "./queue/sim-lambda-event-source-queues.js";
+import type { SimLambdaEventSourceArn } from "./sim-lambda-event-source-arn.js";
+import type { SimLambdaEventSourceStreams } from "./stream/sim-lambda-event-source-streams.js";
+
+interface SimLambdaEventSourceReachableProperties {
+  readonly queues: SimLambdaEventSourceQueues;
+  readonly streams: SimLambdaEventSourceStreams;
+}
+
+/**
+ * Reads the event source a mapping names, as the function's execution role.
+ *
+ * Real Lambda looks at the source when the mapping is created rather than
+ * finding out at the first poll, because a mapping on a source that is not
+ * there looks like a working subscription and delivers nothing. The read is the
+ * one the poller will make, so it fails for the same reasons: the source is
+ * missing, or the role may not read it.
+ */
+export class SimLambdaEventSourceReachable {
+  private readonly queues: SimLambdaEventSourceQueues;
+  private readonly streams: SimLambdaEventSourceStreams;
+
+  constructor(properties: SimLambdaEventSourceReachableProperties) {
+    this.queues = properties.queues;
+    this.streams = properties.streams;
+  }
+
+  /**
+   * Refuse a mapping whose event source cannot be read as the execution role.
+   */
+  async assertReachable(
+    roleArn: string,
+    eventSourceArn: SimLambdaEventSourceArn,
+  ): Promise<void> {
+    const caller = { kind: "arn", arn: roleArn } as const;
+
+    switch (eventSourceArn.kind) {
+      case "sqs": {
+        await this.queues.visibilityTimeoutSeconds({
+          queueArn: eventSourceArn.value,
+          caller,
+        });
+
+        return;
+      }
+
+      case "dynamodb-stream": {
+        await this.streams.tableName({
+          streamArn: eventSourceArn.value,
+          caller,
+        });
+
+        return;
+      }
+    }
+  }
+}

--- a/src/service/lambda/event-source/sim-lambda-event-source-starting-position.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-starting-position.ts
@@ -1,0 +1,114 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+/**
+ * Where on a stream a mapping starts reading.
+ *
+ * `AT_TIMESTAMP` is the third position real Lambda takes, and it is for a
+ * Kinesis stream rather than a DynamoDB one, so it is refused by name rather
+ * than left out of this type quietly.
+ */
+export type SimLambdaEventSourceStartingPosition = "TRIM_HORIZON" | "LATEST";
+
+/**
+ * The parts of a request that say where a mapping starts reading.
+ *
+ * Taken as its own small input rather than as the whole command input, so the
+ * rules stay with the event source they belong to rather than importing the
+ * command they are read from.
+ */
+export interface SimLambdaEventSourceStartingPositionInput {
+  readonly startingPosition?: string | undefined;
+  readonly startingPositionTimestamp?: Date | undefined;
+}
+
+/**
+ * Whether the event source a mapping names has a starting position, and which
+ * ones it takes.
+ *
+ * A queue has none: a mapping on one always delivers from the front of the
+ * queue, and real Lambda refuses a request that names a position for it. A
+ * stream has to be given one, because there is no sensible default between
+ * replaying everything the stream still holds and taking only what happens
+ * next.
+ */
+export interface SimLambdaEventSourceStartingPositionRules {
+  /**
+   * The position a mapping on this source starts from, refusing a request that
+   * asks for one this source does not have.
+   */
+  positionIn(
+    input: SimLambdaEventSourceStartingPositionInput,
+  ): SimLambdaEventSourceStartingPosition | undefined;
+}
+
+/**
+ * The rules for an event source with no starting position.
+ */
+export class SimLambdaNoStartingPosition implements SimLambdaEventSourceStartingPositionRules {
+  private readonly sourceDescription: string;
+
+  constructor(sourceDescription: string) {
+    this.sourceDescription = sourceDescription;
+  }
+
+  /**
+   * Refuse a starting position, since this source has nowhere else to start.
+   */
+  positionIn(
+    input: SimLambdaEventSourceStartingPositionInput,
+  ): SimLambdaEventSourceStartingPosition | undefined {
+    if (
+      input.startingPosition === undefined &&
+      input.startingPositionTimestamp === undefined
+    ) {
+      return undefined;
+    }
+
+    throw new SimLambdaInvalidParameterValueException(
+      `StartingPosition is not valid for ${this.sourceDescription}: a mapping ` +
+        "on one always starts from the front",
+    );
+  }
+}
+
+/**
+ * The rules for a DynamoDB stream, which takes one of two positions.
+ */
+export class SimLambdaStreamStartingPosition implements SimLambdaEventSourceStartingPositionRules {
+  /**
+   * The position a mapping on a stream starts from.
+   *
+   * `StartingPositionTimestamp` only goes with `AT_TIMESTAMP`, so it is refused
+   * along with it rather than being accepted and ignored.
+   */
+  positionIn(
+    input: SimLambdaEventSourceStartingPositionInput,
+  ): SimLambdaEventSourceStartingPosition {
+    const requested = input.startingPosition;
+
+    if (requested === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        "StartingPosition is required for a DynamoDB stream event source " +
+          "mapping. TRIM_HORIZON reads what the stream still holds, LATEST " +
+          "reads only what the table changes from now on",
+      );
+    }
+
+    if (requested !== "TRIM_HORIZON" && requested !== "LATEST") {
+      throw new SimLambdaInvalidParameterValueException(
+        `StartingPosition ${requested} is not valid for a DynamoDB stream: ` +
+          "TRIM_HORIZON and LATEST are the two a DynamoDB stream takes, and " +
+          "AT_TIMESTAMP is for a Kinesis stream",
+      );
+    }
+
+    if (input.startingPositionTimestamp !== undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        "StartingPositionTimestamp only goes with the StartingPosition " +
+          "AT_TIMESTAMP, which is for a Kinesis stream",
+      );
+    }
+
+    return requested;
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
@@ -1,0 +1,119 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimDynamoDbEventSourceStreamShard } from "./sim-dynamodb-event-source-stream-shard.js";
+import type { SimLambdaEventSourceStreamCommands } from "./sim-lambda-event-source-stream-service.js";
+
+const streamArn =
+  "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-08-04T09:00:00.000";
+const request = {
+  streamArn,
+  caller: { kind: "arn", arn: "arn:aws:iam::111111111111:role/Projector" },
+} as const;
+
+/**
+ * Streams commands answering with whatever a test needs them to.
+ *
+ * Simulated DynamoDB never answers with any of this: a stream it resolved by
+ * ARN has a table and a shard, and hands out an iterator for it. The port is
+ * shaped as the SDK shapes it, where every part of an answer is optional, so
+ * these are what the reader does with an answer it cannot read on from.
+ */
+function commandsAnswering(
+  answers: Partial<SimLambdaEventSourceStreamCommands>,
+): SimLambdaEventSourceStreamCommands {
+  return {
+    describeStream: () =>
+      Promise.resolve({ StreamDescription: { TableName: "orders" } }),
+    getShardIterator: () => Promise.resolve({ ShardIterator: "iterator-1" }),
+    getRecords: () =>
+      Promise.resolve({ Records: [], NextShardIterator: "iterator-2" }),
+    ...answers,
+  };
+}
+
+describe("sim DynamoDB event source stream shard", () => {
+  it("refuses a stream that could not be described", async () => {
+    // Given streams answering with no description at all.
+    const shard = new SimDynamoDbEventSourceStreamShard(
+      commandsAnswering({ describeStream: () => Promise.resolve({}) }),
+    );
+
+    // When the table behind the stream is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await shard.tableName(request);
+    });
+
+    // Then the mapping is told, rather than polling a stream it knows nothing
+    // about.
+    assertStringIncludes(error.message, `Stream ${streamArn}`);
+    assertStringIncludes(error.message, "could not be described");
+  });
+
+  it("refuses a stream that names no table", async () => {
+    // Given a stream description with no table on it.
+    const shard = new SimDynamoDbEventSourceStreamShard(
+      commandsAnswering({
+        describeStream: () => Promise.resolve({ StreamDescription: {} }),
+      }),
+    );
+
+    // When the table behind the stream is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await shard.tableName(request);
+    });
+
+    // Then the mapping is told.
+    assertStringIncludes(
+      error.message,
+      "reports no table to poll changes from",
+    );
+  });
+
+  it("refuses a stream with no shard to read", async () => {
+    // Given a stream description carrying no shards.
+    const shard = new SimDynamoDbEventSourceStreamShard(
+      commandsAnswering({
+        describeStream: () =>
+          Promise.resolve({
+            StreamDescription: { TableName: "orders", Shards: [] },
+          }),
+      }),
+    );
+
+    // When a place to start reading is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await shard.iteratorFor(request, "TRIM_HORIZON");
+    });
+
+    // Then the mapping is told.
+    assertStringIncludes(
+      error.message,
+      "reports no shard to read records from",
+    );
+  });
+
+  it("refuses a stream that hands out no iterator", async () => {
+    // Given a stream with a shard, answering with no iterator for it.
+    const shard = new SimDynamoDbEventSourceStreamShard(
+      commandsAnswering({
+        describeStream: () =>
+          Promise.resolve({
+            StreamDescription: {
+              TableName: "orders",
+              Shards: [{ ShardId: "shardId-1" }],
+            },
+          }),
+        getShardIterator: () => Promise.resolve({}),
+      }),
+    );
+
+    // When a place to start reading is asked for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await shard.iteratorFor(request, "LATEST");
+    });
+
+    // Then the mapping is told.
+    assertStringIncludes(error.message, "gave out no shard iterator");
+  });
+});

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
@@ -1,0 +1,153 @@
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+import type {
+  SimLambdaEventSourceStreamCommands,
+  SimLambdaEventSourceStreamDescription,
+} from "./sim-lambda-event-source-stream-service.js";
+import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+import type {
+  SimLambdaEventSourceStreamBatch,
+  SimLambdaEventSourceStreamReadRequest,
+  SimLambdaEventSourceStreamRequest,
+} from "./sim-lambda-event-source-streams.js";
+
+/**
+ * What DescribeStream tells a poller about the stream it is about to read.
+ *
+ * Both answers come from the same call, which is why they are together: the
+ * table a stream carries changes for, and the shard those changes are on. A
+ * mapping asks for the table once, when it is created, and for a place on the
+ * shard whenever it has nowhere to carry on from.
+ */
+export class SimDynamoDbEventSourceStreamShard {
+  private readonly commands: SimLambdaEventSourceStreamCommands;
+
+  constructor(commands: SimLambdaEventSourceStreamCommands) {
+    this.commands = commands;
+  }
+
+  /**
+   * The table whose changes a stream carries.
+   */
+  async tableName(request: SimLambdaEventSourceStreamRequest): Promise<string> {
+    const described = await this.describe(request);
+    const tableName = described.TableName;
+
+    if (tableName === undefined) {
+      refuse(request, "reports no table to poll changes from");
+    }
+
+    return tableName;
+  }
+
+  /**
+   * A place on the shard to start reading from.
+   *
+   * A simulated stream has one shard, so the first shard DescribeStream reports
+   * is the shard.
+   */
+  async iteratorFor(
+    request: SimLambdaEventSourceStreamRequest,
+    startingPosition: SimLambdaEventSourceStartingPosition,
+  ): Promise<string> {
+    const { caller, streamArn } = request;
+    const description = await this.describe(request);
+    const shardId = description.Shards?.[0]?.ShardId;
+
+    if (shardId === undefined) {
+      refuse(request, "reports no shard to read records from");
+    }
+
+    const iterator = await this.commands.getShardIterator(
+      {
+        input: {
+          StreamArn: streamArn,
+          ShardId: shardId,
+          ShardIteratorType: startingPosition,
+        },
+      },
+      { caller },
+    );
+
+    if (iterator.ShardIterator === undefined) {
+      refuse(request, "gave out no shard iterator");
+    }
+
+    return iterator.ShardIterator;
+  }
+
+  /**
+   * Read up to a batch of records from where a position left off.
+   *
+   * The iterator the read hands back is the place to carry on from, and a
+   * caller that does not take it reads the same records again. That is what
+   * makes a failed batch retry from where it was rather than being skipped.
+   */
+  async read(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<SimLambdaEventSourceStreamBatch> {
+    const { batchSize, caller, position } = request;
+    const shardIterator = await this.iteratorOf(request);
+    const output = await this.commands.getRecords(
+      { input: { ShardIterator: shardIterator, Limit: batchSize } },
+      { caller },
+    );
+    const next = output.NextShardIterator;
+
+    return {
+      records: output.Records ?? [],
+      // A shard with no next iterator is finished with, so there is nowhere to
+      // carry on from and the position handed in stands.
+      next:
+        next === undefined
+          ? position
+          : { kind: "iterator", shardIterator: next },
+      drained: next === undefined,
+    };
+  }
+
+  /**
+   * The place a read starts from: the one the caller already has, or a new one
+   * for a mapping that has only its starting position.
+   */
+  private async iteratorOf(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<string> {
+    const { position } = request;
+
+    if (position.kind === "iterator") {
+      return position.shardIterator;
+    }
+
+    return await this.iteratorFor(request, position.startingPosition);
+  }
+
+  private async describe(
+    request: SimLambdaEventSourceStreamRequest,
+  ): Promise<SimLambdaEventSourceStreamDescription> {
+    const { caller, streamArn } = request;
+    const described = await this.commands.describeStream(
+      { input: { StreamArn: streamArn } },
+      { caller },
+    );
+
+    if (described.StreamDescription === undefined) {
+      refuse(request, "could not be described");
+    }
+
+    return described.StreamDescription;
+  }
+}
+
+/**
+ * Refuse a stream that answered with something a poller cannot read on from.
+ *
+ * Nothing simulated DynamoDB answers with reaches these, since a stream it
+ * resolved by ARN has a table and a shard. They are here because the port is
+ * shaped as the SDK shapes it, where every part of an answer is optional.
+ */
+function refuse(
+  request: SimLambdaEventSourceStreamRequest,
+  problem: string,
+): never {
+  throw new SimLambdaError(`Stream ${request.streamArn} ${problem}`);
+}

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-streams.ts
@@ -1,0 +1,76 @@
+import { SimDynamoDbEventSourceStreamShard } from "./sim-dynamodb-event-source-stream-shard.js";
+import type {
+  SimLambdaEventSourceStreamActivity,
+  SimLambdaEventSourceStreamService,
+} from "./sim-lambda-event-source-stream-service.js";
+import type {
+  SimLambdaEventSourceStreamBatch,
+  SimLambdaEventSourceStreamReadRequest,
+  SimLambdaEventSourceStreamRequest,
+  SimLambdaEventSourceStreams,
+  SimLambdaEventSourceStreamWatcher,
+} from "./sim-lambda-event-source-streams.js";
+
+interface SimDynamoDbEventSourceStreamsProperties {
+  readonly dynamoDb: SimLambdaEventSourceStreamService;
+}
+
+/**
+ * Simulated DynamoDB as the streams a Lambda event source mapping polls.
+ *
+ * Every call goes through the DynamoDB Streams command it would go through on
+ * real AWS, as the function's execution role, so a role without
+ * `dynamodb:DescribeStream`, `dynamodb:GetShardIterator` or
+ * `dynamodb:GetRecords` on the stream is refused here rather than quietly
+ * polling anyway.
+ */
+export class SimDynamoDbEventSourceStreams implements SimLambdaEventSourceStreams {
+  private readonly activity: SimLambdaEventSourceStreamActivity;
+  private readonly shard: SimDynamoDbEventSourceStreamShard;
+
+  constructor(properties: SimDynamoDbEventSourceStreamsProperties) {
+    const { dynamoDb } = properties;
+
+    this.activity = dynamoDb.streamActivity();
+    this.shard = new SimDynamoDbEventSourceStreamShard(dynamoDb.streams());
+  }
+
+  /**
+   * The table whose changes a stream carries.
+   *
+   * This is a DescribeStream call, which is also how a mapping finds out
+   * whether the stream it names is there at all: real Lambda needs the same
+   * permission for the same reason.
+   */
+  async tableName(request: SimLambdaEventSourceStreamRequest): Promise<string> {
+    return await this.shard.tableName(request);
+  }
+
+  /**
+   * Read up to a batch of records from where a position left off.
+   */
+  async read(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<SimLambdaEventSourceStreamBatch> {
+    return await this.shard.read(request);
+  }
+
+  /**
+   * Watch a stream for the records written to it.
+   */
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.activity.watch(streamArn, watcher);
+  }
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void {
+    this.activity.unwatch(streamArn, watcher);
+  }
+
+  /**
+   * The iterator a read starts from, asking the stream for one when the
+   * mapping has only the starting position it was created with.
+   */
+}

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-attribute-value.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-attribute-value.ts
@@ -139,6 +139,7 @@ export type SimLambdaDynamoDbAttributeValue =
       readonly NS?: never;
       readonly NULL?: never;
       readonly S?: never;
+      readonly $unknown?: never;
     }
   | {
       readonly $unknown: [string, unknown];

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-attribute-value.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-attribute-value.ts
@@ -1,0 +1,162 @@
+/**
+ * One attribute value in the images a stream record carries.
+ *
+ * Exactly one tag is set and the rest are absent, which is how the AWS SDK
+ * declares an attribute value. Saying that, rather than allowing any
+ * combination, is what lets a handler pass an image straight to `unmarshall`
+ * without a cast.
+ *
+ * This is declared here rather than taken from simulated DynamoDB so that
+ * neither service imports the other. What crosses between them is the shape of
+ * a record, not either service's own types.
+ */
+export type SimLambdaDynamoDbAttributeValue =
+  | {
+      readonly B: Uint8Array;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly BOOL: boolean;
+      readonly B?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly BS: Uint8Array[];
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly L: SimLambdaDynamoDbAttributeValue[];
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly M: Readonly<Record<string, SimLambdaDynamoDbAttributeValue>>;
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly N: string;
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly NS: string[];
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly NULL: boolean;
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly S?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly S: string;
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly SS?: never;
+      readonly $unknown?: never;
+    }
+  | {
+      readonly SS: string[];
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+    }
+  | {
+      readonly $unknown: [string, unknown];
+      readonly B?: never;
+      readonly BOOL?: never;
+      readonly BS?: never;
+      readonly L?: never;
+      readonly M?: never;
+      readonly N?: never;
+      readonly NS?: never;
+      readonly NULL?: never;
+      readonly S?: never;
+      readonly SS?: never;
+    };
+
+/**
+ * One item image as a stream record carries it.
+ */
+export type SimLambdaDynamoDbImage = Readonly<
+  Record<string, SimLambdaDynamoDbAttributeValue>
+>;

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.iso.test.ts
@@ -1,0 +1,103 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaDynamoDbStreamEventSourceArn } from "./sim-lambda-dynamodb-stream-event-source-arn.js";
+
+const streamArn =
+  "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-08-04T09:00:00.000";
+
+describe("sim Lambda DynamoDB stream event source ARNs", () => {
+  it("reads the stream a mapping polls out of its ARN", () => {
+    // Given a stream ARN, whose label carries two colons of its own.
+    // When it is read.
+    const eventSourceArn = SimLambdaDynamoDbStreamEventSourceArn.of(streamArn);
+
+    // Then the table and the label come out whole, rather than the label being
+    // cut up by a naive split on colons.
+    assertIdentical(eventSourceArn.kind, "dynamodb-stream");
+    assertIdentical(eventSourceArn.serviceLabel, "DynamoDB Streams");
+    assertIdentical(eventSourceArn.regionName, "eu-west-2");
+    assertIdentical(eventSourceArn.accountId, "111111111111");
+    assertIdentical(eventSourceArn.tableName, "orders");
+    assertIdentical(eventSourceArn.label, "2026-08-04T09:00:00.000");
+  });
+
+  it("names the operations a poller has to be allowed to call", () => {
+    // Given a stream ARN.
+    // When its polling permissions are read.
+    const permissions =
+      SimLambdaDynamoDbStreamEventSourceArn.of(streamArn).pollingPermissions;
+
+    // Then they are the three operations a poller performs on the stream, plus
+    // listing streams, which is on every stream rather than on one.
+    assertArrayEquals(
+      permissions.map((permission) => permission.action),
+      [
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams",
+      ],
+    );
+    assertArrayEquals(
+      permissions.map((permission) => permission.resource),
+      [streamArn, streamArn, streamArn, "*"],
+    );
+  });
+
+  it("delivers a hundred records at a time when a mapping asks for no size", () => {
+    // Given a stream ARN.
+    // When its batch rules are read.
+    const { batchRules } = SimLambdaDynamoDbStreamEventSourceArn.of(streamArn);
+
+    // Then they are the ones real Lambda and CDK both use for a stream.
+    assertIdentical(batchRules.sizeIn(undefined), 100);
+    assertIdentical(batchRules.maximumSize, 10_000);
+  });
+
+  it("refuses a batch size a stream would never deliver", () => {
+    // Given a stream ARN.
+    const { batchRules } = SimLambdaDynamoDbStreamEventSourceArn.of(streamArn);
+
+    // When a mapping asks for more than a stream hands out.
+    const error = assertThrowsError(() => batchRules.sizeIn(10_001));
+
+    // Then the refusal says what a stream does deliver.
+    assertStringIncludes(error.message, "a DynamoDB stream delivers");
+    assertStringIncludes(error.message, "between 1 and 10000");
+  });
+
+  it("is not read from an ARN naming something else", () => {
+    // Given ARNs that are not a DynamoDB stream ARN.
+    // When each is read.
+    // Then nothing comes back, so the ARN dispatcher can try the next kind.
+    assertUndefined(
+      SimLambdaDynamoDbStreamEventSourceArn.parse(
+        "arn:aws:dynamodb:eu-west-2:111111111111:table/orders",
+      ),
+    );
+    assertUndefined(
+      SimLambdaDynamoDbStreamEventSourceArn.parse(
+        "arn:aws:sqs:eu-west-2:111111111111:orders",
+      ),
+    );
+  });
+
+  it("refuses an ARN that is not a stream ARN at all", () => {
+    // Given something that is not an ARN.
+    // When it is read as a stream ARN.
+    const error = assertThrowsError(() =>
+      SimLambdaDynamoDbStreamEventSourceArn.of("orders"),
+    );
+
+    // Then the refusal says how a stream ARN is written.
+    assertStringIncludes(error.message, "is not a DynamoDB stream ARN");
+    assertStringIncludes(error.message, "table/<table-name>/stream/<label>");
+  });
+});

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.ts
@@ -1,0 +1,118 @@
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
+import type { SimLambdaEventSourceStartingPositionRules } from "../sim-lambda-event-source-starting-position.js";
+import {
+  dynamoDbStreamBatchRules,
+  dynamoDbStreamPollingOperations,
+  dynamoDbStreamStartingPositionRules,
+} from "./sim-lambda-dynamodb-stream-event-source-rules.js";
+
+/**
+ * A stream ARN is a table ARN with a label after it, and the label is an ISO
+ * timestamp carrying two colons of its own. Splitting the ARN on colons
+ * therefore cuts the label in three, so the table and the label are taken from
+ * the resource part by the `table/` and `/stream/` separators instead.
+ */
+const streamArnPattern =
+  /^arn:aws:dynamodb:(?<region>[a-z0-9-]+):(?<account>\d{12}):table\/(?<table>[\w.-]{3,255})\/stream\/(?<label>\S+)$/u;
+
+/**
+ * The DynamoDB stream ARN an event source mapping is created for.
+ *
+ * Everything a poller needs comes out of it: the ARN the Streams calls name,
+ * the Region the event records report, and the table the stream belongs to,
+ * which is what a refusal names when a function writes back into its own
+ * source.
+ */
+export class SimLambdaDynamoDbStreamEventSourceArn {
+  /**
+   * How an ARN naming this kind of event source is written, for a refusal to
+   * say what it wanted instead.
+   */
+  static readonly arnShape =
+    "A DynamoDB stream ARN is " +
+    "arn:aws:dynamodb:<region>:<account-id>:table/<table-name>/stream/<label>";
+
+  public readonly kind = "dynamodb-stream" as const;
+  public readonly serviceLabel = "DynamoDB Streams";
+  public readonly value: string;
+  public readonly regionName: string;
+  public readonly accountId: string;
+  public readonly tableName: string;
+  public readonly label: string;
+  public readonly pollingPermissions: readonly SimLambdaEventSourcePollingPermission[];
+
+  private constructor(value: string, parts: Record<string, string>) {
+    this.value = value;
+    this.regionName = parts["region"] ?? "";
+    this.accountId = parts["account"] ?? "";
+    this.tableName = parts["table"] ?? "";
+    this.label = parts["label"] ?? "";
+    this.pollingPermissions = [
+      ...dynamoDbStreamPollingOperations.map(
+        (operation) =>
+          new SimLambdaEventSourcePollingPermission(
+            `dynamodb:${operation}`,
+            value,
+          ),
+      ),
+      new SimLambdaEventSourcePollingPermission("dynamodb:ListStreams", "*"),
+    ];
+  }
+
+  /**
+   * Read a stream ARN, answering with nothing when the ARN names something
+   * else.
+   *
+   * This is what the event source ARN dispatcher asks, so that deciding what a
+   * mapping may name stays in one place rather than in each parser.
+   */
+  static parse(
+    streamArn: string,
+  ): SimLambdaDynamoDbStreamEventSourceArn | undefined {
+    const parts = streamArnPattern.exec(streamArn)?.groups;
+
+    if (parts === undefined) {
+      return undefined;
+    }
+
+    return new this(streamArn, parts);
+  }
+
+  /**
+   * Read a stream ARN, refusing one that is not a stream ARN at all.
+   */
+  static of(streamArn: string): SimLambdaDynamoDbStreamEventSourceArn {
+    const parsed = this.parse(streamArn);
+
+    if (parsed === undefined) {
+      throw new SimLambdaInvalidParameterValueException(
+        `${streamArn} is not a DynamoDB stream ARN. ${this.arnShape}`,
+      );
+    }
+
+    return parsed;
+  }
+
+  /**
+   * The batch sizes a mapping on this stream may deliver with.
+   */
+  get batchRules(): SimLambdaEventSourceBatchRules {
+    return dynamoDbStreamBatchRules;
+  }
+
+  /**
+   * The starting positions a mapping on this stream may be created with.
+   */
+  get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
+    return dynamoDbStreamStartingPositionRules;
+  }
+
+  /**
+   * Whether this stream is in an Account and Region.
+   */
+  isIn(accountId: string, regionName: string): boolean {
+    return this.accountId === accountId && this.regionName === regionName;
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
@@ -1,0 +1,37 @@
+import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaStreamStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+
+/**
+ * What a function's execution role has to be allowed to do on a stream for
+ * Lambda to poll it.
+ *
+ * These are the three operations a poller performs on the stream itself.
+ * `ListStreams` goes with them, on every stream rather than on one: nothing
+ * here ever calls it, but both the AWS managed policy and CDK's own grant
+ * include it, so a role that would work on AWS is a role that works here.
+ */
+export const dynamoDbStreamPollingOperations = [
+  "DescribeStream",
+  "GetRecords",
+  "GetShardIterator",
+] as const;
+
+/**
+ * The batch sizes a DynamoDB stream event source delivers with.
+ *
+ * A hundred is what real Lambda uses when the mapping names none, and what CDK
+ * puts on every `DynamoEventSource`. Ten thousand is the largest a mapping may
+ * ask for.
+ */
+export const dynamoDbStreamBatchRules = new SimLambdaEventSourceBatchRules({
+  defaultSize: 100,
+  maximumSize: 10_000,
+  sourceDescription: "a DynamoDB stream",
+  unitName: "records",
+});
+
+/**
+ * A stream mapping has to say where it starts reading from.
+ */
+export const dynamoDbStreamStartingPositionRules =
+  new SimLambdaStreamStartingPosition();

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-delivery-context.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-delivery-context.ts
@@ -1,0 +1,48 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * One poller, while it is inside a delivery.
+ *
+ * Typed as a bare object because only its identity is used, as a key.
+ */
+export type SimLambdaEventSourceDelivering = object;
+
+const storage = new AsyncLocalStorage<
+  ReadonlySet<SimLambdaEventSourceDelivering>
+>();
+
+/**
+ * Which pollers are currently inside a delivery, tracked with Node.js
+ * asynchronous context tracking.
+ *
+ * This is how a mapping tells a record its own function wrote from a record
+ * something else wrote while the function was running. Everything the handler
+ * does, including the simulated writes it awaits, happens inside the delivery's
+ * asynchronous context; a write made anywhere else does not, however exactly it
+ * lands in the same moment.
+ *
+ * A set rather than a single poller, so two mappings feeding each other are
+ * caught as well as one feeding itself: the inner delivery keeps the outer one
+ * visible for as long as it runs.
+ */
+export const simLambdaEventSourceDeliveryContext = {
+  /**
+   * Run a delivery, marking the poller making it.
+   */
+  async run<T>(
+    delivering: SimLambdaEventSourceDelivering,
+    delivery: () => Promise<T>,
+  ): Promise<T> {
+    const inside = new Set(storage.getStore());
+    inside.add(delivering);
+
+    return await storage.run(inside, delivery);
+  },
+
+  /**
+   * Whether a poller is inside a delivery of its own right now.
+   */
+  isDelivering(delivering: SimLambdaEventSourceDelivering): boolean {
+    return storage.getStore()?.has(delivering) ?? false;
+  },
+};

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-stream-service.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-stream-service.ts
@@ -1,0 +1,75 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimLambdaEventSourceStreamRecord,
+  SimLambdaEventSourceStreamWatcher,
+} from "./sim-lambda-event-source-streams.js";
+
+interface StreamCommandOptions {
+  readonly caller: SimAwsCaller;
+}
+
+/**
+ * One shard of a stream, as DescribeStream reports it.
+ */
+interface StreamShardDescription {
+  readonly ShardId?: string | undefined;
+}
+
+/**
+ * A stream, as DescribeStream reports it: what it carries changes for, and the
+ * shard those changes are read from.
+ */
+export interface SimLambdaEventSourceStreamDescription {
+  readonly TableName?: string | undefined;
+  readonly Shards?: readonly StreamShardDescription[] | undefined;
+}
+
+/**
+ * The narrow slice of simulated DynamoDB that event source polling needs.
+ * SimDynamoDb structurally implements this interface.
+ */
+export interface SimLambdaEventSourceStreamService {
+  streams(): SimLambdaEventSourceStreamCommands;
+  streamActivity(): SimLambdaEventSourceStreamActivity;
+}
+
+/**
+ * The DynamoDB Streams commands a poller reads a stream with.
+ *
+ * These are the SDK operations a real poller performs, in the order it performs
+ * them: find the shard, ask for a place on it, then read from there. Going
+ * through the commands rather than through a read interface of Yulin's own is
+ * what makes each call authorize as the function's execution role.
+ */
+export interface SimLambdaEventSourceStreamCommands {
+  describeStream(
+    command: { input: { StreamArn: string } },
+    options?: StreamCommandOptions,
+  ): Promise<{
+    StreamDescription?: SimLambdaEventSourceStreamDescription | undefined;
+  }>;
+
+  getShardIterator(
+    command: {
+      input: { StreamArn: string; ShardId: string; ShardIteratorType: string };
+    },
+    options?: StreamCommandOptions,
+  ): Promise<{ ShardIterator?: string | undefined }>;
+
+  getRecords(
+    command: { input: { ShardIterator: string; Limit: number } },
+    options?: StreamCommandOptions,
+  ): Promise<{
+    Records?: readonly SimLambdaEventSourceStreamRecord[] | undefined;
+    NextShardIterator?: string | undefined;
+  }>;
+}
+
+/**
+ * The part of simulated DynamoDB that says when a record has been written to a
+ * stream.
+ */
+export interface SimLambdaEventSourceStreamActivity {
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+}

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
@@ -1,0 +1,174 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
+import type { SimLambdaDynamoDbImage } from "./sim-lambda-dynamodb-attribute-value.js";
+
+/**
+ * The change one stream record reports, as the stream hands it out.
+ *
+ * These are the Streams API's own names for the parts of a record. Turning them
+ * into the event a function sees is the event builder's job, and it is a real
+ * translation rather than a copy: the API capitalizes the identity and gives an
+ * instant where the event lower-cases the identity and gives epoch seconds.
+ */
+export interface SimLambdaEventSourceStreamRecordBody {
+  readonly ApproximateCreationDateTime?: Date | undefined;
+  readonly Keys?: SimLambdaDynamoDbImage | undefined;
+  readonly NewImage?: SimLambdaDynamoDbImage | undefined;
+  readonly OldImage?: SimLambdaDynamoDbImage | undefined;
+  readonly SequenceNumber?: string | undefined;
+  readonly SizeBytes?: number | undefined;
+  readonly StreamViewType?: string | undefined;
+}
+
+/**
+ * Who made a change, when it was not the application.
+ */
+export interface SimLambdaEventSourceStreamIdentity {
+  readonly PrincipalId?: string | undefined;
+  readonly Type?: string | undefined;
+}
+
+/**
+ * One record as a stream hands it to a poller.
+ */
+export interface SimLambdaEventSourceStreamRecord {
+  readonly eventID?: string | undefined;
+  readonly eventName?: string | undefined;
+  readonly eventVersion?: string | undefined;
+  readonly awsRegion?: string | undefined;
+  readonly dynamodb?: SimLambdaEventSourceStreamRecordBody | undefined;
+  readonly userIdentity?: SimLambdaEventSourceStreamIdentity | undefined;
+}
+
+/**
+ * Where a mapping has reached on the stream it polls.
+ *
+ * A mapping that has read nothing yet has only the starting position it was
+ * created with. One that has read something holds the shard iterator the last
+ * read handed back, which is the place itself rather than a description of it.
+ */
+export type SimLambdaEventSourceStreamPosition =
+  | {
+      readonly kind: "starting";
+      readonly startingPosition: SimLambdaEventSourceStartingPosition;
+    }
+  | { readonly kind: "iterator"; readonly shardIterator: string };
+
+/**
+ * A poller's request to the stream it polls, made as the function's execution
+ * role so simulated IAM applies to it as it does on real Lambda.
+ */
+export interface SimLambdaEventSourceStreamRequest {
+  readonly streamArn: string;
+  readonly caller: SimAwsCaller;
+}
+
+export interface SimLambdaEventSourceStreamReadRequest extends SimLambdaEventSourceStreamRequest {
+  readonly position: SimLambdaEventSourceStreamPosition;
+  readonly batchSize: number;
+}
+
+/**
+ * What one read of a stream came back with.
+ *
+ * `drained` is only true of a shard the reader has reached the end of, which
+ * happens when the table's stream has been switched off. An empty batch from an
+ * open shard is the ordinary answer for a mapping that has caught up.
+ */
+export interface SimLambdaEventSourceStreamBatch {
+  readonly records: readonly SimLambdaEventSourceStreamRecord[];
+  readonly next: SimLambdaEventSourceStreamPosition;
+  readonly drained: boolean;
+}
+
+/**
+ * Something watching a stream on a poller's behalf.
+ */
+export interface SimLambdaEventSourceStreamWatcher {
+  /**
+   * A record has been written and can be read now.
+   *
+   * There is no instant here, unlike the queue watcher this mirrors: a stream
+   * record is readable the moment it is written.
+   */
+  recordsAvailable(): void;
+}
+
+/**
+ * The streams a simulated Lambda event source mapping polls.
+ *
+ * This is the narrow slice of simulated DynamoDB Streams that polling needs,
+ * kept as an interface so Lambda depends on what it does with a stream rather
+ * than on the DynamoDB service object. Every operation carries the caller,
+ * because polling on real Lambda is done with the function's execution role and
+ * is refused when that role has no permission for it.
+ */
+export interface SimLambdaEventSourceStreams {
+  /**
+   * The table whose changes a stream carries, and by asking, whether the
+   * stream is there to be polled at all.
+   */
+  tableName(request: SimLambdaEventSourceStreamRequest): Promise<string>;
+
+  /**
+   * Read up to a batch of records from where a position left off.
+   */
+  read(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<SimLambdaEventSourceStreamBatch>;
+
+  /**
+   * Watch a stream for the records written to it.
+   */
+  watch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+
+  /**
+   * Stop watching a stream.
+   */
+  unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void;
+}
+
+/**
+ * Event source streams used when no simulated DynamoDB is wired up, such as for
+ * a standalone SimLambda constructed outside SimAws.
+ */
+export class SimLambdaNoEventSourceStreams implements SimLambdaEventSourceStreams {
+  /**
+   * Refuse to look at a stream, explaining how to reach one.
+   */
+  tableName(request: SimLambdaEventSourceStreamRequest): Promise<string> {
+    return Promise.reject(this.noStreams(request.streamArn));
+  }
+
+  /**
+   * Refuse to poll, explaining how to reach a stream.
+   */
+  read(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<SimLambdaEventSourceStreamBatch> {
+    return Promise.reject(this.noStreams(request.streamArn));
+  }
+
+  /**
+   * Watch nothing: there is no stream to watch.
+   */
+  watch(): void {
+    //
+  }
+
+  /**
+   * Stop watching nothing.
+   */
+  unwatch(): void {
+    //
+  }
+
+  private noStreams(streamArn: string): SimLambdaError {
+    return new SimLambdaError(
+      `Cannot poll ${streamArn}: this SimLambda has no simulated DynamoDB to ` +
+        "poll. Create the event source mapping through SimAws, or construct " +
+        "SimLambda with eventSourceStreams.",
+    );
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-lambda-no-event-source-streams.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-no-event-source-streams.iso.test.ts
@@ -1,0 +1,49 @@
+import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaNoEventSourceStreams } from "./sim-lambda-event-source-streams.js";
+
+const streamArn =
+  "arn:aws:dynamodb:eu-west-2:111111111111:table/orders/stream/2026-08-04T09:00:00.000";
+const request = {
+  streamArn,
+  caller: { kind: "arn", arn: "arn:aws:iam::111111111111:role/Projector" },
+} as const;
+
+describe("sim Lambda event source streams with no simulated DynamoDB", () => {
+  it("refuses every read operation, saying how to reach a stream", async () => {
+    // Given a simulated Lambda with no simulated DynamoDB behind it.
+    const streams = new SimLambdaNoEventSourceStreams();
+
+    // When each polling operation is attempted.
+    const errors = await Promise.all([
+      assertThrowsErrorAsync(async () => {
+        await streams.tableName(request);
+      }),
+      assertThrowsErrorAsync(async () => {
+        await streams.read({
+          ...request,
+          position: { kind: "starting", startingPosition: "TRIM_HORIZON" },
+          batchSize: 100,
+        });
+      }),
+    ]);
+
+    // Then each says there is nothing to poll, and how to fix it.
+    for (const error of errors) {
+      assertStringIncludes(error.message, "no simulated DynamoDB to poll");
+      assertStringIncludes(error.message, streamArn);
+    }
+  });
+
+  it("watches nothing, because there is no stream to watch", () => {
+    // Given a simulated Lambda with no simulated DynamoDB behind it.
+    const streams = new SimLambdaNoEventSourceStreams();
+
+    // When a poller watches a stream and then stops.
+    streams.watch();
+    streams.unwatch();
+
+    // Then nothing happened, and nothing threw.
+  });
+});

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
@@ -1,0 +1,68 @@
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaDynamoDbStreamEventSourceArn } from "./sim-lambda-dynamodb-stream-event-source-arn.js";
+import { simLambdaEventSourceDeliveryContext } from "./sim-lambda-event-source-delivery-context.js";
+import { SimLambdaStreamCascadeError } from "./sim-lambda-stream-cascade.error.js";
+
+interface SimLambdaStreamCascadeGuardProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly eventSourceArn: SimLambdaDynamoDbStreamEventSourceArn;
+}
+
+/**
+ * Watches one mapping's deliveries for the function writing back into the table
+ * whose stream invoked it.
+ *
+ * The delivery runs inside its own asynchronous context, so a record written by
+ * the handler is told apart from one written by anything else that happened to
+ * be running at the same time. That distinction is the whole point: several
+ * items written at once are an ordinary batch, and a handler feeding its own
+ * source is a loop.
+ */
+export class SimLambdaStreamCascadeGuard {
+  private readonly properties: SimLambdaStreamCascadeGuardProperties;
+  private cascaded = false;
+
+  constructor(properties: SimLambdaStreamCascadeGuardProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Run one delivery, refusing afterwards if the function fed its own source.
+   *
+   * The refusal comes after the delivery rather than during it, so the handler
+   * sees its own write succeed and the loop is reported to whoever is waiting
+   * for the simulation to settle.
+   */
+  async around<Result>(delivery: () => Promise<Result>): Promise<Result> {
+    const result = await simLambdaEventSourceDeliveryContext.run(
+      this,
+      delivery,
+    );
+
+    if (this.cascaded) {
+      const { mapping, eventSourceArn } = this.properties;
+
+      throw new SimLambdaStreamCascadeError({
+        functionName: mapping.functionName,
+        streamArn: eventSourceArn.value,
+        tableName: eventSourceArn.tableName,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Note a record written to the polled stream, answering with whether this
+   * mapping's own function wrote it.
+   */
+  noteRecordWritten(): boolean {
+    if (!simLambdaEventSourceDeliveryContext.isDelivering(this)) {
+      return false;
+    }
+
+    this.cascaded = true;
+
+    return true;
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
@@ -1,0 +1,33 @@
+import { SimLambdaError } from "../../error/sim-lambda.error.js";
+
+interface SimLambdaStreamCascadeErrorProperties {
+  readonly functionName: string;
+  readonly streamArn: string;
+  readonly tableName: string;
+}
+
+/**
+ * A function writing back into the table whose stream invoked it.
+ *
+ * Every one of those writes is another stream record, which is another
+ * delivery, which is another write. Real Lambda runs that loop for as long as
+ * the account is willing to pay for it. Nothing here stops on its own, so the
+ * simulation would go round until the test timed out with nothing to point at.
+ *
+ * This is a simulator guard rather than AWS behaviour, and it is deliberately
+ * not silent: a projection or an aggregate belongs in a second table, and a
+ * test whose handler writes to its own source table is testing a loop.
+ */
+export class SimLambdaStreamCascadeError extends SimLambdaError {
+  public override readonly name = "SimLambdaStreamCascadeError";
+
+  constructor(properties: SimLambdaStreamCascadeErrorProperties) {
+    super(
+      `Function ${properties.functionName} wrote to the table ` +
+        `${properties.tableName} while handling records from that table's ` +
+        `own stream ${properties.streamArn}. Each write would be delivered ` +
+        "back to the function, so the simulation would never settle. Write " +
+        "the result to a different table.",
+    );
+  }
+}

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -23,3 +23,14 @@ export type {
   SimLambdaSqsEventMessageAttribute,
   SimLambdaSqsEventRecord,
 } from "./event-source/poll/sim-lambda-sqs-event.js";
+export type {
+  SimLambdaDynamoDbStreamEvent,
+  SimLambdaDynamoDbStreamEventRecord,
+  SimLambdaDynamoDbStreamEventRecordBody,
+  SimLambdaDynamoDbStreamEventUserIdentity,
+} from "./event-source/poll/sim-lambda-dynamodb-stream-event.js";
+export type {
+  SimLambdaDynamoDbAttributeValue,
+  SimLambdaDynamoDbImage,
+} from "./event-source/stream/sim-lambda-dynamodb-attribute-value.js";
+export { SimLambdaStreamCascadeError } from "./event-source/stream/sim-lambda-stream-cascade.error.js";

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -24,11 +24,13 @@ export type {
   SimLambdaSqsEventRecord,
 } from "./event-source/poll/sim-lambda-sqs-event.js";
 export type {
+  SimLambdaDynamoDbEventAttributeValue,
+  SimLambdaDynamoDbEventImage,
   SimLambdaDynamoDbStreamEvent,
   SimLambdaDynamoDbStreamEventRecord,
   SimLambdaDynamoDbStreamEventRecordBody,
   SimLambdaDynamoDbStreamEventUserIdentity,
-} from "./event-source/poll/sim-lambda-dynamodb-stream-event.js";
+} from "./event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
 export type {
   SimLambdaDynamoDbAttributeValue,
   SimLambdaDynamoDbImage,

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -18,6 +18,10 @@ import {
   type SimLambdaEventSourceQueues,
   SimLambdaNoEventSourceQueues,
 } from "./event-source/queue/sim-lambda-event-source-queues.js";
+import {
+  type SimLambdaEventSourceStreams,
+  SimLambdaNoEventSourceStreams,
+} from "./event-source/stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
@@ -38,6 +42,7 @@ export interface SimLambdaProperties {
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
   readonly urlRegistry?: SimLambdaUrlRegistry;
   readonly eventSourceQueues?: SimLambdaEventSourceQueues;
+  readonly eventSourceStreams?: SimLambdaEventSourceStreams;
 }
 
 interface SimLambdaCommandsProperties extends SimLambdaProperties {
@@ -72,9 +77,11 @@ export class SimLambdaCommands {
       // is enough; a SimAws-created one shares the environment-wide registry
       // the serving layer routes with.
       urlRegistry = new SimLambdaUrlRegistry(),
-      // A standalone SimLambda has no simulated SQS to poll, so an event source
-      // mapping made on one is refused rather than never delivering.
+      // A standalone SimLambda has no simulated SQS or DynamoDB to poll, so an
+      // event source mapping made on one is refused rather than never
+      // delivering.
       eventSourceQueues = new SimLambdaNoEventSourceQueues(),
+      eventSourceStreams = new SimLambdaNoEventSourceStreams(),
     } = properties;
 
     this.functionLookup = new SimLambdaFunctionLookup({
@@ -102,9 +109,11 @@ export class SimLambdaCommands {
       pollers: new SimLambdaEventSourcePollers({
         functions: this.functionLookup,
         queues: eventSourceQueues,
+        streams: eventSourceStreams,
         background,
       }),
       queues: eventSourceQueues,
+      streams: eventSourceStreams,
       functions: this.functionLookup,
       iam,
       background,

--- a/test/lambda/event-source-fixture.ts
+++ b/test/lambda/event-source-fixture.ts
@@ -121,28 +121,32 @@ export async function makeConsumerFunction(
 
 /**
  * A handler that records the events it is given.
+ *
+ * The event type is the parameter, because what a mapping delivers depends on
+ * the event source it polls: a queue mapping hands over an SQS event and a
+ * stream mapping hands over a DynamoDB stream event.
  */
-export interface RecordingHandler {
+export interface RecordingHandler<Event> {
   readonly handler: SimLambdaHandler;
-  readonly events: SimLambdaSqsEvent[];
+  readonly events: Event[];
 }
 
 /**
  * Make a handler recording every event it receives, and returning a result.
  */
-export function recordingHandler(
-  result: (event: SimLambdaSqsEvent) => unknown = (): undefined => undefined,
-): RecordingHandler {
-  const events: SimLambdaSqsEvent[] = [];
+export function recordingHandler<Event = SimLambdaSqsEvent>(
+  result: (event: Event) => unknown = (): undefined => undefined,
+): RecordingHandler<Event> {
+  const events: Event[] = [];
 
   return {
     events,
     handler: (event: unknown): unknown => {
-      const sqsEvent = event as SimLambdaSqsEvent;
+      const received = event as Event;
 
-      events.push(sqsEvent);
+      events.push(received);
 
-      return result(sqsEvent);
+      return result(received);
     },
   };
 }

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -1,0 +1,196 @@
+/**
+ * The parts a DynamoDB stream event source mapping test needs before it can say
+ * anything about delivery: a streamed table, a role that may read its stream, a
+ * function to deliver to, and the mapping between them.
+ *
+ * A sibling of the queue fixture rather than part of it: the recording handler
+ * is shared from there, and everything else about a stream mapping differs.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  type EventSourcePosition,
+} from "@aws-sdk/client-lambda";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simDynamoDbStreamedTableFactory } from "../../src/service/dynamodb/stream/sim-dynamodb-streamed-table.factory.js";
+import type { SimDynamoDbStreamViewType } from "../../src/service/dynamodb/stream/sim-dynamodb-stream.types.js";
+import type { SimLambdaDynamoDbStreamEvent } from "../../src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+import { recordingHandler } from "./event-source-fixture.js";
+
+/**
+ * The DynamoDB Streams operations real Lambda requires an execution role to be
+ * allowed before it will create an event source mapping on a stream.
+ */
+export const streamPollingActions: readonly string[] = [
+  "dynamodb:DescribeStream",
+  "dynamodb:GetRecords",
+  "dynamodb:GetShardIterator",
+];
+
+/**
+ * One simulated AWS with a streamed table on it.
+ */
+export interface SimDynamoDbSourceStream {
+  readonly simAws: SimAws;
+  readonly tableName: string;
+  readonly streamArn: string;
+}
+
+interface SourceStreamOptions {
+  readonly tableName?: string;
+  readonly viewType?: SimDynamoDbStreamViewType;
+}
+
+/**
+ * Make a table with a stream for an event source mapping to poll.
+ */
+export async function makeSourceStream(
+  simAws: SimAws,
+  options: SourceStreamOptions = {},
+): Promise<SimDynamoDbSourceStream> {
+  const tableName = options.tableName ?? "orders";
+  const table = await simDynamoDbStreamedTableFactory.make(
+    {
+      tableName,
+      ...(options.viewType !== undefined && { viewType: options.viewType }),
+    },
+    simAws,
+  );
+  const streamArn = table.stream.latest?.arn;
+
+  assertNonNullable(streamArn, "The table has a stream ARN");
+
+  return { simAws, tableName, streamArn };
+}
+
+/**
+ * Make an execution role allowed to read a stream.
+ *
+ * `dynamodb:ListStreams` is on every stream rather than on one, which is what
+ * both the AWS managed policy and CDK's own grant do.
+ */
+export async function makeStreamPollingRole(
+  simAws: SimAws,
+  streamArn: string,
+  actions: readonly string[] = streamPollingActions,
+): Promise<string> {
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderProjectorRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderProjectorRole",
+      PolicyName: "ProjectOrders",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          { Effect: "Allow", Action: actions, Resource: streamArn },
+          {
+            Effect: "Allow",
+            Action: "dynamodb:ListStreams",
+            Resource: "*",
+          },
+          { Effect: "Allow", Action: "dynamodb:PutItem", Resource: "*" },
+        ],
+      }),
+    }),
+  );
+
+  const roleArn = role.Role.Arn;
+  assertNonNullable(roleArn, "CreateRole answered with a role ARN");
+
+  return roleArn;
+}
+
+/**
+ * One simulated AWS with a table's stream delivering to a function.
+ */
+export interface SimDynamoDbStreamEventSourceFixture extends SimDynamoDbSourceStream {
+  readonly functionName: string;
+  readonly roleArn: string;
+  readonly events: SimLambdaDynamoDbStreamEvent[];
+  readonly uuid: string;
+}
+
+interface StreamEventSourceOptions {
+  readonly simAws?: SimAws;
+  readonly tableName?: string;
+  readonly viewType?: SimDynamoDbStreamViewType;
+  readonly roleActions?: readonly string[];
+  readonly handlerResult?: (event: SimLambdaDynamoDbStreamEvent) => unknown;
+  readonly batchSize?: number;
+  readonly startingPosition?: EventSourcePosition;
+}
+
+/**
+ * Make a simulated AWS with a streamed table, a projector function, and a
+ * mapping from one to the other.
+ */
+export async function simAwsWithStreamEventSource(
+  options: StreamEventSourceOptions = {},
+): Promise<SimDynamoDbStreamEventSourceFixture> {
+  const simAws = options.simAws ?? new SimAws();
+  const stream = await makeSourceStream(simAws, {
+    ...(options.tableName !== undefined && { tableName: options.tableName }),
+    ...(options.viewType !== undefined && { viewType: options.viewType }),
+  });
+  const roleArn = await makeStreamPollingRole(
+    simAws,
+    stream.streamArn,
+    options.roleActions,
+  );
+  const { handler, events } = recordingHandler<SimLambdaDynamoDbStreamEvent>(
+    options.handlerResult,
+  );
+  const functionName = await makeProjectorFunction(simAws, roleArn, handler);
+
+  const mapping = await simAws.lambda().createEventSourceMapping(
+    new CreateEventSourceMappingCommand({
+      EventSourceArn: stream.streamArn,
+      FunctionName: functionName,
+      StartingPosition: options.startingPosition ?? "TRIM_HORIZON",
+      ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
+    }),
+  );
+
+  assertNonNullable(mapping.UUID, "The mapping has a UUID");
+
+  return { ...stream, functionName, roleArn, events, uuid: mapping.UUID };
+}
+
+/**
+ * Make a function backed by a real in-process handler, so a test can watch what
+ * the handler was given.
+ */
+async function makeProjectorFunction(
+  simAws: SimAws,
+  roleArn: string,
+  handler: SimLambdaHandler,
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "order-projector",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  return "order-projector";
+}

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -18,7 +18,7 @@ import { assertNonNullable } from "@kensio/smartass";
 import { SimAws } from "../../src/service/aws/sim-aws.js";
 import { simDynamoDbStreamedTableFactory } from "../../src/service/dynamodb/stream/sim-dynamodb-streamed-table.factory.js";
 import type { SimDynamoDbStreamViewType } from "../../src/service/dynamodb/stream/sim-dynamodb-stream.types.js";
-import type { SimLambdaDynamoDbStreamEvent } from "../../src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.js";
+import type { SimLambdaDynamoDbStreamEvent } from "../../src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
 import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
 import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
 import { recordingHandler } from "./event-source-fixture.js";


### PR DESCRIPTION
… function

An event source mapping from a table's stream to a function invokes it with the DynamoDB stream event when the table changes. A failing batch blocks its shard until it is through or discarded, and a function writing back into its own source table is refused rather than delivered its own writes forever.

Resolves https://github.com/KensioSoftware/yulin/issues/341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for delivering DynamoDB Streams records to Lambda through event source mappings.
  * Added configurable starting positions, including `TRIM_HORIZON` and `LATEST`.
  * Added AWS-shaped DynamoDB stream event payloads and attribute image types.
  * Added stream batching, retries, checkpointing, shard ordering, and lifecycle handling.
  * Added safeguards against self-triggering write cascades.

* **Documentation**
  * Added setup guidance, permissions, limitations, event formats, retry behavior, and a complete usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->