### PR TITLE
feat: control simulated Rekognition results by image name and content…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm i -D @kensio/yulin
 - [IAM](./docs/services/iam "Simulated IAM docs")
 - [KMS](./docs/services/kms "Simulated KMS docs")
 - [Lambda](./docs/services/lambda "Simulated Lambda docs")
+- [Rekognition](./docs/services/rekognition "Simulated Rekognition docs")
 - [Route53](./docs/services/route53 "Simulated Route53 docs")
 - [S3](./docs/services/s3 "Simulated S3 docs")
 - [Secrets Manager](./docs/services/secretsmanager "Simulated Secrets Manager docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [IAM](./services/iam/ "Simulated IAM usage docs")
 - [KMS](./services/kms/ "Simulated KMS usage docs")
 - [Lambda](./services/lambda/ "Simulated Lambda usage docs")
+- [Rekognition](./services/rekognition/ "Simulated Rekognition usage docs")
 - [Route53](./services/route53/ "Simulated Route53 usage docs")
 - [S3](./services/s3/ "Simulated S3 usage docs")
 - [Secrets Manager](./services/secretsmanager/ "Simulated Secrets Manager usage docs")

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -243,8 +243,8 @@ which descriptors is in
 ## Supported services and Commands
 
 All simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
-Cognito, DynamoDB, DynamoDB Streams, IAM, KMS, Lambda, Route53, S3, Secrets Manager, SQS, SSM and
-STS. Each service's own docs under
+Cognito, DynamoDB, DynamoDB Streams, IAM, KMS, Lambda, Rekognition, Route53, S3, Secrets Manager,
+SQS, SSM and STS. Each service's own docs under
 [docs/services](../services/) list the Commands it simulates.
 
 Both kinds of gap are refused on send rather than misbehaving silently, with a different error each:

--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -75,8 +75,6 @@ from, and each rule matches an exact S3 object name, an exact content hash, or a
  * The three kinds of rule, and which one wins.
  */
 
-import { readFileSync } from "node:fs";
-
 import { SimAws } from "@kensio/yulin";
 import { simRekognitionImageHash } from "@kensio/yulin/rekognition";
 
@@ -90,8 +88,12 @@ moderation.byDefault({ labels: [] });
 moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
 
 // One image, by the hash of its bytes, for a system that generates its own
-// object keys.
-const fixture = readFileSync("test/fixtures/violent.jpg");
+// object keys. These bytes would usually come from a fixture file, read with
+// readFileSync, and the hash is of the exact bytes the test uploads.
+const fixture = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOQs7kDAAGyATf/cv8XAAAAAElFTkSuQmCC",
+  "base64",
+);
 moderation.onHash(simRekognitionImageHash(fixture), {
   labels: [{ name: "Weapon Violence", confidence: 88.4 }],
 });
@@ -156,8 +158,10 @@ so a surviving label never names a parent that is not in the response. A label t
 reported once, at the higher of the two confidences.
 
 A label the taxonomy does not have is refused where it is declared rather than at detection time.
-That includes the version 6.1 names: `Graphic Male Nudity` became `Exposed Male Genitalia`, and
-`Explicit Nudity` moved from being a top-level category to sitting under `Explicit`.
+That includes a version 6.1 name that version 7.0 dropped, such as `Graphic Male Nudity`, which
+became `Exposed Male Genitalia`. Some names survived the move with a different place in the
+taxonomy: `Explicit Nudity` is still a label, but it now sits under `Explicit` rather than being a
+top-level category itself.
 
 ## Filtering by confidence
 
@@ -251,11 +255,20 @@ await simAws.iam().putRolePolicy(
     PolicyName: "ModeratePolicy",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: {
-        Effect: "Allow",
-        Action: ["rekognition:DetectModerationLabels", "s3:GetObject"],
-        Resource: "*",
-      },
+      Statement: [
+        // A detection has no resource to name, so this one has to be `*`.
+        {
+          Effect: "Allow",
+          Action: "rekognition:DetectModerationLabels",
+          Resource: "*",
+        },
+        // Reading the image does, so this one names the Bucket.
+        {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::uploads/*",
+        },
+      ],
     }),
   }),
 );

--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -1,0 +1,424 @@
+# Simulated Rekognition
+
+Simulated Rekognition answers detection calls from results declared against images, so a test can
+say which image fails moderation without any image analysis happening. No recognition of any kind is
+performed on the bytes.
+
+Rekognition-specific types are imported from the `@kensio/yulin/rekognition` subpath.
+
+## Moderating an image
+
+`DetectModerationLabels` takes an image as bytes or as an S3 object. Every image is clean until a
+rule says otherwise.
+
+```typescript sim-rekognition-detect-moderation-labels
+/**
+ * Declaring a moderation result for one S3 object and detecting it.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/nsfw.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+// The object is declared to fail moderation.
+simAws
+  .rekognition()
+  .moderation()
+  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+const detected = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/nsfw.png" } },
+  }),
+);
+
+console.log(detected.ModerationLabels.map((label) => label.Name));
+// [ "Explicit", "Explicit Nudity" ]
+console.log(detected.ModerationModelVersion); // "7.0"
+```
+
+The image is read through simulated S3 as the caller making the detection, so the caller needs
+`s3:GetObject` for it as well as `rekognition:DetectModerationLabels`.
+
+Image bytes go in as `Image.Bytes` instead, which needs no Bucket:
+
+```typescript
+const detected = await simAws
+  .rekognition()
+  .detectModerationLabels(
+    new DetectModerationLabelsCommand({ Image: { Bytes: imageBytes } }),
+  );
+```
+
+## Declaring results
+
+Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
+from, and each rule matches an exact S3 object name, an exact content hash, or anything at all.
+
+```typescript sim-rekognition-moderation-rules
+/**
+ * The three kinds of rule, and which one wins.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionImageHash } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const moderation = simAws.rekognition().moderation();
+
+// Everything not matched by another rule.
+moderation.byDefault({ labels: [] });
+
+// One S3 object, by the Name a request gives Rekognition.
+moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+// One image, by the hash of its bytes, for a system that generates its own
+// object keys.
+const fixture = readFileSync("test/fixtures/violent.jpg");
+moderation.onHash(simRekognitionImageHash(fixture), {
+  labels: [{ name: "Weapon Violence", confidence: 88.4 }],
+});
+```
+
+A hash rule wins, then a name rule, then the default. Matching is exact, with no pattern syntax, so
+which rule applies never depends on how specific a pattern looks.
+
+A name is the `Name` in the request, which is the S3 object key. It is matched on its own rather
+than with the Bucket, so a rule for a key applies to that key in whichever Bucket the request names.
+An image passed as `Image.Bytes` has no name at all, so it consults hash rules and then the default.
+
+The hash is the sha256 digest of the image bytes as they were received, as lowercase hex.
+`simRekognitionImageHash` produces it from a fixture. Re-encoding an image between uploading it and
+detecting on it changes the digest, so hash the exact bytes the test puts through the system.
+
+A label can be declared as a name on its own, which reports it at a confidence of
+`96.68000030517578`, or as a name with the confidence to report it at.
+
+## Labels come back with their parents
+
+A declared label expands to its whole chain in the version 7.0 moderation taxonomy, so handler code
+that filters on the top-level category sees what it would see on AWS. Each label carries the
+`ParentName` and `TaxonomyLevel` real Rekognition reports.
+
+```typescript sim-rekognition-taxonomy-chain
+/**
+ * A third level label arrives with the two labels above it.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .byDefault({ labels: [{ name: "Drinking", confidence: 92 }] });
+
+const detected = await simAws
+  .rekognition()
+  .detectModerationLabels(
+    new DetectModerationLabelsCommand({ Image: { Bytes: imageBytes } }),
+  );
+
+console.log(detected.ModerationLabels);
+// [
+//   { Name: "Alcohol", ParentName: "", TaxonomyLevel: 1, Confidence: 92 },
+//   { Name: "Alcohol Use", ParentName: "Alcohol", TaxonomyLevel: 2, ... },
+//   { Name: "Drinking", ParentName: "Alcohol Use", TaxonomyLevel: 3, ... },
+// ]
+```
+
+Every label in one chain shares that chain's confidence, and `MinConfidence` filters whole chains,
+so a surviving label never names a parent that is not in the response. A label two chains share is
+reported once, at the higher of the two confidences.
+
+A label the taxonomy does not have is refused where it is declared rather than at detection time.
+That includes the version 6.1 names: `Graphic Male Nudity` became `Exposed Male Genitalia`, and
+`Explicit Nudity` moved from being a top-level category to sitting under `Explicit`.
+
+## Filtering by confidence
+
+`MinConfidence` defaults to 50, which is what real content moderation uses, and compares inclusively.
+An explicit `0` asks for every label rather than being read as unset.
+
+```typescript sim-rekognition-min-confidence
+/**
+ * Two labels declared with different confidences, filtered by the request.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .byDefault({
+    labels: [
+      { name: "Weapons", confidence: 96 },
+      { name: "Gambling", confidence: 41 },
+    ],
+  });
+
+const strict = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { Bytes: imageBytes },
+    MinConfidence: 80,
+  }),
+);
+
+console.log(strict.ModerationLabels.map((label) => label.Name));
+// [ "Violence", "Weapons" ]
+```
+
+Confidences are float32 values, as real Rekognition confidences are, so a declared `99.4` comes back
+as `99.4000015258789`.
+
+## Moderating an upload
+
+An upload can moderate itself: a Bucket notification invokes a function, and the function moderates
+the object the event names. The function calls Rekognition in the Account and Region it runs in, so
+the rules a test registers on `simAws.rekognition()` are the ones it finds.
+
+```typescript sim-rekognition-upload-pipeline
+/**
+ * An upload moderated by the Lambda function its Bucket notifies.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const moderatorArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:moderator`;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ModeratorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ModeratorRole",
+    PolicyName: "ModeratePolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["rekognition:DetectModerationLabels", "s3:GetObject"],
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "moderator",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: {
+      ZipFile: makeLambdaCodeZip({
+        "index.js": `
+const {
+  RekognitionClient,
+  DetectModerationLabelsCommand,
+} = require("@aws-sdk/client-rekognition");
+
+exports.handler = async (event) => {
+  const record = event.Records[0].s3;
+  const detected = await new RekognitionClient({}).send(
+    new DetectModerationLabelsCommand({
+      Image: {
+        S3Object: { Bucket: record.bucket.name, Name: record.object.key },
+      },
+    }),
+  );
+
+  console.log(record.object.key, detected.ModerationLabels.length);
+
+  return detected.ModerationLabels.length === 0 ? "clean" : "flagged";
+};
+`,
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "moderator",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "moderate-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: moderatorArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/nsfw.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+// Delivery and the detection it triggers both happen in the background.
+await simAws.backgroundTasksComplete();
+```
+
+A handler that writes a moderated copy back into the Bucket that triggered it will notify itself for
+ever, so filter the notification configuration by prefix or suffix as this one does.
+
+## Permissions and errors
+
+`DetectModerationLabels` is authorized as `rekognition:DetectModerationLabels` against `*`. Real
+Rekognition gives the detection operations no resource-level permissions, so a policy naming an ARN
+reaches nothing, here as on AWS. A denial throws `AccessDeniedException` with a 400 status, which is
+what real Rekognition answers with rather than the 403 several other services use.
+
+The caller is authorized for the detection before the image is read, so a caller without the
+Rekognition permission is told about that rather than about an S3 object.
+
+Every S3 problem becomes `InvalidS3ObjectException`, as it does on real Rekognition, whether the
+Bucket is missing, the object is missing, or the caller may not read it. The underlying simulator
+error is kept as the error's `cause`, so a missing `s3:GetObject` grant is still diagnosable:
+
+```typescript
+try {
+  await simAws.rekognition().detectModerationLabels(command);
+} catch (error) {
+  console.log(error.name); // "InvalidS3ObjectException"
+  console.log(error.cause); // the sim IAM access denial
+}
+```
+
+Bytes that are not a PNG or a JPEG are refused with `InvalidImageFormatException`. The format comes
+from the leading bytes of the image, so a test that stores a placeholder string in a Bucket and
+moderates it gets that error.
+
+## Accounts and Regions
+
+Rekognition is scoped to an Account and a Region, and so are the rules registered against it. A
+detection made in one Region is answered by the rules registered in that Region.
+
+```typescript
+simAws.account("111111111111").region("eu-west-2").rekognition();
+```
+
+An image is read from a Bucket in another Account when that Bucket's policy allows the caller, as
+real Rekognition reads across Accounts. A Bucket in another Region is refused, as real Rekognition
+reads only Buckets in its own Region.
+
+## Available functionality
+
+Simulated Rekognition currently supports:
+
+- `DetectModerationLabelsCommand`, for an image supplied as `Image.Bytes` or as `Image.S3Object`
+- Results declared by exact S3 object name, by exact image content hash, or as a default, with the
+  hash rule winning, then the name rule, then the default
+- The complete version 7.0 content moderation taxonomy, with a declared label expanding to its
+  parents and carrying `ParentName` and `TaxonomyLevel`
+- `MinConfidence` filtering, defaulting to 50 and filtering whole label chains
+- `simRekognitionImageHash`, for hashing a fixture to declare a rule against
+- PNG and JPEG format detection from the image bytes
+- IAM authorization on `rekognition:DetectModerationLabels`, with the image read from S3 as the
+  caller
+- SDK interception of `RekognitionClient`, including from inside a simulated Lambda function
+
+## Limitations
+
+- `DetectLabels`, `DetectFaces`, `DetectText`, face collections and the video operations are not
+  simulated. An intercepted client sending one of those Commands is refused by name.
+- A custom moderation adapter named with `ProjectVersion`, and a human review loop named with
+  `HumanLoopConfig`, are both refused rather than ignored. Answering from the built-in model would
+  make an adapter look applied here and be applied in production.
+- `ContentTypes` is always empty. Real Rekognition puts `Animated` or `Illustrated` there for
+  content it identifies as such, which needs an image to look at.
+- Nothing looks at the image beyond its first few bytes. A PNG of a kitten declared as `Violence`
+  comes back as `Violence`.
+- The format comes from the image bytes and never from a stored content type. Simulated S3 keeps a
+  `ContentType` given to `PutObject` as a metadata key, and has none at all when the uploader did
+  not set one, so trusting it would make the same bytes detectable or not depending on how they were
+  uploaded.
+- A `Version` on an `Image.S3Object` is refused, because simulated S3 has no object versions and
+  would have answered with the current one.
+- There are no CloudFormation resource types for Rekognition, and Rekognition is not served over
+  `serveSimAws`.
+- The moderation taxonomy is the published version 7.0 label list. A label from version 6.1 is
+  refused, since real Rekognition no longer returns one.

--- a/docs/services/rekognition/sim-rekognition-detect-moderation-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-moderation-labels.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Declaring a moderation result for one S3 object and detecting it.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/nsfw.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+// The object is declared to fail moderation.
+simAws
+  .rekognition()
+  .moderation()
+  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+const detected = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/nsfw.png" } },
+  }),
+);
+
+console.log(detected.ModerationLabels.map((label) => label.Name));
+// [ "Explicit", "Explicit Nudity" ]
+console.log(detected.ModerationModelVersion); // "7.0"

--- a/docs/services/rekognition/sim-rekognition-min-confidence.example.ts
+++ b/docs/services/rekognition/sim-rekognition-min-confidence.example.ts
@@ -1,0 +1,33 @@
+/**
+ * Two labels declared with different confidences, filtered by the request.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .byDefault({
+    labels: [
+      { name: "Weapons", confidence: 96 },
+      { name: "Gambling", confidence: 41 },
+    ],
+  });
+
+const strict = await simAws.rekognition().detectModerationLabels(
+  new DetectModerationLabelsCommand({
+    Image: { Bytes: imageBytes },
+    MinConfidence: 80,
+  }),
+);
+
+console.log(strict.ModerationLabels.map((label) => label.Name));
+// [ "Violence", "Weapons" ]

--- a/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
+++ b/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
@@ -1,0 +1,24 @@
+/**
+ * The three kinds of rule, and which one wins.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { SimAws } from "@kensio/yulin";
+import { simRekognitionImageHash } from "@kensio/yulin/rekognition";
+
+const simAws = new SimAws();
+const moderation = simAws.rekognition().moderation();
+
+// Everything not matched by another rule.
+moderation.byDefault({ labels: [] });
+
+// One S3 object, by the Name a request gives Rekognition.
+moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+// One image, by the hash of its bytes, for a system that generates its own
+// object keys.
+const fixture = readFileSync("test/fixtures/violent.jpg");
+moderation.onHash(simRekognitionImageHash(fixture), {
+  labels: [{ name: "Weapon Violence", confidence: 88.4 }],
+});

--- a/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
+++ b/docs/services/rekognition/sim-rekognition-moderation-rules.example.ts
@@ -2,8 +2,6 @@
  * The three kinds of rule, and which one wins.
  */
 
-import { readFileSync } from "node:fs";
-
 import { SimAws } from "@kensio/yulin";
 import { simRekognitionImageHash } from "@kensio/yulin/rekognition";
 
@@ -17,8 +15,12 @@ moderation.byDefault({ labels: [] });
 moderation.onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
 
 // One image, by the hash of its bytes, for a system that generates its own
-// object keys.
-const fixture = readFileSync("test/fixtures/violent.jpg");
+// object keys. These bytes would usually come from a fixture file, read with
+// readFileSync, and the hash is of the exact bytes the test uploads.
+const fixture = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOQs7kDAAGyATf/cv8XAAAAAElFTkSuQmCC",
+  "base64",
+);
 moderation.onHash(simRekognitionImageHash(fixture), {
   labels: [{ name: "Weapon Violence", confidence: 88.4 }],
 });

--- a/docs/services/rekognition/sim-rekognition-taxonomy-chain.example.ts
+++ b/docs/services/rekognition/sim-rekognition-taxonomy-chain.example.ts
@@ -1,0 +1,31 @@
+/**
+ * A third level label arrives with the two labels above it.
+ */
+
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .byDefault({ labels: [{ name: "Drinking", confidence: 92 }] });
+
+const detected = await simAws
+  .rekognition()
+  .detectModerationLabels(
+    new DetectModerationLabelsCommand({ Image: { Bytes: imageBytes } }),
+  );
+
+console.log(detected.ModerationLabels);
+// [
+//   { Name: "Alcohol", ParentName: "", TaxonomyLevel: 1, Confidence: 92 },
+//   { Name: "Alcohol Use", ParentName: "Alcohol", TaxonomyLevel: 2, ... },
+//   { Name: "Drinking", ParentName: "Alcohol Use", TaxonomyLevel: 3, ... },
+// ]

--- a/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
+++ b/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
@@ -39,11 +39,20 @@ await simAws.iam().putRolePolicy(
     PolicyName: "ModeratePolicy",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: {
-        Effect: "Allow",
-        Action: ["rekognition:DetectModerationLabels", "s3:GetObject"],
-        Resource: "*",
-      },
+      Statement: [
+        // A detection has no resource to name, so this one has to be `*`.
+        {
+          Effect: "Allow",
+          Action: "rekognition:DetectModerationLabels",
+          Resource: "*",
+        },
+        // Reading the image does, so this one names the Bucket.
+        {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::uploads/*",
+        },
+      ],
     }),
   }),
 );

--- a/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
+++ b/docs/services/rekognition/sim-rekognition-upload-pipeline.example.ts
@@ -1,0 +1,130 @@
+/**
+ * An upload moderated by the Lambda function its Bucket notifies.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaCodeZip } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const moderatorArn = `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:moderator`;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ModeratorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ModeratorRole",
+    PolicyName: "ModeratePolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["rekognition:DetectModerationLabels", "s3:GetObject"],
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "moderator",
+    Role: role.Role.Arn,
+    Handler: "index.handler",
+    Code: {
+      ZipFile: makeLambdaCodeZip({
+        "index.js": `
+const {
+  RekognitionClient,
+  DetectModerationLabelsCommand,
+} = require("@aws-sdk/client-rekognition");
+
+exports.handler = async (event) => {
+  const record = event.Records[0].s3;
+  const detected = await new RekognitionClient({}).send(
+    new DetectModerationLabelsCommand({
+      Image: {
+        S3Object: { Bucket: record.bucket.name, Name: record.object.key },
+      },
+    }),
+  );
+
+  console.log(record.object.key, detected.ModerationLabels.length);
+
+  return detected.ModerationLabels.length === 0 ? "clean" : "flagged";
+};
+`,
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "moderator",
+    StatementId: "AllowS3",
+    Action: "lambda:InvokeFunction",
+    Principal: "s3.amazonaws.com",
+    SourceArn: "arn:aws:s3:::uploads",
+    SourceAccount: simAws.defaultAccountId,
+  }),
+);
+
+await simAws.s3().putBucketNotificationConfiguration(
+  new PutBucketNotificationConfigurationCommand({
+    Bucket: "uploads",
+    NotificationConfiguration: {
+      LambdaFunctionConfigurations: [
+        {
+          Id: "moderate-uploads",
+          Events: ["s3:ObjectCreated:*"],
+          LambdaFunctionArn: moderatorArn,
+          Filter: { Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] } },
+        },
+      ],
+    },
+  }),
+);
+
+simAws
+  .rekognition()
+  .moderation()
+  .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/nsfw.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+// Delivery and the detection it triggers both happen in the background.
+await simAws.backgroundTasksComplete();

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -19,6 +19,7 @@
       "@kensio/yulin/iam": ["../src/service/iam/index.ts"],
       "@kensio/yulin/kms": ["../src/service/kms/index.ts"],
       "@kensio/yulin/lambda": ["../src/service/lambda/index.ts"],
+      "@kensio/yulin/rekognition": ["../src/service/rekognition/index.ts"],
       "@kensio/yulin/route53": ["../src/service/route53/index.ts"],
       "@kensio/yulin/s3": ["../src/service/s3/index.ts"],
       "@kensio/yulin/sdk": ["../src/sdk/index.ts"],

--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
       "types": "./dist/service/lambda/index.d.ts"
     },
     "./package.json": "./package.json",
+    "./rekognition": {
+      "import": "./dist/service/rekognition/index.js",
+      "types": "./dist/service/rekognition/index.d.ts"
+    },
     "./s3": {
       "import": "./dist/service/s3/index.js",
       "types": "./dist/service/s3/index.d.ts"
@@ -132,6 +136,7 @@
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kms": "^3.1101.0",
     "@aws-sdk/client-lambda": "^3.1101.0",
+    "@aws-sdk/client-rekognition": "^3.1101.0",
     "@aws-sdk/client-route-53": "^3.1101.0",
     "@aws-sdk/client-s3": "^3.1101.0",
     "@aws-sdk/client-secrets-manager": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@aws-sdk/client-lambda':
         specifier: ^3.1101.0
         version: 3.1101.0
+      '@aws-sdk/client-rekognition':
+        specifier: ^3.1101.0
+        version: 3.1101.0
       '@aws-sdk/client-route-53':
         specifier: ^3.1101.0
         version: 3.1101.0
@@ -233,6 +236,10 @@ packages:
 
   '@aws-sdk/client-lambda@3.1101.0':
     resolution: {integrity: sha512-OiMqyOfqWBMqh0Ov33uICt5ZXT/PQLUEDGXg9M+MinndyIEuJRuSONrmxUShQn6xjcjohCugpUSTjTrMUAt1UQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-rekognition@3.1101.0':
+    resolution: {integrity: sha512-M+bb4PuyAk4WC5oxn65aFMP5mYcPM9CAVmwu4Fzd3fridCX8ElBVYBE8L4micpihtV6VvN1NQb8PzeT4qm244g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-route-53@3.1101.0':
@@ -2078,6 +2085,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-lambda@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-rekognition@3.1101.0':
     dependencies:
       '@aws-sdk/core': 3.977.4
       '@aws-sdk/credential-provider-node': 3.972.76

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -53,6 +53,9 @@ export function resolveSimSdkCommandRouter(
     case "Lambda": {
       return scoped.lambda().sdkCommandRouter();
     }
+    case "Rekognition": {
+      return scoped.rekognition().sdkCommandRouter();
+    }
     case "Route 53": {
       return scoped.route53().sdkCommandRouter();
     }

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -20,12 +20,10 @@ import { SimSqsEventSourceQueues } from "../../lambda/event-source/queue/sim-sqs
 import { SimDynamoDbEventSourceStreams } from "../../lambda/event-source/stream/sim-dynamodb-event-source-streams.js";
 import { SimS3LambdaCodeStore } from "../../lambda/function/code/store/sim-s3-lambda-code-store.js";
 import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.js";
+import { SimRekognition } from "../../rekognition/index.js";
+import { SimAwsRekognitionImageObjects } from "../../rekognition/image/s3/sim-aws-rekognition-image-objects.js";
 import { SimS3 } from "../../s3/sim-s3.js";
-import { SimAwsS3NotificationFunctions } from "../../s3/notification/destination/lambda/sim-aws-s3-notification-functions.js";
-import { SimS3LambdaNotificationDestination } from "../../s3/notification/destination/lambda/sim-s3-lambda-notification-destination.js";
-import { SimS3ServiceNotificationDestinations } from "../../s3/notification/destination/sim-s3-service-notification-destinations.js";
-import { SimAwsS3NotificationQueues } from "../../s3/notification/destination/sqs/sim-aws-s3-notification-queues.js";
-import { SimS3SqsNotificationDestination } from "../../s3/notification/destination/sqs/sim-s3-sqs-notification-destination.js";
+import { simAwsS3NotificationDestinations } from "./sim-aws-s3-notification-destinations.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
 import { SimSsm } from "../../ssm/index.js";
@@ -205,6 +203,25 @@ export class SimAwsAccountRegionServiceBuilder {
   }
 
   /**
+   * Create simulated Rekognition for an Account Region scope.
+   *
+   * Rekognition is Region-scoped because the results declared against it are:
+   * a detection made in one Region is answered by that Region's rules. Image
+   * objects come from the whole simulation rather than this scope's S3, since
+   * real Rekognition reads a Bucket another Account's policy admits it to.
+   */
+  createRekognition(scope: SimAwsAccountRegionContainer): SimRekognition {
+    return new SimRekognition({
+      iam: this.accountServices.createIam(scope),
+      background: this.background,
+      images: new SimAwsRekognitionImageObjects({
+        simAws: this.simAws,
+        accountRegionScope: scope.accountRegionScope,
+      }),
+    });
+  }
+
+  /**
    * Create simulated S3 for an Account Region scope.
    *
    * Bucket event notification destinations are resolved when a configuration
@@ -221,7 +238,7 @@ export class SimAwsAccountRegionServiceBuilder {
       s3GlobalRegistry: this.registries.s3,
       iam: this.accountServices.createIam(scope),
       background: this.background,
-      notificationDestinations: this.s3NotificationDestinations(),
+      notificationDestinations: simAwsS3NotificationDestinations(this.simAws),
     });
   }
 
@@ -276,24 +293,6 @@ export class SimAwsAccountRegionServiceBuilder {
       accountRegionScope: scope.accountRegionScope,
       background: this.background,
       iamResolver: this.iamRegistry,
-    });
-  }
-
-  /**
-   * Where a simulated S3 Bucket can send its event notifications.
-   *
-   * A notification configuration names a destination by ARN, and that ARN can
-   * name any Account and Region, so the destinations come from the whole
-   * simulation rather than from one scope.
-   */
-  private s3NotificationDestinations(): SimS3ServiceNotificationDestinations {
-    return new SimS3ServiceNotificationDestinations({
-      lambda: new SimS3LambdaNotificationDestination({
-        functions: new SimAwsS3NotificationFunctions({ simAws: this.simAws }),
-      }),
-      sqs: new SimS3SqsNotificationDestination({
-        queues: new SimAwsS3NotificationQueues({ simAws: this.simAws }),
-      }),
     });
   }
 }

--- a/src/service/aws/factory/sim-aws-s3-notification-destinations.ts
+++ b/src/service/aws/factory/sim-aws-s3-notification-destinations.ts
@@ -1,0 +1,26 @@
+import type { SimAws } from "../sim-aws.js";
+import { SimAwsS3NotificationFunctions } from "../../s3/notification/destination/lambda/sim-aws-s3-notification-functions.js";
+import { SimS3LambdaNotificationDestination } from "../../s3/notification/destination/lambda/sim-s3-lambda-notification-destination.js";
+import { SimS3ServiceNotificationDestinations } from "../../s3/notification/destination/sim-s3-service-notification-destinations.js";
+import { SimAwsS3NotificationQueues } from "../../s3/notification/destination/sqs/sim-aws-s3-notification-queues.js";
+import { SimS3SqsNotificationDestination } from "../../s3/notification/destination/sqs/sim-s3-sqs-notification-destination.js";
+
+/**
+ * Where a simulated S3 Bucket can send its event notifications.
+ *
+ * A notification configuration names a destination by ARN, and that ARN can
+ * name any Account and Region, so the destinations come from the whole
+ * simulation rather than from the scope the Bucket belongs to.
+ */
+export function simAwsS3NotificationDestinations(
+  simAws: SimAws,
+): SimS3ServiceNotificationDestinations {
+  return new SimS3ServiceNotificationDestinations({
+    lambda: new SimS3LambdaNotificationDestination({
+      functions: new SimAwsS3NotificationFunctions({ simAws }),
+    }),
+    sqs: new SimS3SqsNotificationDestination({
+      queues: new SimAwsS3NotificationQueues({ simAws }),
+    }),
+  });
+}

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -12,6 +12,7 @@ import type { SimCognitoIdentityProvider } from "../../cognito/index.js";
 import { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import type { SimCloudFront } from "../../cloudfront/sim-cloudfront.js";
 import type { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
+import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
 import type { SimS3 } from "../../s3/sim-s3.js";
 import type { SimIam } from "../../iam/index.js";
@@ -169,6 +170,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Lambda for an Account Region scope. */
   createLambda(scope: SimAwsAccountRegionContainer): SimLambda {
     return this.accountRegionServices.createLambda(scope);
+  }
+
+  /** Create simulated Rekognition for an Account Region scope. */
+  createRekognition(scope: SimAwsAccountRegionContainer): SimRekognition {
+    return this.accountRegionServices.createRekognition(scope);
   }
 
   /** Create or get simulated Route53 for an Account scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -10,6 +10,7 @@ import type {
 } from "../dynamodb/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
 import type { SimCognitoIdentityProvider } from "../cognito/index.js";
+import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
@@ -147,6 +148,15 @@ export class SimAwsAccountRegionContainer {
   lambda(): SimLambda {
     return this.memo.getOrCreate("lambda", () =>
       this.simAws.serviceFactory.createLambda(this),
+    );
+  }
+
+  /**
+   * Get simulated Rekognition for this account and region.
+   */
+  rekognition(): SimRekognition {
+    return this.memo.getOrCreate("rekognition", () =>
+      this.simAws.serviceFactory.createRekognition(this),
     );
   }
 

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -11,6 +11,7 @@ import type {
 import type { SimIam } from "../iam/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
+import type { SimRekognition } from "../rekognition/index.js";
 import type { SimRoute53 } from "../route53/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimSecretsManager } from "../secretsmanager/index.js";
@@ -80,6 +81,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Lambda in the default Account Region scope. */
   lambda(): SimLambda {
     return this.defaultAccountRegionScope().lambda();
+  }
+
+  /** Get simulated Rekognition in the default Account Region scope. */
+  rekognition(): SimRekognition {
+    return this.defaultAccountRegionScope().rekognition();
   }
 
   /** Get simulated Route53 in the default Account scope. */

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -1,0 +1,126 @@
+# Simulated Rekognition implementation
+
+This directory contains the simulated Rekognition implementation. Only image content moderation is
+simulated: `DetectModerationLabels`, for an image supplied as bytes or as an S3 object.
+
+The guiding decision here is that no image recognition happens. Rekognition is a service where the
+interesting behaviour is not the call but what the call returns, so the simulation maintains no
+opinion about the bytes and answers from results a test declared, in the way simulated ACM issues
+certificates without producing real TLS certificates. Everything else in this directory exists to
+make the parts around that answer behave the way AWS does: the request checking, the S3 read, the
+IAM decision, and the taxonomy a returned label belongs to.
+
+## Entry points
+
+- `sim-rekognition.ts` is the service facade for one account/region scope.
+- `index.ts` exports the public Rekognition simulator API for `@kensio/yulin/rekognition`.
+
+`SimRekognition` owns a `SimRekognitionModeration`, which owns the rules `DetectModerationLabels`
+answers from. Rules are grouped per operation rather than hung off the facade, so `labels()` and
+`faces()` can be added beside `moderation()` without the facade growing a result shape for each.
+
+The service is scoped to an account and region because its rules are: a detection made in one Region
+is answered by the rules registered in that Region, as a real Rekognition endpoint answers for the
+Region it belongs to.
+
+## The rule mechanism
+
+`rule/sim-rekognition-result-rules.ts` is the whole of it, and it is generic over the result type so
+each operation group keeps its own. There is one kind of rule and one order between them: an exact
+content hash wins, then an exact S3 object name, then the default.
+
+Matching is exact, with no pattern syntax. Partial globs were considered and dropped, because they
+force a specificity rule, and a specificity rule is where a surprising answer comes from.
+
+The name a rule matches is the `Name` in the request, which is the S3 object key. It is matched
+without the Bucket, so a rule for a key applies to that key in whichever Bucket the request names.
+That is a simulator convention rather than AWS behaviour, and it is documented as such.
+
+An image supplied as `Image.Bytes` has no name, which is why hash rules exist: a system that
+generates its own object keys has nothing a test can usefully match a name against.
+
+## The moderation model
+
+`moderation/sim-rekognition-moderation-labels.ts` holds the complete version 7.0 taxonomy, all 52
+labels, as a name and a parent name each, with `simRekognitionModerationModelVersion` beside them.
+Real Rekognition moved from 6.1 to 7.0 by renaming most of the top-level categories, so a response
+naming one version's labels under the other version's number would describe nothing AWS has ever
+returned. Keeping the label list and the version in one file is what stops that.
+
+`moderation/sim-rekognition-moderation-taxonomy.ts` is the behaviour over that list: a lookup, and
+the chain of labels above one. Levels are derived by walking up from a label rather than being
+stated per label, so a label cannot be numbered inconsistently with its own parent. The two are
+separate files because the label list is 52 names of dense vocabulary, and holding it beside the
+logic pushes the file over the FTA complexity threshold.
+
+`moderation/sim-rekognition-moderation-result.ts` turns a declaration into the labels a response
+carries. A declaration is resolved when the rule is registered rather than when a detection runs, so
+a label real Rekognition has never heard of is refused where it was written.
+
+Two rules there are worth keeping:
+
+- every label in one chain carries that chain's confidence, so filtering on `MinConfidence` cannot
+  leave a label naming a parent that is not in the response;
+- a label two chains share is reported once, at the highest confidence any chain declared for it,
+  because real Rekognition reports a parent at least as confidently as the child that implies it.
+
+Confidences pass through `Math.fround`. Real confidences are float32 values with a long tail, such
+as `99.44782257080078`, and a value rounded to four decimals is identifiable as fake.
+
+## Images
+
+`image/` is the path from a request to the bytes a rule is matched against.
+
+`SimRekognitionImageRequests.parse` reads the `Image` member and answers with a request for bytes or
+a request for an S3 object. Parsing and reading are separate steps because they happen at different
+points: the request is checked before anything else, and the image is read only once the caller has
+been authorized for the detection.
+
+`SimRekognitionImage` is the image itself. Its format is decided when it is made, from PNG and JPEG
+magic bytes, so bytes that are not an image are refused before any rule is consulted. The stored
+content type of an S3 object is deliberately not consulted: simulated S3 keeps a supplied
+`ContentType` as a metadata key and has none at all when the uploader did not set one, so trusting
+it would make the same bytes detectable or not depending on how they were uploaded.
+
+`SimRekognitionImageObjects` is the seam for reading an S3 object, with two implementations.
+`SimAwsRekognitionImageObjects` finds the Bucket through the S3 Bucket registry rather than through
+this scope's own S3, so a Bucket owned by another Account resolves, and reads it with an ordinary
+GetObject made as the caller. `SimRekognitionUnreachableImageObjects` is what a standalone
+`SimRekognition` gets, and says the service was built without S3 rather than reporting the object
+missing.
+
+Every S3 failure becomes `InvalidS3ObjectException`, as it does on real Rekognition, with the
+underlying simulator error kept as the `cause`. A missing `s3:GetObject` grant would otherwise be
+indistinguishable from a missing object.
+
+## Authorization
+
+`command/authorize/sim-rekognition-authorizer.ts` authorizes against `*`, because real Rekognition
+gives the detection operations no resource-level permissions. A denial is Rekognition's own
+`AccessDeniedException` with a 400 status rather than the shared IAM error, following the
+`SimS3AccessDenied` precedent: the error name and status are part of what a caller has to handle.
+
+The order in `DetectModerationLabelsHandler` is deliberate. Checking the request first means a
+malformed one fails the same way whatever else the simulation is doing. Authorizing before reading
+means a caller without `rekognition:DetectModerationLabels` is told about that rather than about an
+S3 object, and goes looking at the right policy.
+
+## Refusals
+
+`command/sim-rekognition-unsimulated-input.ts` refuses request inputs this simulation does not
+model, working from the small accepted set rather than from a list of everything Rekognition offers,
+so an option nobody thought about is refused rather than dropped.
+
+`ProjectVersion` is the one that matters. A request naming a custom moderation adapter would
+otherwise be answered by the built-in model, which is the failure that looks like a pass: the
+adapter would appear applied here and be applied for real in production.
+
+## Testing
+
+Tests are colocated with the code they exercise. `sim-rekognition-moderation-pipeline.iso.test.ts`
+is the exception and sits at the top level, because it is about the whole path rather than one
+piece: an upload notifies a function, the function moderates the object the event names with its own
+SDK client, and the rules it finds are the ones registered for the Account and Region it runs in.
+
+`test/rekognition/image-fixture.ts` holds the image bytes tests detect on. The PNGs are complete 1x1
+files; the JPEG is a file header, which is the whole of what the format check reads.

--- a/src/service/rekognition/command/authorize/sim-rekognition-authorizer.ts
+++ b/src/service/rekognition/command/authorize/sim-rekognition-authorizer.ts
@@ -1,0 +1,62 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { SimRekognitionAccessDeniedException } from "../../error/sim-rekognition.error.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+
+/**
+ * The resource every Rekognition detection authorizes against.
+ *
+ * Real Rekognition gives the detection operations no resource-level
+ * permissions, because the image is passed in rather than being a Rekognition
+ * resource there is an ARN for. A policy allowing
+ * `rekognition:DetectModerationLabels` has to use a resource of `*`, and one
+ * naming an ARN reaches nothing, here as on AWS.
+ */
+const anyResource = "*";
+
+interface SimRekognitionAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies simulated IAM authorization to Rekognition requests.
+ *
+ * A denial is reported as Rekognition's own AccessDeniedException rather than
+ * the shared IAM error, because that is the error name and the 400 status a
+ * real Rekognition caller would have to handle. The S3 read that follows a
+ * successful authorization is authorized separately, as the caller, by
+ * simulated S3.
+ */
+export class SimRekognitionAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(properties: SimRekognitionAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may perform a detection action.
+   */
+  authorize(
+    action: string,
+    options: SimRekognitionRequestOptions = {},
+  ): SimAwsResolvedCaller {
+    const decision = this.iam.authorize({
+      action,
+      resource: anyResource,
+      caller: options.caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimRekognitionAccessDeniedException(
+        `User: ${this.callerIdentifier.format(decision.caller.principal)} is ` +
+          `not authorized to perform: ${action} because no identity-based ` +
+          `policy allows the ${action} action`,
+      );
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-iam.iso.test.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-iam.iso.test.ts
@@ -1,0 +1,193 @@
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import {
+  SimRekognitionAccessDeniedException,
+  SimRekognitionInvalidS3ObjectException,
+} from "../../error/sim-rekognition.error.js";
+
+const detectAction = "rekognition:DetectModerationLabels";
+
+async function simAwsWithImage(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "uploads",
+      Key: "selfie.png",
+      Body: redPngBytes,
+    }),
+  );
+
+  return simAws;
+}
+
+const imageCommand = new DetectModerationLabelsCommand({
+  Image: { S3Object: { Bucket: "uploads", Name: "selfie.png" } },
+});
+
+describe("Authorizing a simulated Rekognition detection", () => {
+  it("allows a caller whose policy permits the detection", async () => {
+    // Given a Role allowed to moderate and to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Moderator", actions: [detectAction, "s3:GetObject"] },
+      simAws,
+    );
+
+    // When it moderates an image.
+    const detected = await simAws
+      .rekognition()
+      .detectModerationLabels(imageCommand, {
+        caller: { kind: "arn", arn: role.Arn },
+      });
+
+    // Then the detection runs.
+    assertIdentical(detected.ModerationModelVersion, "7.0");
+  });
+
+  it("refuses a caller with no Rekognition permission", async () => {
+    // Given a Role allowed to read the image but not to moderate it.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Reader", actions: ["s3:GetObject"] },
+      simAws,
+    );
+
+    // When it moderates an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then Rekognition's own AccessDeniedException is thrown, with the 400
+    // status real Rekognition answers with rather than the 403 several other
+    // services use.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+    assertIdentical(error.name, "AccessDeniedException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, detectAction);
+  });
+
+  it("refuses a policy that names a resource rather than everything", async () => {
+    // Given a Role allowed the detection on an ARN rather than on `*`.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ScopedModerator",
+        actions: [detectAction, "s3:GetObject"],
+        resource: "arn:aws:s3:::uploads/*",
+      },
+      simAws,
+    );
+
+    // When it moderates an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is refused, because a detection has no resource to name and is
+    // authorized against `*`, here as on real AWS.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+  });
+
+  it("reports a missing s3:GetObject as an image problem, with the denial as its cause", async () => {
+    // Given a Role allowed to moderate but not to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "BlindModerator", actions: [detectAction] },
+      simAws,
+    );
+
+    // When it moderates an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is the S3 object error real Rekognition reports, and the IAM
+    // denial underneath it is still readable, so the missing grant can be
+    // found from what was thrown.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertInstanceOf(error.cause, Error);
+    assertStringIncludes(error.cause.message, "s3:GetObject");
+  });
+
+  it("reads an image from a Bucket in another Account", async () => {
+    // Given a Bucket in another Account whose policy admits this Role.
+    const otherAccountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "CrossAccountModerator",
+        actions: [detectAction, "s3:GetObject"],
+      },
+      simAws,
+    );
+
+    const otherS3 = simAws
+      .accountRegionScope(otherAccountId, simAws.defaultRegionName)
+      .s3();
+    await otherS3.createBucket(new CreateBucketCommand({ Bucket: "partner" }));
+    await otherS3.putObject(
+      new PutObjectCommand({
+        Bucket: "partner",
+        Key: "selfie.png",
+        Body: redPngBytes,
+      }),
+    );
+    await otherS3.putBucketPolicy({
+      input: {
+        Bucket: "partner",
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: role.Arn },
+              Action: "s3:GetObject",
+              Resource: "arn:aws:s3:::partner/*",
+            },
+          ],
+        }),
+      },
+    });
+
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("selfie.png", { labels: ["Violence"] });
+
+    // When the image is moderated from this Account.
+    const detected = await simAws.rekognition().detectModerationLabels(
+      new DetectModerationLabelsCommand({
+        Image: { S3Object: { Bucket: "partner", Name: "selfie.png" } },
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then it is read across the Account boundary, as real Rekognition reads
+    // a Bucket another Account's policy admits it to.
+    assertIdentical(detected.ModerationLabels[0]?.Name, "Violence");
+  });
+});

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
@@ -52,7 +52,14 @@ export class DetectModerationLabelsRequest {
       return defaultMinConfidence;
     }
 
-    if (input.MinConfidence < 0 || input.MinConfidence > 100) {
+    // A NaN is refused here rather than compared against. Every comparison
+    // with one is false, so it would filter every label out and look like an
+    // image with nothing to report.
+    if (
+      !Number.isFinite(input.MinConfidence) ||
+      input.MinConfidence < 0 ||
+      input.MinConfidence > 100
+    ) {
       throw new SimRekognitionInvalidParameterException(
         `Request has invalid parameters: MinConfidence of ` +
           `${String(input.MinConfidence)} is not a percentage from 0 to 100`,

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
@@ -1,0 +1,64 @@
+import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
+import {
+  parseSimRekognitionImageRequest,
+  type SimRekognitionImageRequest,
+} from "../../image/sim-rekognition-image-request.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import type { SimDetectModerationLabelsCommandInput } from "./detect-moderation-labels.command.js";
+
+/**
+ * The confidence real Rekognition filters moderation labels at when a request
+ * does not say. Content moderation uses 50 here, which is not the 55 label
+ * detection uses.
+ */
+const defaultMinConfidence = 50;
+
+const operation = "DetectModerationLabels";
+const acceptedInput = ["Image", "MinConfidence"];
+
+/**
+ * A DetectModerationLabels request, checked before anything acts on it.
+ *
+ * `HumanLoopConfig` and `ProjectVersion` are refused here rather than ignored.
+ * A request naming a custom moderation adapter through `ProjectVersion` would
+ * otherwise be answered by the built-in model, which is the failure that looks
+ * like a pass: the adapter would appear applied here and be applied for real
+ * in production.
+ */
+export class DetectModerationLabelsRequest {
+  public readonly image: SimRekognitionImageRequest;
+  public readonly minConfidence: number;
+
+  constructor(input: SimDetectModerationLabelsCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.image = parseSimRekognitionImageRequest(input.Image);
+    this.minConfidence = DetectModerationLabelsRequest.confidenceOf(input);
+  }
+
+  /**
+   * The minimum confidence this request filters at.
+   *
+   * The default is applied only when the request left it out, so an explicit
+   * `0` asks for every label rather than being promoted to 50.
+   */
+  private static confidenceOf(
+    input: SimDetectModerationLabelsCommandInput,
+  ): number {
+    if (input.MinConfidence === undefined) {
+      return defaultMinConfidence;
+    }
+
+    if (input.MinConfidence < 0 || input.MinConfidence > 100) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: MinConfidence of ` +
+          `${String(input.MinConfidence)} is not a percentage from 0 to 100`,
+      );
+    }
+
+    return input.MinConfidence;
+  }
+}

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-validation.iso.test.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-validation.iso.test.ts
@@ -135,6 +135,31 @@ describe("Rejecting a malformed DetectModerationLabels request", () => {
     assertStringIncludes(error.message, "percentage from 0 to 100");
   });
 
+  it("refuses a MinConfidence that is not a number at all", async () => {
+    // Given a request asking to filter at NaN.
+    const simAws = new SimAws();
+    simAws
+      .rekognition()
+      .moderation()
+      .byDefault({ labels: ["Violence"] });
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { Bytes: redPngBytes },
+            MinConfidence: NaN,
+          }),
+        ),
+    );
+
+    // Then it is refused. Every comparison with NaN is false, so filtering at
+    // it would answer with no labels and read as a clean image.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
   it("refuses a request naming a custom moderation adapter", async () => {
     // Given a request naming a ProjectVersion, which is a trained adapter.
     const simAws = new SimAws();

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-validation.iso.test.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-validation.iso.test.ts
@@ -1,0 +1,343 @@
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  jpegBytes,
+  redPngBytes,
+} from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimRekognition } from "../../sim-rekognition.js";
+import {
+  SimRekognitionError,
+  SimRekognitionInvalidImageFormatException,
+  SimRekognitionInvalidParameterException,
+  SimRekognitionInvalidS3ObjectException,
+  SimRekognitionUnsimulatedInputException,
+} from "../../error/sim-rekognition.error.js";
+
+async function simAwsWithObject(body: Uint8Array | string): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "uploads",
+      Key: "selfie.png",
+      Body: body,
+    }),
+  );
+
+  return simAws;
+}
+
+describe("Rejecting a malformed DetectModerationLabels request", () => {
+  it("requires an image", async () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a request names no image at all. The SDK's own types require one,
+    // so this is the shape a JavaScript caller can still send.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels({ input: {} }),
+    );
+
+    // Then it is refused as an invalid parameter, as real Rekognition
+    // refuses it.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "Image is required");
+  });
+
+  it("refuses an image carrying both bytes and an S3 object", async () => {
+    // Given an image named both ways at once.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: {
+              Bytes: redPngBytes,
+              S3Object: { Bucket: "uploads", Name: "selfie.png" },
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused rather than one of the two being picked.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "not both");
+  });
+
+  it("refuses an image carrying neither bytes nor an S3 object", async () => {
+    // Given an empty image.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws
+          .rekognition()
+          .detectModerationLabels(
+            new DetectModerationLabelsCommand({ Image: {} }),
+          ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "either Bytes or S3Object");
+  });
+
+  it("refuses an S3 object missing its Bucket or Name", async () => {
+    // Given an S3 object named without a key.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "uploads" } },
+          }),
+        ),
+    );
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "both Bucket and Name");
+  });
+
+  it("refuses a MinConfidence outside 0 to 100", async () => {
+    // Given a request asking for an impossible confidence.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { Bytes: redPngBytes },
+            MinConfidence: 140,
+          }),
+        ),
+    );
+
+    // Then it is refused, rather than being clamped into range.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a request naming a custom moderation adapter", async () => {
+    // Given a request naming a ProjectVersion, which is a trained adapter.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { Bytes: redPngBytes },
+            ProjectVersion: "arn:aws:rekognition:us-east-1:1:project/x/1",
+          }),
+        ),
+    );
+
+    // Then it is refused by name, because answering from the built-in model
+    // would make the adapter look applied here and be applied in production.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "ProjectVersion is not simulated");
+  });
+
+  it("refuses a request asking for a human review loop", async () => {
+    // Given a request naming a HumanLoopConfig.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { Bytes: redPngBytes },
+            HumanLoopConfig: {
+              HumanLoopName: "review",
+              FlowDefinitionArn: "arn:aws:sagemaker:us-east-1:1:flow/x",
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused, so no response carries a HumanLoopActivationOutput
+    // this simulation would have had to invent.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "HumanLoopConfig is not simulated");
+  });
+
+  it("refuses an S3 object version", async () => {
+    // Given a request naming a version of an S3 object.
+    const simAws = await simAwsWithObject(redPngBytes);
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: {
+              S3Object: {
+                Bucket: "uploads",
+                Name: "selfie.png",
+                Version: "3",
+              },
+            },
+          }),
+        ),
+    );
+
+    // Then it is refused, since simulated S3 has no object versions and would
+    // have answered with the current one.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "Version is not simulated");
+  });
+});
+
+describe("Reading a simulated image Rekognition cannot use", () => {
+  it("refuses bytes that are not a PNG or a JPEG", async () => {
+    // Given an Object holding a placeholder string rather than an image.
+    const simAws = await simAwsWithObject("cat picture");
+
+    // When it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "uploads", Name: "selfie.png" } },
+          }),
+        ),
+    );
+
+    // Then the format is refused, as real Rekognition refuses anything that
+    // is not one of the two formats it reads.
+    assertInstanceOf(error, SimRekognitionInvalidImageFormatException);
+    assertStringIncludes(error.message, "neither PNG nor JPEG");
+  });
+
+  it("accepts JPEG bytes as readily as PNG bytes", async () => {
+    // Given a JPEG.
+    const simAws = new SimAws();
+
+    // When it is moderated.
+    const detected = await simAws
+      .rekognition()
+      .detectModerationLabels(
+        new DetectModerationLabelsCommand({ Image: { Bytes: jpegBytes } }),
+      );
+
+    // Then the format is identified from the bytes and the detection runs.
+    assertStringIncludes(detected.ModerationModelVersion, "7.");
+  });
+
+  it("reports an unknown Bucket as an S3 object problem", async () => {
+    // Given no Bucket of that name anywhere in the simulation.
+    const simAws = new SimAws();
+
+    // When an image in it is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "nowhere", Name: "selfie.png" } },
+          }),
+        ),
+    );
+
+    // Then it is an S3 object error, which is how real Rekognition reports
+    // every S3 problem.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertStringIncludes(error.message, "Unable to get object metadata");
+  });
+
+  it("reports a missing object with the underlying error as its cause", async () => {
+    // Given a Bucket with nothing of that name in it.
+    const simAws = await simAwsWithObject(redPngBytes);
+
+    // When a missing object is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "uploads", Name: "missing.png" } },
+          }),
+        ),
+    );
+
+    // Then the S3 error is kept as the cause, so what actually went wrong is
+    // still readable from what was thrown.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertInstanceOf(error.cause, Error);
+    assertStringIncludes(error.cause.name, "NoSuchKey");
+  });
+
+  it("refuses a Bucket in another Region", async () => {
+    // Given a Bucket created in another Region.
+    const simAws = new SimAws();
+    await simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "elsewhere" }));
+
+    // When an image in it is moderated from this Region.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "elsewhere", Name: "selfie.png" } },
+          }),
+        ),
+    );
+
+    // Then it is refused, as real Rekognition reads only Buckets in its own
+    // Region, and the message says where the Bucket actually is.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertStringIncludes(error.message, "the Bucket is in eu-west-2");
+  });
+
+  it("says so when a standalone Rekognition has no S3 to read from", async () => {
+    // Given a Rekognition built on its own rather than through SimAws.
+    const simRekognition = new SimRekognition();
+
+    // When an S3 object is moderated.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simRekognition.detectModerationLabels(
+          new DetectModerationLabelsCommand({
+            Image: { S3Object: { Bucket: "uploads", Name: "selfie.png" } },
+          }),
+        ),
+    );
+
+    // Then the wiring is named rather than the object being reported missing.
+    assertInstanceOf(error, SimRekognitionError);
+    assertStringIncludes(error.message, "built without simulated S3");
+  });
+
+  it("moderates bytes without any simulated S3 at all", async () => {
+    // Given a Rekognition built on its own.
+    const simRekognition = new SimRekognition();
+    simRekognition.moderation().byDefault({ labels: ["Gambling"] });
+
+    // When an image is moderated as bytes.
+    const detected = await simRekognition.detectModerationLabels(
+      new DetectModerationLabelsCommand({ Image: { Bytes: redPngBytes } }),
+    );
+
+    // Then it answers, since nothing needed reading.
+    assertStringIncludes(detected.ModerationLabels[0]?.Name ?? "", "Gambling");
+  });
+});

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
@@ -34,6 +34,17 @@ export interface SimRekognitionModerationLabelOutput {
 }
 
 /**
+ * A kind of content an image was identified as, such as animated or
+ * illustrated.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_ContentType.html
+ */
+export interface SimRekognitionContentTypeOutput {
+  readonly Confidence?: number | undefined;
+  readonly Name?: string | undefined;
+}
+
+/**
  * Minimal structural sim Rekognition DetectModerationLabels command.
  *
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/DetectModerationLabelsCommand/
@@ -50,6 +61,6 @@ export interface SimDetectModerationLabelsCommandInput {
 export interface SimDetectModerationLabelsCommandOutput {
   readonly ModerationLabels: readonly SimRekognitionModerationLabelOutput[];
   readonly ModerationModelVersion: string;
-  readonly ContentTypes: readonly string[];
+  readonly ContentTypes: readonly SimRekognitionContentTypeOutput[];
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
@@ -1,0 +1,55 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * An image as a Rekognition detection request names it.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Image.html
+ */
+export interface SimRekognitionImageInput {
+  readonly Bytes?: Uint8Array | undefined;
+  readonly S3Object?: SimRekognitionS3ObjectInput | undefined;
+}
+
+/**
+ * An S3 object as a Rekognition detection request names it.
+ *
+ * The object key is `Name` here rather than the `Key` every S3 command uses.
+ */
+export interface SimRekognitionS3ObjectInput {
+  readonly Bucket?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Version?: string | undefined;
+}
+
+/**
+ * A detected moderation label, with the label above it in the taxonomy.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_ModerationLabel.html
+ */
+export interface SimRekognitionModerationLabelOutput {
+  readonly Confidence: number;
+  readonly Name: string;
+  readonly ParentName: string;
+  readonly TaxonomyLevel: number;
+}
+
+/**
+ * Minimal structural sim Rekognition DetectModerationLabels command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/DetectModerationLabelsCommand/
+ */
+export interface SimDetectModerationLabelsCommand {
+  readonly input: SimDetectModerationLabelsCommandInput;
+}
+
+export interface SimDetectModerationLabelsCommandInput {
+  readonly Image?: SimRekognitionImageInput | undefined;
+  readonly MinConfidence?: number | undefined;
+}
+
+export interface SimDetectModerationLabelsCommandOutput {
+  readonly ModerationLabels: readonly SimRekognitionModerationLabelOutput[];
+  readonly ModerationModelVersion: string;
+  readonly ContentTypes: readonly string[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.handler.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.handler.ts
@@ -12,15 +12,6 @@ import type {
 
 const action = "rekognition:DetectModerationLabels";
 
-/**
- * The content types real Rekognition reports an image as.
- *
- * A photograph is neither animated nor illustrated, and comes back with an
- * empty list. Simulated Rekognition does not look at the image, so it has
- * nothing to say here and says nothing, which is what a photograph would get.
- */
-const contentTypes: readonly string[] = [];
-
 interface DetectModerationLabelsHandlerProperties {
   readonly moderation: SimRekognitionModeration;
   readonly authorizer: SimRekognitionAuthorizer;
@@ -71,7 +62,11 @@ export class DetectModerationLabelsHandler {
     return {
       ModerationLabels: detection.labelsAbove(request.minConfidence),
       ModerationModelVersion: simRekognitionModerationModelVersion,
-      ContentTypes: contentTypes,
+      // A photograph is neither animated nor illustrated, and comes back with
+      // an empty list. Simulated Rekognition does not look at the image, so it
+      // has nothing to say here and says nothing, which is what a photograph
+      // would get. Each response gets its own array rather than sharing one.
+      ContentTypes: [],
       $metadata: {},
     };
   }

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.handler.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.handler.ts
@@ -1,0 +1,78 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimRekognitionImageObjects } from "../../image/sim-rekognition-image-objects.js";
+import type { SimRekognitionModeration } from "../../moderation/sim-rekognition-moderation.js";
+import { simRekognitionModerationModelVersion } from "../../moderation/sim-rekognition-moderation-taxonomy.js";
+import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+import { DetectModerationLabelsRequest } from "./detect-moderation-labels-request.js";
+import type {
+  SimDetectModerationLabelsCommand,
+  SimDetectModerationLabelsCommandOutput,
+} from "./detect-moderation-labels.command.js";
+
+const action = "rekognition:DetectModerationLabels";
+
+/**
+ * The content types real Rekognition reports an image as.
+ *
+ * A photograph is neither animated nor illustrated, and comes back with an
+ * empty list. Simulated Rekognition does not look at the image, so it has
+ * nothing to say here and says nothing, which is what a photograph would get.
+ */
+const contentTypes: readonly string[] = [];
+
+interface DetectModerationLabelsHandlerProperties {
+  readonly moderation: SimRekognitionModeration;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly images: SimRekognitionImageObjects;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Handles a DetectModerationLabels command.
+ *
+ * The order of the steps is the point of this class. The request is checked
+ * first, so a malformed one fails the same way whatever else the simulation is
+ * doing. The caller is then authorized for the Rekognition action before the
+ * image is read, so a caller without `rekognition:DetectModerationLabels` is
+ * told about that rather than about an S3 object, and goes looking at the
+ * right policy. Only then is the image read, as the caller, and the rules
+ * consulted.
+ */
+export class DetectModerationLabelsHandler {
+  private readonly moderation: SimRekognitionModeration;
+  private readonly authorizer: SimRekognitionAuthorizer;
+  private readonly images: SimRekognitionImageObjects;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DetectModerationLabelsHandlerProperties) {
+    this.moderation = properties.moderation;
+    this.authorizer = properties.authorizer;
+    this.images = properties.images;
+    this.background = properties.background;
+  }
+
+  /**
+   * Detect the moderation labels an image is declared to have.
+   */
+  async handle(
+    command: SimDetectModerationLabelsCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimDetectModerationLabelsCommandOutput> {
+    const request = new DetectModerationLabelsRequest(command.input);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(action, options);
+
+    const image = await request.image.read(this.images, options);
+    const detection = this.moderation.detectionFor(image);
+
+    return {
+      ModerationLabels: detection.labelsAbove(request.minConfidence),
+      ModerationModelVersion: simRekognitionModerationModelVersion,
+      ContentTypes: contentTypes,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.iso.test.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.iso.test.ts
@@ -1,0 +1,300 @@
+import { DetectModerationLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  bluePngBytes,
+  redPngBytes,
+} from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRekognitionImageHash } from "../../image/sim-rekognition-image-hash.js";
+import type { SimDetectModerationLabelsCommandOutput } from "./detect-moderation-labels.command.js";
+
+async function simAwsWithImage(
+  objectName = "selfie.png",
+  bytes = redPngBytes,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws
+    .s3()
+    .putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: objectName, Body: bytes }),
+    );
+
+  return simAws;
+}
+
+async function detect(
+  simAws: SimAws,
+  objectName: string,
+  minConfidence?: number,
+): Promise<SimDetectModerationLabelsCommandOutput> {
+  return await simAws.rekognition().detectModerationLabels(
+    new DetectModerationLabelsCommand({
+      Image: { S3Object: { Bucket: "uploads", Name: objectName } },
+      ...(minConfidence !== undefined && { MinConfidence: minConfidence }),
+    }),
+  );
+}
+
+describe("Detecting moderation labels in a simulated image", () => {
+  it("reports an image as clean until a rule says otherwise", async () => {
+    // Given an image in a Bucket and no rules registered against it.
+    const simAws = await simAwsWithImage();
+
+    // When it is moderated.
+    const detected = await detect(simAws, "selfie.png");
+
+    // Then it comes back clean, from the version of the model whose taxonomy
+    // the labels would have come from.
+    assertArrayLength(detected.ModerationLabels, 0);
+    assertIdentical(detected.ModerationModelVersion, "7.0");
+    assertArrayLength(detected.ContentTypes, 0);
+  });
+
+  it("answers with the labels declared for an object name", async () => {
+    // Given an object declared to fail moderation.
+    const simAws = await simAwsWithImage("nsfw.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("nsfw.png", { labels: ["Explicit Nudity"] });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "nsfw.png");
+
+    // Then the declared label comes back with the category above it, as real
+    // Rekognition returns a detected label with its whole chain.
+    assertArrayLength(detected.ModerationLabels, 2);
+    const [top, declared] = detected.ModerationLabels;
+    assertNonNullable(top);
+    assertNonNullable(declared);
+    assertIdentical(top.Name, "Explicit");
+    assertIdentical(top.ParentName, "");
+    assertIdentical(top.TaxonomyLevel, 1);
+    assertIdentical(declared.Name, "Explicit Nudity");
+    assertIdentical(declared.ParentName, "Explicit");
+    assertIdentical(declared.TaxonomyLevel, 2);
+  });
+
+  it("expands a third level label to both labels above it", async () => {
+    // Given an object declared with a third level label.
+    const simAws = await simAwsWithImage("party.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("party.png", { labels: ["Drinking"] });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "party.png");
+
+    // Then all three levels of the chain come back.
+    assertIdentical(
+      detected.ModerationLabels.map((label) => label.Name).join(" / "),
+      "Alcohol / Alcohol Use / Drinking",
+    );
+    assertIdentical(
+      detected.ModerationLabels.map((label) => label.TaxonomyLevel).join(","),
+      "1,2,3",
+    );
+  });
+
+  it("reports a shared parent once, at the higher confidence", async () => {
+    // Given an object declared with two labels under one parent, one of them
+    // more confident than the other.
+    const simAws = await simAwsWithImage("fight.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("fight.png", {
+        labels: [
+          { name: "Physical Violence", confidence: 82 },
+          { name: "Blood & Gore", confidence: 91 },
+        ],
+      });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "fight.png");
+
+    // Then the parent appears once, as confidently as its most confident
+    // child, which is what keeps it from being filtered out from under one.
+    const violence = detected.ModerationLabels.filter(
+      (label) => label.Name === "Graphic Violence",
+    );
+    assertArrayLength(violence, 1);
+    assertIdentical(violence[0].Confidence, Math.fround(91));
+  });
+
+  it("reports a shared parent at the highest confidence whatever order the labels were declared in", async () => {
+    // Given the same two labels declared with the confident one first.
+    const simAws = await simAwsWithImage("brawl.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("brawl.png", {
+        labels: [
+          { name: "Blood & Gore", confidence: 91 },
+          { name: "Physical Violence", confidence: 82 },
+        ],
+      });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "brawl.png");
+
+    // Then the parent still carries the higher of the two confidences.
+    const violence = detected.ModerationLabels.filter(
+      (label) => label.Name === "Graphic Violence",
+    );
+    assertArrayLength(violence, 1);
+    assertIdentical(violence[0].Confidence, Math.fround(91));
+  });
+
+  it("filters whole chains below the requested confidence", async () => {
+    // Given an object declared with a confident label and a doubtful one.
+    const simAws = await simAwsWithImage("mixed.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("mixed.png", {
+        labels: [
+          { name: "Weapons", confidence: 96 },
+          { name: "Gambling", confidence: 41 },
+        ],
+      });
+
+    // When it is moderated at the default confidence.
+    const detected = await detect(simAws, "mixed.png");
+
+    // Then the doubtful chain is gone entirely, so no surviving label names a
+    // parent that is not there.
+    assertIdentical(
+      detected.ModerationLabels.map((label) => label.Name).join(" / "),
+      "Violence / Weapons",
+    );
+  });
+
+  it("returns every label when the request asks for a confidence of zero", async () => {
+    // Given an object declared with a label below the default confidence.
+    const simAws = await simAwsWithImage("maybe.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("maybe.png", { labels: [{ name: "Gambling", confidence: 41 }] });
+
+    // When it is moderated with an explicit zero rather than no value at all.
+    const detected = await detect(simAws, "maybe.png", 0);
+
+    // Then the label survives: an explicit 0 is a request for everything, not
+    // an unset value to be promoted to the default of 50.
+    assertArrayLength(detected.ModerationLabels, 1);
+  });
+
+  it("reports confidences as the float32 values real Rekognition returns", async () => {
+    // Given an object declared with a confidence that is not exact in float32.
+    const simAws = await simAwsWithImage("smoke.png");
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("smoke.png", { labels: [{ name: "Smoking", confidence: 99.4 }] });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "smoke.png");
+
+    // Then the confidence carries the trailing digits a real response has,
+    // rather than a rounded number no model would produce.
+    assertIdentical(detected.ModerationLabels[0]?.Confidence, 99.4000015258789);
+  });
+
+  it("matches an image by content hash whatever it is called", async () => {
+    // Given a rule for the hash of some image bytes, and an object storing
+    // those bytes under a name nothing was declared for.
+    const simAws = await simAwsWithImage("2f9c1e40-uuid.png", bluePngBytes);
+    simAws
+      .rekognition()
+      .moderation()
+      .onHash(simRekognitionImageHash(bluePngBytes), {
+        labels: ["Violence"],
+      });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "2f9c1e40-uuid.png");
+
+    // Then the hash rule answers, which is what makes a system that generates
+    // its own object keys testable.
+    assertIdentical(detected.ModerationLabels[0]?.Name, "Violence");
+  });
+
+  it("prefers a hash rule to a name rule for the same image", async () => {
+    // Given an object matched by both a name rule and a hash rule.
+    const simAws = await simAwsWithImage("photo.png");
+    const moderation = simAws.rekognition().moderation();
+    moderation.onName("photo.png", { labels: ["Gambling"] });
+    moderation.onHash(simRekognitionImageHash(redPngBytes), {
+      labels: ["Violence"],
+    });
+
+    // When it is moderated.
+    const detected = await detect(simAws, "photo.png");
+
+    // Then the hash rule wins, being about the image itself rather than about
+    // what it happens to be called.
+    assertIdentical(detected.ModerationLabels[0]?.Name, "Violence");
+  });
+
+  it("consults hash rules and the default for an image passed as bytes", async () => {
+    // Given a name rule, a hash rule and a default.
+    const simAws = new SimAws();
+    const moderation = simAws.rekognition().moderation();
+    moderation.byDefault({ labels: ["Gambling"] });
+    moderation.onName("selfie.png", { labels: ["Violence"] });
+    moderation.onHash(simRekognitionImageHash(bluePngBytes), {
+      labels: ["Weapons"],
+    });
+
+    // When images are moderated as bytes rather than as S3 objects.
+    const hashed = await simAws
+      .rekognition()
+      .detectModerationLabels(
+        new DetectModerationLabelsCommand({ Image: { Bytes: bluePngBytes } }),
+      );
+    const unknown = await simAws
+      .rekognition()
+      .detectModerationLabels(
+        new DetectModerationLabelsCommand({ Image: { Bytes: redPngBytes } }),
+      );
+
+    // Then the hash rule matches and the default answers for the rest, since
+    // bytes have no name for a name rule to match.
+    assertIdentical(hashed.ModerationLabels.at(-1)?.Name, "Weapons");
+    assertIdentical(unknown.ModerationLabels.at(-1)?.Name, "Gambling");
+  });
+
+  it("keeps rules to the Account and Region they were registered in", async () => {
+    // Given a rule registered in one Region only.
+    const simAws = new SimAws();
+    simAws
+      .rekognition()
+      .moderation()
+      .byDefault({ labels: ["Explicit Sexual Activity"] });
+
+    // When an image is moderated in another Region.
+    const elsewhere = await simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .rekognition()
+      .detectModerationLabels(
+        new DetectModerationLabelsCommand({ Image: { Bytes: redPngBytes } }),
+      );
+
+    // Then that Region answers from its own rules, as a real Rekognition
+    // endpoint answers for the Region it belongs to.
+    assertArrayLength(elsewhere.ModerationLabels, 0);
+  });
+});

--- a/src/service/rekognition/command/sim-rekognition-request-options.ts
+++ b/src/service/rekognition/command/sim-rekognition-request-options.ts
@@ -1,0 +1,16 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The request context a simulated Rekognition operation is made in.
+ */
+export interface SimRekognitionRequestOptions {
+  /**
+   * The principal making the request. Defaults to the Account root.
+   *
+   * It is authorized for the Rekognition action, and it is also the principal
+   * the image is read from S3 as, so a caller allowed to detect but not
+   * allowed `s3:GetObject` on the image is refused the way it would be on real
+   * AWS.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+}

--- a/src/service/rekognition/command/sim-rekognition-unsimulated-input.ts
+++ b/src/service/rekognition/command/sim-rekognition-unsimulated-input.ts
@@ -1,0 +1,35 @@
+import { SimRekognitionUnsimulatedInputException } from "../error/sim-rekognition.error.js";
+
+/**
+ * Refuses the request inputs this simulation does not model.
+ *
+ * The refusal works from the small set of options each command accepts rather
+ * than from a list of everything Rekognition offers, so an option nobody
+ * thought about is refused rather than dropped. Dropping is the failure mode
+ * worth avoiding here: a request naming a custom moderation adapter through
+ * `ProjectVersion` would be answered by the built-in model, which is the one
+ * answer that looks right and is not.
+ */
+export class SimRekognitionUnsimulatedInput {
+  private readonly operation: string;
+
+  constructor(operation: string) {
+    this.operation = operation;
+  }
+
+  /**
+   * Refuse every supplied input that is not one of the accepted options.
+   */
+  refuseUnaccepted(input: object, accepted: readonly string[]): void {
+    for (const [option, value] of Object.entries(input)) {
+      if (value === undefined || accepted.includes(option)) {
+        continue;
+      }
+
+      throw new SimRekognitionUnsimulatedInputException(
+        `${this.operation} ${option} is not simulated: it would be ignored ` +
+          `here and applied on real AWS`,
+      );
+    }
+  }
+}

--- a/src/service/rekognition/error/sim-rekognition.error.ts
+++ b/src/service/rekognition/error/sim-rekognition.error.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimal metadata shape for simulated Rekognition errors.
+ */
+export interface SimRekognitionErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Rekognition errors.
+ */
+export class SimRekognitionError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimRekognitionErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Rekognition InvalidParameterException error.
+ *
+ * Real Rekognition reports a malformed request this way: an image with
+ * neither bytes nor an S3 object, both at once, or a MinConfidence outside
+ * the range it accepts.
+ */
+export class SimRekognitionInvalidParameterException extends SimRekognitionError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Rekognition InvalidS3ObjectException error.
+ *
+ * Real Rekognition reports every S3 problem this way, whether the Bucket is
+ * missing, the object is missing, or its own role cannot read it. The
+ * simulator's underlying error is kept as the `cause`, so a missing
+ * `s3:GetObject` grant is still diagnosable from the thrown error.
+ */
+export class SimRekognitionInvalidS3ObjectException extends SimRekognitionError {
+  public override readonly name = "InvalidS3ObjectException";
+
+  constructor(message: string, options: { readonly cause?: unknown } = {}) {
+    super(message, { httpStatusCode: 400 });
+
+    if (options.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+/**
+ * Simulated Rekognition InvalidImageFormatException error.
+ *
+ * Real Rekognition accepts PNG and JPEG image bytes and reports anything else
+ * this way, including bytes that are not an image at all.
+ */
+export class SimRekognitionInvalidImageFormatException extends SimRekognitionError {
+  public override readonly name = "InvalidImageFormatException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Rekognition AccessDeniedException error.
+ *
+ * Rekognition reports an IAM denial under its own error name with a 400
+ * status rather than the 403 several other services use, so the simulation
+ * raises its own error here instead of letting the shared IAM one out. A test
+ * asserting on `AccessDeniedException` is asserting on what real Rekognition
+ * would have thrown.
+ */
+export class SimRekognitionAccessDeniedException extends SimRekognitionError {
+  public override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Rekognition error for a request input this simulation does not
+ * model.
+ *
+ * This is not an error real Rekognition has. It is refused here rather than
+ * ignored, because an ignored input looks applied to the request that sent it
+ * and unapplied to everything else.
+ */
+export class SimRekognitionUnsimulatedInputException extends SimRekognitionError {
+  public override readonly name = "InvalidParameterException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Rekognition error for a result declared against this simulation
+ * that it cannot answer with.
+ *
+ * This is a simulator configuration error rather than an AWS one, so it is
+ * raised where the declaration is made rather than where the detection runs.
+ * A moderation label real Rekognition has never heard of would otherwise sit
+ * there until a detection returned it, and a test asserting on it would pass
+ * against something AWS could not produce.
+ */
+export class SimRekognitionDeclarationError extends SimRekognitionError {
+  public override readonly name = "SimRekognitionDeclarationError";
+}

--- a/src/service/rekognition/image/s3/sim-aws-rekognition-image-objects.ts
+++ b/src/service/rekognition/image/s3/sim-aws-rekognition-image-objects.ts
@@ -1,0 +1,120 @@
+import { buffer } from "node:stream/consumers";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimRekognitionInvalidS3ObjectException } from "../../error/sim-rekognition.error.js";
+import type {
+  SimRekognitionImageObjectRequest,
+  SimRekognitionImageObjects,
+} from "../sim-rekognition-image-objects.js";
+
+interface SimAwsRekognitionImageObjectsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated S3 objects of one simulated AWS instance, as images
+ * Rekognition can detect on.
+ *
+ * The Bucket is found through the S3 Bucket registry rather than through this
+ * scope's own S3, so a Bucket owned by another Account resolves, as real
+ * Rekognition reads across Accounts given a Bucket policy that allows it.
+ * The read itself is an ordinary simulated GetObject made as the caller, so
+ * that policy is what decides it.
+ */
+export class SimAwsRekognitionImageObjects implements SimRekognitionImageObjects {
+  private readonly simAws: SimAws;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsRekognitionImageObjectsProperties) {
+    this.simAws = properties.simAws;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read an image object's bytes.
+   *
+   * Every way this can fail becomes InvalidS3ObjectException, as it does on
+   * real Rekognition, which reports a missing Bucket, a missing object and an
+   * object it may not read with the same error. The underlying simulator error
+   * is kept as the `cause`, so a missing `s3:GetObject` grant is still
+   * diagnosable from the error that was thrown.
+   */
+  async read(request: SimRekognitionImageObjectRequest): Promise<Uint8Array> {
+    const bucketScope = this.requireBucketScope(request);
+
+    try {
+      return await this.getObjectBytes(bucketScope, request);
+    } catch (error) {
+      throw new SimRekognitionInvalidS3ObjectException(
+        `${this.unableToGet(request)} (${String(error)})`,
+        { cause: error },
+      );
+    }
+  }
+
+  /**
+   * Where the named Bucket lives, refusing one this Region cannot reach.
+   *
+   * Real Rekognition reads a Bucket in its own Region only, and reports one
+   * in another Region as an S3 object problem rather than as a request
+   * problem. The message says which Region the Bucket is in, because that is
+   * the part a caller cannot see from the request.
+   */
+  private requireBucketScope(
+    request: SimRekognitionImageObjectRequest,
+  ): SimAwsAccountRegionScope {
+    const bucketScope = this.simAws.s3().findBucketScope(request.bucketName);
+
+    if (bucketScope === undefined) {
+      throw new SimRekognitionInvalidS3ObjectException(
+        `${this.unableToGet(request)} (no simulated Bucket is named ` +
+          `${request.bucketName})`,
+      );
+    }
+
+    if (bucketScope.regionName !== this.accountRegionScope.regionName) {
+      throw new SimRekognitionInvalidS3ObjectException(
+        `${this.unableToGet(request)} (the Bucket is in ` +
+          `${bucketScope.regionName} and Rekognition is in ` +
+          `${this.accountRegionScope.regionName}, and Rekognition reads only ` +
+          `Buckets in its own Region)`,
+      );
+    }
+
+    return bucketScope;
+  }
+
+  private async getObjectBytes(
+    bucketScope: SimAwsAccountRegionScope,
+    request: SimRekognitionImageObjectRequest,
+  ): Promise<Uint8Array> {
+    const s3 = this.simAws
+      .accountRegionScope(bucketScope.accountId, bucketScope.regionName)
+      .s3();
+
+    const output = await s3.getObject(
+      { input: { Bucket: request.bucketName, Key: request.objectName } },
+      request.caller === undefined ? undefined : { caller: request.caller },
+    );
+
+    assertDefined(
+      output.Body,
+      `s3://${request.bucketName}/${request.objectName} has no body`,
+    );
+
+    return await buffer(output.Body);
+  }
+
+  /**
+   * The message real Rekognition reports every S3 failure with.
+   */
+  private unableToGet(request: SimRekognitionImageObjectRequest): string {
+    return (
+      `Unable to get object metadata from S3 for ` +
+      `s3://${request.bucketName}/${request.objectName}. Check object key, ` +
+      `region and/or access permissions.`
+    );
+  }
+}

--- a/src/service/rekognition/image/sim-rekognition-image-format.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-format.ts
@@ -1,0 +1,41 @@
+import { SimRekognitionInvalidImageFormatException } from "../error/sim-rekognition.error.js";
+
+/**
+ * The image formats Rekognition detection operations accept.
+ */
+export type SimRekognitionImageFormatName = "PNG" | "JPEG";
+
+const pngMagicBytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const jpegMagicBytes = [0xff, 0xd8, 0xff];
+
+function startsWith(bytes: Uint8Array, magic: readonly number[]): boolean {
+  return magic.every((byte, index) => bytes.at(index) === byte);
+}
+
+/**
+ * Identify the format of some image bytes, from the bytes themselves.
+ *
+ * Real Rekognition accepts PNG and JPEG and refuses everything else, and it
+ * decides which it has from the content rather than from anything the caller
+ * said about it. The stored content type of an S3 object is deliberately not
+ * consulted for the same reason: simulated S3 keeps a supplied `ContentType`
+ * as a metadata key and has none at all unless the uploader set one, so
+ * trusting it would make the same bytes detectable or not depending on how
+ * they were uploaded.
+ */
+export function simRekognitionImageFormat(
+  bytes: Uint8Array,
+): SimRekognitionImageFormatName {
+  if (startsWith(bytes, pngMagicBytes)) {
+    return "PNG";
+  }
+
+  if (startsWith(bytes, jpegMagicBytes)) {
+    return "JPEG";
+  }
+
+  throw new SimRekognitionInvalidImageFormatException(
+    "Request has invalid image format: the image bytes are neither PNG " +
+      "nor JPEG",
+  );
+}

--- a/src/service/rekognition/image/sim-rekognition-image-hash.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-hash.ts
@@ -1,0 +1,21 @@
+import { createHash } from "node:crypto";
+
+/**
+ * The content hash simulated Rekognition matches a rule against.
+ *
+ * It is the sha256 digest of the image bytes as they were received, as
+ * lowercase hex, with no normalisation of any kind. Re-encoding an image
+ * between uploading it and detecting on it therefore changes it, as does any
+ * resizing, stripping of metadata or change of quality setting, so hash the
+ * exact bytes the test will put through the system.
+ */
+export function simRekognitionImageHash(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Whether a string is shaped like an image content hash.
+ */
+export function isSimRekognitionImageHash(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value);
+}

--- a/src/service/rekognition/image/sim-rekognition-image-objects.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-objects.ts
@@ -1,0 +1,45 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimRekognitionError } from "../error/sim-rekognition.error.js";
+
+/**
+ * An S3 object a detection request named, and who is asking for it.
+ */
+export interface SimRekognitionImageObjectRequest {
+  readonly bucketName: string;
+  readonly objectName: string;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * The S3 objects simulated Rekognition can read images from.
+ *
+ * Rekognition reads the object itself rather than being handed the bytes, so
+ * this is the seam where that read happens. The read is made as the caller, so
+ * simulated IAM applies to the image object exactly as `s3:GetObject`
+ * authorization would on real AWS.
+ */
+export interface SimRekognitionImageObjects {
+  read(request: SimRekognitionImageObjectRequest): Promise<Uint8Array>;
+}
+
+/**
+ * The image objects of a simulated Rekognition built without simulated S3.
+ *
+ * A standalone SimRekognition has no S3 to read from, so an `Image.S3Object`
+ * request says so rather than failing as though the object were missing.
+ * Passing the bytes as `Image.Bytes` still works, and reaching Rekognition
+ * through SimAws is what connects the two services.
+ */
+export class SimRekognitionUnreachableImageObjects implements SimRekognitionImageObjects {
+  /**
+   * Refuse the read, naming the object that cannot be reached.
+   */
+  read(request: SimRekognitionImageObjectRequest): Promise<Uint8Array> {
+    throw new SimRekognitionError(
+      `Simulated Rekognition cannot read ` +
+        `s3://${request.bucketName}/${request.objectName} because it was ` +
+        `built without simulated S3. Reach Rekognition through SimAws to ` +
+        `detect on an Image.S3Object, or pass the image as Image.Bytes.`,
+    );
+  }
+}

--- a/src/service/rekognition/image/sim-rekognition-image-request.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-request.ts
@@ -1,0 +1,124 @@
+import type {
+  SimRekognitionImageInput,
+  SimRekognitionS3ObjectInput,
+} from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
+import type { SimRekognitionRequestOptions } from "../command/sim-rekognition-request-options.js";
+import {
+  SimRekognitionInvalidParameterException,
+  SimRekognitionUnsimulatedInputException,
+} from "../error/sim-rekognition.error.js";
+import { SimRekognitionImage } from "./sim-rekognition-image.js";
+import type { SimRekognitionImageObjects } from "./sim-rekognition-image-objects.js";
+
+/**
+ * The image a detection request named, before it has been read.
+ *
+ * Parsing the request and reading the image are separate steps because they
+ * happen at different points in an operation: the request is checked before
+ * anything else, and the image is read only once the caller has been
+ * authorized for the detection.
+ */
+export interface SimRekognitionImageRequest {
+  read(
+    images: SimRekognitionImageObjects,
+    options: SimRekognitionRequestOptions,
+  ): Promise<SimRekognitionImage>;
+}
+
+/**
+ * An image the request carried the bytes of.
+ *
+ * It has no name, so only a hash rule or the default can match it.
+ */
+export class SimRekognitionImageBytesRequest implements SimRekognitionImageRequest {
+  constructor(private readonly bytes: Uint8Array) {}
+
+  /**
+   * Take the bytes the request already carries.
+   */
+  read(): Promise<SimRekognitionImage> {
+    return Promise.resolve(new SimRekognitionImage({ bytes: this.bytes }));
+  }
+}
+
+/**
+ * An image the request named as an S3 object.
+ */
+export class SimRekognitionImageS3Request implements SimRekognitionImageRequest {
+  constructor(
+    private readonly bucketName: string,
+    private readonly objectName: string,
+  ) {}
+
+  /**
+   * Read the object, as the caller making the detection request.
+   */
+  async read(
+    images: SimRekognitionImageObjects,
+    options: SimRekognitionRequestOptions,
+  ): Promise<SimRekognitionImage> {
+    const bytes = await images.read({
+      bucketName: this.bucketName,
+      objectName: this.objectName,
+      caller: options.caller,
+    });
+
+    return new SimRekognitionImage({ bytes, name: this.objectName });
+  }
+}
+
+function parseS3Object(
+  s3Object: SimRekognitionS3ObjectInput,
+): SimRekognitionImageRequest {
+  if (s3Object.Version !== undefined) {
+    throw new SimRekognitionUnsimulatedInputException(
+      "DetectModerationLabels S3Object Version is not simulated: simulated " +
+        "S3 has no object versions, so the version would be ignored here and " +
+        "applied on real AWS",
+    );
+  }
+
+  if (s3Object.Bucket === undefined || s3Object.Name === undefined) {
+    throw new SimRekognitionInvalidParameterException(
+      "Request has invalid parameters: Image S3Object needs both Bucket " +
+        "and Name",
+    );
+  }
+
+  return new SimRekognitionImageS3Request(s3Object.Bucket, s3Object.Name);
+}
+
+/**
+ * Read the `Image` member of a detection request.
+ *
+ * Real Rekognition takes exactly one of bytes or an S3 object, so neither and
+ * both are equally invalid requests.
+ */
+export function parseSimRekognitionImageRequest(
+  image: SimRekognitionImageInput | undefined,
+): SimRekognitionImageRequest {
+  if (image === undefined) {
+    throw new SimRekognitionInvalidParameterException(
+      "Request has invalid parameters: Image is required",
+    );
+  }
+
+  if (image.Bytes !== undefined && image.S3Object !== undefined) {
+    throw new SimRekognitionInvalidParameterException(
+      "Request has invalid parameters: Image takes either Bytes or " +
+        "S3Object, not both",
+    );
+  }
+
+  if (image.Bytes !== undefined) {
+    return new SimRekognitionImageBytesRequest(image.Bytes);
+  }
+
+  if (image.S3Object !== undefined) {
+    return parseS3Object(image.S3Object);
+  }
+
+  throw new SimRekognitionInvalidParameterException(
+    "Request has invalid parameters: Image needs either Bytes or S3Object",
+  );
+}

--- a/src/service/rekognition/image/sim-rekognition-image.ts
+++ b/src/service/rekognition/image/sim-rekognition-image.ts
@@ -1,0 +1,45 @@
+import {
+  simRekognitionImageFormat,
+  type SimRekognitionImageFormatName,
+} from "./sim-rekognition-image-format.js";
+import { simRekognitionImageHash } from "./sim-rekognition-image-hash.js";
+
+interface SimRekognitionImageProperties {
+  readonly bytes: Uint8Array;
+  readonly name?: string | undefined;
+}
+
+/**
+ * An image a detection operation was given, as the thing a rule matches
+ * against.
+ *
+ * An image has a name only when the request named an S3 object, since bytes
+ * passed straight to the operation have nothing to be called. Both always have
+ * a content hash, which is why a hash rule is the one that reaches every
+ * image.
+ *
+ * The format is decided when the image is made, so bytes that are not an image
+ * are refused before any rule is consulted.
+ */
+export class SimRekognitionImage {
+  public readonly bytes: Uint8Array;
+  public readonly name: string | undefined;
+  public readonly format: SimRekognitionImageFormatName;
+
+  private hashDigest: string | undefined;
+
+  constructor(properties: SimRekognitionImageProperties) {
+    this.bytes = properties.bytes;
+    this.name = properties.name;
+    this.format = simRekognitionImageFormat(properties.bytes);
+  }
+
+  /**
+   * The sha256 hash of this image's bytes, as lowercase hex.
+   */
+  hash(): string {
+    this.hashDigest ??= simRekognitionImageHash(this.bytes);
+
+    return this.hashDigest;
+  }
+}

--- a/src/service/rekognition/image/sim-rekognition-image.ts
+++ b/src/service/rekognition/image/sim-rekognition-image.ts
@@ -29,9 +29,12 @@ export class SimRekognitionImage {
   private hashDigest: string | undefined;
 
   constructor(properties: SimRekognitionImageProperties) {
-    this.bytes = properties.bytes;
+    // The bytes are copied rather than kept, so an image is the bytes as they
+    // were received. A caller reading into a reused buffer would otherwise
+    // change the hash of an image that has already been detected on.
+    this.bytes = new Uint8Array(properties.bytes);
     this.name = properties.name;
-    this.format = simRekognitionImageFormat(properties.bytes);
+    this.format = simRekognitionImageFormat(this.bytes);
   }
 
   /**

--- a/src/service/rekognition/index.ts
+++ b/src/service/rekognition/index.ts
@@ -1,0 +1,22 @@
+export { SimRekognition } from "./sim-rekognition.js";
+export type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
+export { SimRekognitionModeration } from "./moderation/sim-rekognition-moderation.js";
+export type {
+  SimRekognitionDeclaredModerationLabel,
+  SimRekognitionModerationLabelDeclaration,
+  SimRekognitionModerationResult,
+} from "./moderation/sim-rekognition-moderation-result.js";
+export {
+  simRekognitionModerationModelVersion,
+  SimRekognitionModerationTaxonomy,
+} from "./moderation/sim-rekognition-moderation-taxonomy.js";
+export { simRekognitionImageHash } from "./image/sim-rekognition-image-hash.js";
+export {
+  SimRekognitionAccessDeniedException,
+  SimRekognitionDeclarationError,
+  SimRekognitionError,
+  SimRekognitionInvalidImageFormatException,
+  SimRekognitionInvalidParameterException,
+  SimRekognitionInvalidS3ObjectException,
+  SimRekognitionUnsimulatedInputException,
+} from "./error/sim-rekognition.error.js";

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
@@ -1,0 +1,81 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+
+describe("Declaring a simulated moderation result", () => {
+  it("refuses a label the moderation taxonomy does not have", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule declares a label real Rekognition would never return, such
+    // as one from the previous version of the taxonomy.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .onName("nsfw.png", { labels: ["Graphic Male Nudity"] });
+    });
+
+    // Then it is refused where it was written, rather than at detection time.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "is not a Rekognition moderation");
+  });
+
+  it("refuses a confidence that is not a percentage", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule declares a confidence outside the range AWS reports in.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .byDefault({ labels: [{ name: "Violence", confidence: 101 }] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a hash rule that is not a sha256 digest", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule is registered against a truncated digest.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .onHash("9f86d081884c7d65", { labels: ["Violence"] });
+    });
+
+    // Then it is refused, rather than being stored as a hash nothing can
+    // ever match.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "64 hex characters");
+  });
+
+  it("refuses a name rule with no name to match", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule is registered against an empty name.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .onName("", { labels: ["Violence"] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "needs an S3 object name");
+  });
+});

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-declaration.iso.test.ts
@@ -44,6 +44,41 @@ describe("Declaring a simulated moderation result", () => {
     assertStringIncludes(error.message, "percentage from 0 to 100");
   });
 
+  it("refuses a negative confidence", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule declares a confidence below the range AWS reports in.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .byDefault({ labels: [{ name: "Violence", confidence: -1 }] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a confidence that is not a number at all", () => {
+    // Given a simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a rule declares a confidence of NaN.
+    const error = assertThrowsError(() => {
+      simAws
+        .rekognition()
+        .moderation()
+        .byDefault({ labels: [{ name: "Violence", confidence: NaN }] });
+    });
+
+    // Then it is refused where it was written, rather than being stored as a
+    // label that silently never survives MinConfidence filtering.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
   it("refuses a hash rule that is not a sha256 digest", () => {
     // Given a simulated Rekognition.
     const simAws = new SimAws();

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-labels.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-labels.ts
@@ -1,0 +1,86 @@
+/**
+ * The version 7.0 content moderation label list, and the model version it is
+ * the label list of.
+ *
+ * The two live together so they cannot drift apart. Real Rekognition moved
+ * from 6.1 to 7.0 by renaming most of the top-level categories, so a response
+ * naming one version's labels under the other version's number would describe
+ * nothing AWS has ever returned.
+ */
+
+/**
+ * The moderation model version this taxonomy is the taxonomy of.
+ *
+ * It is pinned here rather than anywhere else so that the version a response
+ * reports and the labels it can carry cannot drift apart. Real Rekognition
+ * moved from 6.1 to 7.0 by renaming most of the top-level categories, so a
+ * response naming one version's labels under the other version's number would
+ * describe nothing AWS has ever returned.
+ */
+export const simRekognitionModerationModelVersion = "7.0";
+
+/**
+ * Every label in the version 7.0 content moderation taxonomy, as a name and
+ * the name of its parent. A top-level label has no parent.
+ *
+ * This is the whole taxonomy rather than a useful subset of it, because the
+ * point of holding it at all is that a declared label expands to the same
+ * ancestors real Rekognition would have returned with it.
+ */
+export const moderationLabels: readonly (readonly [string, string])[] = [
+  ["Explicit", ""],
+  ["Explicit Nudity", "Explicit"],
+  ["Exposed Male Genitalia", "Explicit Nudity"],
+  ["Exposed Female Genitalia", "Explicit Nudity"],
+  ["Exposed Buttocks or Anus", "Explicit Nudity"],
+  ["Exposed Female Nipple", "Explicit Nudity"],
+  ["Explicit Sexual Activity", "Explicit"],
+  ["Sex Toys", "Explicit"],
+  ["Non-Explicit Nudity of Intimate parts and Kissing", ""],
+  ["Non-Explicit Nudity", "Non-Explicit Nudity of Intimate parts and Kissing"],
+  ["Bare Back", "Non-Explicit Nudity"],
+  ["Exposed Male Nipple", "Non-Explicit Nudity"],
+  ["Partially Exposed Buttocks", "Non-Explicit Nudity"],
+  ["Partially Exposed Female Breast", "Non-Explicit Nudity"],
+  ["Implied Nudity", "Non-Explicit Nudity"],
+  [
+    "Obstructed Intimate Parts",
+    "Non-Explicit Nudity of Intimate parts and Kissing",
+  ],
+  ["Obstructed Female Nipple", "Obstructed Intimate Parts"],
+  ["Obstructed Male Genitalia", "Obstructed Intimate Parts"],
+  ["Kissing on the Lips", "Non-Explicit Nudity of Intimate parts and Kissing"],
+  ["Swimwear or Underwear", ""],
+  ["Female Swimwear or Underwear", "Swimwear or Underwear"],
+  ["Male Swimwear or Underwear", "Swimwear or Underwear"],
+  ["Violence", ""],
+  ["Weapons", "Violence"],
+  ["Graphic Violence", "Violence"],
+  ["Weapon Violence", "Graphic Violence"],
+  ["Physical Violence", "Graphic Violence"],
+  ["Self-Harm", "Graphic Violence"],
+  ["Blood & Gore", "Graphic Violence"],
+  ["Explosions and Blasts", "Graphic Violence"],
+  ["Visually Disturbing", ""],
+  ["Death and Emaciation", "Visually Disturbing"],
+  ["Emaciated Bodies", "Death and Emaciation"],
+  ["Corpses", "Death and Emaciation"],
+  ["Crashes", "Visually Disturbing"],
+  ["Air Crash", "Crashes"],
+  ["Drugs & Tobacco", ""],
+  ["Products", "Drugs & Tobacco"],
+  ["Pills", "Products"],
+  ["Drugs & Tobacco Paraphernalia & Use", "Drugs & Tobacco"],
+  ["Smoking", "Drugs & Tobacco Paraphernalia & Use"],
+  ["Alcohol", ""],
+  ["Alcohol Use", "Alcohol"],
+  ["Drinking", "Alcohol Use"],
+  ["Alcoholic Beverages", "Alcohol"],
+  ["Rude Gestures", ""],
+  ["Middle Finger", "Rude Gestures"],
+  ["Gambling", ""],
+  ["Hate Symbols", ""],
+  ["Nazi Party", "Hate Symbols"],
+  ["White Supremacy", "Hate Symbols"],
+  ["Extremist", "Hate Symbols"],
+];

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
@@ -74,7 +74,10 @@ class SimRekognitionModerationChain {
   ): number {
     const confidence = declared.confidence ?? defaultModerationConfidence;
 
-    if (confidence < 0 || confidence > 100) {
+    // A NaN is refused with everything else out of range. Every comparison
+    // with one is false, so a label declared at NaN would never survive
+    // MinConfidence filtering and would look like a rule that never matched.
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 100) {
       throw new SimRekognitionDeclarationError(
         `A confidence of ${String(confidence)} declared for ` +
           `'${declared.name}' is not a Rekognition confidence, which is a ` +

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
@@ -1,0 +1,146 @@
+import type { SimRekognitionModerationLabelOutput } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import {
+  type SimRekognitionModerationLabelNode,
+  simRekognitionModerationTaxonomy,
+} from "./sim-rekognition-moderation-taxonomy.js";
+
+/**
+ * The confidence a declared label carries when none is declared for it.
+ *
+ * Real Rekognition confidences are float32 values that print with a long
+ * tail, so declared confidences pass through Math.fround and this default is
+ * one of them rather than a round number. A test that asserts on the exact
+ * value is asserting on something the shape of what AWS returns.
+ */
+const defaultModerationConfidence = 96.68;
+
+/**
+ * A moderation label declared against an image, with the confidence
+ * Rekognition is to report it at.
+ */
+export interface SimRekognitionDeclaredModerationLabel {
+  readonly name: string;
+  readonly confidence?: number | undefined;
+}
+
+/**
+ * A moderation label as a rule declares it: a label name on its own, or a
+ * name with the confidence to report it at.
+ */
+export type SimRekognitionModerationLabelDeclaration =
+  string | SimRekognitionDeclaredModerationLabel;
+
+/**
+ * What DetectModerationLabels answers with for an image.
+ *
+ * An empty `labels` is a clean image, which is what most images are and what
+ * the built-in default rule declares.
+ */
+export interface SimRekognitionModerationResult {
+  readonly labels: readonly SimRekognitionModerationLabelDeclaration[];
+}
+
+/**
+ * One declared label and the labels above it in the taxonomy.
+ *
+ * Every label in a chain carries the chain's confidence, so filtering a whole
+ * chain in or out on `MinConfidence` cannot leave a label naming a parent that
+ * is not in the response.
+ */
+class SimRekognitionModerationChain {
+  public readonly confidence: number;
+  public readonly nodes: readonly SimRekognitionModerationLabelNode[];
+
+  constructor(declaration: SimRekognitionModerationLabelDeclaration) {
+    const declared = SimRekognitionModerationChain.declared(declaration);
+
+    this.confidence = SimRekognitionModerationChain.confidenceOf(declared);
+    this.nodes = simRekognitionModerationTaxonomy.chain(declared.name);
+  }
+
+  private static declared(
+    declaration: SimRekognitionModerationLabelDeclaration,
+  ): SimRekognitionDeclaredModerationLabel {
+    if (typeof declaration === "string") {
+      return { name: declaration };
+    }
+
+    return declaration;
+  }
+
+  private static confidenceOf(
+    declared: SimRekognitionDeclaredModerationLabel,
+  ): number {
+    const confidence = declared.confidence ?? defaultModerationConfidence;
+
+    if (confidence < 0 || confidence > 100) {
+      throw new SimRekognitionDeclarationError(
+        `A confidence of ${String(confidence)} declared for ` +
+          `'${declared.name}' is not a Rekognition confidence, which is a ` +
+          `percentage from 0 to 100.`,
+      );
+    }
+
+    return Math.fround(confidence);
+  }
+}
+
+/**
+ * The moderation result one rule answers with, resolved against the taxonomy.
+ *
+ * The declaration is resolved when the rule is registered rather than when a
+ * detection runs, so a label real Rekognition has never heard of is refused
+ * where it was written.
+ */
+export class SimRekognitionModerationDetection {
+  private readonly chains: readonly SimRekognitionModerationChain[];
+
+  constructor(result: SimRekognitionModerationResult) {
+    this.chains = result.labels.map(
+      (declaration) => new SimRekognitionModerationChain(declaration),
+    );
+  }
+
+  /**
+   * The labels to report for this result at a given minimum confidence.
+   *
+   * A label declared in two chains, as two labels sharing a parent are, is
+   * reported once at the highest confidence any of its chains declared. Real
+   * Rekognition reports a parent at least as confidently as the child that
+   * implies it, so taking the highest is what keeps a parent from being
+   * filtered out from under a child that survived.
+   */
+  labelsAbove(
+    minConfidence: number,
+  ): readonly SimRekognitionModerationLabelOutput[] {
+    const highest = new Map<string, SimRekognitionModerationLabelOutput>();
+
+    for (const chain of this.chains) {
+      for (const node of chain.nodes) {
+        const found = highest.get(node.name);
+
+        if (found === undefined || found.Confidence < chain.confidence) {
+          highest.set(node.name, this.label(node, chain.confidence));
+        }
+      }
+    }
+
+    return highest
+      .values()
+      .filter((label) => label.Confidence >= minConfidence)
+      .toArray();
+  }
+
+  private label(
+    node: SimRekognitionModerationLabelNode,
+    confidence: number,
+  ): SimRekognitionModerationLabelOutput {
+    return {
+      Confidence: confidence,
+      Name: node.name,
+      ParentName: node.parentName,
+      TaxonomyLevel: node.taxonomyLevel,
+    };
+  }
+}

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.iso.test.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.iso.test.ts
@@ -1,0 +1,89 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import {
+  SimRekognitionModerationTaxonomy,
+  simRekognitionModerationModelVersion,
+  simRekognitionModerationTaxonomy,
+} from "./sim-rekognition-moderation-taxonomy.js";
+
+describe("The simulated Rekognition moderation taxonomy", () => {
+  it("numbers a label by how deep it sits", () => {
+    // Given the published taxonomy.
+    const taxonomy = new SimRekognitionModerationTaxonomy();
+
+    // When labels from each of its three levels are looked up.
+    const top = taxonomy.require("Violence");
+    const second = taxonomy.require("Graphic Violence");
+    const third = taxonomy.require("Self-Harm");
+
+    // Then each carries the level real Rekognition reports it at, and a top
+    // level label carries an empty parent name rather than no parent at all.
+    assertIdentical(top.taxonomyLevel, 1);
+    assertIdentical(top.parentName, "");
+    assertIdentical(second.taxonomyLevel, 2);
+    assertIdentical(second.parentName, "Violence");
+    assertIdentical(third.taxonomyLevel, 3);
+    assertIdentical(third.parentName, "Graphic Violence");
+  });
+
+  it("answers a label with the labels above it, top level first", () => {
+    // Given the taxonomy.
+    const taxonomy = simRekognitionModerationTaxonomy;
+
+    // When a third level label's chain is taken.
+    const chain = taxonomy.chain("Implied Nudity");
+
+    // Then it runs from the top level category down to the label itself.
+    assertArrayLength(chain, 3);
+    assertIdentical(
+      chain.map((node) => node.name).join(" / "),
+      "Non-Explicit Nudity of Intimate parts and Kissing / " +
+        "Non-Explicit Nudity / Implied Nudity",
+    );
+  });
+
+  it("answers a top level label with only itself", () => {
+    // Given the taxonomy.
+    const taxonomy = simRekognitionModerationTaxonomy;
+
+    // When a top level label's chain is taken.
+    const chain = taxonomy.chain("Gambling");
+
+    // Then it is the label alone, since there is nothing above it. Gambling
+    // is the one category with no second level labels under it either.
+    assertArrayLength(chain, 1);
+    assertIdentical(chain[0].name, "Gambling");
+  });
+
+  it("knows a label it has and refuses one it does not", () => {
+    // Given the taxonomy.
+    const taxonomy = simRekognitionModerationTaxonomy;
+
+    // When a label is checked and an invented one is required.
+    const error = assertThrowsError(() => taxonomy.require("Kittens"));
+
+    // Then the invented one is refused, naming how many labels there are to
+    // choose from.
+    assertTrue(taxonomy.has("Middle Finger"));
+    assertTrue(!taxonomy.has("Kittens"));
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "52 labels");
+  });
+
+  it("names the model version its labels belong to", () => {
+    // Given the taxonomy and the version pinned beside it.
+    // Then the version is the one whose label names these are: the previous
+    // one called this category Explicit Nudity rather than Explicit.
+    assertIdentical(simRekognitionModerationModelVersion, "7.0");
+    assertTrue(simRekognitionModerationTaxonomy.has("Explicit"));
+  });
+});

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-taxonomy.ts
@@ -1,0 +1,110 @@
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import {
+  moderationLabels,
+  simRekognitionModerationModelVersion,
+} from "./sim-rekognition-moderation-labels.js";
+
+/**
+ * One label in the moderation taxonomy.
+ *
+ * A top-level label carries a parent name of `""` rather than no parent at
+ * all, which is what real Rekognition puts in `ParentName` for one.
+ */
+export class SimRekognitionModerationLabelNode {
+  constructor(
+    public readonly name: string,
+    public readonly parentName: string,
+    public readonly taxonomyLevel: number,
+  ) {}
+}
+
+/**
+ * The content moderation label taxonomy, as the thing a declared label is
+ * resolved against.
+ *
+ * Declaring a label is declaring a whole chain: real Rekognition returns the
+ * detected label together with every label above it, so an image declared as
+ * `Implied Nudity` comes back as that, its `Non-Explicit Nudity` parent, and
+ * the top-level category above that. Handler code filtering on the top-level
+ * category therefore sees what it would see on AWS.
+ */
+export class SimRekognitionModerationTaxonomy {
+  private readonly nodes = new Map<string, SimRekognitionModerationLabelNode>();
+
+  constructor() {
+    for (const [name, parentName] of moderationLabels) {
+      this.nodes.set(
+        name,
+        new SimRekognitionModerationLabelNode(
+          name,
+          parentName,
+          this.levelOf(parentName) + 1,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Whether a name is a label in this taxonomy.
+   */
+  has(name: string): boolean {
+    return this.nodes.has(name);
+  }
+
+  /**
+   * The chain of labels a detected label comes back with, from the top-level
+   * category down to the label itself.
+   */
+  chain(name: string): readonly SimRekognitionModerationLabelNode[] {
+    const node = this.require(name);
+
+    if (node.parentName === "") {
+      return [node];
+    }
+
+    return [...this.chain(node.parentName), node];
+  }
+
+  /**
+   * Get a label by name, refusing one this taxonomy does not have.
+   */
+  require(name: string): SimRekognitionModerationLabelNode {
+    const node = this.nodes.get(name);
+
+    if (node === undefined) {
+      throw new SimRekognitionDeclarationError(
+        `'${name}' is not a Rekognition moderation label. Declare one of the ` +
+          `${String(this.nodes.size)} labels in the version ` +
+          `${simRekognitionModerationModelVersion} content moderation ` +
+          `taxonomy, such as 'Explicit Nudity' or 'Violence'.`,
+      );
+    }
+
+    return node;
+  }
+
+  /**
+   * How deep a parent sits, so its children can be numbered below it.
+   *
+   * The labels are declared parents-first, so a parent is always in place by
+   * the time its children are built.
+   */
+  private levelOf(parentName: string): number {
+    if (parentName === "") {
+      return 0;
+    }
+
+    return this.require(parentName).taxonomyLevel;
+  }
+}
+
+/**
+ * The one taxonomy instance the simulation resolves labels against.
+ *
+ * It holds no per-simulation state, only the published label list, so there is
+ * nothing for one SimAws to leak into another through it.
+ */
+export const simRekognitionModerationTaxonomy =
+  new SimRekognitionModerationTaxonomy();
+
+export { simRekognitionModerationModelVersion } from "./sim-rekognition-moderation-labels.js";

--- a/src/service/rekognition/moderation/sim-rekognition-moderation.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation.ts
@@ -1,0 +1,58 @@
+import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
+import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import {
+  SimRekognitionModerationDetection,
+  type SimRekognitionModerationResult,
+} from "./sim-rekognition-moderation-result.js";
+
+/**
+ * What DetectModerationLabels answers with before anything is configured.
+ *
+ * A clean image is the useful default: a moderation pipeline is mostly
+ * exercised by images that pass, with the ones that fail declared image by
+ * image. Which images those are is a decision about the system under test, so
+ * the simulation does not invent one.
+ */
+const cleanImage: SimRekognitionModerationResult = { labels: [] };
+
+/**
+ * The moderation results simulated Rekognition answers with.
+ *
+ * The rules are grouped per operation rather than hung off the service, so
+ * `moderation()`, and the operation groups added beside it, each own the
+ * result shape their own operation answers with.
+ */
+export class SimRekognitionModeration {
+  private readonly rules =
+    new SimRekognitionResultRules<SimRekognitionModerationDetection>(
+      new SimRekognitionModerationDetection(cleanImage),
+    );
+
+  /**
+   * Answer with this result for any image no other rule matches.
+   */
+  byDefault(result: SimRekognitionModerationResult): void {
+    this.rules.byDefault(new SimRekognitionModerationDetection(result));
+  }
+
+  /**
+   * Answer with this result for the S3 object with this exact name.
+   */
+  onName(name: string, result: SimRekognitionModerationResult): void {
+    this.rules.onName(name, new SimRekognitionModerationDetection(result));
+  }
+
+  /**
+   * Answer with this result for the image with this exact content hash.
+   */
+  onHash(hash: string, result: SimRekognitionModerationResult): void {
+    this.rules.onHash(hash, new SimRekognitionModerationDetection(result));
+  }
+
+  /**
+   * The moderation result for one image.
+   */
+  detectionFor(image: SimRekognitionImage): SimRekognitionModerationDetection {
+    return this.rules.resultFor(image);
+  }
+}

--- a/src/service/rekognition/rule/sim-rekognition-result-rules.ts
+++ b/src/service/rekognition/rule/sim-rekognition-result-rules.ts
@@ -1,0 +1,97 @@
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { isSimRekognitionImageHash } from "../image/sim-rekognition-image-hash.js";
+import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
+
+/**
+ * The results one detection operation answers with, by image.
+ *
+ * Simulated Rekognition does no image recognition. Every operation answers
+ * from the rules registered against it, in the way simulated ACM issues
+ * certificates without producing real TLS certificates.
+ *
+ * There are three kinds of rule and one order between them: a rule for an
+ * exact content hash wins, then a rule for an exact S3 object name, then the
+ * default. Matching is exact, with no pattern syntax, so which rule applies
+ * never depends on how specific a pattern is thought to be.
+ *
+ * An image passed as `Image.Bytes` has no name, so it consults hash rules and
+ * then the default.
+ */
+export class SimRekognitionResultRules<TResult> {
+  private defaultResult: TResult;
+  private readonly resultsByName = new Map<string, TResult>();
+  private readonly resultsByHash = new Map<string, TResult>();
+
+  constructor(defaultResult: TResult) {
+    this.defaultResult = defaultResult;
+  }
+
+  /**
+   * Answer with this result for any image no other rule matches.
+   */
+  byDefault(result: TResult): void {
+    this.defaultResult = result;
+  }
+
+  /**
+   * Answer with this result for an image read from an S3 object with this
+   * exact name.
+   *
+   * The name is the `Name` a request gives Rekognition, which is the object
+   * key. It is matched on its own rather than with the Bucket, so a rule for
+   * a key applies to that key in whichever Bucket the request names.
+   */
+  onName(name: string, result: TResult): void {
+    if (name.length === 0) {
+      throw new SimRekognitionDeclarationError(
+        "A simulated Rekognition name rule needs an S3 object name to match",
+      );
+    }
+
+    this.resultsByName.set(name, result);
+  }
+
+  /**
+   * Answer with this result for an image whose bytes have this exact content
+   * hash.
+   *
+   * This is the rule for a system that generates its own object keys, where
+   * the name is not something a test can usefully match on. The hash is the
+   * sha256 digest of the image bytes as lowercase hex, which
+   * `simRekognitionImageHash` produces from a fixture.
+   */
+  onHash(hash: string, result: TResult): void {
+    const digest = hash.toLowerCase();
+
+    if (!isSimRekognitionImageHash(digest)) {
+      throw new SimRekognitionDeclarationError(
+        `'${hash}' is not a simulated Rekognition image hash. A hash rule ` +
+          `matches a sha256 digest of the image bytes, as 64 hex ` +
+          `characters, which simRekognitionImageHash produces.`,
+      );
+    }
+
+    this.resultsByHash.set(digest, result);
+  }
+
+  /**
+   * The result for one image.
+   */
+  resultFor(image: SimRekognitionImage): TResult {
+    const byHash = this.resultsByHash.get(image.hash());
+
+    if (byHash !== undefined) {
+      return byHash;
+    }
+
+    return this.byNameOrDefault(image);
+  }
+
+  private byNameOrDefault(image: SimRekognitionImage): TResult {
+    if (image.name === undefined) {
+      return this.defaultResult;
+    }
+
+    return this.resultsByName.get(image.name) ?? this.defaultResult;
+  }
+}

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
@@ -1,0 +1,35 @@
+import { assertArrayIncludesAll, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimRekognitionSdkCommandRouter", () => {
+  it("names every Command simulated Rekognition handles", () => {
+    // Given a scoped simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws
+      .rekognition()
+      .sdkCommandRouter()
+      .supportedCommandNames();
+
+    // Then the simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, ["DetectModerationLabelsCommand"]);
+  });
+
+  it("has no route for a Command simulated Rekognition does not handle", () => {
+    // Given a scoped simulated Rekognition.
+    const simAws = new SimAws();
+
+    // When a detection operation that is not simulated yet is looked up.
+    const route = simAws
+      .rekognition()
+      .sdkCommandRouter()
+      .route("DetectFacesCommand");
+
+    // Then there is no route for it, so an intercepted client is told the
+    // Command is unsupported rather than being answered with nothing.
+    assertUndefined(route);
+  });
+});

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
@@ -1,0 +1,43 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type { SimDetectModerationLabelsCommand } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
+import type { SimRekognition } from "../sim-rekognition.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Rekognition
+ * instance.
+ */
+export class SimRekognitionSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simRekognition: SimRekognition) {
+    this.routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "DetectModerationLabelsCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.detectModerationLabels(
+            command as SimDetectModerationLabelsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+    ]);
+  }
+
+  /**
+   * The SDK Command names simulated Rekognition can handle.
+   */
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  /**
+   * Get the route for an SDK Command name, if simulated Rekognition supports
+   * it.
+   */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -1,0 +1,38 @@
+import {
+  DetectModerationLabelsCommand,
+  RekognitionClient,
+} from "@aws-sdk/client-rekognition";
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../test/rekognition/image-fixture.js";
+import { SimSdk } from "../../../sdk/index.js";
+
+describe("Rekognition SDK interception", () => {
+  it("routes an intercepted RekognitionClient to simulated Rekognition", async () => {
+    // Given an intercepted Rekognition SDK client, with an image declared to
+    // fail moderation.
+    const simSdk = new SimSdk();
+    simSdk.intercept(RekognitionClient);
+    simSdk.simAws
+      .rekognition()
+      .moderation()
+      .byDefault({ labels: ["Explicit Nudity"] });
+
+    const rekognition = new RekognitionClient({ region: "us-east-1" });
+
+    // When ordinary SDK code moderates an image.
+    const detected = await rekognition.send(
+      new DetectModerationLabelsCommand({ Image: { Bytes: redPngBytes } }),
+    );
+
+    // Then the declared result comes back, with nothing touching the network.
+    assertIdentical(detected.ModerationModelVersion, "7.0");
+    assertStringIncludes(
+      (detected.ModerationLabels ?? []).map((label) => label.Name).join(","),
+      "Explicit Nudity",
+    );
+
+    simSdk.restoreAll();
+  });
+});

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -12,7 +12,7 @@ describe("Rekognition SDK interception", () => {
   it("routes an intercepted RekognitionClient to simulated Rekognition", async () => {
     // Given an intercepted Rekognition SDK client, with an image declared to
     // fail moderation.
-    const simSdk = new SimSdk();
+    using simSdk = new SimSdk();
     simSdk.intercept(RekognitionClient);
     simSdk.simAws
       .rekognition()
@@ -32,7 +32,5 @@ describe("Rekognition SDK interception", () => {
       (detected.ModerationLabels ?? []).map((label) => label.Name).join(","),
       "Explicit Nudity",
     );
-
-    simSdk.restoreAll();
   });
 });

--- a/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
+++ b/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
@@ -1,0 +1,201 @@
+import { text } from "node:stream/consumers";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  bluePngBytes,
+  redPngBytes,
+} from "../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../lambda/function/code/make-lambda-code-zip.js";
+
+/**
+ * A moderation handler as an application would write one: it reads the object
+ * the event names, moderates it, and writes the labels somewhere else in the
+ * Bucket when there are any.
+ *
+ * It is real function code rather than a stowaway handler because the SDK
+ * calls it makes are the point: they run as the function's execution Role,
+ * which is what makes the Role's policy part of what the test exercises.
+ */
+const moderatorSource =
+  'const { RekognitionClient, DetectModerationLabelsCommand } = require("@aws-sdk/client-rekognition");\n' +
+  'const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");\n' +
+  "exports.handler = async (event) => {\n" +
+  "  const record = event.Records[0].s3;\n" +
+  "  const detected = await new RekognitionClient({}).send(\n" +
+  "    new DetectModerationLabelsCommand({\n" +
+  "      Image: { S3Object: { Bucket: record.bucket.name, Name: record.object.key } },\n" +
+  "    }),\n" +
+  "  );\n" +
+  "  if (detected.ModerationLabels.length === 0) {\n" +
+  '    return "clean";\n' +
+  "  }\n" +
+  "  await new S3Client({}).send(new PutObjectCommand({\n" +
+  "    Bucket: record.bucket.name,\n" +
+  '    Key: "flagged/" + record.object.key,\n' +
+  '    Body: detected.ModerationLabels.map((label) => label.Name).join(","),\n' +
+  "  }));\n" +
+  '  return "flagged";\n' +
+  "};\n";
+
+async function simAwsWithModerationPipeline(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ModeratorRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "ModeratorRole",
+      PolicyName: "ModeratePolicy",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: [
+            "rekognition:DetectModerationLabels",
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          Resource: "*",
+        },
+      }),
+    }),
+  );
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "moderator",
+      Role: role.Role.Arn,
+      Handler: "index.handler",
+      Code: { ZipFile: makeLambdaCodeZip({ "index.js": moderatorSource }) },
+    }),
+  );
+
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: "moderator",
+      StatementId: "AllowS3",
+      Action: "lambda:InvokeFunction",
+      Principal: "s3.amazonaws.com",
+      SourceArn: "arn:aws:s3:::uploads",
+      SourceAccount: simAws.defaultAccountId,
+    }),
+  );
+
+  // The handler writes back into the Bucket that triggers it, so the
+  // configuration is filtered to the prefix uploads arrive under. Without the
+  // filter the function would notify itself for ever.
+  await simAws.s3().putBucketNotificationConfiguration(
+    new PutBucketNotificationConfigurationCommand({
+      Bucket: "uploads",
+      NotificationConfiguration: {
+        LambdaFunctionConfigurations: [
+          {
+            Id: "moderate-uploads",
+            Events: ["s3:ObjectCreated:*"],
+            LambdaFunctionArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:moderator`,
+            Filter: {
+              Key: { FilterRules: [{ Name: "prefix", Value: "raw/" }] },
+            },
+          },
+        ],
+      },
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+describe("Moderating an uploaded image through a simulated pipeline", () => {
+  it("flags an upload the moderation rules declare as explicit", async () => {
+    // Given a Bucket that moderates its uploads with a Lambda function, and an
+    // image declared to fail moderation.
+    const simAws = await simAwsWithModerationPipeline();
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("raw/nsfw.png", { labels: ["Explicit Nudity"] });
+
+    // When the image is uploaded.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/nsfw.png",
+        Body: redPngBytes,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler's own Rekognition call found the declared labels and
+    // wrote them where the application puts them.
+    const flagged = await simAws.s3().getObject(
+      new GetObjectCommand({
+        Bucket: "uploads",
+        Key: "flagged/raw/nsfw.png",
+      }),
+    );
+    assertNonNullable(flagged.Body);
+    assertStringIncludes(await text(flagged.Body), "Explicit,Explicit Nudity");
+  });
+
+  it("leaves a clean upload alone", async () => {
+    // Given the same pipeline and an image nothing was declared for.
+    const simAws = await simAwsWithModerationPipeline();
+
+    // When the image is uploaded.
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "raw/holiday.png",
+        Body: bluePngBytes,
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing was flagged, because an image is clean until a rule says
+    // otherwise.
+    await assertThrowsErrorAsync(
+      async () =>
+        await simAws.s3().getObject(
+          new GetObjectCommand({
+            Bucket: "uploads",
+            Key: "flagged/raw/holiday.png",
+          }),
+        ),
+    );
+  });
+});

--- a/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
+++ b/src/service/rekognition/sim-rekognition-moderation-pipeline.iso.test.ts
@@ -75,17 +75,22 @@ async function simAwsWithModerationPipeline(): Promise<SimAws> {
     new PutRolePolicyCommand({
       RoleName: "ModeratorRole",
       PolicyName: "ModeratePolicy",
+      // The policy the docs show: a detection has no resource to name, so it
+      // has to be `*`, while reading and writing the image does.
       PolicyDocument: JSON.stringify({
         Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: [
-            "rekognition:DetectModerationLabels",
-            "s3:GetObject",
-            "s3:PutObject",
-          ],
-          Resource: "*",
-        },
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "rekognition:DetectModerationLabels",
+            Resource: "*",
+          },
+          {
+            Effect: "Allow",
+            Action: ["s3:GetObject", "s3:PutObject"],
+            Resource: "arn:aws:s3:::uploads/*",
+          },
+        ],
       }),
     }),
   );

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -1,0 +1,98 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimRekognitionAuthorizer } from "./command/authorize/sim-rekognition-authorizer.js";
+import { DetectModerationLabelsHandler } from "./command/detect-moderation-labels/detect-moderation-labels.handler.js";
+import type {
+  SimDetectModerationLabelsCommand,
+  SimDetectModerationLabelsCommandOutput,
+} from "./command/detect-moderation-labels/detect-moderation-labels.command.js";
+import type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
+import {
+  type SimRekognitionImageObjects,
+  SimRekognitionUnreachableImageObjects,
+} from "./image/sim-rekognition-image-objects.js";
+import { SimRekognitionModeration } from "./moderation/sim-rekognition-moderation.js";
+import { SimRekognitionSdkCommandRouter } from "./sdk/sim-rekognition-sdk-command-router.js";
+
+interface SimRekognitionProperties {
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+  readonly images?: SimRekognitionImageObjects;
+}
+
+/**
+ * Simulated Rekognition. Handles SDK commands. Emulates AWS behaviour and
+ * state.
+ *
+ * No image recognition happens here. Rekognition is a service where the
+ * interesting behaviour is not the call but what the call returns, so the
+ * simulation answers from results declared against images by name or by
+ * content hash. A test says which image fails moderation and which does not,
+ * and the system under test makes the same calls it would make against AWS.
+ *
+ * Results are declared per operation, through `moderation()`, so this facade
+ * stays a facade as operations are added.
+ */
+export class SimRekognition {
+  private readonly moderationRules = new SimRekognitionModeration();
+  private readonly detectModerationLabelsCommand: DetectModerationLabelsHandler;
+  private readonly sdkRouter = new SimRekognitionSdkCommandRouter(this);
+
+  constructor(properties: SimRekognitionProperties = {}) {
+    const {
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+      images = new SimRekognitionUnreachableImageObjects(),
+    } = properties;
+
+    this.detectModerationLabelsCommand = new DetectModerationLabelsHandler({
+      moderation: this.moderationRules,
+      authorizer: new SimRekognitionAuthorizer({ iam }),
+      images,
+      background,
+    });
+  }
+
+  /**
+   * The moderation results this simulated Rekognition answers with.
+   *
+   * Every image is clean until a rule says otherwise:
+   *
+   * ```typescript
+   * simAws.rekognition().moderation().onName("nsfw.jpg", {
+   *   labels: ["Explicit Nudity"],
+   * });
+   * ```
+   */
+  moderation(): SimRekognitionModeration {
+    return this.moderationRules;
+  }
+
+  /**
+   * Handle a DetectModerationLabels Command from the SDK.
+   *
+   * Background sequencing happens inside the command rather than here,
+   * because the request is checked before it: a malformed request is a
+   * malformed request whatever else the simulation has in flight.
+   */
+  async detectModerationLabels(
+    command: SimDetectModerationLabelsCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDetectModerationLabelsCommandOutput> {
+    return await this.detectModerationLabelsCommand.handle(command, options);
+  }
+
+  /**
+   * Get this service's SDK Command router for SDK client interception.
+   */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+}

--- a/test/rekognition/image-fixture.ts
+++ b/test/rekognition/image-fixture.ts
@@ -1,0 +1,51 @@
+/**
+ * Image bytes for simulated Rekognition tests.
+ *
+ * The two PNGs are complete 1x1 PNG files, differing only in the colour of
+ * their one pixel, so they are genuinely different images with genuinely
+ * different content hashes.
+ *
+ * The JPEG fixture is a JPEG file header rather than a whole photograph.
+ * Simulated Rekognition identifies a format from an image's leading bytes and
+ * decodes nothing, so a header is the whole of what it reads. Simulated
+ * Rekognition sample images, which are whole files, are a separate piece of
+ * work.
+ *
+ * This lives under `test/` because eslint rejects a test file that exports
+ * helpers alongside its own `describe` calls, and `test/**` is type-checked
+ * with everything else while being excluded from the published build.
+ */
+
+const redPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC";
+
+const bluePngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOQs7kDAAGyATf/cv8XAAAAAElFTkSuQmCC";
+
+/**
+ * A 1x1 red PNG.
+ */
+export const redPngBytes = Uint8Array.from(Buffer.from(redPngBase64, "base64"));
+
+/**
+ * A 1x1 blue PNG, which is a different image to the red one.
+ */
+export const bluePngBytes = Uint8Array.from(
+  Buffer.from(bluePngBase64, "base64"),
+);
+
+/**
+ * The start of a JFIF JPEG file: the SOI marker and an APP0 segment.
+ */
+export const jpegBytes = Uint8Array.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01,
+  0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+]);
+
+/**
+ * Bytes that are not an image at all, as a test putting a placeholder string
+ * in a Bucket would produce.
+ */
+export const notAnImageBytes = Uint8Array.from(
+  Buffer.from("cat picture", "utf8"),
+);


### PR DESCRIPTION
… hash

Add simulated Rekognition with DetectModerationLabels, answering from results declared against an image by exact S3 object name, exact content hash, or a default. A declared label expands to its chain in the version 7.0 moderation taxonomy, and MinConfidence filters whole chains.

Resolves https://github.com/KensioSoftware/yulin/issues/317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated Amazon Rekognition support through the SDK and service accessors.
  * Added moderation label detection for image bytes and S3 objects.
  * Added configurable default, object-name, and image-hash moderation rules.
  * Added confidence filtering, taxonomy expansion, image validation, IAM authorization, and account/Region scoping.
  * Added Lambda/S3 upload-pipeline support for automated clean or flagged image handling.

* **Documentation**
  * Added comprehensive Rekognition service documentation and executable usage examples.

* **Tests**
  * Added coverage for moderation, validation, authorization, SDK routing, taxonomy, and upload pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->