### PR TITLE
feat: create a simulated Lambda event source mapping for a DynamoDB s…

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -570,7 +570,9 @@ or an empty `batchItemFailures` list, has handled the whole batch.
 `AWS::Lambda::EventSourceMapping` deploys the same thing, which is what CDK's
 `fn.addEventSource(new SqsEventSource(queue))` emits. `EventSourceArn` and `FunctionName` accept the
 `Fn::GetAtt` and `Ref` values a template gives them, `Ref` on the mapping returns its UUID, and
-`Fn::GetAtt` exposes `Id` and `EventSourceMappingArn`.
+`Fn::GetAtt` exposes `Id` and `EventSourceMappingArn`. A queue mapping has no `StartingPosition`, and
+a template naming one is refused. The same Resource deploys a
+[stream mapping](#stream-mappings-in-templates), which has to have one.
 
 ## Triggering a function from a DynamoDB stream
 
@@ -845,6 +847,140 @@ apart by where the write came from rather than by when it landed.
 
 Writing the projection into a second table is what the guard is asking for, and is what a real
 aggregation or search index does anyway.
+
+### Stream mappings in templates
+
+`AWS::Lambda::EventSourceMapping` deploys a stream mapping too. `EventSourceArn` takes the
+`Fn::GetAtt … StreamArn` of a
+[streamed table](../dynamodb/#deploying-a-table-with-a-stream "Simulated DynamoDB table stream in CloudFormation docs")
+in the same template, which is also what makes the mapping wait for the table. `StartingPosition` is
+required, as it is for an SDK caller, and the properties go to `CreateEventSourceMapping` unjudged,
+so a template that gets one wrong is refused in the words the command refuses it in.
+
+```typescript sim-lambda-cloudformation-dynamodb-event-source
+/**
+ * Deploying a table's stream, a function, and the mapping between them.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimLambdaDynamoDbStreamEvent } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const projected: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+        },
+      },
+      ProjectorRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrderProjectorRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ReadOrdersStream",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "dynamodb:DescribeStream",
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                    ],
+                    Resource: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+                  },
+                  {
+                    Effect: "Allow",
+                    Action: "dynamodb:ListStreams",
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      ProjectorFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "order-projector",
+          Role: { "Fn::GetAtt": ["ProjectorRole", "Arn"] },
+        },
+      },
+      OrderProjectorMapping: {
+        Type: "AWS::Lambda::EventSourceMapping",
+        Properties: {
+          EventSourceArn: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+          FunctionName: { Ref: "ProjectorFunction" },
+          BatchSize: 100,
+          StartingPosition: "TRIM_HORIZON",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "ProjectorFunction",
+      handler: (event: SimLambdaDynamoDbStreamEvent): void => {
+        for (const record of event.Records) {
+          projected.push(record.dynamodb.Keys?.["orderId"]?.S ?? "");
+        }
+      },
+    },
+  ],
+});
+await stack.waitForDeployComplete();
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+console.log(projected); // ["order-1"]
+```
+
+CDK's `fn.addEventSource(new DynamoEventSource(table, { startingPosition }))` synthesises exactly
+this, and deploys without hand-editing. The grant CDK writes alongside it is an inline policy with
+the three stream actions on the stream ARN and `dynamodb:ListStreams` on every stream, which is what
+the mapping's execution-role check is looking for.
+
+The properties a non-default `DynamoEventSource` adds are refused by name: `FilterCriteria`,
+`ParallelizationFactor`, `BisectBatchOnFunctionError`, `TumblingWindowInSeconds` and
+`DestinationConfig`.
+
+A hand-written template or a SAM application usually gives the function the AWS managed policy
+`AWSLambdaDynamoDBExecutionRole` instead. Simulated IAM does not model managed policy ARNs, so that
+role reaches the mapping with no stream permissions and the mapping is refused when it is created.
+Write the grant as an inline policy, as the example above and CDK both do.
 
 ## Function URLs
 
@@ -1609,6 +1745,9 @@ Sim Lambda currently supports:
 - The `AWS::Lambda::Function`, `AWS::Lambda::Url`, `AWS::Lambda::Permission` and
   `AWS::Lambda::EventSourceMapping` CloudFormation resources, with `Ref`/`Fn::GetAtt` support and
   deploy-time executable bindings
+- `AWS::Lambda::EventSourceMapping` on a queue or on a table's stream, including the
+  `StartingPosition` a stream mapping needs, so a CDK `SqsEventSource` or `DynamoEventSource`
+  deploys as it is synthesised
 
 ## Limitations
 
@@ -1674,6 +1813,11 @@ Current documented limitations:
   `BatchSize` above 10 needs a batching window is not enforced, because the same AWS documentation
   gives a stream mapping `BatchSize` 100 and window 0 as simultaneous defaults, and CDK emits
   exactly that.
+- An execution role that gets its stream permissions from the AWS managed policy
+  `AWSLambdaDynamoDBExecutionRole` has none here, since simulated IAM does not model managed policy
+  ARNs, so the mapping is refused when it is created. A hand-written template and a SAM application
+  usually attach that policy where CDK writes an inline one, so the two declaration paths differ.
+  Write the grant inline to deploy either.
 - `UpdateEventSourceMapping` is not supported, so a mapping's batch size or enabled state is fixed
   once it is created. `Enabled: false` at creation is simulated.
 - One poll delivers one batch. Real Lambda runs several pollers at once and scales them with the

--- a/docs/services/lambda/sim-lambda-cloudformation-dynamodb-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-dynamodb-event-source.example.ts
@@ -1,0 +1,108 @@
+/**
+ * Deploying a table's stream, a function, and the mapping between them.
+ */
+
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimLambdaDynamoDbStreamEvent } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const projected: string[] = [];
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+        },
+      },
+      ProjectorRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrderProjectorRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "ReadOrdersStream",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "dynamodb:DescribeStream",
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                    ],
+                    Resource: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+                  },
+                  {
+                    Effect: "Allow",
+                    Action: "dynamodb:ListStreams",
+                    Resource: "*",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      ProjectorFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "order-projector",
+          Role: { "Fn::GetAtt": ["ProjectorRole", "Arn"] },
+        },
+      },
+      OrderProjectorMapping: {
+        Type: "AWS::Lambda::EventSourceMapping",
+        Properties: {
+          EventSourceArn: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+          FunctionName: { Ref: "ProjectorFunction" },
+          BatchSize: 100,
+          StartingPosition: "TRIM_HORIZON",
+        },
+      },
+    },
+  },
+  bindings: [
+    {
+      logicalId: "ProjectorFunction",
+      handler: (event: SimLambdaDynamoDbStreamEvent): void => {
+        for (const record of event.Records) {
+          projected.push(record.dynamodb.Keys?.["orderId"]?.S ?? "");
+        }
+      },
+    },
+  ],
+});
+await stack.waitForDeployComplete();
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+console.log(projected); // ["order-1"]

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-dynamodb-event-source.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-dynamodb-event-source.loc.test.ts
@@ -1,0 +1,145 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertStringStartsWith,
+  assertTypeString,
+} from "@kensio/smartass";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file to pass to sim CloudFormation, so the template under test is
+ * one CDK actually produced rather than one written by hand.
+ */
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+const accountIdOneOnes = "111111111111" as SimAwsAccountId;
+
+/**
+ * A handler sending each stream record's key on to the queue CDK put in its
+ * environment, so the test can see what the mapping delivered.
+ */
+const projectorHandlerSource = `
+const { SQSClient, SendMessageCommand } = require("@aws-sdk/client-sqs");
+const client = new SQSClient({});
+exports.handler = async (event) => {
+  for (const record of event.Records) {
+    await client.send(
+      new SendMessageCommand({
+        QueueUrl: process.env.PROJECTIONS_QUEUE_URL,
+        MessageBody: JSON.stringify({
+          eventName: record.eventName,
+          orderId: record.dynamodb.Keys.orderId.S,
+        }),
+      }),
+    );
+  }
+  return { projected: event.Records.length };
+};
+`;
+
+describe("Sim CDK Lambda DynamoDB event source local integration", () => {
+  it("deploys a CDK DynamoEventSource that delivers a table's changes", async () => {
+    // Given a CDK stack with a streamed table and a function subscribed to it
+    // through DynamoEventSource, sending what it is given on to a queue.
+    const cdkProject = new TestCdkProject();
+    await cdkProject.writeCdkAppFile(
+      `
+import * as cdk from "aws-cdk-lib/core";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { DynamoEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-2" },
+});
+
+const ordersTable = new dynamodb.Table(stack, "OrdersTable", {
+  partitionKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+  stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+});
+
+const projectionsQueue = new sqs.Queue(stack, "ProjectionsQueue");
+
+const projectorFunction = new lambda.Function(stack, "ProjectorFunction", {
+  functionName: "cdk-order-projector",
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(${JSON.stringify(projectorHandlerSource)}),
+  environment: {
+    PROJECTIONS_QUEUE_URL: projectionsQueue.queueUrl,
+  },
+});
+
+projectionsQueue.grantSendMessages(projectorFunction);
+
+projectorFunction.addEventSource(
+  new DynamoEventSource(ordersTable, {
+    startingPosition: lambda.StartingPosition.TRIM_HORIZON,
+  }),
+);
+
+new cdk.CfnOutput(stack, "OrdersTableName", {
+  value: ordersTable.tableName,
+});
+
+new cdk.CfnOutput(stack, "ProjectionsQueueUrl", {
+  value: projectionsQueue.queueUrl,
+});
+
+app.synth();
+      `,
+    );
+
+    // And we synth the CDK template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When we deploy the synthesized template into the account and region the
+    // CDK app declares, with no hand-editing of the
+    // AWS::Lambda::EventSourceMapping Resource CDK emits.
+    const simAws = new SimAws();
+    const scoped = simAws.account(accountIdOneOnes).region("eu-west-2");
+    const stack = await scoped
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the table CDK named after the stack and the logical ID is deployed
+    // with its stream.
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+    assertTypeString(tableName);
+    assertStringStartsWith(tableName, "TestStack-OrdersTable");
+
+    // And a write to the deployed table reaches the deployed function, whose
+    // execution role was granted the stream by CDK's own inline policy.
+    await scoped.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const queueUrl = stack.outputs.get("ProjectionsQueueUrl")?.value;
+    assertTypeString(queueUrl);
+
+    const received = await scoped
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(
+      received.Messages?.at(0)?.Body,
+      JSON.stringify({ eventName: "INSERT", orderId: "order-1" }),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -504,10 +504,16 @@ omit template `Code` and `Handler`. Unbound functions keep their template code o
 CloudFormation concerns.
 
 `cfn/event-source-mapping/` creates `AWS::Lambda::EventSourceMapping`, which is what CDK's
-`fn.addEventSource(new SqsEventSource(queue))` emits. The properties this simulation has no
-behaviour for fail the resource rather than being dropped, worded as an invalid resource so the
-engine does not skip it: a stack that deployed the queue and the function and nothing between them
-would look like a working subscription.
+`fn.addEventSource(new SqsEventSource(queue))` and `fn.addEventSource(new DynamoEventSource(table))`
+emit. The properties this simulation has no behaviour for fail the resource rather than being
+dropped, worded as an invalid resource so the engine does not skip it: a stack that deployed the
+queue and the function and nothing between them would look like a working subscription.
+
+The event source ARN is read before anything else about the Resource is judged, for the reason
+`SimLambdaEventSourceMappingInput` reads it first: what a mapping may ask for is the source's own
+rule. `StartingPosition` and `StartingPositionTimestamp` are read and passed on rather than judged
+here, since a stream mapping has to have a position and a queue mapping is refused for naming one,
+and only `CreateEventSourceMapping` knows which source the ARN names.
 
 Other `AWS::Lambda::*` resource types (`Version`, `Alias`, ...) are not supported and are skipped by
 the CloudFormation engine with an "Unsupported" diagnostic.

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
@@ -1,0 +1,249 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaDynamoDbStreamEvent } from "../../event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
+
+/**
+ * The mapping a default `DynamoEventSource` emits: the stream ARN, the
+ * function, the batch size CDK always states, and a starting position.
+ */
+const mappingProperties: SimCfnTemplateValueRecord = {
+  EventSourceArn: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+  FunctionName: { Ref: "ProjectorFunction" },
+  BatchSize: 100,
+  StartingPosition: "TRIM_HORIZON",
+};
+
+/**
+ * A template with a streamed table, a projector function whose role may read
+ * the stream, and a mapping between them.
+ *
+ * The role's grant is split the way CDK's own `grantStreamRead` splits it: the
+ * three stream operations on the stream ARN, and `ListStreams` on every stream.
+ */
+function projectorTemplate(
+  properties: SimCfnTemplateValueRecord,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      OrdersTable: {
+        Type: "AWS::DynamoDB::Table",
+        Properties: {
+          TableName: "orders",
+          KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+          AttributeDefinitions: [
+            { AttributeName: "orderId", AttributeType: "S" },
+          ],
+          BillingMode: "PAY_PER_REQUEST",
+          StreamSpecification: { StreamViewType: "NEW_AND_OLD_IMAGES" },
+        },
+      },
+      OrderQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders" },
+      },
+      ProjectorRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrderProjectorRole",
+          AssumeRolePolicyDocument: assumeRolePolicyDocument,
+          Policies: [
+            {
+              PolicyName: "ReadOrdersStream",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "dynamodb:DescribeStream",
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                    ],
+                    Resource: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+                  },
+                  {
+                    Effect: "Allow",
+                    Action: "dynamodb:ListStreams",
+                    Resource: "*",
+                  },
+                  {
+                    Effect: "Allow",
+                    Action: [
+                      "sqs:ReceiveMessage",
+                      "sqs:DeleteMessage",
+                      "sqs:GetQueueAttributes",
+                    ],
+                    Resource: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      ProjectorFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "order-projector",
+          Role: { "Fn::GetAtt": ["ProjectorRole", "Arn"] },
+        },
+      },
+      OrderProjectorMapping: {
+        Type: "AWS::Lambda::EventSourceMapping",
+        Properties: properties,
+      },
+    },
+  };
+}
+
+/**
+ * Deploy the projector template, answering with what the function was given.
+ */
+async function deployProjector(
+  properties: SimCfnTemplateValueRecord,
+): Promise<readonly SimLambdaDynamoDbStreamEvent[]> {
+  const simAws = new SimAws();
+  const events: SimLambdaDynamoDbStreamEvent[] = [];
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: projectorTemplate(properties),
+    bindings: [
+      {
+        logicalId: "ProjectorFunction",
+        handler: (event: SimLambdaDynamoDbStreamEvent): undefined => {
+          events.push(event);
+
+          return undefined;
+        },
+      },
+    ],
+  });
+  await stack.waitForDeployComplete();
+
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "orders",
+      Item: { orderId: { S: "order-1" }, total: { N: "101" } },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return events;
+}
+
+/**
+ * The error the projector template is refused with.
+ */
+async function projectorDeployError(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await deployProjector(properties);
+  });
+}
+
+describe("Lambda CloudFormation DynamoDB stream event source mapping", () => {
+  it("deploys a mapping that delivers a table's changes to a function", async () => {
+    // Given a template with a streamed table, a function and a mapping between
+    // them, as CDK's DynamoEventSource emits.
+
+    // When the template is deployed and an item is written to the table.
+    const events = await deployProjector(mappingProperties);
+
+    // Then the write reached the deployed function as a stream event.
+    assertArrayLength(events, 1);
+
+    const record = events[0].Records[0];
+    assertNonNullable(record);
+    assertIdentical(record.eventName, "INSERT");
+    assertIdentical(record.dynamodb.NewImage?.["total"]?.N, "101");
+  });
+
+  it("refuses a stream mapping with no StartingPosition", async () => {
+    // Given a template leaving out the position a stream mapping starts from,
+    // which real Lambda requires.
+
+    // When the template is deployed, then it fails in the words
+    // CreateEventSourceMapping refuses an SDK caller in.
+    const error = await projectorDeployError({
+      EventSourceArn: { "Fn::GetAtt": ["OrdersTable", "StreamArn"] },
+      FunctionName: { Ref: "ProjectorFunction" },
+      BatchSize: 100,
+    });
+
+    assertStringIncludes(
+      error.message,
+      "StartingPosition is required for a DynamoDB stream event source mapping",
+    );
+  });
+
+  it("refuses StartingPosition on a queue mapping", async () => {
+    // Given a template naming a starting position for a queue, which has
+    // nowhere but the front of the queue to start from.
+    const error = await projectorDeployError({
+      ...mappingProperties,
+      EventSourceArn: { "Fn::GetAtt": ["OrderQueue", "Arn"] },
+      BatchSize: 10,
+    });
+
+    // Then the mapping is refused rather than deployed ignoring it.
+    assertStringIncludes(
+      error.message,
+      "StartingPosition is not valid for a queue",
+    );
+  });
+
+  it("refuses StartingPositionTimestamp by name", async () => {
+    // Given a template asking to start at an instant, which is for a Kinesis
+    // stream read with AT_TIMESTAMP.
+    const error = await projectorDeployError({
+      ...mappingProperties,
+      StartingPositionTimestamp: 1_767_225_600,
+    });
+
+    // Then the refusal names the property.
+    assertStringIncludes(
+      error.message,
+      "StartingPositionTimestamp only goes with the StartingPosition " +
+        "AT_TIMESTAMP",
+    );
+  });
+
+  it("refuses a StartingPositionTimestamp that is not a number", async () => {
+    // Given a template carrying the timestamp as text, where CloudFormation
+    // takes Unix time seconds.
+    const error = await projectorDeployError({
+      ...mappingProperties,
+      StartingPositionTimestamp: "2026-01-01T00:00:00Z",
+    });
+
+    // Then the refusal names the property and what it should have been.
+    assertStringIncludes(
+      error.message,
+      "StartingPositionTimestamp must be a number",
+    );
+  });
+});

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -6,6 +6,12 @@ import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-
 import { assertSimulatedEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-property-rules.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
 
+/**
+ * What a CloudFormation Unix time seconds value is multiplied by to reach the
+ * milliseconds a Date takes.
+ */
+const millisecondsPerSecond = 1000;
+
 interface SimCfnLambdaEventSourceMappingPropertiesProperties {
   readonly resource: SimCfnResource;
   readonly properties: SimCfnTemplateValueRecord;
@@ -31,19 +37,25 @@ export class SimCfnLambdaEventSourceMappingProperties {
 
   /**
    * The create input this Resource asks for, refusing what is not simulated.
+   *
+   * The event source ARN is read before anything else is judged, as the command
+   * reads it first for the same reason: what a mapping may ask for depends on
+   * the kind of source it names.
    */
   createInput(): SimCreateEventSourceMappingCommandInput {
+    const eventSourceArn = this.parser.requiredString(
+      this.resource,
+      this.properties["EventSourceArn"],
+      "EventSourceArn",
+    );
+
     assertSimulatedEventSourceMappingProperties(
       this.resource.logicalId,
       this.properties,
     );
 
     return {
-      EventSourceArn: this.parser.requiredString(
-        this.resource,
-        this.properties["EventSourceArn"],
-        "EventSourceArn",
-      ),
+      EventSourceArn: eventSourceArn,
       FunctionName: simCfnLambdaTargetFunctionName(
         this.parser.requiredString(
           this.resource,
@@ -66,8 +78,37 @@ export class SimCfnLambdaEventSourceMappingProperties {
         this.properties["MaximumBatchingWindowInSeconds"],
         "MaximumBatchingWindowInSeconds",
       ),
+      StartingPosition: this.parser.optionalString(
+        this.resource,
+        this.properties["StartingPosition"],
+        "StartingPosition",
+      ),
+      StartingPositionTimestamp: this.startingPositionTimestamp(),
       FunctionResponseTypes: this.functionResponseTypes(),
     };
+  }
+
+  /**
+   * The instant a mapping asked to start reading from.
+   *
+   * CloudFormation carries it as Unix time seconds where the command takes a
+   * Date. Nothing judges it here: every source this simulation has refuses the
+   * property, a queue because it has no starting position at all and a stream
+   * because a timestamp only goes with the Kinesis-only `AT_TIMESTAMP`, so the
+   * refusal comes from the command and names the property.
+   */
+  private startingPositionTimestamp(): Date | undefined {
+    const seconds = this.parser.optionalNumber(
+      this.resource,
+      this.properties["StartingPositionTimestamp"],
+      "StartingPositionTimestamp",
+    );
+
+    if (seconds === undefined) {
+      return undefined;
+    }
+
+    return new Date(seconds * millisecondsPerSecond);
   }
 
   private functionResponseTypes():

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -2,6 +2,12 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 
 /**
  * The AWS::Lambda::EventSourceMapping properties this simulation acts on.
+ *
+ * The two starting position properties are here rather than among the
+ * unsimulated ones because whether a mapping may carry one is the event
+ * source's own rule: a stream has to be given a position and a queue is refused
+ * for naming one. That is decided by CreateEventSourceMapping, which knows
+ * which source the ARN names, so both are read and passed on.
  */
 const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "BatchSize",
@@ -10,6 +16,8 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "FunctionName",
   "FunctionResponseTypes",
   "MaximumBatchingWindowInSeconds",
+  "StartingPosition",
+  "StartingPositionTimestamp",
 ]);
 
 /**
@@ -37,8 +45,6 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "SelfManagedEventSource",
   "SelfManagedKafkaEventSourceConfig",
   "SourceAccessConfigurations",
-  "StartingPosition",
-  "StartingPositionTimestamp",
   "Tags",
   "Topics",
   "TumblingWindowInSeconds",

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -39,6 +39,20 @@ const mappingProperties: SimCfnTemplateValueRecord = {
 };
 
 /**
+ * The same mapping as a Resource created on its own is given it, with the
+ * intrinsics already resolved.
+ *
+ * The event source ARN is read before anything else about the Resource is
+ * judged, since what a mapping may ask for depends on the kind of source it
+ * names, so a test about another property has to state a real ARN.
+ */
+const resolvedMappingProperties: SimCfnTemplateValueRecord = {
+  ...mappingProperties,
+  EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
+  FunctionName: "order-consumer",
+};
+
+/**
  * A template with a queue, a consumer function whose role may poll it, and a
  * mapping between them, as CDK's `fn.addEventSource(new SqsEventSource(queue))`
  * synthesises one.
@@ -222,7 +236,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
   it("refuses a property this simulation does not model", async () => {
     // Given a template asking a mapping to filter events.
     const error = await mappingCreationError({
-      ...mappingProperties,
+      ...resolvedMappingProperties,
       FilterCriteria: { Filters: [{ Pattern: "{}" }] },
     });
 
@@ -237,7 +251,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
   it("refuses a property AWS::Lambda::EventSourceMapping does not have", async () => {
     // Given a template with a made-up property.
     const error = await mappingCreationError({
-      ...mappingProperties,
+      ...resolvedMappingProperties,
       Nonsense: "true",
     });
 


### PR DESCRIPTION
…tream from CloudFormation

StartingPosition and StartingPositionTimestamp are read off AWS::Lambda::EventSourceMapping and passed to CreateEventSourceMapping rather than refused by name, so the command decides per source: a stream mapping needs a position and a queue mapping is refused for naming one. The event source ARN is read before anything else about the Resource is judged, as the command reads it first.

A CDK stack with a streamed table and a DynamoEventSource now deploys as it is synthesised, and a write to the table reaches the function.

Resolves https://github.com/KensioSoftware/yulin/issues/344