### PR TITLE
feat: create a simulated DynamoDB table with a stream from CloudForma…

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3012,9 +3012,9 @@ console.log(stack.outputs.get("OrdersTableArn")?.value);
 
 The properties that are read are `TableName`, `KeySchema`, `AttributeDefinitions`, `BillingMode`,
 `ProvisionedThroughput`, `TableClass`, `DeletionProtectionEnabled`, `Tags`,
-`GlobalSecondaryIndexes`, `LocalSecondaryIndexes` and `TimeToLiveSpecification`. All but the last are
-passed to `CreateTable` rather than applied here, so a value the template gets wrong fails the same
-way it would for an SDK caller.
+`GlobalSecondaryIndexes`, `LocalSecondaryIndexes`, `StreamSpecification` and
+`TimeToLiveSpecification`. All but the last are passed to `CreateTable` rather than applied here, so
+a value the template gets wrong fails the same way it would for an SDK caller.
 
 `TimeToLiveSpecification` is applied after the table is created, through `UpdateTimeToLive`. Real
 `CreateTable` has no parameter for it either, so real CloudFormation makes the table and then
@@ -3027,22 +3027,16 @@ that, which a template cannot predict either way. Two stacks deploying the same 
 differently named tables. The generated name is trimmed to the 255 characters a table name allows,
 ending in a hash of the untrimmed name so two long names that start the same stay apart.
 
-`Fn::GetAtt … StreamArn` on a table that was created is refused by name. A template cannot declare a
-streamed table yet, so a table CloudFormation created never has a stream, and an invented stream ARN
-would read as a working stream to whatever the template handed it to.
-
-A table declaring `StreamSpecification` is skipped rather than created, though, and a skipped
-Resource never reaches that refusal. `Fn::GetAtt … StreamArn` on it resolves to the CloudFormation
-stand-in `OrdersTable.StreamArn` instead, which is not an ARN and fails wherever the simulator reads
-it as one. See
-[values from a skipped Resource](../cloudformation/README.md#values-from-a-skipped-resource).
+`Fn::GetAtt … StreamArn` gives the ARN of the stream the table's `StreamSpecification` gave it. On a
+table with no `StreamSpecification` it is refused by name, naming the table, since an invented stream
+ARN would read as a working stream to whatever the template handed it to. Real CloudFormation refuses
+the same template while validating it, where this refuses when the attribute is asked for.
 
 A property with behaviour that is not simulated skips the resource, with a reason naming the
-property, and the rest of the stack still deploys: `StreamSpecification`,
-`KinesisStreamSpecification`, `SSESpecification`, `PointInTimeRecoverySpecification`,
-`ContributorInsightsSpecification`, `ImportSourceSpecification`, `ResourcePolicy`,
-`OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` does not have fails the
-resource instead, since that is a template real CloudFormation would refuse too.
+property, and the rest of the stack still deploys: `KinesisStreamSpecification`, `SSESpecification`,
+`PointInTimeRecoverySpecification`, `ContributorInsightsSpecification`, `ImportSourceSpecification`,
+`ResourcePolicy`, `OnDemandThroughput` and `WarmThroughput`. A property `AWS::DynamoDB::Table` does
+not have fails the resource instead, since that is a template real CloudFormation would refuse too.
 
 `AWS::DynamoDB::GlobalTable` is skipped rather than deployed, since replication across regions is
 not simulated.
@@ -3165,6 +3159,101 @@ so anything further on one fails the resource, as it would on real CloudFormatio
 A CDK `Table` with `addGlobalSecondaryIndex` and `addLocalSecondaryIndex` synthesises a template that
 deploys here without hand-editing.
 
+## Deploying a table with a stream
+
+A `StreamSpecification` on the resource deploys a table with a stream, and `Fn::GetAtt … StreamArn`
+gives the stream's ARN. CloudFormation's `StreamSpecification` has no `StreamEnabled` field, unlike
+the SDK's: declaring the property is what asks for the stream, and `StreamViewType` is required.
+
+```typescript sim-dynamodb-cloudformation-stream
+/**
+ * Deploying a table with a stream from a CloudFormation template.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+        },
+      },
+    },
+    Outputs: {
+      OrdersStreamArn: {
+        Value: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The Output holds the ARN of the stream the deployed table captures on.
+const streamArn = stack.outputs.get("OrdersStreamArn")?.value as string;
+
+console.log(streamArn.includes("/stream/")); // true
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+// The write is on the stream, read the way any consumer reads it.
+const dynamoDbStreams = simAws.dynamoDbStreams();
+
+const described = await dynamoDbStreams.describeStream(
+  new DescribeStreamCommand({ StreamArn: streamArn }),
+);
+
+const iterator = await dynamoDbStreams.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamArn: streamArn,
+    ShardId: described.StreamDescription?.Shards?.[0]?.ShardId,
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const read = await dynamoDbStreams.getRecords(
+  new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+);
+
+console.log(read.Records?.[0]?.eventName); // "INSERT"
+```
+
+The specification goes to `CreateTable` with the rest of the table, so a template naming a view type
+that does not exist, or naming none at all, is refused in the words `CreateTable` refuses an SDK
+caller in.
+
+`StreamSpecification.ResourcePolicy` is a policy on the stream rather than on the table. It is not
+simulated, so a template declaring one skips the table, naming the whole property path.
+
+Changing `StreamViewType` in a deployed template is a different thing here to what it is on real
+CloudFormation, which replaces the table. `UpdateTable` refuses the change in place, so switching the
+stream off and on again is what gives a table a stream with a different view type.
+
 ## IAM authorization
 
 `CreateTable` authorizes `dynamodb:CreateTable` against the ARN the table is about to have, before
@@ -3250,8 +3339,9 @@ nothing is written.
   `TrimmedDataAccessException` past the trim point.
 - `AWS::DynamoDB::Table` in CloudFormation, created through `CreateTable`, with `Ref` giving the
   table name, `Fn::GetAtt … Arn` the table ARN, `TimeToLiveSpecification` deploying a table that
-  expires items, `Tags` deploying a tagged table, and `GlobalSecondaryIndexes` and
-  `LocalSecondaryIndexes` deploying a table whose indexes are then queried and scanned.
+  expires items, `Tags` deploying a tagged table, `GlobalSecondaryIndexes` and
+  `LocalSecondaryIndexes` deploying a table whose indexes are then queried and scanned, and
+  `StreamSpecification` deploying a table with a stream that `Fn::GetAtt … StreamArn` names.
 - SDK interception, so an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
   simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
@@ -3340,8 +3430,11 @@ nothing is written.
 - A Lambda event source mapping is the only simulated service integration that consumes a stream.
   Anything else reads one through the Streams API itself. A
   Kinesis Data Streams destination is not simulated.
-- A `StreamSpecification` in a CloudFormation template still skips the table, so a streamed table
-  has to be created through `CreateTable`.
+- `Fn::GetAtt … StreamArn` on a table with no `StreamSpecification` is refused when the attribute is
+  asked for, where real CloudFormation refuses the template while validating it. The timing differs,
+  the outcome does not.
+- Changing a deployed table's `StreamViewType` is not the table replacement real CloudFormation
+  performs. The change goes through `UpdateTable`, which refuses a view type change in place.
 - A shard iterator never expires. Real DynamoDB gives one 15 minutes and then answers
   `ExpiredIteratorException`, which a consumer handles by asking for another from the sequence
   number it last checkpointed. Nothing here refuses an iterator for being old.

--- a/docs/services/dynamodb/sim-dynamodb-cloudformation-stream.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-cloudformation-stream.example.ts
@@ -1,0 +1,75 @@
+/**
+ * Deploying a table with a stream from a CloudFormation template.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+        },
+      },
+    },
+    Outputs: {
+      OrdersStreamArn: {
+        Value: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+await simAws.backgroundTasksComplete();
+
+// The Output holds the ARN of the stream the deployed table captures on.
+const streamArn = stack.outputs.get("OrdersStreamArn")?.value as string;
+
+console.log(streamArn.includes("/stream/")); // true
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+
+// The write is on the stream, read the way any consumer reads it.
+const dynamoDbStreams = simAws.dynamoDbStreams();
+
+const described = await dynamoDbStreams.describeStream(
+  new DescribeStreamCommand({ StreamArn: streamArn }),
+);
+
+const iterator = await dynamoDbStreams.getShardIterator(
+  new GetShardIteratorCommand({
+    StreamArn: streamArn,
+    ShardId: described.StreamDescription?.Shards?.[0]?.ShardId,
+    ShardIteratorType: "TRIM_HORIZON",
+  }),
+);
+
+const read = await dynamoDbStreams.getRecords(
+  new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+);
+
+console.log(read.Records?.[0]?.eventName); // "INSERT"

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.iso.test.ts
@@ -37,9 +37,9 @@ function tableAttributeTemplate(attributeName: string): CfnTemplateBodyRecord {
 }
 
 describe("AWS::DynamoDB::Table CloudFormation values", () => {
-  it("refuses Fn::GetAtt StreamArn by name", async () => {
-    // Given a template asking for the table's stream ARN, which is not
-    // simulated because streams are not.
+  it("refuses Fn::GetAtt StreamArn on a table with no stream", async () => {
+    // Given a template asking for the stream ARN of a table it declared no
+    // StreamSpecification on, so the table has no stream.
     const simAws = new SimAws({
       defaultAccountId: accountIdOneOnes,
       defaultRegionName: "eu-west-2",
@@ -56,9 +56,11 @@ describe("AWS::DynamoDB::Table CloudFormation values", () => {
       await stack.waitForDeployComplete();
     });
 
+    // And the refusal names the table it was asked of.
     assertStringIncludes(
       error.message,
-      "Unsupported AWS::DynamoDB::Table attribute StreamArn",
+      "Unsupported AWS::DynamoDB::Table attribute StreamArn: table orders " +
+        "has no StreamSpecification",
     );
   });
 

--- a/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/dynamodb/sim-dynamodb-table-cfn.ts
@@ -28,9 +28,8 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
   /**
    * AWS::DynamoDB::Table attributes.
    *
-   * `Arn` is what an IAM policy names the table by. `StreamArn` is refused by
-   * name: DynamoDB streams are not simulated, and an invented stream ARN would
-   * read as a working stream to whatever the template handed it to.
+   * `Arn` is what an IAM policy names the table by. `StreamArn` is the ARN of
+   * the stream the table's `StreamSpecification` gave it.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     switch (attributeName) {
@@ -38,11 +37,7 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
         return this.table.arn;
       }
       case "StreamArn": {
-        throw new Error(
-          `Unsupported AWS::DynamoDB::Table attribute StreamArn: DynamoDB ` +
-            `streams are not simulated, so there is no stream ARN to give ` +
-            `rather than one nothing is publishing to`,
-        );
+        return this.streamArn();
       }
       default: {
         throw new Error(
@@ -50,5 +45,27 @@ export class SimDynamoDbTableCfn implements SimCfnResourceValueAdapter {
         );
       }
     }
+  }
+
+  /**
+   * The ARN of the table's stream, which it only has if it was asked for.
+   *
+   * A table with no `StreamSpecification` has no stream ARN to give, and an
+   * invented one would read as a working stream to whatever the template handed
+   * it to. Real CloudFormation refuses the same template while validating it,
+   * where this refuses when the attribute is asked for.
+   */
+  private streamArn(): SimCfnTemplateValue {
+    const arn = this.table.stream.latest?.arn;
+
+    if (arn === undefined) {
+      throw new Error(
+        `Unsupported AWS::DynamoDB::Table attribute StreamArn: table ` +
+          `${this.table.tableName} has no StreamSpecification, so it has no ` +
+          `stream and no stream ARN`,
+      );
+    }
+
+    return arn;
   }
 }

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -946,6 +946,8 @@ The parts under `cfn/table/` split by responsibility:
   `GlobalSecondaryIndexes` and `LocalSecondaryIndexes`. The two kinds have different property sets:
   a local secondary index has no throughput or insights settings on AWS either, so anything of the
   sort on one fails the resource rather than skipping it.
+- `SimCfnDynamoDbTableStreamRules` applies the same rule to the `StreamSpecification`, whose nested
+  `ResourcePolicy` is a policy on the stream rather than the table's own.
 - `SimCfnDynamoDbTableValues` reads the plain shapes a property can hold, naming the property path in
   each refusal. It takes a number from the string a template Parameter carries one as.
 - `SimCfnDynamoDbTableProperties` turns the template properties into `CreateTable` input, and
@@ -953,7 +955,9 @@ The parts under `cfn/table/` split by responsibility:
   `SimCfnGeneratedResourceName`. The parts several properties share are read by
   `readSimCfnDynamoDbKeySchema`, `readSimCfnDynamoDbThroughput` and
   `readSimCfnDynamoDbTableIndexes`, since a table and its indexes state their keys and their
-  capacity the same way.
+  capacity the same way. `readSimCfnDynamoDbTableStream` synthesizes the `StreamEnabled` that
+  `CreateTable` requires and CloudFormation's `StreamSpecification` has no field for, from the
+  property being declared at all.
 - `SimCfnDynamoDbTableCreator` calls `SimDynamoDb.createTable()` with that input and finds the
   created table through `SimDynamoDb.findTable()`.
 
@@ -970,8 +974,9 @@ unlikely to be about.
 
 `Ref` and `Fn::GetAtt` behaviour lives with the CloudFormation engine rather than on the table, in
 `SimDynamoDbTableCfn` under `cloudformation/resource/cfn/dynamodb/`. `Ref` answers with the table
-name and `Fn::GetAtt Arn` with the table ARN. `StreamArn` is refused by name, since an invented
-stream ARN would read as a working stream.
+name and `Fn::GetAtt Arn` with the table ARN. `StreamArn` answers with the ARN of the stream the
+table's `StreamSpecification` gave it, and is refused by name on a table with no stream, since an
+invented stream ARN would read as a working stream.
 
 ## Error model
 

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-stream.iso.test.ts
@@ -1,0 +1,246 @@
+import { DescribeTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  ListStreamsCommand,
+} from "@aws-sdk/client-dynamodb-streams";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimDynamoDbStreamsRecord } from "../command/stream/stream.types.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnStack } from "../../cloudformation/stack/sim-cfn-stack.js";
+import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
+
+/**
+ * Deploy a table Resource carrying the properties a test is about.
+ *
+ * The Outputs are stated per test rather than always, since a table that was
+ * skipped or failed has no stream ARN for an Output to take.
+ */
+async function deployTable(
+  simAws: SimAws,
+  properties: SimCfnTemplateValueRecord,
+  outputs: SimCfnTemplateValueRecord = {},
+): Promise<SimCfnStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersTable: simCfnDynamoDbTableResourceFactory.make({
+          tableName: "orders",
+          partitionKeyName: "orderId",
+          properties,
+        }),
+      },
+      Outputs: outputs,
+    },
+  });
+  await stack.waitForDeployComplete();
+  await simAws.backgroundTasksComplete();
+
+  return stack;
+}
+
+/**
+ * The Output a template declaring a stream goes on to use.
+ */
+const streamArnOutputs: SimCfnTemplateValueRecord = {
+  OrdersStreamArn: { Value: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] } },
+};
+
+/**
+ * The records the table's stream holds, read the way a consumer reads them.
+ */
+async function readOrderRecords(
+  simAws: SimAws,
+): Promise<readonly SimDynamoDbStreamsRecord[]> {
+  const dynamoDbStreams = simAws.dynamoDbStreams();
+
+  const listed = await dynamoDbStreams.listStreams(
+    new ListStreamsCommand({ TableName: "orders" }),
+  );
+  const streamArn = listed.Streams?.[0]?.StreamArn;
+
+  const described = await dynamoDbStreams.describeStream(
+    new DescribeStreamCommand({ StreamArn: streamArn }),
+  );
+  const iterator = await dynamoDbStreams.getShardIterator(
+    new GetShardIteratorCommand({
+      StreamArn: streamArn,
+      ShardId: described.StreamDescription?.Shards?.[0]?.ShardId,
+      ShardIteratorType: "TRIM_HORIZON",
+    }),
+  );
+
+  const read = await dynamoDbStreams.getRecords(
+    new GetRecordsCommand({ ShardIterator: iterator.ShardIterator }),
+  );
+
+  return read.Records ?? [];
+}
+
+describe("DynamoDB CloudFormation Table stream", () => {
+  it("deploys a table that captures its changes on a stream", async () => {
+    // Given a template declaring a stream on its table, which CloudFormation
+    // states as a view type with no StreamEnabled of its own.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await deployTable(simAws, {
+      StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+    });
+
+    // Then the table reports the stream, as it would for an SDK caller.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+    assertNonNullable(described.Table?.StreamSpecification);
+    assertTrue(described.Table.StreamSpecification.StreamEnabled);
+    assertIdentical(
+      described.Table.StreamSpecification.StreamViewType,
+      "NEW_AND_OLD_IMAGES",
+    );
+
+    // And a write to the deployed table is captured on the stream.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+      }),
+    );
+
+    const records = await readOrderRecords(simAws);
+    assertArrayLength(records, 1);
+
+    const record = records[0];
+    assertNonNullable(record);
+    assertIdentical(record.eventName, "INSERT");
+    assertIdentical(record.dynamodb?.NewImage?.["total"]?.N, "101");
+  });
+
+  it("resolves Fn::GetAtt StreamArn to the stream ARN", async () => {
+    // Given a template handing its table's stream ARN to an Output, which is
+    // what an event source mapping takes.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployTable(
+      simAws,
+      { StreamSpecification: { StreamViewType: "KEYS_ONLY" } },
+      streamArnOutputs,
+    );
+
+    // Then the Output holds the ARN the table reports as its latest stream,
+    // rather than a stand-in nothing is publishing to.
+    const described = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+    assertNonNullable(described.Table?.LatestStreamArn);
+    assertIdentical(
+      stack.outputs.get("OrdersStreamArn")?.value,
+      described.Table.LatestStreamArn,
+    );
+  });
+
+  it("fails a table whose StreamSpecification names no view type", async () => {
+    // Given a template declaring a stream without saying which images its
+    // records carry, which real CloudFormation requires.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then it fails in the words CreateTable
+    // refuses an SDK caller in.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployTable(simAws, { StreamSpecification: {} });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "StreamViewType is required when StreamEnabled is true",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("skips a table publishing its changes to a Kinesis stream", async () => {
+    // Given a template asking for a Kinesis stream, which is a different thing
+    // from the table's own stream and is not simulated.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployTable(simAws, {
+      KinesisStreamSpecification: {
+        StreamArn: "arn:aws:kinesis:eu-west-2:111111111111:stream/orders",
+      },
+    });
+
+    // Then the table is skipped, naming the property, rather than deployed
+    // publishing its changes nowhere.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "KinesisStreamSpecification is a real AWS::DynamoDB::Table property " +
+        "that simulated DynamoDB does not simulate",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("skips a table asking for a policy on its stream", async () => {
+    // Given a template putting a resource policy on the stream, which is a
+    // different property from the table's own ResourcePolicy.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployTable(simAws, {
+      StreamSpecification: {
+        StreamViewType: "NEW_IMAGE",
+        ResourcePolicy: { PolicyDocument: { Version: "2012-10-17" } },
+      },
+    });
+
+    // Then the table is skipped, naming the whole path to the property, rather
+    // than deployed with a stream anything could read.
+    const resource = stack.getResource("OrdersTable");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertStringIncludes(
+      resource.skippedReason ?? "",
+      "StreamSpecification.ResourcePolicy is a real AWS::DynamoDB::Table " +
+        "property that simulated DynamoDB does not simulate",
+    );
+    assertUndefined(simAws.dynamoDb().findTable("orders"));
+  });
+
+  it("fails a table whose StreamSpecification has a made up property", async () => {
+    // Given a template stating something StreamSpecification has no such thing
+    // as, which real CloudFormation would refuse too.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the failure names the property path.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployTable(simAws, {
+        StreamSpecification: {
+          StreamViewType: "NEW_IMAGE",
+          StreamEnabled: true,
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "StreamSpecification.StreamEnabled is not an AWS::DynamoDB::Table " +
+        "StreamSpecification property",
+    );
+  });
+});

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -51,6 +51,7 @@ export class SimCfnDynamoDbTableCreator {
         LocalSecondaryIndexes: tableProperties.localSecondaryIndexes(),
         TableClass: tableProperties.tableClass(),
         DeletionProtectionEnabled: tableProperties.deletionProtectionEnabled(),
+        StreamSpecification: tableProperties.streamSpecification(),
         Tags: tableProperties.tags(),
       },
     });

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-properties.ts
@@ -9,9 +9,11 @@ import type {
   SimDynamoDbTagInput,
 } from "../../command/table/table.types.js";
 import type { SimDynamoDbTimeToLiveSpecificationInput } from "../../command/time-to-live/time-to-live.types.js";
+import type { SimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream.types.js";
 import { readSimCfnDynamoDbTableIndexes } from "./sim-cfn-dynamodb-table-indexes.js";
 import { readSimCfnDynamoDbKeySchema } from "./sim-cfn-dynamodb-table-key-schema.js";
 import { SimCfnDynamoDbTablePropertyRules } from "./sim-cfn-dynamodb-table-property-rules.js";
+import { readSimCfnDynamoDbTableStream } from "./sim-cfn-dynamodb-table-stream.js";
 import { readSimCfnDynamoDbThroughput } from "./sim-cfn-dynamodb-table-throughput.js";
 import { readSimCfnDynamoDbTableTimeToLive } from "./sim-cfn-dynamodb-table-time-to-live.js";
 import { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
@@ -146,6 +148,13 @@ export class SimCfnDynamoDbTableProperties {
    */
   deletionProtectionEnabled(): boolean | undefined {
     return this.values.boolean("DeletionProtectionEnabled");
+  }
+
+  /**
+   * The stream the template asks for, when it asks for one.
+   */
+  streamSpecification(): SimDynamoDbStreamSpecification | undefined {
+    return readSimCfnDynamoDbTableStream(this.values);
   }
 
   /**

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-property-rules.ts
@@ -3,6 +3,7 @@ import {
   dynamoDbTablePropertyError,
   dynamoDbTableUnsimulatedPropertyError,
 } from "./sim-cfn-dynamodb-table-property-error.js";
+import { SimCfnDynamoDbTableStreamRules } from "./sim-cfn-dynamodb-table-stream-rules.js";
 import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
 
 /**
@@ -20,6 +21,7 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "KeySchema",
   "LocalSecondaryIndexes",
   "ProvisionedThroughput",
+  "StreamSpecification",
   "TableClass",
   "TableName",
   "Tags",
@@ -29,9 +31,10 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
 /**
  * Real AWS::DynamoDB::Table properties this simulation does not model.
  *
- * Each one changes what the table does. A table deployed without the stream its
- * changes were meant to be published to would leave whatever reads that stream
- * waiting, so the Resource is skipped rather than deployed as something else.
+ * Each one changes what the table does. A table deployed without the Kinesis
+ * stream its changes were meant to be published to would leave whatever reads
+ * that stream waiting, so the Resource is skipped rather than deployed as
+ * something else.
  */
 const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "ContributorInsightsSpecification",
@@ -41,7 +44,6 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "PointInTimeRecoverySpecification",
   "ResourcePolicy",
   "SSESpecification",
-  "StreamSpecification",
   "WarmThroughput",
 ]);
 
@@ -59,8 +61,8 @@ interface SimCfnDynamoDbTablePropertyRulesProperties {
  * fails the Resource instead, because that is a template real CloudFormation
  * would refuse too.
  *
- * The two index properties carry properties of their own, which are held to the
- * same rule a level down.
+ * The two index properties and the stream specification carry properties of
+ * their own, which are held to the same rule a level down.
  */
 export class SimCfnDynamoDbTablePropertyRules {
   private readonly logicalId: string;
@@ -79,7 +81,7 @@ export class SimCfnDynamoDbTablePropertyRules {
       this.assertSimulatedProperty(name);
     }
 
-    this.assertSimulatedIndexes();
+    this.assertSimulatedMembers();
   }
 
   private assertSimulatedProperty(name: string): void {
@@ -98,14 +100,18 @@ export class SimCfnDynamoDbTablePropertyRules {
   }
 
   /**
-   * Refuse what the entries of the two index properties ask for and cannot get.
+   * Refuse what the properties carrying properties of their own ask for and
+   * cannot get: the two index lists, and the stream specification.
    */
-  private assertSimulatedIndexes(): void {
-    SimCfnDynamoDbTableIndexRules.global(this.logicalId).assertSimulated(
+  private assertSimulatedMembers(): void {
+    const logicalId = this.logicalId;
+
+    SimCfnDynamoDbTableIndexRules.global(logicalId).assertSimulated(
       this.values.list("GlobalSecondaryIndexes"),
     );
-    SimCfnDynamoDbTableIndexRules.local(this.logicalId).assertSimulated(
+    SimCfnDynamoDbTableIndexRules.local(logicalId).assertSimulated(
       this.values.list("LocalSecondaryIndexes"),
     );
+    new SimCfnDynamoDbTableStreamRules(logicalId).assertSimulated(this.values);
   }
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream-rules.ts
@@ -1,0 +1,84 @@
+import {
+  dynamoDbTablePropertyError,
+  dynamoDbTableUnsimulatedPropertyError,
+} from "./sim-cfn-dynamodb-table-property-error.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * The StreamSpecification properties this simulation acts on.
+ *
+ * CloudFormation's StreamSpecification is not the SDK's: it has no
+ * `StreamEnabled` field at all, so a template declaring the property at all is
+ * asking for a stream, and the view type is the only thing left to say.
+ */
+const simulatedStreamPropertyNames: ReadonlySet<string> = new Set([
+  "StreamViewType",
+]);
+
+/**
+ * Real StreamSpecification properties this simulation does not model.
+ *
+ * The nested `ResourcePolicy` is a policy on the stream rather than on the
+ * table, and is a different property from the table's own `ResourcePolicy`, so
+ * it is named here rather than left to read as a property that does not exist.
+ */
+const unsimulatedStreamPropertyNames: ReadonlySet<string> = new Set([
+  "ResourcePolicy",
+]);
+
+/**
+ * Which properties of a table's StreamSpecification simulated DynamoDB can act
+ * on.
+ *
+ * This is the table's own property rule applied a level down, as the index
+ * rules are. A real property that is not simulated skips the table, since a
+ * stream deployed without a policy the template asked for would be read by
+ * whatever that policy was meant to keep out.
+ */
+export class SimCfnDynamoDbTableStreamRules {
+  private readonly logicalId: string;
+
+  constructor(logicalId: string) {
+    this.logicalId = logicalId;
+  }
+
+  /**
+   * Refuse everything about the table's StreamSpecification that is not
+   * simulated.
+   *
+   * A table declaring no stream has nothing here to refuse.
+   */
+  assertSimulated(values: SimCfnDynamoDbTableValues): void {
+    const specification = values.object("StreamSpecification");
+
+    if (specification === undefined) {
+      return;
+    }
+
+    for (const name of specification.names) {
+      this.assertSimulatedProperty(specification, name);
+    }
+  }
+
+  private assertSimulatedProperty(
+    specification: SimCfnDynamoDbTableValues,
+    name: string,
+  ): void {
+    if (simulatedStreamPropertyNames.has(name)) {
+      return;
+    }
+
+    if (unsimulatedStreamPropertyNames.has(name)) {
+      throw dynamoDbTableUnsimulatedPropertyError(
+        this.logicalId,
+        specification.pathTo(name),
+      );
+    }
+
+    throw dynamoDbTablePropertyError(
+      this.logicalId,
+      `${specification.pathTo(name)} is not an AWS::DynamoDB::Table ` +
+        `StreamSpecification property`,
+    );
+  }
+}

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-stream.ts
@@ -1,0 +1,30 @@
+import type { SimDynamoDbStreamSpecification } from "../../stream/sim-dynamodb-stream.types.js";
+import type { SimCfnDynamoDbTableValues } from "./sim-cfn-dynamodb-table-values.js";
+
+/**
+ * Read the stream an AWS::DynamoDB::Table Resource asks for.
+ *
+ * CloudFormation's StreamSpecification carries no `StreamEnabled`, where the
+ * SDK's requires one, so declaring the property is how a template says it wants
+ * a stream. `StreamEnabled` is synthesized from the property being there at
+ * all, because passing the block straight through would make a table whose
+ * stream was never switched on.
+ *
+ * The view type is passed through as the template wrote it, so a template
+ * naming one that does not exist is refused in the words CreateTable refuses it
+ * in.
+ */
+export function readSimCfnDynamoDbTableStream(
+  values: SimCfnDynamoDbTableValues,
+): SimDynamoDbStreamSpecification | undefined {
+  const specification = values.object("StreamSpecification");
+
+  if (specification === undefined) {
+    return undefined;
+  }
+
+  return {
+    StreamEnabled: true,
+    StreamViewType: specification.string("StreamViewType"),
+  };
+}


### PR DESCRIPTION
…tion

An AWS::DynamoDB::Table carrying a StreamSpecification now deploys a table with a stream through CreateTable, rather than being skipped. CloudFormation's StreamSpecification has no StreamEnabled field, so it is synthesized from the property being declared. Fn::GetAtt StreamArn gives the stream ARN, and is refused naming the table when the table has no stream.

Resolves https://github.com/KensioSoftware/yulin/issues/343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for creating DynamoDB tables with streams.
  * Stream records can be captured and read after table updates.
  * `StreamArn` can now be retrieved for tables with configured streams.
  * Added documentation and an example workflow for deploying streamed tables and reading `INSERT` events.

* **Bug Fixes**
  * Invalid or incomplete stream configurations now produce clear validation errors.
  * Unsupported stream options are handled consistently.
  * Changes to the stream view type are rejected instead of unexpectedly replacing the table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->