### PR TITLE
feat: detect faces in simulated Rekognition images

### DIFF
--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -140,11 +140,175 @@ Nothing is filled in from a label name. Declaring `Dog` with no parents reports 
 parents, and declaring a `Pizza` nobody has heard of reports `Pizza`, because Yulin ships no general
 label ontology to check a name against or to expand one from.
 
+## Detecting faces in an image
+
+`DetectFaces` answers with the faces an image is declared to hold. A face says where it is and what
+it looks like, and the response carries the attributes the request asked for.
+
+```typescript sim-rekognition-detect-faces
+/**
+ * Declaring the faces in one S3 object and detecting them.
+ */
+
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/selfie.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+simAws
+  .rekognition()
+  .faces()
+  .onName("raw/selfie.png", {
+    faces: [
+      {
+        // A bounding box is in ratios of the image size, as AWS reports it.
+        boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 },
+        confidence: 99.4,
+        ageRange: { low: 18, high: 26 },
+        gender: "Female",
+        smile: true,
+        sunglasses: { value: false, confidence: 99.9 },
+        emotions: ["CALM"],
+      },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectFaces(
+  new DetectFacesCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/selfie.png" } },
+    Attributes: ["ALL"],
+  }),
+);
+
+console.log(detected.FaceDetails.length); // 1
+console.log(detected.FaceDetails[0]?.AgeRange); // { Low: 18, High: 26 }
+console.log(detected.FaceDetails[0]?.Smile);
+// { Value: true, Confidence: 99.4000015258789 }
+```
+
+Faces come back in the order they were declared. An attribute with no confidence of its own takes
+the face's, so a face detected at 99.4 is reported as smiling at 99.4. A face declared with no
+confidence at all is detected at the built-in one.
+
+An image with nobody in it is `{ faces: [] }`. Two built-in results cover the counting a test
+usually does:
+
+```typescript
+import {
+  simRekognitionNoFaces,
+  simRekognitionSeveralFaces,
+} from "@kensio/yulin/rekognition";
+
+const faces = simAws.rekognition().faces();
+
+faces.onName("raw/landscape.png", simRekognitionNoFaces);
+faces.onName("raw/crowd.png", simRekognitionSeveralFaces);
+```
+
+An image no rule matches gets the built-in default result: the one face from the example response in
+the AWS `DetectFaces` documentation, with the attributes and all thirty landmarks AWS documents it
+with. That is a real Rekognition response, but which face an unconfigured image gets is a simulator
+convention rather than what AWS would return for it.
+
+## Choosing the facial attributes
+
+`BoundingBox`, `Confidence`, `Pose`, `Quality` and `Landmarks` come back whatever a request asked
+for, which is the default subset AWS always returns. `ALL` adds the rest, and naming one attribute
+adds that one, so `["FACE_OCCLUDED"]` is the default subset with face occlusion on top.
+`["ALL", "DEFAULT"]` is the union the two describe together.
+
+Landmarks follow AWS too: five come back unless `ALL` was asked for, and every declared landmark
+when it was.
+
+```typescript sim-rekognition-face-attributes
+/**
+ * One face detected twice, with the default attributes and with ALL.
+ */
+
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .faces()
+  .byDefault({
+    faces: [
+      {
+        boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 },
+        confidence: 99.4,
+        landmarks: {
+          eyeLeft: { x: 0.35, y: 0.3 },
+          eyeRight: { x: 0.5, y: 0.3 },
+          chinBottom: { x: 0.43, y: 0.62 },
+        },
+        smile: true,
+      },
+    ],
+  });
+
+const byDefault = await simAws
+  .rekognition()
+  .detectFaces(new DetectFacesCommand({ Image: { Bytes: imageBytes } }));
+
+console.log(Object.keys(byDefault.FaceDetails[0] ?? {}));
+// [ "BoundingBox", "Confidence", "Landmarks" ]
+console.log(
+  byDefault.FaceDetails[0]?.Landmarks?.map((landmark) => landmark.Type),
+);
+// [ "eyeLeft", "eyeRight" ]
+
+const everything = await simAws.rekognition().detectFaces(
+  new DetectFacesCommand({
+    Image: { Bytes: imageBytes },
+    Attributes: ["ALL"],
+  }),
+);
+
+console.log(everything.FaceDetails[0]?.Smile?.Value); // true
+console.log(
+  everything.FaceDetails[0]?.Landmarks?.map((landmark) => landmark.Type),
+);
+// [ "eyeLeft", "eyeRight", "chinBottom" ]
+```
+
+An attribute nothing was declared for is left out of the response rather than carried as an empty
+one, so a face declared with a bounding box and nothing else comes back as a bounding box and a
+confidence however many attributes the request asked for.
+
+A declaration is checked where it is written. A bounding box or a landmark outside the image is
+refused, as is an age range that ends before it begins, an emotion Rekognition does not report, and
+a pair of landmarks that runs the wrong way across the face, such as an `eyeLeft` to the right of
+`eyeRight`. So is a result declaring more than a hundred faces, which is the most real Rekognition
+detects in one image. Landmarks are not required to sit inside the bounding box, because a real
+Rekognition face box routinely excludes the chin.
+
 ## Declaring results
 
 Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
-from and `labels()` holds the rules `DetectLabels` answers from. Both take the same three kinds of
-rule: an exact S3 object name, an exact content hash, or anything at all.
+from, `labels()` holds the rules `DetectLabels` answers from, and `faces()` holds the rules
+`DetectFaces` answers from. All three take the same three kinds of rule: an exact S3 object name, an
+exact content hash, or anything at all.
 
 ```typescript sim-rekognition-moderation-rules
 /**
@@ -479,8 +643,9 @@ ever, so filter the notification configuration by prefix or suffix as this one d
 
 ## Permissions and errors
 
-Each detection is authorized as its own action against `*`: `rekognition:DetectModerationLabels` and
-`rekognition:DetectLabels`. Real Rekognition gives the detection operations no resource-level
+Each detection is authorized as its own action against `*`: `rekognition:DetectModerationLabels`,
+`rekognition:DetectLabels` and `rekognition:DetectFaces`. Real Rekognition gives the detection
+operations no resource-level
 permissions, so a policy naming an ARN reaches nothing, here as on AWS. A denial throws
 `AccessDeniedException` with a 400 status, which is what real Rekognition answers with rather than
 the 403 several other services use.
@@ -522,8 +687,8 @@ reads only Buckets in its own Region.
 
 Simulated Rekognition currently supports:
 
-- `DetectModerationLabelsCommand` and `DetectLabelsCommand`, for an image supplied as `Image.Bytes`
-  or as `Image.S3Object`
+- `DetectModerationLabelsCommand`, `DetectLabelsCommand` and `DetectFacesCommand`, for an image
+  supplied as `Image.Bytes` or as `Image.S3Object`
 - Results declared by exact S3 object name, by exact image content hash, or as a default, with the
   hash rule winning, then the name rule, then the default
 - The complete version 7.0 content moderation taxonomy, with a declared label expanding to its
@@ -532,16 +697,32 @@ Simulated Rekognition currently supports:
   descending confidence
 - `MinConfidence` filtering, defaulting to 50 for moderation and 55 for label detection, and
   `MaxLabels` after it
+- Detected faces carrying the declared bounding box, confidence, pose, quality, landmarks, age
+  range, gender, emotions, eye direction and the eight yes or no attributes
+- `Attributes` handling for face detection, with the default subset always returned, `ALL` adding
+  the rest, and five landmarks reported unless `ALL` was asked for
+- `simRekognitionNoFaces` and `simRekognitionSeveralFaces`, for a test that counts faces
 - `simRekognitionImageHash`, for hashing a fixture to declare a rule against
 - PNG and JPEG format detection from the image bytes
-- IAM authorization on `rekognition:DetectModerationLabels` and `rekognition:DetectLabels`, with the
-  image read from S3 as the caller
+- IAM authorization on `rekognition:DetectModerationLabels`, `rekognition:DetectLabels` and
+  `rekognition:DetectFaces`, with the image read from S3 as the caller
 - SDK interception of `RekognitionClient`, including from inside a simulated Lambda function
 
 ## Limitations
 
-- `DetectFaces`, `DetectText`, face collections and the video operations are not simulated. An
-  intercepted client sending one of those Commands is refused by name.
+- `DetectText`, `CompareFaces`, the face collection operations and the video operations are not
+  simulated. An intercepted client sending one of those Commands is refused by name.
+- A face detection reports the emotions that were declared and no others. Real `DetectFaces` returns
+  all eight emotion types every time, the ones it did not see at a low confidence. Declare the
+  emotions the code under test reads.
+- `OrientationCorrection` is not carried on a `DetectFaces` response, because AWS documents its
+  value as always null.
+- A declared bounding box has to sit inside the image. Real Rekognition can report a box that does
+  not, for a face at the image edge that is only partly visible. The check is kept because it
+  catches a box written in pixels.
+- Landmark pairs that run across the face, such as `eyeLeft` and `eyeRight`, have to be declared in
+  the order Rekognition reports them in. A face rolled past upright is the one case where that
+  ordering does not hold on AWS, and it cannot be declared here.
 - Yulin ships no general label ontology, because AWS's is thousands of entries with no published
   enumerable table.
 - A declared label's `Parents` appear on that label alone. Real `DetectLabels` also returns each

--- a/docs/services/rekognition/sim-rekognition-detect-faces.example.ts
+++ b/docs/services/rekognition/sim-rekognition-detect-faces.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Declaring the faces in one S3 object and detecting them.
+ */
+
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "raw/selfie.png",
+    Body: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+      "base64",
+    ),
+  }),
+);
+
+simAws
+  .rekognition()
+  .faces()
+  .onName("raw/selfie.png", {
+    faces: [
+      {
+        // A bounding box is in ratios of the image size, as AWS reports it.
+        boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 },
+        confidence: 99.4,
+        ageRange: { low: 18, high: 26 },
+        gender: "Female",
+        smile: true,
+        sunglasses: { value: false, confidence: 99.9 },
+        emotions: ["CALM"],
+      },
+    ],
+  });
+
+const detected = await simAws.rekognition().detectFaces(
+  new DetectFacesCommand({
+    Image: { S3Object: { Bucket: "uploads", Name: "raw/selfie.png" } },
+    Attributes: ["ALL"],
+  }),
+);
+
+console.log(detected.FaceDetails.length); // 1
+console.log(detected.FaceDetails[0]?.AgeRange); // { Low: 18, High: 26 }
+console.log(detected.FaceDetails[0]?.Smile);
+// { Value: true, Confidence: 99.4000015258789 }

--- a/docs/services/rekognition/sim-rekognition-face-attributes.example.ts
+++ b/docs/services/rekognition/sim-rekognition-face-attributes.example.ts
@@ -1,0 +1,55 @@
+/**
+ * One face detected twice, with the default attributes and with ALL.
+ */
+
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const imageBytes = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO4I2IDAAL8AS3VzMq8AAAAAElFTkSuQmCC",
+  "base64",
+);
+
+simAws
+  .rekognition()
+  .faces()
+  .byDefault({
+    faces: [
+      {
+        boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 },
+        confidence: 99.4,
+        landmarks: {
+          eyeLeft: { x: 0.35, y: 0.3 },
+          eyeRight: { x: 0.5, y: 0.3 },
+          chinBottom: { x: 0.43, y: 0.62 },
+        },
+        smile: true,
+      },
+    ],
+  });
+
+const byDefault = await simAws
+  .rekognition()
+  .detectFaces(new DetectFacesCommand({ Image: { Bytes: imageBytes } }));
+
+console.log(Object.keys(byDefault.FaceDetails[0] ?? {}));
+// [ "BoundingBox", "Confidence", "Landmarks" ]
+console.log(
+  byDefault.FaceDetails[0]?.Landmarks?.map((landmark) => landmark.Type),
+);
+// [ "eyeLeft", "eyeRight" ]
+
+const everything = await simAws.rekognition().detectFaces(
+  new DetectFacesCommand({
+    Image: { Bytes: imageBytes },
+    Attributes: ["ALL"],
+  }),
+);
+
+console.log(everything.FaceDetails[0]?.Smile?.Value); // true
+console.log(
+  everything.FaceDetails[0]?.Landmarks?.map((landmark) => landmark.Type),
+);
+// [ "eyeLeft", "eyeRight", "chinBottom" ]

--- a/src/service/rekognition/README.md
+++ b/src/service/rekognition/README.md
@@ -1,8 +1,8 @@
 # Simulated Rekognition implementation
 
-This directory contains the simulated Rekognition implementation. Two image detections are
-simulated, `DetectModerationLabels` and `DetectLabels`, each for an image supplied as bytes or as an
-S3 object.
+This directory contains the simulated Rekognition implementation. Three image detections are
+simulated, `DetectModerationLabels`, `DetectLabels` and `DetectFaces`, each for an image supplied as
+bytes or as an S3 object.
 
 The guiding decision here is that no image recognition happens. Rekognition is a service where the
 interesting behaviour is not the call but what the call returns, so the simulation maintains no
@@ -16,10 +16,10 @@ IAM decision, and the taxonomy a returned label belongs to.
 - `sim-rekognition.ts` is the service facade for one account/region scope.
 - `index.ts` exports the public Rekognition simulator API for `@kensio/yulin/rekognition`.
 
-`SimRekognition` owns a `SimRekognitionModeration` and a `SimRekognitionLabels`, which own the rules
-`DetectModerationLabels` and `DetectLabels` answer from. Rules are grouped per operation rather than
-hung off the facade, so `faces()` can be added beside `moderation()` and `labels()` without the
-facade growing a result shape for each.
+`SimRekognition` owns a `SimRekognitionModeration`, a `SimRekognitionLabels` and a
+`SimRekognitionFaces`, which own the rules the three detections answer from. Rules are grouped per
+operation rather than hung off the facade, so an operation group is added beside the others without
+the facade growing a result shape for each.
 
 The service is scoped to an account and region because its rules are: a detection made in one Region
 is answered by the rules registered in that Region, as a real Rekognition endpoint answers for the
@@ -92,6 +92,54 @@ returned. The two belong in one file because the labels are what that version of
 Labels have no equivalent of a clean image to default to: an empty result would look like a broken
 detection rather than a useful starting point.
 
+## The face model
+
+`face/` is the largest of the three models, because a `FaceDetail` is seventeen members and a
+request decides which of them come back.
+
+`face/sim-rekognition-face-declaration.ts` is the declared shape and nothing else. The readers that
+go with it are in `sim-rekognition-declared-value.ts`, which reads the attributes that can be
+written as a bare value or as a value with a confidence, in the way a label can be written as a bare
+name.
+
+`face/sim-rekognition-detected-face.ts` is one resolved face. It holds six small pieces, each
+owning the attributes it can check as a group:
+
+- `sim-rekognition-face-frame.ts`, the default subset bar the landmarks: bounding box, confidence,
+  pose and quality;
+- `sim-rekognition-face-landmarks.ts`, which reports the landmarks that
+  `sim-rekognition-face-landmark-points.ts` resolved;
+- `sim-rekognition-face-features.ts`, the eight attributes Rekognition answers yes or no to;
+- `sim-rekognition-face-emotions.ts`;
+- `sim-rekognition-face-age-and-gender.ts`;
+- `sim-rekognition-face-eye-direction.ts`.
+
+The split is not decoration. One renderer covering the optional attributes, written to this repo's
+conventions, scores over the FTA threshold on its own. `sim-rekognition-face-feature-members.ts` is
+split out for the same reason the moderation label list is: it is a table of names, and holding it
+beside the code that reads it pushes that file over.
+
+Each piece adds its members through `sim-rekognition-face-detail-builder.ts`, which carries a member
+only when the request asked for the attribute it belongs to and the face declared a value for it. A
+member with no declared value is left out of the response rather than carried as `undefined`, so a
+test can ask which attributes came back. The attribute a member belongs to is passed in beside it
+because the two do not share a name: `EyesOpen` is asked for as `EYES_OPEN`.
+
+`sim-rekognition-face-attributes.ts` is the requested set. The default subset is always wanted, so
+`["FACE_OCCLUDED"]` is that subset with face occlusion added, and `["ALL", "DEFAULT"]` is the union
+the two describe together. It also decides the landmark set: real Rekognition reports five landmarks
+unless `ALL` was asked for, and the whole set when it was.
+
+`sim-rekognition-face-defaults.ts` holds the built-in result, which is the AWS documentation's own
+example response attribute for attribute, along with `simRekognitionNoFaces` and
+`simRekognitionSeveralFaces` for the two results a test that only counts faces needs.
+
+The declaration checks are in the pieces that own the values, and two are worth knowing about.
+Landmarks are not required to sit inside the bounding box, because a real Rekognition face box
+routinely excludes the chin. Landmark pairs that run across the face, such as `eyeLeft` and
+`eyeRight`, are required to be in the order Rekognition reports them in, so a declaration with the
+two swapped is refused where it was written.
+
 ## Images
 
 `image/` is the path from a request to the bytes a rule is matched against.
@@ -119,6 +167,12 @@ missing.
 Every S3 failure becomes `InvalidS3ObjectException`, as it does on real Rekognition, with the
 underlying simulator error kept as the `cause`. A missing `s3:GetObject` grant would otherwise be
 indistinguishable from a missing object.
+
+`image/sim-rekognition-bounding-box.ts` is shared by the label and face models, because a bounding
+box is the same four ratios in both. It refuses a box that does not sit inside the image, which is
+stricter than AWS: a real response can put a box outside the image bounds for a face at the edge
+that is only partly visible. The check is kept because it catches a box written in pixels, which is
+the mistake worth catching.
 
 ## Authorization
 

--- a/src/service/rekognition/command/detect-faces/detect-faces-attributes.iso.test.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces-attributes.iso.test.ts
@@ -1,0 +1,213 @@
+import {
+  type Attribute,
+  DetectFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimRekognitionFacesResult } from "../../face/sim-rekognition-face-declaration.js";
+import type {
+  SimDetectFacesCommandOutput,
+  SimRekognitionFaceDetailOutput,
+} from "./detect-faces.command.js";
+
+const wholeFace: SimRekognitionFacesResult = {
+  faces: [
+    {
+      boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 },
+      confidence: 99.4,
+      pose: { roll: -5.8, yaw: -2.4, pitch: 2.6 },
+      quality: { brightness: 96.1, sharpness: 95.5 },
+      landmarks: {
+        eyeLeft: { x: 0.35, y: 0.3 },
+        eyeRight: { x: 0.5, y: 0.3 },
+        nose: { x: 0.42, y: 0.36 },
+        mouthLeft: { x: 0.37, y: 0.45 },
+        mouthRight: { x: 0.49, y: 0.45 },
+        chinBottom: { x: 0.43, y: 0.62 },
+      },
+      ageRange: { low: 18, high: 26 },
+      gender: { value: "Female", confidence: 99.8 },
+      emotions: ["CALM", { type: "HAPPY", confidence: 65.5 }],
+      eyeDirection: { yaw: 16.3, pitch: -6.4, confidence: 99.9 },
+      smile: { value: true, confidence: 89.7 },
+      eyeglasses: false,
+      sunglasses: false,
+      beard: false,
+      mustache: false,
+      eyesOpen: true,
+      mouthOpen: false,
+      faceOccluded: { value: false, confidence: 99.9 },
+    },
+  ],
+};
+
+async function detect(
+  attributes?: Attribute[],
+  result = wholeFace,
+): Promise<SimDetectFacesCommandOutput> {
+  const simAws = new SimAws();
+  simAws.rekognition().faces().byDefault(result);
+
+  return await simAws.rekognition().detectFaces(
+    new DetectFacesCommand({
+      Image: { Bytes: redPngBytes },
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+}
+
+function onlyFace(
+  detected: SimDetectFacesCommandOutput,
+): SimRekognitionFaceDetailOutput {
+  const [face] = detected.FaceDetails;
+  assertNonNullable(face);
+
+  return face;
+}
+
+function landmarkNames(face: SimRekognitionFaceDetailOutput): string[] {
+  return (face.Landmarks ?? []).map((landmark) => landmark.Type);
+}
+
+describe("Choosing the attributes a face detection reports", () => {
+  it("reports the default subset for a request that asks for nothing", async () => {
+    // Given a face declared with every attribute on it.
+    // When it is detected with no Attributes at all.
+    const face = onlyFace(await detect());
+
+    // Then the five default attributes come back and nothing else, which is
+    // the subset AWS always returns.
+    assertArrayEquals(
+      Object.keys(face).toSorted((one, other) => one.localeCompare(other)),
+      ["BoundingBox", "Confidence", "Landmarks", "Pose", "Quality"],
+    );
+  });
+
+  it("reports every attribute for a request that asks for ALL", async () => {
+    // Given a face declared with every attribute on it.
+    // When it is detected with ALL.
+    const face = onlyFace(await detect(["ALL"]));
+
+    // Then the facial attributes come back beside the default subset.
+    assertIdentical(face.AgeRange?.Low, 18);
+    assertIdentical(face.Gender?.Value, "Female");
+    assertTrue(face.Smile?.Value);
+    assertFalse(face.Eyeglasses?.Value);
+    assertFalse(face.Sunglasses?.Value);
+    assertFalse(face.Beard?.Value);
+    assertFalse(face.Mustache?.Value);
+    assertTrue(face.EyesOpen?.Value);
+    assertFalse(face.MouthOpen?.Value);
+    assertFalse(face.FaceOccluded?.Value);
+    assertIdentical(face.EyeDirection?.Yaw, Math.fround(16.3));
+    assertArrayLength(face.Emotions ?? [], 2);
+    assertIdentical(face.Confidence, Math.fround(99.4));
+  });
+
+  it("adds one requested attribute to the default subset", async () => {
+    // Given a face declared with every attribute on it.
+    // When it is detected asking only for face occlusion.
+    const face = onlyFace(await detect(["FACE_OCCLUDED"]));
+
+    // Then occlusion arrives with the default subset, since AWS returns that
+    // subset whatever else was asked for.
+    assertFalse(face.FaceOccluded?.Value);
+    assertIdentical(face.Confidence, Math.fround(99.4));
+    assertUndefined(face.Smile);
+    assertUndefined(face.AgeRange);
+  });
+
+  it("treats ALL and DEFAULT together as the union of the two", async () => {
+    // Given a face declared with every attribute on it.
+    // When it is detected asking for both.
+    const face = onlyFace(await detect(["ALL", "DEFAULT"]));
+
+    // Then everything comes back, as AWS documents the two combining.
+    assertIdentical(face.AgeRange?.High, 26);
+    assertIdentical(face.Quality?.Sharpness, Math.fround(95.5));
+  });
+
+  it("leaves out an attribute nothing was declared for", async () => {
+    // Given a face declared with a bounding box and nothing else.
+    const declared = {
+      faces: [
+        { boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 } },
+      ],
+    };
+
+    // When it is detected with every attribute.
+    const face = onlyFace(await detect(["ALL"], declared));
+
+    // Then the members with no declared value are absent rather than present
+    // and undefined, so a test can ask which attributes came back.
+    assertArrayEquals(
+      Object.keys(face).toSorted((one, other) => one.localeCompare(other)),
+      ["BoundingBox", "Confidence"],
+    );
+    assertFalse(Object.hasOwn(face, "AgeRange"));
+  });
+
+  it("reports the five default landmarks unless ALL was asked for", async () => {
+    // Given a face declared with six landmarks on it.
+    // When it is detected with the default attributes.
+    const face = onlyFace(await detect());
+
+    // Then the five landmarks AWS reports by default come back, in the order
+    // it reports them in, and the sixth is left out.
+    assertArrayEquals(landmarkNames(face), [
+      "eyeLeft",
+      "eyeRight",
+      "mouthLeft",
+      "mouthRight",
+      "nose",
+    ]);
+  });
+
+  it("reports every declared landmark for a request that asks for ALL", async () => {
+    // Given a face declared with six landmarks on it.
+    // When it is detected with ALL.
+    const face = onlyFace(await detect(["ALL"]));
+
+    // Then the chin comes back too, which is what makes ALL worth asking for.
+    assertArrayLength(face.Landmarks ?? [], 6);
+    assertIdentical(face.Landmarks?.[5]?.Type, "chinBottom");
+    assertIdentical(face.Landmarks[5].X, Math.fround(0.43));
+  });
+
+  it("orders emotions by descending confidence", async () => {
+    // Given a face declared as calm at the face's own confidence and happy at
+    // a lower one.
+    // When it is detected with ALL.
+    const face = onlyFace(await detect(["ALL"]));
+
+    // Then the most confident emotion is first, as real Rekognition reports
+    // them, and the bare name took the face's confidence.
+    assertArrayEquals(
+      (face.Emotions ?? []).map((emotion) => emotion.Type),
+      ["CALM", "HAPPY"],
+    );
+    assertIdentical(face.Emotions?.[0]?.Confidence, Math.fround(99.4));
+  });
+
+  it("leaves landmarks out entirely when none were declared", async () => {
+    // Given a face declared without landmarks.
+    const declared = { faces: [{ confidence: 90 }] };
+
+    // When it is detected.
+    const face = onlyFace(await detect(["ALL"], declared));
+
+    // Then there is no empty Landmarks member to read as a face with no eyes.
+    assertFalse(Object.hasOwn(face, "Landmarks"));
+  });
+});

--- a/src/service/rekognition/command/detect-faces/detect-faces-iam.iso.test.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces-iam.iso.test.ts
@@ -1,0 +1,128 @@
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import {
+  SimRekognitionAccessDeniedException,
+  SimRekognitionInvalidS3ObjectException,
+} from "../../error/sim-rekognition.error.js";
+
+const detectAction = "rekognition:DetectFaces";
+
+async function simAwsWithImage(): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws.s3().putObject(
+    new PutObjectCommand({
+      Bucket: "uploads",
+      Key: "selfie.jpg",
+      Body: redPngBytes,
+    }),
+  );
+
+  return simAws;
+}
+
+const imageCommand = new DetectFacesCommand({
+  Image: { S3Object: { Bucket: "uploads", Name: "selfie.jpg" } },
+});
+
+describe("Authorizing a simulated Rekognition face detection", () => {
+  it("allows a caller whose policy permits the detection", async () => {
+    // Given a Role allowed to detect faces and to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "FaceReader", actions: [detectAction, "s3:GetObject"] },
+      simAws,
+    );
+
+    // When it detects faces in an image.
+    const detected = await simAws.rekognition().detectFaces(imageCommand, {
+      caller: { kind: "arn", arn: role.Arn },
+    });
+
+    // Then the detection runs.
+    assertArrayLength(detected.FaceDetails, 1);
+  });
+
+  it("refuses a caller with no Rekognition permission", async () => {
+    // Given a Role allowed to read the image but not to detect faces in it.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Reader", actions: ["s3:GetObject"] },
+      simAws,
+    );
+
+    // When it detects faces in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectFaces(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then Rekognition's own AccessDeniedException is thrown, with the 400
+    // status real Rekognition answers with.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertStringIncludes(error.message, detectAction);
+  });
+
+  it("refuses a caller allowed only another detection", async () => {
+    // Given a Role allowed to detect labels but not faces.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Tagger",
+        actions: ["rekognition:DetectLabels", "s3:GetObject"],
+      },
+      simAws,
+    );
+
+    // When it detects faces in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectFaces(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is refused, since each detection is its own action.
+    assertInstanceOf(error, SimRekognitionAccessDeniedException);
+  });
+
+  it("reports a missing s3:GetObject as an image problem, with the denial as its cause", async () => {
+    // Given a Role allowed to detect faces but not to read the image.
+    const simAws = await simAwsWithImage();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "BlindFaceReader", actions: [detectAction] },
+      simAws,
+    );
+
+    // When it detects faces in an image.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.rekognition().detectFaces(imageCommand, {
+          caller: { kind: "arn", arn: role.Arn },
+        }),
+    );
+
+    // Then it is the S3 object error real Rekognition reports, and the IAM
+    // denial underneath it is still readable.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+    assertInstanceOf(error.cause, Error);
+    assertStringIncludes(error.cause.message, "s3:GetObject");
+  });
+});

--- a/src/service/rekognition/command/detect-faces/detect-faces-request.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces-request.ts
@@ -1,0 +1,28 @@
+import { SimRekognitionFaceAttributes } from "../../face/sim-rekognition-face-attributes.js";
+import {
+  type SimRekognitionImageRequest,
+  SimRekognitionImageRequests,
+} from "../../image/sim-rekognition-image-request.js";
+import { SimRekognitionUnsimulatedInput } from "../sim-rekognition-unsimulated-input.js";
+import type { SimDetectFacesCommandInput } from "./detect-faces.command.js";
+
+const operation = "DetectFaces";
+const acceptedInput = ["Image", "Attributes"];
+
+/**
+ * A DetectFaces request, checked before anything acts on it.
+ */
+export class DetectFacesRequest {
+  public readonly image: SimRekognitionImageRequest;
+  public readonly attributes: SimRekognitionFaceAttributes;
+
+  constructor(input: SimDetectFacesCommandInput) {
+    new SimRekognitionUnsimulatedInput(operation).refuseUnaccepted(
+      input,
+      acceptedInput,
+    );
+
+    this.image = new SimRekognitionImageRequests(operation).parse(input.Image);
+    this.attributes = new SimRekognitionFaceAttributes(input.Attributes);
+  }
+}

--- a/src/service/rekognition/command/detect-faces/detect-faces-validation.iso.test.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces-validation.iso.test.ts
@@ -1,0 +1,153 @@
+import { DetectFacesCommand } from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { redPngBytes } from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimRekognitionInvalidImageFormatException,
+  SimRekognitionInvalidParameterException,
+  SimRekognitionInvalidS3ObjectException,
+  SimRekognitionUnsimulatedInputException,
+} from "../../error/sim-rekognition.error.js";
+import { SimRekognition } from "../../sim-rekognition.js";
+import type { SimDetectFacesCommandInput } from "./detect-faces.command.js";
+
+async function detectFailure(
+  input: SimDetectFacesCommandInput,
+  simAws = new SimAws(),
+): Promise<Error> {
+  return await assertThrowsErrorAsync(
+    async () => await simAws.rekognition().detectFaces({ input }),
+  );
+}
+
+describe("Rejecting a malformed DetectFaces request", () => {
+  it("requires an image", async () => {
+    // Given a request naming no image at all. The SDK's own types require
+    // one, so this is the shape a JavaScript caller can still send.
+    // When its faces are detected.
+    const error = await detectFailure({});
+
+    // Then it is refused as an invalid parameter, as real Rekognition
+    // refuses it.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "Image is required");
+  });
+
+  it("refuses an attribute Rekognition does not report", async () => {
+    // Given a request asking for an attribute outside the enumeration.
+    // When its faces are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      Attributes: ["ALL", "HAIR_COLOUR"],
+    });
+
+    // Then it is refused, as real Rekognition refuses a value that is not one
+    // of the ones it accepts.
+    assertInstanceOf(error, SimRekognitionInvalidParameterException);
+    assertStringIncludes(error.message, "HAIR_COLOUR");
+  });
+
+  it("refuses an input this simulation does not model", async () => {
+    // Given a request carrying an option DetectFaces does not take.
+    // When its faces are detected.
+    const error = await detectFailure({
+      Image: { Bytes: redPngBytes },
+      QualityFilter: "HIGH",
+    } as SimDetectFacesCommandInput);
+
+    // Then it is refused by name rather than dropped, since a dropped option
+    // looks applied to the request that sent it.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "DetectFaces QualityFilter");
+  });
+
+  it("refuses an S3 object version, naming the operation that sent it", async () => {
+    // Given an object and a request naming a version of it.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "selfie.jpg",
+        Body: redPngBytes,
+      }),
+    );
+
+    // When its faces are detected.
+    const error = await detectFailure(
+      {
+        Image: {
+          S3Object: { Bucket: "uploads", Name: "selfie.jpg", Version: "3" },
+        },
+      },
+      simAws,
+    );
+
+    // Then it is refused, and the refusal names DetectFaces rather than
+    // whichever operation shares the image member.
+    assertInstanceOf(error, SimRekognitionUnsimulatedInputException);
+    assertStringIncludes(error.message, "DetectFaces S3Object Version");
+  });
+});
+
+describe("Detecting faces in an image Rekognition cannot use", () => {
+  it("refuses bytes that are not a PNG or a JPEG", async () => {
+    // Given an Object holding a placeholder string rather than an image.
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "selfie.jpg",
+        Body: "face picture",
+      }),
+    );
+
+    // When its faces are detected.
+    const error = await detectFailure(
+      { Image: { S3Object: { Bucket: "uploads", Name: "selfie.jpg" } } },
+      simAws,
+    );
+
+    // Then the format is refused, as real Rekognition refuses anything that
+    // is not one of the two formats it reads.
+    assertInstanceOf(error, SimRekognitionInvalidImageFormatException);
+  });
+
+  it("reports an unknown Bucket as an S3 object problem", async () => {
+    // Given no Bucket of that name anywhere in the simulation.
+    // When faces in an image in it are detected.
+    const error = await detectFailure({
+      Image: { S3Object: { Bucket: "nowhere", Name: "selfie.jpg" } },
+    });
+
+    // Then it is an S3 object error, which is how real Rekognition reports
+    // every S3 problem.
+    assertInstanceOf(error, SimRekognitionInvalidS3ObjectException);
+  });
+
+  it("detects faces in bytes without any simulated S3 at all", async () => {
+    // Given a Rekognition built on its own rather than through SimAws.
+    const simRekognition = new SimRekognition();
+
+    // When faces are detected in bytes.
+    const detected = await simRekognition.detectFaces(
+      new DetectFacesCommand({ Image: { Bytes: redPngBytes } }),
+    );
+
+    // Then it answers, since nothing needed reading.
+    assertArrayLength(detected.FaceDetails, 1);
+  });
+});

--- a/src/service/rekognition/command/detect-faces/detect-faces.command.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces.command.ts
@@ -1,0 +1,144 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRekognitionBoundingBoxOutput } from "../../image/sim-rekognition-bounding-box.js";
+import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image-input.js";
+
+/**
+ * A face attribute Rekognition answers yes or no to, with how sure it is of
+ * the answer.
+ *
+ * `Smile`, `Eyeglasses`, `Sunglasses`, `Beard`, `Mustache`, `EyesOpen`,
+ * `MouthOpen` and `FaceOccluded` are all this shape on the wire, and all
+ * separate types in the SDK, so one structural type stands in for each.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Smile.html
+ */
+export interface SimRekognitionFaceFeatureOutput {
+  readonly Value: boolean;
+  readonly Confidence: number;
+}
+
+/**
+ * The gender predicted for a detected face.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Gender.html
+ */
+export interface SimRekognitionGenderOutput {
+  readonly Value: string;
+  readonly Confidence: number;
+}
+
+/**
+ * The age range estimated for a detected face, in years.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_AgeRange.html
+ */
+export interface SimRekognitionAgeRangeOutput {
+  readonly Low: number;
+  readonly High: number;
+}
+
+/**
+ * One emotion a detected face appears to express.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Emotion.html
+ */
+export interface SimRekognitionEmotionOutput {
+  readonly Type: string;
+  readonly Confidence: number;
+}
+
+/**
+ * One facial landmark, located as ratios of the image's own size.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Landmark.html
+ */
+export interface SimRekognitionLandmarkOutput {
+  readonly Type: string;
+  readonly X: number;
+  readonly Y: number;
+}
+
+/**
+ * How a detected face is turned, in degrees.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Pose.html
+ */
+export interface SimRekognitionPoseOutput {
+  readonly Roll: number;
+  readonly Yaw: number;
+  readonly Pitch: number;
+}
+
+/**
+ * How well a detected face was captured.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_ImageQuality.html
+ */
+export interface SimRekognitionImageQualityOutput {
+  readonly Brightness: number;
+  readonly Sharpness: number;
+}
+
+/**
+ * Where a detected face is looking, in degrees.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_EyeDirection.html
+ */
+export interface SimRekognitionEyeDirectionOutput {
+  readonly Yaw: number;
+  readonly Pitch: number;
+  readonly Confidence: number;
+}
+
+/**
+ * One detected face.
+ *
+ * Every member is optional, as it is on AWS: a response carries the attributes
+ * the request asked for and leaves the rest out entirely.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_FaceDetail.html
+ */
+export interface SimRekognitionFaceDetailOutput {
+  readonly BoundingBox?: SimRekognitionBoundingBoxOutput;
+  readonly Confidence?: number;
+  readonly Pose?: SimRekognitionPoseOutput;
+  readonly Quality?: SimRekognitionImageQualityOutput;
+  readonly Landmarks?: readonly SimRekognitionLandmarkOutput[];
+  readonly AgeRange?: SimRekognitionAgeRangeOutput;
+  readonly Gender?: SimRekognitionGenderOutput;
+  readonly Emotions?: readonly SimRekognitionEmotionOutput[];
+  readonly EyeDirection?: SimRekognitionEyeDirectionOutput;
+  readonly Smile?: SimRekognitionFaceFeatureOutput;
+  readonly Eyeglasses?: SimRekognitionFaceFeatureOutput;
+  readonly Sunglasses?: SimRekognitionFaceFeatureOutput;
+  readonly Beard?: SimRekognitionFaceFeatureOutput;
+  readonly Mustache?: SimRekognitionFaceFeatureOutput;
+  readonly EyesOpen?: SimRekognitionFaceFeatureOutput;
+  readonly MouthOpen?: SimRekognitionFaceFeatureOutput;
+  readonly FaceOccluded?: SimRekognitionFaceFeatureOutput;
+}
+
+/**
+ * Minimal structural sim Rekognition DetectFaces command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/rekognition/command/DetectFacesCommand/
+ */
+export interface SimDetectFacesCommand {
+  readonly input: SimDetectFacesCommandInput;
+}
+
+export interface SimDetectFacesCommandInput {
+  readonly Image?: SimRekognitionImageInput | undefined;
+  readonly Attributes?: readonly string[] | undefined;
+}
+
+/**
+ * The DetectFaces response.
+ *
+ * `OrientationCorrection` is not carried, because AWS documents its value as
+ * always null.
+ */
+export interface SimDetectFacesCommandOutput {
+  readonly FaceDetails: readonly SimRekognitionFaceDetailOutput[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/rekognition/command/detect-faces/detect-faces.handler.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces.handler.ts
@@ -1,0 +1,65 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimRekognitionFaces } from "../../face/sim-rekognition-faces.js";
+import type { SimRekognitionImageObjects } from "../../image/sim-rekognition-image-objects.js";
+import type { SimRekognitionAuthorizer } from "../authorize/sim-rekognition-authorizer.js";
+import type { SimRekognitionRequestOptions } from "../sim-rekognition-request-options.js";
+import { DetectFacesRequest } from "./detect-faces-request.js";
+import type {
+  SimDetectFacesCommand,
+  SimDetectFacesCommandOutput,
+} from "./detect-faces.command.js";
+
+const action = "rekognition:DetectFaces";
+
+interface DetectFacesHandlerProperties {
+  readonly faces: SimRekognitionFaces;
+  readonly authorizer: SimRekognitionAuthorizer;
+  readonly images: SimRekognitionImageObjects;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Handles a DetectFaces command.
+ *
+ * The steps are in the same order as the other detections. The request is
+ * checked first, so a malformed one fails the same way whatever else the
+ * simulation is doing. The caller is then authorized for the Rekognition
+ * action before the image is read, so a caller without
+ * `rekognition:DetectFaces` is told about that rather than about an S3 object.
+ * Only then is the image read, as the caller, and the rules consulted.
+ */
+export class DetectFacesHandler {
+  private readonly faces: SimRekognitionFaces;
+  private readonly authorizer: SimRekognitionAuthorizer;
+  private readonly images: SimRekognitionImageObjects;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DetectFacesHandlerProperties) {
+    this.faces = properties.faces;
+    this.authorizer = properties.authorizer;
+    this.images = properties.images;
+    this.background = properties.background;
+  }
+
+  /**
+   * Detect the faces an image is declared to hold.
+   */
+  async handle(
+    command: SimDetectFacesCommand,
+    options: SimRekognitionRequestOptions = {},
+  ): Promise<SimDetectFacesCommandOutput> {
+    const request = new DetectFacesRequest(command.input);
+
+    await this.background.sequence();
+
+    this.authorizer.authorize(action, options);
+
+    const image = await request.image.read(this.images, options);
+    const detection = this.faces.detectionFor(image);
+
+    return {
+      FaceDetails: detection.detailsFor(request.attributes),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/rekognition/command/detect-faces/detect-faces.iso.test.ts
+++ b/src/service/rekognition/command/detect-faces/detect-faces.iso.test.ts
@@ -1,0 +1,247 @@
+import {
+  type Attribute,
+  DetectFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  bluePngBytes,
+  redPngBytes,
+} from "../../../../../test/rekognition/image-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  simRekognitionNoFaces,
+  simRekognitionSeveralFaces,
+} from "../../face/sim-rekognition-face-defaults.js";
+import { simRekognitionImageHash } from "../../image/sim-rekognition-image-hash.js";
+import type { SimDetectFacesCommandOutput } from "./detect-faces.command.js";
+
+async function simAwsWithImage(
+  objectName = "selfie.jpg",
+  bytes = redPngBytes,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+  await simAws
+    .s3()
+    .putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: objectName, Body: bytes }),
+    );
+
+  return simAws;
+}
+
+async function detect(
+  simAws: SimAws,
+  objectName: string,
+  attributes?: Attribute[],
+): Promise<SimDetectFacesCommandOutput> {
+  return await simAws.rekognition().detectFaces(
+    new DetectFacesCommand({
+      Image: { S3Object: { Bucket: "uploads", Name: objectName } },
+      ...(attributes !== undefined && { Attributes: attributes }),
+    }),
+  );
+}
+
+describe("Detecting faces in a simulated image", () => {
+  it("answers with the built-in result until a rule says otherwise", async () => {
+    // Given an image in a Bucket and no rules registered against it.
+    const simAws = await simAwsWithImage();
+
+    // When its faces are detected.
+    const detected = await detect(simAws, "selfie.jpg");
+
+    // Then the one face from the documented AWS example response comes back,
+    // with the default subset of attributes on it.
+    assertArrayLength(detected.FaceDetails, 1);
+
+    const [face] = detected.FaceDetails;
+    assertNonNullable(face);
+    assertIdentical(face.Confidence, 99.99872589111328);
+    assertIdentical(face.BoundingBox?.Left, 0.08881539851427078);
+    assertIdentical(face.Pose?.Roll, -5.83309268951416);
+    assertIdentical(face.Quality?.Brightness, 96.16363525390625);
+  });
+
+  it("answers with the faces declared for an object name", async () => {
+    // Given an object declared to hold two people.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .faces()
+      .onName("selfie.jpg", {
+        faces: [
+          {
+            boundingBox: { left: 0.1, top: 0.2, width: 0.3, height: 0.4 },
+            confidence: 99.4,
+          },
+          {
+            boundingBox: { left: 0.5, top: 0.2, width: 0.3, height: 0.4 },
+          },
+        ],
+      });
+
+    // When its faces are detected.
+    const detected = await detect(simAws, "selfie.jpg");
+
+    // Then both come back in the order they were declared, and the one with
+    // no confidence of its own is detected at the built-in confidence.
+    assertArrayLength(detected.FaceDetails, 2);
+    assertIdentical(detected.FaceDetails[0].Confidence, Math.fround(99.4));
+    assertIdentical(
+      detected.FaceDetails[0].BoundingBox?.Left,
+      Math.fround(0.1),
+    );
+    assertIdentical(detected.FaceDetails[1].Confidence, 99.99872589111328);
+  });
+
+  it("answers with no faces for an image declared without any", async () => {
+    // Given an object declared to be a photograph of a landscape.
+    const simAws = await simAwsWithImage("landscape.jpg");
+    simAws.rekognition().faces().onName("landscape.jpg", { faces: [] });
+
+    // When its faces are detected.
+    const detected = await detect(simAws, "landscape.jpg");
+
+    // Then the detection found nothing, which is a result rather than a
+    // missing rule.
+    assertArrayLength(detected.FaceDetails, 0);
+  });
+
+  it("declares an empty image and a crowded one from the built-in results", async () => {
+    // Given the two built-in results declared against two objects.
+    const simAws = await simAwsWithImage("landscape.jpg");
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "crowd.jpg",
+        Body: bluePngBytes,
+      }),
+    );
+    const faces = simAws.rekognition().faces();
+    faces.onName("landscape.jpg", simRekognitionNoFaces);
+    faces.onName("crowd.jpg", simRekognitionSeveralFaces);
+
+    // When both are detected.
+    const empty = await detect(simAws, "landscape.jpg");
+    const crowd = await detect(simAws, "crowd.jpg");
+
+    // Then a test that only counts faces needs to declare nothing of its own.
+    assertArrayLength(empty.FaceDetails, 0);
+    assertArrayLength(crowd.FaceDetails, 3);
+    assertIdentical(crowd.FaceDetails[2].Confidence, Math.fround(98.62));
+  });
+
+  it("gives an attribute the face's confidence when it declares none", async () => {
+    // Given a face declared as smiling, with no confidence on the smile.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .faces()
+      .onName("selfie.jpg", {
+        faces: [{ confidence: 98.5, smile: true, gender: "Female" }],
+      });
+
+    // When its faces are detected with every attribute.
+    const detected = await detect(simAws, "selfie.jpg", ["ALL"]);
+
+    // Then the attributes take the face's own confidence, since a face
+    // detected at 98.5 is not usually judged to be smiling at 40.
+    const [face] = detected.FaceDetails;
+    assertNonNullable(face);
+    assertTrue(face.Smile?.Value);
+    assertIdentical(face.Smile.Confidence, Math.fround(98.5));
+    assertIdentical(face.Gender?.Value, "Female");
+    assertIdentical(face.Gender.Confidence, Math.fround(98.5));
+  });
+
+  it("matches an image by content hash whatever it is called", async () => {
+    // Given a rule for the hash of some image bytes, and an object storing
+    // those bytes under a name nothing was declared for.
+    const simAws = await simAwsWithImage("2f9c1e40-uuid.png", bluePngBytes);
+    simAws
+      .rekognition()
+      .faces()
+      .onHash(simRekognitionImageHash(bluePngBytes), simRekognitionNoFaces);
+
+    // When its faces are detected.
+    const detected = await detect(simAws, "2f9c1e40-uuid.png");
+
+    // Then the hash rule answers, which is what makes a system that generates
+    // its own object keys testable.
+    assertArrayLength(detected.FaceDetails, 0);
+  });
+
+  it("consults hash rules and the default for an image passed as bytes", async () => {
+    // Given a name rule, a hash rule and a default.
+    const simAws = new SimAws();
+    const faces = simAws.rekognition().faces();
+    faces.byDefault(simRekognitionSeveralFaces);
+    faces.onName("selfie.jpg", { faces: [{ confidence: 90 }] });
+    faces.onHash(simRekognitionImageHash(bluePngBytes), simRekognitionNoFaces);
+
+    // When images are detected as bytes rather than as S3 objects.
+    const hashed = await simAws
+      .rekognition()
+      .detectFaces(new DetectFacesCommand({ Image: { Bytes: bluePngBytes } }));
+    const unknown = await simAws
+      .rekognition()
+      .detectFaces(new DetectFacesCommand({ Image: { Bytes: redPngBytes } }));
+
+    // Then the hash rule matches and the default answers for the rest, since
+    // bytes have no name for a name rule to match.
+    assertArrayLength(hashed.FaceDetails, 0);
+    assertArrayLength(unknown.FaceDetails, 3);
+  });
+
+  it("keeps face rules apart from label rules", async () => {
+    // Given an object declared to hold a dog and no faces.
+    const simAws = await simAwsWithImage();
+    simAws
+      .rekognition()
+      .labels()
+      .onName("selfie.jpg", { labels: ["Dog"] });
+    simAws.rekognition().faces().onName("selfie.jpg", simRekognitionNoFaces);
+
+    // When its faces and its labels are detected.
+    const faces = await detect(simAws, "selfie.jpg");
+    const labels = await simAws.rekognition().detectLabels({
+      input: { Image: { S3Object: { Bucket: "uploads", Name: "selfie.jpg" } } },
+    });
+
+    // Then each operation answers from its own rules, since each owns the
+    // result shape it answers with.
+    assertArrayLength(faces.FaceDetails, 0);
+    assertArrayEquals(
+      labels.Labels.map((label) => label.Name),
+      ["Dog"],
+    );
+  });
+
+  it("keeps rules to the Account and Region they were registered in", async () => {
+    // Given a rule registered in one Region only.
+    const simAws = new SimAws();
+    simAws.rekognition().faces().byDefault(simRekognitionNoFaces);
+
+    // When faces are detected in another Region.
+    const elsewhere = await simAws
+      .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+      .rekognition()
+      .detectFaces(new DetectFacesCommand({ Image: { Bytes: redPngBytes } }));
+
+    // Then that Region answers from its own rules, as a real Rekognition
+    // endpoint answers for the Region it belongs to.
+    assertArrayLength(elsewhere.FaceDetails, 1);
+  });
+});

--- a/src/service/rekognition/command/detect-labels/detect-labels.command.ts
+++ b/src/service/rekognition/command/detect-labels/detect-labels.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimRekognitionBoundingBoxOutput } from "../../image/sim-rekognition-bounding-box.js";
 import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image-input.js";
 
 /**
@@ -12,19 +13,6 @@ import type { SimRekognitionImageInput } from "../../image/sim-rekognition-image
  */
 export interface SimRekognitionLabelNameOutput {
   readonly Name: string;
-}
-
-/**
- * Where in an image one instance of a detected label is, as ratios of the
- * image's own width and height.
- *
- * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_BoundingBox.html
- */
-export interface SimRekognitionBoundingBoxOutput {
-  readonly Left: number;
-  readonly Top: number;
-  readonly Width: number;
-  readonly Height: number;
 }
 
 /**

--- a/src/service/rekognition/face/sim-rekognition-declared-value.ts
+++ b/src/service/rekognition/face/sim-rekognition-declared-value.ts
@@ -1,0 +1,57 @@
+import type {
+  SimRekognitionDeclaredEmotion,
+  SimRekognitionDeclaredFaceFeature,
+  SimRekognitionDeclaredGender,
+} from "./sim-rekognition-face-declaration.js";
+
+/**
+ * What a declaration says, whichever of its two forms it was written in.
+ *
+ * Several face attributes can be declared as a bare value or as a value with a
+ * confidence, in the way a label can be declared as a bare name. The
+ * confidence is left undefined when it was not declared, so the face's own
+ * confidence can stand in for it.
+ */
+export interface SimRekognitionDeclaredValue<TValue> {
+  readonly value: TValue;
+  readonly confidence: number | undefined;
+}
+
+/**
+ * Read a yes or no attribute that may be a bare boolean.
+ */
+export function simRekognitionDeclaredFaceFeature(
+  declaration: SimRekognitionDeclaredFaceFeature,
+): SimRekognitionDeclaredValue<boolean> {
+  if (typeof declaration === "boolean") {
+    return { value: declaration, confidence: undefined };
+  }
+
+  return { value: declaration.value, confidence: declaration.confidence };
+}
+
+/**
+ * Read a gender that may be a bare value.
+ */
+export function simRekognitionDeclaredGender(
+  declaration: SimRekognitionDeclaredGender,
+): SimRekognitionDeclaredValue<string> {
+  if (typeof declaration === "string") {
+    return { value: declaration, confidence: undefined };
+  }
+
+  return { value: declaration.value, confidence: declaration.confidence };
+}
+
+/**
+ * Read an emotion that may be a bare name.
+ */
+export function simRekognitionDeclaredEmotion(
+  declaration: SimRekognitionDeclaredEmotion,
+): SimRekognitionDeclaredValue<string> {
+  if (typeof declaration === "string") {
+    return { value: declaration, confidence: undefined };
+  }
+
+  return { value: declaration.type, confidence: declaration.confidence };
+}

--- a/src/service/rekognition/face/sim-rekognition-detected-face.ts
+++ b/src/service/rekognition/face/sim-rekognition-detected-face.ts
@@ -1,0 +1,85 @@
+import type { SimRekognitionFaceDetailOutput } from "../command/detect-faces/detect-faces.command.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import { SimRekognitionFaceAgeAndGender } from "./sim-rekognition-face-age-and-gender.js";
+import type { SimRekognitionFaceAttributes } from "./sim-rekognition-face-attributes.js";
+import type { SimRekognitionDeclaredFace } from "./sim-rekognition-face-declaration.js";
+import { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { SimRekognitionFaceEmotions } from "./sim-rekognition-face-emotions.js";
+import { SimRekognitionFaceEyeDirection } from "./sim-rekognition-face-eye-direction.js";
+import { SimRekognitionFaceFeatures } from "./sim-rekognition-face-features.js";
+import { SimRekognitionFaceFrame } from "./sim-rekognition-face-frame.js";
+import { SimRekognitionFaceLandmarks } from "./sim-rekognition-face-landmarks.js";
+
+/**
+ * One declared face, resolved into what a response can carry for it.
+ *
+ * The declaration is resolved when the rule is registered rather than when a
+ * detection runs, so a bounding box or an angle that is out of range is
+ * refused where it was written.
+ *
+ * The attributes are held by the small pieces that own them, and each adds
+ * its own members to a detail. A request asking for a subset of them is
+ * answered by leaving the rest out, so nothing here has to know which
+ * attributes any one request wanted.
+ */
+export class SimRekognitionDetectedFace {
+  private readonly frame: SimRekognitionFaceFrame;
+  private readonly landmarks: SimRekognitionFaceLandmarks;
+  private readonly features: SimRekognitionFaceFeatures;
+  private readonly emotions: SimRekognitionFaceEmotions;
+  private readonly ageAndGender: SimRekognitionFaceAgeAndGender;
+  private readonly eyeDirection: SimRekognitionFaceEyeDirection;
+
+  constructor(subject: string, declared: SimRekognitionDeclaredFace) {
+    this.frame = new SimRekognitionFaceFrame(subject, declared);
+
+    // An attribute with no confidence of its own takes the face's, since a
+    // face detected at 99.9 is not usually judged to be smiling at 40.
+    const confidence = new SimRekognitionDeclaredConfidence(
+      this.frame.confidence,
+    );
+
+    this.landmarks = new SimRekognitionFaceLandmarks(
+      subject,
+      declared.landmarks,
+    );
+    this.features = new SimRekognitionFaceFeatures(
+      subject,
+      confidence,
+      declared,
+    );
+    this.emotions = new SimRekognitionFaceEmotions(
+      subject,
+      confidence,
+      declared.emotions,
+    );
+    this.ageAndGender = new SimRekognitionFaceAgeAndGender(
+      subject,
+      confidence,
+      declared,
+    );
+    this.eyeDirection = new SimRekognitionFaceEyeDirection(
+      subject,
+      confidence,
+      declared.eyeDirection,
+    );
+  }
+
+  /**
+   * The detail to report for this face, as one request asked for it.
+   */
+  detailFor(
+    attributes: SimRekognitionFaceAttributes,
+  ): SimRekognitionFaceDetailOutput {
+    const builder = new SimRekognitionFaceDetailBuilder(attributes);
+
+    this.frame.addTo(builder);
+    this.landmarks.addTo(builder, attributes);
+    this.features.addTo(builder);
+    this.emotions.addTo(builder);
+    this.ageAndGender.addTo(builder);
+    this.eyeDirection.addTo(builder);
+
+    return builder.build();
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-emotion-name.ts
+++ b/src/service/rekognition/face/sim-rekognition-emotion-name.ts
@@ -1,0 +1,36 @@
+/**
+ * The emotions real Rekognition names on a face.
+ *
+ * These are appearances rather than feelings, as AWS is careful to say: the
+ * value describes what the face looks like and not what the person is.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Emotion.html
+ */
+export const simRekognitionEmotionNames = [
+  "HAPPY",
+  "SAD",
+  "ANGRY",
+  "CONFUSED",
+  "DISGUSTED",
+  "SURPRISED",
+  "CALM",
+  "FEAR",
+  "UNKNOWN",
+] as const;
+
+/**
+ * The name of one emotion Rekognition reports.
+ */
+export type SimRekognitionEmotionName =
+  (typeof simRekognitionEmotionNames)[number];
+
+const emotionNames: ReadonlySet<string> = new Set(simRekognitionEmotionNames);
+
+/**
+ * Whether a name is one of the emotions Rekognition reports.
+ */
+export function isSimRekognitionEmotionName(
+  name: string,
+): name is SimRekognitionEmotionName {
+  return emotionNames.has(name);
+}

--- a/src/service/rekognition/face/sim-rekognition-face-age-and-gender.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-age-and-gender.ts
@@ -1,0 +1,95 @@
+import type {
+  SimRekognitionAgeRangeOutput,
+  SimRekognitionGenderOutput,
+} from "../command/detect-faces/detect-faces.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import { simRekognitionDeclaredGender } from "./sim-rekognition-declared-value.js";
+import type {
+  SimRekognitionDeclaredAgeRange,
+  SimRekognitionDeclaredFace,
+  SimRekognitionDeclaredGender,
+} from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { SimRekognitionFaceMeasures } from "./sim-rekognition-face-measures.js";
+
+/**
+ * The two attributes describing the person rather than the picture: the age
+ * range estimated for a declared face and the gender predicted for it.
+ *
+ * Both are estimates real Rekognition reports as such, and neither is filled
+ * in when a declaration leaves it out.
+ */
+export class SimRekognitionFaceAgeAndGender {
+  private readonly ageRange: SimRekognitionAgeRangeOutput | undefined;
+  private readonly gender: SimRekognitionGenderOutput | undefined;
+
+  constructor(
+    private readonly subject: string,
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredFace,
+  ) {
+    this.ageRange = this.ageRangeOf(declared.ageRange);
+    this.gender = this.genderOf(confidence, declared.gender);
+  }
+
+  /**
+   * Add the age range and gender this face declared to a detail.
+   */
+  addTo(builder: SimRekognitionFaceDetailBuilder): void {
+    builder
+      .carry("AgeRange", "AGE_RANGE", this.ageRange)
+      .carry("Gender", "GENDER", this.gender);
+  }
+
+  private ageRangeOf(
+    declared: SimRekognitionDeclaredAgeRange | undefined,
+  ): SimRekognitionAgeRangeOutput | undefined {
+    if (declared === undefined) {
+      return undefined;
+    }
+
+    const measures = new SimRekognitionFaceMeasures(this.subject);
+    const range = {
+      Low: measures.years("low", declared.low),
+      High: measures.years("high", declared.high),
+    };
+
+    if (range.High < range.Low) {
+      throw new SimRekognitionDeclarationError(
+        `An age range declared for '${this.subject}' runs from ` +
+          `${String(range.Low)} to ${String(range.High)}, which ends before ` +
+          `it begins.`,
+      );
+    }
+
+    return range;
+  }
+
+  private genderOf(
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredGender | undefined,
+  ): SimRekognitionGenderOutput | undefined {
+    if (declared === undefined) {
+      return undefined;
+    }
+
+    const gender = simRekognitionDeclaredGender(declared);
+
+    return {
+      Value: this.genderValue(gender.value),
+      Confidence: confidence.of(this.subject, gender.confidence),
+    };
+  }
+
+  private genderValue(value: string): string {
+    if (value === "Male" || value === "Female") {
+      return value;
+    }
+
+    throw new SimRekognitionDeclarationError(
+      `A gender of '${value}' declared for '${this.subject}' is not one ` +
+        `real Rekognition predicts, which is 'Male' or 'Female'.`,
+    );
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-attributes.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-attributes.ts
@@ -1,0 +1,95 @@
+import { SimRekognitionInvalidParameterException } from "../error/sim-rekognition.error.js";
+
+/**
+ * The attribute the members every response carries belong to.
+ *
+ * `BoundingBox`, `Confidence`, `Pose`, `Quality` and `Landmarks` come back
+ * whatever the request asked for, which is what AWS means by a default subset.
+ */
+export const simRekognitionDefaultFaceAttribute = "DEFAULT";
+
+const allAttributes = "ALL";
+
+/**
+ * The values `Attributes` accepts, other than `DEFAULT` and `ALL`.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_DetectFaces.html
+ */
+export const simRekognitionFaceAttributeNames = [
+  "AGE_RANGE",
+  "BEARD",
+  "EMOTIONS",
+  "EYE_DIRECTION",
+  "EYEGLASSES",
+  "EYES_OPEN",
+  "GENDER",
+  "MOUTH_OPEN",
+  "MUSTACHE",
+  "FACE_OCCLUDED",
+  "SMILE",
+  "SUNGLASSES",
+] as const;
+
+/**
+ * The name of one facial attribute a response can carry.
+ */
+export type SimRekognitionFaceAttributeName =
+  | typeof simRekognitionDefaultFaceAttribute
+  | (typeof simRekognitionFaceAttributeNames)[number];
+
+const accepted: ReadonlySet<string> = new Set([
+  simRekognitionDefaultFaceAttribute,
+  allAttributes,
+  ...simRekognitionFaceAttributeNames,
+]);
+
+/**
+ * The facial attributes one DetectFaces request asked for.
+ *
+ * The default subset is always carried, so `["FACE_OCCLUDED"]` is the default
+ * subset with face occlusion added rather than face occlusion on its own, and
+ * `["ALL", "DEFAULT"]` is the union the two describe together.
+ */
+export class SimRekognitionFaceAttributes {
+  private readonly requested: ReadonlySet<string>;
+
+  constructor(requested: readonly string[] = []) {
+    for (const attribute of requested) {
+      SimRekognitionFaceAttributes.refuseUnknown(attribute);
+    }
+
+    this.requested = new Set(requested);
+  }
+
+  private static refuseUnknown(attribute: string): void {
+    if (accepted.has(attribute)) {
+      return;
+    }
+
+    throw new SimRekognitionInvalidParameterException(
+      `Request has invalid parameters: Attributes of ${attribute} is not a ` +
+        `facial attribute Rekognition reports`,
+    );
+  }
+
+  /**
+   * Whether a response is to carry the members of one attribute.
+   */
+  wants(attribute: SimRekognitionFaceAttributeName): boolean {
+    if (attribute === simRekognitionDefaultFaceAttribute) {
+      return true;
+    }
+
+    return this.requested.has(allAttributes) || this.requested.has(attribute);
+  }
+
+  /**
+   * Whether every declared landmark is to be reported.
+   *
+   * Real Rekognition reports five landmarks unless `ALL` was asked for, and
+   * the whole set when it was.
+   */
+  wantsEveryLandmark(): boolean {
+    return this.requested.has(allAttributes);
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-declaration.iso.test.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-declaration.iso.test.ts
@@ -1,0 +1,260 @@
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type {
+  SimRekognitionDeclaredFace,
+  SimRekognitionDeclaredLandmarks,
+} from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaces } from "./sim-rekognition-faces.js";
+
+function faces(): SimRekognitionFaces {
+  return new SimAws().rekognition().faces();
+}
+
+function declarationError(face: SimRekognitionDeclaredFace): Error {
+  return assertThrowsError(() => {
+    faces().byDefault({ faces: [face] });
+  });
+}
+
+function landmarkError(landmarks: SimRekognitionDeclaredLandmarks): Error {
+  return declarationError({ landmarks });
+}
+
+describe("Declaring a simulated face result", () => {
+  it("accepts a face declared with nothing but a bounding box", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a face by where it is.
+    faces().byDefault({
+      faces: [
+        { boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.4 } },
+      ],
+    });
+
+    // Then it is accepted, since everything else is an attribute a request
+    // may never ask for.
+  });
+
+  it("refuses a bounding box that is not a ratio of the image size", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a box in pixels rather than in ratios.
+    const error = declarationError({
+      boundingBox: { left: 350, top: 50, width: 70, height: 90 },
+    });
+
+    // Then it is refused where it was written.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "not a ratio of the image size");
+  });
+
+  it("refuses a bounding box that runs off the edge of the image", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a box whose left and width add up past the image.
+    const error = declarationError({
+      boundingBox: { left: 0.8, top: 0.2, width: 0.4, height: 0.4 },
+    });
+
+    // Then it is refused, which is the check that catches a box written in
+    // the wrong units.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "puts it outside the image");
+  });
+
+  it("refuses a confidence that is not a percentage", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a face detected at more than certain.
+    const error = declarationError({ confidence: 101 });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "percentage from 0 to 100");
+  });
+
+  it("refuses a pose that is not an angle", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a face turned further than a face can turn.
+    const error = declarationError({ pose: { roll: 0, yaw: 400, pitch: 0 } });
+
+    // Then it is refused, naming the angle that was wrong.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "A yaw declared for 'face 1'");
+    assertStringIncludes(error.message, "from -180 to 180");
+  });
+
+  it("refuses a quality outside the range AWS reports it in", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a brightness above 100.
+    const error = declarationError({
+      quality: { brightness: 120, sharpness: 95 },
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "not a measure from 0 to 100");
+  });
+
+  it("refuses an eye direction that is not an angle", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a gaze further round than a gaze goes.
+    const error = declarationError({ eyeDirection: { yaw: 200, pitch: 0 } });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "eye direction yaw");
+  });
+
+  it("refuses an age that is not a whole number of years", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares an age of two and a half.
+    const error = declarationError({ ageRange: { low: 2.5, high: 26 } });
+
+    // Then it is refused, since real Rekognition estimates whole years.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "whole number of years");
+  });
+
+  it("refuses an age range that ends before it begins", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a range the wrong way round.
+    const error = declarationError({ ageRange: { low: 40, high: 20 } });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "ends before it begins");
+  });
+
+  it("refuses a gender real Rekognition does not predict", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a value outside the two AWS reports.
+    const error = declarationError({
+      gender: { value: "Nonbinary" } as unknown as "Male",
+    });
+
+    // Then it is refused, because the response would carry a value no real
+    // caller has to handle.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "'Male' or 'Female'");
+  });
+
+  it("refuses an emotion Rekognition does not report", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a feeling that is not one of the nine.
+    const error = declarationError({
+      emotions: ["BORED" as unknown as "CALM"],
+    });
+
+    // Then it is refused where it was written.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "not an emotion Rekognition reports");
+  });
+
+  it("refuses the same emotion twice", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a face as happy at two confidences.
+    const error = declarationError({
+      emotions: ["HAPPY", { type: "HAPPY", confidence: 20 }],
+    });
+
+    // Then it is refused, since real Rekognition reports each emotion once.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "declared twice");
+  });
+
+  it("refuses a landmark Rekognition does not report", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a landmark that is not one of the thirty.
+    const error = landmarkError({
+      earLeft: { x: 0.2, y: 0.4 },
+    } as unknown as SimRekognitionDeclaredLandmarks);
+
+    // Then it is refused rather than silently dropped from the response.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "not a landmark Rekognition reports");
+  });
+
+  it("refuses a landmark that is not a ratio of the image size", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares an eye off the image.
+    const error = landmarkError({ eyeLeft: { x: 1.4, y: 0.4 } });
+
+    // Then it is refused, naming the landmark and the axis.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "The 'eyeLeft' landmark");
+    assertStringIncludes(error.message, "has an x of 1.4");
+  });
+
+  it("refuses eyes that are the wrong way round", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares the left eye to the right of the right one.
+    const error = landmarkError({
+      eyeLeft: { x: 0.7, y: 0.3 },
+      eyeRight: { x: 0.3, y: 0.3 },
+    });
+
+    // Then it is refused, because a test asserting that the left eye is on
+    // the left would pass here and fail on AWS.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "look swapped");
+  });
+
+  it("accepts a landmark outside the bounding box", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a chin below the box the face was found in.
+    faces().byDefault({
+      faces: [
+        {
+          boundingBox: { left: 0.3, top: 0.2, width: 0.3, height: 0.3 },
+          landmarks: { chinBottom: { x: 0.45, y: 0.62 } },
+        },
+      ],
+    });
+
+    // Then it is accepted, because a real Rekognition face box routinely
+    // excludes the chin.
+  });
+
+  it("refuses more faces than Rekognition detects in one image", () => {
+    // Given a simulated Rekognition.
+    // When a rule declares a hundred and one faces.
+    const error = assertThrowsError(() => {
+      faces().byDefault({
+        faces: Array.from({ length: 101 }, () => ({ confidence: 90 })),
+      });
+    });
+
+    // Then it is refused, since AWS detects the hundred largest faces and no
+    // more.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "100 largest faces");
+  });
+
+  it("refuses a rule with no S3 object name to match", () => {
+    // Given a simulated Rekognition.
+    // When a name rule is registered with an empty name.
+    const error = assertThrowsError(() => {
+      faces().onName("", { faces: [] });
+    });
+
+    // Then it is refused, as the other operation groups refuse it.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "needs an S3 object name");
+  });
+
+  it("refuses a hash rule that is not a content hash", () => {
+    // Given a simulated Rekognition.
+    // When a hash rule is registered with something that is not a digest.
+    const error = assertThrowsError(() => {
+      faces().onHash("not-a-digest", { faces: [] });
+    });
+
+    // Then it is refused.
+    assertInstanceOf(error, SimRekognitionDeclarationError);
+    assertStringIncludes(error.message, "sha256 digest");
+  });
+});

--- a/src/service/rekognition/face/sim-rekognition-face-declaration.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-declaration.ts
@@ -1,0 +1,135 @@
+import type { SimRekognitionDeclaredBoundingBox } from "../image/sim-rekognition-bounding-box.js";
+import type { SimRekognitionEmotionName } from "./sim-rekognition-emotion-name.js";
+import type { SimRekognitionLandmarkName } from "./sim-rekognition-landmark-name.js";
+
+/**
+ * A point on a face, as ratios of the image's own width and height.
+ */
+export interface SimRekognitionDeclaredPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Where the landmarks of a declared face are.
+ *
+ * Landmarks are keyed by the names Rekognition reports them under, so a face
+ * declares the ones the test cares about and leaves the rest out. They are
+ * not required to sit inside the bounding box: a real Rekognition face box
+ * routinely excludes the chin.
+ */
+export type SimRekognitionDeclaredLandmarks = Partial<
+  Record<SimRekognitionLandmarkName, SimRekognitionDeclaredPoint>
+>;
+
+/**
+ * A face attribute Rekognition answers yes or no to, such as whether the face
+ * is smiling.
+ *
+ * A bare boolean is the attribute at the face's own confidence. The longer
+ * form says how sure Rekognition is of the answer, which is a confidence in
+ * the determination rather than in the value: a `false` at 99 is a face
+ * Rekognition is sure is not smiling.
+ */
+export type SimRekognitionDeclaredFaceFeature =
+  | boolean
+  | {
+      readonly value: boolean;
+      readonly confidence?: number | undefined;
+    };
+
+/**
+ * The gender Rekognition predicts for a face.
+ *
+ * Real Rekognition predicts `Male` or `Female` and nothing else, so those are
+ * the two values a declaration can use.
+ */
+export type SimRekognitionDeclaredGender =
+  | "Male"
+  | "Female"
+  | {
+      readonly value: "Male" | "Female";
+      readonly confidence?: number | undefined;
+    };
+
+/**
+ * One emotion a declared face appears to express.
+ */
+export type SimRekognitionDeclaredEmotion =
+  | SimRekognitionEmotionName
+  | {
+      readonly type: SimRekognitionEmotionName;
+      readonly confidence?: number | undefined;
+    };
+
+/**
+ * The age range Rekognition estimates for a face, in whole years.
+ */
+export interface SimRekognitionDeclaredAgeRange {
+  readonly low: number;
+  readonly high: number;
+}
+
+/**
+ * How a declared face is turned, in degrees.
+ */
+export interface SimRekognitionDeclaredPose {
+  readonly roll: number;
+  readonly yaw: number;
+  readonly pitch: number;
+}
+
+/**
+ * How well a declared face was captured, each from 0 to 100.
+ */
+export interface SimRekognitionDeclaredFaceQuality {
+  readonly brightness: number;
+  readonly sharpness: number;
+}
+
+/**
+ * Where a declared face is looking, in degrees.
+ */
+export interface SimRekognitionDeclaredEyeDirection {
+  readonly yaw: number;
+  readonly pitch: number;
+  readonly confidence?: number | undefined;
+}
+
+/**
+ * A face declared against an image, with what Rekognition is to report for it.
+ *
+ * Everything is optional. An attribute nothing was declared for is left out of
+ * the response rather than invented, so a face declared with a bounding box
+ * and nothing else comes back as a bounding box and a confidence however many
+ * attributes the request asked for.
+ */
+export interface SimRekognitionDeclaredFace {
+  readonly boundingBox?: SimRekognitionDeclaredBoundingBox | undefined;
+  readonly confidence?: number | undefined;
+  readonly pose?: SimRekognitionDeclaredPose | undefined;
+  readonly quality?: SimRekognitionDeclaredFaceQuality | undefined;
+  readonly landmarks?: SimRekognitionDeclaredLandmarks | undefined;
+  readonly ageRange?: SimRekognitionDeclaredAgeRange | undefined;
+  readonly gender?: SimRekognitionDeclaredGender | undefined;
+  readonly emotions?: readonly SimRekognitionDeclaredEmotion[] | undefined;
+  readonly eyeDirection?: SimRekognitionDeclaredEyeDirection | undefined;
+  readonly smile?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly eyeglasses?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly sunglasses?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly beard?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly mustache?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly eyesOpen?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly mouthOpen?: SimRekognitionDeclaredFaceFeature | undefined;
+  readonly faceOccluded?: SimRekognitionDeclaredFaceFeature | undefined;
+}
+
+/**
+ * What DetectFaces answers with for an image.
+ *
+ * An image with no faces in it is `{ faces: [] }`, which is a detection that
+ * found nothing rather than an image nothing was declared for.
+ */
+export interface SimRekognitionFacesResult {
+  readonly faces: readonly SimRekognitionDeclaredFace[];
+}

--- a/src/service/rekognition/face/sim-rekognition-face-defaults.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-defaults.ts
@@ -1,0 +1,123 @@
+import type { SimRekognitionFacesResult } from "./sim-rekognition-face-declaration.js";
+
+/**
+ * What DetectFaces answers with before anything is configured.
+ *
+ * This is the example response from the AWS DetectFaces documentation,
+ * attribute for attribute, so an unconfigured detection answers with something
+ * real Rekognition has actually returned rather than something invented here.
+ * One face is the common shape: an uploaded photograph of a person.
+ *
+ * Which face comes back for an arbitrary image is a simulator convention. No
+ * image is looked at, so a photograph of a lighthouse gets this face too.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/dg/faces-detect-images.html
+ */
+export const simRekognitionDefaultFaces: SimRekognitionFacesResult = {
+  faces: [
+    {
+      boundingBox: {
+        left: 0.08881539851427078,
+        top: 0.151064932346344,
+        width: 0.7919622659683228,
+        height: 0.7510867118835449,
+      },
+      confidence: 99.99872589111328,
+      ageRange: { low: 18, high: 26 },
+      gender: { value: "Female", confidence: 99.85968780517578 },
+      smile: { value: false, confidence: 89.77348327636719 },
+      eyeglasses: { value: true, confidence: 99.99996948242188 },
+      sunglasses: { value: true, confidence: 93.652374267578125 },
+      beard: { value: false, confidence: 77.52591705322266 },
+      mustache: { value: false, confidence: 94.489044189453125 },
+      eyesOpen: { value: true, confidence: 98.57169342041016 },
+      mouthOpen: { value: false, confidence: 74.33953094482422 },
+      faceOccluded: { value: true, confidence: 99.99726104736328 },
+      eyeDirection: {
+        yaw: 16.299732,
+        pitch: -6.407457,
+        confidence: 99.968704,
+      },
+      pose: {
+        roll: -5.83309268951416,
+        yaw: -2.4244730472564697,
+        pitch: 2.6216139793395996,
+      },
+      quality: { brightness: 96.16363525390625, sharpness: 95.51618957519531 },
+      emotions: [
+        { type: "SAD", confidence: 65.56403350830078 },
+        { type: "CONFUSED", confidence: 31.277774810791016 },
+        { type: "DISGUSTED", confidence: 15.553778648376465 },
+        { type: "ANGRY", confidence: 8.012762069702148 },
+        { type: "SURPRISED", confidence: 7.621500015258789 },
+        { type: "FEAR", confidence: 7.243380546569824 },
+        { type: "CALM", confidence: 5.8196024894714355 },
+        { type: "HAPPY", confidence: 2.2830512523651123 },
+      ],
+      landmarks: {
+        eyeLeft: { x: 0.30225440859794617, y: 0.41018882393836975 },
+        eyeRight: { x: 0.6439348459243774, y: 0.40341562032699585 },
+        mouthLeft: { x: 0.343580037355423, y: 0.6951127648353577 },
+        mouthRight: { x: 0.6306480765342712, y: 0.6898072361946106 },
+        nose: { x: 0.47164231538772583, y: 0.5763645172119141 },
+        leftEyeBrowLeft: { x: 0.1732882857322693, y: 0.34452149271965027 },
+        leftEyeBrowRight: { x: 0.3655243515968323, y: 0.33231860399246216 },
+        leftEyeBrowUp: { x: 0.2671719491481781, y: 0.31669262051582336 },
+        rightEyeBrowLeft: { x: 0.5613729953765869, y: 0.32813435792922974 },
+        rightEyeBrowRight: { x: 0.7665090560913086, y: 0.3318614959716797 },
+        rightEyeBrowUp: { x: 0.6612788438796997, y: 0.3082450032234192 },
+        leftEyeLeft: { x: 0.2416982799768448, y: 0.4085965156555176 },
+        leftEyeRight: { x: 0.36943578720092773, y: 0.41230902075767517 },
+        leftEyeUp: { x: 0.29974061250686646, y: 0.3971870541572571 },
+        leftEyeDown: { x: 0.30360740423202515, y: 0.42347756028175354 },
+        rightEyeLeft: { x: 0.5755768418312073, y: 0.4081145226955414 },
+        rightEyeRight: { x: 0.7050536870956421, y: 0.39924031496047974 },
+        rightEyeUp: { x: 0.642906129360199, y: 0.39026668667793274 },
+        rightEyeDown: { x: 0.6423097848892212, y: 0.41669243574142456 },
+        noseLeft: { x: 0.4122826159000397, y: 0.5987403392791748 },
+        noseRight: { x: 0.5394935011863708, y: 0.5960900187492371 },
+        mouthUp: { x: 0.478581964969635, y: 0.6660456657409668 },
+        mouthDown: { x: 0.483366996049881, y: 0.7497162818908691 },
+        leftPupil: { x: 0.30225440859794617, y: 0.41018882393836975 },
+        rightPupil: { x: 0.6439348459243774, y: 0.40341562032699585 },
+        upperJawlineLeft: { x: 0.11031254380941391, y: 0.3980775475502014 },
+        midJawlineLeft: { x: 0.19301874935626984, y: 0.7034031748771667 },
+        chinBottom: { x: 0.4939905107021332, y: 0.8877836465835571 },
+        midJawlineRight: { x: 0.7990140914916992, y: 0.6899225115776062 },
+        upperJawlineRight: { x: 0.8548634648323059, y: 0.38160091638565063 },
+      },
+    },
+  ],
+};
+
+/**
+ * An image with nobody in it.
+ *
+ * This is the result to declare for a photograph of a landscape, or for the
+ * upload a face detection is meant to reject.
+ */
+export const simRekognitionNoFaces: SimRekognitionFacesResult = { faces: [] };
+
+/**
+ * An image with three people in it, side by side.
+ *
+ * The faces carry a bounding box and a confidence each and nothing else, so a
+ * request for `ALL` gets three faces with only the default attributes on them.
+ * Declare the attributes the code under test reads.
+ */
+export const simRekognitionSeveralFaces: SimRekognitionFacesResult = {
+  faces: [
+    {
+      boundingBox: { left: 0.08, top: 0.22, width: 0.19, height: 0.28 },
+      confidence: 99.94,
+    },
+    {
+      boundingBox: { left: 0.4, top: 0.18, width: 0.2, height: 0.3 },
+      confidence: 99.87,
+    },
+    {
+      boundingBox: { left: 0.7, top: 0.24, width: 0.18, height: 0.27 },
+      confidence: 98.62,
+    },
+  ],
+};

--- a/src/service/rekognition/face/sim-rekognition-face-detail-builder.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-detail-builder.ts
@@ -1,0 +1,57 @@
+import type { SimRekognitionFaceDetailOutput } from "../command/detect-faces/detect-faces.command.js";
+import type {
+  SimRekognitionFaceAttributeName,
+  SimRekognitionFaceAttributes,
+} from "./sim-rekognition-face-attributes.js";
+
+type SimRekognitionFaceDetailMember = keyof SimRekognitionFaceDetailOutput;
+
+type SimRekognitionMutableFaceDetail = {
+  -readonly [
+    TMember in SimRekognitionFaceDetailMember
+  ]?: SimRekognitionFaceDetailOutput[TMember];
+};
+
+/**
+ * Builds the FaceDetail one response carries for one face.
+ *
+ * A member is carried when the request asked for the attribute it belongs to
+ * and the face declared a value for it. An attribute with no declared value is
+ * left out of the response rather than carried as an undefined member, which
+ * is how a real response reports an attribute that was not asked for.
+ *
+ * The attribute a member belongs to is passed in beside it, because the two
+ * do not share a name: `EyesOpen` is the `EYES_OPEN` attribute, and four
+ * separate members are the default subset.
+ */
+export class SimRekognitionFaceDetailBuilder {
+  private readonly detail: SimRekognitionMutableFaceDetail = {};
+
+  constructor(private readonly attributes: SimRekognitionFaceAttributes) {}
+
+  /**
+   * Carry one member of the detail, if the request wants it and the face has
+   * it.
+   */
+  carry<TMember extends SimRekognitionFaceDetailMember>(
+    member: TMember,
+    attribute: SimRekognitionFaceAttributeName,
+    value: Required<SimRekognitionFaceDetailOutput>[TMember] | undefined,
+  ): this {
+    if (value === undefined || !this.attributes.wants(attribute)) {
+      return this;
+    }
+
+    // eslint-disable-next-line security/detect-object-injection -- a FaceDetail member name, from the code adding it.
+    this.detail[member] = value;
+
+    return this;
+  }
+
+  /**
+   * The detail as built.
+   */
+  build(): SimRekognitionFaceDetailOutput {
+    return this.detail;
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-detection.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-detection.ts
@@ -1,0 +1,47 @@
+import type { SimRekognitionFaceDetailOutput } from "../command/detect-faces/detect-faces.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import { SimRekognitionDetectedFace } from "./sim-rekognition-detected-face.js";
+import type { SimRekognitionFaceAttributes } from "./sim-rekognition-face-attributes.js";
+import type { SimRekognitionFacesResult } from "./sim-rekognition-face-declaration.js";
+
+/**
+ * The most faces real Rekognition detects in one image.
+ */
+const mostFaces = 100;
+
+/**
+ * The face result one rule answers with, resolved from its declaration.
+ *
+ * Faces are reported in the order they were declared. Real Rekognition
+ * detects the hundred largest faces in an image, so a declaration with more
+ * than that in it describes a response AWS could not return and is refused
+ * where it was written.
+ */
+export class SimRekognitionFaceDetection {
+  private readonly faces: readonly SimRekognitionDetectedFace[];
+
+  constructor(result: SimRekognitionFacesResult) {
+    if (result.faces.length > mostFaces) {
+      throw new SimRekognitionDeclarationError(
+        `A simulated Rekognition face result declares ` +
+          `${String(result.faces.length)} faces. Real Rekognition detects the ` +
+          `${String(mostFaces)} largest faces in an image and no more.`,
+      );
+    }
+
+    this.faces = result.faces.map(
+      (face, index) =>
+        new SimRekognitionDetectedFace(`face ${String(index + 1)}`, face),
+    );
+  }
+
+  /**
+   * The face details to report for this result, as one request asked for
+   * them.
+   */
+  detailsFor(
+    attributes: SimRekognitionFaceAttributes,
+  ): readonly SimRekognitionFaceDetailOutput[] {
+    return this.faces.map((face) => face.detailFor(attributes));
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-emotions.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-emotions.ts
@@ -1,0 +1,79 @@
+import type { SimRekognitionEmotionOutput } from "../command/detect-faces/detect-faces.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import { isSimRekognitionEmotionName } from "./sim-rekognition-emotion-name.js";
+import { simRekognitionDeclaredEmotion } from "./sim-rekognition-declared-value.js";
+import type { SimRekognitionDeclaredEmotion } from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+
+/**
+ * The emotions one declared face appears to express.
+ *
+ * They are reported in descending order of confidence, which is the order real
+ * Rekognition reports them in. An emotion declared as a bare name takes the
+ * face's own confidence.
+ */
+export class SimRekognitionFaceEmotions {
+  private readonly emotions: readonly SimRekognitionEmotionOutput[];
+
+  constructor(
+    private readonly subject: string,
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: readonly SimRekognitionDeclaredEmotion[] = [],
+  ) {
+    this.emotions = declared
+      .map((emotion) => this.emotionOf(confidence, emotion))
+      .toSorted((one, other) => other.Confidence - one.Confidence);
+
+    this.refuseRepeated();
+  }
+
+  /**
+   * Add the emotions this face declared to a detail.
+   */
+  addTo(builder: SimRekognitionFaceDetailBuilder): void {
+    if (this.emotions.length === 0) {
+      return;
+    }
+
+    builder.carry("Emotions", "EMOTIONS", this.emotions);
+  }
+
+  private emotionOf(
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredEmotion,
+  ): SimRekognitionEmotionOutput {
+    const emotion = simRekognitionDeclaredEmotion(declared);
+
+    return {
+      Type: this.emotionName(emotion.value),
+      Confidence: confidence.of(this.subject, emotion.confidence),
+    };
+  }
+
+  private emotionName(name: string): string {
+    if (isSimRekognitionEmotionName(name)) {
+      return name;
+    }
+
+    throw new SimRekognitionDeclarationError(
+      `'${name}' declared for '${this.subject}' is not an emotion ` +
+        `Rekognition reports.`,
+    );
+  }
+
+  private refuseRepeated(): void {
+    const reported = new Set<string>();
+
+    for (const emotion of this.emotions) {
+      if (reported.has(emotion.Type)) {
+        throw new SimRekognitionDeclarationError(
+          `'${emotion.Type}' is declared twice for '${this.subject}'. Real ` +
+            `Rekognition reports each emotion once.`,
+        );
+      }
+
+      reported.add(emotion.Type);
+    }
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-eye-direction.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-eye-direction.ts
@@ -1,0 +1,52 @@
+import type { SimRekognitionEyeDirectionOutput } from "../command/detect-faces/detect-faces.command.js";
+import type { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import type { SimRekognitionDeclaredEyeDirection } from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { SimRekognitionFaceMeasures } from "./sim-rekognition-face-measures.js";
+
+/**
+ * Where one declared face is looking.
+ *
+ * This is the gaze rather than the pose: a face turned one way can be looking
+ * another, which is why Rekognition reports the two separately.
+ */
+export class SimRekognitionFaceEyeDirection {
+  private readonly eyeDirection: SimRekognitionEyeDirectionOutput | undefined;
+
+  constructor(
+    subject: string,
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredEyeDirection | undefined,
+  ) {
+    this.eyeDirection = SimRekognitionFaceEyeDirection.directionOf(
+      subject,
+      confidence,
+      declared,
+    );
+  }
+
+  private static directionOf(
+    subject: string,
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredEyeDirection | undefined,
+  ): SimRekognitionEyeDirectionOutput | undefined {
+    if (declared === undefined) {
+      return undefined;
+    }
+
+    const measures = new SimRekognitionFaceMeasures(subject);
+
+    return {
+      Yaw: measures.angle("eye direction yaw", declared.yaw),
+      Pitch: measures.angle("eye direction pitch", declared.pitch),
+      Confidence: confidence.of(subject, declared.confidence),
+    };
+  }
+
+  /**
+   * Add the eye direction this face declared to a detail.
+   */
+  addTo(builder: SimRekognitionFaceDetailBuilder): void {
+    builder.carry("EyeDirection", "EYE_DIRECTION", this.eyeDirection);
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-feature-members.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-feature-members.ts
@@ -1,0 +1,38 @@
+import type { SimRekognitionFaceDetailOutput } from "../command/detect-faces/detect-faces.command.js";
+import type { SimRekognitionFaceAttributeName } from "./sim-rekognition-face-attributes.js";
+import type { SimRekognitionDeclaredFace } from "./sim-rekognition-face-declaration.js";
+
+/**
+ * How one yes or no attribute is declared, reported and asked for.
+ *
+ * The three names are listed beside each other because none of them match:
+ * `eyesOpen` is declared, reported as `EyesOpen` and asked for as
+ * `EYES_OPEN`.
+ */
+export interface SimRekognitionFaceFeatureMember {
+  readonly declared: keyof SimRekognitionDeclaredFace;
+  readonly member: keyof SimRekognitionFaceDetailOutput;
+  readonly attribute: SimRekognitionFaceAttributeName;
+}
+
+/**
+ * The face attributes Rekognition answers yes or no to.
+ *
+ * All eight are one value and one confidence on the wire, so all eight are
+ * declared, checked and reported the same way. The list is here rather than
+ * beside the code that reads it because it is a table of names.
+ */
+export const simRekognitionFaceFeatureMembers = [
+  { declared: "smile", member: "Smile", attribute: "SMILE" },
+  { declared: "eyeglasses", member: "Eyeglasses", attribute: "EYEGLASSES" },
+  { declared: "sunglasses", member: "Sunglasses", attribute: "SUNGLASSES" },
+  { declared: "beard", member: "Beard", attribute: "BEARD" },
+  { declared: "mustache", member: "Mustache", attribute: "MUSTACHE" },
+  { declared: "eyesOpen", member: "EyesOpen", attribute: "EYES_OPEN" },
+  { declared: "mouthOpen", member: "MouthOpen", attribute: "MOUTH_OPEN" },
+  {
+    declared: "faceOccluded",
+    member: "FaceOccluded",
+    attribute: "FACE_OCCLUDED",
+  },
+] as const satisfies readonly SimRekognitionFaceFeatureMember[];

--- a/src/service/rekognition/face/sim-rekognition-face-features.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-features.ts
@@ -1,0 +1,57 @@
+import type { SimRekognitionFaceFeatureOutput } from "../command/detect-faces/detect-faces.command.js";
+import type { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import { simRekognitionDeclaredFaceFeature } from "./sim-rekognition-declared-value.js";
+import type { SimRekognitionDeclaredFace } from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { simRekognitionFaceFeatureMembers } from "./sim-rekognition-face-feature-members.js";
+
+type SimRekognitionResolvedFeature =
+  (typeof simRekognitionFaceFeatureMembers)[number] & {
+    readonly value: SimRekognitionFaceFeatureOutput;
+  };
+
+/**
+ * The yes or no attributes one declared face carries.
+ *
+ * A feature declared as a bare `true` or `false` takes the face's own
+ * confidence, since a face detected at 99.9 is not usually judged to be
+ * wearing sunglasses at 40.
+ */
+export class SimRekognitionFaceFeatures {
+  private readonly features: readonly SimRekognitionResolvedFeature[];
+
+  constructor(
+    subject: string,
+    confidence: SimRekognitionDeclaredConfidence,
+    declared: SimRekognitionDeclaredFace,
+  ) {
+    this.features = simRekognitionFaceFeatureMembers.flatMap((feature) => {
+      const value = declared[feature.declared];
+
+      if (value === undefined) {
+        return [];
+      }
+
+      const read = simRekognitionDeclaredFaceFeature(value);
+
+      return [
+        {
+          ...feature,
+          value: {
+            Value: read.value,
+            Confidence: confidence.of(subject, read.confidence),
+          },
+        },
+      ];
+    });
+  }
+
+  /**
+   * Add the features this face declared to a detail.
+   */
+  addTo(builder: SimRekognitionFaceDetailBuilder): void {
+    for (const feature of this.features) {
+      builder.carry(feature.member, feature.attribute, feature.value);
+    }
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-frame.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-frame.ts
@@ -1,0 +1,107 @@
+import type {
+  SimRekognitionImageQualityOutput,
+  SimRekognitionPoseOutput,
+} from "../command/detect-faces/detect-faces.command.js";
+import {
+  SimRekognitionBoundingBoxes,
+  type SimRekognitionBoundingBoxOutput,
+} from "../image/sim-rekognition-bounding-box.js";
+import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
+import { simRekognitionDefaultFaceAttribute as defaultAttribute } from "./sim-rekognition-face-attributes.js";
+import type {
+  SimRekognitionDeclaredFace,
+  SimRekognitionDeclaredFaceQuality,
+  SimRekognitionDeclaredPose,
+} from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { SimRekognitionFaceMeasures } from "./sim-rekognition-face-measures.js";
+
+/**
+ * The confidence a declared face is detected at when none is declared for it.
+ *
+ * It is the confidence in the AWS DetectFaces example response rather than a
+ * round number, because declared confidences pass through `Math.fround` and a
+ * real one has the float32 tail a test can assert on.
+ */
+const faceConfidence = new SimRekognitionDeclaredConfidence(99.99872589111328);
+
+function boundingBoxOf(
+  subject: string,
+  declared: SimRekognitionDeclaredFace,
+): SimRekognitionBoundingBoxOutput | undefined {
+  if (declared.boundingBox === undefined) {
+    return undefined;
+  }
+
+  return new SimRekognitionBoundingBoxes(subject).of(declared.boundingBox);
+}
+
+function poseOf(
+  measures: SimRekognitionFaceMeasures,
+  declared: SimRekognitionDeclaredPose | undefined,
+): SimRekognitionPoseOutput | undefined {
+  if (declared === undefined) {
+    return undefined;
+  }
+
+  return {
+    Roll: measures.angle("roll", declared.roll),
+    Yaw: measures.angle("yaw", declared.yaw),
+    Pitch: measures.angle("pitch", declared.pitch),
+  };
+}
+
+function qualityOf(
+  measures: SimRekognitionFaceMeasures,
+  declared: SimRekognitionDeclaredFaceQuality | undefined,
+): SimRekognitionImageQualityOutput | undefined {
+  if (declared === undefined) {
+    return undefined;
+  }
+
+  return {
+    Brightness: measures.percentage("brightness", declared.brightness),
+    Sharpness: measures.percentage("sharpness", declared.sharpness),
+  };
+}
+
+/**
+ * The default subset of a detected face, bar its landmarks: where it is, how
+ * sure Rekognition is that it is a face, how it is turned and how well it was
+ * captured.
+ *
+ * The confidence is the one member always reported, since a declared face is a
+ * face the detection found. Everything else here is carried only when it was
+ * declared.
+ */
+export class SimRekognitionFaceFrame {
+  /**
+   * The confidence this face was detected at, which its attributes take when
+   * they declare none of their own.
+   */
+  public readonly confidence: number;
+
+  private readonly boundingBox: SimRekognitionBoundingBoxOutput | undefined;
+  private readonly pose: SimRekognitionPoseOutput | undefined;
+  private readonly quality: SimRekognitionImageQualityOutput | undefined;
+
+  constructor(subject: string, declared: SimRekognitionDeclaredFace) {
+    const measures = new SimRekognitionFaceMeasures(subject);
+
+    this.confidence = faceConfidence.of(subject, declared.confidence);
+    this.boundingBox = boundingBoxOf(subject, declared);
+    this.pose = poseOf(measures, declared.pose);
+    this.quality = qualityOf(measures, declared.quality);
+  }
+
+  /**
+   * Add what this face frame reports to a detail.
+   */
+  addTo(builder: SimRekognitionFaceDetailBuilder): void {
+    builder
+      .carry("BoundingBox", defaultAttribute, this.boundingBox)
+      .carry("Confidence", defaultAttribute, this.confidence)
+      .carry("Pose", defaultAttribute, this.pose)
+      .carry("Quality", defaultAttribute, this.quality);
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-landmark-points.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-landmark-points.ts
@@ -1,0 +1,130 @@
+import type { SimRekognitionLandmarkOutput } from "../command/detect-faces/detect-faces.command.js";
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type {
+  SimRekognitionDeclaredLandmarks,
+  SimRekognitionDeclaredPoint,
+} from "./sim-rekognition-face-declaration.js";
+import {
+  isSimRekognitionLandmarkName,
+  simRekognitionLandmarkNames,
+  type SimRekognitionLandmarkName,
+} from "./sim-rekognition-landmark-name.js";
+
+/**
+ * The landmark pairs a face reports in a fixed order across the image.
+ *
+ * Rekognition reports the first of each pair at the smaller X. A declaration
+ * with them the other way round has the two swapped, which is worth refusing
+ * where it was written: a test asserting that the left eye is on the left
+ * would pass here and fail on AWS.
+ */
+const acrossTheFace: readonly (readonly [
+  SimRekognitionLandmarkName,
+  SimRekognitionLandmarkName,
+])[] = [
+  ["eyeLeft", "eyeRight"],
+  ["mouthLeft", "mouthRight"],
+  ["noseLeft", "noseRight"],
+];
+
+/**
+ * The landmarks declared for one face, resolved into what a response carries.
+ *
+ * They are resolved in the order real Rekognition reports them in rather than
+ * the order they were declared in, and they are not required to sit inside the
+ * bounding box, because a real Rekognition face box routinely excludes the
+ * chin.
+ */
+export class SimRekognitionFaceLandmarkPoints {
+  constructor(
+    private readonly subject: string,
+    private readonly declared: SimRekognitionDeclaredLandmarks,
+  ) {}
+
+  /**
+   * The declared landmarks, checked and in reporting order.
+   */
+  resolve(): readonly SimRekognitionLandmarkOutput[] {
+    this.refuseUnknown();
+    this.refuseSwapped();
+
+    return simRekognitionLandmarkNames.flatMap((name) => this.landmarkOf(name));
+  }
+
+  private landmarkOf(
+    name: SimRekognitionLandmarkName,
+  ): readonly SimRekognitionLandmarkOutput[] {
+    // eslint-disable-next-line security/detect-object-injection -- one of the landmark names this file lists.
+    const point = this.declared[name];
+
+    if (point === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        Type: name,
+        X: this.ratio(name, "x", point.x),
+        Y: this.ratio(name, "y", point.y),
+      },
+    ];
+  }
+
+  private ratio(
+    name: SimRekognitionLandmarkName,
+    axis: string,
+    value: number,
+  ): number {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new SimRekognitionDeclarationError(
+        `The '${name}' landmark declared for '${this.subject}' has an ` +
+          `${axis} of ${String(value)}, which is not a ratio of the image ` +
+          `size from 0 to 1.`,
+      );
+    }
+
+    return Math.fround(value);
+  }
+
+  private refuseUnknown(): void {
+    for (const name of Object.keys(this.declared)) {
+      if (isSimRekognitionLandmarkName(name)) {
+        continue;
+      }
+
+      throw new SimRekognitionDeclarationError(
+        `'${name}' declared for '${this.subject}' is not a landmark ` +
+          `Rekognition reports.`,
+      );
+    }
+  }
+
+  private refuseSwapped(): void {
+    for (const [left, right] of acrossTheFace) {
+      // eslint-disable-next-line security/detect-object-injection -- the landmark names of one pair listed above.
+      this.refusePair(left, right, this.declared[left], this.declared[right]);
+    }
+  }
+
+  private refusePair(
+    left: SimRekognitionLandmarkName,
+    right: SimRekognitionLandmarkName,
+    leftPoint: SimRekognitionDeclaredPoint | undefined,
+    rightPoint: SimRekognitionDeclaredPoint | undefined,
+  ): void {
+    if (leftPoint === undefined || rightPoint === undefined) {
+      return;
+    }
+
+    if (leftPoint.x < rightPoint.x) {
+      return;
+    }
+
+    throw new SimRekognitionDeclarationError(
+      `The '${left}' landmark declared for '${this.subject}' is at an x of ` +
+        `${String(leftPoint.x)} and '${right}' is at ${String(rightPoint.x)}. ` +
+        `Real Rekognition reports '${left}' at the smaller x, so these two ` +
+        `look swapped.`,
+    );
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-landmarks.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-landmarks.ts
@@ -1,0 +1,57 @@
+import type { SimRekognitionLandmarkOutput } from "../command/detect-faces/detect-faces.command.js";
+import {
+  simRekognitionDefaultFaceAttribute,
+  type SimRekognitionFaceAttributes,
+} from "./sim-rekognition-face-attributes.js";
+import type { SimRekognitionDeclaredLandmarks } from "./sim-rekognition-face-declaration.js";
+import type { SimRekognitionFaceDetailBuilder } from "./sim-rekognition-face-detail-builder.js";
+import { SimRekognitionFaceLandmarkPoints } from "./sim-rekognition-face-landmark-points.js";
+import { simRekognitionDefaultLandmarkNames } from "./sim-rekognition-landmark-name.js";
+
+/**
+ * The landmarks one declared face reports.
+ */
+export class SimRekognitionFaceLandmarks {
+  private readonly landmarks: readonly SimRekognitionLandmarkOutput[];
+
+  constructor(subject: string, declared: SimRekognitionDeclaredLandmarks = {}) {
+    this.landmarks = new SimRekognitionFaceLandmarkPoints(
+      subject,
+      declared,
+    ).resolve();
+  }
+
+  /**
+   * Add the landmarks this face declared to a detail.
+   *
+   * A request that did not ask for `ALL` gets the five landmarks real
+   * Rekognition reports by default, so a caller reading `chinBottom` from a
+   * default request reads nothing here and nothing on AWS.
+   */
+  addTo(
+    builder: SimRekognitionFaceDetailBuilder,
+    attributes: SimRekognitionFaceAttributes,
+  ): void {
+    builder.carry(
+      "Landmarks",
+      simRekognitionDefaultFaceAttribute,
+      this.reported(attributes),
+    );
+  }
+
+  private reported(
+    attributes: SimRekognitionFaceAttributes,
+  ): readonly SimRekognitionLandmarkOutput[] | undefined {
+    if (this.landmarks.length === 0) {
+      return undefined;
+    }
+
+    if (attributes.wantsEveryLandmark()) {
+      return this.landmarks;
+    }
+
+    return this.landmarks.filter((landmark) =>
+      simRekognitionDefaultLandmarkNames.has(landmark.Type),
+    );
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-face-measures.ts
+++ b/src/service/rekognition/face/sim-rekognition-face-measures.ts
@@ -1,0 +1,58 @@
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+
+/**
+ * The ranges the numbers declared for a face have to sit in.
+ *
+ * Pose, eye direction, quality and age all carry plain numbers with a meaning
+ * of their own, so each is checked against the range real Rekognition reports
+ * it in and refused where it was declared.
+ *
+ * Angles and percentages go through `Math.fround`, as confidences do: real
+ * Rekognition reports them as float32 values such as `-5.83309268951416`.
+ */
+export class SimRekognitionFaceMeasures {
+  constructor(private readonly subject: string) {}
+
+  /**
+   * An angle in degrees.
+   */
+  angle(part: string, value: number): number {
+    if (!Number.isFinite(value) || value < -180 || value > 180) {
+      throw new SimRekognitionDeclarationError(
+        `A ${part} declared for '${this.subject}' is ${String(value)}, which ` +
+          `is not an angle in degrees from -180 to 180.`,
+      );
+    }
+
+    return Math.fround(value);
+  }
+
+  /**
+   * A measure Rekognition reports from 0 to 100.
+   */
+  percentage(part: string, value: number): number {
+    if (!Number.isFinite(value) || value < 0 || value > 100) {
+      throw new SimRekognitionDeclarationError(
+        `A ${part} declared for '${this.subject}' is ${String(value)}, which ` +
+          `is not a measure from 0 to 100.`,
+      );
+    }
+
+    return Math.fround(value);
+  }
+
+  /**
+   * A whole number of years.
+   */
+  years(part: string, value: number): number {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new SimRekognitionDeclarationError(
+        `An age declared for '${this.subject}' has a ${part} of ` +
+          `${String(value)}, which is not a whole number of years from 0 ` +
+          `upwards.`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-faces.ts
+++ b/src/service/rekognition/face/sim-rekognition-faces.ts
@@ -1,0 +1,47 @@
+import type { SimRekognitionImage } from "../image/sim-rekognition-image.js";
+import { SimRekognitionResultRules } from "../rule/sim-rekognition-result-rules.js";
+import type { SimRekognitionFacesResult } from "./sim-rekognition-face-declaration.js";
+import { SimRekognitionFaceDetection } from "./sim-rekognition-face-detection.js";
+import { simRekognitionDefaultFaces } from "./sim-rekognition-face-defaults.js";
+
+/**
+ * The face results simulated Rekognition answers with.
+ *
+ * The rules are grouped per operation rather than hung off the service, so
+ * `faces()` and the operation groups beside it each own the result shape their
+ * own operation answers with.
+ */
+export class SimRekognitionFaces {
+  private readonly rules =
+    new SimRekognitionResultRules<SimRekognitionFaceDetection>(
+      new SimRekognitionFaceDetection(simRekognitionDefaultFaces),
+    );
+
+  /**
+   * Answer with this result for any image no other rule matches.
+   */
+  byDefault(result: SimRekognitionFacesResult): void {
+    this.rules.byDefault(new SimRekognitionFaceDetection(result));
+  }
+
+  /**
+   * Answer with this result for the S3 object with this exact name.
+   */
+  onName(name: string, result: SimRekognitionFacesResult): void {
+    this.rules.onName(name, new SimRekognitionFaceDetection(result));
+  }
+
+  /**
+   * Answer with this result for the image with this exact content hash.
+   */
+  onHash(hash: string, result: SimRekognitionFacesResult): void {
+    this.rules.onHash(hash, new SimRekognitionFaceDetection(result));
+  }
+
+  /**
+   * The face result for one image.
+   */
+  detectionFor(image: SimRekognitionImage): SimRekognitionFaceDetection {
+    return this.rules.resultFor(image);
+  }
+}

--- a/src/service/rekognition/face/sim-rekognition-landmark-name.ts
+++ b/src/service/rekognition/face/sim-rekognition-landmark-name.ts
@@ -1,0 +1,77 @@
+/**
+ * Every facial landmark real Rekognition reports, in the order it reports
+ * them in.
+ *
+ * The order is the one the AWS `DetectFaces` example response uses, so
+ * landmarks come back in the same order whichever order a declaration wrote
+ * them in.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_Landmark.html
+ */
+export const simRekognitionLandmarkNames = [
+  "eyeLeft",
+  "eyeRight",
+  "mouthLeft",
+  "mouthRight",
+  "nose",
+  "leftEyeBrowLeft",
+  "leftEyeBrowRight",
+  "leftEyeBrowUp",
+  "rightEyeBrowLeft",
+  "rightEyeBrowRight",
+  "rightEyeBrowUp",
+  "leftEyeLeft",
+  "leftEyeRight",
+  "leftEyeUp",
+  "leftEyeDown",
+  "rightEyeLeft",
+  "rightEyeRight",
+  "rightEyeUp",
+  "rightEyeDown",
+  "noseLeft",
+  "noseRight",
+  "mouthUp",
+  "mouthDown",
+  "leftPupil",
+  "rightPupil",
+  "upperJawlineLeft",
+  "midJawlineLeft",
+  "chinBottom",
+  "midJawlineRight",
+  "upperJawlineRight",
+] as const;
+
+/**
+ * The name of one facial landmark.
+ */
+export type SimRekognitionLandmarkName =
+  (typeof simRekognitionLandmarkNames)[number];
+
+/**
+ * The landmarks a response carries when `ALL` was not asked for.
+ *
+ * Real Rekognition reports these five for a default request and the whole set
+ * for `ALL`, which is what makes `Attributes` worth simulating: a caller
+ * reading `chinBottom` from a default request reads nothing on AWS either.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/dg/faces-detect-images.html
+ */
+export const simRekognitionDefaultLandmarkNames: ReadonlySet<string> =
+  new Set<SimRekognitionLandmarkName>([
+    "eyeLeft",
+    "eyeRight",
+    "nose",
+    "mouthLeft",
+    "mouthRight",
+  ]);
+
+const landmarkNames: ReadonlySet<string> = new Set(simRekognitionLandmarkNames);
+
+/**
+ * Whether a name is one of the landmarks Rekognition reports.
+ */
+export function isSimRekognitionLandmarkName(
+  name: string,
+): name is SimRekognitionLandmarkName {
+  return landmarkNames.has(name);
+}

--- a/src/service/rekognition/image/sim-rekognition-bounding-box.ts
+++ b/src/service/rekognition/image/sim-rekognition-bounding-box.ts
@@ -1,0 +1,90 @@
+import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+
+/**
+ * Where something declared against an image sits in it, as ratios of the
+ * image's own width and height.
+ *
+ * The four numbers are the `BoundingBox` real Rekognition reports, in the same
+ * units: `left` and `top` are the corner nearest the image origin, and `width`
+ * and `height` are the size, each from 0 to 1.
+ */
+export interface SimRekognitionDeclaredBoundingBox {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * A bounding box as a response carries it.
+ *
+ * https://docs.aws.amazon.com/rekognition/latest/APIReference/API_BoundingBox.html
+ */
+export interface SimRekognitionBoundingBoxOutput {
+  readonly Left: number;
+  readonly Top: number;
+  readonly Width: number;
+  readonly Height: number;
+}
+
+/**
+ * Resolves the bounding boxes declared for one label or one face.
+ *
+ * Values go through `Math.fround` for the same reason confidences do: real
+ * ones are float32 values such as `0.26779675483703613`.
+ *
+ * A box has to sit inside the image. Real Rekognition can return a box that
+ * does not, for an object at the image edge that is only partly visible, so
+ * this is stricter than AWS. It is the check that catches a box written in
+ * pixels, which is the mistake worth catching: a `left` of 350 would otherwise
+ * be reported as a face 350 image widths from the left.
+ */
+export class SimRekognitionBoundingBoxes {
+  constructor(private readonly subject: string) {}
+
+  /**
+   * Resolve one declared bounding box.
+   */
+  of(box: SimRekognitionDeclaredBoundingBox): SimRekognitionBoundingBoxOutput {
+    const resolved = {
+      Left: this.ratio("left", box.left),
+      Top: this.ratio("top", box.top),
+      Width: this.ratio("width", box.width),
+      Height: this.ratio("height", box.height),
+    };
+
+    this.refuseOverflow("left", box.left, "width", box.width);
+    this.refuseOverflow("top", box.top, "height", box.height);
+
+    return resolved;
+  }
+
+  private ratio(part: string, value: number): number {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new SimRekognitionDeclarationError(
+        `A bounding box declared for '${this.subject}' has a ${part} of ` +
+          `${String(value)}, which is not a ratio of the image size from 0 ` +
+          `to 1.`,
+      );
+    }
+
+    return Math.fround(value);
+  }
+
+  private refuseOverflow(
+    corner: string,
+    cornerValue: number,
+    size: string,
+    sizeValue: number,
+  ): void {
+    if (cornerValue + sizeValue <= 1) {
+      return;
+    }
+
+    throw new SimRekognitionDeclarationError(
+      `A bounding box declared for '${this.subject}' has a ${corner} of ` +
+        `${String(cornerValue)} and a ${size} of ${String(sizeValue)}, which ` +
+        `puts it outside the image.`,
+    );
+  }
+}

--- a/src/service/rekognition/index.ts
+++ b/src/service/rekognition/index.ts
@@ -1,8 +1,36 @@
 export { SimRekognition } from "./sim-rekognition.js";
 export type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
+export { SimRekognitionFaces } from "./face/sim-rekognition-faces.js";
+export type {
+  SimRekognitionDeclaredAgeRange,
+  SimRekognitionDeclaredEmotion,
+  SimRekognitionDeclaredEyeDirection,
+  SimRekognitionDeclaredFace,
+  SimRekognitionDeclaredFaceFeature,
+  SimRekognitionDeclaredFaceQuality,
+  SimRekognitionDeclaredGender,
+  SimRekognitionDeclaredLandmarks,
+  SimRekognitionDeclaredPoint,
+  SimRekognitionDeclaredPose,
+  SimRekognitionFacesResult,
+} from "./face/sim-rekognition-face-declaration.js";
+export {
+  simRekognitionDefaultFaces,
+  simRekognitionNoFaces,
+  simRekognitionSeveralFaces,
+} from "./face/sim-rekognition-face-defaults.js";
+export {
+  simRekognitionEmotionNames,
+  type SimRekognitionEmotionName,
+} from "./face/sim-rekognition-emotion-name.js";
+export {
+  simRekognitionDefaultLandmarkNames,
+  simRekognitionLandmarkNames,
+  type SimRekognitionLandmarkName,
+} from "./face/sim-rekognition-landmark-name.js";
+export type { SimRekognitionDeclaredBoundingBox } from "./image/sim-rekognition-bounding-box.js";
 export { SimRekognitionLabels } from "./label/sim-rekognition-labels.js";
 export type {
-  SimRekognitionDeclaredBoundingBox,
   SimRekognitionDeclaredLabel,
   SimRekognitionDeclaredLabelInstance,
   SimRekognitionLabelDeclaration,

--- a/src/service/rekognition/label/sim-rekognition-label-declaration.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-declaration.ts
@@ -1,17 +1,4 @@
-/**
- * Where one instance of a declared label sits in the image, as ratios of the
- * image's own width and height.
- *
- * The four numbers are the `BoundingBox` real Rekognition reports, in the same
- * units: `left` and `top` are the corner nearest the image origin, and `width`
- * and `height` are the size, each from 0 to 1.
- */
-export interface SimRekognitionDeclaredBoundingBox {
-  readonly left: number;
-  readonly top: number;
-  readonly width: number;
-  readonly height: number;
-}
+import type { SimRekognitionDeclaredBoundingBox } from "../image/sim-rekognition-bounding-box.js";
 
 /**
  * One instance of a declared label, at a place in the image.

--- a/src/service/rekognition/label/sim-rekognition-label-instances.ts
+++ b/src/service/rekognition/label/sim-rekognition-label-instances.ts
@@ -1,30 +1,24 @@
-import type {
-  SimRekognitionBoundingBoxOutput,
-  SimRekognitionLabelInstanceOutput,
-} from "../command/detect-labels/detect-labels.command.js";
-import { SimRekognitionDeclarationError } from "../error/sim-rekognition.error.js";
+import type { SimRekognitionLabelInstanceOutput } from "../command/detect-labels/detect-labels.command.js";
+import { SimRekognitionBoundingBoxes } from "../image/sim-rekognition-bounding-box.js";
 import { SimRekognitionDeclaredConfidence } from "../rule/sim-rekognition-declared-confidence.js";
-import type {
-  SimRekognitionDeclaredBoundingBox,
-  SimRekognitionDeclaredLabelInstance,
-} from "./sim-rekognition-label-declaration.js";
+import type { SimRekognitionDeclaredLabelInstance } from "./sim-rekognition-label-declaration.js";
 
 /**
  * The instances of one declared label, resolved into what a response carries.
  *
  * An instance takes its label's confidence when none is declared for it, since
- * a label detected at 98 is not usually located at 40. Bounding box values go
- * through `Math.fround` for the same reason confidences do: real ones are
- * float32 values such as `0.26779675483703613`.
+ * a label detected at 98 is not usually located at 40.
  */
 export class SimRekognitionLabelInstances {
   private readonly confidence: SimRekognitionDeclaredConfidence;
+  private readonly boundingBoxes: SimRekognitionBoundingBoxes;
 
   constructor(
     private readonly labelName: string,
     labelConfidence: number,
   ) {
     this.confidence = new SimRekognitionDeclaredConfidence(labelConfidence);
+    this.boundingBoxes = new SimRekognitionBoundingBoxes(labelName);
   }
 
   /**
@@ -34,31 +28,8 @@ export class SimRekognitionLabelInstances {
     declared: readonly SimRekognitionDeclaredLabelInstance[],
   ): readonly SimRekognitionLabelInstanceOutput[] {
     return declared.map((instance) => ({
-      BoundingBox: this.boundingBox(instance.boundingBox),
+      BoundingBox: this.boundingBoxes.of(instance.boundingBox),
       Confidence: this.confidence.of(this.labelName, instance.confidence),
     }));
-  }
-
-  private boundingBox(
-    box: SimRekognitionDeclaredBoundingBox,
-  ): SimRekognitionBoundingBoxOutput {
-    return {
-      Left: this.ratio("left", box.left),
-      Top: this.ratio("top", box.top),
-      Width: this.ratio("width", box.width),
-      Height: this.ratio("height", box.height),
-    };
-  }
-
-  private ratio(part: string, value: number): number {
-    if (!Number.isFinite(value) || value < 0 || value > 1) {
-      throw new SimRekognitionDeclarationError(
-        `A bounding box declared for '${this.labelName}' has a ${part} of ` +
-          `${String(value)}, which is not a ratio of the image size from 0 ` +
-          `to 1.`,
-      );
-    }
-
-    return Math.fround(value);
   }
 }

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.iso.test.ts
@@ -18,6 +18,7 @@ describe("SimRekognitionSdkCommandRouter", () => {
     assertArrayIncludesAll(names, [
       "DetectModerationLabelsCommand",
       "DetectLabelsCommand",
+      "DetectFacesCommand",
     ]);
   });
 
@@ -29,7 +30,7 @@ describe("SimRekognitionSdkCommandRouter", () => {
     const route = simAws
       .rekognition()
       .sdkCommandRouter()
-      .route("DetectFacesCommand");
+      .route("DetectTextCommand");
 
     // Then there is no route for it, so an intercepted client is told the
     // Command is unsupported rather than being answered with nothing.

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-command-router.ts
@@ -3,6 +3,7 @@ import {
   type SimSdkCommandRoute,
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
+import type { SimDetectFacesCommand } from "../command/detect-faces/detect-faces.command.js";
 import type { SimDetectLabelsCommand } from "../command/detect-labels/detect-labels.command.js";
 import type { SimDetectModerationLabelsCommand } from "../command/detect-moderation-labels/detect-moderation-labels.command.js";
 import type { SimRekognition } from "../sim-rekognition.js";
@@ -29,6 +30,14 @@ export class SimRekognitionSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simRekognition.detectLabels(
             command as SimDetectLabelsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DetectFacesCommand",
+        async (command, context): Promise<unknown> =>
+          await simRekognition.detectFaces(
+            command as SimDetectFacesCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
+++ b/src/service/rekognition/sdk/sim-rekognition-sdk-routing.iso.test.ts
@@ -1,9 +1,15 @@
 import {
+  DetectFacesCommand,
   DetectLabelsCommand,
   DetectModerationLabelsCommand,
   RekognitionClient,
 } from "@aws-sdk/client-rekognition";
-import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertTrue,
+  assertStringIncludes,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { redPngBytes } from "../../../../test/rekognition/image-fixture.js";
@@ -58,5 +64,32 @@ describe("Rekognition SDK interception", () => {
       (detected.Labels ?? []).map((label) => label.Name).join(","),
       "Dog",
     );
+  });
+
+  it("routes an intercepted face detection to simulated Rekognition", async () => {
+    // Given an intercepted Rekognition SDK client, with an image declared to
+    // hold two faces.
+    using simSdk = new SimSdk();
+    simSdk.intercept(RekognitionClient);
+    simSdk.simAws
+      .rekognition()
+      .faces()
+      .byDefault({
+        faces: [{ confidence: 99.4, smile: true }, { confidence: 91 }],
+      });
+
+    const rekognition = new RekognitionClient({ region: "us-east-1" });
+
+    // When ordinary SDK code detects faces in an image.
+    const detected = await rekognition.send(
+      new DetectFacesCommand({
+        Image: { Bytes: redPngBytes },
+        Attributes: ["ALL"],
+      }),
+    );
+
+    // Then the declared result comes back, with nothing touching the network.
+    assertArrayLength(detected.FaceDetails ?? [], 2);
+    assertTrue(detected.FaceDetails?.[0]?.Smile?.Value);
   });
 });

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -8,6 +8,11 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimRekognitionAuthorizer } from "./command/authorize/sim-rekognition-authorizer.js";
+import { DetectFacesHandler } from "./command/detect-faces/detect-faces.handler.js";
+import type {
+  SimDetectFacesCommand,
+  SimDetectFacesCommandOutput,
+} from "./command/detect-faces/detect-faces.command.js";
 import { DetectLabelsHandler } from "./command/detect-labels/detect-labels.handler.js";
 import type {
   SimDetectLabelsCommand,
@@ -19,6 +24,7 @@ import type {
   SimDetectModerationLabelsCommandOutput,
 } from "./command/detect-moderation-labels/detect-moderation-labels.command.js";
 import type { SimRekognitionRequestOptions } from "./command/sim-rekognition-request-options.js";
+import { SimRekognitionFaces } from "./face/sim-rekognition-faces.js";
 import {
   type SimRekognitionImageObjects,
   SimRekognitionUnreachableImageObjects,
@@ -49,8 +55,10 @@ interface SimRekognitionProperties {
 export class SimRekognition {
   private readonly moderationRules = new SimRekognitionModeration();
   private readonly labelRules = new SimRekognitionLabels();
+  private readonly faceRules = new SimRekognitionFaces();
   private readonly detectModerationLabelsCommand: DetectModerationLabelsHandler;
   private readonly detectLabelsCommand: DetectLabelsHandler;
+  private readonly detectFacesCommand: DetectFacesHandler;
   private readonly sdkRouter = new SimRekognitionSdkCommandRouter(this);
 
   constructor(properties: SimRekognitionProperties = {}) {
@@ -70,6 +78,13 @@ export class SimRekognition {
 
     this.detectLabelsCommand = new DetectLabelsHandler({
       labels: this.labelRules,
+      authorizer,
+      images,
+      background,
+    });
+
+    this.detectFacesCommand = new DetectFacesHandler({
+      faces: this.faceRules,
       authorizer,
       images,
       background,
@@ -107,6 +122,19 @@ export class SimRekognition {
   }
 
   /**
+   * The face results this simulated Rekognition answers with.
+   *
+   * Every image holds the built-in default face until a rule says otherwise:
+   *
+   * ```typescript
+   * simAws.rekognition().faces().onName("landscape.jpg", { faces: [] });
+   * ```
+   */
+  faces(): SimRekognitionFaces {
+    return this.faceRules;
+  }
+
+  /**
    * Handle a DetectModerationLabels Command from the SDK.
    *
    * Background sequencing happens inside the command rather than here,
@@ -128,6 +156,16 @@ export class SimRekognition {
     options?: SimRekognitionRequestOptions,
   ): Promise<SimDetectLabelsCommandOutput> {
     return await this.detectLabelsCommand.handle(command, options);
+  }
+
+  /**
+   * Handle a DetectFaces Command from the SDK.
+   */
+  async detectFaces(
+    command: SimDetectFacesCommand,
+    options?: SimRekognitionRequestOptions,
+  ): Promise<SimDetectFacesCommandOutput> {
+    return await this.detectFacesCommand.handle(command, options);
   }
 
   /**


### PR DESCRIPTION
DetectFaces answers from rules declared under simAws.rekognition().faces(), with Attributes deciding which members each FaceDetail carries. The default subset is always returned, ALL adds the rest, and an attribute nothing was declared for is left out rather than reported as undefined. Landmarks follow AWS too: five unless ALL was asked for.

The built-in default is the one face from the AWS DetectFaces example response, with simRekognitionNoFaces and simRekognitionSeveralFaces beside it.

Resolves https://github.com/KensioSoftware/yulin/issues/319