### PR TITLE
feat: detect labels in simulated Rekognition images

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -1,8 +1,8 @@
 # Simulated Rekognition
 
 Simulated Rekognition answers detection calls from results declared against images, so a test can
-say which image fails moderation without any image analysis happening. No recognition of any kind is
-performed on the bytes.
+say which image fails moderation or holds a dog without any image analysis happening. No recognition
+of any kind is performed on the bytes.
 
 Rekognition-specific types are imported from the `@kensio/yulin/rekognition` subpath.
 
@@ -65,10 +65,86 @@ const detected = await simAws
   );
 ```
 
+## Detecting labels in an image
+
+`DetectLabels` answers with the objects, scenes and concepts an image is declared to hold. Each
+label carries the parents, aliases, categories and instances it was declared with, and nothing else:
+a label is reported as written.
+
+```typescript sim-rekognition-detect-labels
+/**
+ * Declaring the labels for one S3 object and detecting them.
+ */
+
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/dog.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+simAws
+  .rekognition()
+  .labels()
+  .onName("raw/dog.png", {
+    labels: [
+      {
+        name: "Dog",
+        confidence: 98.2,
+        parents: ["Animal", "Pet", "Canine"],
+        aliases: ["Puppy"],
+        categories: ["Animals and Pets"],
+        // A bounding box is in ratios of the image size, as AWS reports it.
+        instances: [
+          { boundingBox: { left: 0.36, top: 0.09, width: 0.26, height: 0.85 } },
+        ],
+      },
+      { name: "Grass", confidence: 71.4 },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectLabels(
+  new DetectLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/dog.png" } },
+    MaxLabels: 10,
+  }),
+);
+
+console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels[0]?.Parents);
+// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Canine" } ]
+console.log(detected.LabelModelVersion); // "3.0"
+```
+
+Labels come back in descending order of confidence, which is the order real Rekognition reports them
+in. A declared instance with no confidence of its own takes its label's.
+
+An image no rule matches gets the built-in default result: the one `Mobile Phone` label from the
+example response in the AWS `DetectLabels` documentation, with the parent, alias, category and
+bounding box AWS documents it with. That is a real Rekognition response, but which labels an
+unconfigured image gets is a simulator convention rather than what AWS would return for it.
+
+Nothing is filled in from a label name. Declaring `Dog` with no parents reports `Dog` with no
+parents, and declaring a `Pizza` nobody has heard of reports `Pizza`, because Yulin ships no general
+label ontology to check a name against or to expand one from.
+
 ## Declaring results
 
 Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
-from, and each rule matches an exact S3 object name, an exact content hash, or anything at all.
+from and `labels()` holds the rules `DetectLabels` answers from. Both take the same three kinds of
+rule: an exact S3 object name, an exact content hash, or anything at all.
 
 ```typescript sim-rekognition-moderation-rules
 /**
@@ -110,10 +186,11 @@ The hash is the sha256 digest of the image bytes as they were received, as lower
 `simRekognitionImageHash` produces it from a fixture. Re-encoding an image between uploading it and
 detecting on it changes the digest, so hash the exact bytes the test puts through the system.
 
-A label can be declared as a name on its own, which reports it at a confidence of
-`96.68000030517578`, or as a name with the confidence to report it at.
+A label can be declared as a name on its own, or as a name with what is to be reported alongside it.
+A moderation label declared as a name reports at a confidence of `96.68000030517578`, and a
+detection label at `97.53010559082031`.
 
-## Labels come back with their parents
+## Moderation labels come back with their parents
 
 A declared label expands to its whole chain in the version 7.0 moderation taxonomy, so handler code
 that filters on the top-level category sees what it would see on AWS. Each label carries the
@@ -165,8 +242,9 @@ top-level category itself.
 
 ## Filtering by confidence
 
-`MinConfidence` defaults to 50, which is what real content moderation uses, and compares inclusively.
-An explicit `0` asks for every label rather than being read as unset.
+`MinConfidence` compares inclusively and defaults to what the operation defaults to on AWS: 50 for
+`DetectModerationLabels` and 55 for `DetectLabels`. An explicit `0` asks for every label rather than
+being read as unset.
 
 ```typescript sim-rekognition-min-confidence
 /**
@@ -206,6 +284,47 @@ console.log(strict.ModerationLabels.map((label) => label.Name));
 
 Confidences are float32 values, as real Rekognition confidences are, so a declared `99.4` comes back
 as `99.4000015258789`.
+
+`DetectLabels` also takes a `MaxLabels`, which applies after the confidence filter and keeps the most
+confident labels of the ones that survived it. An explicit `0` asks for no labels rather than being
+read as unset.
+
+```typescript sim-rekognition-max-labels
+/**
+ * Three labels, narrowed by confidence and then by how many were asked for.
+ */
+
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .labels()
+  .byDefault({
+    labels: [
+      { name: "Dog", confidence: 98.2 },
+      { name: "Grass", confidence: 88 },
+      { name: "Fence", confidence: 62 },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectLabels(
+  new DetectLabelsCommand({
+    Image: { Bytes: imageBytes },
+    MinConfidence: 80,
+    MaxLabels: 2,
+  }),
+);
+
+console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+```
 
 ## Moderating an upload
 
@@ -360,10 +479,11 @@ ever, so filter the notification configuration by prefix or suffix as this one d
 
 ## Permissions and errors
 
-`DetectModerationLabels` is authorized as `rekognition:DetectModerationLabels` against `*`. Real
-Rekognition gives the detection operations no resource-level permissions, so a policy naming an ARN
-reaches nothing, here as on AWS. A denial throws `AccessDeniedException` with a 400 status, which is
-what real Rekognition answers with rather than the 403 several other services use.
+Each detection is authorized as its own action against `*`: `rekognition:DetectModerationLabels` and
+`rekognition:DetectLabels`. Real Rekognition gives the detection operations no resource-level
+permissions, so a policy naming an ARN reaches nothing, here as on AWS. A denial throws
+`AccessDeniedException` with a 400 status, which is what real Rekognition answers with rather than
+the 403 several other services use.
 
 The caller is authorized for the detection before the image is read, so a caller without the
 Rekognition permission is told about that rather than about an S3 object.
@@ -402,29 +522,43 @@ reads only Buckets in its own Region.
 
 Simulated Rekognition currently supports:
 
-- `DetectModerationLabelsCommand`, for an image supplied as `Image.Bytes` or as `Image.S3Object`
+- `DetectModerationLabelsCommand` and `DetectLabelsCommand`, for an image supplied as `Image.Bytes`
+  or as `Image.S3Object`
 - Results declared by exact S3 object name, by exact image content hash, or as a default, with the
   hash rule winning, then the name rule, then the default
 - The complete version 7.0 content moderation taxonomy, with a declared label expanding to its
   parents and carrying `ParentName` and `TaxonomyLevel`
-- `MinConfidence` filtering, defaulting to 50 and filtering whole label chains
+- Detected labels carrying declared `Parents`, `Aliases`, `Categories` and `Instances`, ordered by
+  descending confidence
+- `MinConfidence` filtering, defaulting to 50 for moderation and 55 for label detection, and
+  `MaxLabels` after it
 - `simRekognitionImageHash`, for hashing a fixture to declare a rule against
 - PNG and JPEG format detection from the image bytes
-- IAM authorization on `rekognition:DetectModerationLabels`, with the image read from S3 as the
-  caller
+- IAM authorization on `rekognition:DetectModerationLabels` and `rekognition:DetectLabels`, with the
+  image read from S3 as the caller
 - SDK interception of `RekognitionClient`, including from inside a simulated Lambda function
 
 ## Limitations
 
-- `DetectLabels`, `DetectFaces`, `DetectText`, face collections and the video operations are not
-  simulated. An intercepted client sending one of those Commands is refused by name.
+- `DetectFaces`, `DetectText`, face collections and the video operations are not simulated. An
+  intercepted client sending one of those Commands is refused by name.
+- Yulin ships no general label ontology, because AWS's is thousands of entries with no published
+  enumerable table.
+- A declared label's `Parents` appear on that label alone. Real `DetectLabels` also returns each
+  ancestor as a label in its own right, which needs the ontology above. Declare the ancestors as
+  labels too when the code under test reads them that way.
+- A declared label name is not checked against anything, for the same reason. Refusing a real AWS
+  label because a Yulin list was missing it would be failing closed against Yulin's own gaps.
+- `DetectLabels` `Settings` filters and `IMAGE_PROPERTIES` are refused rather than ignored. Applying
+  no filters would answer with labels the caller asked to have left out, and image quality and
+  dominant colours would have to be invented by a simulation that looks at no images.
 - A custom moderation adapter named with `ProjectVersion`, and a human review loop named with
   `HumanLoopConfig`, are both refused rather than ignored. Answering from the built-in model would
   make an adapter look applied here and be applied in production.
 - `ContentTypes` is always empty. Real Rekognition puts `Animated` or `Illustrated` there for
   content it identifies as such, which needs an image to look at.
 - Nothing looks at the image beyond its first few bytes. A PNG of a kitten declared as `Violence`
-  comes back as `Violence`.
+  comes back as `Violence`, and an image no rule matches gets the built-in `Mobile Phone` result.
 - The format comes from the image bytes and never from a stored content type. Simulated S3 keeps a
   `ContentType` given to `PutObject` as a metadata key, and has none at all when the uploader did
   not set one, so trusting it would make the same bytes detectable or not depending on how they were

--- a/docs/services/rekognition/sim-rekognition-detect-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-labels.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Declaring the labels for one S3 object and detecting them.
+ */
+
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/dog.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+simAws
+  .rekognition()
+  .labels()
+  .onName("raw/dog.png", {
+    labels: [
+      {
+        name: "Dog",
+        confidence: 98.2,
+        parents: ["Animal", "Pet", "Canine"],
+        aliases: ["Puppy"],
+        categories: ["Animals and Pets"],
+        // A bounding box is in ratios of the image size, as AWS reports it.
+        instances: [
+          { boundingBox: { left: 0.36, top: 0.09, width: 0.26, height: 0.85 } },
+        ],
+      },
+      { name: "Grass", confidence: 71.4 },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectLabels(
+  new DetectLabelsCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/dog.png" } },
+    MaxLabels: 10,
+  }),
+);
+
+console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]
+console.log(detected.Labels[0]?.Parents);
+// [ { Name: "Animal" }, { Name: "Pet" }, { Name: "Canine" } ]
+console.log(detected.LabelModelVersion); // "3.0"

--- a/docs/services/rekognition/sim-rekognition-max-labels.example.ts
+++ b/docs/services/rekognition/sim-rekognition-max-labels.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Three labels, narrowed by confidence and then by how many were asked for.
+ */
+
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .labels()
+  .byDefault({
+    labels: [
+      { name: "Dog", confidence: 98.2 },
+      { name: "Grass", confidence: 88 },
+      { name: "Fence", confidence: 62 },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectLabels(
+  new DetectLabelsCommand({
+    Image: { Bytes: imageBytes },
+    MinConfidence: 80,
+    MaxLabels: 2,
+  }),
+);
+
+console.log(detected.Labels.map((label) => label.Name)); // [ "Dog", "Grass" ]

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -1,7 +1,8 @@
 # Simulated Rekognition implementation
 
-This directory contains the simulated Rekognition implementation. Only image content moderation is
-simulated: `DetectModerationLabels`, for an image supplied as bytes or as an S3 object.
+This directory contains the simulated Rekognition implementation. Two image detections are
+simulated, `DetectModerationLabels` and `DetectLabels`, each for an image supplied as bytes or as an
+S3 object.
 
 The guiding decision here is that no image recognition happens. Rekognition is a service where the
 interesting behaviour is not the call but what the call returns, so the simulation maintains no
@@ -15,9 +16,10 @@ IAM decision, and the taxonomy a returned label belongs to.
 - `sim-rekognition.ts` is the service facade for one account/region scope.
 - `index.ts` exports the public Rekognition simulator API for `@kensio/yulin/rekognition`.
 
-`SimRekognition` owns a `SimRekognitionModeration`, which owns the rules `DetectModerationLabels`
-answers from. Rules are grouped per operation rather than hung off the facade, so `labels()` and
-`faces()` can be added beside `moderation()` without the facade growing a result shape for each.
+`SimRekognition` owns a `SimRekognitionModeration` and a `SimRekognitionLabels`, which own the rules
+`DetectModerationLabels` and `DetectLabels` answer from. Rules are grouped per operation rather than
+hung off the facade, so `faces()` can be added beside `moderation()` and `labels()` without the
+facade growing a result shape for each.
 
 The service is scoped to an account and region because its rules are: a detection made in one Region
 is answered by the rules registered in that Region, as a real Rekognition endpoint answers for the
@@ -64,8 +66,31 @@ Two rules there are worth keeping:
 - a label two chains share is reported once, at the highest confidence any chain declared for it,
   because real Rekognition reports a parent at least as confidently as the child that implies it.
 
-Confidences pass through `Math.fround`. Real confidences are float32 values with a long tail, such
-as `99.44782257080078`, and a value rounded to four decimals is identifiable as fake.
+Confidences pass through `Math.fround`, in `rule/sim-rekognition-declared-confidence.ts`, which both
+operation groups declare their confidences through. Real confidences are float32 values with a long
+tail, such as `99.44782257080078`, and a value rounded to four decimals is identifiable as fake.
+
+## The label model
+
+`label/` is much less than the moderation model, because there is nothing to resolve a declared
+label against. Yulin ships no general label ontology: AWS's is thousands of entries with no
+published enumerable table, so any subset here would be a Yulin invention that could never be
+regenerated from an upstream source. A declared label name is therefore accepted as it stands, and
+its parents, aliases, categories and instances are whatever the declaration said and empty
+otherwise.
+
+`label/sim-rekognition-label-detection.ts` is the resolution, which is validation and ordering. It
+refuses a nameless label, a nameless parent and a bounding box that is not a ratio of the image
+size, all where the declaration was written. Labels are sorted by descending confidence when the
+rule is registered, which is the order real Rekognition reports them in and what makes `MaxLabels`
+the most confident labels rather than the first ones declared.
+
+`label/sim-rekognition-label-defaults.ts` holds the built-in default result and
+`simRekognitionLabelModelVersion` beside it. The default is the AWS documentation's own example
+response, label for label, so an unconfigured detection answers with something real Rekognition has
+returned. The two belong in one file because the labels are what that version of the model reported.
+Labels have no equivalent of a clean image to default to: an empty result would look like a broken
+detection rather than a useful starting point.
 
 ## Images
 
@@ -74,7 +99,9 @@ as `99.44782257080078`, and a value rounded to four decimals is identifiable as 
 `SimRekognitionImageRequests.parse` reads the `Image` member and answers with a request for bytes or
 a request for an S3 object. Parsing and reading are separate steps because they happen at different
 points: the request is checked before anything else, and the image is read only once the caller has
-been authorized for the detection.
+been authorized for the detection. It is made with the name of the operation that is parsing, so a
+refusal names the command the caller sent rather than whichever operation happened to be written
+first.
 
 `SimRekognitionImage` is the image itself. Its format is decided when it is made, from PNG and JPEG
 magic bytes, so bytes that are not an image are refused before any rule is consulted. The stored
@@ -113,7 +140,10 @@ so an option nobody thought about is refused rather than dropped.
 
 `ProjectVersion` is the one that matters. A request naming a custom moderation adapter would
 otherwise be answered by the built-in model, which is the failure that looks like a pass: the
-adapter would appear applied here and be applied for real in production.
+adapter would appear applied here and be applied for real in production. `DetectLabels` has two of
+its own with the same shape: `Settings`, whose filters decide which labels a response carries, and a
+`Features` naming `IMAGE_PROPERTIES`, whose sharpness and dominant colours would have to be invented
+by a simulation that looks at no images.
 
 ## Testing
 

--- a/src/service/rekognition/command/detect-labels/detect-labels-iam.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels-iam.iso.test.ts
@@ -1,0 +1,159 @@
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import {
+  SimRekognitionAccessDeniedException,
+  SimRekognitionInvalidS3ObjectException,
+} from "../../error/sim-rekognition.error.js";
+
+const detectAction = "rekognition:DetectLabels";
+
+async function simAwsWithImage(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "uploads",
+      Key: "dog.jpg",
+      Body: redPngBytes,
+    }),
+  );
+
+  return simAws;
+}
+
+const imageCommand = new DetectLabelsCommand({
+  Image: { S3Object: { Bucket: "uploads", Name: "dog.jpg" } },
+});
+
+describe("Authorizing a simulated Rekognition label detection", () => {
+  it("allows a caller whose policy permits the detection", async () => {
+    // Given a Role allowed to detect labels and to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Tagger", actions: [detectAction, "s3:GetObject"] },
+      simAws,
+    );
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: ["Dog"] });
+
+    // When it detects labels in an image.
+    const detected = await simAws.rekognition().detectLabels(imageCommand, {
+      caller: { kind: "arn", arn: role.Arn },
+    });
+
+    // Then the detection runs.
+    assertIdentical(detected.Labels[0]?.Name, "Dog");
+  });
+
+  it("refuses a caller with no Rekognition permission", async () => {
+    // Given a Role allowed to read the image but not to detect labels in it.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Reader", actions: ["s3:GetObject"] },
+      simAws,
+    );
+
+    // When it detects labels in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then Rekognition's own AccessDeniedException is thrown, with the 400
+    // status real Rekognition answers with rather than the 403 several other
+    // services use.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+    assertIdentical(error.name, "AccessDeniedException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, detectAction);
+  });
+
+  it("refuses a caller allowed only the other detection", async () => {
+    // Given a Role allowed to moderate images but not to detect labels.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Moderator",
+        actions: ["rekognition:DetectModerationLabels", "s3:GetObject"],
+      },
+      simAws,
+    );
+
+    // When it detects labels in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is refused, since each detection is its own action.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+  });
+
+  it("refuses a policy that names a resource rather than everything", async () => {
+    // Given a Role allowed the detection on an ARN rather than on `*`.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ScopedTagger",
+        actions: [detectAction, "s3:GetObject"],
+        resource: "arn:aws:s3:::uploads/*",
+      },
+      simAws,
+    );
+
+    // When it detects labels in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is refused, because a detection has no resource to name and is
+    // authorized against `*`, here as on real AWS.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+  });
+
+  it("reports a missing s3:GetObject as an image problem, with the denial as its cause", async () => {
+    // Given a Role allowed to detect labels but not to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "BlindTagger", actions: [detectAction] },
+      simAws,
+    );
+
+    // When it detects labels in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectLabels(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is the S3 object error real Rekognition reports, and the IAM
+    // denial underneath it is still readable, so the missing grant can be
+    // found from what was thrown.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertInstanceOf(error.cause, Error);
+    assertStringIncludes(error.cause.message, "s3:GetObject");
+  });
+});

--- a/src/service/rekognition/command/detect-labels/detect-labels-request.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels-request.ts
@@ -1,0 +1,103 @@
+import {
+  SimRekognitionInvalidParameterException,
+  SimRekognitionUnsimulatedInputException,
+} from "../../error/sim-rekognition.error.js";
+import {
+  type SimRekognitionImageRequest,
+  SimRekognitionImageRequests,
+} from "../../image/sim-rekognition-image-request.js";
+import { SimRekognitionMinConfidence } from "../sim-rekognition-min-confidence.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import type { SimDetectLabelsCommandInput } from "./detect-labels.command.js";
+
+/**
+ * The confidence real Rekognition filters labels at when a request does not
+ * say. Label detection uses 55 here, which is not the 50 content moderation
+ * uses.
+ */
+const minConfidence = new SimRekognitionMinConfidence(55);
+
+const operation = "DetectLabels";
+const acceptedInput = ["Image", "MaxLabels", "MinConfidence", "Features"];
+
+const generalLabels = "GENERAL_LABELS";
+const imageProperties = "IMAGE_PROPERTIES";
+
+/**
+ * A DetectLabels request, checked before anything acts on it.
+ *
+ * `Settings` is refused with everything else this simulation does not model,
+ * because its filters decide which labels a response carries: applying none of
+ * them would answer with labels a real caller asked to have left out.
+ */
+export class DetectLabelsRequest {
+  public readonly image: SimRekognitionImageRequest;
+  public readonly minConfidence: number;
+  public readonly maxLabels: number | undefined;
+
+  constructor(input: SimDetectLabelsCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+    DetectLabelsRequest.refuseUnsimulatedFeatures(input.Features);
+
+    this.image = new SimRekognitionImageRequests(operation).parse(input.Image);
+    this.minConfidence = minConfidence.of(input.MinConfidence);
+    this.maxLabels = DetectLabelsRequest.maxLabelsOf(input.MaxLabels);
+  }
+
+  /**
+   * The most labels this request wants back, if it said.
+   *
+   * There is no cap when the request left it out, so an explicit `0` asks for
+   * no labels rather than being read as unset.
+   */
+  private static maxLabelsOf(
+    requested: number | undefined,
+  ): number | undefined {
+    if (requested === undefined) {
+      return undefined;
+    }
+
+    if (!Number.isSafeInteger(requested) || requested < 0) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: MaxLabels of ${String(requested)} ` +
+          `is not a whole number of labels from 0 upwards`,
+      );
+    }
+
+    return requested;
+  }
+
+  /**
+   * Refuse the response members this simulation cannot fill in.
+   *
+   * `GENERAL_LABELS` is the whole of what is simulated, and it is what a
+   * request asking for no features gets, here as on AWS.
+   */
+  private static refuseUnsimulatedFeatures(
+    requested: readonly string[] | undefined,
+  ): void {
+    const features = requested ?? [];
+
+    for (const feature of features) {
+      if (feature === generalLabels) {
+        continue;
+      }
+
+      if (feature === imageProperties) {
+        throw new SimRekognitionUnsimulatedInputException(
+          `${operation} ${imageProperties} is not simulated: nothing here ` +
+            `looks at the image, so the quality and dominant colours a ` +
+            `response carries would be invented rather than measured`,
+        );
+      }
+
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: Features of ${feature} is neither ` +
+          `${generalLabels} nor ${imageProperties}`,
+      );
+    }
+  }
+}

--- a/src/service/rekognition/command/detect-labels/detect-labels-validation.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels-validation.iso.test.ts
@@ -1,0 +1,235 @@
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimRekognition } from "../../sim-rekognition.js";
+import {
+  SimRekognitionInvalidImageFormatException,
+  SimRekognitionInvalidParameterException,
+  SimRekognitionInvalidS3ObjectException,
+  SimRekognitionUnsimulatedInputException,
+} from "../../error/sim-rekognition.error.js";
+import type { SimDetectLabelsCommandInput } from "./detect-labels.command.js";
+
+async function detectFailure(
+  input: SimDetectLabelsCommandInput,
+  simAws = new SimAws(),
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () => await simAws.rekognition().detectLabels({ input }),
+  );
+}
+
+describe("Rejecting a malformed DetectLabels request", () => {
+  it("requires an image", async () => {
+    // Given a request naming no image at all. The SDK's own types require
+    // one, so this is the shape a JavaScript caller can still send.
+    // When its labels are detected.
+    const error = await detectFailure({});
+
+    // Then it is refused as an invalid parameter, as real Rekognition
+    // refuses it.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "Image is required");
+  });
+
+  it("refuses a MinConfidence outside 0 to 100", async () => {
+    // Given a request asking for an impossible confidence.
+    // When its labels are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      MinConfidence: 140,
+    });
+
+    // Then it is refused, rather than being clamped into range.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a MaxLabels below zero", async () => {
+    // Given a request asking for a negative number of labels.
+    // When its labels are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      MaxLabels: -1,
+    });
+
+    // Then it is refused, as real Rekognition refuses anything below its
+    // minimum of zero.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "whole number of labels");
+  });
+
+  it("refuses a MaxLabels that is not a whole number", async () => {
+    // Given a request asking for two and a half labels.
+    // When its labels are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      MaxLabels: 2.5,
+    });
+
+    // Then it is refused rather than rounded, since MaxLabels is an integer
+    // on real Rekognition.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "whole number of labels");
+  });
+
+  it("refuses a request asking for image properties", async () => {
+    // Given a request asking for the quality and colours of the image.
+    // When its labels are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      Features: ["GENERAL_LABELS", "IMAGE_PROPERTIES"],
+    });
+
+    // Then it is refused by name, because nothing here looks at the image and
+    // an invented sharpness would read as a measured one.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "IMAGE_PROPERTIES is not simulated");
+  });
+
+  it("refuses a feature Rekognition does not have", async () => {
+    // Given a request naming a feature that is not one of the two.
+    // When its labels are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      Features: ["FACE_PROPERTIES"],
+    });
+
+    // Then it is refused as an invalid parameter, as real Rekognition
+    // refuses a value outside the enumeration.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "neither GENERAL_LABELS nor");
+  });
+
+  it("detects labels for a request asking for them explicitly", async () => {
+    // Given a request naming the feature that is simulated.
+    const simAws = new SimAws();
+
+    // When its labels are detected.
+    const detected = await simAws.rekognition().detectLabels(
+      new DetectLabelsCommand({
+        Image: { Bytes: redPngBytes },
+        Features: ["GENERAL_LABELS"],
+      }),
+    );
+
+    // Then it answers as a request naming no features at all does, since
+    // GENERAL_LABELS is what AWS uses when nothing is named.
+    assertArrayLength(detected.Labels, 1);
+  });
+
+  it("refuses a request filtering labels through Settings", async () => {
+    // Given a request naming label filters.
+    const simAws = new SimAws();
+
+    // When its labels are detected.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectLabels(
+          new DetectLabelsCommand({
+            Image: { Bytes: redPngBytes },
+            Settings: { GeneralLabels: { LabelInclusionFilters: ["Cat"] } },
+          }),
+        ),
+    );
+
+    // Then it is refused rather than ignored, because unapplied filters would
+    // answer with labels the caller asked to have left out.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "Settings is not simulated");
+  });
+
+  it("refuses an S3 object version, naming the operation that sent it", async () => {
+    // Given an object and a request naming a version of it.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "dog.jpg",
+        Body: redPngBytes,
+      }),
+    );
+
+    // When its labels are detected.
+    const error = await detectFailure(
+      {
+        Image: {
+          S3Object: { Bucket: "uploads", Name: "dog.jpg", Version: "3" },
+        },
+      },
+      simAws,
+    );
+
+    // Then it is refused, and the refusal names DetectLabels rather than the
+    // other operation that shares the image member.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "DetectLabels S3Object Version");
+  });
+});
+
+describe("Detecting labels in an image Rekognition cannot use", () => {
+  it("refuses bytes that are not a PNG or a JPEG", async () => {
+    // Given an Object holding a placeholder string rather than an image.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "dog.jpg",
+        Body: "dog picture",
+      }),
+    );
+
+    // When its labels are detected.
+    const error = await detectFailure(
+      { Image: { S3Object: { Bucket: "uploads", Name: "dog.jpg" } } },
+      simAws,
+    );
+
+    // Then the format is refused, as real Rekognition refuses anything that
+    // is not one of the two formats it reads.
+    assertInstanceOf(error, SimRekognitionInvalidImageFormatException);
+    assertStringIncludes(error.message, "neither PNG nor JPEG");
+  });
+
+  it("reports an unknown Bucket as an S3 object problem", async () => {
+    // Given no Bucket of that name anywhere in the simulation.
+    // When labels in an image in it are detected.
+    const error = await detectFailure({
+      Image: { S3Object: { Bucket: "nowhere", Name: "dog.jpg" } },
+    });
+
+    // Then it is an S3 object error, which is how real Rekognition reports
+    // every S3 problem.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+  });
+
+  it("detects labels in bytes without any simulated S3 at all", async () => {
+    // Given a Rekognition built on its own rather than through SimAws.
+    const simRekognition = new SimRekognition();
+    simRekognition.labels().byDefault({ labels: ["Dog"] });
+
+    // When labels are detected in bytes.
+    const detected = await simRekognition.detectLabels(
+      new DetectLabelsCommand({ Image: { Bytes: redPngBytes } }),
+    );
+
+    // Then it answers, since nothing needed reading.
+    assertIdentical(detected.Labels[0]?.Name, "Dog");
+  });
+});

--- a/src/service/rekognition/command/detect-labels/detect-labels.command.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels.command.ts
@@ -1,0 +1,74 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image-input.js";
+
+/**
+ * A name Rekognition reports alongside a detected label: a parent, an alias
+ * or a category.
+ *
+ * All three are the same shape on the wire, and all three are separate types
+ * in the SDK, so one structural type stands in for each of them.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Parent.html
+ */
+export interface SimRekognitionLabelNameOutput {
+  readonly Name: string;
+}
+
+/**
+ * Where in an image one instance of a detected label is, as ratios of the
+ * image's own width and height.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_BoundingBox.html
+ */
+export interface SimRekognitionBoundingBoxOutput {
+  readonly Left: number;
+  readonly Top: number;
+  readonly Width: number;
+  readonly Height: number;
+}
+
+/**
+ * One instance of a detected label, located in the image.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Instance.html
+ */
+export interface SimRekognitionLabelInstanceOutput {
+  readonly BoundingBox: SimRekognitionBoundingBoxOutput;
+  readonly Confidence: number;
+}
+
+/**
+ * A detected label: an object, a scene or a concept found in an image.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Label.html
+ */
+export interface SimRekognitionLabelOutput {
+  readonly Name: string;
+  readonly Confidence: number;
+  readonly Parents: readonly SimRekognitionLabelNameOutput[];
+  readonly Aliases: readonly SimRekognitionLabelNameOutput[];
+  readonly Categories: readonly SimRekognitionLabelNameOutput[];
+  readonly Instances: readonly SimRekognitionLabelInstanceOutput[];
+}
+
+/**
+ * Minimal structural sim Rekognition DetectLabels command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/DetectLabelsCommand/
+ */
+export interface SimDetectLabelsCommand {
+  readonly input: SimDetectLabelsCommandInput;
+}
+
+export interface SimDetectLabelsCommandInput {
+  readonly Image?: SimRekognitionImageInput | undefined;
+  readonly MaxLabels?: number | undefined;
+  readonly MinConfidence?: number | undefined;
+  readonly Features?: readonly string[] | undefined;
+}
+
+export interface SimDetectLabelsCommandOutput {
+  readonly Labels: readonly SimRekognitionLabelOutput[];
+  readonly LabelModelVersion: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/rekognition/command/detect-labels/detect-labels.handler.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels.handler.ts
@@ -1,0 +1,67 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimRekognitionImageObjects } from "../../image/sim-rekognition-image-objects.js";
+import type { SimRekognitionLabels } from "../../label/sim-rekognition-labels.js";
+import { simRekognitionLabelModelVersion } from "../../label/sim-rekognition-label-defaults.js";
+import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+import { DetectLabelsRequest } from "./detect-labels-request.js";
+import type {
+  SimDetectLabelsCommand,
+  SimDetectLabelsCommandOutput,
+} from "./detect-labels.command.js";
+
+const action = "rekognition:DetectLabels";
+
+interface DetectLabelsHandlerProperties {
+  readonly labels: SimRekognitionLabels;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly images: SimRekognitionImageObjects;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Handles a DetectLabels command.
+ *
+ * The steps are in the same order as the other detections. The request is
+ * checked first, so a malformed one fails the same way whatever else the
+ * simulation is doing. The caller is then authorized for the Rekognition
+ * action before the image is read, so a caller without
+ * `rekognition:DetectLabels` is told about that rather than about an S3
+ * object. Only then is the image read, as the caller, and the rules consulted.
+ */
+export class DetectLabelsHandler {
+  private readonly labels: SimRekognitionLabels;
+  private readonly authorizer: SimRekognitionAuthorizer;
+  private readonly images: SimRekognitionImageObjects;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DetectLabelsHandlerProperties) {
+    this.labels = properties.labels;
+    this.authorizer = properties.authorizer;
+    this.images = properties.images;
+    this.background = properties.background;
+  }
+
+  /**
+   * Detect the labels an image is declared to have.
+   */
+  async handle(
+    command: SimDetectLabelsCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimDetectLabelsCommandOutput> {
+    const request = new DetectLabelsRequest(command.input);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(action, options);
+
+    const image = await request.image.read(this.images, options);
+    const detection = this.labels.detectionFor(image);
+
+    return {
+      Labels: detection.labelsFor(request),
+      LabelModelVersion: simRekognitionLabelModelVersion,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/rekognition/command/detect-labels/detect-labels.iso.test.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels.iso.test.ts
@@ -1,0 +1,391 @@
+import { DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  bluePngBytes,
+  redPngBytes,
+} from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simRekognitionImageHash } from "../../image/sim-rekognition-image-hash.js";
+import type { SimDetectLabelsCommandOutput } from "./detect-labels.command.js";
+
+async function simAwsWithImage(
+  objectName = "dog.jpg",
+  bytes = redPngBytes,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws
+    .s3()
+    .putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: objectName, Body: bytes }),
+    );
+
+  return simAws;
+}
+
+async function detect(
+  simAws: SimAws,
+  objectName: string,
+  input: { MaxLabels?: number; MinConfidence?: number } = {},
+): Promise<SimDetectLabelsCommandOutput> {
+  return await simAws.rekognition().detectLabels(
+    new DetectLabelsCommand({
+      Image: { S3Object: { Bucket: "uploads", Name: objectName } },
+      ...input,
+    }),
+  );
+}
+
+function labelNames(detected: SimDetectLabelsCommandOutput): string[] {
+  return detected.Labels.map((label) => label.Name);
+}
+
+describe("Detecting labels in a simulated image", () => {
+  it("answers with the built-in result until a rule says otherwise", async () => {
+    // Given an image in a Bucket and no rules registered against it.
+    const simAws = await simAwsWithImage();
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then the documented AWS example response comes back, from the version
+    // of the model it was published against.
+    assertArrayEquals(labelNames(detected), ["Mobile Phone"]);
+    assertIdentical(detected.LabelModelVersion, "3.0");
+
+    const [label] = detected.Labels;
+    assertNonNullable(label);
+    assertIdentical(label.Confidence, 99.9364013671875);
+    assertArrayEquals(
+      label.Parents.map((parent) => parent.Name),
+      ["Phone"],
+    );
+    assertArrayEquals(
+      label.Aliases.map((alias) => alias.Name),
+      ["Cell Phone"],
+    );
+    assertArrayEquals(
+      label.Categories.map((category) => category.Name),
+      ["Technology and Computing"],
+    );
+    assertIdentical(label.Instances[0]?.BoundingBox.Left, 0.3604024350643158);
+  });
+
+  it("answers with the labels declared for an object name", async () => {
+    // Given an object declared to hold a photograph of a dog.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          {
+            name: "Dog",
+            confidence: 98.2,
+            parents: ["Animal", "Pet", "Canine"],
+          },
+        ],
+      });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 10 });
+
+    // Then the declared label comes back with what was declared alongside it.
+    assertArrayEquals(labelNames(detected), ["Dog"]);
+    const [dog] = detected.Labels;
+    assertNonNullable(dog);
+    assertIdentical(dog.Confidence, Math.fround(98.2));
+    assertArrayEquals(
+      dog.Parents.map((parent) => parent.Name),
+      ["Animal", "Pet", "Canine"],
+    );
+    // Nothing is filled in from the label name, so what was not declared is
+    // empty rather than guessed at from an ontology Yulin does not have.
+    assertArrayLength(dog.Aliases, 0);
+    assertArrayLength(dog.Categories, 0);
+    assertArrayLength(dog.Instances, 0);
+  });
+
+  it("reports a label declared as a bare name", async () => {
+    // Given a label declared as a name on its own.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: ["Dog"] });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then it is reported at the default confidence, which is a float32 value
+    // as every real Rekognition confidence is.
+    assertIdentical(detected.Labels[0]?.Confidence, Math.fround(97.530106));
+  });
+
+  it("orders labels by descending confidence", async () => {
+    // Given labels declared in no particular order.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          { name: "Pet", confidence: 71.5 },
+          { name: "Dog", confidence: 98.2 },
+          { name: "Grass", confidence: 88 },
+        ],
+      });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then the most confident label is first, as real Rekognition reports
+    // them.
+    assertArrayEquals(labelNames(detected), ["Dog", "Grass", "Pet"]);
+  });
+
+  it("filters labels below the requested confidence", async () => {
+    // Given a confident label and a doubtful one.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          { name: "Dog", confidence: 98.2 },
+          { name: "Fence", confidence: 62 },
+        ],
+      });
+
+    // When its labels are detected at a confidence above one of them.
+    const detected = await detect(simAws, "dog.jpg", { MinConfidence: 80 });
+
+    // Then the doubtful one is gone.
+    assertArrayEquals(labelNames(detected), ["Dog"]);
+  });
+
+  it("filters at 55 when the request does not say", async () => {
+    // Given a label below the label detection default but above the content
+    // moderation one.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: [{ name: "Fence", confidence: 52 }] });
+
+    // When its labels are detected with no MinConfidence.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then it is filtered out, because label detection defaults to 55 rather
+    // than to the 50 moderation uses.
+    assertArrayLength(detected.Labels, 0);
+  });
+
+  it("returns every label when the request asks for a confidence of zero", async () => {
+    // Given a label well below the default confidence.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: [{ name: "Fence", confidence: 12 }] });
+
+    // When its labels are detected with an explicit zero rather than no value
+    // at all.
+    const detected = await detect(simAws, "dog.jpg", { MinConfidence: 0 });
+
+    // Then the label survives: an explicit 0 is a request for everything, not
+    // an unset value to be promoted to 55.
+    assertArrayLength(detected.Labels, 1);
+  });
+
+  it("takes the most confident labels when MaxLabels caps them", async () => {
+    // Given more labels than the request wants back.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          { name: "Pet", confidence: 71.5 },
+          { name: "Dog", confidence: 98.2 },
+          { name: "Grass", confidence: 88 },
+        ],
+      });
+
+    // When its labels are detected with room for two.
+    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 2 });
+
+    // Then the two most confident come back, which is what AWS documents
+    // MaxLabels as returning.
+    assertArrayEquals(labelNames(detected), ["Dog", "Grass"]);
+  });
+
+  it("applies MaxLabels after the confidence filter", async () => {
+    // Given a confident label, a doubtful one, and a request that would fit
+    // both.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          { name: "Dog", confidence: 98.2 },
+          { name: "Fence", confidence: 62 },
+          { name: "Grass", confidence: 88 },
+        ],
+      });
+
+    // When its labels are detected with a confidence one of them fails.
+    const detected = await detect(simAws, "dog.jpg", {
+      MaxLabels: 2,
+      MinConfidence: 80,
+    });
+
+    // Then the room is spent on labels that survived the filter rather than
+    // on labels that then filtered out.
+    assertArrayEquals(labelNames(detected), ["Dog", "Grass"]);
+  });
+
+  it("answers with nothing when the request asks for no labels", async () => {
+    // Given a declared label.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: ["Dog"] });
+
+    // When its labels are detected with an explicit MaxLabels of zero.
+    const detected = await detect(simAws, "dog.jpg", { MaxLabels: 0 });
+
+    // Then no labels come back: an explicit 0 is a request for none, not an
+    // unset value to be read as uncapped.
+    assertArrayLength(detected.Labels, 0);
+  });
+
+  it("reports the instances a label was declared with", async () => {
+    // Given a label declared with two of the object in the image.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", {
+        labels: [
+          {
+            name: "Dog",
+            confidence: 98.2,
+            instances: [
+              {
+                boundingBox: { left: 0.1, top: 0.2, width: 0.3, height: 0.4 },
+                confidence: 96.5,
+              },
+              {
+                boundingBox: { left: 0.5, top: 0.2, width: 0.3, height: 0.4 },
+              },
+            ],
+          },
+        ],
+      });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then both instances are located, and the one with no confidence of its
+    // own takes the label's, since a dog detected at 98 is not located at 40.
+    const [dog] = detected.Labels;
+    assertNonNullable(dog);
+    assertArrayLength(dog.Instances, 2);
+    assertIdentical(dog.Instances[0].Confidence, Math.fround(96.5));
+    assertIdentical(dog.Instances[0].BoundingBox.Height, Math.fround(0.4));
+    assertIdentical(dog.Instances[1].Confidence, Math.fround(98.2));
+  });
+
+  it("matches an image by content hash whatever it is called", async () => {
+    // Given a rule for the hash of some image bytes, and an object storing
+    // those bytes under a name nothing was declared for.
+    const simAws = await simAwsWithImage("2f9c1e40-uuid.png", bluePngBytes);
+    simAws
+      .rekognition()
+      .labels()
+      .onHash(simRekognitionImageHash(bluePngBytes), { labels: ["Dog"] });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "2f9c1e40-uuid.png");
+
+    // Then the hash rule answers, which is what makes a system that generates
+    // its own object keys testable.
+    assertArrayEquals(labelNames(detected), ["Dog"]);
+  });
+
+  it("consults hash rules and the default for an image passed as bytes", async () => {
+    // Given a name rule, a hash rule and a default.
+    const simAws = new SimAws();
+    const labels = simAws.rekognition().labels();
+    labels.byDefault({ labels: ["Grass"] });
+    labels.onName("dog.jpg", { labels: ["Dog"] });
+    labels.onHash(simRekognitionImageHash(bluePngBytes), { labels: ["Cat"] });
+
+    // When images are detected as bytes rather than as S3 objects.
+    const hashed = await simAws
+      .rekognition()
+      .detectLabels(
+        new DetectLabelsCommand({ Image: { Bytes: bluePngBytes } }),
+      );
+    const unknown = await simAws
+      .rekognition()
+      .detectLabels(new DetectLabelsCommand({ Image: { Bytes: redPngBytes } }));
+
+    // Then the hash rule matches and the default answers for the rest, since
+    // bytes have no name for a name rule to match.
+    assertArrayEquals(labelNames(hashed), ["Cat"]);
+    assertArrayEquals(labelNames(unknown), ["Grass"]);
+  });
+
+  it("keeps label rules apart from moderation rules", async () => {
+    // Given an object declared to hold a dog and to fail moderation.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("dog.jpg", { labels: ["Dog"] });
+    simAws
+      .rekognition()
+      .moderation()
+      .onName("dog.jpg", { labels: ["Explicit Nudity"] });
+
+    // When its labels are detected.
+    const detected = await detect(simAws, "dog.jpg");
+
+    // Then it answers from the label rules alone, since each operation owns
+    // the result shape it answers with.
+    assertArrayEquals(labelNames(detected), ["Dog"]);
+  });
+
+  it("keeps rules to the Account and Region they were registered in", async () => {
+    // Given a rule registered in one Region only.
+    const simAws = new SimAws();
+    simAws
+      .rekognition()
+      .labels()
+      .byDefault({ labels: ["Dog"] });
+
+    // When labels are detected in another Region.
+    const elsewhere = await simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .rekognition()
+      .detectLabels(new DetectLabelsCommand({ Image: { Bytes: redPngBytes } }));
+
+    // Then that Region answers from its own rules, as a real Rekognition
+    // endpoint answers for the Region it belongs to.
+    assertArrayEquals(labelNames(elsewhere), ["Mobile Phone"]);
+  });
+});

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels-request.ts
@@ -1,8 +1,8 @@
-import { SimRekognitionInvalidParameterException } from "../../error/sim-rekognition.error.js";
 import {
-  parseSimRekognitionImageRequest,
   type SimRekognitionImageRequest,
+  SimRekognitionImageRequests,
 } from "../../image/sim-rekognition-image-request.js";
+import { SimRekognitionMinConfidence } from "../sim-rekognition-min-confidence.js";
 import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
 import type { SimDetectModerationLabelsCommandInput } from "./detect-moderation-labels.command.js";
 
@@ -11,7 +11,7 @@ import type { SimDetectModerationLabelsCommandInput } from "./detect-moderation-
  * does not say. Content moderation uses 50 here, which is not the 55 label
  * detection uses.
  */
-const defaultMinConfidence = 50;
+const minConfidence = new SimRekognitionMinConfidence(50);
 
 const operation = "DetectModerationLabels";
 const acceptedInput = ["Image", "MinConfidence"];
@@ -35,37 +35,7 @@ export class DetectModerationLabelsRequest {
       acceptedInput,
     );
 
-    this.image = parseSimRekognitionImageRequest(input.Image);
-    this.minConfidence = DetectModerationLabelsRequest.confidenceOf(input);
-  }
-
-  /**
-   * The minimum confidence this request filters at.
-   *
-   * The default is applied only when the request left it out, so an explicit
-   * `0` asks for every label rather than being promoted to 50.
-   */
-  private static confidenceOf(
-    input: SimDetectModerationLabelsCommandInput,
-  ): number {
-    if (input.MinConfidence === undefined) {
-      return defaultMinConfidence;
-    }
-
-    // A NaN is refused here rather than compared against. Every comparison
-    // with one is false, so it would filter every label out and look like an
-    // image with nothing to report.
-    if (
-      !Number.isFinite(input.MinConfidence) ||
-      input.MinConfidence < 0 ||
-      input.MinConfidence > 100
-    ) {
-      throw new SimRekognitionInvalidParameterException(
-        `Request has invalid parameters: MinConfidence of ` +
-          `${String(input.MinConfidence)} is not a percentage from 0 to 100`,
-      );
-    }
-
-    return input.MinConfidence;
+    this.image = new SimRekognitionImageRequests(operation).parse(input.Image);
+    this.minConfidence = minConfidence.of(input.MinConfidence);
   }
 }

--- a/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
+++ b/src/service/rekognition/command/detect-moderation-labels/detect-moderation-labels.command.ts
@@ -1,25 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
-
-/**
- * An image as a Rekognition detection request names it.
- *
- * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Image.html
- */
-export interface SimRekognitionImageInput {
-  readonly Bytes?: Uint8Array | undefined;
-  readonly S3Object?: SimRekognitionS3ObjectInput | undefined;
-}
-
-/**
- * An S3 object as a Rekognition detection request names it.
- *
- * The object key is `Name` here rather than the `Key` every S3 command uses.
- */
-export interface SimRekognitionS3ObjectInput {
-  readonly Bucket?: string | undefined;
-  readonly Name?: string | undefined;
-  readonly Version?: string | undefined;
-}
+import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image-input.js";
 
 /**
  * A detected moderation label, with the label above it in the taxonomy.

--- a/src/service/rekognition/command/sim-rekognition-min-confidence.ts
+++ b/src/service/rekognition/command/sim-rekognition-min-confidence.ts
@@ -1,0 +1,36 @@
+import { SimRekognitionInvalidParameterException } from "../error/sim-rekognition.error.js";
+
+/**
+ * The confidence one detection operation filters its results at.
+ *
+ * The default belongs to the operation rather than to the service: content
+ * moderation filters at 50 and label detection at 55, so each operation makes
+ * one of these with its own.
+ */
+export class SimRekognitionMinConfidence {
+  constructor(private readonly whenUnset: number) {}
+
+  /**
+   * The minimum confidence a request filters at.
+   *
+   * The default is applied only when the request left it out, so an explicit
+   * `0` asks for every result rather than being promoted to the default.
+   */
+  of(requested: number | undefined): number {
+    if (requested === undefined) {
+      return this.whenUnset;
+    }
+
+    // A NaN is refused here rather than compared against. Every comparison
+    // with one is false, so it would filter every result out and look like an
+    // image with nothing to report.
+    if (!Number.isFinite(requested) || requested < 0 || requested > 100) {
+      throw new SimRekognitionInvalidParameterException(
+        `Request has invalid parameters: MinConfidence of ` +
+          `${String(requested)} is not a percentage from 0 to 100`,
+      );
+    }
+
+    return requested;
+  }
+}

--- a/src/service/rekognition/image/sim-rekognition-image-input.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-input.ts
@@ -1,0 +1,23 @@
+/**
+ * An image as a Rekognition detection request names it.
+ *
+ * Every detection operation takes the same `Image` member, so it lives beside
+ * the code that reads it rather than in one command's own types.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Image.html
+ */
+export interface SimRekognitionImageInput {
+  readonly Bytes?: Uint8Array | undefined;
+  readonly S3Object?: SimRekognitionS3ObjectInput | undefined;
+}
+
+/**
+ * An S3 object as a Rekognition detection request names it.
+ *
+ * The object key is `Name` here rather than the `Key` every S3 command uses.
+ */
+export interface SimRekognitionS3ObjectInput {
+  readonly Bucket?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly Version?: string | undefined;
+}

--- a/src/service/rekognition/image/sim-rekognition-image-request.ts
+++ b/src/service/rekognition/image/sim-rekognition-image-request.ts
@@ -1,13 +1,13 @@
-import type {
-  SimRekognitionImageInput,
-  SimRekognitionS3ObjectInput,
-} from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
 import type { SimRekognitionRequestOptions } from "../command/sim-rekognition-request-options.js";
 import {
   SimRekognitionInvalidParameterException,
   SimRekognitionUnsimulatedInputException,
 } from "../error/sim-rekognition.error.js";
 import { SimRekognitionImage } from "./sim-rekognition-image.js";
+import type {
+  SimRekognitionImageInput,
+  SimRekognitionS3ObjectInput,
+} from "./sim-rekognition-image-input.js";
 import type { SimRekognitionImageObjects } from "./sim-rekognition-image-objects.js";
 
 /**
@@ -67,58 +67,68 @@ export class SimRekognitionImageS3Request implements SimRekognitionImageRequest 
   }
 }
 
-function parseS3Object(
-  s3Object: SimRekognitionS3ObjectInput,
-): SimRekognitionImageRequest {
-  if (s3Object.Version !== undefined) {
-    throw new SimRekognitionUnsimulatedInputException(
-      "DetectModerationLabels S3Object Version is not simulated: simulated " +
-        "S3 has no object versions, so the version would be ignored here and " +
-        "applied on real AWS",
-    );
-  }
-
-  if (s3Object.Bucket === undefined || s3Object.Name === undefined) {
-    throw new SimRekognitionInvalidParameterException(
-      "Request has invalid parameters: Image S3Object needs both Bucket " +
-        "and Name",
-    );
-  }
-
-  return new SimRekognitionImageS3Request(s3Object.Bucket, s3Object.Name);
-}
-
 /**
- * Read the `Image` member of a detection request.
+ * Reads the `Image` member of one operation's detection requests.
  *
- * Real Rekognition takes exactly one of bytes or an S3 object, so neither and
- * both are equally invalid requests.
+ * The operation is carried here so a refusal names the command the caller
+ * sent, since every detection operation shares this member.
  */
-export function parseSimRekognitionImageRequest(
-  image: SimRekognitionImageInput | undefined,
-): SimRekognitionImageRequest {
-  if (image === undefined) {
+export class SimRekognitionImageRequests {
+  constructor(private readonly operation: string) {}
+
+  /**
+   * Read the `Image` member of a detection request.
+   *
+   * Real Rekognition takes exactly one of bytes or an S3 object, so neither
+   * and both are equally invalid requests.
+   */
+  parse(
+    image: SimRekognitionImageInput | undefined,
+  ): SimRekognitionImageRequest {
+    if (image === undefined) {
+      throw new SimRekognitionInvalidParameterException(
+        "Request has invalid parameters: Image is required",
+      );
+    }
+
+    if (image.Bytes !== undefined && image.S3Object !== undefined) {
+      throw new SimRekognitionInvalidParameterException(
+        "Request has invalid parameters: Image takes either Bytes or " +
+          "S3Object, not both",
+      );
+    }
+
+    if (image.Bytes !== undefined) {
+      return new SimRekognitionImageBytesRequest(image.Bytes);
+    }
+
+    if (image.S3Object !== undefined) {
+      return this.parseS3Object(image.S3Object);
+    }
+
     throw new SimRekognitionInvalidParameterException(
-      "Request has invalid parameters: Image is required",
+      "Request has invalid parameters: Image needs either Bytes or S3Object",
     );
   }
 
-  if (image.Bytes !== undefined && image.S3Object !== undefined) {
-    throw new SimRekognitionInvalidParameterException(
-      "Request has invalid parameters: Image takes either Bytes or " +
-        "S3Object, not both",
-    );
-  }
+  private parseS3Object(
+    s3Object: SimRekognitionS3ObjectInput,
+  ): SimRekognitionImageRequest {
+    if (s3Object.Version !== undefined) {
+      throw new SimRekognitionUnsimulatedInputException(
+        `${this.operation} S3Object Version is not simulated: simulated S3 ` +
+          `has no object versions, so the version would be ignored here and ` +
+          `applied on real AWS`,
+      );
+    }
 
-  if (image.Bytes !== undefined) {
-    return new SimRekognitionImageBytesRequest(image.Bytes);
-  }
+    if (s3Object.Bucket === undefined || s3Object.Name === undefined) {
+      throw new SimRekognitionInvalidParameterException(
+        "Request has invalid parameters: Image S3Object needs both Bucket " +
+          "and Name",
+      );
+    }
 
-  if (image.S3Object !== undefined) {
-    return parseS3Object(image.S3Object);
+    return new SimRekognitionImageS3Request(s3Object.Bucket, s3Object.Name);
   }
-
-  throw new SimRekognitionInvalidParameterException(
-    "Request has invalid parameters: Image needs either Bytes or S3Object",
-  );
 }

--- a/src/service/rekognition/index.ts
+++ b/src/service/rekognition/index.ts
@@ -1,5 +1,17 @@
 export { SimRekognition } from "./sim-rekognition.js";
 export type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
+export { SimRekognitionLabels } from "./label/sim-rekognition-labels.js";
+export type {
+  SimRekognitionDeclaredBoundingBox,
+  SimRekognitionDeclaredLabel,
+  SimRekognitionDeclaredLabelInstance,
+  SimRekognitionLabelDeclaration,
+  SimRekognitionLabelsResult,
+} from "./label/sim-rekognition-label-declaration.js";
+export {
+  simRekognitionDefaultLabels,
+  simRekognitionLabelModelVersion,
+} from "./label/sim-rekognition-label-defaults.js";
 export { SimRekognitionModeration } from "./moderation/sim-rekognition-moderation.js";
 export type {
   SimRekognitionDeclaredModerationLabel,

--- a/src/service/rekognition/label/sim-rekognition-detected-label.ts
+++ b/src/service/rekognition/label/sim-rekognition-detected-label.ts
@@ -1,0 +1,72 @@
+import type {
+  SimRekognitionLabelNameOutput,
+  SimRekognitionLabelOutput,
+} from "../command/detect-labels/detect-labels.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import type { SimRekognitionDeclaredLabel } from "./sim-rekognition-label-declaration.js";
+import { SimRekognitionLabelInstances } from "./sim-rekognition-label-instances.js";
+
+/**
+ * The confidence a declared label carries when none is declared for it.
+ *
+ * It is a value from an AWS DetectLabels example response rather than a round
+ * number, because declared confidences pass through Math.fround and a real one
+ * has the float32 tail a test can assert on.
+ */
+const labelConfidence = new SimRekognitionDeclaredConfidence(97.530106);
+
+/**
+ * The parents, aliases or categories declared for a label, as a response
+ * carries them.
+ *
+ * All three are a list of names on the wire, so all three are checked the same
+ * way: a name with nothing in it is refused where it was declared rather than
+ * reported as a nameless parent.
+ */
+function named(
+  labelName: string,
+  kind: string,
+  declared: readonly string[] | undefined,
+): readonly SimRekognitionLabelNameOutput[] {
+  return (declared ?? []).map((name) => {
+    if (name.length === 0) {
+      throw new SimRekognitionDeclarationError(
+        `A declared ${kind} for '${labelName}' has no name of its own`,
+      );
+    }
+
+    return { Name: name };
+  });
+}
+
+/**
+ * One declared label, as a response carries it.
+ *
+ * Nothing here is filled in from the label name. Yulin ships no general label
+ * ontology, so a label arrives with the parents, aliases, categories and
+ * instances its declaration gave it and with none otherwise.
+ */
+export function simRekognitionDetectedLabel(
+  declared: SimRekognitionDeclaredLabel,
+): SimRekognitionLabelOutput {
+  if (declared.name.length === 0) {
+    throw new SimRekognitionDeclarationError(
+      "A simulated Rekognition label declaration needs a label name",
+    );
+  }
+
+  const confidence = labelConfidence.of(declared.name, declared.confidence);
+
+  return {
+    Name: declared.name,
+    Confidence: confidence,
+    Parents: named(declared.name, "parent", declared.parents),
+    Aliases: named(declared.name, "alias", declared.aliases),
+    Categories: named(declared.name, "category", declared.categories),
+    Instances: new SimRekognitionLabelInstances(
+      declared.name,
+      confidence,
+    ).resolve(declared.instances ?? []),
+  };
+}

--- a/src/service/rekognition/label/sim-rekognition-label-declaration.iso.test.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-declaration.iso.test.ts
@@ -1,0 +1,161 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type { SimRekognitionLabels } from "./sim-rekognition-labels.js";
+
+function labels(): SimRekognitionLabels {
+  return new SimAws().rekognition().labels();
+}
+
+describe("Declaring a simulated label result", () => {
+  it("accepts any label name, since Yulin has no label ontology", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a label that is nowhere in Yulin.
+    labels().byDefault({ labels: ["Pizza"] });
+
+    // Then it is accepted. Real Rekognition returns thousands of labels with
+    // no published enumerable list, so refusing a name would be failing
+    // closed against Yulin's own incompleteness rather than against something
+    // AWS cannot do.
+  });
+
+  it("refuses a label with no name", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a label with an empty name.
+    const error = assertThrowsError(() => {
+      labels().byDefault({ labels: [""] });
+    });
+
+    // Then it is refused where it was written.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "needs a label name");
+  });
+
+  it("refuses a confidence that is not a percentage", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a confidence outside the range AWS reports in.
+    const error = assertThrowsError(() => {
+      labels().byDefault({ labels: [{ name: "Dog", confidence: 101 }] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a parent with no name of its own", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a label whose parent has an empty name.
+    const error = assertThrowsError(() => {
+      labels().onName("dog.jpg", {
+        labels: [{ name: "Dog", parents: ["Animal", ""] }],
+      });
+    });
+
+    // Then it is refused, rather than a response carrying a nameless parent.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "A declared parent for 'Dog'");
+  });
+
+  it("refuses an alias with no name of its own", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a label whose alias has an empty name.
+    const error = assertThrowsError(() => {
+      labels().byDefault({ labels: [{ name: "Dog", aliases: [""] }] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "A declared alias for 'Dog'");
+  });
+
+  it("refuses a category with no name of its own", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a label whose category has an empty name.
+    const error = assertThrowsError(() => {
+      labels().byDefault({ labels: [{ name: "Dog", categories: [""] }] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "A declared category for 'Dog'");
+  });
+
+  it("refuses a bounding box that is not a ratio of the image size", () => {
+    // Given a simulated Rekognition.
+    // When a rule locates an instance in pixels rather than in ratios.
+    const error = assertThrowsError(() => {
+      labels().byDefault({
+        labels: [
+          {
+            name: "Dog",
+            instances: [
+              { boundingBox: { left: 120, top: 40, width: 300, height: 220 } },
+            ],
+          },
+        ],
+      });
+    });
+
+    // Then it is refused where it was written, since real Rekognition reports
+    // a bounding box as ratios of the image's own width and height.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "has a left of 120");
+    assertStringIncludes(error.message, "ratio of the image size");
+  });
+
+  it("refuses an instance confidence that is not a percentage", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares an instance at an impossible confidence.
+    const error = assertThrowsError(() => {
+      labels().byDefault({
+        labels: [
+          {
+            name: "Dog",
+            instances: [
+              {
+                boundingBox: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 },
+                confidence: -3,
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a hash rule that is not a sha256 digest", () => {
+    // Given a simulated Rekognition.
+    // When a rule is registered against a truncated digest.
+    const error = assertThrowsError(() => {
+      labels().onHash("9f86d081884c7d65", { labels: ["Dog"] });
+    });
+
+    // Then it is refused, rather than being stored as a hash nothing can ever
+    // match.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "64 hex characters");
+  });
+
+  it("refuses a name rule with no name to match", () => {
+    // Given a simulated Rekognition.
+    // When a rule is registered against an empty name.
+    const error = assertThrowsError(() => {
+      labels().onName("", { labels: ["Dog"] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "needs an S3 object name");
+  });
+});

--- a/src/service/rekognition/label/sim-rekognition-label-declaration.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-declaration.ts
@@ -1,0 +1,70 @@
+/**
+ * Where one instance of a declared label sits in the image, as ratios of the
+ * image's own width and height.
+ *
+ * The four numbers are the `BoundingBox` real Rekognition reports, in the same
+ * units: `left` and `top` are the corner nearest the image origin, and `width`
+ * and `height` are the size, each from 0 to 1.
+ */
+export interface SimRekognitionDeclaredBoundingBox {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * One instance of a declared label, at a place in the image.
+ *
+ * Real Rekognition reports instances for common objects, so a label declared
+ * with two instances is two of that object in the image.
+ */
+export interface SimRekognitionDeclaredLabelInstance {
+  readonly boundingBox: SimRekognitionDeclaredBoundingBox;
+  readonly confidence?: number | undefined;
+}
+
+/**
+ * A label declared against an image, with what Rekognition is to report
+ * alongside it.
+ *
+ * Everything but the name is optional and empty when it is left out. Yulin
+ * ships no general label ontology, so nothing here is filled in from a label
+ * name: a `Dog` that is to arrive with its parents says what they are.
+ */
+export interface SimRekognitionDeclaredLabel {
+  readonly name: string;
+  readonly confidence?: number | undefined;
+  readonly parents?: readonly string[] | undefined;
+  readonly aliases?: readonly string[] | undefined;
+  readonly categories?: readonly string[] | undefined;
+  readonly instances?:
+    readonly SimRekognitionDeclaredLabelInstance[] | undefined;
+}
+
+/**
+ * A label as a rule declares it: a label name on its own, or a name with what
+ * is to be reported with it.
+ */
+export type SimRekognitionLabelDeclaration =
+  string | SimRekognitionDeclaredLabel;
+
+/**
+ * What DetectLabels answers with for an image.
+ */
+export interface SimRekognitionLabelsResult {
+  readonly labels: readonly SimRekognitionLabelDeclaration[];
+}
+
+/**
+ * Read a declaration that may be a bare label name.
+ */
+export function simRekognitionDeclaredLabel(
+  declaration: SimRekognitionLabelDeclaration,
+): SimRekognitionDeclaredLabel {
+  if (typeof declaration === "string") {
+    return { name: declaration };
+  }
+
+  return declaration;
+}

--- a/src/service/rekognition/label/sim-rekognition-label-defaults.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-defaults.ts
@@ -1,0 +1,44 @@
+import type { SimRekognitionLabelsResult } from "./sim-rekognition-label-declaration.js";
+
+/**
+ * The version of the label detection model these results come from.
+ *
+ * It is pinned beside the default result rather than made up per response,
+ * because the two describe each other: the labels below are what this version
+ * of the model reported for the image AWS documents them against.
+ */
+export const simRekognitionLabelModelVersion = "3.0";
+
+/**
+ * What DetectLabels answers with before anything is configured.
+ *
+ * This is the example response from the AWS DetectLabels documentation, label
+ * for label, so an unconfigured detection answers with something real
+ * Rekognition has actually returned rather than something invented here.
+ * Which labels come back for an arbitrary image is a simulator convention: no
+ * image is looked at, so a photograph of a lighthouse gets these too.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/dg/labels-detect-labels-image.html
+ */
+export const simRekognitionDefaultLabels: SimRekognitionLabelsResult = {
+  labels: [
+    {
+      name: "Mobile Phone",
+      confidence: 99.9364013671875,
+      parents: ["Phone"],
+      aliases: ["Cell Phone"],
+      categories: ["Technology and Computing"],
+      instances: [
+        {
+          boundingBox: {
+            left: 0.3604024350643158,
+            top: 0.09245597571134567,
+            width: 0.26779675483703613,
+            height: 0.8562285900115967,
+          },
+          confidence: 99.9364013671875,
+        },
+      ],
+    },
+  ],
+};

--- a/src/service/rekognition/label/sim-rekognition-label-detection.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-detection.ts
@@ -1,0 +1,57 @@
+import type { SimRekognitionLabelOutput } from "../command/detect-labels/detect-labels.command.js";
+import { simRekognitionDetectedLabel } from "./sim-rekognition-detected-label.js";
+import {
+  simRekognitionDeclaredLabel,
+  type SimRekognitionLabelsResult,
+} from "./sim-rekognition-label-declaration.js";
+
+/**
+ * How one request narrows the labels a result answers with.
+ */
+export interface SimRekognitionLabelFilter {
+  readonly minConfidence: number;
+  readonly maxLabels: number | undefined;
+}
+
+/**
+ * The label result one rule answers with, resolved from its declaration.
+ *
+ * The declaration is resolved when the rule is registered rather than when a
+ * detection runs, so a confidence or a bounding box that is out of range is
+ * refused where it was written.
+ *
+ * Labels are ordered by descending confidence, which is the order real
+ * Rekognition reports them in and what makes `MaxLabels` the most confident
+ * labels rather than the first ones declared.
+ */
+export class SimRekognitionLabelDetection {
+  private readonly labels: readonly SimRekognitionLabelOutput[];
+
+  constructor(result: SimRekognitionLabelsResult) {
+    this.labels = result.labels
+      .map((declaration) =>
+        simRekognitionDetectedLabel(simRekognitionDeclaredLabel(declaration)),
+      )
+      .toSorted((one, other) => other.Confidence - one.Confidence);
+  }
+
+  /**
+   * The labels to report for this result, as one request asked for them.
+   *
+   * `MaxLabels` applies after the confidence filter, so a request for three
+   * labels at 90 does not spend its three on labels that then filter out.
+   */
+  labelsFor(
+    filter: SimRekognitionLabelFilter,
+  ): readonly SimRekognitionLabelOutput[] {
+    const confident = this.labels.filter(
+      (label) => label.Confidence >= filter.minConfidence,
+    );
+
+    if (filter.maxLabels === undefined) {
+      return confident;
+    }
+
+    return confident.slice(0, filter.maxLabels);
+  }
+}

--- a/src/service/rekognition/label/sim-rekognition-label-instances.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-instances.ts
@@ -1,0 +1,64 @@
+import type {
+  SimRekognitionBoundingBoxOutput,
+  SimRekognitionLabelInstanceOutput,
+} from "../command/detect-labels/detect-labels.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import type {
+  SimRekognitionDeclaredBoundingBox,
+  SimRekognitionDeclaredLabelInstance,
+} from "./sim-rekognition-label-declaration.js";
+
+/**
+ * The instances of one declared label, resolved into what a response carries.
+ *
+ * An instance takes its label's confidence when none is declared for it, since
+ * a label detected at 98 is not usually located at 40. Bounding box values go
+ * through `Math.fround` for the same reason confidences do: real ones are
+ * float32 values such as `0.26779675483703613`.
+ */
+export class SimRekognitionLabelInstances {
+  private readonly confidence: SimRekognitionDeclaredConfidence;
+
+  constructor(
+    private readonly labelName: string,
+    labelConfidence: number,
+  ) {
+    this.confidence = new SimRekognitionDeclaredConfidence(labelConfidence);
+  }
+
+  /**
+   * Resolve the declared instances of this label.
+   */
+  resolve(
+    declared: readonly SimRekognitionDeclaredLabelInstance[],
+  ): readonly SimRekognitionLabelInstanceOutput[] {
+    return declared.map((instance) => ({
+      BoundingBox: this.boundingBox(instance.boundingBox),
+      Confidence: this.confidence.of(this.labelName, instance.confidence),
+    }));
+  }
+
+  private boundingBox(
+    box: SimRekognitionDeclaredBoundingBox,
+  ): SimRekognitionBoundingBoxOutput {
+    return {
+      Left: this.ratio("left", box.left),
+      Top: this.ratio("top", box.top),
+      Width: this.ratio("width", box.width),
+      Height: this.ratio("height", box.height),
+    };
+  }
+
+  private ratio(part: string, value: number): number {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new SimRekognitionDeclarationError(
+        `A bounding box declared for '${this.labelName}' has a ${part} of ` +
+          `${String(value)}, which is not a ratio of the image size from 0 ` +
+          `to 1.`,
+      );
+    }
+
+    return Math.fround(value);
+  }
+}

--- a/src/service/rekognition/label/sim-rekognition-labels.ts
+++ b/src/service/rekognition/label/sim-rekognition-labels.ts
@@ -1,0 +1,47 @@
+import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
+import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import type { SimRekognitionLabelsResult } from "./sim-rekognition-label-declaration.js";
+import { SimRekognitionLabelDetection } from "./sim-rekognition-label-detection.js";
+import { simRekognitionDefaultLabels } from "./sim-rekognition-label-defaults.js";
+
+/**
+ * The label results simulated Rekognition answers with.
+ *
+ * The rules are grouped per operation rather than hung off the service, so
+ * `labels()` and the operation groups beside it each own the result shape
+ * their own operation answers with.
+ */
+export class SimRekognitionLabels {
+  private readonly rules =
+    new SimRekognitionResultRules<SimRekognitionLabelDetection>(
+      new SimRekognitionLabelDetection(simRekognitionDefaultLabels),
+    );
+
+  /**
+   * Answer with this result for any image no other rule matches.
+   */
+  byDefault(result: SimRekognitionLabelsResult): void {
+    this.rules.byDefault(new SimRekognitionLabelDetection(result));
+  }
+
+  /**
+   * Answer with this result for the S3 object with this exact name.
+   */
+  onName(name: string, result: SimRekognitionLabelsResult): void {
+    this.rules.onName(name, new SimRekognitionLabelDetection(result));
+  }
+
+  /**
+   * Answer with this result for the image with this exact content hash.
+   */
+  onHash(hash: string, result: SimRekognitionLabelsResult): void {
+    this.rules.onHash(hash, new SimRekognitionLabelDetection(result));
+  }
+
+  /**
+   * The label result for one image.
+   */
+  detectionFor(image: SimRekognitionImage): SimRekognitionLabelDetection {
+    return this.rules.resultFor(image);
+  }
+}

--- a/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
+++ b/src/service/rekognition/moderation/sim-rekognition-moderation-result.ts
@@ -1,5 +1,5 @@
 import type { SimRekognitionModerationLabelOutput } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
-import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
 import {
   type SimRekognitionModerationLabelNode,
   simRekognitionModerationTaxonomy,
@@ -13,7 +13,7 @@ import {
  * one of them rather than a round number. A test that asserts on the exact
  * value is asserting on something the shape of what AWS returns.
  */
-const defaultModerationConfidence = 96.68;
+const moderationConfidence = new SimRekognitionDeclaredConfidence(96.68);
 
 /**
  * A moderation label declared against an image, with the confidence
@@ -55,7 +55,10 @@ class SimRekognitionModerationChain {
   constructor(declaration: SimRekognitionModerationLabelDeclaration) {
     const declared = SimRekognitionModerationChain.declared(declaration);
 
-    this.confidence = SimRekognitionModerationChain.confidenceOf(declared);
+    this.confidence = moderationConfidence.of(
+      declared.name,
+      declared.confidence,
+    );
     this.nodes = simRekognitionModerationTaxonomy.chain(declared.name);
   }
 
@@ -67,25 +70,6 @@ class SimRekognitionModerationChain {
     }
 
     return declaration;
-  }
-
-  private static confidenceOf(
-    declared: SimRekognitionDeclaredModerationLabel,
-  ): number {
-    const confidence = declared.confidence ?? defaultModerationConfidence;
-
-    // A NaN is refused with everything else out of range. Every comparison
-    // with one is false, so a label declared at NaN would never survive
-    // MinConfidence filtering and would look like a rule that never matched.
-    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 100) {
-      throw new SimRekognitionDeclarationError(
-        `A confidence of ${String(confidence)} declared for ` +
-          `'${declared.name}' is not a Rekognition confidence, which is a ` +
-          `percentage from 0 to 100.`,
-      );
-    }
-
-    return Math.fround(confidence);
   }
 }
 

--- a/src/service/rekognition/rule/sim-rekognition-declared-confidence.ts
+++ b/src/service/rekognition/rule/sim-rekognition-declared-confidence.ts
@@ -1,0 +1,36 @@
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+
+/**
+ * The confidence a declared result reports a label at.
+ *
+ * Every operation group declares confidences the same way and defaults them
+ * differently, so the range check lives here and the default is passed in.
+ *
+ * Confidences pass through `Math.fround`. Real Rekognition confidences are
+ * float32 values with a long tail, such as `99.44782257080078`, and a value
+ * rounded to four decimals is identifiable as fake.
+ */
+export class SimRekognitionDeclaredConfidence {
+  constructor(private readonly whenUndeclared: number) {}
+
+  /**
+   * The confidence to report a declared label at.
+   *
+   * The label name is only used to say which declaration was wrong.
+   */
+  of(name: string, declared: number | undefined): number {
+    const confidence = declared ?? this.whenUndeclared;
+
+    // A NaN is refused with everything else out of range. Every comparison
+    // with one is false, so a label declared at NaN would never survive
+    // MinConfidence filtering and would look like a rule that never matched.
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 100) {
+      throw new SimRekognitionDeclarationError(
+        `A confidence of ${String(confidence)} declared for '${name}' is not ` +
+          `a Rekognition confidence, which is a percentage from 0 to 100.`,
+      );
+    }
+
+    return Math.fround(confidence);
+  }
+}

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
@@ -14,8 +14,11 @@ describe("SimRekognitionSdkCommandRouter", () => {
       .sdkCommandRouter()
       .supportedCommandNames();
 
-    // Then the simulated operation is routable by SDK Command name.
-    assertArrayIncludesAll(names, ["DetectModerationLabelsCommand"]);
+    // Then every simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "DetectModerationLabelsCommand",
+      "DetectLabelsCommand",
+    ]);
   });
 
   it("has no route for a Command simulated Rekognition does not handle", () => {

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
@@ -3,6 +3,7 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type { SimDetectLabelsCommand } from "../command/detect-labels/detect-labels.command.js";
 import type { SimDetectModerationLabelsCommand } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
 import type { SimRekognition } from "../sim-rekognition.js";
 
@@ -20,6 +21,14 @@ export class SimRekognitionSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRekognition.detectModerationLabels(
             command as SimDetectModerationLabelsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DetectLabelsCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.detectLabels(
+            command as SimDetectLabelsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  DetectLabelsCommand,
   DetectModerationLabelsCommand,
   RekognitionClient,
 } from "@aws-sdk/client-rekognition";
@@ -31,6 +32,31 @@ describe("Rekognition SDK interception", () => {
     assertStringIncludes(
       (detected.ModerationLabels ?? []).map((label) => label.Name).join(","),
       "Explicit Nudity",
+    );
+  });
+
+  it("routes an intercepted label detection to simulated Rekognition", async () => {
+    // Given an intercepted Rekognition SDK client, with an image declared to
+    // hold a dog.
+    using simSdk = new SimSdk();
+    simSdk.intercept(RekognitionClient);
+    simSdk.simAws
+      .rekognition()
+      .labels()
+      .byDefault({ labels: [{ name: "Dog", parents: ["Animal"] }] });
+
+    const rekognition = new RekognitionClient({ region: "us-east-1" });
+
+    // When ordinary SDK code detects labels in an image.
+    const detected = await rekognition.send(
+      new DetectLabelsCommand({ Image: { Bytes: redPngBytes }, MaxLabels: 10 }),
+    );
+
+    // Then the declared result comes back, with nothing touching the network.
+    assertIdentical(detected.LabelModelVersion, "3.0");
+    assertStringIncludes(
+      (detected.Labels ?? []).map((label) => label.Name).join(","),
+      "Dog",
     );
   });
 });

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -8,6 +8,11 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimRekognitionAuthorizer } from "./command/authorize/sim-rekognition-authorizer.js";
+import { DetectLabelsHandler } from "./command/detect-labels/detect-labels.handler.js";
+import type {
+  SimDetectLabelsCommand,
+  SimDetectLabelsCommandOutput,
+} from "./command/detect-labels/detect-labels.command.js";
 import { DetectModerationLabelsHandler } from "./command/detect-moderation-labels/detect-moderation-labels.handler.js";
 import type {
   SimDetectModerationLabelsCommand,
@@ -18,6 +23,7 @@ import {
   type SimRekognitionImageObjects,
   SimRekognitionUnreachableImageObjects,
 } from "./image/sim-rekognition-image-objects.js";
+import { SimRekognitionLabels } from "./label/sim-rekognition-labels.js";
 import { SimRekognitionModeration } from "./moderation/sim-rekognition-moderation.js";
 import { SimRekognitionSdkCommandRouter } from "./sdk/sim-rekognition-sdk-command-router.js";
 
@@ -42,7 +48,9 @@ interface SimRekognitionProperties {
  */
 export class SimRekognition {
   private readonly moderationRules = new SimRekognitionModeration();
+  private readonly labelRules = new SimRekognitionLabels();
   private readonly detectModerationLabelsCommand: DetectModerationLabelsHandler;
+  private readonly detectLabelsCommand: DetectLabelsHandler;
   private readonly sdkRouter = new SimRekognitionSdkCommandRouter(this);
 
   constructor(properties: SimRekognitionProperties = {}) {
@@ -51,10 +59,18 @@ export class SimRekognition {
       background = new BackgroundTasks(),
       images = new SimRekognitionUnreachableImageObjects(),
     } = properties;
+    const authorizer = new SimRekognitionAuthorizer({ iam });
 
     this.detectModerationLabelsCommand = new DetectModerationLabelsHandler({
       moderation: this.moderationRules,
-      authorizer: new SimRekognitionAuthorizer({ iam }),
+      authorizer,
+      images,
+      background,
+    });
+
+    this.detectLabelsCommand = new DetectLabelsHandler({
+      labels: this.labelRules,
+      authorizer,
       images,
       background,
     });
@@ -76,6 +92,21 @@ export class SimRekognition {
   }
 
   /**
+   * The label results this simulated Rekognition answers with.
+   *
+   * Every image gets the built-in default result until a rule says otherwise:
+   *
+   * ```typescript
+   * simAws.rekognition().labels().onName("dog.jpg", {
+   *   labels: [{ name: "Dog", parents: ["Animal", "Pet"] }],
+   * });
+   * ```
+   */
+  labels(): SimRekognitionLabels {
+    return this.labelRules;
+  }
+
+  /**
    * Handle a DetectModerationLabels Command from the SDK.
    *
    * Background sequencing happens inside the command rather than here,
@@ -87,6 +118,16 @@ export class SimRekognition {
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDetectModerationLabelsCommandOutput> {
     return await this.detectModerationLabelsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DetectLabels Command from the SDK.
+   */
+  async detectLabels(
+    command: SimDetectLabelsCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDetectLabelsCommandOutput> {
+    return await this.detectLabelsCommand.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
DetectLabels answers from the same rule mechanism as moderation, under simAws.rekognition().labels(), honouring MinConfidence, MaxLabels and Features. Declared labels carry their own parents, aliases, categories and instances, since Yulin ships no general label ontology.

Resolves https://github.com/KensioSoftware/yulin/issues/318