### PR TITLE
feat: report individual record failures from a simulated DynamoDB str…

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -539,9 +539,10 @@ the sender sees is the message coming back.
 
 ### Reporting individual message failures
 
-A mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
+A queue mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
 `batchItemFailures` list the handler returns: the message ids named in it go back to the queue, and
-the rest of the batch is deleted.
+the rest of the batch is deleted. A stream mapping takes the same list and does something else with
+it, which is [reporting individual record failures](#reporting-individual-record-failures).
 
 ```typescript
 await simAws.lambda().createEventSourceMapping(
@@ -783,6 +784,46 @@ documents no delay between attempts and retries until the records age out of the
 later. A delay of zero here would fall due at the instant the clock already reads, so a handler that
 always throws would leave `advanceBy` with work falling due forever, and waiting out a simulated day
 is the same problem with more steps.
+
+### Reporting individual record failures
+
+A stream mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
+`batchItemFailures` list the handler returns. For a stream the identifier is the record's
+`SequenceNumber`:
+
+```typescript
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+    FunctionResponseTypes: ["ReportBatchItemFailures"],
+  }),
+);
+
+// The handler reports the sequence numbers it could not handle.
+const handler = (event: SimLambdaDynamoDbStreamEvent) => ({
+  batchItemFailures: event.Records.filter((record) => !canHandle(record)).map(
+    (record) => ({ itemIdentifier: record.dynamodb.SequenceNumber }),
+  ),
+});
+```
+
+What a stream does with that report is not what a queue does with it. A queue takes back the
+messages the report names and deletes the rest. A stream moves its checkpoint to the lowest sequence
+number the report names and delivers everything from there again, including the records after it
+that the handler did handle. That is real AWS behaviour rather than a simulation artifact, and it is
+why a stream consumer has to be idempotent.
+
+So a report naming only the last record of a batch delivers that record again. A report naming the
+first record delivers the whole batch again. The redelivery is a retry like any other: it waits out
+the same backoff, counts against the same five attempts, and what is left is discarded when they run
+out.
+
+A report naming a sequence number that was not in the batch delivers the whole batch again, as real
+Lambda does with a report it cannot trust. So does an entry with no `itemIdentifier`. A handler that
+returns nothing, or an empty `batchItemFailures` list, has handled the whole batch. A mapping
+created without `FunctionResponseTypes` ignores a report entirely.
 
 ### Writing back to the source table
 
@@ -1551,7 +1592,8 @@ Sim Lambda currently supports:
 - `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, with a failing batch
   blocking its shard until it is through or discarded
 - `FunctionResponseTypes: ["ReportBatchItemFailures"]` on a queue mapping, returning only the
-  message ids the handler reported
+  message ids the handler reported, and on a stream mapping, rewinding to the lowest sequence number
+  the handler reported
 - Function code from three sources:
   - an in-process handler function passed via `makeLambdaZipFileInput(...)`
   - zip archive bytes on `Code.ZipFile` (build them with `makeLambdaCodeZip(...)`)
@@ -1615,15 +1657,13 @@ Current documented limitations:
   `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
   `ParallelizationFactor`, `TumblingWindowInSeconds` and the other mapping inputs this simulation
   has no behaviour for.
-- `FunctionResponseTypes: ["ReportBatchItemFailures"]` is refused on a stream mapping rather than
-  accepted and ignored. A stream retries a batch from the record a report names onward, where a
-  queue takes back the messages it names, and a failing stream batch is retried whole here. That
-  rule is [issue 342](https://github.com/KensioSoftware/yulin/issues/342).
 - A stream batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, and then
   discarded. AWS
   documents no delay between attempts and retries until the records age out. Both differences are
   deliberate: a delay of zero falls due at the instant the clock already reads, so a handler that
-  always throws would leave `advanceBy` with work falling due forever.
+  always throws would leave `advanceBy` with work falling due forever. A batch item failure report
+  counts against the same five attempts, rather than starting them again for the records it rewound
+  to.
 - A handler writing into the table whose stream invoked it is refused with
   `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
   that loop.

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -325,6 +325,16 @@ last read handed back) alongside the retry backoff and the poll schedule, becaus
 decision. A batch the function took moves the checkpoint and the mapping reads on. A batch it threw
 on leaves the checkpoint where it is, so the same records are read again and nothing behind them is
 delivered until they are through: that is a stream mapping blocking its shard.
+
+`SimLambdaStreamBatchResponse` is what a report from the function does to that checkpoint, and it is
+a sibling of `SimLambdaSqsBatchResponse` rather than a reuse of it. A queue partitions the batch,
+because each message is deleted or returned on its own. A stream holds one place, so the answer is
+one place: `SimLambdaStreamBatchOutcome` is either the batch finished with or the sequence number to
+go back to, which is the lowest one the report named. Everything from there is delivered again,
+including the records after it that the function handled. Partitioning a stream batch the way a
+queue batch is partitioned would checkpoint past records the function never reached and lose them
+with no error. Reading the report itself is shared with the queue in `SimLambdaBatchItemFailures`,
+and so is the defence that a report naming something outside the batch fails the whole batch.
 `SimLambdaStreamRetryBackoff` is why the wait is strictly positive and why the attempts are counted.
 A retry scheduled at the instant the clock already reads falls due inside every interval
 `advanceBy` walks, so a handler that always throws would never let it return, and both that trap and
@@ -347,8 +357,12 @@ it makes and however it makes them, and are refused with `SimLambdaStreamCascade
 delivery is over rather than left to spin.
 
 `SimDynamoDbEventSourceStreams` implements the port over the DynamoDB Streams commands, as the
-execution role, and `SimDynamoDbEventSourceStreamShard` is the part that finds the table and the
-shard and reads records off it. The port is SDK-shaped for the same reason the Streams API exists at
+execution role. `SimDynamoDbEventSourceStreamShard` is the part that finds the table and the shard,
+including the shard iterator a place is read from, and `SimDynamoDbEventSourceStreamReader` reads
+the records. `sim-dynamodb-event-source-stream-positions.ts` translates between the places a mapping
+holds and what `GetShardIterator` is asked for: a mapping sent back by a failure report asks with
+`AT_SEQUENCE_NUMBER`, since the record it named is one the function is to be given again rather than
+one it is finished with. The port is SDK-shaped for the same reason the Streams API exists at
 all: a bespoke read interface would be `GetRecords` under another name, and would not authorize.
 The `SimLambdaEventSourceStreamService` and `SimLambdaEventSourceStreamActivity` interfaces are
 declared here and satisfied structurally by `SimDynamoDb`, so neither service imports the other.

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -78,7 +78,7 @@ export class SimLambdaEventSourceMappingInput {
         startingPositionTimestamp: input.StartingPositionTimestamp,
       }),
       enabled: input.Enabled ?? true,
-      functionResponseTypes: functionResponseTypesIn(input, eventSourceArn),
+      functionResponseTypes: functionResponseTypesIn(input),
     });
   }
 }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-values.ts
@@ -1,25 +1,16 @@
-import type { SimLambdaEventSourceArn } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
-import {
-  SimLambdaInvalidParameterValueException,
-  SimLambdaValidationException,
-} from "../../error/sim-lambda.error.js";
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
 import type { SimCreateEventSourceMappingCommandInput } from "./event-source-mapping.command.js";
 
 /**
- * The response types the function reports, refusing one Lambda does not have
- * and one the event source has no simulated rule for.
+ * The response types the function reports, refusing one Lambda does not have.
  *
- * A batch item failure report means different things to the two sources. A
- * queue takes back the messages a report names; a stream retries the batch from
- * the record it names onward, and a failing stream batch is retried whole here.
- * Accepting the flag on a stream mapping would be a mapping that says it does
- * one thing and does another, which is
- * https://github.com/KensioSoftware/yulin/issues/342.
+ * Both event sources take a batch item failure report, and each does its own
+ * thing with it: a queue takes back the messages a report names, and a stream
+ * goes back to the record it names and delivers everything from there again.
  */
 export function functionResponseTypesIn(
   input: SimCreateEventSourceMappingCommandInput,
-  eventSourceArn: SimLambdaEventSourceArn,
 ): readonly SimLambdaFunctionResponseType[] {
   const responseTypes = input.FunctionResponseTypes ?? [];
 
@@ -30,15 +21,6 @@ export function functionResponseTypesIn(
           "function response type. ReportBatchItemFailures is the only one",
       );
     }
-  }
-
-  if (responseTypes.length > 0 && eventSourceArn.kind === "dynamodb-stream") {
-    throw new SimLambdaInvalidParameterValueException(
-      "FunctionResponseTypes on a DynamoDB stream event source mapping is " +
-        "not simulated: a stream retries a batch from the record a report " +
-        "names onward, rather than taking back the records it names, and a " +
-        "failing batch is retried whole here",
-    );
   }
 
   return responseTypes as readonly SimLambdaFunctionResponseType[];

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -4,6 +4,8 @@ import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda
 import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
 import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
 
 interface SimLambdaDynamoDbStreamDeliveryProperties {
   readonly mapping: SimLambdaEventSourceMapping;
@@ -11,16 +13,15 @@ interface SimLambdaDynamoDbStreamDeliveryProperties {
 }
 
 /**
- * Hands one batch of stream records to a function and says whether it took
- * them.
+ * Hands one batch of stream records to a function and says what became of it.
  *
  * The batch is invoked directly rather than through the Invoke command because
  * the handler's error has to be seen: an asynchronous invocation drops it, and
  * this is what decides whether the mapping's checkpoint moves.
  *
- * There is no partial answer here, unlike a queue delivery. A function reading
- * a stream either handled the batch or did not, until it is allowed to report
- * its own batch item failures.
+ * The answer is one place on the shard rather than a pair of lists, which is
+ * the difference between a stream and a queue. What that place is depends on
+ * what the function said, so the batch response decides it.
  *
  * What the function did with the table while it ran is part of the same
  * question, so the cascade guard belongs here too: a handler writing back into
@@ -28,22 +29,26 @@ interface SimLambdaDynamoDbStreamDeliveryProperties {
  */
 export class SimLambdaDynamoDbStreamDelivery {
   private readonly eventBuilder: SimLambdaDynamoDbStreamEventBuilder;
+  private readonly batchResponse: SimLambdaStreamBatchResponse;
   private readonly cascade: SimLambdaStreamCascadeGuard;
 
   constructor(properties: SimLambdaDynamoDbStreamDeliveryProperties) {
     this.eventBuilder = new SimLambdaDynamoDbStreamEventBuilder(
       properties.eventSourceArn,
     );
+    this.batchResponse = new SimLambdaStreamBatchResponse(
+      properties.mapping.reportsBatchItemFailures,
+    );
     this.cascade = new SimLambdaStreamCascadeGuard(properties);
   }
 
   /**
-   * Deliver a batch, answering with whether the function handled it.
+   * Deliver a batch, answering with what became of it.
    */
   async to(
     simFunction: SimLambdaFunction,
     records: readonly SimLambdaEventSourceStreamRecord[],
-  ): Promise<boolean> {
+  ): Promise<SimLambdaStreamBatchOutcome> {
     return await this.cascade.around(
       async () => await this.handled(simFunction, records),
     );
@@ -60,15 +65,16 @@ export class SimLambdaDynamoDbStreamDelivery {
   private async handled(
     simFunction: SimLambdaFunction,
     records: readonly SimLambdaEventSourceStreamRecord[],
-  ): Promise<boolean> {
+  ): Promise<SimLambdaStreamBatchOutcome> {
     try {
-      await simFunction.invoke(this.eventBuilder.of(records));
-
-      return true;
+      return this.batchResponse.handled(
+        records,
+        await simFunction.invoke(this.eventBuilder.of(records)),
+      );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs. What
       // the table sees is the batch being tried again.
-      return false;
+      return this.batchResponse.failed();
     }
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
@@ -1,0 +1,62 @@
+import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+
+/**
+ * What became of one batch of stream records handed to a function.
+ *
+ * A queue batch splits into the messages that were handled and the ones that
+ * go back, because each message is deleted or returned on its own. A stream
+ * batch does not split. The mapping holds one place on the shard, so the answer
+ * is one place: either the batch is finished with, or reading goes back to a
+ * record and everything from there is delivered again.
+ */
+export class SimLambdaStreamBatchOutcome {
+  public readonly isHandled: boolean;
+
+  private readonly rewindTo: string | undefined;
+
+  private constructor(isHandled: boolean, rewindTo: string | undefined) {
+    this.isHandled = isHandled;
+    this.rewindTo = rewindTo;
+  }
+
+  /**
+   * A batch the function took in full.
+   */
+  static handled(): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome(true, undefined);
+  }
+
+  /**
+   * A batch the function did not take, which is read again from where it was.
+   */
+  static failed(): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome(false, undefined);
+  }
+
+  /**
+   * A batch the function reported failing partway through, which is read again
+   * from the record it named.
+   */
+  static failedFrom(sequenceNumber: string): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome(false, sequenceNumber);
+  }
+
+  /**
+   * Where the next read starts when the batch goes back.
+   *
+   * A batch that failed whole goes back to where it was read from, which is the
+   * place handed in. One the function reported on goes back to the record it
+   * named, which may be behind or ahead of that place.
+   */
+  retryPosition(
+    readFrom: SimLambdaEventSourceStreamPosition,
+  ): SimLambdaEventSourceStreamPosition {
+    const sequenceNumber = this.rewindTo;
+
+    if (sequenceNumber === undefined) {
+      return readFrom;
+    }
+
+    return { kind: "sequence", sequenceNumber };
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
@@ -1,0 +1,144 @@
+import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type {
+  SimLambdaEventSourceStreamPosition,
+  SimLambdaEventSourceStreamRecord,
+} from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
+
+/**
+ * Where the mapping read this batch from, which is where a batch that failed
+ * whole is read again from.
+ */
+const readFrom: SimLambdaEventSourceStreamPosition = {
+  kind: "iterator",
+  shardIterator: "iterator-1",
+};
+
+const records: readonly SimLambdaEventSourceStreamRecord[] = [
+  { eventID: "event-1", dynamodb: { SequenceNumber: "100" } },
+  { eventID: "event-2", dynamodb: { SequenceNumber: "200" } },
+  { eventID: "event-3", dynamodb: { SequenceNumber: "300" } },
+];
+
+/**
+ * The sequence number the next read starts at, or the iterator it starts from
+ * when the batch goes back whole.
+ */
+function retryFrom(position: SimLambdaEventSourceStreamPosition): string {
+  if (position.kind === "sequence") {
+    return position.sequenceNumber;
+  }
+
+  return "read from where it was";
+}
+
+describe("sim Lambda stream batch responses", () => {
+  it("goes back to the lowest sequence number a report names", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function reports the last two records, out of order.
+    const outcome = response.handled(records, {
+      batchItemFailures: [{ itemIdentifier: "300" }, { itemIdentifier: "200" }],
+    });
+
+    // Then reading goes back to the earlier of them, so the record after it is
+    // delivered again even though the function did not name it. That is the
+    // checkpoint rewind AWS documents, and the reason a stream consumer has to
+    // be idempotent.
+    assertIdentical(retryFrom(outcome.retryPosition(readFrom)), "200");
+  });
+
+  it("keeps the whole batch when the mapping expects no failure report", () => {
+    // Given a mapping the function does not report batch item failures to.
+    const response = new SimLambdaStreamBatchResponse(false);
+
+    // When the function returns a report anyway.
+    const outcome = response.handled(records, {
+      batchItemFailures: [{ itemIdentifier: "100" }],
+    });
+
+    // Then it is ignored, as real Lambda ignores one it was not told to
+    // expect.
+    assertTrue(outcome.isHandled);
+  });
+
+  it("keeps the whole batch for a report naming nothing", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function returns an empty report.
+    const outcome = response.handled(records, { batchItemFailures: [] });
+
+    // Then the batch is finished with.
+    assertTrue(outcome.isHandled);
+  });
+
+  it("reads the whole batch again for a report naming a record outside it", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function names a sequence number that was not in the batch.
+    const outcome = response.handled(records, {
+      batchItemFailures: [{ itemIdentifier: "400" }],
+    });
+
+    // Then the whole batch goes over again rather than guessing which record
+    // was meant. Guessing wrong on a stream skips records rather than
+    // repeating them.
+    assertIdentical(
+      retryFrom(outcome.retryPosition(readFrom)),
+      "read from where it was",
+    );
+  });
+
+  it("reads the whole batch again for an entry with no sequence number", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function reports an entry whose identifier is empty.
+    const outcome = response.handled(records, {
+      batchItemFailures: [{ itemIdentifier: "" }],
+    });
+
+    // Then the whole batch goes over again.
+    assertIdentical(
+      retryFrom(outcome.retryPosition(readFrom)),
+      "read from where it was",
+    );
+  });
+
+  it("names no record for a batch whose records carry no sequence number", () => {
+    // Given a mapping expecting a failure report, and a batch of records the
+    // stream handed over without sequence numbers.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function reports an entry naming nothing.
+    const outcome = response.handled([{ eventID: "event-1" }], {
+      batchItemFailures: [{ itemIdentifier: "" }],
+    });
+
+    // Then a record with nothing to name it is not named by an empty
+    // identifier: the batch goes over again whole.
+    assertIdentical(
+      retryFrom(outcome.retryPosition(readFrom)),
+      "read from where it was",
+    );
+  });
+
+  it("reads the whole batch again when the function threw", () => {
+    // Given a mapping expecting a failure report.
+    const response = new SimLambdaStreamBatchResponse(true);
+
+    // When the function threw rather than returning anything.
+    const outcome = response.failed();
+
+    // Then the batch is read again from where it was.
+    assertIdentical(
+      retryFrom(outcome.retryPosition(readFrom)),
+      "read from where it was",
+    );
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
@@ -1,0 +1,96 @@
+import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaBatchItemFailures } from "./sim-lambda-batch-item-failures.js";
+import { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+
+/**
+ * Reads what a function said about the batch of stream records it was given.
+ *
+ * A sibling of the queue's batch response rather than a variation on it, and
+ * the rule is the one AWS states for a stream: the lowest sequence number the
+ * report names becomes the checkpoint, and everything from there is delivered
+ * again. Records after it that the function did handle are delivered again too,
+ * which is why a stream consumer has to be idempotent.
+ *
+ * A report naming a record that was not in the batch returns the whole batch,
+ * as it does for a queue: the alternative is to guess which record was meant,
+ * and guessing wrong on a stream skips records rather than repeating them.
+ */
+export class SimLambdaStreamBatchResponse {
+  private readonly batchItemFailures: SimLambdaBatchItemFailures;
+
+  constructor(reportsBatchItemFailures: boolean) {
+    this.batchItemFailures = new SimLambdaBatchItemFailures(
+      reportsBatchItemFailures,
+    );
+  }
+
+  /**
+   * What became of a batch the function returned from.
+   */
+  handled(
+    records: readonly SimLambdaEventSourceStreamRecord[],
+    result: unknown,
+  ): SimLambdaStreamBatchOutcome {
+    const failedIds = this.batchItemFailures.idsIn(result);
+
+    if (failedIds === undefined) {
+      return SimLambdaStreamBatchOutcome.handled();
+    }
+
+    const rewindTo = rewindPoint(failedIds, sequenceNumbersOf(records));
+
+    if (rewindTo === undefined) {
+      return this.failed();
+    }
+
+    return SimLambdaStreamBatchOutcome.failedFrom(rewindTo);
+  }
+
+  /**
+   * What becomes of a batch the function threw on: the whole of it is read
+   * again.
+   */
+  failed(): SimLambdaStreamBatchOutcome {
+    return SimLambdaStreamBatchOutcome.failed();
+  }
+}
+
+/**
+ * The sequence numbers a batch's records can be named by, in stream order.
+ *
+ * A record carrying none is left out rather than given an empty name, so a
+ * report entry with no identifier names nothing and the whole batch goes back.
+ */
+function sequenceNumbersOf(
+  records: readonly SimLambdaEventSourceStreamRecord[],
+): readonly string[] {
+  return records.flatMap((record) => {
+    const sequenceNumber = record.dynamodb?.SequenceNumber;
+
+    if (sequenceNumber === undefined || sequenceNumber === "") {
+      return [];
+    }
+
+    return [sequenceNumber];
+  });
+}
+
+/**
+ * The record a report sends the mapping back to, or undefined for a report it
+ * cannot be trusted.
+ *
+ * The batch is in stream order, so the first record the report names is the
+ * lowest sequence number it named.
+ */
+function rewindPoint(
+  failedIds: readonly string[],
+  sequenceNumbers: readonly string[],
+): string | undefined {
+  if (failedIds.some((failedId) => !sequenceNumbers.includes(failedId))) {
+    return undefined;
+  }
+
+  return sequenceNumbers.find((sequenceNumber) =>
+    failedIds.includes(sequenceNumber),
+  );
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
@@ -39,7 +39,8 @@ export class SimLambdaStreamCheckpoint {
    * A batch that failed whole is read again from where it was. One the function
    * reported failing partway through moves the checkpoint to the record it
    * named, so that record and everything after it goes over again, including
-   * the records before it in the batch that the function did handle.
+   * the records after it that the function did handle. The records before it
+   * are finished with.
    */
   retry(outcome: SimLambdaStreamBatchOutcome): void {
     this.#position = outcome.retryPosition(this.#position);

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
@@ -1,5 +1,6 @@
 import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 
 /**
  * How far along its stream one mapping has got.
@@ -30,5 +31,17 @@ export class SimLambdaStreamCheckpoint {
    */
   advanceTo(position: SimLambdaEventSourceStreamPosition): void {
     this.#position = position;
+  }
+
+  /**
+   * Take a batch the function did not finish.
+   *
+   * A batch that failed whole is read again from where it was. One the function
+   * reported failing partway through moves the checkpoint to the record it
+   * named, so that record and everything after it goes over again, including
+   * the records before it in the batch that the function did handle.
+   */
+  retry(outcome: SimLambdaStreamBatchOutcome): void {
+    this.#position = outcome.retryPosition(this.#position);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -9,6 +9,7 @@ import type {
   SimLambdaEventSourceStreamPosition,
 } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaEventSourcePollSchedule } from "./sim-lambda-event-source-poll-schedule.js";
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamCheckpoint } from "./sim-lambda-stream-checkpoint.js";
 import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
 
@@ -24,8 +25,10 @@ interface SimLambdaStreamProgressProperties {
  * The two belong together because they are the same decision. A batch the
  * function took moves the checkpoint and the mapping reads on; a batch it threw
  * on leaves the checkpoint where it is and the mapping tries the same records
- * again after a wait. Nothing behind a failing batch is read until it is
- * through, which is what it means for a stream mapping to block its shard.
+ * again after a wait; a batch it reported failing partway through moves the
+ * checkpoint back to the record it named. Nothing behind a failing batch is
+ * read until it is through, which is what it means for a stream mapping to
+ * block its shard.
  */
 export class SimLambdaStreamProgress {
   private readonly checkpoint: SimLambdaStreamCheckpoint;
@@ -71,14 +74,17 @@ export class SimLambdaStreamProgress {
   /**
    * Take what became of a batch: move past it, or wait and try it again.
    */
-  after(handled: boolean, batch: SimLambdaEventSourceStreamBatch): void {
-    if (handled) {
+  after(
+    outcome: SimLambdaStreamBatchOutcome,
+    batch: SimLambdaEventSourceStreamBatch,
+  ): void {
+    if (outcome.isHandled) {
       this.handled(batch);
 
       return;
     }
 
-    this.failed(batch);
+    this.failed(outcome, batch);
   }
 
   /**
@@ -99,14 +105,23 @@ export class SimLambdaStreamProgress {
    * Giving up discards the records and carries on with the stream, which is
    * what AWS does when a stream mapping's error handling runs out. Parking the
    * shard instead would be a simulator invention.
+   *
+   * A report naming a record moves the checkpoint before the wait, so what goes
+   * over again is the batch from that record on. The attempts are still counted
+   * against the same limit: a batch that keeps failing partway through has as
+   * many tries as one that keeps failing whole.
    */
-  failed(batch: SimLambdaEventSourceStreamBatch): void {
+  failed(
+    outcome: SimLambdaStreamBatchOutcome,
+    batch: SimLambdaEventSourceStreamBatch,
+  ): void {
     if (this.backoff.isExhausted) {
       this.handled(batch);
 
       return;
     }
 
+    this.checkpoint.retry(outcome);
     this.schedule.afterSeconds(this.backoff.nextSeconds());
   }
 }

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-batch-failures.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-batch-failures.iso.test.ts
@@ -1,0 +1,232 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type {
+  SimLambdaDynamoDbStreamEvent,
+  SimLambdaDynamoDbStreamEventRecord,
+} from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+
+/**
+ * The orders one batch carries.
+ */
+const orderIds = ["order-1", "order-2", "order-3"];
+
+/**
+ * The whole batch, as one delivery of it reads.
+ */
+const wholeBatch = orderIds.join(", ");
+
+/**
+ * What one report entry names, which is a sequence number for a stream.
+ */
+interface BatchItemFailure {
+  readonly itemIdentifier: unknown;
+}
+
+/**
+ * A handler reporting a batch item failure the first time it is given the
+ * batch, and handling everything it is given after that.
+ *
+ * The retry is the interesting part of every test here, so the failure has to
+ * stop: a handler that always reports would be delivered the same records until
+ * the mapping gives up on them.
+ */
+function reportingOnce(
+  failures: (
+    event: SimLambdaDynamoDbStreamEvent,
+  ) => readonly BatchItemFailure[],
+): (event: SimLambdaDynamoDbStreamEvent) => unknown {
+  let reported = false;
+
+  return (event: SimLambdaDynamoDbStreamEvent): unknown => {
+    if (reported) {
+      return { batchItemFailures: [] };
+    }
+
+    reported = true;
+
+    return { batchItemFailures: failures(event) };
+  };
+}
+
+/**
+ * The sequence number of the record for one order in a batch.
+ */
+function sequenceNumberOf(
+  event: SimLambdaDynamoDbStreamEvent,
+  orderId: string,
+): string {
+  return (
+    event.Records.find((record) => orderIdOf(record) === orderId)?.dynamodb
+      .SequenceNumber ?? ""
+  );
+}
+
+function orderIdOf(record: SimLambdaDynamoDbStreamEventRecord): string {
+  return record.dynamodb.Keys?.["orderId"]?.S ?? "";
+}
+
+/**
+ * The orders each delivery carried, one line per delivery, in the order they
+ * were delivered.
+ */
+function deliveries(events: readonly SimLambdaDynamoDbStreamEvent[]): string[] {
+  return events.map((event) =>
+    event.Records.map((record) => orderIdOf(record)).join(", "),
+  );
+}
+
+/**
+ * Write the batch's orders to the table at once, so one poll reads them all.
+ */
+async function writeOrders(simAws: SimAws, tableName: string): Promise<void> {
+  await Promise.all(
+    orderIds.map(async (orderId) =>
+      simAws.dynamoDb().putItem(
+        new PutItemCommand({
+          TableName: tableName,
+          Item: { orderId: { S: orderId } },
+        }),
+      ),
+    ),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("sim Lambda DynamoDB stream batch item failure reports", () => {
+  it("delivers only the last record again when the report names it", async () => {
+    // Given a stream mapping whose function reports its own batch item
+    // failures, and a handler failing on the last record of the batch.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: sequenceNumberOf(event, "order-3") },
+      ]),
+    });
+
+    // When the batch is delivered and the mapping tries the report again.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then only the record it named went over again.
+    assertArrayEquals(deliveries(events), [wholeBatch, "order-3"]);
+  });
+
+  it("delivers a named record and everything after it, including what succeeded", async () => {
+    // Given a handler failing on the first record of the batch.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: sequenceNumberOf(event, "order-1") },
+      ]),
+    });
+
+    // When the batch is delivered and the mapping tries the report again.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then reading went back to that record and everything from there was
+    // delivered again, including the two records the handler did handle. That
+    // is a checkpoint rewind rather than a set of records taken back, and it is
+    // why a stream consumer has to be idempotent.
+    assertArrayEquals(deliveries(events), [wholeBatch, wholeBatch]);
+  });
+
+  it("takes an empty report as the whole batch handled", async () => {
+    // Given a handler reporting no failures.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: (): unknown => ({ batchItemFailures: [] }),
+    });
+
+    // When the batch is delivered and time passes.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    // Then nothing went over again.
+    assertArrayLength(events, 1);
+  });
+
+  it("delivers the whole batch again for a report naming nothing", async () => {
+    // Given a handler reporting an entry with no sequence number on it.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce(() => [{ itemIdentifier: null }]),
+    });
+
+    // When the batch is delivered and the mapping tries the report again.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the whole batch went over again, as real Lambda does with a report
+    // it cannot trust.
+    assertArrayEquals(deliveries(events), [wholeBatch, wholeBatch]);
+  });
+
+  it("delivers the whole batch again for a report naming a record outside it", async () => {
+    // Given a handler naming a sequence number that was not in the batch.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: reportingOnce(() => [
+        { itemIdentifier: "100000000000000009999" },
+      ]),
+    });
+
+    // When the batch is delivered and the mapping tries the report again.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the whole batch went over again rather than the mapping guessing
+    // which record was meant.
+    assertArrayEquals(deliveries(events), [wholeBatch, wholeBatch]);
+  });
+
+  it("ignores a report from a mapping that was not told to expect one", async () => {
+    // Given a mapping created without FunctionResponseTypes, whose handler
+    // reports a failure anyway.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: reportingOnce((event) => [
+        { itemIdentifier: sequenceNumberOf(event, "order-1") },
+      ]),
+    });
+
+    // When the batch is delivered and time passes.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    // Then the report was ignored and the batch is finished with, as it is on
+    // real Lambda.
+    assertArrayLength(events, 1);
+  });
+
+  it("gives up on a batch the report keeps naming rather than rewinding forever", async () => {
+    // Given a handler that always reports the same record.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      handlerResult: (event): unknown => ({
+        batchItemFailures: [
+          { itemIdentifier: sequenceNumberOf(event, "order-2") },
+        ],
+      }),
+    });
+
+    // When an hour of simulated time passes.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the records from the one it named were delivered five more times,
+    // after 1, 2, 4, 8 and 16 seconds, and then discarded. A report counts
+    // against the same attempts a failing batch does.
+    assertArrayEquals(deliveries(events), [
+      wholeBatch,
+      "order-2, order-3",
+      "order-2, order-3",
+      "order-2, order-3",
+      "order-2, order-3",
+      "order-2, order-3",
+    ]);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-validation.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-event-source-validation.iso.test.ts
@@ -18,7 +18,6 @@ interface StreamMappingRequest {
   readonly StartingPosition?: EventSourcePosition;
   readonly StartingPositionTimestamp?: Date;
   readonly BatchSize?: number;
-  readonly FunctionResponseTypes?: "ReportBatchItemFailures"[];
 }
 
 /**
@@ -102,24 +101,6 @@ describe("sim Lambda DynamoDB stream event source mapping validation", () => {
 
     // Then it is refused, saying what a stream does deliver.
     assertStringIncludes(error.message, "a DynamoDB stream delivers");
-  });
-
-  it("refuses a batch item failure report from a stream mapping", async () => {
-    // Given a stream and a function.
-    // When a mapping says the function reports its own batch item failures.
-    const error = await createStreamMapping({
-      StartingPosition: "TRIM_HORIZON",
-      FunctionResponseTypes: ["ReportBatchItemFailures"],
-    });
-
-    // Then it is refused rather than accepted and ignored: a stream retries
-    // from the record a report names, which is not what a failing batch does
-    // here.
-    assertStringIncludes(
-      error.message,
-      "FunctionResponseTypes on a DynamoDB stream event source mapping is " +
-        "not simulated",
-    );
   });
 
   it("refuses a mapping whose execution role cannot read the stream", async () => {

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-positions.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-positions.ts
@@ -1,0 +1,55 @@
+import type { SimLambdaEventSourceStreamPosition } from "./sim-lambda-event-source-streams.js";
+
+/**
+ * A place named as something other than an iterator, which is what an iterator
+ * has to be asked for.
+ */
+export type SimLambdaEventSourceStreamNamedPosition = Exclude<
+  SimLambdaEventSourceStreamPosition,
+  { readonly kind: "iterator" }
+>;
+
+/**
+ * What GetShardIterator is asked for a named place with.
+ */
+export interface SimDynamoDbEventSourceIteratorType {
+  readonly ShardIteratorType: string;
+  readonly SequenceNumber?: string;
+}
+
+/**
+ * The GetShardIterator input fields a named place asks for.
+ *
+ * A sequence number is asked for with `AT_SEQUENCE_NUMBER` rather than
+ * `AFTER_SEQUENCE_NUMBER`: the record named is one the function is to be given
+ * again, not one it is finished with.
+ */
+export function simDynamoDbEventSourceIteratorTypeOf(
+  position: SimLambdaEventSourceStreamNamedPosition,
+): SimDynamoDbEventSourceIteratorType {
+  if (position.kind === "starting") {
+    return { ShardIteratorType: position.startingPosition };
+  }
+
+  return {
+    ShardIteratorType: "AT_SEQUENCE_NUMBER",
+    SequenceNumber: position.sequenceNumber,
+  };
+}
+
+/**
+ * Where a read leaves the reader.
+ *
+ * A shard with no next iterator is finished with, so there is nowhere to carry
+ * on from and the place the read started at stands.
+ */
+export function simDynamoDbEventSourceNextPosition(
+  shardIterator: string | undefined,
+  readFrom: SimLambdaEventSourceStreamPosition,
+): SimLambdaEventSourceStreamPosition {
+  if (shardIterator === undefined) {
+    return readFrom;
+  }
+
+  return { kind: "iterator", shardIterator };
+}

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-reader.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-reader.ts
@@ -1,0 +1,72 @@
+import type { SimDynamoDbEventSourceStreamShard } from "./sim-dynamodb-event-source-stream-shard.js";
+import { simDynamoDbEventSourceNextPosition } from "./sim-dynamodb-event-source-stream-positions.js";
+import type { SimLambdaEventSourceStreamCommands } from "./sim-lambda-event-source-stream-service.js";
+import type {
+  SimLambdaEventSourceStreamBatch,
+  SimLambdaEventSourceStreamReadRequest,
+} from "./sim-lambda-event-source-streams.js";
+
+interface SimDynamoDbEventSourceStreamReaderProperties {
+  readonly commands: SimLambdaEventSourceStreamCommands;
+  readonly shard: SimDynamoDbEventSourceStreamShard;
+}
+
+/**
+ * Reads batches of records off the shard a mapping polls.
+ *
+ * The iterator a read hands back is the place to carry on from, and a caller
+ * that does not take it reads the same records again. That is what makes a
+ * failed batch go over again from where it was rather than being skipped, and
+ * what makes a batch item failure report able to send the reader back to a
+ * record it has already been given.
+ */
+export class SimDynamoDbEventSourceStreamReader {
+  private readonly commands: SimLambdaEventSourceStreamCommands;
+  private readonly shard: SimDynamoDbEventSourceStreamShard;
+
+  constructor(properties: SimDynamoDbEventSourceStreamReaderProperties) {
+    this.commands = properties.commands;
+    this.shard = properties.shard;
+  }
+
+  /**
+   * Read up to a batch of records from where a position left off.
+   */
+  async read(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<SimLambdaEventSourceStreamBatch> {
+    const { batchSize, caller, position } = request;
+    const output = await this.commands.getRecords(
+      {
+        input: {
+          ShardIterator: await this.iteratorOf(request),
+          Limit: batchSize,
+        },
+      },
+      { caller },
+    );
+    const next = output.NextShardIterator;
+
+    return {
+      records: output.Records ?? [],
+      next: simDynamoDbEventSourceNextPosition(next, position),
+      drained: next === undefined,
+    };
+  }
+
+  /**
+   * The place a read starts from: the one the caller already has, or one the
+   * stream is asked for when the caller names a place instead.
+   */
+  private async iteratorOf(
+    request: SimLambdaEventSourceStreamReadRequest,
+  ): Promise<string> {
+    const { position } = request;
+
+    if (position.kind === "iterator") {
+      return position.shardIterator;
+    }
+
+    return await this.shard.iteratorFor(request, position);
+  }
+}

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.iso.test.ts
@@ -81,9 +81,13 @@ describe("sim DynamoDB event source stream shard", () => {
       }),
     );
 
-    // When a place to start reading is asked for.
+    // When a mapping with only its starting position asks for a place to read
+    // from.
     const error = await assertThrowsErrorAsync(async () => {
-      await shard.iteratorFor(request, "TRIM_HORIZON");
+      await shard.iteratorFor(request, {
+        kind: "starting",
+        startingPosition: "TRIM_HORIZON",
+      });
     });
 
     // Then the mapping is told.
@@ -108,9 +112,13 @@ describe("sim DynamoDB event source stream shard", () => {
       }),
     );
 
-    // When a place to start reading is asked for.
+    // When a mapping sent back to a record by a failure report asks for a
+    // place to read from.
     const error = await assertThrowsErrorAsync(async () => {
-      await shard.iteratorFor(request, "LATEST");
+      await shard.iteratorFor(request, {
+        kind: "sequence",
+        sequenceNumber: "100000000000000000001",
+      });
     });
 
     // Then the mapping is told.

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
@@ -3,12 +3,11 @@ import type {
   SimLambdaEventSourceStreamCommands,
   SimLambdaEventSourceStreamDescription,
 } from "./sim-lambda-event-source-stream-service.js";
-import type { SimLambdaEventSourceStartingPosition } from "../sim-lambda-event-source-starting-position.js";
-import type {
-  SimLambdaEventSourceStreamBatch,
-  SimLambdaEventSourceStreamReadRequest,
-  SimLambdaEventSourceStreamRequest,
-} from "./sim-lambda-event-source-streams.js";
+import {
+  type SimLambdaEventSourceStreamNamedPosition,
+  simDynamoDbEventSourceIteratorTypeOf,
+} from "./sim-dynamodb-event-source-stream-positions.js";
+import type { SimLambdaEventSourceStreamRequest } from "./sim-lambda-event-source-streams.js";
 
 /**
  * What DescribeStream tells a poller about the stream it is about to read.
@@ -40,14 +39,14 @@ export class SimDynamoDbEventSourceStreamShard {
   }
 
   /**
-   * A place on the shard to start reading from.
+   * A place on the shard to read from.
    *
    * A simulated stream has one shard, so the first shard DescribeStream reports
    * is the shard.
    */
   async iteratorFor(
     request: SimLambdaEventSourceStreamRequest,
-    startingPosition: SimLambdaEventSourceStartingPosition,
+    position: SimLambdaEventSourceStreamNamedPosition,
   ): Promise<string> {
     const { caller, streamArn } = request;
     const description = await this.describe(request);
@@ -62,7 +61,7 @@ export class SimDynamoDbEventSourceStreamShard {
         input: {
           StreamArn: streamArn,
           ShardId: shardId,
-          ShardIteratorType: startingPosition,
+          ...simDynamoDbEventSourceIteratorTypeOf(position),
         },
       },
       { caller },
@@ -73,52 +72,6 @@ export class SimDynamoDbEventSourceStreamShard {
     }
 
     return iterator.ShardIterator;
-  }
-
-  /**
-   * Read up to a batch of records from where a position left off.
-   *
-   * The iterator the read hands back is the place to carry on from, and a
-   * caller that does not take it reads the same records again. That is what
-   * makes a failed batch retry from where it was rather than being skipped.
-   */
-  async read(
-    request: SimLambdaEventSourceStreamReadRequest,
-  ): Promise<SimLambdaEventSourceStreamBatch> {
-    const { batchSize, caller, position } = request;
-    const shardIterator = await this.iteratorOf(request);
-    const output = await this.commands.getRecords(
-      { input: { ShardIterator: shardIterator, Limit: batchSize } },
-      { caller },
-    );
-    const next = output.NextShardIterator;
-
-    return {
-      records: output.Records ?? [],
-      // A shard with no next iterator is finished with, so there is nowhere to
-      // carry on from and the position handed in stands.
-      next:
-        next === undefined
-          ? position
-          : { kind: "iterator", shardIterator: next },
-      drained: next === undefined,
-    };
-  }
-
-  /**
-   * The place a read starts from: the one the caller already has, or a new one
-   * for a mapping that has only its starting position.
-   */
-  private async iteratorOf(
-    request: SimLambdaEventSourceStreamReadRequest,
-  ): Promise<string> {
-    const { position } = request;
-
-    if (position.kind === "iterator") {
-      return position.shardIterator;
-    }
-
-    return await this.iteratorFor(request, position.startingPosition);
   }
 
   private async describe(

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-streams.ts
@@ -1,3 +1,4 @@
+import { SimDynamoDbEventSourceStreamReader } from "./sim-dynamodb-event-source-stream-reader.js";
 import { SimDynamoDbEventSourceStreamShard } from "./sim-dynamodb-event-source-stream-shard.js";
 import type {
   SimLambdaEventSourceStreamActivity,
@@ -27,12 +28,18 @@ interface SimDynamoDbEventSourceStreamsProperties {
 export class SimDynamoDbEventSourceStreams implements SimLambdaEventSourceStreams {
   private readonly activity: SimLambdaEventSourceStreamActivity;
   private readonly shard: SimDynamoDbEventSourceStreamShard;
+  private readonly reader: SimDynamoDbEventSourceStreamReader;
 
   constructor(properties: SimDynamoDbEventSourceStreamsProperties) {
     const { dynamoDb } = properties;
+    const commands = dynamoDb.streams();
 
     this.activity = dynamoDb.streamActivity();
-    this.shard = new SimDynamoDbEventSourceStreamShard(dynamoDb.streams());
+    this.shard = new SimDynamoDbEventSourceStreamShard(commands);
+    this.reader = new SimDynamoDbEventSourceStreamReader({
+      commands,
+      shard: this.shard,
+    });
   }
 
   /**
@@ -52,7 +59,7 @@ export class SimDynamoDbEventSourceStreams implements SimLambdaEventSourceStream
   async read(
     request: SimLambdaEventSourceStreamReadRequest,
   ): Promise<SimLambdaEventSourceStreamBatch> {
-    return await this.shard.read(request);
+    return await this.reader.read(request);
   }
 
   /**
@@ -68,9 +75,4 @@ export class SimDynamoDbEventSourceStreams implements SimLambdaEventSourceStream
   unwatch(streamArn: string, watcher: SimLambdaEventSourceStreamWatcher): void {
     this.activity.unwatch(streamArn, watcher);
   }
-
-  /**
-   * The iterator a read starts from, asking the stream for one when the
-   * mapping has only the starting position it was created with.
-   */
 }

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-stream-service.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-stream-service.ts
@@ -51,7 +51,12 @@ export interface SimLambdaEventSourceStreamCommands {
 
   getShardIterator(
     command: {
-      input: { StreamArn: string; ShardId: string; ShardIteratorType: string };
+      input: {
+        StreamArn: string;
+        ShardId: string;
+        ShardIteratorType: string;
+        SequenceNumber?: string | undefined;
+      };
     },
     options?: StreamCommandOptions,
   ): Promise<{ ShardIterator?: string | undefined }>;

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
@@ -47,13 +47,19 @@ export interface SimLambdaEventSourceStreamRecord {
  * A mapping that has read nothing yet has only the starting position it was
  * created with. One that has read something holds the shard iterator the last
  * read handed back, which is the place itself rather than a description of it.
+ *
+ * A sequence number is the third, and it is a place the mapping has already
+ * been: a function that reported failing partway through a batch sends the
+ * mapping back to the record it named, and reading starts at that record rather
+ * than after it.
  */
 export type SimLambdaEventSourceStreamPosition =
   | {
       readonly kind: "starting";
       readonly startingPosition: SimLambdaEventSourceStartingPosition;
     }
-  | { readonly kind: "iterator"; readonly shardIterator: string };
+  | { readonly kind: "iterator"; readonly shardIterator: string }
+  | { readonly kind: "sequence"; readonly sequenceNumber: string };
 
 /**
  * A poller's request to the stream it polls, made as the function's execution

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -137,6 +137,7 @@ interface StreamEventSourceOptions {
   readonly handlerResult?: (event: SimLambdaDynamoDbStreamEvent) => unknown;
   readonly batchSize?: number;
   readonly startingPosition?: EventSourcePosition;
+  readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
 }
 
 /**
@@ -167,6 +168,9 @@ export async function simAwsWithStreamEventSource(
       FunctionName: functionName,
       StartingPosition: options.startingPosition ?? "TRIM_HORIZON",
       ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
+      ...(options.functionResponseTypes !== undefined && {
+        FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
     }),
   );
 


### PR DESCRIPTION
…eam batch

A stream mapping created with ReportBatchItemFailures now rewinds to the lowest sequence number the function reported and delivers everything from there again, rather than partitioning the batch the way a queue mapping does. Splitting a stream batch would checkpoint past records the function never reached.

Resolves https://github.com/KensioSoftware/yulin/issues/342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial batch failure reporting in DynamoDB stream event sources.
  * Failed records can now trigger retries from the earliest reported sequence number, with subsequent records redelivered.
  * Retry behavior respects existing backoff, retry limits, and eventual record discard rules.
  * Added support for configuring and testing batch failure responses.

* **Documentation**
  * Updated guidance for stream handling, validation, availability, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->